### PR TITLE
3.0.14 — run-hours tz-naive feather fix

### DIFF
--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.13"
+__version__ = "3.0.14"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.13"
+version = "3.0.14"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
+++ b/workspace/data/rules_py/acme_rtu-01_fan_and_system_run_hours.py
@@ -73,6 +73,11 @@ if ts_col is None:
         "metrics": {},
     }
 else:
+    ts_type = table[ts_col].type
+    if pa.types.is_timestamp(ts_type) and ts_type.tz is not None:
+        ts_naive = pc.cast(pc.cast(table[ts_col], pa.int64()), pa.timestamp("us"))
+        col_idx = table.column_names.index(ts_col)
+        table = table.set_column(col_idx, ts_col, ts_naive)
     fan_on = _fan_on_mask(table, cfg)
     system_on = _system_on_mask(table, cfg, fan_on)
     dt = _dt_hours(table, ts_col, cfg.get("max_gap_hours", 2.0))

--- a/workspace/data/rules_py/ahu_run_hours.py
+++ b/workspace/data/rules_py/ahu_run_hours.py
@@ -73,6 +73,11 @@ if ts_col is None:
         "metrics": {},
     }
 else:
+    ts_type = table[ts_col].type
+    if pa.types.is_timestamp(ts_type) and ts_type.tz is not None:
+        ts_naive = pc.cast(pc.cast(table[ts_col], pa.int64()), pa.timestamp("us"))
+        col_idx = table.column_names.index(ts_col)
+        table = table.set_column(col_idx, ts_col, ts_naive)
     fan_on = _fan_on_mask(table, cfg)
     system_on = _system_on_mask(table, cfg, fan_on)
     dt = _dt_hours(table, ts_col, cfg.get("max_gap_hours", 2.0))


### PR DESCRIPTION
acme-ahu-run-hours status ok on live Acme batch.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 3.0.14.

* **Bug Fixes**
  * Fixed timezone normalization in fan and system run-hour calculations to ensure accurate metrics when processing timezone-aware timestamp data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->