### PR TITLE
Restore missing frontend lib helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,87 @@
+const apiKey = import.meta.env.VITE_OFDD_API_KEY as string | undefined;
+
+function buildHeaders(init?: HeadersInit): Headers {
+  const headers = new Headers(init ?? {});
+  if (apiKey && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${apiKey}`);
+  }
+  return headers;
+}
+
+function buildUrl(path: string): string {
+  if (/^https?:\/\//.test(path)) return path;
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  try {
+    if (contentType.includes("application/json")) {
+      const payload = (await response.json()) as {
+        detail?: string | { msg?: string }[];
+        error?: string;
+        message?: string;
+      };
+      if (typeof payload.detail === "string") return payload.detail;
+      if (Array.isArray(payload.detail)) {
+        return payload.detail.map((item) => item.msg ?? "Validation error").join("; ");
+      }
+      if (payload.error) return payload.error;
+      if (payload.message) return payload.message;
+    }
+
+    const text = await response.text();
+    if (text.trim()) return text.trim();
+  } catch {
+    // Fall through to generic status text.
+  }
+
+  return response.statusText || `HTTP ${response.status}`;
+}
+
+export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(buildUrl(path), {
+    ...init,
+    headers: buildHeaders(init?.headers),
+  });
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response);
+    throw new Error(`${response.status} ${message}`.trim());
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function apiFetchText(path: string, init?: RequestInit): Promise<string> {
+  const response = await fetch(buildUrl(path), {
+    ...init,
+    headers: buildHeaders(init?.headers),
+  });
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response);
+    throw new Error(`${response.status} ${message}`.trim());
+  }
+
+  return response.text();
+}
+
+export async function apiFetchBlob(path: string, init?: RequestInit): Promise<Blob> {
+  const response = await fetch(buildUrl(path), {
+    ...init,
+    headers: buildHeaders(init?.headers),
+  });
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response);
+    throw new Error(`${response.status} ${message}`.trim());
+  }
+
+  return response.blob();
+}

--- a/frontend/src/lib/crud-api.ts
+++ b/frontend/src/lib/crud-api.ts
@@ -1,0 +1,146 @@
+import { apiFetch } from "@/lib/api";
+import type {
+  DataModelExportRow,
+  DataModelImportBody,
+  DataModelImportResponse,
+  PlatformConfig,
+  Site,
+} from "@/types/api";
+
+export interface SiteCreate {
+  name: string;
+  description?: string | null;
+}
+
+export interface DataModelCheckResponse {
+  triple_count: number;
+  blank_node_count: number;
+  orphan_blank_nodes: number;
+  sites: number;
+  bacnet_devices: number;
+  warnings: string[];
+}
+
+export interface WhoIsRangeBody {
+  request: {
+    start_instance: number;
+    end_instance: number;
+  };
+  url?: string;
+}
+
+export interface PointDiscoveryBody {
+  instance: {
+    device_instance: number;
+  };
+  url?: string;
+}
+
+export interface PointDiscoveryToGraphBody extends PointDiscoveryBody {
+  update_graph?: boolean;
+  write_file?: boolean;
+}
+
+export interface WhoIsResponse {
+  ok?: boolean;
+  body?: unknown;
+  error?: string;
+}
+
+export interface PointDiscoveryResponse {
+  ok?: boolean;
+  body?: unknown;
+  error?: string;
+}
+
+export function getConfig() {
+  return apiFetch<PlatformConfig>("/config");
+}
+
+export function putConfig(body: PlatformConfig) {
+  return apiFetch<PlatformConfig>("/config", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function createSite(body: SiteCreate) {
+  return apiFetch<Site>("/sites", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteSite(siteId: string) {
+  return apiFetch<{ status: string }>(`/sites/${siteId}`, {
+    method: "DELETE",
+  });
+}
+
+export function deleteEquipment(equipmentId: string) {
+  return apiFetch<{ status: string }>(`/equipment/${equipmentId}`, {
+    method: "DELETE",
+  });
+}
+
+export function deletePoint(pointId: string) {
+  return apiFetch<{ status: string }>(`/points/${pointId}`, {
+    method: "DELETE",
+  });
+}
+
+export function dataModelExport() {
+  return apiFetch<DataModelExportRow[]>("/data-model/export");
+}
+
+export function dataModelImport(body: DataModelImportBody) {
+  return apiFetch<DataModelImportResponse>("/data-model/import", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function dataModelSerialize() {
+  return apiFetch<{ status: string; path?: string; path_resolved?: string; error?: string }>(
+    "/data-model/serialize",
+    { method: "POST" },
+  );
+}
+
+export function dataModelReset() {
+  return apiFetch<{ status: string; path?: string; message?: string; error?: string }>(
+    "/data-model/reset",
+    { method: "POST" },
+  );
+}
+
+export function dataModelCheck() {
+  return apiFetch<DataModelCheckResponse>("/data-model/check");
+}
+
+export function bacnetWhoisRange(body: WhoIsRangeBody) {
+  return apiFetch<WhoIsResponse>("/bacnet/whois_range", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function bacnetPointDiscovery(body: PointDiscoveryBody) {
+  return apiFetch<PointDiscoveryResponse>("/bacnet/point_discovery", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function bacnetPointDiscoveryToGraph(body: PointDiscoveryToGraphBody) {
+  return apiFetch<PointDiscoveryResponse>("/bacnet/point_discovery_to_graph", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/lib/csv.ts
+++ b/frontend/src/lib/csv.ts
@@ -1,0 +1,112 @@
+import { apiFetchBlob, apiFetchText } from "@/lib/api";
+
+export interface CsvRequest {
+  site_id: string;
+  start_date: string;
+  end_date: string;
+  format?: "wide" | "long";
+  point_ids?: string[];
+}
+
+export interface LongCsvRow {
+  timestamp: number;
+  pointKey: string;
+  value: number;
+}
+
+export interface PivotRow {
+  timestamp: number;
+  [key: string]: number;
+}
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      out.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+
+  out.push(current);
+  return out;
+}
+
+export async function fetchCsv(body: CsvRequest): Promise<string> {
+  return apiFetchText("/download/csv", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "text/csv" },
+    body: JSON.stringify({ ...body, format: body.format ?? "wide" }),
+  });
+}
+
+export function parseLongCsv(csv: string): LongCsvRow[] {
+  const normalized = csv.replace(/^\uFEFF/, "").trim();
+  if (!normalized) return [];
+
+  const lines = normalized.split(/\r?\n/).filter(Boolean);
+  if (lines.length <= 1) return [];
+
+  const headers = parseCsvLine(lines[0]).map((header) => header.trim().toLowerCase());
+  const tsIndex = headers.findIndex((h) => h === "ts" || h === "timestamp" || h === "time");
+  const keyIndex = headers.findIndex(
+    (h) => h === "point_key" || h === "point_id" || h === "external_id" || h === "point",
+  );
+  const valueIndex = headers.findIndex((h) => h === "value");
+
+  if (tsIndex < 0 || keyIndex < 0 || valueIndex < 0) return [];
+
+  return lines
+    .slice(1)
+    .map((line) => parseCsvLine(line))
+    .map((cols) => {
+      const date = new Date(cols[tsIndex] ?? "");
+      const value = Number(cols[valueIndex]);
+      return {
+        timestamp: date.getTime(),
+        pointKey: cols[keyIndex] ?? "",
+        value,
+      };
+    })
+    .filter((row) => Number.isFinite(row.timestamp) && row.pointKey && Number.isFinite(row.value));
+}
+
+export function pivotForChart(rows: LongCsvRow[]): PivotRow[] {
+  const byTimestamp = new Map<number, PivotRow>();
+
+  for (const row of rows) {
+    const existing = byTimestamp.get(row.timestamp) ?? { timestamp: row.timestamp };
+    existing[row.pointKey] = row.value;
+    byTimestamp.set(row.timestamp, existing);
+  }
+
+  return Array.from(byTimestamp.values()).sort((a, b) => a.timestamp - b.timestamp);
+}
+
+export async function downloadTimeseriesCsv(body: CsvRequest, filename: string): Promise<void> {
+  const blob = await apiFetchBlob("/download/csv", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "text/csv" },
+    body: JSON.stringify({ ...body, format: body.format ?? "wide" }),
+  });
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,70 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function parseUtcTimestamp(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const normalized = /z$/i.test(value) || /[+-]\d\d:\d\d$/.test(value) ? value : `${value}Z`;
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function timeAgo(value: string | null | undefined): string {
+  const date = parseUtcTimestamp(value);
+  if (!date) return "unknown";
+
+  const diffMs = Date.now() - date.getTime();
+  const future = diffMs < 0;
+  const absMs = Math.abs(diffMs);
+  const absSec = Math.round(absMs / 1000);
+
+  if (absSec < 45) return future ? "in a few seconds" : "just now";
+
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ["year", 60 * 60 * 24 * 365],
+    ["month", 60 * 60 * 24 * 30],
+    ["day", 60 * 60 * 24],
+    ["hour", 60 * 60],
+    ["minute", 60],
+  ];
+
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  for (const [unit, seconds] of units) {
+    if (absSec >= seconds) {
+      const amount = Math.round(absSec / seconds);
+      return rtf.format(future ? amount : -amount, unit);
+    }
+  }
+
+  return future ? `in ${absSec} seconds` : `${absSec} seconds ago`;
+}
+
+export function severityVariant(severity: string | null | undefined):
+  | "default"
+  | "secondary"
+  | "destructive"
+  | "success"
+  | "warning"
+  | "outline" {
+  switch ((severity ?? "").toLowerCase()) {
+    case "critical":
+    case "high":
+    case "error":
+      return "destructive";
+    case "warning":
+    case "medium":
+      return "warning";
+    case "ok":
+    case "healthy":
+    case "success":
+    case "low":
+      return "success";
+    case "info":
+      return "secondary";
+    default:
+      return "outline";
+  }
+}


### PR DESCRIPTION
## Summary
Restore the missing frontend helper modules under frontend/src/lib and narrow the broad .gitignore lib/ rule so those files are tracked normally.

## Why
The React frontend imports shared helpers from src/lib, but those files were absent from the repository. On a clean Linux/Docker build this causes Vite import-resolution failures such as '@/lib/api' not found, preventing the frontend from loading.

## Change
- add frontend/src/lib/api.ts
- add frontend/src/lib/crud-api.ts
- add frontend/src/lib/csv.ts
- add frontend/src/lib/utils.ts
- change .gitignore from lib/ to /lib/ so frontend/src/lib is no longer ignored

## Validation
Reproduced on Raspberry Pi / Docker by loading the frontend at open-fdd-pi.local:5173. After restoring these files, the frontend loaded successfully instead of failing on missing @/lib imports.