### PR TITLE
Plots: one legend/tooltip per fault rule; fault timestamps as ISO UTC…

### DIFF
--- a/frontend/src/components/pages/PlotsPage.tsx
+++ b/frontend/src/components/pages/PlotsPage.tsx
@@ -134,11 +134,13 @@ function TrendChart({
     () => new Set(selectedFaultIds.map((id) => String(id).trim()).filter(Boolean)),
     [selectedFaultIds],
   );
+  /** One key per selected fault rule (unique), so legend and tooltip show one entry per rule. */
   const faultKeys = useMemo(() => {
     if (!faultData?.series?.length || set.size === 0) return [];
-    return faultData.series
+    const ids = faultData.series
       .filter((s) => set.has(String(s.metric).trim()))
       .map((s) => String(s.metric).trim());
+    return Array.from(new Set(ids));
   }, [faultData, set]);
   /** Fault active windows [startMs, endMs) per fault_id for swim-lane value 0/1. */
   const faultSegmentsList = useMemo(() => {
@@ -149,6 +151,7 @@ function TrendChart({
       .filter((s) => s.value > 0 && set.has(String(s.metric).trim()))
       .forEach((s) => {
         const t = new Date(s.time).getTime();
+        if (!Number.isFinite(t)) return;
         list.push({ start: t, end: t + bucketMs, fault_id: String(s.metric).trim() });
       });
     return list;
@@ -219,12 +222,12 @@ function TrendChart({
   type ChartRow = { timestamp: number; [k: string]: number };
   const fullData = useMemo((): ChartRow[] => {
     if (data?.length) {
-      const timeSet = new Set<number>(data.map((d) => d.timestamp));
+      const timeSet = new Set<number>(data.filter((d) => Number.isFinite(d.timestamp)).map((d) => d.timestamp));
       faultSegmentsList.forEach((s) => {
         timeSet.add(s.start);
         timeSet.add(s.end - 1);
       });
-      const sorted = Array.from(timeSet).sort((a, b) => a - b);
+      const sorted = Array.from(timeSet).filter(Number.isFinite).sort((a, b) => a - b);
       return sorted.map((timestamp) => {
         const existing = data.find((d) => d.timestamp === timestamp);
         const row: ChartRow = { timestamp };
@@ -301,6 +304,11 @@ function TrendChart({
     setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
   }, []);
 
+  const chartData = useMemo(() => {
+    const raw = displayedData.length > 0 ? displayedData : fullData;
+    return raw.filter((row) => Number.isFinite(row.timestamp));
+  }, [displayedData, fullData]);
+
   const loadingPoints = pointIds.length > 0 && isLoading;
   const loadingFaultsOnly = pointIds.length === 0 && selectedFaultIds.length > 0 && faultLoading;
   const hasAnyData = fullData.length > 0;
@@ -350,10 +358,20 @@ function TrendChart({
     );
   }
 
-  const chartData = displayedData.length > 0 ? displayedData : fullData;
   const hasPointLines = pointIds.length > 0 && keys.length > 0;
   const hasFaultLines = faultKeys.length > 0;
   const chartMarginRight = hasSecondPointAxis ? 80 : hasFaultLines ? 52 : 24;
+
+  if (chartData.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-lg border border-dashed border-border bg-muted/20 text-sm text-muted-foreground"
+        style={{ minHeight: CHART_MIN_HEIGHT }}
+      >
+        No valid data in this range (timestamps may be invalid).
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full flex-col gap-2">

--- a/open_fdd/platform/api/analytics.py
+++ b/open_fdd/platform/api/analytics.py
@@ -4,7 +4,7 @@ If the data model has no fan/VFD point for motor runtime, returns NO DATA.
 For MSI/cloud integrators and Grafana (via JSON datasource or downstream ETL).
 """
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Optional
 
 import pandas as pd
@@ -219,12 +219,20 @@ def get_fault_timeseries(
             )
             rows = cur.fetchall()
 
+    def _ts_iso_utc(dt):
+        """Format datetime as ISO UTC with Z so frontend parses as UTC and displays in local time (DST-safe)."""
+        if dt is None:
+            return None
+        if getattr(dt, "tzinfo", None) is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
     return {
         "site_id": site_id,
         "period": {"start": str(start_date), "end": str(end_date)},
         "bucket": bucket,
         "series": [
-            {"time": r["time"].isoformat() if hasattr(r["time"], "isoformat") else str(r["time"]), "metric": r["metric"], "value": float(r["value"])}
+            {"time": _ts_iso_utc(r["time"]), "metric": r["metric"], "value": float(r["value"])}
             for r in rows
         ],
     }

--- a/open_fdd/platform/api/download.py
+++ b/open_fdd/platform/api/download.py
@@ -252,11 +252,13 @@ def get_download_faults(
     if format == "json":
         from fastapi.responses import JSONResponse
 
+        from open_fdd.platform.api.timeseries import _ts_to_iso_utc
+
         data = []
         for r in rows:
             row = dict(r)
-            if "ts" in row and hasattr(row["ts"], "isoformat"):
-                row["ts"] = row["ts"].isoformat()
+            if "ts" in row:
+                row["ts"] = _ts_to_iso_utc(row["ts"]) if hasattr(row["ts"], "isoformat") else str(row["ts"])
             data.append(row)
         return JSONResponse(
             content={"faults": data, "count": len(data)},


### PR DESCRIPTION
… (Z)

- PlotsPage: dedupe faultKeys so legend and hover show one entry per rule
- analytics: fault-timeseries API emits time with Z for DST-safe local display
- download: fault export JSON ts formatted as UTC Z

