### PR TITLE
fix(ci): install deps before publish pytest

### DIFF
--- a/.github/workflows/publish-open-fdd.yml
+++ b/.github/workflows/publish-open-fdd.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Pytest playground (source tree)
         run: |
           python -m pip install pytest
+          python -m pip install -e .
           python -m pytest open_fdd/tests/playground -q
 
       - name: Publish to PyPI


### PR DESCRIPTION
PyPI publish was blocked: pytest imported open_fdd.engine without PyYAML installed.

Made with [Cursor](https://cursor.com)