### PR TITLE
docs: GHCR deploy, branch hygiene, and release flow

### DIFF
--- a/docs/architecture/edge_stack.md
+++ b/docs/architecture/edge_stack.md
@@ -14,7 +14,7 @@ Three layers on a field host (today: **Ubuntu + Docker CE**; future: thin image 
 | **Supervisor** | `supervisor/` | Manifest, compose contracts, health — `./scripts/openfdd_stack.sh` |
 | **Apps** | `docker/` images | bridge, commission, poll, mcp-rag |
 | **State** | `workspace/` | Feather, rules, BRICK model, BACnet config (bind-mounted) |
-| **Deploy** | `infra/ansible/` | Image tar + workspace sync — `deploy.sh docker` |
+| **Deploy** | `infra/ansible/` | GHCR `compose pull` + workspace sync — `deploy.sh docker` (tar optional) |
 
 ```text
   [Caddy :80]

--- a/docs/edge_deploy_docker.md
+++ b/docs/edge_deploy_docker.md
@@ -70,29 +70,39 @@ set -a && source secrets/acme.env.local && set +a
 ./deploy.sh caddy --limit acme_vm_bbartling
 ```
 
-### Build images + bundle on bensserver
+### Publish images (GitHub Actions)
 
-```bash
-cd ~/open-fdd
-./scripts/build_and_test.sh          # or build_operator_dashboard.sh prod
-./scripts/docker_build.sh --save     # writes docker/dist/openfdd-images-local.tar.gz
-```
+1. Actions → **Publish Docker addons** → run with tag e.g. `2026.06.04-edge`.
+2. Wait for green build (four images pushed to `ghcr.io/bbartling/`).
 
-### Push to Acme via Ansible
+Details: [Publish Docker addons](howto/publish_docker_addons.md). Bot/feature branch cleanup: [GitHub branches and release](howto/github_branches_and_release.md).
+
+### Deploy to Acme (pull from GHCR — default)
+
+Pin the tag in `host_vars/acme_vm_bbartling.yml` (`openfdd_docker_pull_from_ghcr: true`, `openfdd_docker_image_tag`) or pass it on the CLI:
 
 ```bash
 cd infra/ansible
 set -a && source secrets/acme.env.local && set +a
-./deploy.sh docker --limit acme_vm_bbartling -e openfdd_docker_ollama=false
+OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling -e openfdd_docker_ollama=false
 ```
+
+Ansible renders `ghcr.io/bbartling/openfdd-*:<tag>` in `docker-compose.yml`, runs **`docker compose pull`** on the VM, then **`up -d`**. No `docker/dist/*.tar.gz` copy for this path.
 
 Use host systemd Ollama (not the compose `ollama` service). The bridge container reaches it via `host.docker.internal:11434` — ensure `sudo systemctl enable --now ollama` on the VM.
 
-Optional tag:
+**Local `:local` builds** (`./scripts/docker_build.sh` on bensserver) are for dev only; Acme does not use them when GHCR pull is enabled.
+
+### Legacy: tar bundle over Ansible
+
+For lab hosts without registry access:
 
 ```bash
-OPENFDD_IMAGE_TAG=2026.06.01 ./scripts/docker_build.sh --save
-./deploy.sh docker --limit acme_vm_bbartling -e openfdd_docker_image_tag=2026.06.01
+cd ~/open-fdd
+./scripts/build_and_test.sh
+OPENFDD_DOCKER_PULL_FROM_GHCR=0 OPENFDD_IMAGE_TAG=local ./scripts/docker_build.sh --save
+cd infra/ansible
+OPENFDD_DOCKER_PULL_FROM_GHCR=0 ./deploy.sh docker --limit acme_vm_bbartling
 ```
 
 ### BACnet poll on Acme
@@ -109,7 +119,9 @@ Re-run `./deploy.sh docker …` — poll container uses **`network_mode: host`**
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `openfdd_docker_image_tag` | `local` | Image tag in compose |
+| `openfdd_docker_pull_from_ghcr` | `true` (via `deploy.sh docker`) | Pull from `ghcr.io/bbartling/*`; set `false` for tar load |
+| `openfdd_docker_image_tag` | required for GHCR | Must match published tag (not `local`) |
+| `openfdd_docker_registry_org` | `bbartling` | GHCR org/user |
 | `openfdd_docker_disable_systemd` | `true` | Stop legacy `openfdd-*` app units (bridge/mcp/poll/commission) |
 | `openfdd_docker_ollama` | `true` | Compose `ollama/ollama` when `enable_ollama`; use `false` + `./deploy.sh ai` for host GPU |
 | `openfdd_docker_sync_workspace_data` | `true` | Tar-sync `workspace/data` (rules); set `false` for image-only |
@@ -121,7 +133,7 @@ Re-run `./deploy.sh docker …` — poll container uses **`network_mode: host`**
 
 ## Disk maintenance (safe prune)
 
-Each `./deploy.sh docker` run loads a new image bundle; without cleanup, old `openfdd-*` layers and the `.tar.gz` fill small Pi/VM disks.
+Each deploy may leave old `openfdd-*` image layers on disk; without cleanup, small Pi/VM disks fill up (tar path also leaves `.tar.gz` until removed).
 
 After the stack is **up**, Ansible runs `infra/ansible/scripts/docker_edge_maintenance.sh`:
 
@@ -153,24 +165,22 @@ Skip prune during deploy:
 
 ## What Ansible syncs (Docker path)
 
-**No Python/API git rsync** — unlike legacy `./deploy.sh all` (`deploy.yml`), the docker playbook does **not** push `workspace/api`, `open_fdd`, or built UI from source trees.
+Unlike legacy `./deploy.sh all` (`deploy.yml`), the docker playbook does **not** rsync the full Python tree from git on every run. The **bridge image** carries the compiled SPA; **`workspace/api`** is still bind-mounted on edges for config and hotfixes (see compose template).
 
-| Artifact | Mechanism | Purpose |
-|----------|-----------|---------|
-| App images | `docker/dist/openfdd-images-*.tar.gz` → `docker load` | Bridge, commission, poll, MCP |
-| Workspace **state** | Optional tar of `workspace/data` (rules, not feather) | Rule store, configs |
-| `model.json` | Single file copy from control | Site BRICK model |
-| `points.csv` | From `edge_backup/local/…` | Commission table |
-| Env / secrets | `auth.env.local`, templates | Login, BACnet bind, bridge secret |
-| Compose file | Template render | Stack definition |
+| Artifact | GHCR path (default) | Tar path (`OPENFDD_DOCKER_PULL_FROM_GHCR=0`) |
+|----------|---------------------|-----------------------------------------------|
+| App images | `docker compose pull` on edge | `docker/dist/openfdd-images-*.tar.gz` → `docker load` |
+| Workspace **state** | Optional tar of `workspace/data` (rules, not feather) | Same |
+| `model.json` | Copy from control | Same |
+| `points.csv` | From `edge_backup/local/…` | Same |
+| Env / secrets | `auth.env.local`, templates | Same |
+| Compose file | Template → `~/open-fdd/docker-compose.yml` | Same |
 
 Skip state sync on image-only deploy:
 
 ```bash
 ./deploy.sh docker --limit acme_vm_bbartling -e openfdd_docker_sync_workspace_data=false
 ```
-
-**Future:** edge `docker compose pull` from GHCR (see [publish Docker addons](howto/publish_docker_addons.md)) — no tar over SSH.
 
 ## Host services (not Compose app containers)
 
@@ -196,13 +206,8 @@ infra/ansible/scripts/docker_edge_maintenance.sh
 infra/ansible/templates/docker-compose.edge.yml.j2
 ```
 
-## Next steps (registry)
+## Related
 
-Replace `docker save` / `copy` / `load` with a private registry pull when you have many sites:
-
-```bash
-docker tag openfdd-bridge:local registry.example/openfdd-bridge:1.2.3
-docker push registry.example/openfdd-bridge:1.2.3
-```
-
-Ansible then runs `docker compose pull` instead of loading a tar.
+- [Publish Docker addons (GHCR)](howto/publish_docker_addons.md)
+- [GitHub branches and release automation](howto/github_branches_and_release.md)
+- `infra/ansible/host_vars/acme_vm_bbartling.yml.example` — Acme pins

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -40,10 +40,21 @@ cd open-fdd
 
 Details: [System overview](overview). Production push: [Edge deploy (Docker)](edge_deploy_docker).
 
+**Production (GHCR — default):** publish a tag in GitHub Actions, then:
+
 ```bash
-./scripts/docker_build.sh --save
-cd infra/ansible && ./deploy.sh docker --limit acme_vm_bbartling
-./deploy.sh ops --limit acme_vm_bbartling    # sync TTL, SPARQL probe, feather check
+cd infra/ansible
+OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling
+OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh ops --limit acme_vm_bbartling
+```
+
+See [Publish Docker addons](howto/publish_docker_addons.md) and [GitHub branches / release](howto/github_branches_and_release.md).
+
+**Lab / air-gap (tar):**
+
+```bash
+OPENFDD_DOCKER_PULL_FROM_GHCR=0 OPENFDD_IMAGE_TAG=local ./scripts/docker_build.sh --save
+OPENFDD_DOCKER_PULL_FROM_GHCR=0 ./deploy.sh docker --limit acme_vm_bbartling
 ```
 
 ---

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -54,6 +54,7 @@ See [Publish Docker addons](howto/publish_docker_addons.md) and [GitHub branches
 
 ```bash
 OPENFDD_DOCKER_PULL_FROM_GHCR=0 OPENFDD_IMAGE_TAG=local ./scripts/docker_build.sh --save
+cd infra/ansible
 OPENFDD_DOCKER_PULL_FROM_GHCR=0 ./deploy.sh docker --limit acme_vm_bbartling
 ```
 

--- a/docs/howto/github_branches_and_release.md
+++ b/docs/howto/github_branches_and_release.md
@@ -1,0 +1,57 @@
+---
+title: GitHub branches and release automation
+nav_order: 12
+---
+
+# GitHub branches and release automation
+
+How **feature branches**, **bot PRs**, and **manual Docker publishes** fit together after GHCR deploy landed on `master`.
+
+## Branch types
+
+| Branch / PR | Who creates it | What to do |
+|-------------|----------------|------------|
+| **`master`** | You merge feature PRs here | Production docs site, CI, and edge deploy pins |
+| **`deploy/*`, `fix/*`, feature branches** | Developers | Open a PR → merge → **delete the branch** (GitHub “Delete branch” or `git push origin --delete <name>`) |
+| **`chore/docs-pdf-refresh`** | **Docs PDF** workflow on GitHub (`docs-pdf.yml`) | Bot opens/updates a PR for `pdf/open-fdd-docs.pdf` and `.txt`. **Merge when the PR is current** so the bundle stays in sync with `docs/`. If **Create PR** failed with `stale info`, re-run the workflow or merge the existing open PR. |
+| **Tags on GHCR** | **Publish Docker addons** workflow (manual dispatch) | Not a git branch — image tag e.g. `2026.06.04-edge`. Pin the same tag in `host_vars` / `OPENFDD_IMAGE_TAG`. |
+
+Merged examples (delete if still on disk): `deploy/ghcr-pull-acme` (PR #190), `fault-codes-updates` (PR #188).
+
+## Typical release flow (Acme / production edge)
+
+1. **Code on `master`** — feature PRs merged; CI green.
+2. **Publish images** — Actions → **Publish Docker addons** → input tag (e.g. `2026.06.04-edge`). Wait for success.
+3. **Deploy edge** — `OPENFDD_IMAGE_TAG=<same-tag> ./deploy.sh docker --limit acme_vm_bbartling` (see [Publish Docker addons](publish_docker_addons.md)).
+4. **Docs PDF (optional same day)** — If **Docs PDF** opened PR #189-style branch, merge the bot PR so `pdf/open-fdd-docs.pdf` / `.txt` match `docs/`.
+5. **Cleanup** — Delete merged feature branches locally and on `origin`.
+
+## Docs PDF workflow notes
+
+- Triggers on pushes to `master`/`main` that touch `docs/**`, `scripts/build_docs_pdf.py`, or the workflow file.
+- Uses `peter-evans/create-pull-request` with branch `chore/docs-pdf-refresh`.
+- If **Create PR** fails with `stale info` on `git push --force-with-lease`, another run may have updated the branch first — check for an **open PR** and merge it, or re-run **Docs PDF** from Actions.
+- Protected `master` cannot take direct bot pushes; the PR is required.
+
+## Docker publish workflow notes
+
+- **Manual only** (`workflow_dispatch`) — does not run on every merge.
+- Requires `workspace/mcp_rag` in git (tracked for `openfdd-mcp-rag` image).
+- First publish after adding an image: set GHCR package **visibility** (public or token on edge).
+
+## Starting new work
+
+After release cleanup:
+
+```bash
+git checkout master && git pull
+git checkout -b fix/your-topic    # or feat/…
+```
+
+Use one branch per PR; avoid long-lived `deploy/*` branches after merge.
+
+## Related
+
+- [Publish Docker addons (GHCR)](publish_docker_addons.md)
+- [Docker edge deploy](../edge_deploy_docker.md)
+- [Contributing](../contributing.md)

--- a/docs/howto/github_branches_and_release.md
+++ b/docs/howto/github_branches_and_release.md
@@ -22,7 +22,7 @@ Merged examples (delete if still on disk): `deploy/ghcr-pull-acme` (PR #190), `f
 
 1. **Code on `master`** — feature PRs merged; CI green.
 2. **Publish images** — Actions → **Publish Docker addons** → input tag (e.g. `2026.06.04-edge`). Wait for success.
-3. **Deploy edge** — `OPENFDD_IMAGE_TAG=<same-tag> ./deploy.sh docker --limit acme_vm_bbartling` (see [Publish Docker addons](publish_docker_addons.md)).
+3. **Deploy edge** — from `infra/ansible`: `OPENFDD_IMAGE_TAG=<same-tag> ./deploy.sh docker --limit acme_vm_bbartling` (see [Publish Docker addons](publish_docker_addons.md)).
 4. **Docs PDF (optional same day)** — If **Docs PDF** opened PR #189-style branch, merge the bot PR so `pdf/open-fdd-docs.pdf` / `.txt` match `docs/`.
 5. **Cleanup** — Delete merged feature branches locally and on `origin`.
 

--- a/docs/howto/publish_docker_addons.md
+++ b/docs/howto/publish_docker_addons.md
@@ -1,13 +1,15 @@
 ---
-title: Publish Docker addons (GHCR) — deferred
-nav_exclude: true
+title: Publish Docker addons (GHCR)
+nav_order: 11
 ---
 
-# Publish Docker addons to GHCR (when ready)
+# Publish Docker addons to GHCR
 
-**Status:** Edge deploy defaults to **`docker compose pull`** from **`ghcr.io/bbartling/`** after you publish a tag. Tar load remains for lab/air-gap (`OPENFDD_DOCKER_PULL_FROM_GHCR=0`).
+Production edges (Acme, Pi) **pull** images from **`ghcr.io/bbartling/`** after you publish a tag. Ansible runs `docker compose pull` on the host — no image tar over SSH unless you opt into the legacy path.
 
-**For AI agents:** Run this only when the operator explicitly asks to publish images or cut an edge release tag. Do not publish on every PR merge.
+**For AI agents:** Publish only when the operator asks to cut an edge release tag. Do not publish on every PR merge.
+
+Branch hygiene and bot PRs: [GitHub branches and release automation](github_branches_and_release.md).
 
 ## Prerequisites
 
@@ -41,16 +43,19 @@ OPENFDD_IMAGE_TAG=2026.06.01-edge ./scripts/docker_publish.sh
 ## After publish — deploy Acme (GHCR pull)
 
 1. GitHub Actions **Publish Docker addons** finishes with your tag (e.g. `2026.06.04-edge`).
-2. Set the same tag in `host_vars/acme_vm_bbartling.yml` (`openfdd_docker_image_tag`) or pass `-e` / `OPENFDD_IMAGE_TAG`.
-3. GHCR packages must be **public**, or set `openfdd_ghcr_token` in host_vars for `docker login` on the edge.
+2. Pin the same tag in `infra/ansible/host_vars/acme_vm_bbartling.yml` (`openfdd_docker_image_tag`) and/or pass `OPENFDD_IMAGE_TAG` on the command line.
+3. Ensure `openfdd_docker_pull_from_ghcr: true` (default via `./deploy.sh docker`).
+4. GHCR packages must be **public**, or set `openfdd_ghcr_token` in host_vars for `docker login` on the edge.
 
 ```bash
 cd infra/ansible
-export SSHPASS='…'   # or secrets/acme.env.local
-OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling
+set -a && source secrets/acme.env.local && set +a
+OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh docker --limit acme_vm_bbartling -e openfdd_docker_ollama=false
 ```
 
-Ansible renders `docker-compose.yml` with `ghcr.io/bbartling/openfdd-*:<tag>`, runs **`docker compose pull`**, then **`up -d`**.
+Ansible renders `docker-compose.yml` with `ghcr.io/bbartling/openfdd-*:<tag>`, runs **`docker compose pull`**, then **`up -d`**. Workspace/API files and env still sync from the control machine; only **images** come from GHCR.
+
+**Ops pass** (TTL sync, probes, feather check): same tag — `OPENFDD_IMAGE_TAG=2026.06.04-edge ./deploy.sh ops --limit acme_vm_bbartling`.
 
 Legacy tar (no registry):
 
@@ -74,5 +79,5 @@ OPENFDD_DOCKER_PULL_FROM_GHCR=0 ./deploy.sh docker --limit <host>
 - [ ] `./scripts/build_and_test.sh` green
 - [ ] Choose `OPENFDD_IMAGE_TAG` (semver or date-edge)
 - [ ] Run Actions workflow or local publish
-- [ ] Smoke one host with tar path OR registry pull (when wired)
+- [ ] Smoke one host with `OPENFDD_IMAGE_TAG=… ./deploy.sh docker` (GHCR pull)
 - [ ] Note tag in PR / release notes

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,9 +56,9 @@ It should **not** be treated as a substitute for locked-down production credenti
 | Channel | Status |
 |---------|--------|
 | **Operator web app** | This repo — Docker bridge + dashboard ([Getting started](getting_started)) |
-| **Git + Docker tar** | `./scripts/docker_build.sh --save`, Ansible load on edge |
+| **GHCR edge images** | [Publish Docker addons](howto/publish_docker_addons) → `ghcr.io/bbartling/openfdd-*:<tag>` → `OPENFDD_IMAGE_TAG=… ./deploy.sh docker` |
+| **Docker tar (legacy)** | `OPENFDD_DOCKER_PULL_FROM_GHCR=0` + `docker_build.sh --save` — lab / air-gap |
 | **PyPI** [`open-fdd`](https://pypi.org/project/open-fdd/) | `engine`, `playground`, `reports` — [PyPI packages](open_fdd_playground_pypi) (library; not the full edge UI) |
-| **GHCR images** | Coming soon — [Publish Docker addons](howto/publish_docker_addons) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Rewrites Acme/edge deploy docs for default **GHCR pull** (`OPENFDD_IMAGE_TAG` + `deploy.sh docker`).
- Enables **Publish Docker addons** howto (no longer deferred/hidden).
- Adds **GitHub branches and release automation** howto (Docs PDF bot PR, feature branch cleanup, Docker publish flow).
- Updates index, getting started, and edge stack architecture blurb.

## Context
Follow-up to merged #190 (GHCR) and #189 (PDF bundle on master).

## Test plan
- [ ] Skim rendered docs on GitHub Pages after merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation to clarify GitHub Container Registry (GHCR) as the primary distribution method for edge releases.
  * Added comprehensive guidance for production and air-gap (offline) deployment scenarios.
  * Documented release automation workflow and branch management procedures.
  * Enhanced Docker addon publication and deployment instructions with clearer operational steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->