### PR TITLE
GHCR pull deploy + track mcp_rag for CI

### DIFF
--- a/docker/images.yaml
+++ b/docker/images.yaml
@@ -1,7 +1,7 @@
 # Published Open-FDD container images (addons).
 # Build: ./scripts/docker_build.sh
 # Publish: ./scripts/docker_publish.sh
-# Deploy: infra/ansible/deploy.sh docker (tar load) or future registry pull
+# Deploy: OPENFDD_IMAGE_TAG=tag ./infra/ansible/deploy.sh docker (GHCR pull) or tar with OPENFDD_DOCKER_PULL_FROM_GHCR=0
 
 registry: ghcr.io
 org: bbartling

--- a/docs/edge_deploy_docker.md
+++ b/docs/edge_deploy_docker.md
@@ -24,16 +24,15 @@ Legacy **pip + rsync + systemd app units** (`./deploy.sh all`) remains for Pi/la
 
 State (feather, rules, model, `points.csv`) lives on the host under **`workspace/`**, bind-mounted into containers.
 
-**GHCR publish (later):** Images can be pushed to `ghcr.io/bbartling/` via manual GitHub Actions when ready. Edge still uses tar load today. See [Publish Docker addons (howto)](howto/publish_docker_addons.md).
+**GHCR (default on production edges):** Publish with GitHub Actions → **Publish Docker addons**, then deploy with `OPENFDD_IMAGE_TAG=<tag> ./deploy.sh docker`. See [Publish Docker addons (howto)](howto/publish_docker_addons.md). Legacy tar: `OPENFDD_DOCKER_PULL_FROM_GHCR=0` + `docker_build.sh --save`.
 
 ## Operational sync (`deploy.sh ops`)
 
 One-shot playbook for production edges: Docker deploy, safe maintenance prune, workspace ownership fix, **POST /api/model/sync-ttl**, SPARQL tree probe (`query_engine=sparql`), feather size check, bridge log scan, HTTP insurance probes.
 
 ```bash
-./scripts/docker_build.sh --save
 export SSHPASS='…'   # or secrets/acme.env.local
-./deploy.sh ops --limit acme_vm_bbartling
+OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh ops --limit acme_vm_bbartling
 ```
 
 BRICK reads (`/api/model/tree`, `/graph`, `/scope`) use **rdflib SPARQL** on synced `workspace/data/data_model.ttl` — not grep/text search on Turtle.

--- a/docs/howto/publish_docker_addons.md
+++ b/docs/howto/publish_docker_addons.md
@@ -5,7 +5,7 @@ nav_exclude: true
 
 # Publish Docker addons to GHCR (when ready)
 
-**Status:** Deferred. Edge deploy today uses **`./scripts/docker_build.sh --save`** + Ansible tar load. Registry publish is wired but not required until edges can `docker pull`.
+**Status:** Edge deploy defaults to **`docker compose pull`** from **`ghcr.io/bbartling/`** after you publish a tag. Tar load remains for lab/air-gap (`OPENFDD_DOCKER_PULL_FROM_GHCR=0`).
 
 **For AI agents:** Run this only when the operator explicitly asks to publish images or cut an edge release tag. Do not publish on every PR merge.
 
@@ -38,19 +38,25 @@ docker login ghcr.io
 OPENFDD_IMAGE_TAG=2026.06.01-edge ./scripts/docker_publish.sh
 ```
 
-## After publish (future edge path)
+## After publish — deploy Acme (GHCR pull)
 
-Not implemented yet on Acme:
-
-1. Pin tag in `supervisor/manifest.yaml` / host_vars (`openfdd_docker_image_tag`).
-2. Replace tar load in Ansible with `docker compose pull` + `up`.
-3. See [Edge stack layout](../architecture/edge_stack.md) and `os/Documentation/roadmap.md`.
-
-Until then, keep:
+1. GitHub Actions **Publish Docker addons** finishes with your tag (e.g. `2026.06.04-edge`).
+2. Set the same tag in `host_vars/acme_vm_bbartling.yml` (`openfdd_docker_image_tag`) or pass `-e` / `OPENFDD_IMAGE_TAG`.
+3. GHCR packages must be **public**, or set `openfdd_ghcr_token` in host_vars for `docker login` on the edge.
 
 ```bash
-./scripts/docker_build.sh --save
-cd infra/ansible && ./deploy.sh docker --limit <host>
+cd infra/ansible
+export SSHPASS='…'   # or secrets/acme.env.local
+OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling
+```
+
+Ansible renders `docker-compose.yml` with `ghcr.io/bbartling/openfdd-*:<tag>`, runs **`docker compose pull`**, then **`up -d`**.
+
+Legacy tar (no registry):
+
+```bash
+OPENFDD_DOCKER_PULL_FROM_GHCR=0 OPENFDD_IMAGE_TAG=2026.06.04-edge ./scripts/docker_build.sh --save
+OPENFDD_DOCKER_PULL_FROM_GHCR=0 ./deploy.sh docker --limit <host>
 ```
 
 ## Related files

--- a/infra/ansible/deploy.sh
+++ b/infra/ansible/deploy.sh
@@ -98,12 +98,12 @@ Components:
   mcp | ai    MCP RAG sidecar (+ edge_ai_stack.yml); ai also runs Ollama bootstrap
   os          apt update + safe upgrade (os_update.yml; -e os_upgrade_reboot=true)
   check       Post-deploy insurance probes only (no file sync)
-  docker      Docker Compose stack (build images locally first — see docs/edge_deploy_docker.md)
+  docker      Docker Compose (default: pull ghcr.io/bbartling/* — set OPENFDD_IMAGE_TAG)
   maintain    Safe Docker prune on edge only (images/networks/containers; never volumes)
   ops         Full Docker deploy + maintenance + TTL sync + SPARQL/feather/log health (edge_operational_sync.yml)
 
 Examples:
-  ./scripts/docker_build.sh --save && ./deploy.sh docker --limit acme_vm_bbartling
+  OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling
   ./scripts/build_and_test.sh && ./deploy.sh ui --limit acme_vm_bbartling
   ./deploy.sh backend --limit acme_vm_bbartling
   ./deploy.sh drivers --limit acme_vm_bbartling -e enable_bacnet_poll_driver=true
@@ -123,13 +123,30 @@ Secrets (gitignored): infra/ansible/secrets/README.md
 EOF
 }
 
-require_docker_bundle() {
-  local tag="${OPENFDD_IMAGE_TAG:-local}"
+require_docker_deploy() {
+  local tag="${OPENFDD_IMAGE_TAG:-}"
+  local pull="${OPENFDD_DOCKER_PULL_FROM_GHCR:-1}"
+  case "$pull" in
+    0|false|no|off) pull=0 ;;
+    *) pull=1 ;;
+  esac
+  if [[ "$pull" == "1" ]]; then
+    if [[ -z "$tag" || "$tag" == "local" ]]; then
+      echo "GHCR deploy: set OPENFDD_IMAGE_TAG to the tag published by GitHub Actions." >&2
+      echo "  Example: OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling" >&2
+      echo "Legacy tar path: OPENFDD_DOCKER_PULL_FROM_GHCR=0 ./scripts/docker_build.sh --save" >&2
+      exit 1
+    fi
+    ANSIBLE_EXTRA+=(-e "openfdd_docker_pull_from_ghcr=true" -e "openfdd_docker_image_tag=${tag}")
+    return 0
+  fi
+  tag="${tag:-local}"
+  ANSIBLE_EXTRA+=(-e "openfdd_docker_pull_from_ghcr=false" -e "openfdd_docker_image_tag=${tag}")
   local tar="${ROOT}/docker/dist/openfdd-images-${tag}.tar.gz"
   if [[ ! -f "$tar" ]]; then
     echo "Missing Docker image bundle: $tar" >&2
-    echo "Run: ./scripts/docker_build.sh --save" >&2
-    echo "Or: OPENFDD_IMAGE_TAG=yourtag ./scripts/docker_build.sh --save" >&2
+    echo "Run: OPENFDD_IMAGE_TAG=${tag} ./scripts/docker_build.sh --save" >&2
+    echo "Or GHCR: OPENFDD_IMAGE_TAG=yourtag ./deploy.sh docker --limit <host>" >&2
     exit 1
   fi
 }
@@ -238,10 +255,7 @@ case "$COMPONENT" in
 esac
 
 if [[ "$COMPONENT" == "docker" || "$COMPONENT" == "ops" ]]; then
-  require_docker_bundle
-  if [[ -n "${OPENFDD_IMAGE_TAG:-}" ]]; then
-    ANSIBLE_EXTRA+=(-e "openfdd_docker_image_tag=${OPENFDD_IMAGE_TAG}")
-  fi
+  require_docker_deploy
 fi
 
 if [[ "$NEEDS_UI" == true ]]; then

--- a/infra/ansible/deploy_docker.yml
+++ b/infra/ansible/deploy_docker.yml
@@ -1,14 +1,14 @@
 ---
 # Docker-based edge deploy — app stack in Compose; host Caddy + FDD/retention timers only.
 #
-#   ./scripts/docker_build.sh --save
-#   ./deploy.sh docker --limit acme_vm_bbartling
-#   ./deploy.sh docker --limit acme_vm_bbartling -e openfdd_docker_image_tag=2026.06.01
+# GHCR (default after Actions publish):
+#   OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling
+#
+# Legacy tar load (lab / air-gap):
+#   OPENFDD_DOCKER_PULL_FROM_GHCR=0 OPENFDD_IMAGE_TAG=2026.06.04-edge ./scripts/docker_build.sh --save
+#   OPENFDD_DOCKER_PULL_FROM_GHCR=0 ./deploy.sh docker --limit acme_vm_bbartling
 #
 # Tags: docker, preflight, config, data, commission, maintain, verify
-#
-# Disk maintenance (prune old images, remove image tar) runs after compose up when
-# openfdd_docker_prune_on_deploy is true (default). Standalone: ./deploy.sh maintain
 #
 # Does NOT rsync Python/API source — only Docker images + workspace state (data/, env).
 # Image-only refresh: -e openfdd_docker_sync_workspace_data=false
@@ -62,21 +62,25 @@
         - "{{ openfdd_remote_dir }}/workspace/bacnet/commissioning"
         - "{{ openfdd_remote_dir }}/workspace/bacnet/polls"
 
-    - name: Stat image bundle on control machine
+    - name: Stat image bundle on control machine (tar deploy path)
       tags: [docker]
       ansible.builtin.stat:
         path: "{{ openfdd_docker_tar_local }}"
       delegate_to: localhost
       become: false
       register: local_docker_tar
+      when: not (openfdd_docker_pull_from_ghcr | default(false) | bool)
 
     - name: Fail when image bundle missing (run scripts/docker_build.sh --save)
       tags: [docker]
       ansible.builtin.fail:
         msg: >-
           Missing {{ openfdd_docker_tar_local }} on control machine.
-          Run: ./scripts/docker_build.sh --save
-      when: not local_docker_tar.stat.exists | default(false)
+          Run: OPENFDD_IMAGE_TAG={{ openfdd_docker_image_tag | default('local') }} ./scripts/docker_build.sh --save
+          Or use GHCR: OPENFDD_IMAGE_TAG=your-tag ./deploy.sh docker --limit <host>
+      when:
+        - not (openfdd_docker_pull_from_ghcr | default(false) | bool)
+        - not local_docker_tar.stat.exists | default(false)
 
     - name: Copy image bundle to edge
       tags: [docker]
@@ -84,8 +88,9 @@
         src: "{{ openfdd_docker_tar_local }}"
         dest: "{{ openfdd_docker_tar_remote }}"
         mode: "0644"
+      when: not (openfdd_docker_pull_from_ghcr | default(false) | bool)
 
-    - name: Load Docker images on edge
+    - name: Load Docker images on edge from tar
       tags: [docker]
       ansible.builtin.command:
         argv:
@@ -94,6 +99,7 @@
           - gunzip -c "{{ openfdd_docker_tar_remote }}" | docker load
       register: docker_load
       changed_when: "'Loaded image' in docker_load.stdout"
+      when: not (openfdd_docker_pull_from_ghcr | default(false) | bool)
 
     - name: Stat workspace auth.env.local on control machine
       tags: [config]
@@ -291,6 +297,39 @@
         src: templates/docker-compose.edge.yml.j2
         dest: "{{ openfdd_remote_dir }}/docker-compose.yml"
         mode: "0644"
+
+    - name: Log in to GHCR on edge (private packages)
+      tags: [docker]
+      ansible.builtin.shell:
+        cmd: >-
+          set -euo pipefail;
+          echo "$TOKEN" | docker login {{ openfdd_docker_registry | default('ghcr.io') }}
+          -u "$USER" --password-stdin
+      environment:
+        TOKEN: "{{ openfdd_ghcr_token }}"
+        USER: "{{ openfdd_ghcr_username | default(openfdd_docker_registry_org | default('bbartling')) }}"
+      no_log: true
+      changed_when: false
+      when:
+        - openfdd_docker_pull_from_ghcr | default(false) | bool
+        - openfdd_ghcr_token | default('') | length > 0
+
+    - name: Pull Open-FDD images from GHCR
+      tags: [docker]
+      ansible.builtin.command:
+        argv:
+          - docker
+          - compose
+          - -f
+          - "{{ openfdd_remote_dir }}/docker-compose.yml"
+          - pull
+      register: compose_pull
+      changed_when: >-
+        (compose_pull.stdout ~ compose_pull.stderr) is search(
+          '(Pulling|Downloading|Extracting|Pulled|Downloaded|Already|up to date)',
+          ignorecase=True
+        )
+      when: openfdd_docker_pull_from_ghcr | default(false) | bool
 
     - name: Stop legacy systemd Open-FDD app units (Docker replaces them)
       tags: [docker]

--- a/infra/ansible/edge_operational_sync.yml
+++ b/infra/ansible/edge_operational_sync.yml
@@ -1,8 +1,7 @@
 ---
 # Operational sync: latest Docker stack + maintenance + SPARQL/TTL + feather/log health.
 #
-#   ./scripts/docker_build.sh --save
-#   export SSHPASS='...' && ./deploy.sh ops --limit acme_vm_bbartling
+#   OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh ops --limit acme_vm_bbartling
 #
 - ansible.builtin.import_playbook: deploy_docker.yml
 

--- a/infra/ansible/group_vars/pi_bcn.yml
+++ b/infra/ansible/group_vars/pi_bcn.yml
@@ -80,6 +80,10 @@ post_check_require_mcp: true
 post_check_require_ollama: false
 
 # Docker Compose deploy (./deploy.sh docker) — see docs/edge_deploy_docker.md
+# GHCR pull is default; set tag via OPENFDD_IMAGE_TAG=… or host_vars. Tar: OPENFDD_DOCKER_PULL_FROM_GHCR=0
+openfdd_docker_pull_from_ghcr: true
+openfdd_docker_registry: ghcr.io
+openfdd_docker_registry_org: bbartling
 openfdd_docker_image_tag: "local"
 openfdd_docker_disable_systemd: true
 openfdd_docker_ollama: true

--- a/infra/ansible/host_vars/acme_vm_bbartling.yml.example
+++ b/infra/ansible/host_vars/acme_vm_bbartling.yml.example
@@ -9,6 +9,10 @@ building_id: vm-bbartling
 edge_model_json: acme_vm-bbartling_gl36_model.json
 openfdd_docker_stack: true
 
+# Pin to tag from GitHub Actions → Publish Docker addons (ghcr.io/bbartling/*)
+openfdd_docker_pull_from_ghcr: true
+openfdd_docker_image_tag: "2026.06.04-edge"
+
 # BACnet Device instance (Who-Is / bind). Change only if the OT network requires a fixed ID.
 bacnet_instance_id: 3456791
 bacnet_device_name: OpenFDD

--- a/infra/ansible/templates/docker-compose.edge.yml.j2
+++ b/infra/ansible/templates/docker-compose.edge.yml.j2
@@ -1,11 +1,18 @@
 # Rendered on edge host by deploy_docker.yml — do not edit on VM by hand.
 # Host Caddy (:80) → bridge on 127.0.0.1:{{ openfdd_bridge_port }}
+{% macro ofdd_image(short_name) -%}
+{%- if openfdd_docker_pull_from_ghcr | default(false) | bool -%}
+{{ openfdd_docker_registry | default('ghcr.io') }}/{{ openfdd_docker_registry_org | default('bbartling') }}/{{ short_name }}:{{ openfdd_docker_image_tag }}
+{%- else -%}
+{{ short_name }}:{{ openfdd_docker_image_tag | default('local') }}
+{%- endif -%}
+{%- endmacro %}
 
 name: openfdd-edge
 
 services:
   bridge:
-    image: openfdd-bridge:{{ openfdd_docker_image_tag | default('local') }}
+    image: {{ ofdd_image('openfdd-bridge') }}
     ports:
       - "127.0.0.1:{{ openfdd_bridge_port }}:8765"
     volumes:
@@ -36,7 +43,7 @@ services:
     restart: unless-stopped
 
   commission:
-    image: openfdd-commission:{{ openfdd_docker_image_tag | default('local') }}
+    image: {{ ofdd_image('openfdd-commission') }}
 {% if bacnet_commission_network_host | default(false) | bool %}
     network_mode: host
 {% endif %}
@@ -49,7 +56,7 @@ services:
 
 {% if enable_mcp | default(true) | bool %}
   mcp-rag:
-    image: openfdd-mcp-rag:{{ openfdd_docker_image_tag | default('local') }}
+    image: {{ ofdd_image('openfdd-mcp-rag') }}
     volumes:
       - {{ openfdd_remote_dir }}/workspace:/var/openfdd/workspace
     restart: unless-stopped
@@ -57,7 +64,7 @@ services:
 
 {% if enable_bacnet_poll_driver | default(false) | bool %}
   bacnet-poll:
-    image: openfdd-bacnet-poll:{{ openfdd_docker_image_tag | default('local') }}
+    image: {{ ofdd_image('openfdd-bacnet-poll') }}
     network_mode: host
     volumes:
       - {{ openfdd_remote_dir }}/workspace:/var/openfdd/workspace

--- a/workspace/.gitignore
+++ b/workspace/.gitignore
@@ -4,6 +4,10 @@
 !*.env.example
 !api/
 !api/**
+!mcp_rag/
+!mcp_rag/**
+**/mcp_rag/**/__pycache__/
+**/mcp_rag/**/*.py[cod]
 **/api/**/__pycache__/
 **/api/**/*.py[cod]
 !dashboard/

--- a/workspace/mcp_rag/app.py
+++ b/workspace/mcp_rag/app.py
@@ -1,0 +1,100 @@
+"""Optional MCP RAG doc search sidecar (:8090)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from .retrieval import RagIndex
+
+INDEX_PATH = Path(
+    os.getenv(
+        "OFDD_MCP_RAG_INDEX_PATH",
+        str(Path(__file__).resolve().parents[1] / "data" / "mcp" / "rag_index.json"),
+    )
+)
+
+app = FastAPI(title="Open-FDD MCP RAG", version="1.0.0")
+_idx: RagIndex | None = None
+
+
+class SearchDocsRequest(BaseModel):
+    query: str
+    top_k: int = Field(default=6, ge=1, le=25)
+    tags: list[str] | None = None
+
+
+class GetSectionRequest(BaseModel):
+    path_or_id: str
+
+
+def _load_index() -> RagIndex:
+    global _idx
+    if _idx is None:
+        if not INDEX_PATH.is_file():
+            raise HTTPException(status_code=503, detail=f"RAG index missing: {INDEX_PATH}")
+        _idx = RagIndex.from_path(INDEX_PATH)
+    return _idx
+
+
+def _serialize_results(query: str, rows: list[Any]) -> dict[str, Any]:
+    return {
+        "query": query,
+        "count": len(rows),
+        "results": [
+            {
+                "chunk_id": r.chunk_id,
+                "score": round(r.score, 5),
+                "source": r.source,
+                "section": r.section,
+                "content": r.content,
+                "endpoint_refs": r.endpoint_refs,
+                "tags": r.tags,
+            }
+            for r in rows
+        ],
+    }
+
+
+@app.get("/health", response_model=None)
+def health() -> dict[str, Any] | JSONResponse:
+    body: dict[str, Any] = {"index_exists": INDEX_PATH.is_file(), "index_path": str(INDEX_PATH)}
+    try:
+        _load_index()
+    except HTTPException as exc:
+        detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        return JSONResponse(status_code=exc.status_code, content={"ok": False, **body, "error": detail})
+    return {"ok": True, **body}
+
+
+@app.get("/manifest")
+def manifest() -> dict[str, Any]:
+    return {
+        "name": "open-fdd-mcp-rag",
+        "version": "1.0.0",
+        "tools": [
+            {"name": "search_docs", "route": "/tools/search_docs"},
+            {"name": "get_doc_section", "route": "/tools/get_doc_section"},
+        ],
+    }
+
+
+@app.post("/tools/search_docs")
+def search_docs(req: SearchDocsRequest) -> dict[str, Any]:
+    idx = _load_index()
+    rows = idx.search(req.query, top_k=req.top_k, tags=req.tags)
+    return _serialize_results(req.query, rows)
+
+
+@app.post("/tools/get_doc_section")
+def get_doc_section(req: GetSectionRequest) -> dict[str, Any]:
+    idx = _load_index()
+    data = idx.get_section(req.path_or_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Section not found.")
+    return data

--- a/workspace/mcp_rag/retrieval.py
+++ b/workspace/mcp_rag/retrieval.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from math import sqrt
+from pathlib import Path
+from typing import Any
+
+from .text_utils import tokenize
+
+
+@dataclass
+class SearchResult:
+    chunk_id: str
+    score: float
+    source: str
+    section: str
+    content: str
+    endpoint_refs: list[str]
+    tags: list[str]
+
+
+class RagIndex:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.docs = payload.get("docs", [])
+        self.idf = payload.get("idf", {})
+        self.postings = payload.get("postings", {})
+        self._doc_map = {d["chunk_id"]: d for d in self.docs}
+
+    @classmethod
+    def from_path(cls, path: Path) -> "RagIndex":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return cls(payload)
+
+    def search(self, query: str, top_k: int = 5, tags: list[str] | None = None) -> list[SearchResult]:
+        q_tokens = tokenize(query)
+        if not q_tokens:
+            return []
+
+        q_tf = Counter(q_tokens)
+        q_vec = {t: tf * float(self.idf.get(t, 1.0)) for t, tf in q_tf.items()}
+        q_norm = sqrt(sum(v * v for v in q_vec.values())) or 1.0
+
+        scores: dict[str, float] = {}
+        d_norms: dict[str, float] = {}
+        for t, q_w in q_vec.items():
+            postings = self.postings.get(t, {})
+            idf = float(self.idf.get(t, 1.0))
+            for chunk_id, tf in postings.items():
+                d_w = float(tf) * idf
+                scores[chunk_id] = scores.get(chunk_id, 0.0) + (q_w * d_w)
+                d_norms[chunk_id] = d_norms.get(chunk_id, 0.0) + (d_w * d_w)
+
+        out: list[SearchResult] = []
+        for chunk_id, dot in scores.items():
+            doc = self._doc_map.get(chunk_id)
+            if not doc:
+                continue
+            if tags and not set(doc.get("tags", [])).intersection(tags):
+                continue
+            norm = sqrt(d_norms.get(chunk_id, 1.0)) * q_norm
+            score = dot / (norm or 1.0)
+            out.append(
+                SearchResult(
+                    chunk_id=chunk_id,
+                    score=score,
+                    source=doc.get("source", ""),
+                    section=doc.get("section", ""),
+                    content=doc.get("content", ""),
+                    endpoint_refs=doc.get("endpoint_refs", []),
+                    tags=doc.get("tags", []),
+                )
+            )
+        out.sort(key=lambda x: x.score, reverse=True)
+        return out[: max(1, min(top_k, 25))]
+
+    def get_section(self, source_or_chunk: str) -> dict[str, Any]:
+        if source_or_chunk in self._doc_map:
+            return self._doc_map[source_or_chunk]
+        candidates = [d for d in self.docs if d.get("source") == source_or_chunk]
+        if not candidates:
+            return {}
+        combined = "\n\n".join(d.get("content", "") for d in candidates[:20])
+        return {
+            "source": source_or_chunk,
+            "section": "combined",
+            "content": combined,
+            "tags": sorted({t for d in candidates for t in d.get("tags", [])}),
+            "endpoint_refs": sorted({e for d in candidates for e in d.get("endpoint_refs", [])}),
+        }

--- a/workspace/mcp_rag/text_utils.py
+++ b/workspace/mcp_rag/text_utils.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import re
+
+TOKEN_RE = re.compile(r"[a-zA-Z0-9_./:-]{2,}")
+
+
+def tokenize(text: str) -> list[str]:
+    return [t.lower() for t in TOKEN_RE.findall(text)]


### PR DESCRIPTION
## Summary
- Edge deploy defaults to `docker compose pull` from `ghcr.io/bbartling/openfdd-*` when `OPENFDD_IMAGE_TAG` is set.
- Track `workspace/mcp_rag` so **Publish Docker addons** can build `openfdd-mcp-rag` on GitHub Actions (was missing from git).

## Test plan
- [ ] Merge PR
- [ ] Run **Publish Docker addons** with tag `2026.06.04-edge`
- [ ] `OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Docker image deployment now defaults to pulling from GHCR registry; optional tar-based air-gap deployment available via configuration.
  * Added MCP RAG service with document search and section retrieval capabilities.

* **Documentation**
  * Updated edge deployment guides to reflect GHCR-first Docker workflow and legacy tar-loading alternatives.

* **Chores**
  * Updated configuration files and deployment templates for Docker registry support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->