### PR TITLE
Fix Acme verify POST stdin pollution (curl --data-binary)

### DIFF
--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -61,21 +61,27 @@ login() {
 
 api_get() { "${CURL[@]}" -H "Authorization: Bearer ${TOKEN}" "${BASE}$1"; }
 api_post() {
-  local path="$1" body="${2:-{}}"
+  local path="$1" body="${2:-\{\}}"
+  local tmp
+  tmp="$(mktemp)"
+  printf '%s' "$body" >"$tmp"
   "${CURL[@]}" -X POST -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
-    -d "$body" "${BASE}${path}"
+    --data-binary "@${tmp}" "${BASE}${path}"
+  rm -f "$tmp"
 }
 
 # Sets API_POST_STATUS and API_POST_BODY (do not call inside $() — subshell drops globals).
 api_post_status() {
-  local path="$1" body="${2:-{}}"
-  local tmp
+  local path="$1" body="${2:-\{\}}"
+  local tmp resp
   tmp="$(mktemp)"
-  API_POST_STATUS="$(curl -sS --connect-timeout 15 --max-time 300 -o "$tmp" -w "%{http_code}" \
+  resp="$(mktemp)"
+  printf '%s' "$body" >"$tmp"
+  API_POST_STATUS="$(curl -sS --connect-timeout 15 --max-time 300 -o "$resp" -w "%{http_code}" \
     -X POST -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
-    -d "$body" "${BASE}${path}" 2>/dev/null)" || API_POST_STATUS="000"
-  API_POST_BODY="$(cat "$tmp")"
-  rm -f "$tmp"
+    --data-binary "@${tmp}" "${BASE}${path}" 2>/dev/null)" || API_POST_STATUS="000"
+  API_POST_BODY="$(cat "$resp")"
+  rm -f "$tmp" "$resp"
 }
 
 wait_job() {


### PR DESCRIPTION
## Summary
- `api_post` / `api_post_status` write JSON to a temp file and use `curl --data-binary` so long verify runs do not append piped stdin to POST bodies (FastAPI 422 extra data).

## Test plan
- [x] `./acme_operational_verify.sh --host 100.122.106.124 --skip-discover --skip-wait` PASSED


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API request handling methods in operational verification scripts to use an alternative approach for managing request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->