### PR TITLE
3.0.10 — AI FDD apply-tuning, check-in JSON fix, log scan hardening

### DIFF
--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -33,6 +33,11 @@ log_ok() { printf '  OK   %s\n' "$*"; }
 log_fail() { printf '  FAIL %s\n' "$*" >&2; FAILURES=$((FAILURES + 1)); }
 log_info() { printf '  ..   %s\n' "$*"; }
 
+# print(json.dumps(...)) adds a trailing newline — FastAPI rejects it as extra JSON.
+json_compact() {
+  python3 -c 'import json,sys; print(json.dumps(json.loads(sys.argv[1])), end="")' "$1"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --host) HOST="$2"; shift 2 ;;
@@ -213,8 +218,17 @@ for path in \
   fi
 done
 
+log_info "Building agent apply-tuning (dry-run — AI bounds proposals)"
+TUNING_BODY="$(json_compact '{"apply": false, "run_fdd_batch": false, "site_id": "acme"}')"
+api_post_status "/api/building-agent/apply-tuning" "$TUNING_BODY"
+if [[ "${API_POST_STATUS:-000}" == "200" ]]; then
+  log_ok "POST /api/building-agent/apply-tuning HTTP 200 (dry_run)"
+else
+  log_fail "POST /api/building-agent/apply-tuning HTTP ${API_POST_STATUS:-000}: ${API_POST_BODY:-}"
+fi
+
 log_info "Building agent check-in (no FDD batch — smoke)"
-CHECKIN_BODY="$(python3 -c 'import json; print(json.dumps({"run_fdd_batch": False, "write_memory": True, "window_minutes": 30, "site_id": "acme"}))')"
+CHECKIN_BODY="$(json_compact '{"run_fdd_batch": false, "write_memory": true, "window_minutes": 30, "site_id": "acme"}')"
 api_post_status "/api/building-agent/checkin" "$CHECKIN_BODY"
 if [[ "${API_POST_STATUS:-000}" == "200" ]]; then
   log_ok "POST /api/building-agent/checkin HTTP 200"

--- a/infra/ansible/scripts/http_probes.py
+++ b/infra/ansible/scripts/http_probes.py
@@ -276,6 +276,28 @@ def check_building_agent_api(base: str, token: str, *, site_id: str = "demo") ->
         if path.startswith("/api/ops") and (payload.get("summary") or {}).get("has_bridge_errors"):
             out["warnings"].append("bridge error log has recent severity errors")
 
+    apply_url = f"{root}/api/building-agent/apply-tuning"
+    try:
+        a_status, a_body = post_json(
+            apply_url,
+            {"apply": False, "run_fdd_batch": False, "site_id": site_id},
+            headers=headers,
+            timeout=60.0,
+        )
+    except RuntimeError as exc:
+        out["errors"].append(f"/api/building-agent/apply-tuning unreachable: {exc}")
+    else:
+        out["building_agent_apply_tuning"] = a_status
+        if a_status != 200:
+            out["errors"].append(f"/api/building-agent/apply-tuning HTTP {a_status}: {a_body[:200]}")
+        else:
+            try:
+                apply_payload = json.loads(a_body)
+                if apply_payload.get("dry_run") is not True:
+                    out["warnings"].append("apply-tuning probe expected dry_run=true")
+            except json.JSONDecodeError:
+                out["errors"].append("/api/building-agent/apply-tuning not JSON")
+
     mem_url = f"{root}/api/sites/{site_id}/memory?kind=memory"
     try:
         m_status, m_body, _ = fetch(mem_url, headers=headers, timeout=30.0)

--- a/infra/ansible/scripts/post_deploy_check.sh
+++ b/infra/ansible/scripts/post_deploy_check.sh
@@ -356,7 +356,7 @@ elif [[ "$INVENTORY_DOCKER_STACK" == "1" ]]; then
         log_fail "Docker service ${svc}: no running container"
         continue
       fi
-      err_lines="$(ssh_remote "docker logs --tail 80 \"${cid}\" 2>&1 | grep -Ei 'ERROR|Traceback|CRITICAL' | grep -v '404 Not Found' | grep -v 'unknown-property' | grep -v 'read-property-multiple' | grep -v 'Connection reset by peer' | grep -v 'CancelledError' | grep -v 'KeyboardInterrupt' | grep -v 'asyncio.exceptions' | tail -5 || true")" || err_lines=""
+      err_lines="$(ssh_remote "docker logs --since 15m \"${cid}\" 2>&1 | grep -Ei 'ERROR|CRITICAL|Exception:|Error:' | grep -v '404 Not Found' | grep -v 'unknown-property' | grep -v 'read-property-multiple' | grep -v 'Connection reset by peer' | grep -v 'CancelledError' | grep -v 'KeyboardInterrupt' | grep -v 'asyncio.exceptions' | grep -v 'most recent call last' | grep -v 'During handling' | tail -5 || true")" || err_lines=""
       if [[ -n "$err_lines" ]]; then
         log_fail "Docker ${svc} (${cid:0:12}) log errors: ${err_lines}"
       else

--- a/infra/ansible/tasks/post_deploy_check.yml
+++ b/infra/ansible/tasks/post_deploy_check.yml
@@ -86,8 +86,8 @@
       set -eu
       cid="{{ item.split('=')[1] | trim }}"
       svc="{{ item.split('=')[0] | trim }}"
-      err="$(docker logs --since 3m "$cid" 2>&1 \
-        | grep -Ei 'ERROR|Traceback|CRITICAL' \
+      err="$(docker logs --since 15m "$cid" 2>&1 \
+        | grep -Ei 'ERROR|CRITICAL|Exception:|Error:' \
         | grep -v '404 Not Found' \
         | grep -v 'unknown-property' \
         | grep -v 'read-property-multiple' \
@@ -96,6 +96,8 @@
         | grep -v 'asyncio.exceptions' \
         | grep -v 'Cannot assign requested address' \
         | grep -v "has no attribute 'server'" \
+        | grep -v 'most recent call last' \
+        | grep -v 'During handling' \
         | tail -5 || true)"
       if [[ -n "$err" ]]; then
         echo "FAIL ${svc}: ${err}"

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.9"
+__version__ = "3.0.10"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.9"
+version = "3.0.10"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/workspace_bridge/test_fdd_tuning.py
+++ b/tests/workspace_bridge/test_fdd_tuning.py
@@ -112,3 +112,102 @@ def test_tuning_brief_endpoint(agent_client, monkeypatch: pytest.MonkeyPatch, tm
     kinds = {x["kind"] for x in body["recommendations"]}
     assert "rule_error" in kinds
     assert "threshold_review" in kinds
+
+
+def test_propose_bounds_patch_widens_high():
+    from openfdd_bridge.fdd_tuning import propose_bounds_patch
+
+    run = {
+        "rule_id": "acme-zn-t-oob-occupied",
+        "rule_name": "Zone OOB",
+        "status": "ok",
+        "rows": 20,
+        "flagged": 18,
+        "analytics": {
+            "min_value_fault": 79.0,
+            "max_value_fault": 82.5,
+            "avg_value_fault": 80.2,
+            "bounds_low": 65.0,
+            "bounds_high": 78.0,
+            "value_unit": "°F",
+        },
+    }
+    rule = {
+        "id": "acme-zn-t-oob-occupied",
+        "name": "Zone OOB",
+        "config": {"bounds_low": 65, "bounds_high": 78},
+    }
+    patch = propose_bounds_patch(run=run, rule=rule)
+    assert patch is not None
+    assert patch["proposed_config"]["bounds_high"] > 78
+    assert "widen high" in patch["rationale"]
+
+
+def test_apply_tuning_dry_run(agent_client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    import os
+
+    from openfdd_bridge import fdd_results as fr
+
+    doc = {
+        "version": 1,
+        "runs": [
+            {
+                "rule_id": "acme-zn-t-oob-occupied",
+                "rule_name": "Zone OOB",
+                "site_id": "acme",
+                "status": "ok",
+                "rows": 20,
+                "flagged": 18,
+                "analytics": {
+                    "min_value_fault": 79.0,
+                    "max_value_fault": 82.5,
+                    "avg_value_fault": 80.2,
+                    "bounds_low": 65.0,
+                    "bounds_high": 78.0,
+                    "value_unit": "°F",
+                },
+            }
+        ],
+    }
+    path = Path(os.environ["OFDD_DESKTOP_DATA_DIR"]) / "fdd_results.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    monkeypatch.setattr(fr, "fdd_results_path", lambda: path)
+    monkeypatch.setattr(
+        "openfdd_bridge.fdd_tuning.compute_poll_throughput",
+        lambda **_: {"ok": True, "status": "healthy", "keepup_ratio": 0.95, "enabled_points": 10},
+    )
+    monkeypatch.setattr(
+        "openfdd_bridge.fdd_tuning.RuleStore",
+        lambda: type(
+            "RS",
+            (),
+            {
+                "list_rules": lambda self: [
+                    {
+                        "id": "acme-zn-t-oob-occupied",
+                        "name": "Zone OOB",
+                        "config": {"bounds_low": 65, "bounds_high": 78},
+                        "code": "def apply_faults_arrow(t,c,cx=None): return {}",
+                        "mode": "rule",
+                    }
+                ],
+                "get": lambda self, rid: {
+                    "id": rid,
+                    "name": "Zone OOB",
+                    "config": {"bounds_low": 65, "bounds_high": 78},
+                    "code": "def apply_faults_arrow(t,c,cx=None): return {}",
+                    "mode": "rule",
+                },
+                "upsert": lambda self, entry, saved_by="x": entry,
+            },
+        )(),
+    )
+    r = agent_client.post(
+        "/api/building-agent/apply-tuning",
+        json={"apply": False, "site_id": "acme", "run_fdd_batch": False},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["dry_run"] is True
+    assert body["applied"] is False
+    assert len(body["patches"]) >= 1

--- a/workspace/api/openfdd_bridge/agent_tools.py
+++ b/workspace/api/openfdd_bridge/agent_tools.py
@@ -35,7 +35,7 @@ from .brick_model_context import (
 from .fault_catalog import all_codes, catalog_graph, entry_for_code, is_valid_code
 from .fault_catalog_scope import build_applicable_payload, validate_scope_with_ollama
 from .building_agent import run_checkin
-from .fdd_tuning import build_tuning_brief
+from .fdd_tuning import apply_tuning_patches, build_tuning_brief
 from .fdd_results import load_results
 from .fdd_runner import run_batch
 from .ops_logs import collect_ops_logs
@@ -413,6 +413,23 @@ def _tool_building_tuning_brief(args: dict[str, Any]) -> dict[str, Any]:
     return build_tuning_brief(site_id=site_id, window_minutes=window_i)
 
 
+def _tool_building_apply_tuning(args: dict[str, Any]) -> dict[str, Any]:
+    site_id = str(args.get("site_id") or "").strip() or ensure_default_site(ModelService(), TtlService())
+    apply_flag = str(args.get("apply") or "false").strip().lower() in {"1", "true", "yes"}
+    run_batch_flag = str(args.get("run_fdd_batch") or "true").strip().lower() not in {"0", "false", "no"}
+    rule_ids = args.get("rule_ids")
+    ids: list[str] | None = None
+    if isinstance(rule_ids, list):
+        ids = [str(x).strip() for x in rule_ids if str(x).strip()]
+    return apply_tuning_patches(
+        site_id=site_id,
+        apply=apply_flag,
+        rule_ids=ids,
+        run_fdd_batch=run_batch_flag,
+        saved_by="agent",
+    )
+
+
 def _tool_building_checkin(args: dict[str, Any]) -> dict[str, Any]:
     site_id = str(args.get("site_id") or "").strip() or None
     run_batch_flag = str(args.get("run_fdd_batch") or "true").strip().lower() in {"1", "true", "yes"}
@@ -484,6 +501,7 @@ _WRITE_TOOLS = frozenset(
         "building.set_alerts",
         "building.checkin",
         "building.tuning_brief",
+        "building.apply_tuning",
         "site.memory_put",
         "app.edit_file",
         "app.rebuild_dashboard",
@@ -510,6 +528,7 @@ _TOOLS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "building.operational_brief": _tool_building_operational_brief,
     "building.checkin": _tool_building_checkin,
     "building.tuning_brief": _tool_building_tuning_brief,
+    "building.apply_tuning": _tool_building_apply_tuning,
     "analytics.poll_throughput": _tool_analytics_poll_throughput,
     "fdd.results": _tool_fdd_results,
     "ops.logs": _tool_ops_logs,
@@ -628,7 +647,12 @@ def tool_specs() -> list[dict[str, Any]]:
         {
             "name": "building.tuning_brief",
             "args": ["site_id?", "window_minutes?"],
-            "writes": "read-only — FDD tuning queue (errors + threshold reviews)",
+            "writes": "read-only — FDD tuning queue (errors + threshold reviews + AI patches)",
+        },
+        {
+            "name": "building.apply_tuning",
+            "args": ["site_id?", "apply?", "rule_ids?", "run_fdd_batch?"],
+            "writes": "rules_store.json config (bounds) when apply=true",
         },
         {
             "name": "analytics.poll_throughput",

--- a/workspace/api/openfdd_bridge/building_agent.py
+++ b/workspace/api/openfdd_bridge/building_agent.py
@@ -182,6 +182,12 @@ def run_checkin(
             detail_lines.append(
                 f"- [{rec.get('priority')}] {rec.get('rule_name') or rec.get('kind')}: {rec.get('detail')}"
             )
+    if tuning.get("patches"):
+        detail_lines.append("\n**AI bounds patches (dry-run via POST /api/building-agent/apply-tuning):**")
+        for patch in tuning["patches"][:4]:
+            detail_lines.append(
+                f"- {patch.get('rule_name')}: {patch.get('rationale')}"
+            )
     elif fdd.get("tuning_candidates"):
         detail_lines.append("\n**Tuning candidates (human review):**")
         for c in fdd["tuning_candidates"][:5]:

--- a/workspace/api/openfdd_bridge/fdd_tuning.py
+++ b/workspace/api/openfdd_bridge/fdd_tuning.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from .fdd_results import load_results
+from .fdd_runner import run_batch
 from .poll_throughput import compute_poll_throughput
+from .rule_store import RuleStore
+
+_BOUNDS_KEYS = ("bounds_low", "bounds_high", "bounds_low_rh", "bounds_high_rh")
+_MAX_WIDEN = 15.0
+_BOUNDS_CUSHION = 2.0
 
 
 def _flagged_pct(run: dict[str, Any]) -> float | None:
@@ -29,22 +36,216 @@ def _error_hint(error: str, rule_id: str) -> str:
     return f"Inspect rule '{rule_id}' in Rule Lab; re-run POST /api/rules/batch after fix."
 
 
-def build_tuning_brief(
+def _float_or_none(val: Any) -> float | None:
+    if val is None or str(val).strip() == "":
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _poll_ready(throughput: dict[str, Any]) -> bool:
+    keepup = throughput.get("keepup_ratio")
+    return throughput.get("status") in {"healthy", "warming"} and (
+        keepup is None or float(keepup) >= 0.85
+    )
+
+
+def propose_bounds_patch(
+    *,
+    run: dict[str, Any],
+    rule: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """AI-assisted bounds proposal from fault analytics (human or API applies)."""
+    pct = _flagged_pct(run)
+    if pct is None or pct < 85.0:
+        return None
+    analytics = run.get("analytics") if isinstance(run.get("analytics"), dict) else {}
+    cfg = (rule or {}).get("config") if isinstance((rule or {}).get("config"), dict) else {}
+    if not cfg and not analytics:
+        return None
+
+    is_rh = analytics.get("value_unit") == "%RH" or bool(
+        cfg.get("bounds_low_rh") is not None or cfg.get("bounds_high_rh") is not None
+    )
+    low_key = "bounds_low_rh" if is_rh else "bounds_low"
+    high_key = "bounds_high_rh" if is_rh else "bounds_high"
+
+    low = _float_or_none(analytics.get(low_key)) or _float_or_none(cfg.get(low_key))
+    high = _float_or_none(analytics.get(high_key)) or _float_or_none(cfg.get(high_key))
+    min_f = _float_or_none(analytics.get("min_value_fault"))
+    max_f = _float_or_none(analytics.get("max_value_fault"))
+    avg_f = _float_or_none(analytics.get("avg_value_fault"))
+    if low is None or high is None or min_f is None or max_f is None:
+        return None
+
+    proposed: dict[str, float] = {}
+    rationale: list[str] = []
+    unit = analytics.get("value_unit") or ("°F" if not is_rh else "%RH")
+
+    if avg_f is not None and avg_f > high - 0.5 and max_f > high:
+        new_high = round(min(max_f + _BOUNDS_CUSHION, high + _MAX_WIDEN), 1)
+        if new_high > high:
+            proposed[high_key] = new_high
+            rationale.append(
+                f"fault avg {avg_f}{unit} above high {high}{unit}; widen high toward {new_high}{unit}"
+            )
+    if avg_f is not None and avg_f < low + 0.5 and min_f < low:
+        new_low = round(max(min_f - _BOUNDS_CUSHION, low - _MAX_WIDEN), 1)
+        if new_low < low:
+            proposed[low_key] = new_low
+            rationale.append(
+                f"fault avg {avg_f}{unit} below low {low}{unit}; widen low toward {new_low}{unit}"
+            )
+
+    if not proposed:
+        return None
+
+    rid = str(run.get("rule_id") or (rule or {}).get("id") or "")
+    return {
+        "rule_id": rid,
+        "rule_name": run.get("rule_name") or (rule or {}).get("name"),
+        "kind": "bounds_widen",
+        "flagged_pct": pct,
+        "current_bounds": {k: cfg[k] for k in _BOUNDS_KEYS if k in cfg},
+        "proposed_config": proposed,
+        "merged_config": {**cfg, **proposed},
+        "rationale": "; ".join(rationale),
+        "analytics": analytics,
+    }
+
+
+def collect_tuning_patches(
     *,
     site_id: str,
-    window_minutes: int = 60,
-) -> dict[str, Any]:
-    """Human + agent readable FDD tuning queue (poll-gated)."""
-    throughput = compute_poll_throughput(window_minutes=window_minutes)
-    keepup = throughput.get("keepup_ratio")
-    poll_ready = (
-        throughput.get("status") in {"healthy", "warming"}
-        and (keepup is None or float(keepup) >= 0.85)
-    )
+    rule_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Collect AI-proposed config patches for high flag-rate rules."""
+    store = RuleStore()
+    rules_by_id = {str(r.get("id")): r for r in store.list_rules() if isinstance(r, dict)}
+    allow = {str(x).strip() for x in (rule_ids or []) if str(x).strip()} or None
 
     doc = load_results()
     runs = [r for r in doc.get("runs", []) if isinstance(r, dict)]
     site_runs = [r for r in runs if str(r.get("site_id") or "") in {"", site_id}]
+
+    patches: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for run in site_runs:
+        if run.get("status") == "error":
+            continue
+        rid = str(run.get("rule_id") or "")
+        if not rid or rid in seen:
+            continue
+        if allow is not None and rid not in allow:
+            continue
+        patch = propose_bounds_patch(run=run, rule=rules_by_id.get(rid))
+        if patch:
+            patches.append(patch)
+            seen.add(rid)
+    return patches
+
+
+def apply_tuning_patches(
+    *,
+    site_id: str,
+    apply: bool = False,
+    rule_ids: list[str] | None = None,
+    run_fdd_batch: bool = False,
+    saved_by: str = "building-agent",
+) -> dict[str, Any]:
+    """Dry-run or apply AI-proposed bounds patches (poll-gated)."""
+    throughput = compute_poll_throughput(window_minutes=60)
+    poll_ready = _poll_ready(throughput)
+    auto_tune_env = os.environ.get("OFDD_AGENT_AUTO_TUNE", "").strip().lower() in {"1", "true", "yes"}
+
+    patches = collect_tuning_patches(site_id=site_id, rule_ids=rule_ids)
+    if not poll_ready:
+        return {
+            "ok": True,
+            "site_id": site_id,
+            "dry_run": not apply,
+            "applied": False,
+            "poll_ready_for_tuning": False,
+            "throughput_status": throughput.get("status"),
+            "keepup_ratio": throughput.get("keepup_ratio"),
+            "patches": patches,
+            "message": "Poll keepup below 85% — proposals only, no apply.",
+            "auto_tune_env": auto_tune_env,
+        }
+
+    if not apply:
+        return {
+            "ok": True,
+            "site_id": site_id,
+            "dry_run": True,
+            "applied": False,
+            "poll_ready_for_tuning": True,
+            "patches": patches,
+            "message": f"{len(patches)} patch(es) ready — POST with apply=true to save.",
+            "auto_tune_env": auto_tune_env,
+        }
+
+    store = RuleStore()
+    applied: list[dict[str, Any]] = []
+    for patch in patches:
+        rid = str(patch.get("rule_id") or "")
+        rule = store.get(rid)
+        if not rule:
+            continue
+        merged = dict(rule)
+        merged["config"] = patch.get("merged_config") or {**(rule.get("config") or {}), **(patch.get("proposed_config") or {})}
+        entry = store.upsert(merged, saved_by=saved_by)
+        applied.append(
+            {
+                "rule_id": rid,
+                "rule_name": entry.get("name"),
+                "proposed_config": patch.get("proposed_config"),
+                "rationale": patch.get("rationale"),
+            }
+        )
+
+    batch_result = None
+    if run_fdd_batch and applied:
+        try:
+            batch_result = run_batch(limit=500)
+        except Exception as exc:  # noqa: BLE001
+            batch_result = {"ok": False, "error": str(exc)[:500]}
+
+    return {
+        "ok": True,
+        "site_id": site_id,
+        "dry_run": False,
+        "applied": bool(applied),
+        "poll_ready_for_tuning": True,
+        "patches_proposed": len(patches),
+        "patches_applied": applied,
+        "batch": batch_result,
+        "auto_tune_env": auto_tune_env,
+        "message": f"Applied {len(applied)} bounds patch(es).",
+    }
+
+
+def build_tuning_brief(
+    *,
+    site_id: str,
+    window_minutes: int = 60,
+    include_patches: bool = True,
+) -> dict[str, Any]:
+    """Human + agent readable FDD tuning queue (poll-gated)."""
+    throughput = compute_poll_throughput(window_minutes=window_minutes)
+    poll_ready = _poll_ready(throughput)
+    keepup = throughput.get("keepup_ratio")
+
+    doc = load_results()
+    runs = [r for r in doc.get("runs", []) if isinstance(r, dict)]
+    site_runs = [r for r in runs if str(r.get("site_id") or "") in {"", site_id}]
+    rules_by_id = {
+        str(r.get("id")): r
+        for r in RuleStore().list_rules()
+        if isinstance(r, dict)
+    }
 
     recommendations: list[dict[str, Any]] = []
     for run in site_runs:
@@ -73,24 +274,30 @@ def build_tuning_brief(
         analytics = run.get("analytics") if isinstance(run.get("analytics"), dict) else {}
         rid = str(run.get("rule_id") or "")
         rname = str(run.get("rule_name") or rid)
+        patch = (
+            propose_bounds_patch(run=run, rule=rules_by_id.get(rid))
+            if include_patches and poll_ready
+            else None
+        )
         if pct >= 85.0:
-            recommendations.append(
-                {
-                    "priority": "high",
-                    "kind": "threshold_review",
-                    "rule_id": rid,
-                    "rule_name": rname,
-                    "fault_code": run.get("fault_code"),
-                    "flagged_pct": pct,
-                    "flagged": flagged_n,
-                    "rows": rows,
-                    "detail": f"{flagged_n}/{rows} samples flagged ({pct}%)",
-                    "hint": "Likely bounds too tight or wrong bind — review config.bounds_low/high",
-                    "analytics": analytics,
-                    "poll_ready": poll_ready,
-                    "suggested_tool": "rules.save (config) + rules.run_batch",
-                }
-            )
+            rec: dict[str, Any] = {
+                "priority": "high",
+                "kind": "threshold_review",
+                "rule_id": rid,
+                "rule_name": rname,
+                "fault_code": run.get("fault_code"),
+                "flagged_pct": pct,
+                "flagged": flagged_n,
+                "rows": rows,
+                "detail": f"{flagged_n}/{rows} samples flagged ({pct}%)",
+                "hint": "Likely bounds too tight or wrong bind — review config.bounds_low/high",
+                "analytics": analytics,
+                "poll_ready": poll_ready,
+                "suggested_tool": "building.apply_tuning (dry_run) then apply=true",
+            }
+            if patch:
+                rec["proposed_patch"] = patch
+            recommendations.append(rec)
         elif pct >= 40.0 and flagged_n >= 3:
             recommendations.append(
                 {
@@ -111,11 +318,15 @@ def build_tuning_brief(
         key=lambda r: {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(str(r.get("priority")), 9)
     )
 
+    patches = collect_tuning_patches(site_id=site_id) if include_patches and poll_ready else []
+
     parts = [
         f"Poll {throughput.get('status')} keepup={keepup}",
         f"{len([r for r in recommendations if r['kind'] == 'rule_error'])} rule error(s)",
         f"{len([r for r in recommendations if r['kind'] == 'threshold_review'])} threshold review(s)",
     ]
+    if patches:
+        parts.append(f"{len(patches)} AI bounds patch(es) ready")
     if not poll_ready:
         parts.append("defer threshold tuning until keepup_ratio >= 0.85")
 
@@ -127,9 +338,11 @@ def build_tuning_brief(
         "keepup_ratio": keepup,
         "enabled_points": throughput.get("enabled_points"),
         "recommendations": recommendations[:20],
+        "patches": patches[:12],
         "summary_sentence": "; ".join(parts),
         "methodology": (
             "Errors fixed first. Threshold tuning only when BACnet poll keepup >= 85%. "
-            "Human approves rules.save config changes; set OFDD_AGENT_AUTO_TUNE=1 for future auto-apply."
+            "GET tuning-brief for AI proposals; POST apply-tuning with apply=true to save. "
+            "Set OFDD_AGENT_AUTO_TUNE=1 for unattended cron apply (future)."
         ),
     }

--- a/workspace/api/openfdd_bridge/routes/building_agent_routes.py
+++ b/workspace/api/openfdd_bridge/routes/building_agent_routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from ..building_agent import get_checkin_status, run_checkin
-from ..fdd_tuning import build_tuning_brief
+from ..fdd_tuning import apply_tuning_patches, build_tuning_brief
 from ..site_defaults import ensure_default_site
 from ..model_service import ModelService
 from ..ttl_service import TtlService
@@ -22,6 +22,13 @@ class CheckinBody(BaseModel):
     run_fdd_batch: bool = True
     write_memory: bool = True
     window_minutes: int = Field(default=60, ge=5, le=180)
+
+
+class ApplyTuningBody(BaseModel):
+    site_id: str | None = None
+    apply: bool = False
+    rule_ids: list[str] | None = None
+    run_fdd_batch: bool = True
 
 
 @router.post("/checkin")
@@ -44,6 +51,23 @@ def building_agent_tuning_brief(
     """Structured FDD tuning queue — errors first, threshold reviews poll-gated."""
     sid = (site_id or "").strip() or ensure_default_site(ModelService(), TtlService())
     return build_tuning_brief(site_id=sid, window_minutes=window_minutes)
+
+
+@router.post("/apply-tuning")
+def building_agent_apply_tuning(
+    body: ApplyTuningBody,
+    user: dict = _AGENT,
+) -> dict:
+    """AI-assisted bounds tuning — dry-run by default; apply=true saves rules_store config."""
+    sid = (body.site_id or "").strip() or ensure_default_site(ModelService(), TtlService())
+    saved_by = str(user.get("sub") or user.get("role") or "building-agent")
+    return apply_tuning_patches(
+        site_id=sid,
+        apply=body.apply,
+        rule_ids=body.rule_ids,
+        run_fdd_batch=body.run_fdd_batch,
+        saved_by=saved_by,
+    )
 
 
 @router.get("/status")


### PR DESCRIPTION
## Summary
- **AI-assisted FDD tuning:** `POST /api/building-agent/apply-tuning` (dry-run default) proposes and optionally applies bounds patches from fault analytics; tuning-brief now includes `patches` and agent tool `building.apply_tuning`.
- **Verify fix:** Acme operational verify uses `json_compact()` so check-in POST no longer sends trailing newline (FastAPI 422 extra data).
- **Ops:** Docker log scans use `--since 15m` and match real errors (not bare Traceback lines).

## Test plan
- [x] `pytest tests/workspace_bridge/test_fdd_tuning.py tests/workspace_bridge/test_building_agent_api.py`
- [ ] CI green
- [ ] Tag `open-fdd-v3.0.10`, GHCR publish
- [ ] Acme upgrade + `post_deploy_check.sh --full` + `acme_operational_verify.sh`
- [ ] Live: tuning-brief → apply-tuning dry-run → check-in POST 200


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI-assisted FDD tuning with proposed bounds widening based on fault analytics
  * New endpoint to apply or preview FDD tuning updates
  * Building agent now displays AI-generated tuning suggestions in check-in reports

* **Bug Fixes**
  * Enhanced deployment error detection with broader pattern matching and extended time window

* **Tests**
  * Added FDD tuning functionality tests

* **Chores**
  * Version updated to 3.0.10

<!-- end of auto-generated comment: release notes by coderabbit.ai -->