### PR TITLE
3.0.9 — FDD tuning brief + script runner + assignments fix

### DIFF
--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -213,7 +213,8 @@ for path in \
 done
 
 log_info "Building agent check-in (no FDD batch — smoke)"
-api_post_status "/api/building-agent/checkin" '{"run_fdd_batch":false,"write_memory":true,"window_minutes":30}'
+CHECKIN_BODY="$(python3 -c 'import json; print(json.dumps({"run_fdd_batch": False, "write_memory": True, "window_minutes": 30, "site_id": "acme"}))')"
+api_post_status "/api/building-agent/checkin" "$CHECKIN_BODY"
 if [[ "${API_POST_STATUS:-000}" == "200" ]]; then
   log_ok "POST /api/building-agent/checkin HTTP 200"
 else

--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -202,7 +202,8 @@ for path in \
   "/api/analytics/poll-throughput?window_minutes=30" \
   "/api/fdd/results?limit=5" \
   "/api/ops/logs?tail=40&include_docker=false" \
-  "/api/building-agent/status"; do
+  "/api/building-agent/status" \
+  "/api/building-agent/tuning-brief?window_minutes=30"; do
   code="$(curl -sS --connect-timeout 15 --max-time 120 -o /dev/null -w "%{http_code}" \
     -H "Authorization: Bearer ${TOKEN}" "${BASE}${path}" 2>/dev/null || echo 000)"
   if [[ "$code" == "200" ]]; then

--- a/infra/ansible/scripts/http_probes.py
+++ b/infra/ansible/scripts/http_probes.py
@@ -249,6 +249,7 @@ def check_building_agent_api(base: str, token: str, *, site_id: str = "demo") ->
         ("/api/fdd/results?limit=5", "fdd_results_status"),
         ("/api/ops/logs?tail=30&include_docker=false", "ops_logs_status"),
         ("/api/building-agent/status", "building_agent_status"),
+        ("/api/building-agent/tuning-brief?window_minutes=30", "building_agent_tuning_brief"),
     ):
         url = f"{root}{path}"
         try:
@@ -895,7 +896,15 @@ def check_fdd_operational(
         try:
             payload = json.loads(body)
             out["assignment_point_rows"] = len(payload.get("points") or [])
+            out["assignment_rule_rows"] = len(payload.get("assignment_rows") or [])
             out["assignment_device_count"] = len(payload.get("devices") or [])
+            bound_pts = sum(1 for p in (payload.get("points") or []) if (p.get("bound_rules") or []))
+            out["assignment_bound_point_rows"] = bound_pts
+            if out.get("rules_binding_refs", 0) > 0 and bound_pts == 0 and out["assignment_point_rows"] == 0:
+                out["warnings"].append(
+                    "assignments API returned 0 point rows but rules have bindings — "
+                    "check model point site_id inference"
+                )
         except json.JSONDecodeError:
             out["warnings"].append("/api/rules/assignments not JSON")
 

--- a/infra/ansible/scripts/post_deploy_check.sh
+++ b/infra/ansible/scripts/post_deploy_check.sh
@@ -356,7 +356,7 @@ elif [[ "$INVENTORY_DOCKER_STACK" == "1" ]]; then
         log_fail "Docker service ${svc}: no running container"
         continue
       fi
-      err_lines="$(ssh_remote "docker logs --tail 80 \"${cid}\" 2>&1 | grep -Ei 'ERROR|Traceback|CRITICAL' | grep -v '404 Not Found' | grep -v 'unknown-property' | grep -v 'read-property-multiple' | grep -v 'Connection reset by peer' | tail -5 || true")" || err_lines=""
+      err_lines="$(ssh_remote "docker logs --tail 80 \"${cid}\" 2>&1 | grep -Ei 'ERROR|Traceback|CRITICAL' | grep -v '404 Not Found' | grep -v 'unknown-property' | grep -v 'read-property-multiple' | grep -v 'Connection reset by peer' | grep -v 'CancelledError' | grep -v 'KeyboardInterrupt' | grep -v 'asyncio.exceptions' | tail -5 || true")" || err_lines=""
       if [[ -n "$err_lines" ]]; then
         log_fail "Docker ${svc} (${cid:0:12}) log errors: ${err_lines}"
       else

--- a/infra/ansible/tasks/post_deploy_check.yml
+++ b/infra/ansible/tasks/post_deploy_check.yml
@@ -92,6 +92,8 @@
         | grep -v 'unknown-property' \
         | grep -v 'read-property-multiple' \
         | grep -v 'CancelledError' \
+        | grep -v 'KeyboardInterrupt' \
+        | grep -v 'asyncio.exceptions' \
         | grep -v 'Cannot assign requested address' \
         | grep -v "has no attribute 'server'" \
         | tail -5 || true)"

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.8"
+__version__ = "3.0.9"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.8"
+version = "3.0.9"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/workspace_bridge/test_fdd_tuning.py
+++ b/tests/workspace_bridge/test_fdd_tuning.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+API_ROOT = Path(__file__).resolve().parents[2] / "workspace" / "api"
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+
+def test_build_assignments_infers_site_from_equipment():
+    from openfdd_bridge.rule_bindings import build_assignments_view
+
+    model = {
+        "sites": [{"id": "acme", "name": "Acme"}],
+        "equipment": [{"id": "rtu-01", "site_id": "acme", "name": "RTU-01"}],
+        "points": [
+            {
+                "id": "1100-analog-output-1",
+                "equipment_id": "rtu-01",
+                "name": "Fan CMD",
+                "bacnet_device_id": 1100,
+            }
+        ],
+    }
+    rules = [
+        {
+            "id": "r1",
+            "name": "run hours",
+            "enabled": True,
+            "bindings": {"point_ids": ["1100-analog-output-1"]},
+        }
+    ]
+    view = build_assignments_view(model, rules, site_id="acme")
+    assert len(view["points"]) == 1
+    assert view["points"][0]["bound_rules"][0]["rule_id"] == "r1"
+
+
+def test_fdd_runner_script_error_uses_table_rows(monkeypatch: pytest.MonkeyPatch):
+    import pyarrow as pa
+
+    from openfdd_bridge import fdd_runner
+
+    table = pa.table({"timestamp": [1, 2, 3], "SAT": [70.0, 71.0, 72.0]})
+    monkeypatch.setattr(
+        "openfdd_bridge.playground.run_arrow_script",
+        lambda *_a, **_k: {"ok": False, "error": "script blew up"},
+    )
+    rule = {
+        "id": "script-err",
+        "name": "Script err",
+        "mode": "script",
+        "code": "out = {}",
+        "config": {},
+        "enabled": True,
+    }
+    run = fdd_runner._run_one(  # noqa: SLF001
+        rule,
+        "acme",
+        limit=10,
+        model={"sites": [{"id": "acme"}]},
+        frame=table,
+    )
+    assert run["status"] == "error"
+    assert run["rows"] == 3
+    assert "df" not in run["error"]
+
+
+def test_tuning_brief_endpoint(agent_client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    import os
+
+    from openfdd_bridge import fdd_results as fr
+
+    doc = {
+        "version": 1,
+        "generated_at": "2026-06-01T00:00:00Z",
+        "runs": [
+            {
+                "rule_id": "acme-zn-t-oob",
+                "rule_name": "Zone OOB",
+                "site_id": "acme",
+                "status": "ok",
+                "rows": 24,
+                "flagged": 22,
+                "fault_code": "VAV-C",
+            },
+            {
+                "rule_id": "acme-ahu-run-hours",
+                "rule_name": "Run hours",
+                "site_id": "acme",
+                "status": "error",
+                "rows": 0,
+                "flagged": 0,
+                "error": "name 'df' is not defined",
+            },
+        ],
+    }
+    path = Path(os.environ["OFDD_DESKTOP_DATA_DIR"]) / "fdd_results.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    monkeypatch.setattr(fr, "fdd_results_path", lambda: path)
+    monkeypatch.setattr(
+        "openfdd_bridge.fdd_tuning.compute_poll_throughput",
+        lambda **_: {"ok": True, "status": "healthy", "keepup_ratio": 0.95, "enabled_points": 10},
+    )
+    r = agent_client.get("/api/building-agent/tuning-brief?site_id=acme")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["poll_ready_for_tuning"] is True
+    kinds = {x["kind"] for x in body["recommendations"]}
+    assert "rule_error" in kinds
+    assert "threshold_review" in kinds

--- a/workspace/api/openfdd_bridge/agent_tools.py
+++ b/workspace/api/openfdd_bridge/agent_tools.py
@@ -35,6 +35,7 @@ from .brick_model_context import (
 from .fault_catalog import all_codes, catalog_graph, entry_for_code, is_valid_code
 from .fault_catalog_scope import build_applicable_payload, validate_scope_with_ollama
 from .building_agent import run_checkin
+from .fdd_tuning import build_tuning_brief
 from .fdd_results import load_results
 from .fdd_runner import run_batch
 from .ops_logs import collect_ops_logs
@@ -402,6 +403,16 @@ def _tool_site_memory_put(args: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _tool_building_tuning_brief(args: dict[str, Any]) -> dict[str, Any]:
+    site_id = str(args.get("site_id") or "").strip() or ensure_default_site(ModelService(), TtlService())
+    window = args.get("window_minutes")
+    try:
+        window_i = int(window) if window is not None else 60
+    except (TypeError, ValueError) as exc:
+        raise ToolError(f"invalid window_minutes: {window!r}") from exc
+    return build_tuning_brief(site_id=site_id, window_minutes=window_i)
+
+
 def _tool_building_checkin(args: dict[str, Any]) -> dict[str, Any]:
     site_id = str(args.get("site_id") or "").strip() or None
     run_batch_flag = str(args.get("run_fdd_batch") or "true").strip().lower() in {"1", "true", "yes"}
@@ -454,6 +465,7 @@ _READ_ONLY_TOOLS = frozenset(
         "building.zone_temps",
         "building.device_health",
         "building.operational_brief",
+        "building.tuning_brief",
         "analytics.poll_throughput",
         "fdd.results",
         "ops.logs",
@@ -471,6 +483,7 @@ _WRITE_TOOLS = frozenset(
         "rules.run_batch",
         "building.set_alerts",
         "building.checkin",
+        "building.tuning_brief",
         "site.memory_put",
         "app.edit_file",
         "app.rebuild_dashboard",
@@ -496,6 +509,7 @@ _TOOLS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "building.device_health": _tool_building_device_health,
     "building.operational_brief": _tool_building_operational_brief,
     "building.checkin": _tool_building_checkin,
+    "building.tuning_brief": _tool_building_tuning_brief,
     "analytics.poll_throughput": _tool_analytics_poll_throughput,
     "fdd.results": _tool_fdd_results,
     "ops.logs": _tool_ops_logs,
@@ -610,6 +624,11 @@ def tool_specs() -> list[dict[str, Any]]:
             "name": "building.checkin",
             "args": ["site_id?", "run_fdd_batch?", "write_memory?", "window_minutes?"],
             "writes": "building_agent_checkin.json + site MEMORY.md append",
+        },
+        {
+            "name": "building.tuning_brief",
+            "args": ["site_id?", "window_minutes?"],
+            "writes": "read-only — FDD tuning queue (errors + threshold reviews)",
         },
         {
             "name": "analytics.poll_throughput",

--- a/workspace/api/openfdd_bridge/building_agent.py
+++ b/workspace/api/openfdd_bridge/building_agent.py
@@ -12,6 +12,7 @@ from .building_status import collect_status
 from .device_poll_health import get_device_poll_snapshot
 from .fdd_results import load_results
 from .fdd_runner import run_batch
+from .fdd_tuning import build_tuning_brief
 from .ops_logs import collect_ops_logs
 from .poll_throughput import compute_poll_throughput
 from .site_defaults import ensure_default_site
@@ -151,6 +152,7 @@ def run_checkin(
     poll_health = get_device_poll_snapshot(site_id=sid, force=True)
     ops = collect_ops_logs(tail=100, include_docker=True)
     fdd = _fdd_summary(site_id=sid)
+    tuning = build_tuning_brief(site_id=sid, window_minutes=window_minutes)
     memory = get_site_memory(site_id=sid, kind="memory")
 
     actions = _actions_from_snapshot(
@@ -174,7 +176,13 @@ def run_checkin(
     detail_lines = []
     for act in actions[:8]:
         detail_lines.append(f"- [{act.get('severity')}] {act.get('kind')}: {act.get('detail')}")
-    if fdd.get("tuning_candidates"):
+    if tuning.get("recommendations"):
+        detail_lines.append("\n**FDD tuning brief:**")
+        for rec in tuning["recommendations"][:6]:
+            detail_lines.append(
+                f"- [{rec.get('priority')}] {rec.get('rule_name') or rec.get('kind')}: {rec.get('detail')}"
+            )
+    elif fdd.get("tuning_candidates"):
         detail_lines.append("\n**Tuning candidates (human review):**")
         for c in fdd["tuning_candidates"][:5]:
             detail_lines.append(f"- {c.get('rule_name')} ({c.get('flagged_pct')}% flagged)")
@@ -221,6 +229,7 @@ def run_checkin(
             "flaky": (poll_health.get("flaky_equipment") or [])[:6],
         },
         "fdd": fdd,
+        "tuning_brief": tuning,
         "ops_logs_summary": ops.get("summary"),
         "actions": actions,
         "batch": batch_result,

--- a/workspace/api/openfdd_bridge/fdd_runner.py
+++ b/workspace/api/openfdd_bridge/fdd_runner.py
@@ -237,7 +237,14 @@ def _run_one(
             script_cfg.setdefault("site_id", site_id)
             result = playground.run_arrow_script(code, table, cfg=script_cfg)
             if not result.get("ok"):
-                return {**base, "status": "error", "rows": int(len(df)), "flagged": 0, "error": result.get("error", "")}
+                row_n = int(table.num_rows) if hasattr(table, "num_rows") else int(result.get("rows") or 0)
+                return {
+                    **base,
+                    "status": "error",
+                    "rows": row_n,
+                    "flagged": 0,
+                    "error": str(result.get("error") or ""),
+                }
             flag_cols = result.get("flag_columns") or []
             flagged = 0
             for row in result.get("preview", []):

--- a/workspace/api/openfdd_bridge/fdd_tuning.py
+++ b/workspace/api/openfdd_bridge/fdd_tuning.py
@@ -1,0 +1,135 @@
+"""FDD tuning brief — structured recommendations for building agent / sales demos."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .fdd_results import load_results
+from .poll_throughput import compute_poll_throughput
+
+
+def _flagged_pct(run: dict[str, Any]) -> float | None:
+    rows = int(run.get("rows") or 0)
+    flagged = int(run.get("flagged") or 0)
+    if rows <= 0:
+        return None
+    return round(100.0 * flagged / rows, 1)
+
+
+def _error_hint(error: str, rule_id: str) -> str:
+    err = (error or "").strip().lower()
+    if "df" in err and "not defined" in err:
+        return "Bridge script-runner bug (fixed in 3.0.9) — redeploy and re-run batch."
+    if "timestamp column required" in err:
+        return "Bind historian columns or widen lookback; script needs feather timestamps."
+    if "name " in err and "not defined" in err:
+        return "Rule Python references undefined variable — open Rule Lab source and fix."
+    if "arrow" in err or "pyarrow" in err:
+        return "Arrow rule failed — verify column_map and feather column names."
+    return f"Inspect rule '{rule_id}' in Rule Lab; re-run POST /api/rules/batch after fix."
+
+
+def build_tuning_brief(
+    *,
+    site_id: str,
+    window_minutes: int = 60,
+) -> dict[str, Any]:
+    """Human + agent readable FDD tuning queue (poll-gated)."""
+    throughput = compute_poll_throughput(window_minutes=window_minutes)
+    keepup = throughput.get("keepup_ratio")
+    poll_ready = (
+        throughput.get("status") in {"healthy", "warming"}
+        and (keepup is None or float(keepup) >= 0.85)
+    )
+
+    doc = load_results()
+    runs = [r for r in doc.get("runs", []) if isinstance(r, dict)]
+    site_runs = [r for r in runs if str(r.get("site_id") or "") in {"", site_id}]
+
+    recommendations: list[dict[str, Any]] = []
+    for run in site_runs:
+        if run.get("status") == "error":
+            rid = str(run.get("rule_id") or "")
+            err = str(run.get("error") or "")
+            recommendations.append(
+                {
+                    "priority": "critical",
+                    "kind": "rule_error",
+                    "rule_id": rid,
+                    "rule_name": run.get("rule_name"),
+                    "fault_code": run.get("fault_code"),
+                    "detail": err[:500],
+                    "hint": _error_hint(err, rid),
+                    "poll_ready": poll_ready,
+                    "suggested_tool": "rules.save (fix code) + rules.run_batch",
+                }
+            )
+            continue
+        pct = _flagged_pct(run)
+        if pct is None:
+            continue
+        flagged_n = int(run.get("flagged") or 0)
+        rows = int(run.get("rows") or 0)
+        analytics = run.get("analytics") if isinstance(run.get("analytics"), dict) else {}
+        rid = str(run.get("rule_id") or "")
+        rname = str(run.get("rule_name") or rid)
+        if pct >= 85.0:
+            recommendations.append(
+                {
+                    "priority": "high",
+                    "kind": "threshold_review",
+                    "rule_id": rid,
+                    "rule_name": rname,
+                    "fault_code": run.get("fault_code"),
+                    "flagged_pct": pct,
+                    "flagged": flagged_n,
+                    "rows": rows,
+                    "detail": f"{flagged_n}/{rows} samples flagged ({pct}%)",
+                    "hint": "Likely bounds too tight or wrong bind — review config.bounds_low/high",
+                    "analytics": analytics,
+                    "poll_ready": poll_ready,
+                    "suggested_tool": "rules.save (config) + rules.run_batch",
+                }
+            )
+        elif pct >= 40.0 and flagged_n >= 3:
+            recommendations.append(
+                {
+                    "priority": "medium",
+                    "kind": "watch",
+                    "rule_id": rid,
+                    "rule_name": rname,
+                    "fault_code": run.get("fault_code"),
+                    "flagged_pct": pct,
+                    "flagged": flagged_n,
+                    "rows": rows,
+                    "detail": f"{flagged_n}/{rows} flagged ({pct}%) — monitor before tuning",
+                    "poll_ready": poll_ready,
+                }
+            )
+
+    recommendations.sort(
+        key=lambda r: {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(str(r.get("priority")), 9)
+    )
+
+    parts = [
+        f"Poll {throughput.get('status')} keepup={keepup}",
+        f"{len([r for r in recommendations if r['kind'] == 'rule_error'])} rule error(s)",
+        f"{len([r for r in recommendations if r['kind'] == 'threshold_review'])} threshold review(s)",
+    ]
+    if not poll_ready:
+        parts.append("defer threshold tuning until keepup_ratio >= 0.85")
+
+    return {
+        "ok": True,
+        "site_id": site_id,
+        "poll_ready_for_tuning": poll_ready,
+        "throughput_status": throughput.get("status"),
+        "keepup_ratio": keepup,
+        "enabled_points": throughput.get("enabled_points"),
+        "recommendations": recommendations[:20],
+        "summary_sentence": "; ".join(parts),
+        "methodology": (
+            "Errors fixed first. Threshold tuning only when BACnet poll keepup >= 85%. "
+            "Human approves rules.save config changes; set OFDD_AGENT_AUTO_TUNE=1 for future auto-apply."
+        ),
+    }

--- a/workspace/api/openfdd_bridge/routes/building_agent_routes.py
+++ b/workspace/api/openfdd_bridge/routes/building_agent_routes.py
@@ -6,6 +6,10 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from ..building_agent import get_checkin_status, run_checkin
+from ..fdd_tuning import build_tuning_brief
+from ..site_defaults import ensure_default_site
+from ..model_service import ModelService
+from ..ttl_service import TtlService
 from ..deps import require_roles
 
 router = APIRouter(prefix="/api/building-agent", tags=["building-agent"])
@@ -29,6 +33,17 @@ def building_agent_checkin(body: CheckinBody, _user: dict = _AGENT) -> dict:
         write_memory=body.write_memory,
         window_minutes=body.window_minutes,
     )
+
+
+@router.get("/tuning-brief")
+def building_agent_tuning_brief(
+    site_id: str | None = Query(default=None),
+    window_minutes: int = Query(default=60, ge=5, le=180),
+    _user: dict = _AGENT,
+) -> dict:
+    """Structured FDD tuning queue — errors first, threshold reviews poll-gated."""
+    sid = (site_id or "").strip() or ensure_default_site(ModelService(), TtlService())
+    return build_tuning_brief(site_id=sid, window_minutes=window_minutes)
 
 
 @router.get("/status")

--- a/workspace/api/openfdd_bridge/rule_bindings.py
+++ b/workspace/api/openfdd_bridge/rule_bindings.py
@@ -137,12 +137,18 @@ def _equipment_label(eq: dict[str, Any]) -> str:
 
 def build_assignments_view(model: dict[str, Any], rules: list[dict[str, Any]], *, site_id: str | None = None) -> dict[str, Any]:
     """Enriched assignments payload for UI and agent context."""
+    from .model_point_utils import point_site_id
+
     sid = str(site_id or "").strip()
     equipment = [e for e in model.get("equipment") or [] if isinstance(e, dict)]
     points = [p for p in model.get("points") or [] if isinstance(p, dict)]
     if sid:
-        equipment = [e for e in equipment if str(e.get("site_id") or "") == sid]
-        points = [p for p in points if str(p.get("site_id") or "") == sid]
+        equipment = [
+            e
+            for e in equipment
+            if str(e.get("site_id") or "").strip() in {"", sid}
+        ]
+        points = [p for p in points if point_site_id(p, model) == sid]
 
     eq_by_id = {str(e.get("id") or ""): e for e in equipment if str(e.get("id") or "")}
 


### PR DESCRIPTION
## Summary
- Fix script-mode FDD batch error path (`len(df)` → `table.num_rows`) so `acme-ahu-run-hours` and other script rules report real failures.
- Fix `/api/rules/assignments` zero point rows — infer `site_id` from parent equipment via `point_site_id()`.
- Add **`GET /api/building-agent/tuning-brief`** — poll-gated FDD tuning queue (errors → threshold reviews → watch list) for AI-assisted commissioning demos.
- Harden post-deploy Docker log scans (CancelledError / asyncio startup noise).
- Fix Acme verify check-in POST body (from 3.0.9 bump commit).

## Test plan
- [x] `pytest tests/workspace_bridge/test_fdd_tuning.py`
- [x] `pytest tests/workspace_bridge/test_rule_bindings.py`
- [ ] CI + CodeRabbit
- [ ] Tag `open-fdd-v3.0.9`, GHCR publish
- [ ] Acme: `post_deploy_check --full`, `acme_operational_verify`, tuning-brief + check-in with batch
- [ ] Confirm assignments point rows > 0 on Acme


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FDD tuning brief endpoint providing ranked recommendations based on rule execution results and polling health metrics.

* **Improvements**
  * Enhanced building-agent monitoring with additional health status checks.
  * Improved Docker log error detection to suppress non-actionable error patterns while maintaining critical alerts.

* **Chores**
  * Version updated to 3.0.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->