### PR TITLE
Default-enable BACnet commissioning mutations + clearer UX

### DIFF
--- a/docker/compose.edge.yml
+++ b/docker/compose.edge.yml
@@ -28,7 +28,6 @@ services:
       OFDD_ALLOW_LAN_INTERNAL_INGEST: "1"
       OFDD_MCP_REST_BASE: http://mcp-rag:8090
       OFDD_BRIDGE_HOST: "0.0.0.0"
-      OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS: "1"
     env_file:
       - path: ./workspace/auth.env.local
         required: false

--- a/docker/compose.edge.yml
+++ b/docker/compose.edge.yml
@@ -28,6 +28,7 @@ services:
       OFDD_ALLOW_LAN_INTERNAL_INGEST: "1"
       OFDD_MCP_REST_BASE: http://mcp-rag:8090
       OFDD_BRIDGE_HOST: "0.0.0.0"
+      OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS: "1"
     env_file:
       - path: ./workspace/auth.env.local
         required: false

--- a/docs/quick-start/docker.md
+++ b/docs/quick-start/docker.md
@@ -84,10 +84,10 @@ Sign in as **integrator** with the password from that file → [First login and 
 | `nano auth.env.local` + `--restart` | Uses **your** edited passwords |
 | `--force-auth` | **Regenerates** random passwords (opt-in only) |
 
-The **bridge** container reads `auth.env.local` at startup only. After you change passwords (manual edit or `--force-auth`), restart bridge:
+The **bridge** container reads `auth.env.local` at startup only. After you change passwords (manual edit or `--force-auth`), recreate bridge (env files are not reloaded by `restart` alone):
 
 ```bash
-cd ~/open-fdd && docker compose restart bridge
+cd ~/open-fdd && docker compose up -d --force-recreate bridge
 ```
 
 Regenerate passwords and reload (stack already running):
@@ -111,7 +111,7 @@ Options:
 | `--image-tag TAG` | default `latest` (falls back to `2026.06.07-edge`) |
 | `--repo-ref BRANCH` | branch for `compose.edge.yml` if not on `master` yet |
 | `--force-auth` | regenerate `auth.env.local` (restarts bridge if stack is up) |
-| `--restart` | restart bridge to reload `auth.env.local`; curls `/health` after restart |
+| `--restart` | recreate bridge to reload `auth.env.local`; curls `/health` after |
 | `--show-secrets` | print passwords at end (lab only) |
 
 From a repo checkout: `./scripts/openfdd_edge_bootstrap.sh --start`

--- a/docs/quick-start/docker.md
+++ b/docs/quick-start/docker.md
@@ -49,14 +49,69 @@ Bootstrap + pull + start in one go:
 bash /tmp/openfdd_edge_bootstrap.sh --start
 ```
 
+**Auth** — bootstrap writes `~/open-fdd/workspace/auth.env.local` (gitignored). This file holds the API signing secret and one username/password per role. Use it for your first dashboard login:
+
+```bash
+cat ~/open-fdd/workspace/auth.env.local
+```
+
+| Variable | Role |
+|----------|------|
+| `OFDD_AUTH_SECRET` | Signs session tokens (do not share) |
+| `OFDD_OPERATOR_*` | Read-only operator |
+| `OFDD_INTEGRATOR_*` | **Default dashboard login** — commissioning + BACnet |
+| `OFDD_AGENT_*` | Agent / automation |
+
+Example shape (passwords are **random on first bootstrap only** — existing file is kept on re-runs):
+
+```
+OFDD_AUTH_SECRET=<random>
+OFDD_OPERATOR_USER=operator
+OFDD_OPERATOR_PASSWORD=<random>
+OFDD_INTEGRATOR_USER=integrator
+OFDD_INTEGRATOR_PASSWORD=<random>
+OFDD_AGENT_USER=agent
+OFDD_AGENT_PASSWORD=<random>
+```
+
+Sign in as **integrator** with the password from that file → [First login and health check](health-check).
+
+| Action | Touches `auth.env.local`? |
+|--------|---------------------------|
+| First `bash …bootstrap.sh --start` | Creates file with random passwords (if missing) |
+| `bash …bootstrap.sh --start` again | **Keeps** your file — does not overwrite |
+| `bash …bootstrap.sh --restart` | **Keeps** your file — only restarts bridge to reload it |
+| `nano auth.env.local` + `--restart` | Uses **your** edited passwords |
+| `--force-auth` | **Regenerates** random passwords (opt-in only) |
+
+The **bridge** container reads `auth.env.local` at startup only. After you change passwords (manual edit or `--force-auth`), restart bridge:
+
+```bash
+cd ~/open-fdd && docker compose restart bridge
+```
+
+Regenerate passwords and reload (stack already running):
+
+```bash
+bash /tmp/openfdd_edge_bootstrap.sh --force-auth --restart --show-secrets
+```
+
+Manual edit then reload:
+
+```bash
+nano ~/open-fdd/workspace/auth.env.local
+bash /tmp/openfdd_edge_bootstrap.sh --restart
+```
+
 Options:
 
 | Flag | Purpose |
 |------|---------|
-| `--start` | `docker compose pull && up -d` after layout |
+| `--start` | `docker compose pull && up -d` after layout; curls `http://127.0.0.1:8765/health` |
 | `--image-tag TAG` | default `latest` (falls back to `2026.06.07-edge`) |
 | `--repo-ref BRANCH` | branch for `compose.edge.yml` if not on `master` yet |
-| `--force-auth` | regenerate `auth.env.local` |
+| `--force-auth` | regenerate `auth.env.local` (restarts bridge if stack is up) |
+| `--restart` | restart bridge to reload `auth.env.local`; curls `/health` after restart |
 | `--show-secrets` | print passwords at end (lab only) |
 
 From a repo checkout: `./scripts/openfdd_edge_bootstrap.sh --start`
@@ -67,17 +122,22 @@ The script prints **BACnet NIC**, **BACNET_BIND**, and file paths — **validate
 nano ~/open-fdd/workspace/bacnet/commissioning/commission.env
 ```
 
-## 3. Start stack (if you skipped `--start`)
+{: .note }
+> If you used `--start`, the stack is already up. Next step → [First login and health check](health-check).
+
+### Manual start (optional)
+
+Use this only if you ran bootstrap **without** `--start` and want to bring the stack up yourself:
 
 ```bash
 cd ~/open-fdd
 docker compose pull
 docker compose up -d
 docker compose ps
-curl -sf http://127.0.0.1:8765/health
+curl -sf http://127.0.0.1:8765/health && echo
 ```
 
-Expected: **bridge**, **commission**, **mcp-rag** — all `Up`.
+Expected: **bridge**, **commission**, **mcp-rag** — all `Up`. Then → [First login and health check](health-check).
 
 ## Long-term operation
 

--- a/scripts/openfdd_edge_bootstrap.sh
+++ b/scripts/openfdd_edge_bootstrap.sh
@@ -11,6 +11,7 @@
 #   --repo-ref REF   GitHub branch for compose.edge.yml (tries master, then this ref)
 #   --root PATH      default: ~/open-fdd
 #   --force-auth     regenerate workspace/auth.env.local
+#   --restart        restart bridge so it reloads auth.env.local (after edit or --force-auth)
 #   --show-secrets   print role passwords at end (lab only)
 set -euo pipefail
 
@@ -21,6 +22,7 @@ OPENFDD_IMAGE_FALLBACK="${OPENFDD_IMAGE_FALLBACK:-2026.06.07-edge}"
 GITHUB_REPO="bbartling/open-fdd"
 DO_START=false
 FORCE_AUTH=false
+DO_RESTART=false
 SHOW_SECRETS=false
 
 while [[ $# -gt 0 ]]; do
@@ -30,6 +32,7 @@ while [[ $# -gt 0 ]]; do
     --repo-ref) OPENFDD_REPO_REF="$2"; shift 2 ;;
     --root) OPENFDD_ROOT="$2"; shift 2 ;;
     --force-auth) FORCE_AUTH=true; shift ;;
+    --restart) DO_RESTART=true; shift ;;
     --show-secrets) SHOW_SECRETS=true; shift ;;
     -h|--help)
       sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
@@ -91,8 +94,11 @@ services:
       OFDD_ALLOW_LAN_INTERNAL_INGEST: "1"
       OFDD_MCP_REST_BASE: http://mcp-rag:8090
       OFDD_BRIDGE_HOST: "0.0.0.0"
+      OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS: "1"
     env_file:
       - path: ./workspace/auth.env.local
+        required: false
+      - path: ./workspace/data.env.local
         required: false
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -214,6 +220,27 @@ PY
   echo "    commission.env → BACNET_BIND=${bind} (interface: ${iface:-auto})"
 }
 
+_ensure_data_env() {
+  local dest="$1"
+  if [[ ! -f "$dest" ]]; then
+    cat >"$dest" <<'DATA'
+# Bridge env (feather caps + BACnet commissioning). Loaded by docker compose.
+OFDD_FEATHER_MAX_GIB=5
+OFDD_FEATHER_RETENTION_DAYS=90
+OFDD_FEATHER_TRIM_CHUNK_HOURS=24
+OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS=1
+DATA
+    echo "    Created ${dest} (commissioning mutations enabled)"
+    return 0
+  fi
+  if ! grep -q '^OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS=' "$dest" 2>/dev/null; then
+    printf '\n# BACnet Add device / driver registry updates\nOFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS=1\n' >>"$dest"
+    echo "    Appended OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS=1 to ${dest}"
+  else
+    echo "    Keeping ${dest}"
+  fi
+}
+
 _write_auth_env() {
   local dest="$1"
   python3 <<'PY' >"$dest"
@@ -263,6 +290,29 @@ _pull_and_start() {
   curl -sf http://127.0.0.1:8765/health && echo || echo "WARN: /health not ready yet"
 }
 
+_restart_bridge() {
+  local compose_path="$1"
+  if [[ ! -f "$compose_path" ]]; then
+    echo "WARN: no compose file — skip bridge restart" >&2
+    return 0
+  fi
+  cd "$OPENFDD_ROOT"
+  if docker compose ps -q bridge 2>/dev/null | grep -q .; then
+    echo "==> Recreating bridge (reload env files — restart alone does not)"
+    docker compose up -d --force-recreate bridge
+    sleep 2
+    curl -sf http://127.0.0.1:8765/health && echo || echo "WARN: /health not ready yet"
+  else
+    echo "WARN: bridge not running — start stack: cd ${OPENFDD_ROOT} && docker compose up -d" >&2
+  fi
+}
+
+if [[ "$DO_RESTART" == true && "$FORCE_AUTH" != true && "$DO_START" != true ]]; then
+  echo "=== Open-FDD bridge restart (reload auth.env.local) ==="
+  _restart_bridge "${OPENFDD_ROOT}/docker-compose.yml"
+  exit 0
+fi
+
 echo "=== Open-FDD edge bootstrap ==="
 echo "Site root: ${OPENFDD_ROOT}"
 _check_docker
@@ -281,6 +331,10 @@ _download_compose "$COMPOSE_PATH"
 
 echo "==> Downloading backup/update scripts"
 _download_helper_scripts "${OPENFDD_ROOT}/scripts"
+
+DATA_ENV_PATH="${OPENFDD_ROOT}/workspace/data.env.local"
+echo "==> Ensuring ${DATA_ENV_PATH}"
+_ensure_data_env "$DATA_ENV_PATH"
 
 AUTH_PATH="${OPENFDD_ROOT}/workspace/auth.env.local"
 if [[ ! -f "$AUTH_PATH" || "$FORCE_AUTH" == true ]]; then
@@ -304,6 +358,8 @@ _write_commission_env "$COMMISSION_PATH" "$BACNET_BIND" "$BACNET_IFACE"
 
 if [[ "$DO_START" == true ]]; then
   _pull_and_start
+elif [[ "$DO_RESTART" == true || "$FORCE_AUTH" == true ]]; then
+  _restart_bridge "$COMPOSE_PATH"
 fi
 
 echo ""

--- a/scripts/openfdd_edge_bootstrap.sh
+++ b/scripts/openfdd_edge_bootstrap.sh
@@ -94,7 +94,6 @@ services:
       OFDD_ALLOW_LAN_INTERNAL_INGEST: "1"
       OFDD_MCP_REST_BASE: http://mcp-rag:8090
       OFDD_BRIDGE_HOST: "0.0.0.0"
-      OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS: "1"
     env_file:
       - path: ./workspace/auth.env.local
         required: false

--- a/tests/workspace_bridge/test_bacnet_mutation_errors.py
+++ b/tests/workspace_bridge/test_bacnet_mutation_errors.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+API_ROOT = Path(__file__).resolve().parents[2] / "workspace" / "api"
+REPO = Path(__file__).resolve().parents[2]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "bacnet" / "commissioning").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("OFDD_AUTH_SECRET", "test-secret-key-32chars-minimum!!")
+    monkeypatch.setenv("OFDD_OPERATOR_USER", "operator")
+    monkeypatch.setenv("OFDD_OPERATOR_PASSWORD", "changeme")
+    monkeypatch.setenv("OFDD_INTEGRATOR_USER", "integrator")
+    monkeypatch.setenv("OFDD_INTEGRATOR_PASSWORD", "msi")
+    monkeypatch.setenv("OPENFDD_REPO_ROOT", str(REPO))
+    monkeypatch.setenv("OPENFDD_WORKSPACE_DIR", str(workspace))
+    monkeypatch.delenv("OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS", raising=False)
+    for name in list(sys.modules):
+        if name == "openfdd_bridge" or name.startswith("openfdd_bridge."):
+            del sys.modules[name]
+    from openfdd_bridge.main import create_app  # noqa: E402
+
+    return TestClient(create_app())
+
+
+def _token(client: TestClient, username: str, password: str) -> str:
+    r = client.post("/api/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200, r.text
+    return r.json()["token"]
+
+
+def test_bacnet_config_mutations_enabled_by_default(client: TestClient):
+    token = _token(client, "integrator", "msi")
+    r = client.get("/config/bacnet", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    assert r.json()["discovery_mutations_enabled"] is True
+
+
+def test_integrator_sync_discovery_denied_when_explicitly_disabled(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS", "0")
+    for name in list(sys.modules):
+        if name.startswith("openfdd_bridge."):
+            del sys.modules[name]
+    from openfdd_bridge.main import create_app  # noqa: E402
+
+    c = TestClient(create_app())
+    token = _token(c, "integrator", "msi")
+    r = c.post(
+        "/api/bacnet/driver/sync-discovery",
+        json={
+            "device_instance": 8,
+            "device_address": "10.0.0.8",
+            "objects": [{"object_identifier": "analog-input,1", "object_name": "x"}],
+            "replace": True,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+    detail = r.json()["detail"]
+    assert detail["code"] == "bacnet_mutations_disabled"
+    assert "point discovery" in detail["message"].lower()
+
+
+def test_operator_sync_discovery_role_error(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS", "1")
+    for name in list(sys.modules):
+        if name.startswith("openfdd_bridge."):
+            del sys.modules[name]
+    from openfdd_bridge.main import create_app  # noqa: E402
+
+    c = TestClient(create_app())
+    token = _token(c, "operator", "changeme")
+    r = c.post(
+        "/api/bacnet/driver/sync-discovery",
+        json={
+            "device_instance": 8,
+            "device_address": "10.0.0.8",
+            "objects": [{"object_identifier": "analog-input,1", "object_name": "x"}],
+            "replace": True,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+    detail = r.json()["detail"]
+    assert detail["code"] == "bacnet_mutations_role"
+    assert "integrator" in detail["message"].lower()

--- a/tests/workspace_bridge/test_bacnet_mutation_errors.py
+++ b/tests/workspace_bridge/test_bacnet_mutation_errors.py
@@ -25,6 +25,7 @@ def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
     monkeypatch.setenv("OPENFDD_REPO_ROOT", str(REPO))
     monkeypatch.setenv("OPENFDD_WORKSPACE_DIR", str(workspace))
     monkeypatch.delenv("OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS", raising=False)
+    monkeypatch.delenv("OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS", raising=False)
     for name in list(sys.modules):
         if name == "openfdd_bridge" or name.startswith("openfdd_bridge."):
             del sys.modules[name]

--- a/tests/workspace_bridge/test_security_regression.py
+++ b/tests/workspace_bridge/test_security_regression.py
@@ -169,9 +169,19 @@ def test_operator_cannot_bacnet_mutate(raw_client: TestClient, operator_headers:
     assert r.status_code == 403
 
 
-def test_integrator_bacnet_mutate_requires_flag(raw_client: TestClient, integrator_headers: dict[str, str]):
+def test_integrator_bacnet_mutate_allowed_by_default(raw_client: TestClient, integrator_headers: dict[str, str]):
+    r = raw_client.delete("/api/bacnet/driver/registry", headers=integrator_headers)
+    assert r.status_code == 200
+
+
+def test_integrator_bacnet_mutate_blocked_when_disabled(
+    raw_client: TestClient, integrator_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS", "1")
     r = raw_client.delete("/api/bacnet/driver/registry", headers=integrator_headers)
     assert r.status_code == 403
+    detail = r.json()["detail"]
+    assert detail["code"] == "bacnet_mutations_disabled"
 
 
 def test_operator_cannot_delete_model_point(raw_client: TestClient, operator_headers: dict[str, str]):

--- a/workspace/api/openfdd_bridge/bacnet_access.py
+++ b/workspace/api/openfdd_bridge/bacnet_access.py
@@ -30,6 +30,34 @@ def require_bacnet_poll_config(user: dict = Depends(require_user)) -> dict:
     raise HTTPException(status_code=403, detail="forbidden")
 
 
+def _bacnet_mutation_denial_detail(role: str | None) -> dict[str, str]:
+    """Human-readable 403 payload for driver/model registry writes."""
+    flag_on = bacnet_discovery_mutations_enabled()
+    if role not in ("integrator", "agent"):
+        return {
+            "code": "bacnet_mutations_role",
+            "message": "Adding BACnet devices to the driver registry requires the integrator account.",
+            "hint": "Sign out and sign in with OFDD_INTEGRATOR_USER from workspace/auth.env.local.",
+        }
+    if role == "agent" and not agent_can_bacnet_mutate():
+        return {
+            "code": "bacnet_mutations_role",
+            "message": "Agent accounts cannot update the BACnet driver registry on this server.",
+            "hint": "Sign in as integrator or set OFDD_AGENT_CAN_BACNET_MUTATE=1 (automation only).",
+        }
+    if not flag_on:
+        return {
+            "code": "bacnet_mutations_disabled",
+            "message": "Driver registry updates are disabled on this bridge (point discovery still works).",
+            "hint": "Remove OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS or set OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS=1, then recreate the bridge container (docker compose up -d --force-recreate bridge).",
+        }
+    return {
+        "code": "bacnet_mutations_denied",
+        "message": "BACnet driver registry update not permitted.",
+        "hint": "",
+    }
+
+
 def require_bacnet_mutation(request: Request, user: dict = Depends(require_user)) -> dict:
     role = user.get("role")
     allowed = False
@@ -39,6 +67,7 @@ def require_bacnet_mutation(request: Request, user: dict = Depends(require_user)
         allowed = True
     if allowed:
         return user
+    denial = _bacnet_mutation_denial_detail(role)
     write_audit(
         event_type="bacnet.command",
         action="mutation denied",
@@ -47,9 +76,6 @@ def require_bacnet_mutation(request: Request, user: dict = Depends(require_user)
         request=request,
         user=user,
         resource_type="bacnet",
-        detail={"role": role, "reason": "BACnet mutations require integrator and OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS"},
+        detail={"role": role, "code": denial.get("code"), "reason": denial.get("message")},
     )
-    raise HTTPException(
-        status_code=403,
-        detail="BACnet model/driver mutations require integrator role and OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS=1",
-    )
+    raise HTTPException(status_code=403, detail=denial)

--- a/workspace/api/openfdd_bridge/routes/bacnet_routes.py
+++ b/workspace/api/openfdd_bridge/routes/bacnet_routes.py
@@ -59,6 +59,7 @@ from ..bacnet_write_guard import (
     validate_write_target,
 )
 from ..bacnet_access import require_bacnet_discovery, require_bacnet_mutation, require_bacnet_poll_config
+from ..security import bacnet_discovery_mutations_enabled
 from ..deps import require_roles
 from ..bacnet_poll_ingest import ingest_poll_samples_to_feather
 
@@ -196,6 +197,7 @@ def bacnet_config() -> dict:
         "commission_agent_ok": commission_ok,
         "commission_agent": commission_detail,
         "openfdd_server_points": server_pts,
+        "discovery_mutations_enabled": bacnet_discovery_mutations_enabled(),
     }
 
 

--- a/workspace/api/openfdd_bridge/security.py
+++ b/workspace/api/openfdd_bridge/security.py
@@ -176,7 +176,13 @@ def agent_can_bacnet_mutate() -> bool:
 
 
 def bacnet_discovery_mutations_enabled() -> bool:
-    return _env_flag("OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS")
+    """Edge commissioning default: integrator can add devices unless explicitly disabled."""
+    if _env_flag("OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS"):
+        return False
+    raw = os.environ.get("OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS", "").strip().lower()
+    if raw in {"0", "false", "no"}:
+        return False
+    return True
 
 
 def operator_can_edit_model() -> bool:

--- a/workspace/dashboard/src/lib/formatApiError.ts
+++ b/workspace/dashboard/src/lib/formatApiError.ts
@@ -3,7 +3,23 @@ function mapForbidden(msg: string): string {
   if (msg === "forbidden") {
     return "Not permitted for your login role — sign in with an account that has access.";
   }
+  if (msg.includes("OFDD_ENABLE_BACNET_DISCOVERY_MUTATIONS") || msg.includes("OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS")) {
+    return "Driver registry updates are disabled on this server (read-only monitor mode). Recreate the bridge after updating site config.";
+  }
+  if (msg.includes("BACnet model/driver mutations require integrator")) {
+    return "Cannot save discovered points to the driver — sign in as integrator, or ask ops to enable commissioning on the bridge.";
+  }
   return msg;
+}
+
+function formatDetailObject(obj: Record<string, unknown>): string {
+  const message = typeof obj.message === "string" ? mapForbidden(obj.message) : "";
+  const hint = typeof obj.hint === "string" ? obj.hint.trim() : "";
+  if (message && hint) return `${message} ${hint}`;
+  if (message) return message;
+  if (typeof obj.error === "string") return mapForbidden(obj.error);
+  if (typeof obj.detail === "string") return mapForbidden(obj.detail);
+  return "";
 }
 
 export function formatApiError(error: unknown): string {
@@ -13,10 +29,8 @@ export function formatApiError(error: unknown): string {
     const detail = body.detail;
     if (typeof detail === "string") return mapForbidden(detail);
     if (detail && typeof detail === "object") {
-      const obj = detail as Record<string, unknown>;
-      if (typeof obj.error === "string") return mapForbidden(obj.error);
-      if (typeof obj.detail === "string") return mapForbidden(obj.detail);
-      if (typeof obj.message === "string") return mapForbidden(obj.message);
+      const formatted = formatDetailObject(detail as Record<string, unknown>);
+      if (formatted) return formatted;
     }
   } catch {
     /* not JSON */

--- a/workspace/dashboard/src/pages/BacnetPage.tsx
+++ b/workspace/dashboard/src/pages/BacnetPage.tsx
@@ -19,6 +19,7 @@ import { formatPollSampleAt } from "../lib/formatPollTime";
 
 type BacnetConfig = {
   commission_agent_ok: boolean;
+  discovery_mutations_enabled?: boolean;
 };
 
 type CommissionStatus = {
@@ -263,9 +264,16 @@ export default function BacnetPage() {
         String((job.result as { device_address?: string } | undefined)?.device_address ?? "");
       let synced = 0;
       if (job.status === "ok" && objects.length) {
-        const sync = await syncDiscoveryToDriver(instance, syncAddr, objects);
-        synced = sync.rows_added ?? objects.length;
-        await loadDriverTree();
+        try {
+          const sync = await syncDiscoveryToDriver(instance, syncAddr, objects);
+          synced = sync.rows_added ?? objects.length;
+          await loadDriverTree();
+        } catch (syncErr) {
+          const msg = formatApiError(syncErr);
+          const err = `Discovered ${objects.length} point(s) but could not save to driver — ${msg}`;
+          setActionError(err);
+          return { instance, ok: false, objectCount: objects.length, error: err };
+        }
       }
       setDiscoveryPreview(objects);
       if (job.status !== "ok") {
@@ -541,6 +549,7 @@ export default function BacnetPage() {
   }
 
   const agentOk = cfg?.commission_agent_ok === true;
+  const mutationsEnabled = cfg?.discovery_mutations_enabled !== false;
   const anyPending = whoisPending || addPending || batchPending;
   const selectedList = Array.from(selectedInstances).sort((a, b) => a - b);
   const inTree = new Set(driverDevices.map((d) => d.device_instance));
@@ -586,6 +595,16 @@ export default function BacnetPage() {
       {anyPending ? (
         <div className="bacnet-active-banner" role="status">
           <Spinner label={activeJobLabel || "BACnet operation in progress…"} />
+        </div>
+      ) : null}
+
+      {cfg && !mutationsEnabled ? (
+        <div className="panel panel-warn" role="alert">
+          <p className="error" style={{ margin: 0 }}>
+            <strong>Add device is blocked:</strong> point discovery works, but saving devices to the driver
+            registry is disabled on this bridge (read-only monitor mode). Ask your integrator to recreate the
+            bridge after removing <code>OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS</code> from site config.
+          </p>
         </div>
       ) : null}
 
@@ -736,16 +755,42 @@ export default function BacnetPage() {
 
         {batchSummary?.length ? (
           <ul className="batch-summary">
-            {batchSummary.map((r) => (
-              <li key={r.instance}>
-                Device {r.instance}:{" "}
-                {r.ok ? (
-                  <span className="ok">{r.objectCount ?? 0} points</span>
-                ) : (
-                  <span className="error">{r.error ?? "failed"}</span>
-                )}
-              </li>
-            ))}
+            {(() => {
+              const failed = batchSummary.filter((r) => !r.ok);
+              const errorGroups = new Map<string, number[]>();
+              for (const row of failed) {
+                const key = row.error ?? "failed";
+                const list = errorGroups.get(key) ?? [];
+                list.push(row.instance);
+                errorGroups.set(key, list);
+              }
+              const shownErrors = new Set<string>();
+              return batchSummary.flatMap((r) => {
+                if (r.ok) {
+                  return [
+                    <li key={r.instance}>
+                      Device {r.instance}: <span className="ok">{r.objectCount ?? 0} points</span>
+                    </li>,
+                  ];
+                }
+                const key = r.error ?? "failed";
+                const peers = errorGroups.get(key) ?? [r.instance];
+                if (shownErrors.has(key)) return [];
+                shownErrors.add(key);
+                if (peers.length > 1) {
+                  return [
+                    <li key={`err-${peers[0]}`}>
+                      Devices {peers.join(", ")}: <span className="error">{key}</span>
+                    </li>,
+                  ];
+                }
+                return [
+                  <li key={r.instance}>
+                    Device {r.instance}: <span className="error">{key}</span>
+                  </li>,
+                ];
+              });
+            })()}
           </ul>
         ) : null}
       </div>

--- a/workspace/data.env.example
+++ b/workspace/data.env.example
@@ -16,3 +16,7 @@ OFDD_FEATHER_RETENTION_DAYS=90
 
 # Oldest time window removed per trim pass when over the GiB cap.
 OFDD_FEATHER_TRIM_CHUNK_HOURS=24
+
+# BACnet driver registry: enabled by default for integrator commissioning on edge stacks.
+# Read-only monitor sites can disable Add device:
+# OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS=1

--- a/workspace/deploy/SECURITY.md
+++ b/workspace/deploy/SECURITY.md
@@ -79,6 +79,12 @@ Lab LAN demo (insecure): add `OFDD_INSECURE_LAN_DEV=1` — never use on producti
 
 Keep BACnet writes disabled unless you are deliberately commissioning with an allowlist.
 
+## BACnet driver registry (Add device)
+
+- **Enabled by default** for integrator commissioning (add/sync/delete devices in the driver tree).
+- Read-only monitor sites: set **`OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS=1`** on the bridge.
+- After changing bridge env files, run **`docker compose up -d --force-recreate bridge`** — `docker compose restart` does not reload `env_file` values.
+
 ## WebSocket tickets
 
 Short-lived tickets (`OFDD_WS_TICKET_TTL_SEC`, default 120s) upgrade Bearer sessions to `/ws/dashboard`. Replay protection is **in-process only** — safe for single-worker uvicorn. Multi-worker deployments need shared ticket state (Redis/SQLite); otherwise tickets may be replayed across workers.


### PR DESCRIPTION
## Summary
- BACnet driver registry mutations enabled by default for integrator commissioning
- Read-only monitor sites opt out with `OFDD_DISABLE_BACNET_DISCOVERY_MUTATIONS=1`
- Compose sets flag explicitly; bootstrap recreates bridge (not restart) to reload env
- Clearer API/UI errors; batch summary groups duplicate failures

## Test plan
- [x] pytest test_bacnet_mutation_errors + security_regression
- [ ] vm-bbartling: patch compose + force-recreate bridge, retry Add device


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--restart` CLI option to reload authentication without restarting the full stack
  * BACnet device discovery mutations can be disabled for read-only monitor deployments

* **Documentation**
  * Updated Docker quick-start guide with authentication configuration and password management details
  * Enhanced security documentation for BACnet driver registry configuration

* **Bug Fixes**
  * Improved error handling and user-friendly messaging for BACnet permission-related failures
  * Enhanced error reporting in batch device-add workflows when discovery sync fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->