### PR TITLE
feat(playground): AWS series eval helpers for fdd_lambda

### DIFF
--- a/open_fdd/playground/__init__.py
+++ b/open_fdd/playground/__init__.py
@@ -21,19 +21,29 @@ from open_fdd.playground.cookbook import (
 )
 from open_fdd.playground.rows import dataframe_to_evaluate_rows, readings_to_evaluate_rows
 from open_fdd.playground.sandbox import compile_evaluate, lint_python, rule_globals, sweep_rule
+from open_fdd.playground.series import (
+    build_series_context,
+    evaluate_rules_on_series,
+    readings_to_rows,
+    slim_fdd_summary,
+)
 
 __all__ = [
     "DEFAULT_THRESHOLDS_F",
     "ONE_HOUR_MS",
     "attach_rolling_avg",
+    "build_series_context",
     "cfg_threshold",
     "compile_evaluate",
     "dataframe_to_evaluate_rows",
+    "evaluate_rules_on_series",
     "hour_window_ready",
     "lint_python",
     "normalize_rolling_avg_minutes",
     "readings_to_evaluate_rows",
+    "readings_to_rows",
     "rule_globals",
+    "slim_fdd_summary",
     "sweep_rule",
     "temp_unit_symbol",
     "window_rows_1h",

--- a/open_fdd/playground/sandbox.py
+++ b/open_fdd/playground/sandbox.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 from contextlib import nullcontext, redirect_stdout
 from typing import Any, Callable
 
-from open_fdd.playground.cookbook import inject_cookbook_helpers
+from open_fdd.playground.cookbook import attach_rolling_avg, inject_cookbook_helpers, normalize_rolling_avg_minutes
 
 try:
     import numpy as np
@@ -221,10 +221,23 @@ def sweep_rule(
     rows: list[dict[str, Any]],
     *,
     capture_print: bool = True,
+    rolling_avg_minutes: int | None = None,
+    series_ctx: dict[str, Any] | None = None,
     exec_timeout_s: float = DEFAULT_EXEC_TIMEOUT_S,
     row_timeout_s: float = DEFAULT_ROW_TIMEOUT_S,
 ) -> tuple[list[bool], list[dict[str, Any]]]:
     """Run ``evaluate`` on each row; return per-row flags and diagnostic events."""
+    if rows:
+        minutes = normalize_rolling_avg_minutes(
+            rolling_avg_minutes
+            if rolling_avg_minutes is not None
+            else cfg.get("rolling_avg_minutes", 5)
+        )
+        explicit_window = rolling_avg_minutes is not None or cfg.get("rolling_avg_minutes") is not None
+        missing_avg = "temp_rolling_avg" not in rows[0]
+        stale_window = rows[0].get("rolling_avg_minutes") != minutes
+        if series_ctx is not None or missing_avg or (explicit_window and stale_window):
+            attach_rolling_avg(rows, minutes=minutes)
     lint = lint_python(code, strict_imports=True)
     if not lint["ok"]:
         lines = [
@@ -255,6 +268,11 @@ def sweep_rule(
         def _eval_row() -> Any:
             ctx = redirect_stdout(buf) if capture_print else nullcontext()
             with ctx:
+                if series_ctx is not None:
+                    try:
+                        return evaluate(row, cfg, prev_row=prev, rows=rows, series=series_ctx)
+                    except TypeError:
+                        return evaluate(row, cfg, prev_row=prev, rows=rows)
                 return evaluate(row, cfg, prev_row=prev, rows=rows)
 
         try:

--- a/open_fdd/playground/series.py
+++ b/open_fdd/playground/series.py
@@ -1,0 +1,98 @@
+"""Cross-sensor rule evaluation and DynamoDB summary helpers (AWS ``fdd_lambda`` parity)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from open_fdd.playground.cookbook import DEFAULT_ROLLING_AVG_MINUTES, attach_rolling_avg, normalize_rolling_avg_minutes
+from open_fdd.playground.sandbox import sweep_rule
+
+
+def readings_to_rows(readings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build row dicts for ``evaluate()`` from historian samples (degF + ts_ms)."""
+    rows: list[dict[str, Any]] = []
+    for i, r in enumerate(readings):
+        ts_iso = r.get("ts_iso") or r.get("ts") or ""
+        rows.append(
+            {
+                "row": i,
+                "ts_ms": int(r["ts_ms"]),
+                "ts": str(ts_iso).replace("T", " ")[:19],
+                "degF": float(r["degF"]),
+                "degC": float(r.get("degC", 0)),
+                "temp": float(r["degF"]),
+                "seq": r.get("seq"),
+                "source": r.get("source"),
+            }
+        )
+    return rows
+
+
+def slim_fdd_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    """Drop bulky chart payloads before writing FDD status to DynamoDB (~400 KB item limit)."""
+    return {k: v for k, v in summary.items() if k not in ("ts_ms", "flag_series", "aux_series")}
+
+
+def build_series_context(
+    series_map: dict[str, list[dict[str, Any]]],
+    row_index: int,
+    *,
+    aliases: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """
+    Per-row ``series`` dict for cross-sensor rules.
+    ``aliases`` maps rule keys (e.g. SAT) → ``series_id``.
+    Each entry: ``{"values": [...], "current": float|None, "series_id": str}``.
+    """
+    ctx: dict[str, Any] = {}
+    alias_to_sid = aliases or {}
+    sid_to_alias = {v: k for k, v in alias_to_sid.items()}
+
+    for sid, samples in series_map.items():
+        values = [s.get("value") for s in samples]
+        cur = values[row_index] if 0 <= row_index < len(values) else None
+        entry = {"values": values, "current": cur, "series_id": sid}
+        ctx[sid] = entry
+        alias = sid_to_alias.get(sid)
+        if alias:
+            ctx[alias] = entry
+    return ctx
+
+
+def evaluate_rules_on_series(
+    rules: list[dict[str, Any]],
+    primary_rows: list[dict[str, Any]],
+    series_map: dict[str, list[dict[str, Any]]],
+    *,
+    default_rolling_avg_minutes: int = DEFAULT_ROLLING_AVG_MINUTES,
+) -> dict[str, list[int]]:
+    """Evaluate rules with cross-sensor ``series`` context aligned to ``primary_rows`` length."""
+    n = len(primary_rows)
+    if n == 0:
+        return {}
+    out: dict[str, list[int]] = {}
+    for rule in rules:
+        if not rule.get("enabled", True):
+            continue
+        code = rule.get("code") or ""
+        cfg = rule.get("config") or {}
+        aliases = cfg.get("series_aliases") or {}
+        minutes = normalize_rolling_avg_minutes(
+            cfg.get("rolling_avg_minutes", default_rolling_avg_minutes)
+        )
+        flags = [0] * n
+        for i in range(n):
+            series_ctx = build_series_context(series_map, i, aliases=aliases)
+            row = primary_rows[i]
+            chunk_flags, _events = sweep_rule(
+                code,
+                cfg,
+                [row],
+                capture_print=False,
+                rolling_avg_minutes=minutes,
+                series_ctx=series_ctx,
+            )
+            if chunk_flags and chunk_flags[0]:
+                flags[i] = 1
+        out[rule["id"]] = flags
+    return out

--- a/open_fdd/tests/playground/test_series.py
+++ b/open_fdd/tests/playground/test_series.py
@@ -1,0 +1,42 @@
+from open_fdd.playground.series import (
+    build_series_context,
+    evaluate_rules_on_series,
+    slim_fdd_summary,
+)
+
+
+def test_slim_fdd_summary_drops_bulk_keys():
+    raw = {"fdd_status": "ok", "ts_ms": [1, 2], "flag_series": {"r": [1]}, "aux_series": {}}
+    slim = slim_fdd_summary(raw)
+    assert slim == {"fdd_status": "ok"}
+
+
+def test_evaluate_rules_on_series_cross_sensor():
+    rows = [
+        {"row": 0, "ts_ms": 1_000, "ts": "t0", "degF": 70.0, "temp": 70.0},
+        {"row": 1, "ts_ms": 2_000, "ts": "t1", "degF": 90.0, "temp": 90.0},
+    ]
+    series_map = {
+        "sat": [
+            {"ts_ms": 1_000, "value": 55.0},
+            {"ts_ms": 2_000, "value": 80.0},
+        ],
+    }
+    code = """
+def evaluate(row, cfg, prev_row=None, rows=None, series=None):
+    sat = series["SAT"]["current"]
+    return sat is not None and sat > 60
+"""
+    rules = [
+        {
+            "id": "sat_high",
+            "enabled": True,
+            "code": code,
+            "config": {"series_aliases": {"SAT": "sat"}},
+        }
+    ]
+    flags = evaluate_rules_on_series(rules, rows, series_map)
+    assert flags["sat_high"] == [0, 1]
+
+    ctx = build_series_context(series_map, 1, aliases={"SAT": "sat"})
+    assert ctx["SAT"]["current"] == 80.0


### PR DESCRIPTION
## Summary
- Add `evaluate_rules_on_series`, `build_series_context`, `slim_fdd_summary`, and `readings_to_rows` to `open_fdd.playground`
- Extend `sweep_rule` with optional `series_ctx` and rolling-avg enrichment for AWS lambda parity
- Unblocks vibe12 `fdd_lambda` migration off vendored `playground_core.py`

## Test plan
- [x] `python3 -m pytest open_fdd/tests/playground -q`
- [ ] Tag `open-fdd-v2.4.0` after merge to publish PyPI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-sensor rule evaluation with customizable series context to enable multi-sensor fault detection workflows.
  * Enhanced rule sweep functionality to support rolling-average parameter overrides for flexible evaluation configurations.

* **Tests**
  * Added test coverage for series utilities, summary optimization, and cross-sensor rule evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->