### PR TITLE
fix(ci): Docs PDF branch races

### DIFF
--- a/.github/workflows/docs-pdf.yml
+++ b/.github/workflows/docs-pdf.yml
@@ -21,7 +21,7 @@ env:
 
 concurrency:
   group: docs-pdf-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pdf:
@@ -67,4 +67,4 @@ jobs:
             pdf/open-fdd-docs.txt
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          delete-branch: true
+          delete-branch: false


### PR DESCRIPTION
Stops cancel-in-progress and delete-branch on chore/docs-pdf-refresh to avoid force-with-lease stale push failures.

Made with [Cursor](https://cursor.com)