### PR TITLE
3.0.11 — run-hours PyArrow fix, tuning 70% preview, building-agent timer

### DIFF
--- a/infra/ansible/deploy_docker.yml
+++ b/infra/ansible/deploy_docker.yml
@@ -419,6 +419,28 @@
       become: true
       when: install_fdd_loop_timer | default(true) | bool
 
+    - name: Install openfdd-building-agent systemd unit and timer
+      tags: [docker, systemd]
+      ansible.builtin.template:
+        src: "templates/{{ item }}.j2"
+        dest: "/etc/systemd/system/{{ item }}"
+        mode: "0644"
+      loop:
+        - openfdd-building-agent.service
+        - openfdd-building-agent.timer
+      become: true
+      when: install_building_agent_timer | default(false) | bool
+
+    - name: Enable openfdd-building-agent timer on edge
+      tags: [docker, systemd]
+      ansible.builtin.systemd:
+        name: openfdd-building-agent.timer
+        enabled: "{{ enable_building_agent_timer | default(false) | bool }}"
+        state: "{{ 'started' if (enable_building_agent_timer | default(false) | bool) else 'stopped' }}"
+        daemon_reload: true
+      become: true
+      when: install_building_agent_timer | default(false) | bool
+
     - name: Run post-deploy insurance checks
       tags: [verify, check]
       ansible.builtin.include_tasks: tasks/post_deploy_check.yml

--- a/infra/ansible/host_vars/acme_vm_bbartling.yml.example
+++ b/infra/ansible/host_vars/acme_vm_bbartling.yml.example
@@ -49,3 +49,10 @@ openfdd_docker_ollama: true
 # ~125 GiB feather cap ≈ 1 year at 1-min temp polling scale
 feather_max_gib: 125
 feather_retention_days: 365
+
+# Building agent check-in timer (poll/FDD/memory append every 6h — no FDD batch by default)
+install_building_agent_timer: true
+enable_building_agent_timer: true
+building_agent_interval_hours: 6
+building_agent_run_fdd_batch: false
+building_agent_window_minutes: 60

--- a/infra/ansible/scripts/http_probes.py
+++ b/infra/ansible/scripts/http_probes.py
@@ -47,6 +47,14 @@ def _agent_fetch_timeout_s() -> float:
         return 45.0
 
 
+def _public_fetch_timeout_s() -> float:
+    raw = os.environ.get("OPENFDD_PROBE_PUBLIC_TIMEOUT_S", "45").strip()
+    try:
+        return max(10.0, float(raw))
+    except ValueError:
+        return 45.0
+
+
 def post_json(url: str, payload: dict[str, Any], *, timeout: float = 20.0, headers: dict[str, str] | None = None) -> tuple[int, str]:
     data = json.dumps(payload).encode("utf-8")
     hdrs = {"Content-Type": "application/json", **(headers or {})}
@@ -314,9 +322,16 @@ def check_public_check_engine(base: str) -> dict[str, Any]:
     """Anonymous read probes for home / faults traffic-light UI (no Bearer token)."""
     out: dict[str, Any] = {"errors": [], "warnings": [], "endpoints": {}}
     root = base.rstrip("/")
+    default_timeout = _public_fetch_timeout_s()
     for path in PUBLIC_CHECK_ENGINE_PATHS:
         url = f"{root}{path}"
-        status, body, _ = fetch(url)
+        timeout = 90.0 if path == "/openfdd-agent/building-insight" else default_timeout
+        try:
+            status, body, _ = fetch(url, timeout=timeout)
+        except RuntimeError as exc:
+            out["errors"].append(f"{path} unreachable: {exc}")
+            out["endpoints"][path] = 0
+            continue
         out["endpoints"][path] = status
         if status == 401:
             out["errors"].append(f"{path} HTTP 401 — check-engine dashboard must not require login")

--- a/infra/ansible/templates/openfdd-building-agent.service.j2
+++ b/infra/ansible/templates/openfdd-building-agent.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=Open-FDD building agent check-in (poll/FDD/memory via bridge API)
+After=network-online.target{% if openfdd_docker_stack | default(false) | bool %} docker.service{% endif %}
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User={{ ansible_user }}
+{% if openfdd_docker_stack | default(false) | bool %}
+WorkingDirectory={{ openfdd_remote_dir }}
+ExecStart=/usr/bin/docker compose -f {{ openfdd_remote_dir }}/docker-compose.yml exec -T bridge python -c "from openfdd_bridge.building_agent import run_checkin; import json; print(json.dumps(run_checkin(site_id='{{ site_id | default('acme') }}', run_fdd_batch={{ building_agent_run_fdd_batch | default(false) | lower }}, write_memory=True, window_minutes={{ building_agent_window_minutes | default(60) }})))"
+{% else %}
+WorkingDirectory={{ openfdd_remote_dir }}/workspace/api
+Environment=OPENFDD_REPO_ROOT={{ openfdd_remote_dir }}
+Environment=OPENFDD_WORKSPACE_DIR={{ openfdd_remote_dir }}/workspace
+Environment=OFDD_DESKTOP_DATA_DIR={{ openfdd_remote_dir }}/workspace/data
+Environment=PYTHONPATH={{ openfdd_remote_dir }}/workspace/api:{{ openfdd_remote_dir }}
+ExecStart={{ openfdd_remote_dir }}/.venv/bin/python -c "from openfdd_bridge.building_agent import run_checkin; import json; print(json.dumps(run_checkin(site_id='{{ site_id | default('acme') }}', run_fdd_batch={{ building_agent_run_fdd_batch | default(false) | lower }}, write_memory=True, window_minutes={{ building_agent_window_minutes | default(60) }})))"
+{% endif %}

--- a/infra/ansible/templates/openfdd-building-agent.timer.j2
+++ b/infra/ansible/templates/openfdd-building-agent.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Open-FDD building agent check-in every {{ building_agent_interval_hours | default(6) }}h
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec={{ building_agent_interval_hours | default(6) }}h
+Persistent=true
+Unit=openfdd-building-agent.service
+
+[Install]
+WantedBy=timers.target

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.10"
+__version__ = "3.0.11"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.10"
+version = "3.0.11"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/workspace_bridge/test_ahu_run_hours_script.py
+++ b/tests/workspace_bridge/test_ahu_run_hours_script.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+API_ROOT = Path(__file__).resolve().parents[2] / "workspace" / "api"
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+
+def test_run_hours_source_uses_pc_divide():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "workspace"
+        / "data"
+        / "rules_py"
+        / "ahu_run_hours.py"
+    )
+    code = script_path.read_text(encoding="utf-8")
+    assert "pc.divide(pc.cast(delta, pa.int64()), 1_000_000)" in code
+    assert "pc.cast(delta, pa.int64()) / 1_000_000" not in code
+
+
+def test_dt_hours_chunked_array_divide_does_not_raise():
+    from open_fdd.arrow_runtime.windows import arrow_shift
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    ts = pa.array([base + timedelta(minutes=i) for i in range(4)], type=pa.timestamp("us", tz="UTC"))
+    table = pa.table({"timestamp": ts})
+    ts_col = "timestamp"
+    prev = arrow_shift(table[ts_col], 1)
+    delta = pc.subtract(pc.cast(table[ts_col], pa.timestamp("us", tz="UTC")), prev)
+    secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)
+    hours = pc.divide(pc.cast(secs, pa.float64()), 3600.0)
+    assert len(hours) == 4
+    assert hours.to_pylist()[1] is not None

--- a/tests/workspace_bridge/test_fdd_tuning.py
+++ b/tests/workspace_bridge/test_fdd_tuning.py
@@ -114,6 +114,52 @@ def test_tuning_brief_endpoint(agent_client, monkeypatch: pytest.MonkeyPatch, tm
     assert "threshold_review" in kinds
 
 
+def test_collect_tuning_patches_at_70_percent(monkeypatch: pytest.MonkeyPatch):
+    import os
+
+    from openfdd_bridge import fdd_results as fr
+    from openfdd_bridge.fdd_tuning import collect_tuning_patches
+
+    runs_doc = {
+        "version": 1,
+        "runs": [
+            {
+                "rule_id": "acme-zn-t-oob-occupied",
+                "rule_name": "Zone OOB",
+                "site_id": "acme",
+                "status": "ok",
+                "rows": 20,
+                "flagged": 15,
+                "analytics": {
+                    "min_value_fault": 79.0,
+                    "max_value_fault": 82.5,
+                    "avg_value_fault": 80.2,
+                    "bounds_low": 65.0,
+                    "bounds_high": 78.0,
+                    "value_unit": "°F",
+                },
+            }
+        ],
+    }
+    path = Path(os.environ["OFDD_DESKTOP_DATA_DIR"]) / "fdd_results.json"
+    path.write_text(json.dumps(runs_doc), encoding="utf-8")
+
+    class _Store:
+        def list_rules(self):
+            return [
+                {
+                    "id": "acme-zn-t-oob-occupied",
+                    "name": "Zone OOB",
+                    "config": {"bounds_low": 65, "bounds_high": 78},
+                }
+            ]
+
+    monkeypatch.setattr(fr, "fdd_results_path", lambda: path)
+    monkeypatch.setattr("openfdd_bridge.fdd_tuning.RuleStore", _Store)
+    patches = collect_tuning_patches(site_id="acme", min_flagged_pct=70.0)
+    assert len(patches) == 1
+
+
 def test_propose_bounds_patch_widens_high():
     from openfdd_bridge.fdd_tuning import propose_bounds_patch
 

--- a/workspace/api/openfdd_bridge/fdd_tuning.py
+++ b/workspace/api/openfdd_bridge/fdd_tuning.py
@@ -56,10 +56,11 @@ def propose_bounds_patch(
     *,
     run: dict[str, Any],
     rule: dict[str, Any] | None,
+    min_flagged_pct: float = 85.0,
 ) -> dict[str, Any] | None:
     """AI-assisted bounds proposal from fault analytics (human or API applies)."""
     pct = _flagged_pct(run)
-    if pct is None or pct < 85.0:
+    if pct is None or pct < float(min_flagged_pct):
         return None
     analytics = run.get("analytics") if isinstance(run.get("analytics"), dict) else {}
     cfg = (rule or {}).get("config") if isinstance((rule or {}).get("config"), dict) else {}
@@ -120,8 +121,9 @@ def collect_tuning_patches(
     *,
     site_id: str,
     rule_ids: list[str] | None = None,
+    min_flagged_pct: float = 70.0,
 ) -> list[dict[str, Any]]:
-    """Collect AI-proposed config patches for high flag-rate rules."""
+    """Collect AI-proposed config patches for elevated flag-rate rules."""
     store = RuleStore()
     rules_by_id = {str(r.get("id")): r for r in store.list_rules() if isinstance(r, dict)}
     allow = {str(x).strip() for x in (rule_ids or []) if str(x).strip()} or None
@@ -140,7 +142,11 @@ def collect_tuning_patches(
             continue
         if allow is not None and rid not in allow:
             continue
-        patch = propose_bounds_patch(run=run, rule=rules_by_id.get(rid))
+        patch = propose_bounds_patch(
+            run=run,
+            rule=rules_by_id.get(rid),
+            min_flagged_pct=min_flagged_pct,
+        )
         if patch:
             patches.append(patch)
             seen.add(rid)
@@ -160,7 +166,11 @@ def apply_tuning_patches(
     poll_ready = _poll_ready(throughput)
     auto_tune_env = os.environ.get("OFDD_AGENT_AUTO_TUNE", "").strip().lower() in {"1", "true", "yes"}
 
-    patches = collect_tuning_patches(site_id=site_id, rule_ids=rule_ids)
+    patches = collect_tuning_patches(
+        site_id=site_id,
+        rule_ids=rule_ids,
+        min_flagged_pct=85.0,
+    )
     if not poll_ready:
         return {
             "ok": True,
@@ -275,8 +285,12 @@ def build_tuning_brief(
         rid = str(run.get("rule_id") or "")
         rname = str(run.get("rule_name") or rid)
         patch = (
-            propose_bounds_patch(run=run, rule=rules_by_id.get(rid))
-            if include_patches and poll_ready
+            propose_bounds_patch(
+                run=run,
+                rule=rules_by_id.get(rid),
+                min_flagged_pct=85.0,
+            )
+            if include_patches and poll_ready and pct is not None and pct >= 85.0
             else None
         )
         if pct >= 85.0:

--- a/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
+++ b/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
@@ -32,8 +32,8 @@ def _dt_hours(table, ts_col, max_gap_hours):
     ts = pc.cast(table[ts_col], pa.timestamp("us", tz="UTC"))
     prev = arrow_shift(ts, 1)
     delta = pc.subtract(ts, prev)
-    secs = pc.cast(delta, pa.int64()) / 1_000_000
-    hours = pc.cast(secs, pa.float64()) / 3600.0
+    secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)
+    hours = pc.divide(pc.cast(secs, pa.float64()), 3600.0)
     py_hours = hours.to_pylist()
     valid = [h for h in py_hours[1:] if h is not None and h > 0]
     typical = sorted(valid)[len(valid) // 2] if valid else (1.0 / 60.0)

--- a/workspace/data/rules_py/ahu_run_hours.py
+++ b/workspace/data/rules_py/ahu_run_hours.py
@@ -32,8 +32,8 @@ def _dt_hours(table, ts_col, max_gap_hours):
     ts = pc.cast(table[ts_col], pa.timestamp("us", tz="UTC"))
     prev = arrow_shift(ts, 1)
     delta = pc.subtract(ts, prev)
-    secs = pc.cast(delta, pa.int64()) / 1_000_000
-    hours = pc.cast(secs, pa.float64()) / 3600.0
+    secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)
+    hours = pc.divide(pc.cast(secs, pa.float64()), 3600.0)
     py_hours = hours.to_pylist()
     valid = [h for h in py_hours[1:] if h is not None and h > 0]
     typical = sorted(valid)[len(valid) // 2] if valid else (1.0 / 60.0)


### PR DESCRIPTION
## Summary
- **FDD fix:** `ahu_run_hours.py` / `acme_rtu-01_fan_and_system_run_hours.py` use `pc.divide` (fixes `ChunkedArray / int` on Acme `acme-ahu-run-hours`).
- **AI tuning:** `collect_tuning_patches` previews bounds at **70%** flag rate; apply-tuning still requires **85%**.
- **Probes:** `check_public_check_engine` uses `OPENFDD_PROBE_PUBLIC_TIMEOUT_S` (default 45s); building-insight gets 90s.
- **Ansible:** optional `openfdd-building-agent.timer` (6h check-in via docker exec); enabled in `acme_vm_bbartling.yml.example`.

## Test plan
- [x] `pytest tests/workspace_bridge/test_ahu_run_hours_script.py tests/workspace_bridge/test_fdd_tuning.py`
- [ ] CI green
- [ ] Tag `open-fdd-v3.0.11`, GHCR publish
- [ ] Acme upgrade + verify + check-in batch (`acme-ahu-run-hours` ok)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional building agent timer scheduling for edge hosts with configurable check-in intervals (default 6 hours).

* **Improvements**
  * Tuning patch thresholds are now configurable per request instead of hardcoded.
  * Enhanced HTTP probe timeout behavior with environment variable configuration.

* **Tests**
  * Added test coverage for timestamp conversion operations and tuning patch collection.

* **Chores**
  * Version bumped to 3.0.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->