### PR TITLE
Release 3.0.6: Acme FDD bindings, Ollama hardening, edge security runbooks

### DIFF
--- a/infra/ansible/deploy.sh
+++ b/infra/ansible/deploy.sh
@@ -163,7 +163,7 @@ require_ui_build() {
 is_component() {
   case "$1" in
     help|-h|--help) return 0 ;;
-    all|ui|web|backend|core|drivers|data|config|caddy|systemd|pip|commission|mcp|ai|os|check|docker|maintain|ops) return 0 ;;
+    all|ui|web|backend|core|drivers|data|config|caddy|systemd|pip|commission|mcp|ai|ollama|os|check|docker|maintain|ops) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -284,6 +284,11 @@ run_playbook() {
 
 echo "==> Deploy component: ${COMPONENT}${TAGS:+ (tags: ${TAGS})}"
 
+if [[ "$COMPONENT" == "ollama" ]]; then
+  run_playbook ollama_bootstrap.yml "${ANSIBLE_EXTRA[@]}"
+  PLAYBOOK=""
+fi
+
 if [[ "$COMPONENT" == "ai" ]]; then
   run_playbook ollama_bootstrap.yml "${ANSIBLE_EXTRA[@]}"
   run_playbook edge_ai_stack.yml "${ANSIBLE_EXTRA[@]}"
@@ -295,7 +300,7 @@ if [[ -n "$PLAYBOOK" ]]; then
 fi
 
 case "$COMPONENT" in
-  all|ui|web|backend|core|drivers|ai|docker|maintain|ops) ;;
+  all|ui|web|backend|core|drivers|ai|ollama|docker|maintain|ops) ;;
   *) RUN_POST_CHECK=0 ;;
 esac
 

--- a/infra/ansible/ollama_bootstrap.yml
+++ b/infra/ansible/ollama_bootstrap.yml
@@ -84,6 +84,21 @@
       become: true
       notify: Reload systemd
 
+    - name: Ensure Ollama listen drop-in directory exists
+      ansible.builtin.file:
+        path: /etc/systemd/system/ollama.service.d
+        state: directory
+        mode: "0755"
+      become: true
+
+    - name: Install Ollama loopback listen drop-in (replaces legacy 0.0.0.0 listen.conf)
+      ansible.builtin.template:
+        src: templates/ollama-listen.conf.j2
+        dest: /etc/systemd/system/ollama.service.d/listen.conf
+        mode: "0644"
+      become: true
+      notify: Reload systemd
+
     - name: Ensure ollama service enabled and running
       ansible.builtin.systemd:
         name: ollama

--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -61,17 +61,16 @@ api_post() {
     -d "$body" "${BASE}${path}"
 }
 
-# Returns HTTP status on stdout; response body in $API_POST_BODY.
+# Sets API_POST_STATUS and API_POST_BODY (do not call inside $() — subshell drops globals).
 api_post_status() {
   local path="$1" body="${2:-{}}"
-  local tmp code
+  local tmp
   tmp="$(mktemp)"
-  code="$(curl -sS --connect-timeout 15 --max-time 300 -o "$tmp" -w "%{http_code}" \
+  API_POST_STATUS="$(curl -sS --connect-timeout 15 --max-time 300 -o "$tmp" -w "%{http_code}" \
     -X POST -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
-    -d "$body" "${BASE}${path}" 2>/dev/null)" || code="000"
+    -d "$body" "${BASE}${path}" 2>/dev/null)" || API_POST_STATUS="000"
   API_POST_BODY="$(cat "$tmp")"
   rm -f "$tmp"
-  echo "$code"
 }
 
 wait_job() {
@@ -152,8 +151,9 @@ print(json.dumps({
 }))
 ")"
 if [[ "$import_body" != "{}" ]]; then
-  import_code="$(api_post_status "/api/bacnet/import-to-model" "$import_body")"
-  imp="$API_POST_BODY"
+  api_post_status "/api/bacnet/import-to-model" "$import_body"
+  import_code="${API_POST_STATUS}"
+  imp="${API_POST_BODY}"
   if [[ "$import_code" == "200" ]]; then
     log_ok "import-to-model: $(echo "$imp" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("equipment_id", d.get("ok", d)))' 2>/dev/null || echo ok)"
   elif [[ "$import_code" == "422" ]]; then

--- a/infra/ansible/scripts/http_probes.py
+++ b/infra/ansible/scripts/http_probes.py
@@ -497,6 +497,15 @@ def check_bacnet_driver(
     return out
 
 
+def _rule_binding_ref_count(bindings: dict[str, Any] | None) -> tuple[int, int, int, int]:
+    """Return (point_ids, equipment_ids, brick_types, total_refs) for one rule bindings dict."""
+    b = bindings if isinstance(bindings, dict) else {}
+    points = len(b.get("point_ids") or [])
+    equipment = len(b.get("equipment_ids") or [])
+    bricks = len(b.get("brick_types") or [])
+    return points, equipment, bricks, points + equipment + bricks
+
+
 def check_model_sparql_health(base: str, token: str) -> dict[str, Any]:
     """BRICK data model health: JSON summary + SPARQL tree/graph over synced TTL."""
     out: dict[str, Any] = {"errors": [], "warnings": []}
@@ -564,7 +573,7 @@ def check_model_sparql_health(base: str, token: str) -> dict[str, Any]:
             out["errors"].append("/api/model/health not JSON")
 
     tree_url = f"{root}/api/model/tree"
-    status, body, _ = fetch(tree_url, headers=headers)
+    status, body, _ = fetch(tree_url, headers=headers, timeout=60.0)
     out["model_tree_status"] = status
     if status != 200:
         detail = ""
@@ -599,7 +608,7 @@ def check_model_sparql_health(base: str, token: str) -> dict[str, Any]:
     if site_id:
         graph_qs = urllib.parse.urlencode({"site_id": site_id})
         graph_url = f"{root}/api/model/graph?{graph_qs}"
-        status, body, _ = fetch(graph_url, headers=headers)
+        status, body, _ = fetch(graph_url, headers=headers, timeout=60.0)
         out["model_graph_status"] = status
         if status != 200:
             detail = ""
@@ -805,20 +814,24 @@ def check_fdd_operational(
         try:
             rules = json.loads(body).get("rules") or []
             enabled = [r for r in rules if isinstance(r, dict) and r.get("enabled") is not False]
-            bound = 0
+            point_refs = 0
+            binding_refs = 0
             for r in enabled:
-                b = r.get("bindings") if isinstance(r.get("bindings"), dict) else {}
-                bound += len(b.get("point_ids") or [])
+                _p, _e, _b, total = _rule_binding_ref_count(r.get("bindings"))
+                point_refs += _p
+                binding_refs += total
             out["rules_saved_count"] = len(rules)
             out["rules_enabled_count"] = len(enabled)
-            out["rules_bound_point_refs"] = bound
+            out["rules_bound_point_refs"] = point_refs
+            out["rules_binding_refs"] = binding_refs
             if len(enabled) < min_saved_rules:
                 out["errors"].append(
                     f"only {len(enabled)} enabled saved rule(s) (need >={min_saved_rules})"
                 )
-            if min_bound_points > 0 and bound < min_bound_points:
+            if min_bound_points > 0 and binding_refs < min_bound_points:
                 out["warnings"].append(
-                    f"FDD bindings cover {bound} point ref(s) (expected >={min_bound_points} on Acme)"
+                    f"FDD bindings cover {binding_refs} ref(s) "
+                    f"({point_refs} explicit points; expected >={min_bound_points} on Acme)"
                 )
         except json.JSONDecodeError:
             out["errors"].append("/api/rules/saved not JSON")

--- a/infra/ansible/scripts/post_deploy_check.sh
+++ b/infra/ansible/scripts/post_deploy_check.sh
@@ -255,8 +255,8 @@ f=json.load(sys.stdin).get("fdd_operational",{})
 sys.exit(0 if f.get("rules_saved_status")==200 and not f.get("errors") else 1)
 '; then
     rules="$(echo "$probe_json" | python3 -c 'import json,sys; f=json.load(sys.stdin).get("fdd_operational",{}); print(f.get("rules_enabled_count",0))')"
-    bound="$(echo "$probe_json" | python3 -c 'import json,sys; f=json.load(sys.stdin).get("fdd_operational",{}); print(f.get("rules_bound_point_refs",0))')"
-    log_ok "FDD saved rules (${rules} enabled, ${bound} bound point refs)"
+    bound="$(echo "$probe_json" | python3 -c 'import json,sys; f=json.load(sys.stdin).get("fdd_operational",{}); print(f.get("rules_binding_refs", f.get("rules_bound_point_refs",0)))')"
+    log_ok "FDD saved rules (${rules} enabled, ${bound} binding refs)"
   fi
 
   if echo "$probe_json" | python3 -c '

--- a/infra/ansible/tasks/post_deploy_check.yml
+++ b/infra/ansible/tasks/post_deploy_check.yml
@@ -89,6 +89,7 @@
       err="$(docker logs --since 3m "$cid" 2>&1 \
         | grep -Ei 'ERROR|Traceback|CRITICAL' \
         | grep -v '404 Not Found' \
+        | grep -v 'unknown-property' \
         | grep -v 'CancelledError' \
         | grep -v 'Cannot assign requested address' \
         | grep -v "has no attribute 'server'" \

--- a/infra/ansible/templates/ollama-listen.conf.j2
+++ b/infra/ansible/templates/ollama-listen.conf.j2
@@ -1,0 +1,3 @@
+# Managed by Open-FDD ollama_bootstrap — overrides any legacy 0.0.0.0 drop-in.
+[Service]
+Environment=OLLAMA_HOST=127.0.0.1:11434

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.5"
+__version__ = "3.0.6"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.5"
+version = "3.0.6"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/security/check_openfdd_exposure.sh
+++ b/scripts/security/check_openfdd_exposure.sh
@@ -79,16 +79,18 @@ if command -v ss >/dev/null 2>&1; then
       echo "  :${port} ${line}"
       case "$port" in
         8765|8090)
-          if echo "$line" | grep -qE '0\.0\.0\.0|\[::\]'; then
+          bind_addr="$(echo "$line" | awk '{print $5}' | sed 's/%.*//')"
+          if echo "$bind_addr" | grep -qE '^0\.0\.0\.0$|^\*$|^\[::\]$'; then
             log_fail "Port ${port} listening on all interfaces — should be loopback or internal only"
           else
-            log_ok "Port ${port} not on 0.0.0.0"
+            log_ok "Port ${port} bind ${bind_addr} (not 0.0.0.0)"
           fi
           ;;
         11434)
-          if echo "$line" | grep -qE '0\.0\.0\.0:11434|\[::\]:11434'; then
+          bind_addr="$(echo "$line" | awk '{print $5}')"
+          if echo "$bind_addr" | grep -qE '^0\.0\.0\.0:11434$|^\*:11434$|^\[::\]:11434$'; then
             log_fail "Ollama on 0.0.0.0:11434 — CRITICAL: no auth; set OLLAMA_HOST=127.0.0.1:11434"
-          elif echo "$line" | grep -q '127.0.0.1:11434'; then
+          elif echo "$bind_addr" | grep -q '127.0.0.1:11434'; then
             log_ok "Ollama loopback only (127.0.0.1:11434)"
           else
             log_warn "Ollama bind: ${line}"

--- a/scripts/security/remediate_ubuntu_host.sh
+++ b/scripts/security/remediate_ubuntu_host.sh
@@ -17,10 +17,23 @@ usage() {
   exit "${1:-0}"
 }
 
+sudo_cmd() {
+  if [[ -n "${SUDO_PASSWORD:-}" ]]; then
+    echo "$SUDO_PASSWORD" | sudo -S "$@"
+  else
+    sudo "$@"
+  fi
+}
+
 run_cmd() {
   echo "+ $*"
   if [[ "$APPLY" == "1" ]]; then
-    "$@"
+    if [[ "$1" == "sudo" ]]; then
+      shift
+      sudo_cmd "$@"
+    else
+      "$@"
+    fi
   fi
 }
 

--- a/scripts/setup_gl36_fdd.py
+++ b/scripts/setup_gl36_fdd.py
@@ -206,6 +206,28 @@ def save_rules(specs: list[dict[str, Any]], *, site_id: str) -> None:
         print(f"Saved rule {spec['id']}")
 
 
+def _save_rule_payload(rule: dict[str, Any]) -> dict[str, Any]:
+    """Map rules_store entry to POST /api/rules/save body."""
+    out: dict[str, Any] = {
+        "id": rule.get("id"),
+        "name": rule.get("name") or "Untitled rule",
+        "description": rule.get("description") or "",
+        "mode": rule.get("mode") or "rule",
+        "code": rule.get("code") or "",
+        "fault_code": rule.get("fault_code") or "",
+        "fault_codes": rule.get("fault_codes") or [],
+        "config": rule.get("config") if isinstance(rule.get("config"), dict) else {},
+        "bindings": rule.get("bindings") if isinstance(rule.get("bindings"), dict) else {},
+        "severity": rule.get("severity") or "warning",
+        "enabled": rule.get("enabled") is not False,
+    }
+    if isinstance(rule.get("applies_to"), dict):
+        out["applies_to"] = rule["applies_to"]
+    if isinstance(rule.get("column_map"), dict):
+        out["column_map"] = rule["column_map"]
+    return out
+
+
 def push_rules_to_edge(base: str, token: str, *, site_id: str, rule_ids: set[str]) -> None:
     store_path = REPO / "workspace" / "data" / "rules_store.json"
     if not store_path.is_file():
@@ -215,9 +237,12 @@ def push_rules_to_edge(base: str, token: str, *, site_id: str, rule_ids: set[str
         rid = str(rule.get("id") or "")
         if rid not in rule_ids:
             continue
-        body = json.dumps(rule).encode()
+        if not str(rule.get("code") or "").strip():
+            print(f"Note: skip push {rid} — no inline code in rules_store")
+            continue
+        body = json.dumps(_save_rule_payload(rule)).encode()
         req = urllib.request.Request(
-            f"{base.rstrip('/')}/api/rules/saved",
+            f"{base.rstrip('/')}/api/rules/save",
             data=body,
             headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
             method="POST",

--- a/tests/test_fdd_binding_probe.py
+++ b/tests/test_fdd_binding_probe.py
@@ -1,0 +1,40 @@
+"""FDD binding ref counting for post-deploy probes."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _load_http_probes():
+    path = REPO / "infra" / "ansible" / "scripts" / "http_probes.py"
+    spec = importlib.util.spec_from_file_location("http_probes", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_rule_binding_ref_count_brick_scoped():
+    hp = _load_http_probes()
+    p, e, b, total = hp._rule_binding_ref_count(
+        {"point_ids": [], "equipment_ids": [], "brick_types": ["Zone_Air_Temperature_Sensor"]}
+    )
+    assert p == 0
+    assert e == 0
+    assert b == 1
+    assert total == 1
+
+
+def test_rule_binding_ref_count_mixed():
+    hp = _load_http_probes()
+    p, e, b, total = hp._rule_binding_ref_count(
+        {
+            "point_ids": ["1100-analog-output-1"],
+            "equipment_ids": ["acme-vm-bbartling-rtu-01"],
+            "brick_types": ["Supply_Air_Temperature_Sensor"],
+        }
+    )
+    assert total == 3


### PR DESCRIPTION
## Summary
- Fix FDD post-deploy binding count (brick/equipment refs, not point_ids only)
- Fix `setup_gl36_fdd.py` rule push → `POST /api/rules/save` (was 405 on `/saved`)
- Ollama loopback drop-in via `deploy.sh ollama` + edge security scripts
- `acme_operational_verify` subshell fix; commission log noise filter
- Tenable remediation docs + host/exposure check scripts (from 3.0.5 merge path)

## Test plan
- [x] Local pytest 362 passed + vitest 41 passed
- [ ] CI green on PR
- [ ] Tag `open-fdd-v3.0.6` → GHCR publish
- [ ] Acme upgrade + post_deploy --full + operational verify


Made with [Cursor](https://cursor.com)