### PR TITLE
chore: bump open-fdd and frontend versions to 2.0.9

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "dependencies": {
         "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.0.8",
+  "version": "2.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "2.0.8"
+version = "2.0.9"
 description = "Fault Detection and Diagnostics for HVAC systems — config-driven, pandas-based"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump for 2.0.9 release tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version from 2.0.8 to 2.0.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->