### PR TITLE
3.0.12 — Acme run-hours PyArrow script on deploy

### DIFF
--- a/infra/ansible/deploy_docker.yml
+++ b/infra/ansible/deploy_docker.yml
@@ -220,10 +220,41 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
 
+    - name: Regenerate GL36 FDD rules_store on control machine
+      tags: [data]
+      ansible.builtin.command:
+        argv:
+          - python3
+          - scripts/setup_gl36_fdd.py
+          - --site-id
+          - "{{ site_id }}"
+          - --building-id
+          - "{{ building_id }}"
+          - --ahu-equipment-id
+          - "{{ gl36_ahu_equipment_id | default(site_id + '-vm-' + building_id + '-rtu-01') }}"
+          - --fan-point-id
+          - "{{ gl36_fan_point_id | default('1100-analog-output-1') }}"
+        chdir: "{{ playbook_dir }}/../.."
+      delegate_to: localhost
+      become: false
+      register: gl36_rules_gen
+      changed_when: true
+      when: regenerate_gl36_rules_on_deploy | default(false) | bool
+
+    - name: Resolve site rules_store source on control machine
+      tags: [data]
+      ansible.builtin.set_fact:
+        site_rules_store_src: >-
+          {{
+            (playbook_dir + '/../../workspace/data/rules_store.json')
+            if (regenerate_gl36_rules_on_deploy | default(false) | bool)
+            else (edge_backup_dir + '/' + site_id + '/' + building_id + '/rules_store.json')
+          }}
+
     - name: Stat site rules_store on control machine
       tags: [data]
       ansible.builtin.stat:
-        path: "{{ edge_backup_dir }}/{{ site_id }}/{{ building_id }}/rules_store.json"
+        path: "{{ site_rules_store_src }}"
       delegate_to: localhost
       become: false
       register: local_site_rules
@@ -231,7 +262,7 @@
     - name: Push site rules_store.json (no cross-site rules from dev workspace)
       tags: [data]
       ansible.builtin.copy:
-        src: "{{ edge_backup_dir }}/{{ site_id }}/{{ building_id }}/rules_store.json"
+        src: "{{ site_rules_store_src }}"
         dest: "{{ openfdd_remote_dir }}/workspace/data/rules_store.json"
         mode: "0644"
         owner: "{{ ansible_user }}"

--- a/infra/ansible/host_vars/acme_vm_bbartling.yml.example
+++ b/infra/ansible/host_vars/acme_vm_bbartling.yml.example
@@ -50,6 +50,11 @@ openfdd_docker_ollama: true
 feather_max_gib: 125
 feather_retention_days: 365
 
+# Regenerate GL36 rules from scripts/setup_gl36_fdd.py on deploy (PyArrow run-hours, not stale edge_backup)
+regenerate_gl36_rules_on_deploy: true
+gl36_ahu_equipment_id: acme-vm-bbartling-rtu-01
+gl36_fan_point_id: "1100-analog-output-1"
+
 # Building agent check-in timer (poll/FDD/memory append every 6h — no FDD batch by default)
 install_building_agent_timer: true
 enable_building_agent_timer: true

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.11"
+__version__ = "3.0.12"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.11"
+version = "3.0.12"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/workspace_bridge/test_ahu_run_hours_script.py
+++ b/tests/workspace_bridge/test_ahu_run_hours_script.py
@@ -29,11 +29,11 @@ def test_dt_hours_chunked_array_divide_does_not_raise():
     from open_fdd.arrow_runtime.windows import arrow_shift
 
     base = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
-    ts = pa.array([base + timedelta(minutes=i) for i in range(4)], type=pa.timestamp("us", tz="UTC"))
+    ts = pa.array([base + timedelta(minutes=i) for i in range(4)], type=pa.timestamp("us"))
     table = pa.table({"timestamp": ts})
     ts_col = "timestamp"
     prev = arrow_shift(table[ts_col], 1)
-    delta = pc.subtract(pc.cast(table[ts_col], pa.timestamp("us", tz="UTC")), prev)
+    delta = pc.subtract(pc.cast(table[ts_col], pa.timestamp("us")), prev)
     secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)
     hours = pc.divide(pc.cast(secs, pa.float64()), 3600.0)
     assert len(hours) == 4

--- a/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
+++ b/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
@@ -29,7 +29,7 @@ def _system_on_mask(table, cfg, fan_on):
 def _dt_hours(table, ts_col, max_gap_hours):
     from open_fdd.arrow_runtime.windows import arrow_shift
 
-    ts = pc.cast(table[ts_col], pa.timestamp("us", tz="UTC"))
+    ts = pc.cast(table[ts_col], pa.timestamp("us"))
     prev = arrow_shift(ts, 1)
     delta = pc.subtract(ts, prev)
     secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)

--- a/workspace/data/rules_py/ahu_run_hours.py
+++ b/workspace/data/rules_py/ahu_run_hours.py
@@ -29,7 +29,7 @@ def _system_on_mask(table, cfg, fan_on):
 def _dt_hours(table, ts_col, max_gap_hours):
     from open_fdd.arrow_runtime.windows import arrow_shift
 
-    ts = pc.cast(table[ts_col], pa.timestamp("us", tz="UTC"))
+    ts = pc.cast(table[ts_col], pa.timestamp("us"))
     prev = arrow_shift(ts, 1)
     delta = pc.subtract(ts, prev)
     secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)


### PR DESCRIPTION
## Summary
- Run-hours scripts: `pc.divide` + timezone-naive `pa.timestamp("us")` (no pytz in GHCR).
- Ansible: `regenerate_gl36_rules_on_deploy` runs `setup_gl36_fdd.py` and pushes fresh `rules_store.json` (fixes stale pandas `df` script in edge_backup).

## Test plan
- [x] pytest test_ahu_run_hours_script
- [ ] Acme deploy with `regenerate_gl36_rules_on_deploy: true`
- [ ] POST /api/rules/batch — `acme-ahu-run-hours` status ok


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional GL36 rules regeneration capability during edge deployment with dynamic source path selection based on configuration settings.
  * Introduced new GL36 configuration parameters for AHU equipment and fan device identification.

* **Bug Fixes**
  * Improved timestamp handling in run-hour calculations to ensure accurate time delta computations without forced timezone conversions.

* **Chores**
  * Version bumped to 3.0.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->