### PR TITLE
chore(openfdd-engine): bump 0.1.2 and refresh PyPI README

### DIFF
--- a/packages/openfdd-engine/README.md
+++ b/packages/openfdd-engine/README.md
@@ -1,6 +1,13 @@
 # openfdd-engine
 
-Standalone Pandas/YAML FDD engine extracted from Open-FDD.
+Thin installable wrapper around **[open-fdd](https://pypi.org/project/open-fdd/)** on PyPI: same **pandas + YAML** fault-detection engine (`RuleRunner`, bounds/flatline/expression rules) without pulling in the full Docker AFDD stack.
+
+| | |
+|--|--|
+| **Engine (this metapackage)** | [openfdd-engine on PyPI](https://pypi.org/project/openfdd-engine/) |
+| **Core library** | [open-fdd on PyPI](https://pypi.org/project/open-fdd/) — `pip install open-fdd` also works for library-only use |
+| **Full platform** | Clone the repo and run `./scripts/bootstrap.sh` for API, UI, TimescaleDB, BACnet, etc. |
+| **Docs** | [open-fdd documentation](https://bbartling.github.io/open-fdd/) |
 
 ## Install
 
@@ -8,7 +15,7 @@ Standalone Pandas/YAML FDD engine extracted from Open-FDD.
 pip install openfdd-engine
 ```
 
-For Brick TTL mapping support:
+For optional Brick TTL / SPARQL helpers used with rules:
 
 ```bash
 pip install "openfdd-engine[brick]"
@@ -16,12 +23,16 @@ pip install "openfdd-engine[brick]"
 
 ## API
 
-- `RuleRunner`
-- `load_rule()`
+- `RuleRunner` — run YAML rules on a DataFrame
+- `load_rule()` / `load_rules_from_dir()`
 - `bounds_map_from_rule()`
-- `resolve_from_ttl()`
+- `resolve_from_ttl()` — Brick column maps when using TTL
 
-Rule authoring guidance remains in the Open-FDD docs:
-- `docs/expression_rule_cookbook.md`
-- [Engine-only deployment and external IoT pipelines](https://github.com/bbartling/open-fdd/blob/develop/docs/howto/engine_only_iot.md) — when to use Docker **engine** mode vs **library-only** `RuleRunner` for external data pipelines.
+Rule authoring and patterns live in the main repo:
 
+- [Expression rule cookbook](https://github.com/bbartling/open-fdd/blob/master/docs/expression_rule_cookbook.md)
+- [Engine-only deployment and external IoT pipelines](https://github.com/bbartling/open-fdd/blob/master/docs/howto/engine_only_iot.md) — `RuleRunner` vs Docker `--mode engine`
+
+## Release alignment
+
+`openfdd-engine` versions track the thin packaging layer; **`open-fdd`** carries the engine implementation version (see `pyproject.toml` in the repo root). Use `pip install -U open-fdd openfdd-engine` to refresh both.

--- a/packages/openfdd-engine/pyproject.toml
+++ b/packages/openfdd-engine/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openfdd-engine"
-version = "0.1.1"
+version = "0.1.2"
 description = "Standalone Open-FDD Pandas/YAML fault detection engine"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Open-FDD Contributors" }]
 requires-python = ">=3.9"
 dependencies = [
-  "open-fdd>=2.0.8",
+  "open-fdd>=2.0.10",
   "pandas",
   "pyyaml",
 ]


### PR DESCRIPTION
Bumps `openfdd-engine` to **0.1.2**, sets `open-fdd>=2.0.10`, and expands the package README (PyPI links, engine vs full stack, docs).

After merge: tag `openfdd-engine-v0.1.2` to trigger [Publish openfdd-engine](.github/workflows/publish-openfdd-engine.yml).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified openfdd-engine architecture and its relationship to the core library.
  * Expanded API reference with additional loader functionality and usage patterns.
  * Added version alignment guidance between package components.

* **Chores**
  * Version bumped to 0.1.2.
  * Updated core library dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->