### PR TITLE
3.0.13 — run-hours Python dt gaps (no pytz)

### DIFF
--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.12"
+__version__ = "3.0.13"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.12"
+version = "3.0.13"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/workspace_bridge/test_ahu_run_hours_script.py
+++ b/tests/workspace_bridge/test_ahu_run_hours_script.py
@@ -12,7 +12,7 @@ if str(API_ROOT) not in sys.path:
     sys.path.insert(0, str(API_ROOT))
 
 
-def test_run_hours_source_uses_pc_divide():
+def test_run_hours_source_avoids_pyarrow_tz_cast():
     script_path = (
         Path(__file__).resolve().parents[2]
         / "workspace"
@@ -21,20 +21,22 @@ def test_run_hours_source_uses_pc_divide():
         / "ahu_run_hours.py"
     )
     code = script_path.read_text(encoding="utf-8")
-    assert "pc.divide(pc.cast(delta, pa.int64()), 1_000_000)" in code
+    assert "total_seconds() / 3600.0" in code
+    assert 'pa.timestamp("us", tz="UTC")' not in code
     assert "pc.cast(delta, pa.int64()) / 1_000_000" not in code
 
 
-def test_dt_hours_chunked_array_divide_does_not_raise():
-    from open_fdd.arrow_runtime.windows import arrow_shift
-
+def test_dt_hours_python_gap_logic():
     base = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
     ts = pa.array([base + timedelta(minutes=i) for i in range(4)], type=pa.timestamp("us"))
     table = pa.table({"timestamp": ts})
-    ts_col = "timestamp"
-    prev = arrow_shift(table[ts_col], 1)
-    delta = pc.subtract(pc.cast(table[ts_col], pa.timestamp("us")), prev)
-    secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)
-    hours = pc.divide(pc.cast(secs, pa.float64()), 3600.0)
-    assert len(hours) == 4
-    assert hours.to_pylist()[1] is not None
+    code = (
+        Path(__file__).resolve().parents[2]
+        / "workspace"
+        / "data"
+        / "rules_py"
+        / "ahu_run_hours.py"
+    ).read_text(encoding="utf-8")
+    ns: dict = {"pa": pa, "pc": pc, "table": table, "cfg": {}}
+    exec(compile(code, "ahu_run_hours.py", "exec"), ns, ns)  # noqa: S102
+    assert ns["out"]["metrics"]["fan_run_hours"] >= 0

--- a/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
+++ b/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
@@ -27,23 +27,37 @@ def _system_on_mask(table, cfg, fan_on):
 
 
 def _dt_hours(table, ts_col, max_gap_hours):
-    from open_fdd.arrow_runtime.windows import arrow_shift
+    from datetime import datetime, timezone
 
-    ts = pc.cast(table[ts_col], pa.timestamp("us"))
-    prev = arrow_shift(ts, 1)
-    delta = pc.subtract(ts, prev)
-    secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)
-    hours = pc.divide(pc.cast(secs, pa.float64()), 3600.0)
-    py_hours = hours.to_pylist()
-    valid = [h for h in py_hours[1:] if h is not None and h > 0]
-    typical = sorted(valid)[len(valid) // 2] if valid else (1.0 / 60.0)
+    def _to_utc(val):
+        if val is None:
+            return None
+        if isinstance(val, datetime):
+            return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+        return datetime.fromisoformat(str(val).replace("Z", "+00:00")).replace(tzinfo=timezone.utc)
+
+    ts_list = [_to_utc(v) for v in table[ts_col].to_pylist()]
     capped = float(max_gap_hours or 2.0)
+    gaps: list[float] = []
+    for i in range(1, len(ts_list)):
+        cur, prev = ts_list[i], ts_list[i - 1]
+        if cur is None or prev is None:
+            continue
+        gap_h = max(0.0, (cur - prev).total_seconds() / 3600.0)
+        if gap_h > 0:
+            gaps.append(min(gap_h, capped))
+    typical = sorted(gaps)[len(gaps) // 2] if gaps else (1.0 / 60.0)
     out = [typical]
-    for h in py_hours[1:]:
-        if h is None or h <= 0:
+    for i in range(1, len(ts_list)):
+        cur, prev = ts_list[i], ts_list[i - 1]
+        if cur is None or prev is None:
+            out.append(typical)
+            continue
+        gap_h = max(0.0, (cur - prev).total_seconds() / 3600.0)
+        if gap_h <= 0:
             out.append(typical)
         else:
-            out.append(min(float(h), capped))
+            out.append(min(gap_h, capped))
     return pa.array(out, type=pa.float64())
 
 

--- a/workspace/data/rules_py/ahu_run_hours.py
+++ b/workspace/data/rules_py/ahu_run_hours.py
@@ -27,23 +27,37 @@ def _system_on_mask(table, cfg, fan_on):
 
 
 def _dt_hours(table, ts_col, max_gap_hours):
-    from open_fdd.arrow_runtime.windows import arrow_shift
+    from datetime import datetime, timezone
 
-    ts = pc.cast(table[ts_col], pa.timestamp("us"))
-    prev = arrow_shift(ts, 1)
-    delta = pc.subtract(ts, prev)
-    secs = pc.divide(pc.cast(delta, pa.int64()), 1_000_000)
-    hours = pc.divide(pc.cast(secs, pa.float64()), 3600.0)
-    py_hours = hours.to_pylist()
-    valid = [h for h in py_hours[1:] if h is not None and h > 0]
-    typical = sorted(valid)[len(valid) // 2] if valid else (1.0 / 60.0)
+    def _to_utc(val):
+        if val is None:
+            return None
+        if isinstance(val, datetime):
+            return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+        return datetime.fromisoformat(str(val).replace("Z", "+00:00")).replace(tzinfo=timezone.utc)
+
+    ts_list = [_to_utc(v) for v in table[ts_col].to_pylist()]
     capped = float(max_gap_hours or 2.0)
+    gaps: list[float] = []
+    for i in range(1, len(ts_list)):
+        cur, prev = ts_list[i], ts_list[i - 1]
+        if cur is None or prev is None:
+            continue
+        gap_h = max(0.0, (cur - prev).total_seconds() / 3600.0)
+        if gap_h > 0:
+            gaps.append(min(gap_h, capped))
+    typical = sorted(gaps)[len(gaps) // 2] if gaps else (1.0 / 60.0)
     out = [typical]
-    for h in py_hours[1:]:
-        if h is None or h <= 0:
+    for i in range(1, len(ts_list)):
+        cur, prev = ts_list[i], ts_list[i - 1]
+        if cur is None or prev is None:
+            out.append(typical)
+            continue
+        gap_h = max(0.0, (cur - prev).total_seconds() / 3600.0)
+        if gap_h <= 0:
             out.append(typical)
         else:
-            out.append(min(float(h), capped))
+            out.append(min(gap_h, capped))
     return pa.array(out, type=pa.float64())
 
 


### PR DESCRIPTION
Fixes acme-ahu-run-hours on GHCR by computing sample gaps in Python datetime.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 3.0.13

* **Tests**
  * Updated validation checks for run-hour calculations
  * Added runtime tests to ensure calculation accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->