### PR TITLE
Latest-only GHCR: drop bacnet-poll, prune to 3 versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,13 +1,13 @@
-# Manual GHCR publish for Open-FDD addon images (supervisor/apps layer).
-# Manual edge image publish — triggered when cutting a release.
+# Publish Open-FDD edge images to GHCR (:latest only; prune retired bacnet-poll + old versions).
 name: Publish Docker addons
 
 on:
   workflow_dispatch:
     inputs:
-      image_tag:
-        description: "Image tag (e.g. 2026.05.30-edge)"
-        required: true
+      keep_versions:
+        description: "GHCR versions to retain per image (default 3)"
+        required: false
+        default: "3"
         type: string
 
 permissions:
@@ -38,11 +38,15 @@ jobs:
       - name: Build addon images
         run: |
           chmod +x scripts/docker_build.sh scripts/docker_publish.sh scripts/validate_supervisor_manifest.sh
-          OPENFDD_IMAGE_TAG="${{ inputs.image_tag }}" ./scripts/docker_build.sh
+          OPENFDD_IMAGE_TAG=latest ./scripts/docker_build.sh
           ./scripts/validate_supervisor_manifest.sh
 
-      - name: Publish to GHCR
+      - name: Publish to GHCR (:latest)
+        run: PUBLISH_LATEST_ONLY=1 OPENFDD_IMAGE_TAG=latest ./scripts/docker_publish.sh
+
+      - name: Prune GHCR (drop retired bacnet-poll; keep N versions)
         env:
-          OPENFDD_IMAGE_TAG: ${{ inputs.image_tag }}
-          PUBLISH_LATEST: "1"
-        run: ./scripts/docker_publish.sh
+          GHCR_KEEP_VERSIONS: ${{ inputs.keep_versions }}
+        run: |
+          chmod +x scripts/ghcr_prune_packages.sh
+          ./scripts/ghcr_prune_packages.sh --delete-retired --keep "${GHCR_KEEP_VERSIONS}"

--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ git clone https://github.com/bbartling/open-fdd.git && cd open-fdd
 ./scripts/docker_build.sh
 
 # or pull from GitHub Container Registry (tags on ghcr.io/bbartling/openfdd-bridge)
-export OPENFDD_IMAGE_TAG=2026.06.07-edge
-docker pull ghcr.io/bbartling/openfdd-bridge:${OPENFDD_IMAGE_TAG}
-docker pull ghcr.io/bbartling/openfdd-commission:${OPENFDD_IMAGE_TAG}
-docker pull ghcr.io/bbartling/openfdd-mcp-rag:${OPENFDD_IMAGE_TAG}
+docker pull ghcr.io/bbartling/openfdd-bridge:latest
+docker pull ghcr.io/bbartling/openfdd-commission:latest
+docker pull ghcr.io/bbartling/openfdd-mcp-rag:latest
 ./scripts/openfdd_stack.sh up
 ```
 

--- a/docker/compose.edge.yml
+++ b/docker/compose.edge.yml
@@ -7,8 +7,7 @@
 #
 # Long-lived site (survives reboot when Docker is enabled):
 #   cd ~/open-fdd
-#   docker compose pull && docker compose up -d   # :latest by default
-#   # Pin: export OPENFDD_IMAGE_TAG=2026.06.07-edge
+#   docker compose pull && docker compose up -d   # :latest
 #   sudo systemctl enable docker
 #
 # See docs/quick-start/docker.md

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -1,12 +1,12 @@
 # Production GHCR images — baked-in bridge UI/API (no workspace/api bind-mount).
 # Use with bench overlay on bensserver:
-#   OPENFDD_IMAGE_TAG=2026.06.07-edge docker compose \
+#   docker compose \
 #     -f docker/compose.dev.yml -f docker/compose.bench.yml -f docker/compose.prod.yml up -d
 name: openfdd-dev
 
 services:
   bridge:
-    image: ghcr.io/bbartling/openfdd-bridge:${OPENFDD_IMAGE_TAG:-2026.06.07-edge}
+    image: ghcr.io/bbartling/openfdd-bridge:${OPENFDD_IMAGE_TAG:-latest}
     pull_policy: always
     build: !reset null
     volumes: !override
@@ -16,14 +16,14 @@ services:
       OFDD_CORS_ALLOW_PRIVATE_LAN: "1"
 
   commission:
-    image: ghcr.io/bbartling/openfdd-commission:${OPENFDD_IMAGE_TAG:-2026.06.07-edge}
+    image: ghcr.io/bbartling/openfdd-commission:${OPENFDD_IMAGE_TAG:-latest}
     pull_policy: always
     build: !reset null
     volumes: !override
       - ../workspace:/var/openfdd/workspace
 
   mcp-rag:
-    image: ghcr.io/bbartling/openfdd-mcp-rag:${OPENFDD_IMAGE_TAG:-2026.06.07-edge}
+    image: ghcr.io/bbartling/openfdd-mcp-rag:${OPENFDD_IMAGE_TAG:-latest}
     pull_policy: always
     build: !reset null
     volumes: !override

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -16,7 +16,7 @@ Open-FDD v3 edge sites run **three** GHCR containers plus optional **host** serv
 | `ghcr.io/bbartling/openfdd-commission` | `commission` | BACnet discover / read / write + **poll loop** |
 | `ghcr.io/bbartling/openfdd-mcp-rag` | `mcp-rag` | Doc-search sidecar for agent tools |
 
-Tags: [GitHub Packages](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-bridge) (e.g. `2026.06.07-edge`).
+Tag: **`latest`** on [GitHub Packages](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-bridge). Retired: `openfdd-bacnet-poll` (poll runs inside **commission**). GHCR retains only the **three newest** versions per image.
 
 Template: `docker/compose.edge.yml` → copy to `~/open-fdd/docker-compose.yml`.
 

--- a/docs/developer/docker-build.md
+++ b/docs/developer/docker-build.md
@@ -18,13 +18,13 @@ Images: `openfdd-bridge`, `openfdd-commission`, `openfdd-mcp-rag`.
 
 ## Publish to GHCR (maintainers)
 
-GitHub Actions workflow **Publish Docker addons** — manual dispatch with a version tag.
+GitHub Actions workflow **Publish Docker addons** — manual dispatch; publishes **`:latest`** only and prunes GHCR (retired `openfdd-bacnet-poll` removed; keep 3 versions per image).
 
 Maintainer checklist:
 
 1. Green CI on `master`
-2. Run workflow with tag e.g. `2026.06.06-edge`
-3. Verify packages at `ghcr.io/bbartling/openfdd-*`
-4. Deploy to a demo edge with `OPENFDD_IMAGE_TAG=<tag>`
+2. Run **Publish Docker addons** workflow
+3. Verify `ghcr.io/bbartling/openfdd-{bridge,commission,mcp-rag}:latest`
+4. Edge hosts: `docker compose pull && docker compose up -d`
 
 Details live in `.github/workflows/` and `scripts/docker_build.sh` — not duplicated here.

--- a/docs/quick-start/docker.md
+++ b/docs/quick-start/docker.md
@@ -16,7 +16,7 @@ Deploy Open-FDD on a Linux edge host using **three published GHCR images**. No g
 | `ghcr.io/bbartling/openfdd-commission` | `commission` | BACnet discover/read/write **and poll loop** |
 | `ghcr.io/bbartling/openfdd-mcp-rag` | `mcp-rag` | Doc-search sidecar |
 
-Compose defaults to **`latest`**. Pin a dated tag with `export OPENFDD_IMAGE_TAG=2026.06.07-edge` when needed.
+Edge hosts pull **`latest`** from GHCR (three images: bridge, commission, mcp-rag). The retired **`openfdd-bacnet-poll`** image is no longer published.
 
 ## 1. Install and validate Docker
 
@@ -108,7 +108,7 @@ Options:
 | Flag | Purpose |
 |------|---------|
 | `--start` | `docker compose pull && up -d` after layout; curls `http://127.0.0.1:8765/health` |
-| `--image-tag TAG` | default `latest` (falls back to `2026.06.07-edge`) |
+| `--image-tag TAG` | default `latest` |
 | `--repo-ref BRANCH` | branch for `compose.edge.yml` if not on `master` yet |
 | `--force-auth` | regenerate `auth.env.local` (restarts bridge if stack is up) |
 | `--restart` | recreate bridge to reload `auth.env.local`; curls `/health` after |

--- a/docs/quick-start/updating.md
+++ b/docs/quick-start/updating.md
@@ -37,14 +37,6 @@ cd ~/open-fdd
 
 Pulls **`:latest`** by default, verifies all three images exist on GHCR, recreates containers, and hits `/health`.
 
-Pin a dated release:
-
-```bash
-export NEW_TAG=2026.06.07-edge
-./scripts/openfdd_site_backup.sh
-./scripts/openfdd_site_update.sh
-```
-
 ## Step by step
 
 ### 1. Backup site state
@@ -77,7 +69,6 @@ echo "All images exist for ${NEW_TAG}"
 
 ```bash
 cd ~/open-fdd
-export NEW_TAG="${NEW_TAG:-latest}"   # optional pin
 ./scripts/openfdd_site_update.sh
 ```
 
@@ -108,12 +99,7 @@ If the release changed the React UI, copy a new `workspace/api/static/app/` buil
 
 ## Rollback
 
-```bash
-cd ~/open-fdd
-export NEW_TAG=2026.06.06-edge          # previous known-good tag
-cp ~/openfdd-backups/<timestamp>/docker-compose.yml.snapshot docker-compose.yml
-./scripts/openfdd_site_update.sh
-```
+Restore `docker-compose.yml` from backup and pull again, or re-run bootstrap from a known-good `master` commit. GHCR keeps only the **three newest** versions per image; early sites should rely on **`latest`** plus `workspace/` backups.
 
 `workspace/` is untouched by image-only upgrades.
 

--- a/scripts/docker_publish.sh
+++ b/scripts/docker_publish.sh
@@ -3,7 +3,8 @@
 #
 #   GITHUB_TOKEN=ghp_… ./scripts/docker_publish.sh
 #   OPENFDD_IMAGE_TAG=2026.06.01 ./scripts/docker_publish.sh
-#   PUBLISH_LATEST=1 OPENFDD_IMAGE_TAG=2026.06.01-edge ./scripts/docker_publish.sh
+#   PUBLISH_LATEST_ONLY=1 OPENFDD_IMAGE_TAG=latest ./scripts/docker_publish.sh
+#   PUBLISH_LATEST=1 OPENFDD_IMAGE_TAG=2026.06.01-edge ./scripts/docker_publish.sh  # legacy dated tag
 #
 # Requires: docker login ghcr.io, images already built (./scripts/docker_build.sh)
 #
@@ -22,14 +23,19 @@ fi
 
 IMAGES=(openfdd-bridge openfdd-commission openfdd-mcp-rag)
 
+publish_tag="${TAG}"
+if [[ "${PUBLISH_LATEST_ONLY:-}" == "1" ]]; then
+  publish_tag="latest"
+fi
+
 for img in "${IMAGES[@]}"; do
   src="${img}:${TAG}"
-  dst="${REGISTRY}/${ORG}/${img}:${TAG}"
+  dst="${REGISTRY}/${ORG}/${img}:${publish_tag}"
   echo "==> tag $src -> $dst"
   docker tag "$src" "$dst"
   echo "==> push $dst"
   docker push "$dst"
-  if [[ "${PUBLISH_LATEST:-}" == "1" && "$TAG" != "latest" ]]; then
+  if [[ "${PUBLISH_LATEST:-}" == "1" && "$publish_tag" != "latest" && "$TAG" != "latest" ]]; then
     latest="${REGISTRY}/${ORG}/${img}:latest"
     docker tag "$src" "$latest"
     docker push "$latest"
@@ -37,5 +43,8 @@ for img in "${IMAGES[@]}"; do
 done
 
 echo ""
-echo "Published ${#IMAGES[@]} images under ${REGISTRY}/${ORG}/ with tag ${TAG}"
+echo "Published ${#IMAGES[@]} images under ${REGISTRY}/${ORG}/ with tag ${publish_tag}"
+if [[ "${PUBLISH_LATEST_ONLY:-}" == "1" ]]; then
+  echo "Tip: ./scripts/ghcr_prune_packages.sh --delete-retired --keep 3"
+fi
 echo "Edge: OPENFDD_IMAGE_TAG=${TAG} ./scripts/docker_build.sh --save  # or compose pull when registry deploy lands"

--- a/scripts/ghcr_prune_packages.sh
+++ b/scripts/ghcr_prune_packages.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Prune GHCR container packages for Open-FDD edge images.
+#
+#   ./scripts/ghcr_prune_packages.sh              # keep 3 versions per active package
+#   ./scripts/ghcr_prune_packages.sh --keep 3
+#   ./scripts/ghcr_prune_packages.sh --delete-retired   # remove openfdd-bacnet-poll entirely
+#
+# Requires: gh auth login with read:packages and delete:packages (or repo admin).
+set -euo pipefail
+
+OWNER="${GHCR_OWNER:-bbartling}"
+KEEP="${GHCR_KEEP_VERSIONS:-3}"
+DELETE_RETIRED=false
+ACTIVE=(openfdd-bridge openfdd-commission openfdd-mcp-rag)
+RETIRED=openfdd-bacnet-poll
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep) KEEP="$2"; shift 2 ;;
+    --delete-retired) DELETE_RETIRED=true; shift ;;
+    -h|--help)
+      sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+_api() {
+  gh api "$@" 2>&1
+}
+
+_delete_version() {
+  local pkg="$1" id="$2"
+  echo "    delete version id=${id}"
+  _api -X DELETE "users/${OWNER}/packages/container/${pkg}/versions/${id}" >/dev/null
+}
+
+_prune_package() {
+  local pkg="$1"
+  echo "==> ${pkg} (keep ${KEEP} newest)"
+  local versions_json
+  if ! versions_json="$(_api "users/${OWNER}/packages/container/${pkg}/versions?per_page=100")"; then
+    echo "WARN: cannot list ${pkg} — ${versions_json}" >&2
+    return 0
+  fi
+  local ids
+  ids="$(echo "$versions_json" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+rows.sort(key=lambda r: r.get('updated_at') or r.get('created_at') or '', reverse=True)
+for r in rows[${KEEP}:]:
+    print(r['id'])
+")"
+  if [[ -z "$ids" ]]; then
+    echo "    nothing to prune"
+    return 0
+  fi
+  while IFS= read -r id; do
+    [[ -n "$id" ]] && _delete_version "$pkg" "$id"
+  done <<<"$ids"
+}
+
+_delete_retired_package() {
+  echo "==> Delete retired package: ${RETIRED}"
+  if _api -X DELETE "users/${OWNER}/packages/container/${RETIRED}" >/dev/null 2>&1; then
+    echo "    removed ${RETIRED}"
+    return 0
+  fi
+  echo "    package not found or already deleted — pruning versions if any"
+  local versions_json
+  if versions_json="$(_api "users/${OWNER}/packages/container/${RETIRED}/versions?per_page=100" 2>/dev/null)"; then
+    echo "$versions_json" | python3 -c "
+import json, sys
+for r in json.load(sys.stdin):
+    print(r['id'])
+" | while IFS= read -r id; do
+      [[ -n "$id" ]] && _delete_version "$RETIRED" "$id"
+    done
+    _api -X DELETE "users/${OWNER}/packages/container/${RETIRED}" >/dev/null 2>&1 || true
+  fi
+}
+
+echo "=== GHCR prune (owner=${OWNER}) ==="
+if [[ "$DELETE_RETIRED" == true ]]; then
+  _delete_retired_package
+fi
+for pkg in "${ACTIVE[@]}"; do
+  _prune_package "$pkg"
+done
+echo "Done."

--- a/scripts/openfdd_edge_bootstrap.sh
+++ b/scripts/openfdd_edge_bootstrap.sh
@@ -7,7 +7,7 @@
 #
 # Options:
 #   --start          docker compose pull && up -d after bootstrap
-#   --image-tag TAG  default: latest (falls back to 2026.06.07-edge if latest missing)
+#   --image-tag TAG  default: latest
 #   --repo-ref REF   GitHub branch for compose.edge.yml (tries master, then this ref)
 #   --root PATH      default: ~/open-fdd
 #   --force-auth     regenerate workspace/auth.env.local
@@ -18,7 +18,6 @@ set -euo pipefail
 OPENFDD_ROOT="${OPENFDD_ROOT:-$HOME/open-fdd}"
 OPENFDD_REPO_REF="${OPENFDD_REPO_REF:-master}"
 OPENFDD_IMAGE_TAG="${OPENFDD_IMAGE_TAG:-latest}"
-OPENFDD_IMAGE_FALLBACK="${OPENFDD_IMAGE_FALLBACK:-2026.06.07-edge}"
 GITHUB_REPO="bbartling/open-fdd"
 DO_START=false
 FORCE_AUTH=false
@@ -275,15 +274,7 @@ _pull_and_start() {
   cd "$OPENFDD_ROOT"
   export OPENFDD_IMAGE_TAG
   echo "==> Pulling images (tag=${OPENFDD_IMAGE_TAG})"
-  if ! docker compose pull 2>/dev/null; then
-    if [[ "$OPENFDD_IMAGE_TAG" == "latest" ]]; then
-      echo "    latest not found — falling back to ${OPENFDD_IMAGE_FALLBACK}"
-      export OPENFDD_IMAGE_TAG="$OPENFDD_IMAGE_FALLBACK"
-      docker compose pull
-    else
-      return 1
-    fi
-  fi
+  docker compose pull
   docker compose up -d
   docker compose ps
   curl -sf http://127.0.0.1:8765/health && echo || echo "WARN: /health not ready yet"
@@ -365,7 +356,7 @@ echo ""
 echo "=== Bootstrap complete ==="
 echo "  Site root:     ${OPENFDD_ROOT}"
 echo "  Compose file:  ${COMPOSE_PATH}"
-echo "  Image tag:     ${OPENFDD_IMAGE_TAG} (fallback: ${OPENFDD_IMAGE_FALLBACK})"
+echo "  Image tag:     ${OPENFDD_IMAGE_TAG}"
 echo "  BACnet NIC:    ${BACNET_IFACE:-unknown}"
 echo "  BACnet bind:   ${BACNET_BIND}"
 echo "  Auth file:     ${AUTH_PATH}"

--- a/scripts/openfdd_stack.sh
+++ b/scripts/openfdd_stack.sh
@@ -14,7 +14,7 @@ COMPOSE=(docker compose -f docker/compose.dev.yml)
 if [[ -f docker/compose.bench.yml ]]; then
   COMPOSE+=(-f docker/compose.bench.yml)
 fi
-PROD_TAG="${OPENFDD_IMAGE_TAG:-2026.06.07-edge}"
+PROD_TAG="${OPENFDD_IMAGE_TAG:-latest}"
 PROD_COMPOSE=("${COMPOSE[@]}" -f docker/compose.prod.yml)
 PROFILES=()
 if [[ "${OPENFDD_COMPOSE_PROFILES:-ai}" == *ai* ]]; then


### PR DESCRIPTION
## Summary
- Publish workflow pushes **`:latest`** only (no dated edge tags)
- `ghcr_prune_packages.sh` deletes retired **openfdd-bacnet-poll** and keeps 3 newest versions per active image
- Edge compose, bootstrap, and quick-start docs default to **`latest`** (no dated fallbacks)

## Test plan
- [x] Scripts updated; prune runs in publish workflow with `packages: write`
- [ ] Merge → run Publish Docker addons → verify GHCR has 3 packages × ≤3 versions


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker quick-start and architecture documentation to reflect simplified `:latest` image tagging strategy.

* **Chores**
  * Docker images now published exclusively with `:latest` tag to GitHub Container Registry.
  * Automatic pruning maintains only three newest image versions per package.
  * Retired `openfdd-bacnet-poll` from active image publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->