### PR TITLE
3.0.8 — Building agent API for Tailscale FDD ops

### DIFF
--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -197,6 +197,29 @@ if [[ "$SKIP_WAIT" -eq 0 ]]; then
     "wc -l ~/open-fdd/workspace/bacnet/polls/samples.csv 2>/dev/null || true" || true
 fi
 
+log_info "Building agent API (poll throughput, FDD results, ops logs)"
+for path in \
+  "/api/analytics/poll-throughput?window_minutes=30" \
+  "/api/fdd/results?limit=5" \
+  "/api/ops/logs?tail=40&include_docker=false" \
+  "/api/building-agent/status"; do
+  code="$(curl -sS --connect-timeout 15 --max-time 120 -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${TOKEN}" "${BASE}${path}" 2>/dev/null || echo 000)"
+  if [[ "$code" == "200" ]]; then
+    log_ok "GET ${path} HTTP 200"
+  else
+    log_fail "GET ${path} HTTP ${code}"
+  fi
+done
+
+log_info "Building agent check-in (no FDD batch — smoke)"
+api_post_status "/api/building-agent/checkin" '{"run_fdd_batch":false,"write_memory":true,"window_minutes":30}'
+if [[ "${API_POST_STATUS:-000}" == "200" ]]; then
+  log_ok "POST /api/building-agent/checkin HTTP 200"
+else
+  log_fail "POST /api/building-agent/checkin HTTP ${API_POST_STATUS:-000}: ${API_POST_BODY:-}"
+fi
+
 echo "---"
 if [[ "$FAILURES" -eq 0 ]]; then
   echo "Acme operational verify PASSED"

--- a/infra/ansible/scripts/http_probes.py
+++ b/infra/ansible/scripts/http_probes.py
@@ -238,6 +238,55 @@ def check_building_dashboard_health(
     return out
 
 
+def check_building_agent_api(base: str, token: str, *, site_id: str = "demo") -> dict[str, Any]:
+    """Building agent REST surface — poll throughput, FDD results, ops logs, check-in status."""
+    out: dict[str, Any] = {"errors": [], "warnings": [], "site_id": site_id}
+    headers = auth_headers(token)
+    root = base.rstrip("/")
+
+    for path, key in (
+        ("/api/analytics/poll-throughput?window_minutes=30", "poll_throughput_status"),
+        ("/api/fdd/results?limit=5", "fdd_results_status"),
+        ("/api/ops/logs?tail=30&include_docker=false", "ops_logs_status"),
+        ("/api/building-agent/status", "building_agent_status"),
+    ):
+        url = f"{root}{path}"
+        try:
+            status, body, _ = fetch(url, headers=headers, timeout=60.0)
+        except RuntimeError as exc:
+            out["errors"].append(f"{path} unreachable: {exc}")
+            continue
+        out[key] = status
+        if status != 200:
+            out["errors"].append(f"{path} HTTP {status}: {body[:200]}")
+            continue
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            out["errors"].append(f"{path} not JSON")
+            continue
+        if path.startswith("/api/analytics"):
+            out["poll_keepup_ratio"] = payload.get("keepup_ratio")
+            out["poll_throughput_status_label"] = payload.get("status")
+            if payload.get("status") in {"lagging", "error"}:
+                out["warnings"].append(
+                    f"poll throughput {payload.get('status')} keepup={payload.get('keepup_ratio')}"
+                )
+        if path.startswith("/api/ops") and (payload.get("summary") or {}).get("has_bridge_errors"):
+            out["warnings"].append("bridge error log has recent severity errors")
+
+    mem_url = f"{root}/api/sites/{site_id}/memory?kind=memory"
+    try:
+        m_status, m_body, _ = fetch(mem_url, headers=headers, timeout=30.0)
+        out["site_memory_status"] = m_status
+        if m_status != 200:
+            out["warnings"].append(f"/api/sites/{{id}}/memory HTTP {m_status}")
+    except RuntimeError as exc:
+        out["warnings"].append(f"site memory probe: {exc}")
+
+    return out
+
+
 def check_public_check_engine(base: str) -> dict[str, Any]:
     """Anonymous read probes for home / faults traffic-light UI (no Bearer token)."""
     out: dict[str, Any] = {"errors": [], "warnings": [], "endpoints": {}}
@@ -1118,6 +1167,15 @@ def main() -> int:
                     result["fdd_operational"] = fdd
                     result["errors"].extend(fdd.get("errors", []))
                     result["warnings"].extend(fdd.get("warnings", []))
+                    agent_api = _run_probe(
+                        "building_agent_api",
+                        lambda: check_building_agent_api(
+                            base, login["token"], site_id=probe_site
+                        ),
+                    )
+                    result["building_agent_api"] = agent_api
+                    result["errors"].extend(agent_api.get("errors", []))
+                    result["warnings"].extend(agent_api.get("warnings", []))
         else:
             result = check_entry(base, require_mcp=require_mcp, require_ollama=require_ollama)
         print(json.dumps(result, indent=2))

--- a/infra/ansible/scripts/post_deploy_check.sh
+++ b/infra/ansible/scripts/post_deploy_check.sh
@@ -356,7 +356,7 @@ elif [[ "$INVENTORY_DOCKER_STACK" == "1" ]]; then
         log_fail "Docker service ${svc}: no running container"
         continue
       fi
-      err_lines="$(ssh_remote "docker logs --tail 80 \"${cid}\" 2>&1 | grep -Ei 'ERROR|Traceback|CRITICAL' | grep -v '404 Not Found' | grep -v 'unknown-property' | grep -v 'Connection reset by peer' | tail -5 || true")" || err_lines=""
+      err_lines="$(ssh_remote "docker logs --tail 80 \"${cid}\" 2>&1 | grep -Ei 'ERROR|Traceback|CRITICAL' | grep -v '404 Not Found' | grep -v 'unknown-property' | grep -v 'read-property-multiple' | grep -v 'Connection reset by peer' | tail -5 || true")" || err_lines=""
       if [[ -n "$err_lines" ]]; then
         log_fail "Docker ${svc} (${cid:0:12}) log errors: ${err_lines}"
       else

--- a/infra/ansible/tasks/post_deploy_check.yml
+++ b/infra/ansible/tasks/post_deploy_check.yml
@@ -90,6 +90,7 @@
         | grep -Ei 'ERROR|Traceback|CRITICAL' \
         | grep -v '404 Not Found' \
         | grep -v 'unknown-property' \
+        | grep -v 'read-property-multiple' \
         | grep -v 'CancelledError' \
         | grep -v 'Cannot assign requested address' \
         | grep -v "has no attribute 'server'" \

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.6"
+__version__ = "3.0.7"
 
 __all__ = ["__version__"]

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.7"
+__version__ = "3.0.8"
 
 __all__ = ["__version__"]

--- a/packages/openfdd-agent-shell/src/openfdd_agent_shell/cron/models.py
+++ b/packages/openfdd-agent-shell/src/openfdd_agent_shell/cron/models.py
@@ -14,6 +14,7 @@ ServiceKind = Literal[
     "fdd_batch",
     "health_bridge",
     "health_hvac",
+    "health_building_agent",
     "webhook",
 ]
 

--- a/packages/openfdd-agent-shell/src/openfdd_agent_shell/cron/scheduler.py
+++ b/packages/openfdd-agent-shell/src/openfdd_agent_shell/cron/scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import os
 import shlex
 import subprocess
 from typing import Any
@@ -196,6 +197,46 @@ class CronScheduler:
             if result.locked:
                 return f"wake locked log={result.log_path.name}"
             return f"wake ok log={result.log_path.name} minis={result.mini_runs}"
+        if job.service == "health_building_agent":
+            import json
+            import urllib.error
+            import urllib.request
+
+            base = str(payload.get("base_url") or "http://127.0.0.1:8765").rstrip("/")
+            token = str(payload.get("token") or os.environ.get("OFDD_AGENT_TOKEN") or "").strip()
+            if not token:
+                user = str(payload.get("user") or os.environ.get("OFDD_AGENT_USER") or "agent")
+                password = str(payload.get("password") or os.environ.get("OFDD_AGENT_PASSWORD") or "")
+                if not password:
+                    raise ValueError("health_building_agent requires token or agent password")
+                login_body = json.dumps({"username": user, "password": password}).encode("utf-8")
+                req = urllib.request.Request(
+                    f"{base}/api/auth/login",
+                    data=login_body,
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    token = str(json.loads(resp.read().decode("utf-8")).get("token") or "")
+            checkin = {
+                "site_id": payload.get("site_id"),
+                "run_fdd_batch": bool(payload.get("run_fdd_batch", False)),
+                "write_memory": bool(payload.get("write_memory", True)),
+                "window_minutes": int(payload.get("window_minutes") or 60),
+            }
+            data = json.dumps(checkin).encode("utf-8")
+            req = urllib.request.Request(
+                f"{base}/api/building-agent/checkin",
+                data=data,
+                headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=600) as resp:
+                    result = json.loads(resp.read().decode("utf-8"))
+            except urllib.error.HTTPError as exc:
+                raise RuntimeError(exc.read().decode("utf-8", errors="replace")[:300]) from exc
+            return str(result.get("summary") or "building agent checkin ok")[:500]
         if job.service in {"fdd_batch", "health_bridge", "health_hvac", "webhook"}:
             target = payload.get("url") or payload.get("endpoint") or payload.get("script")
             return f"queued {job.service} target={target or 'workspace'}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.6"
+version = "3.0.7"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.7"
+version = "3.0.8"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/building_agent_checkin.py
+++ b/scripts/building_agent_checkin.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Remote building agent check-in via Tailscale/LAN REST API (no SSH).
+
+Usage:
+  python scripts/building_agent_checkin.py --base-url http://100.122.106.124
+  python scripts/building_agent_checkin.py --base-url http://127.0.0.1:8765 --run-batch
+
+Reads credentials from env (OFDD_AGENT_USER / OFDD_AGENT_PASSWORD) or --token.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def _login(base: str, user: str, password: str) -> str:
+    payload = json.dumps({"username": user, "password": password}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base.rstrip('/')}/api/auth/login",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    token = str(body.get("token") or "").strip()
+    if not token:
+        raise RuntimeError("login returned no token")
+    return token
+
+
+def _api_post(base: str, token: str, path: str, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base.rstrip('/')}{path}",
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"HTTP {exc.code}: {detail}") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Building agent check-in (API only)")
+    parser.add_argument("--base-url", default=os.environ.get("OFDD_BRIDGE_BASE_URL", "http://127.0.0.1:8765"))
+    parser.add_argument("--token", default=os.environ.get("OFDD_AGENT_TOKEN", "").strip())
+    parser.add_argument("--user", default=os.environ.get("OFDD_AGENT_USER", "agent"))
+    parser.add_argument("--password", default=os.environ.get("OFDD_AGENT_PASSWORD", ""))
+    parser.add_argument("--site-id", default=os.environ.get("OFDD_SITE_ID", ""))
+    parser.add_argument("--run-batch", action="store_true")
+    parser.add_argument("--no-memory", action="store_true")
+    parser.add_argument("--window-minutes", type=int, default=60)
+    parser.add_argument("--json", action="store_true", help="Print full JSON response")
+    args = parser.parse_args(argv)
+
+    token = args.token
+    if not token:
+        if not args.password:
+            print("Set --token or OFDD_AGENT_PASSWORD", file=sys.stderr)
+            return 2
+        token = _login(args.base_url, args.user, args.password)
+
+    body = {
+        "run_fdd_batch": bool(args.run_batch),
+        "write_memory": not args.no_memory,
+        "window_minutes": args.window_minutes,
+    }
+    if args.site_id.strip():
+        body["site_id"] = args.site_id.strip()
+
+    result = _api_post(args.base_url, token, "/api/building-agent/checkin", body)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(result.get("summary") or json.dumps(result)[:400])
+        actions = result.get("actions") or []
+        for act in actions[:6]:
+            print(f"  - {act.get('kind')}: {act.get('detail')}")
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/building_agent_jobs.json.example
+++ b/scripts/building_agent_jobs.json.example
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "jobs": [
+    {
+      "id": "building-agent-6h",
+      "name": "Building agent check-in (6h commissioning)",
+      "enabled": true,
+      "session": "worker",
+      "service": "shell",
+      "schedule": {
+        "kind": "every",
+        "every_seconds": 21600
+      },
+      "payload": {
+        "command": "python3 scripts/building_agent_checkin.py --base-url http://127.0.0.1:8765 --run-batch"
+      }
+    },
+    {
+      "id": "building-agent-12h",
+      "name": "Building agent check-in (12h stable)",
+      "enabled": false,
+      "session": "worker",
+      "service": "shell",
+      "schedule": {
+        "kind": "every",
+        "every_seconds": 43200
+      },
+      "payload": {
+        "command": "python3 scripts/building_agent_checkin.py --base-url http://127.0.0.1:8765"
+      }
+    }
+  ]
+}

--- a/tests/workspace_bridge/test_building_agent_api.py
+++ b/tests/workspace_bridge/test_building_agent_api.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+API_ROOT = Path(__file__).resolve().parents[2] / "workspace" / "api"
+REPO = Path(__file__).resolve().parents[2]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+
+def test_poll_throughput_endpoint(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "openfdd_bridge.poll_throughput.commission_poll_status",
+        lambda: (200, {"enabled_points": 2, "samples": 2, "interval_s": 60, "at": "2026-06-01T12:00:00Z"}),
+    )
+    r = client.get("/api/analytics/poll-throughput?window_minutes=15")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert "expected_all_polled_per_min" in body
+    assert body["cycle_model"] == "all_enabled_each_cycle"
+
+
+def test_site_memory_roundtrip(agent_client: TestClient):
+    import os
+
+    mem_root = Path(os.environ["OPENFDD_WORKSPACE_DIR"]) / "memory" / "sites"
+    r = agent_client.put(
+        "/api/sites/acme-test/memory?kind=memory",
+        json={"content": "# Acme test memory\n", "mode": "replace"},
+    )
+    assert r.status_code == 200
+    assert r.json()["site_id"] == "acme-test"
+    g = agent_client.get("/api/sites/acme-test/memory?kind=memory")
+    assert g.status_code == 200
+    assert "Acme test memory" in g.json()["content"]
+    assert (mem_root / "acme-test.md").is_file()
+
+
+def test_fdd_results_endpoint(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    import os
+
+    from openfdd_bridge import fdd_results as fr
+
+    doc = {
+        "version": 1,
+        "generated_at": "2026-06-01T00:00:00Z",
+        "runs": [{"rule_id": "r1", "site_id": "s1", "flagged": 3, "rows": 10}],
+    }
+    path = Path(os.environ["OFDD_DESKTOP_DATA_DIR"]) / "fdd_results.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    monkeypatch.setattr(fr, "fdd_results_path", lambda: path)
+    r = client.get("/api/fdd/results?site_id=s1")
+    assert r.status_code == 200
+    assert r.json()["summary"]["runs"] == 1
+
+
+def test_ops_logs_endpoint(client: TestClient):
+    r = client.get("/api/ops/logs?tail=20&include_docker=false")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert "bridge_errors" in body
+
+
+def test_building_agent_checkin(agent_client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "openfdd_bridge.building_agent.compute_poll_throughput",
+        lambda **_: {
+            "ok": True,
+            "status": "healthy",
+            "keepup_ratio": 1.0,
+            "enabled_points": 1,
+            "observed_samples_per_min": 1.0,
+        },
+    )
+    monkeypatch.setattr(
+        "openfdd_bridge.building_agent.run_batch",
+        lambda **_: {"ok": True, "rules_run": 0},
+    )
+    monkeypatch.setattr(
+        "openfdd_bridge.building_agent.get_device_poll_snapshot",
+        lambda **_: {"summary_sentence": "ok", "healthy_count": 0, "offline_equipment": [], "flaky_equipment": []},
+    )
+    monkeypatch.setattr(
+        "openfdd_bridge.building_agent.collect_ops_logs",
+        lambda **_: {"ok": True, "summary": {"healthy": True, "has_bridge_errors": False}},
+    )
+    r = agent_client.post(
+        "/api/building-agent/checkin",
+        json={"site_id": "checkin-site", "run_fdd_batch": False, "write_memory": True, "window_minutes": 15},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert "summary" in body
+    assert body["memory"]["site_id"] == "checkin-site"
+
+
+def test_poll_throughput_with_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from openfdd_bridge.poll_throughput import compute_poll_throughput
+
+    ws = tmp_path / "workspace"
+    polls = ws / "bacnet" / "polls"
+    polls.mkdir(parents=True)
+    comm = ws / "bacnet" / "commissioning"
+    comm.mkdir(parents=True)
+    (comm / "points_discovered.csv").write_text(
+        "point_id,device_instance,object_type,object_instance,enabled\n"
+        "p1,1,analogInput,1,1\n",
+        encoding="utf-8",
+    )
+    (comm / "points.csv").write_text(
+        "point_id,enabled,poll_interval_s,series_id\np1,1,60,s1\n",
+        encoding="utf-8",
+    )
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    rows = []
+    for i in range(5):
+        ts = (now - timedelta(minutes=i)).isoformat()
+        rows.append(f"{ts},site,bld,sys,p1,s1,1,analogInput,1,{70+i}")
+    (polls / "samples.csv").write_text(
+        "timestamp_utc,site_id,building_id,system_id,point_id,series_id,device_instance,object_type,object_instance,value\n"
+        + "\n".join(rows),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENFDD_WORKSPACE_DIR", str(ws))
+    monkeypatch.setattr(
+        "openfdd_bridge.poll_throughput.commission_poll_status",
+        lambda: (200, {"enabled_points": 1, "samples": 1, "interval_s": 60, "at": now.isoformat()}),
+    )
+    out = compute_poll_throughput(window_minutes=30)
+    assert out["enabled_points"] == 1
+    assert out["observed"]["rows_in_window"] >= 1

--- a/workspace/api/openfdd_bridge/agent_tools.py
+++ b/workspace/api/openfdd_bridge/agent_tools.py
@@ -34,7 +34,12 @@ from .brick_model_context import (
 )
 from .fault_catalog import all_codes, catalog_graph, entry_for_code, is_valid_code
 from .fault_catalog_scope import build_applicable_payload, validate_scope_with_ollama
+from .building_agent import run_checkin
+from .fdd_results import load_results
 from .fdd_runner import run_batch
+from .ops_logs import collect_ops_logs
+from .poll_throughput import compute_poll_throughput
+from .site_memory import get_site_memory, put_site_memory
 from .model_health import model_health_summary
 from .model_service import ModelService
 from .model_store import ModelStore
@@ -342,6 +347,78 @@ def _tool_app_edit_file(args: dict[str, Any]) -> dict[str, Any]:
     return {"path": str(target), "existed": existed, "bytes": len(content.encode("utf-8"))}
 
 
+def _tool_analytics_poll_throughput(args: dict[str, Any]) -> dict[str, Any]:
+    window = args.get("window_minutes")
+    try:
+        window_i = int(window) if window is not None else 60
+    except (TypeError, ValueError) as exc:
+        raise ToolError(f"invalid window_minutes: {window!r}") from exc
+    return compute_poll_throughput(window_minutes=window_i)
+
+
+def _tool_fdd_results(args: dict[str, Any]) -> dict[str, Any]:
+    doc = load_results()
+    site_id = str(args.get("site_id") or "").strip() or None
+    limit = args.get("limit")
+    try:
+        lim = int(limit) if limit is not None else 50
+    except (TypeError, ValueError) as exc:
+        raise ToolError(f"invalid limit: {limit!r}") from exc
+    runs = [r for r in doc.get("runs", []) if isinstance(r, dict)]
+    if site_id:
+        runs = [r for r in runs if str(r.get("site_id") or "") in {"", site_id}]
+    runs = runs[-max(1, min(lim, 200)) :]
+    return {"generated_at": doc.get("generated_at"), "runs": runs, "count": len(runs)}
+
+
+def _tool_ops_logs(args: dict[str, Any]) -> dict[str, Any]:
+    tail = args.get("tail")
+    try:
+        tail_i = int(tail) if tail is not None else 80
+    except (TypeError, ValueError) as exc:
+        raise ToolError(f"invalid tail: {tail!r}") from exc
+    return collect_ops_logs(
+        tail=tail_i,
+        service=str(args.get("service") or "bridge"),
+        include_docker=str(args.get("include_docker") or "true").strip().lower() not in {"0", "false", "no"},
+    )
+
+
+def _tool_site_memory_get(args: dict[str, Any]) -> dict[str, Any]:
+    site_id = str(args.get("site_id") or "").strip() or ensure_default_site(ModelService(), TtlService())
+    kind = str(args.get("kind") or "memory").strip().lower()
+    return get_site_memory(site_id=site_id, kind=kind)
+
+
+def _tool_site_memory_put(args: dict[str, Any]) -> dict[str, Any]:
+    _require(args, "site_id", "content")
+    kind = str(args.get("kind") or "memory").strip().lower()
+    mode = str(args.get("mode") or "replace").strip().lower()
+    return put_site_memory(
+        site_id=str(args["site_id"]),
+        content=str(args["content"]),
+        kind=kind,
+        mode=mode,
+    )
+
+
+def _tool_building_checkin(args: dict[str, Any]) -> dict[str, Any]:
+    site_id = str(args.get("site_id") or "").strip() or None
+    run_batch_flag = str(args.get("run_fdd_batch") or "true").strip().lower() in {"1", "true", "yes"}
+    write_memory = str(args.get("write_memory") or "true").strip().lower() not in {"0", "false", "no"}
+    window = args.get("window_minutes")
+    try:
+        window_i = int(window) if window is not None else 60
+    except (TypeError, ValueError) as exc:
+        raise ToolError(f"invalid window_minutes: {window!r}") from exc
+    return run_checkin(
+        site_id=site_id,
+        run_fdd_batch=run_batch_flag,
+        write_memory=write_memory,
+        window_minutes=window_i,
+    )
+
+
 def _tool_app_rebuild_dashboard(_args: dict[str, Any]) -> dict[str, Any]:
     if not app_edit_enabled():
         raise ToolError("app rebuild disabled — set OFDD_AGENT_ALLOW_APP_EDIT=1 to enable")
@@ -377,6 +454,10 @@ _READ_ONLY_TOOLS = frozenset(
         "building.zone_temps",
         "building.device_health",
         "building.operational_brief",
+        "analytics.poll_throughput",
+        "fdd.results",
+        "ops.logs",
+        "site.memory_get",
     }
 )
 
@@ -389,6 +470,8 @@ _WRITE_TOOLS = frozenset(
         "rules.bind",
         "rules.run_batch",
         "building.set_alerts",
+        "building.checkin",
+        "site.memory_put",
         "app.edit_file",
         "app.rebuild_dashboard",
     }
@@ -412,6 +495,12 @@ _TOOLS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "building.zone_temps": _tool_building_zone_temps,
     "building.device_health": _tool_building_device_health,
     "building.operational_brief": _tool_building_operational_brief,
+    "building.checkin": _tool_building_checkin,
+    "analytics.poll_throughput": _tool_analytics_poll_throughput,
+    "fdd.results": _tool_fdd_results,
+    "ops.logs": _tool_ops_logs,
+    "site.memory_get": _tool_site_memory_get,
+    "site.memory_put": _tool_site_memory_put,
     "app.edit_file": _tool_app_edit_file,
     "app.rebuild_dashboard": _tool_app_rebuild_dashboard,
 }
@@ -516,6 +605,32 @@ def tool_specs() -> list[dict[str, Any]]:
             "name": "building.operational_brief",
             "args": ["force?"],
             "writes": "read-only — zone temps + device health + fault sentences JSON",
+        },
+        {
+            "name": "building.checkin",
+            "args": ["site_id?", "run_fdd_batch?", "write_memory?", "window_minutes?"],
+            "writes": "building_agent_checkin.json + site MEMORY.md append",
+        },
+        {
+            "name": "analytics.poll_throughput",
+            "args": ["window_minutes?"],
+            "writes": "read-only — expected vs observed BACnet samples/min",
+        },
+        {"name": "fdd.results", "args": ["site_id?", "limit?"], "writes": "read-only — fdd_results.json runs"},
+        {
+            "name": "ops.logs",
+            "args": ["tail?", "service?", "include_docker?"],
+            "writes": "read-only — bridge error/audit + optional docker compose tail",
+        },
+        {
+            "name": "site.memory_get",
+            "args": ["site_id?", "kind?"],
+            "writes": "read-only — workspace/memory/sites/<id>.md or SKILLS.md",
+        },
+        {
+            "name": "site.memory_put",
+            "args": ["site_id", "content", "kind?", "mode?"],
+            "writes": "workspace/memory/sites/",
         },
         {
             "name": "model.graph",

--- a/workspace/api/openfdd_bridge/building_agent.py
+++ b/workspace/api/openfdd_bridge/building_agent.py
@@ -1,0 +1,235 @@
+"""Building agent check-in — poll health, faults, logs, memory (API-only, no SSH)."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .building_status import collect_status
+from .device_poll_health import get_device_poll_snapshot
+from .fdd_results import load_results
+from .fdd_runner import run_batch
+from .ops_logs import collect_ops_logs
+from .poll_throughput import compute_poll_throughput
+from .site_defaults import ensure_default_site
+from .site_memory import append_checkin_note, get_site_memory
+from .model_service import ModelService
+from .ttl_service import TtlService
+
+_CHECKIN_STATE = "building_agent_checkin.json"
+
+
+def _state_path() -> Path:
+    from .paths import data_dir
+
+    return data_dir() / _CHECKIN_STATE
+
+
+def _load_state() -> dict[str, Any]:
+    path = _state_path()
+    if not path.is_file():
+        return {"version": 1, "runs": []}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"version": 1, "runs": []}
+    return raw if isinstance(raw, dict) else {"version": 1, "runs": []}
+
+
+def _save_state(doc: dict[str, Any]) -> None:
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+
+def _resolve_site_id(site_id: str | None) -> str:
+    if site_id and str(site_id).strip():
+        return str(site_id).strip()
+    return ensure_default_site(ModelService(), TtlService())
+
+
+def _fdd_summary(*, site_id: str) -> dict[str, Any]:
+    doc = load_results()
+    runs = [r for r in doc.get("runs", []) if isinstance(r, dict)]
+    site_runs = [r for r in runs if str(r.get("site_id") or "") in {"", site_id}]
+    flagged = [r for r in site_runs if int(r.get("flagged") or 0) > 0]
+    errors = [r for r in site_runs if r.get("status") == "error"]
+    tuning_candidates: list[dict[str, Any]] = []
+    for run in flagged:
+        rows = int(run.get("rows") or 0)
+        flagged_n = int(run.get("flagged") or 0)
+        if rows <= 0:
+            continue
+        pct = round(100.0 * flagged_n / rows, 1)
+        if pct >= 85.0:
+            tuning_candidates.append(
+                {
+                    "rule_id": run.get("rule_id"),
+                    "rule_name": run.get("rule_name"),
+                    "flagged_pct": pct,
+                    "fault_code": run.get("fault_code"),
+                    "analytics": run.get("analytics"),
+                    "hint": "High flag rate — review bounds before auto-tune",
+                }
+            )
+    return {
+        "generated_at": doc.get("generated_at"),
+        "runs_total": len(site_runs),
+        "runs_flagged": len(flagged),
+        "runs_error": len(errors),
+        "tuning_candidates": tuning_candidates[:12],
+        "recent_flagged": flagged[:8],
+        "recent_errors": errors[:6],
+    }
+
+
+def _actions_from_snapshot(
+    *,
+    throughput: dict[str, Any],
+    building: dict[str, Any],
+    ops: dict[str, Any],
+    fdd: dict[str, Any],
+    auto_tune: bool,
+) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    keepup = throughput.get("keepup_ratio")
+    if throughput.get("status") in {"lagging", "error"}:
+        actions.append(
+            {
+                "kind": "poll_degraded",
+                "severity": "critical" if throughput.get("status") == "error" else "warning",
+                "detail": f"Poll keepup_ratio={keepup} status={throughput.get('status')}",
+            }
+        )
+    if (ops.get("summary") or {}).get("has_bridge_errors"):
+        actions.append(
+            {
+                "kind": "bridge_errors",
+                "severity": "warning",
+                "detail": f"bridge_error_count={(ops.get('summary') or {}).get('bridge_error_count')}",
+            }
+        )
+    for cand in fdd.get("tuning_candidates") or []:
+        actions.append(
+            {
+                "kind": "rule_tune_review",
+                "severity": "info",
+                "rule_id": cand.get("rule_id"),
+                "detail": f"{cand.get('rule_name')} flagged {cand.get('flagged_pct')}%",
+                "auto_tune_eligible": bool(auto_tune and (keepup is None or keepup >= 0.85)),
+            }
+        )
+    alert_n = len(building.get("alerts") or [])
+    if alert_n:
+        actions.append({"kind": "active_alerts", "severity": "info", "detail": f"{alert_n} alert(s) on check-engine"})
+    return actions
+
+
+def run_checkin(
+    *,
+    site_id: str | None = None,
+    run_fdd_batch: bool = True,
+    write_memory: bool = True,
+    window_minutes: int = 60,
+) -> dict[str, Any]:
+    """Single building check-in cycle (callable from REST or cron)."""
+    sid = _resolve_site_id(site_id)
+    auto_tune = os.environ.get("OFDD_AGENT_AUTO_TUNE", "").strip().lower() in {"1", "true", "yes"}
+
+    batch_result: dict[str, Any] | None = None
+    if run_fdd_batch:
+        try:
+            batch_result = run_batch(limit=500)
+        except Exception as exc:  # noqa: BLE001
+            batch_result = {"ok": False, "error": str(exc)[:500]}
+
+    throughput = compute_poll_throughput(window_minutes=window_minutes)
+    building = collect_status()
+    poll_health = get_device_poll_snapshot(site_id=sid, force=True)
+    ops = collect_ops_logs(tail=100, include_docker=True)
+    fdd = _fdd_summary(site_id=sid)
+    memory = get_site_memory(site_id=sid, kind="memory")
+
+    actions = _actions_from_snapshot(
+        throughput=throughput,
+        building=building,
+        ops=ops,
+        fdd=fdd,
+        auto_tune=auto_tune,
+    )
+
+    summary_parts = [
+        f"Poll {throughput.get('status')} keepup={throughput.get('keepup_ratio')}",
+        f"enabled={throughput.get('enabled_points')} obs/min={throughput.get('observed_samples_per_min')}",
+        f"FDD flagged={fdd.get('runs_flagged')}/{fdd.get('runs_total')}",
+        f"alerts={len(building.get('alerts') or [])}",
+    ]
+    if (ops.get("summary") or {}).get("has_bridge_errors"):
+        summary_parts.append("bridge errors present")
+    summary = "; ".join(summary_parts)
+
+    detail_lines = []
+    for act in actions[:8]:
+        detail_lines.append(f"- [{act.get('severity')}] {act.get('kind')}: {act.get('detail')}")
+    if fdd.get("tuning_candidates"):
+        detail_lines.append("\n**Tuning candidates (human review):**")
+        for c in fdd["tuning_candidates"][:5]:
+            detail_lines.append(f"- {c.get('rule_name')} ({c.get('flagged_pct')}% flagged)")
+
+    memory_result = None
+    if write_memory:
+        memory_result = append_checkin_note(
+            site_id=sid,
+            summary=summary,
+            detail="\n".join(detail_lines),
+        )
+
+    run_doc = {
+        "at": datetime.now(timezone.utc).isoformat(),
+        "site_id": sid,
+        "summary": summary,
+        "throughput_status": throughput.get("status"),
+        "keepup_ratio": throughput.get("keepup_ratio"),
+        "actions_count": len(actions),
+    }
+    state = _load_state()
+    runs = state.setdefault("runs", [])
+    if isinstance(runs, list):
+        runs.append(run_doc)
+        state["runs"] = runs[-48:]
+    state["last_checkin"] = run_doc
+    _save_state(state)
+
+    return {
+        "ok": True,
+        "site_id": sid,
+        "summary": summary,
+        "throughput": throughput,
+        "building_status": {
+            "status": building.get("status"),
+            "traffic": building.get("traffic"),
+            "alert_count": len(building.get("alerts") or []),
+            "fdd_alert_count": building.get("fdd_alert_count"),
+        },
+        "device_poll_health": {
+            "summary_sentence": poll_health.get("summary_sentence"),
+            "healthy_count": poll_health.get("healthy_count"),
+            "offline": (poll_health.get("offline_equipment") or [])[:6],
+            "flaky": (poll_health.get("flaky_equipment") or [])[:6],
+        },
+        "fdd": fdd,
+        "ops_logs_summary": ops.get("summary"),
+        "actions": actions,
+        "batch": batch_result,
+        "memory": memory_result,
+        "auto_tune_enabled": auto_tune,
+        "checkin_state_path": str(_state_path()),
+    }
+
+
+def get_checkin_status() -> dict[str, Any]:
+    state = _load_state()
+    return {"ok": True, **state}

--- a/workspace/api/openfdd_bridge/main.py
+++ b/workspace/api/openfdd_bridge/main.py
@@ -15,16 +15,20 @@ from .security_headers import SecurityHeadersMiddleware
 from .static_files import CachedStaticFiles
 from .routes import (
     agent_routes,
+    analytics_routes,
     audit_routes,
     auth_routes,
     bacnet_routes,
+    building_agent_routes,
     building_routes,
+    fdd_routes,
     faults_routes,
     health,
     host_routes,
     json_api_routes,
     modbus_routes,
     model_routes,
+    ops_routes,
     playground_routes,
     rules_routes,
     sites_routes,
@@ -81,6 +85,10 @@ def create_app() -> FastAPI:
     app.include_router(model_routes.router)
     app.include_router(timeseries_routes.router)
     app.include_router(building_routes.router)
+    app.include_router(building_agent_routes.router)
+    app.include_router(analytics_routes.router)
+    app.include_router(fdd_routes.router)
+    app.include_router(ops_routes.router)
     app.include_router(faults_routes.router)
     app.include_router(sites_routes.router)
     app.include_router(bacnet_routes.router)

--- a/workspace/api/openfdd_bridge/ops_logs.py
+++ b/workspace/api/openfdd_bridge/ops_logs.py
@@ -1,0 +1,143 @@
+"""Operational log tail — bridge error/audit JSONL + optional Docker Compose services."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .audit import audit_log_path, error_log_path, tail_jsonl
+
+_ALLOWED_SERVICES = frozenset({"bridge", "commission", "mcp-rag", "ollama", "caddy"})
+_ERROR_PAT = re.compile(
+    r"(error|exception|traceback|failed|fatal|panic|crit)",
+    re.IGNORECASE,
+)
+
+
+def _compose_dir() -> Path | None:
+    raw = os.environ.get("OFDD_OPS_DOCKER_COMPOSE_DIR", "").strip()
+    if raw:
+        p = Path(raw)
+        return p if p.is_dir() else None
+    for candidate in (
+        Path("/host/open-fdd"),
+        Path.home() / "open-fdd",
+    ):
+        if (candidate / "docker-compose.yml").is_file():
+            return candidate
+    return None
+
+
+def _docker_available() -> bool:
+    if os.environ.get("OFDD_OPS_DOCKER_DISABLED", "").strip().lower() in {"1", "true", "yes"}:
+        return False
+    try:
+        proc = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=8,
+            check=False,
+        )
+        return proc.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _tail_compose_logs(*, service: str, tail: int) -> dict[str, Any]:
+    compose_dir = _compose_dir()
+    if compose_dir is None:
+        return {"available": False, "reason": "compose dir not found (set OFDD_OPS_DOCKER_COMPOSE_DIR)"}
+    if not _docker_available():
+        return {"available": False, "reason": "docker CLI unavailable in bridge container"}
+    svc = service if service in _ALLOWED_SERVICES else "bridge"
+    cmd = [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_dir / "docker-compose.yml"),
+        "logs",
+        "--no-color",
+        "--tail",
+        str(max(10, min(tail, 500))),
+        svc,
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(compose_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"available": False, "reason": str(exc)[:200]}
+    lines = (proc.stdout or "").splitlines()
+    error_lines = [ln for ln in lines if _ERROR_PAT.search(ln)]
+    return {
+        "available": True,
+        "service": svc,
+        "exit_code": proc.returncode,
+        "line_count": len(lines),
+        "error_line_count": len(error_lines),
+        "lines": lines[-tail:],
+        "error_lines": error_lines[:40],
+        "compose_dir": str(compose_dir),
+    }
+
+
+def collect_ops_logs(
+    *,
+    tail: int = 80,
+    service: str = "bridge",
+    include_audit: bool = True,
+    include_errors: bool = True,
+    include_docker: bool = True,
+) -> dict[str, Any]:
+    """Aggregate log tails for remote agent triage (Tailscale API, no SSH)."""
+    tail = max(10, min(int(tail), 500))
+    out: dict[str, Any] = {"ok": True, "tail": tail}
+
+    if include_errors:
+        err_rows = tail_jsonl(error_log_path(), limit=tail)
+        out["bridge_errors"] = {
+            "path": str(error_log_path()),
+            "count": len(err_rows),
+            "events": err_rows,
+            "severity_error_count": sum(
+                1 for e in err_rows if str(e.get("severity") or "").lower() in {"error", "critical"}
+            ),
+        }
+
+    if include_audit:
+        audit_rows = tail_jsonl(audit_log_path(), limit=min(tail, 200))
+        agent_events = [
+            e
+            for e in audit_rows
+            if str(e.get("event_type") or "") in {"agent.tool", "api.error"}
+            or str(e.get("outcome") or "") == "failure"
+        ]
+        out["bridge_audit"] = {
+            "path": str(audit_log_path()),
+            "count": len(audit_rows),
+            "agent_or_failure_count": len(agent_events),
+            "recent": agent_events[:30],
+        }
+
+    if include_docker:
+        out["docker_compose"] = _tail_compose_logs(service=service, tail=tail)
+
+    err_n = int((out.get("bridge_errors") or {}).get("severity_error_count") or 0)
+    docker_err = int((out.get("docker_compose") or {}).get("error_line_count") or 0)
+    out["summary"] = {
+        "has_bridge_errors": err_n > 0,
+        "bridge_error_count": err_n,
+        "docker_error_lines": docker_err,
+        "healthy": err_n == 0 and docker_err == 0,
+    }
+    return out

--- a/workspace/api/openfdd_bridge/poll_throughput.py
+++ b/workspace/api/openfdd_bridge/poll_throughput.py
@@ -1,0 +1,199 @@
+"""BACnet poll throughput — expected vs observed samples per minute."""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+
+from .bacnet_driver_store import driver_tree
+from .commission_client import commission_poll_status
+from .paths import bacnet_poll_csv, data_dir
+
+DEFAULT_WINDOW_MIN = 60
+MIN_WINDOW_MIN = 5
+MAX_WINDOW_MIN = 180
+
+
+def _window_minutes(raw: int | None) -> int:
+    if raw is None:
+        return DEFAULT_WINDOW_MIN
+    return max(MIN_WINDOW_MIN, min(int(raw), MAX_WINDOW_MIN))
+
+
+def _poll_csv_samples_in_window(*, window_min: int) -> dict[str, Any]:
+    path = bacnet_poll_csv()
+    if not path.is_file() or path.stat().st_size == 0:
+        return {
+            "csv_present": False,
+            "rows_in_window": 0,
+            "unique_points_in_window": 0,
+            "observed_samples_per_min": 0.0,
+            "window_minutes": window_min,
+        }
+    try:
+        df = pd.read_csv(path, usecols=["timestamp_utc", "point_id"], low_memory=False)
+    except (ValueError, pd.errors.EmptyDataError, OSError):
+        return {
+            "csv_present": True,
+            "rows_in_window": 0,
+            "unique_points_in_window": 0,
+            "observed_samples_per_min": 0.0,
+            "window_minutes": window_min,
+            "parse_error": True,
+        }
+    if df.empty or "timestamp_utc" not in df.columns:
+        return {
+            "csv_present": True,
+            "rows_in_window": 0,
+            "unique_points_in_window": 0,
+            "observed_samples_per_min": 0.0,
+            "window_minutes": window_min,
+        }
+    ts = pd.to_datetime(df["timestamp_utc"], utc=True, errors="coerce")
+    cutoff = pd.Timestamp.now(tz="UTC") - pd.Timedelta(minutes=window_min)
+    mask = ts >= cutoff
+    window_df = df.loc[mask]
+    rows = int(len(window_df))
+    unique_pts = int(window_df["point_id"].nunique()) if "point_id" in window_df.columns else 0
+    rate = round(rows / max(window_min, 1), 2)
+    return {
+        "csv_present": True,
+        "rows_in_window": rows,
+        "unique_points_in_window": unique_pts,
+        "observed_samples_per_min": rate,
+        "window_minutes": window_min,
+        "csv_mtime_age_s": round(time.time() - path.stat().st_mtime, 1),
+    }
+
+
+def _ingest_lag_s() -> float | None:
+    path = data_dir() / "bacnet_ingest_state.json"
+    if not path.is_file():
+        return None
+    try:
+        import json
+
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        at = str(raw.get("last_ingest_at") or raw.get("last_timestamp_utc") or "").strip()
+        if not at:
+            return None
+        ts = datetime.fromisoformat(at.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return max(0.0, (datetime.now(timezone.utc) - ts).total_seconds())
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _enabled_points_from_tree() -> list[dict[str, Any]]:
+    tree = driver_tree()
+    points: list[dict[str, Any]] = []
+    for dev in tree.get("devices") or []:
+        if not isinstance(dev, dict):
+            continue
+        for pt in dev.get("points") or []:
+            if not isinstance(pt, dict) or not pt.get("enabled"):
+                continue
+            try:
+                interval = int(pt.get("poll_interval_s") or 60)
+            except (TypeError, ValueError):
+                interval = 60
+            points.append(
+                {
+                    "point_id": str(pt.get("point_id") or ""),
+                    "poll_interval_s": max(60, interval),
+                    "device_instance": str(dev.get("device_instance") or ""),
+                }
+            )
+    return points
+
+
+def compute_poll_throughput(*, window_minutes: int | None = None) -> dict[str, Any]:
+    """Summarize BACnet poll duty vs observed CSV ingest rate.
+
+    Note: the commission poll loop sleeps ``min(poll_interval_s)`` and RPM-polls
+    **all** enabled points each cycle. Per-point intervals are configuration labels
+    until per-point scheduling lands; ``cycle_model`` documents that behavior.
+    """
+    window_min = _window_minutes(window_minutes)
+    enabled = _enabled_points_from_tree()
+    enabled_n = len(enabled)
+
+    by_interval: dict[int, int] = {}
+    configured_duty_per_min = 0.0
+    for pt in enabled:
+        iv = int(pt["poll_interval_s"])
+        by_interval[iv] = by_interval.get(iv, 0) + 1
+        configured_duty_per_min += 60.0 / iv
+
+    cycle_interval_s = 60.0
+    if by_interval:
+        cycle_interval_s = float(min(by_interval.keys()))
+    cycles_per_min = 60.0 / max(cycle_interval_s, 15.0)
+    expected_all_polled_per_min = round(enabled_n * cycles_per_min, 2)
+
+    code, poll_payload = commission_poll_status()
+    live: dict[str, Any] = {}
+    if code == 200 and isinstance(poll_payload, dict):
+        live = {
+            "enabled_points": int(poll_payload.get("enabled_points") or enabled_n),
+            "last_cycle_samples": int(poll_payload.get("samples") or 0),
+            "last_poll_at": str(poll_payload.get("at") or ""),
+            "last_poll_error": str(poll_payload.get("error") or "").strip(),
+            "commission_interval_s": float(poll_payload.get("interval_s") or cycle_interval_s),
+        }
+
+    observed = _poll_csv_samples_in_window(window_min=window_min)
+    ingest_lag = _ingest_lag_s()
+
+    expected = expected_all_polled_per_min
+    observed_rate = float(observed.get("observed_samples_per_min") or 0.0)
+    keepup_ratio = round(observed_rate / expected, 3) if expected > 0 else None
+
+    status = "unknown"
+    if enabled_n == 0:
+        status = "idle"
+    elif live.get("last_poll_error"):
+        status = "error"
+    elif keepup_ratio is not None:
+        if keepup_ratio >= 0.85:
+            status = "healthy"
+        elif keepup_ratio >= 0.5:
+            status = "degraded"
+        else:
+            status = "lagging"
+    elif observed_rate > 0:
+        status = "warming"
+
+    notes = [
+        "Poll loop RPMs all enabled points each cycle; sleep uses minimum configured interval.",
+        "configured_duty_per_min sums 60/interval per point (ideal per-point scheduling).",
+        "expected_all_polled_per_min matches current driver: enabled_points × cycles_per_min.",
+    ]
+
+    return {
+        "ok": True,
+        "status": status,
+        "window_minutes": window_min,
+        "enabled_points": enabled_n,
+        "cycle_interval_s": cycle_interval_s,
+        "cycles_per_min": round(cycles_per_min, 3),
+        "configured_duty_per_min": round(configured_duty_per_min, 2),
+        "expected_all_polled_per_min": expected_all_polled_per_min,
+        "observed_samples_per_min": observed_rate,
+        "keepup_ratio": keepup_ratio,
+        "interval_buckets": [
+            {"poll_interval_s": iv, "points": n, "duty_per_min": round(n * 60.0 / iv, 2)}
+            for iv, n in sorted(by_interval.items())
+        ],
+        "live_poll": live,
+        "observed": observed,
+        "ingest_lag_s": round(ingest_lag, 1) if ingest_lag is not None else None,
+        "cycle_model": "all_enabled_each_cycle",
+        "notes": notes,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/workspace/api/openfdd_bridge/routes/analytics_routes.py
+++ b/workspace/api/openfdd_bridge/routes/analytics_routes.py
@@ -1,0 +1,21 @@
+"""Operational analytics — poll throughput and ingest health."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from ..deps import require_roles
+from ..poll_throughput import compute_poll_throughput
+
+router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+
+_AGENT = Depends(require_roles("integrator", "agent", "operator"))
+
+
+@router.get("/poll-throughput")
+def poll_throughput(
+    window_minutes: int = Query(default=60, ge=5, le=180),
+    _user: dict = _AGENT,
+) -> dict:
+    """Expected vs observed BACnet samples/minute (mixed poll intervals documented)."""
+    return compute_poll_throughput(window_minutes=window_minutes)

--- a/workspace/api/openfdd_bridge/routes/building_agent_routes.py
+++ b/workspace/api/openfdd_bridge/routes/building_agent_routes.py
@@ -1,0 +1,54 @@
+"""Building agent check-in — scheduled FDD/poll/memory loop."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+
+from ..building_agent import get_checkin_status, run_checkin
+from ..deps import require_roles
+
+router = APIRouter(prefix="/api/building-agent", tags=["building-agent"])
+
+_AGENT = Depends(require_roles("integrator", "agent"))
+
+
+class CheckinBody(BaseModel):
+    site_id: str | None = None
+    run_fdd_batch: bool = True
+    write_memory: bool = True
+    window_minutes: int = Field(default=60, ge=5, le=180)
+
+
+@router.post("/checkin")
+def building_agent_checkin(body: CheckinBody, _user: dict = _AGENT) -> dict:
+    """Run one check-in: poll throughput, faults, logs, optional FDD batch, memory append."""
+    return run_checkin(
+        site_id=body.site_id,
+        run_fdd_batch=body.run_fdd_batch,
+        write_memory=body.write_memory,
+        window_minutes=body.window_minutes,
+    )
+
+
+@router.get("/status")
+def building_agent_status(_user: dict = _AGENT) -> dict:
+    """Last check-in runs persisted under data/building_agent_checkin.json."""
+    return get_checkin_status()
+
+
+@router.get("/checkin")
+def building_agent_checkin_get(
+    site_id: str | None = Query(default=None),
+    run_fdd_batch: bool = Query(default=False),
+    write_memory: bool = Query(default=True),
+    window_minutes: int = Query(default=60, ge=5, le=180),
+    _user: dict = _AGENT,
+) -> dict:
+    """Idempotent GET check-in for simple cron wget/curl (batch off by default)."""
+    return run_checkin(
+        site_id=site_id,
+        run_fdd_batch=run_fdd_batch,
+        write_memory=write_memory,
+        window_minutes=window_minutes,
+    )

--- a/workspace/api/openfdd_bridge/routes/fdd_routes.py
+++ b/workspace/api/openfdd_bridge/routes/fdd_routes.py
@@ -1,0 +1,40 @@
+"""FDD batch results API for rule tuning analytics."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from ..deps import require_roles
+from ..fdd_results import load_results
+
+router = APIRouter(prefix="/api/fdd", tags=["fdd"])
+
+_AGENT = Depends(require_roles("integrator", "agent"))
+
+
+@router.get("/results")
+def fdd_results(
+    site_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    _user: dict = _AGENT,
+) -> dict:
+    """Latest FDD batch runs with per-rule analytics (tuning feedback)."""
+    doc = load_results()
+    runs = [r for r in doc.get("runs", []) if isinstance(r, dict)]
+    if site_id:
+        sid = site_id.strip()
+        runs = [r for r in runs if str(r.get("site_id") or "") in {"", sid}]
+    runs = runs[-limit:]
+    flagged = sum(1 for r in runs if int(r.get("flagged") or 0) > 0)
+    errors = sum(1 for r in runs if r.get("status") == "error")
+    return {
+        "ok": True,
+        "generated_at": doc.get("generated_at"),
+        "site_id": site_id,
+        "runs": runs,
+        "summary": {
+            "runs": len(runs),
+            "flagged": flagged,
+            "errors": errors,
+        },
+    }

--- a/workspace/api/openfdd_bridge/routes/ops_routes.py
+++ b/workspace/api/openfdd_bridge/routes/ops_routes.py
@@ -1,0 +1,31 @@
+"""Operational logs for remote agent triage (no SSH)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from ..deps import require_roles
+from ..ops_logs import collect_ops_logs
+
+router = APIRouter(prefix="/api/ops", tags=["ops"])
+
+_AGENT = Depends(require_roles("integrator", "agent"))
+
+
+@router.get("/logs")
+def ops_logs(
+    tail: int = Query(default=80, ge=10, le=500),
+    service: str = Query(default="bridge"),
+    include_audit: bool = Query(default=True),
+    include_errors: bool = Query(default=True),
+    include_docker: bool = Query(default=True),
+    _user: dict = _AGENT,
+) -> dict:
+    """Tail bridge error/audit JSONL and optional docker compose service logs."""
+    return collect_ops_logs(
+        tail=tail,
+        service=service,
+        include_audit=include_audit,
+        include_errors=include_errors,
+        include_docker=include_docker,
+    )

--- a/workspace/api/openfdd_bridge/routes/sites_routes.py
+++ b/workspace/api/openfdd_bridge/routes/sites_routes.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
 
 from ..data_loader import load_demo_dataframe, records_from_dataframe
-from ..deps import require_user
+from ..deps import require_roles, require_user
 from ..model_sparql import list_model_sites
 from ..model_service import ModelService
 from ..site_defaults import ensure_default_site
+from ..site_memory import get_site_memory, put_site_memory
 from ..ttl_service import TtlService
 
 router = APIRouter(prefix="/api/sites", tags=["sites"], dependencies=[Depends(require_user)])
+
+_AGENT_WRITE = Depends(require_roles("integrator", "agent"))
+
+
+class SiteMemoryBody(BaseModel):
+    content: str = ""
+    mode: str = Field(default="replace", pattern="^(replace|append)$")
 
 MAX_FRAME_LIMIT = 500
 DEFAULT_FRAME_LIMIT = 200
@@ -34,3 +43,34 @@ def site_frame(site_id: str, limit: int = DEFAULT_FRAME_LIMIT) -> dict:
     safe_limit = max(1, min(int(limit), MAX_FRAME_LIMIT))
     df = load_demo_dataframe(site_id)
     return {"site_id": site_id, "records": records_from_dataframe(df, limit=safe_limit)}
+
+
+@router.get("/{site_id}/memory")
+def site_memory_get(site_id: str, kind: str = "memory") -> dict:
+    """Per-building MEMORY.md (kind=memory) or SKILLS.md (kind=skills)."""
+    if kind not in {"memory", "skills"}:
+        raise HTTPException(status_code=400, detail="kind must be memory or skills")
+    try:
+        return get_site_memory(site_id=site_id, kind=kind)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.put("/{site_id}/memory")
+def site_memory_put(
+    site_id: str,
+    body: SiteMemoryBody,
+    kind: str = "memory",
+    _user: dict = _AGENT_WRITE,
+) -> dict:
+    if kind not in {"memory", "skills"}:
+        raise HTTPException(status_code=400, detail="kind must be memory or skills")
+    try:
+        return put_site_memory(
+            site_id=site_id,
+            content=body.content,
+            kind=kind,
+            mode=body.mode,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/workspace/api/openfdd_bridge/site_memory.py
+++ b/workspace/api/openfdd_bridge/site_memory.py
@@ -1,0 +1,149 @@
+"""Per-building MEMORY.md and SKILLS.md under workspace/memory/sites/."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .paths import workspace_dir
+
+_SAFE_SITE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$")
+_MAX_BODY_CHARS = 200_000
+
+
+def _sites_root() -> Path:
+    root = workspace_dir() / "memory" / "sites"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def validate_site_id(site_id: str) -> str:
+    sid = (site_id or "").strip()
+    if not sid or not _SAFE_SITE.match(sid):
+        raise ValueError(f"invalid site_id: {site_id!r}")
+    return sid
+
+
+def site_memory_path(site_id: str) -> Path:
+    sid = validate_site_id(site_id)
+    return _sites_root() / f"{sid}.md"
+
+
+def site_skills_path(site_id: str) -> Path:
+    sid = validate_site_id(site_id)
+    d = _sites_root() / sid
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "SKILLS.md"
+
+
+def _read_file(path: Path) -> str:
+    if not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _write_file(path: Path, text: str) -> None:
+    if len(text) > _MAX_BODY_CHARS:
+        raise ValueError(f"content exceeds {_MAX_BODY_CHARS} characters")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _default_memory(site_id: str) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return (
+        f"# Site memory — {site_id}\n\n"
+        f"Curated facts for building-agent check-ins. Promote stable decisions here; "
+        f"append session detail to daily notes under `memory/`.\n\n"
+        f"## Last updated\n\n{now}\n\n"
+        "## BACnet / polling\n\n"
+        "## FDD rules / tuning\n\n"
+        "## Open loops\n\n"
+    )
+
+
+def _default_skills(site_id: str) -> str:
+    return (
+        f"# Site skills — {site_id}\n\n"
+        "Operator-approved playbooks for this building. The building agent reads this "
+        "before auto-tuning or escalating.\n\n"
+        "## Check-in cadence\n\n"
+        "- Early commissioning: every 6h (21600s cron job)\n"
+        "- Stable ops target: daily → every other day → weekly\n\n"
+        "## Tuning guardrails\n\n"
+        "- Do not change rule thresholds when poll keepup_ratio < 0.85\n"
+        "- Human in the loop for any write to rule config\n"
+        "- Prefer `bounds_low` / `bounds_high` tweaks over disabling rules\n\n"
+        "## Escalation\n\n"
+        "- Critical poll offline → building alerts + memory note only (no auto-tune)\n"
+    )
+
+
+def get_site_memory(*, site_id: str, kind: str = "memory") -> dict[str, Any]:
+    sid = validate_site_id(site_id)
+    if kind == "skills":
+        path = site_skills_path(sid)
+        default = _default_skills(sid)
+    else:
+        path = site_memory_path(sid)
+        default = _default_memory(sid)
+    exists = path.is_file()
+    text = _read_file(path) if exists else default
+    return {
+        "ok": True,
+        "site_id": sid,
+        "kind": kind,
+        "path": str(path),
+        "exists": exists,
+        "bytes": len(text.encode("utf-8")),
+        "content": text,
+        "updated_at": datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+        if exists
+        else None,
+    }
+
+
+def put_site_memory(
+    *,
+    site_id: str,
+    content: str,
+    kind: str = "memory",
+    mode: str = "replace",
+) -> dict[str, Any]:
+    sid = validate_site_id(site_id)
+    if kind == "skills":
+        path = site_skills_path(sid)
+    else:
+        path = site_memory_path(sid)
+    text = str(content or "")
+    if mode == "append":
+        existing = _read_file(path)
+        sep = "\n\n" if existing and not existing.endswith("\n") else "\n"
+        text = existing + sep + text
+    elif mode != "replace":
+        raise ValueError(f"unsupported mode: {mode}")
+    _write_file(path, text)
+    return {
+        "ok": True,
+        "site_id": sid,
+        "kind": kind,
+        "path": str(path),
+        "bytes": len(text.encode("utf-8")),
+        "mode": mode,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def append_checkin_note(*, site_id: str, summary: str, detail: str = "") -> dict[str, Any]:
+    """Append a dated block to site MEMORY.md (building agent check-ins)."""
+    sid = validate_site_id(site_id)
+    path = site_memory_path(sid)
+    if not path.is_file():
+        _write_file(path, _default_memory(sid))
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    block = f"## Check-in {stamp}\n\n{summary.strip()}\n"
+    if detail.strip():
+        block += f"\n{detail.strip()}\n"
+    return put_site_memory(site_id=sid, content=block, kind="memory", mode="append")


### PR DESCRIPTION
## Summary
- Add REST APIs for remote building-agent monitoring without SSH: poll throughput (`/api/analytics/poll-throughput`), FDD batch results (`/api/fdd/results`), ops log tail (`/api/ops/logs`), per-site MEMORY/SKILLS (`/api/sites/{id}/memory`), and check-in (`/api/building-agent/checkin`).
- Wire agent tools (`building.checkin`, `analytics.poll_throughput`, `fdd.results`, `ops.logs`, `site.memory_*`) and a `scripts/building_agent_checkin.py` CLI for Tailscale/LAN cron.
- Extend `post_deploy_check` / `acme_operational_verify` probes for the new surface. Bump version to **3.0.8**.

## Test plan
- [x] `pytest tests/workspace_bridge/test_building_agent_api.py`
- [x] `pytest tests/workspace_bridge/test_agent_tools.py`
- [ ] CI green + CodeRabbit review
- [ ] GHCR publish `open-fdd-v3.0.8`
- [ ] Acme upgrade + `post_deploy_check --full`
- [ ] `building_agent_checkin.py` against Acme Tailscale IP
- [ ] Copy `scripts/building_agent_jobs.json.example` → edge `workspace/cron/jobs.json` (6h cadence)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added building agent check-in API for remote diagnostics and health verification.
  * Added CLI tool and cron job scheduling support for automated check-ins.
  * Added poll throughput analytics endpoint to monitor BACnet polling performance.
  * Added FDD results retrieval endpoint for remote diagnostics.
  * Added operational logs collection endpoint for troubleshooting.
  * Added per-site memory storage for managing site-specific context.

* **Bug Fixes**
  * Enhanced post-deployment verification to exclude additional benign log patterns.

* **Tests**
  * Added comprehensive test coverage for building agent APIs.

* **Chores**
  * Version bumped to 3.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->