### PR TITLE
Allow Vite access from .local hostnames

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
   resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
   server: {
     host: "0.0.0.0",
+    allowedHosts: ["localhost", ".local"],
     proxy: {
       ...Object.fromEntries(
         apiRoutes.map((r) => [r, { target: apiTarget, bypass: spaBypass }]),


### PR DESCRIPTION
## Summary
Allow Vite dev-server access from .local hostnames such as open-fdd-pi.local.

## Why
When the frontend is accessed over LAN or mDNS on a Raspberry Pi, Vite rejects the Host header unless the hostname is explicitly allowed. That blocks the default frontend URL on the Pi even though the service is otherwise healthy.

## Change
Add .local to server.allowedHosts in frontend/vite.config.ts.

## Validation
Verified locally by accessing the frontend through open-fdd-pi.local:5173 after restarting the frontend container.