### PR TITLE
Release 3.0.18: Grade-A fault catalog, portfolio fixes, Acme verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           python -m pytest open_fdd/tests/arrow_runtime -q
           python -m pytest open_fdd/tests/playground -q
           # Separate invocations — both dirs have test_cookbook.py
+          python -m pytest open_fdd/tests/faults -q
+          python -m pytest tests/test_no_pandas_edge_fdd.py -q
 
       - name: Arrow benchmark smoke
         run: |

--- a/docs/development/fdd_grade_a_gap_audit.md
+++ b/docs/development/fdd_grade_a_gap_audit.md
@@ -1,0 +1,161 @@
+---
+title: Grade-A FDD gap audit
+parent: Developer Guide
+nav_exclude: true
+---
+
+# Grade-A FDD gap audit (Open-FDD 3.0.16 → 3.0.18)
+
+Audit date: 2026-06-09. Baseline: merged **3.0.16** (portfolio rollup, expression cookbook, sensor catalog).
+
+## Standards alignment target
+
+| Source | Role in Open-FDD |
+|--------|------------------|
+| ORNL/LBNL unified HVAC fault taxonomy | Canonical ontology backbone (`canonical_id`, `fault_mode`) |
+| ASHRAE Guideline 36 | Expected sequences, trim-and-respond, plant requests, supervisory FDD |
+| ASHRAE Standard 207 | Economizer FDD test-method language |
+| Brick Schema | Primary semantic anchor (`required_point_roles`, equipment relationships) |
+| Project Haystack | Optional tag crosswalk |
+
+There is **no** universal industry fault-code standard. Open-FDD will use **short stable codes** (`AHU-ECON-001`) plus **semantic `canonical_id`** (`ahu.economizer.not_using_free_cooling`), with **legacy letter aliases** (`AHU-E`).
+
+---
+
+## Current fault families (v2 catalog)
+
+Implemented in `workspace/api/openfdd_bridge/fault_catalog.py` (letter codes only):
+
+| Family | Codes | Grade-A gap |
+|--------|-------|-------------|
+| AHU | A–F (6) | Need 20+ AHU modes (SAT, static, economizer, humidity, freeze, filter proxy) |
+| VAV | A–E (5) | Need flow/damper/reheat/G36 request rules |
+| HEATPUMP | A–E (5) | OK starter; align to RTU/HP templates |
+| GEO | A–D (4) | OK for geo sites |
+| CHILLER | A–F (6) | Plant-level CHW/CTW/PMP not split |
+| DATACENTER | A–E (5) | Partial overlap with CRS healthcare |
+| BUILDING | A–D (4) | DATA/CTRL/BACNET not separate families |
+
+**Missing families entirely:** DOAS, MAU, FCU, FPU, CHW (plant), CTW, BLR, HWS, PMP, HX, ERV, CRS (healthcare), DATA, CTRL, BACNET.
+
+---
+
+## Rule cookbook & Arrow runtime
+
+| Asset | Status |
+|-------|--------|
+| `docs/rule-cookbook/expression-cookbook.md` | Legacy pandas/YAML → Arrow translation (3.0.16) |
+| `open_fdd/arrow_runtime/cookbook.py` | flatline, oob, mixing, rate_of_change, schedule masks |
+| `open_fdd/arrow_runtime/sensor_catalog.py` | Bounds/flatline defaults per sensor kind |
+| `open_fdd/arrow_runtime/rules.py` | Backend detection only — **no rule primitives** |
+| Rule templates by system | **Missing** (`open_fdd/faults/templates/`) |
+| Evidence builder | **Missing** (`evidence.py`) |
+| Synthetic PyArrow tests per rule | Partial (bench rules only) |
+
+### Arrow-native cookbook patterns (v2)
+
+`flatline_1h`, `spread_1h`, `oob_rolling`, `rate_of_change`, `mixing_envelope`, `duct_spread_1h`, `custom_arrow`, `schedule_compare`, `stale_points`.
+
+**Missing primitives:** persistence, deadband, cmd/fb mismatch, valve leak, damper stuck, reset stuck, low ΔT, approach, chatter, short-cycle, load/equipment mismatch, pressure relationship, G36 request rollup.
+
+---
+
+## Rule metadata gap
+
+Current catalog entry fields: `code`, `category`, `title`, `severity`, `description`, `likely_causes`, `suggested_checks`, `cookbook_patterns`.
+
+**Missing for Grade-A:**
+
+- `canonical_id`, `subsystem`, `component`, `fault_mode`, `symptom`
+- `required_point_roles` / `optional_point_roles`
+- `rule_template_id`, `rule_doc_path`
+- `related_faults`, `suppresses_faults`, `suppressed_by_faults`
+- `standards_crosswalk` (ORNL, G36, 207, Brick, Haystack)
+- `tuning_params` (persistence, deadband, seasonal/occupancy applicability)
+- `evidence_fields` contract
+- `operator_guidance` (technician / engineer / commissioning roles)
+- `confidence` model
+
+---
+
+## Portfolio / central layer
+
+| Component | Status |
+|-----------|--------|
+| `GET /api/building/portfolio-rollup` | Edge snapshot (faults, run hours, P8 overrides) |
+| `portfolio/collector/` | HTTP poll + CSV append |
+| `portfolio/dash/` | Per-site charts, light/dark, stock-style Δ |
+| `portfolio/agent/*.example` | Skills/memory for central agent |
+| Interval summary schema | **Started** (`portfolio/store/interval_schema.py`) |
+| Tuning proposal schema | **Not implemented** |
+| AI agent auto-tuning apply | **Not implemented** (edge has `apply-tuning` dry-run only) |
+| Cross-site false-positive analytics | **Not implemented** |
+| DuckDB/Parquet central store | **Not implemented** (CSV only) |
+
+---
+
+## Pandas on edge — violations & isolation
+
+**Clean (no pandas):** `open_fdd/arrow_runtime/*`, `open_fdd/playground/arrow_templates.py`, Rule Lab `apply_faults_arrow` rules in `rules_py/`.
+
+**Pandas present (edge bridge / ingest — migration target):**
+
+| Module | Role | Grade-A action |
+|--------|------|----------------|
+| `feather_store.py` | Historian read/write | Keep pandas for CSV ingest path short-term; Arrow path for FDD batch |
+| `fdd_runner.py` | Batch evaluation | Pandas only in legacy_row path; arrow path preferred |
+| `bacnet_poll_ingest.py` | Poll CSV | Ingest layer — isolate, not Rule Lab |
+| `poll_throughput.py` | Analytics | Read-only analytics |
+| `playground.py` / `playground_exec.py` | Legacy evaluate | Deprecate `evaluate()` on edge |
+| `data_loader.py`, `fdd_row_prep.py` | Legacy pipeline | Mark legacy |
+| `open_fdd/playground/rows.py`, `sandbox.py` | Legacy row rules | Portfolio/dev only |
+
+**Allowed pandas:** `portfolio/dash/`, `portfolio/store/` (future pandas/DuckDB), tests, `scripts/ahu_runtime_report.py`, legacy `open_fdd/engine/` (PyPI pandas era).
+
+**Policy (3.0.18+):** New edge FDD code **must not** add pandas imports. CI guard: `tests/test_no_pandas_edge_fdd.py`.
+
+---
+
+## Healthcare / critical spaces
+
+No dedicated CRS catalog. DATACENTER family partially covers CRAH. Need:
+
+- Pressure relationship loss, isolation/OR pressurization
+- ACH shortfall, humidity/temperature excursion
+- `healthcare_risk` category separate from `energy`
+
+---
+
+## Central plant
+
+CHILLER family covers chiller unit only. Missing documented rules for:
+
+- Low ΔT syndrome, CHWST/DP reset stuck, bypass/decoupler
+- Tower approach, condenser reset, staging chatter
+- Boiler/HWS reset stuck, short cycling, simultaneous heat/cool rollup
+
+---
+
+## Dashboard analytics gap
+
+Current Dash: run hours, fault counts, P8 overrides per site.
+
+Missing operator cards: portfolio health score, false-positive rate, tuning queue, data-quality score, plant health rollups, healthcare risk panel, AI recommendations queue.
+
+---
+
+## Recommended implementation order
+
+1. **3.0.18** — Schema + starter YAML catalog + primitives + audit (this patch)
+2. **3.0.19** — Bridge sync: `fault_catalog.py` reads `open_fdd.faults.catalog` + aliases
+3. **3.0.20** — Rule templates (DATA, AHU, VAV, CHW) + synthetic tests
+4. **3.0.21** — Portfolio interval ingest + tuning proposal schema
+5. **3.0.22** — Dash operator cards + AI agent tuning loop docs
+
+---
+
+## References
+
+- [Rule cookbook](https://bbartling.github.io/open-fdd/rule-cookbook/)
+- [Fault codes](https://bbartling.github.io/open-fdd/fault-codes/)
+- [Portfolio (GitHub)](https://github.com/bbartling/open-fdd/tree/master/portfolio)

--- a/docs/development/grade_a_changelog.md
+++ b/docs/development/grade_a_changelog.md
@@ -1,0 +1,53 @@
+---
+title: Grade-A FDD changelog (3.0.18)
+nav_exclude: true
+---
+
+# Grade-A FDD — 3.0.18 foundation
+
+## Added
+
+- **Gap audit:** `docs/development/fdd_grade_a_gap_audit.md`
+- **Canonical fault schema:** `open_fdd/faults/schema.py`
+- **YAML catalog (starter, 19 faults):** `open_fdd/faults/catalog/*.yaml` — DATA, CTRL, BACNET, AHU, CHW, VAV, RTU, CRS
+- **Catalog loader:** `open_fdd/faults/catalog.py` with legacy letter aliases (`AHU-E` → `AHU-ECON-001`)
+- **Arrow primitives:** `open_fdd/arrow_runtime/primitives.py`
+- **Evidence builder:** `open_fdd/arrow_runtime/evidence.py`
+- **Portfolio interval schema:** `portfolio/store/interval_schema.py` + `TuningProposal`
+- **Tests:** catalog validation, primitives, no-pandas edge guard
+
+## Naming convention (new)
+
+| Old | New example |
+|-----|-------------|
+| `AHU-E` | `AHU-ECON-001` (`ahu.economizer.not_using_free_cooling`) |
+| `AHU-B` | `AHU-SHC-001` |
+| `BLD-D` | `DATA-STAL-001` |
+| `CH-B` | `CHW-DT-001` |
+
+Letter codes remain **aliases** until bridge `fault_catalog.py` sync (planned 3.0.19).
+
+## Remaining (future patches)
+
+- Rule templates per system (`open_fdd/faults/templates/`)
+- Full family YAML (VAV, RTU, DOAS, FCU, CTW, BLR, CRS, ERV)
+- Bridge API reads `open_fdd.faults.catalog_export()`
+- Portfolio interval ingest (JSONL/Parquet) + Dash operator cards
+- AI tuning proposal workflow + `docs/portfolio/ai-agent-tuning.md`
+- Pandas removal from `fdd_runner` arrow path
+- Docs pages: central-plants, healthcare, G36, ASHRAE 207 economizer
+
+## How to run tests
+
+```bash
+python3 -m pytest open_fdd/tests/faults open_fdd/tests/arrow_runtime/test_primitives.py tests/test_no_pandas_edge_fdd.py -q
+```
+
+## Portfolio (unchanged from 3.0.17)
+
+```bash
+source infra/ansible/secrets/acme.env.local
+python3 scripts/portfolio_collect.py
+.venv/bin/python portfolio/dash/app.py
+# http://127.0.0.1:8050
+```

--- a/docs/fault-codes/convention.md
+++ b/docs/fault-codes/convention.md
@@ -6,26 +6,45 @@ nav_order: 1
 
 # Fault code convention
 
-## Format
+## Format (Grade-A, 3.0.18+)
 
-`FAMILY-SUFFIX` — suffix is **1–3 letters** (e.g. `VAV-C`, `AHU-B`). Numeric suffixes like `VAV-03` are avoided (collision with physical equipment names).
+**Short stable code:** `FAMILY-SUBSYSTEM-NNN` — e.g. `AHU-ECON-001`, `CHW-DT-001`, `DATA-STAL-001`.
 
-## Categories
+**Semantic ID:** dotted `canonical_id` — e.g. `ahu.economizer.not_using_free_cooling`.
+
+**Legacy letter codes** (`AHU-E`, `VAV-C`) remain **aliases** in `open_fdd/faults/catalog/*.yaml` until bridge sync completes.
+
+| Field | Example |
+|-------|---------|
+| `code` | `AHU-ECON-001` |
+| `canonical_id` | `ahu.economizer.not_using_free_cooling` |
+| `family` | `AHU`, `VAV`, `CHW`, `DATA`, `CRS`, … |
+| `rule_doc_path` | Link to rule cookbook recipe |
+
+Full schema: `open_fdd/faults/schema.py`. Catalog loader: `open_fdd/faults/catalog.py`.
+
+## Categories (Grade-A)
 
 | Category | Meaning |
 |----------|---------|
-| `performance_degradation` | Efficiency or capacity drift |
-| `simultaneous_heat_cool` | Heating and cooling fighting |
-| `sensor_fault` | Flatline, OOB, inconsistent readings |
-| `io_fault` | Command vs feedback mismatch |
+| `energy` | Waste, reset stuck, plant inefficiency |
+| `comfort` | Setpoint not met, poor zone performance |
+| `reliability` | Short cycling, staging, equipment stress |
+| `maintenance` | Leaking valves, filters, fouling proxies |
+| `indoor_air_quality` | Ventilation shortfall, humidity |
+| `healthcare_risk` | Pressure, isolation, critical-space excursions |
+| `data_quality` | Stale, flatline, OOB, missing historian |
+| `controls_integrity` | Overrides, chatter, schedule violations |
 
 ## Severity
 
 | Level | Operator response |
 |-------|-------------------|
 | `info` | Log; trend for maintenance window |
-| `warning` | Investigate within days |
-| `critical` | Prompt attention; may affect comfort/energy significantly |
+| `low` | Review in routine rounds |
+| `medium` | Investigate within days |
+| `high` | Prompt attention; comfort/energy impact likely |
+| `critical` | Immediate operational risk (especially `healthcare_risk`) |
 
 ## Linking rules
 

--- a/docs/fault-codes/standards-crosswalk.md
+++ b/docs/fault-codes/standards-crosswalk.md
@@ -1,0 +1,30 @@
+---
+title: Standards crosswalk
+parent: Fault Codes
+nav_order: 2
+---
+
+# Standards crosswalk
+
+Grade-A fault definitions carry a `standards_crosswalk` block in `open_fdd/faults/catalog/*.yaml`.
+
+| Field | Source | Use in Open-FDD |
+|-------|--------|-----------------|
+| `ornl_lbnl_taxonomy` | ORNL/LBNL unified HVAC fault taxonomy | Canonical ontology backbone |
+| `ashrae_g36_reference_type` | ASHRAE Guideline 36 | Trim-and-respond, plant requests, supervisory sequences |
+| `ashrae_207_reference_type` | ASHRAE Standard 207 | Economizer FDD test categories |
+| `brick_classes` | [Brick Schema](https://brickschema.org/) | Equipment/point semantic roles |
+| `haystack_tags` | Project Haystack (optional) | Interoperability tags |
+
+## Example
+
+```yaml
+standards_crosswalk:
+  ornl_lbnl_taxonomy: ahu/economizer/free_cooling
+  ashrae_g36_reference_type: supply_air_temp_reset
+  ashrae_207_reference_type: economizer_fault_detection
+  brick_classes: [brick:Air_Handler_Unit, brick:Economizer]
+  haystack_tags: [equip, ahu, econ]
+```
+
+Export full catalog: `python3 -c "from open_fdd.faults.catalog import catalog_export; import json; print(json.dumps(catalog_export(), indent=2))"`

--- a/docs/portfolio/central-collection.md
+++ b/docs/portfolio/central-collection.md
@@ -1,0 +1,37 @@
+---
+title: Central collection
+parent: Portfolio
+nav_order: 1
+---
+
+# Portfolio central collection
+
+Edge Open-FDD sites emit **interval summaries** (not raw historian by default). Central portfolio ingests, stores, and aggregates for Dash and the AI tuning agent.
+
+## Interval summary schema
+
+Defined in `portfolio/store/interval_schema.py` as `FaultIntervalSummary`:
+
+- Identity: `site_id`, `building_id`, `equipment_id`, `equipment_family`
+- Window: `timestamp_start`, `timestamp_end`
+- Fault: `fault_code`, `canonical_id`, `severity`, `confidence`
+- Activity: `active_minutes`, `percent_active`, `occurrence_count`
+- Evidence: `evidence_json` (summarized, not full trend)
+- Tuning: `tuning_version`, `tuning_params_hash`
+- Operator: `operator_status` (`new` | `acknowledged` | `resolved` | `false_positive` | …)
+
+## Edge export formats
+
+- JSONL (append-only events)
+- Parquet / Feather (batch intervals)
+
+## Collect today (rollup API)
+
+```bash
+source infra/ansible/secrets/acme.env.local
+python3 scripts/portfolio_collect.py
+```
+
+## Tuning proposals
+
+Human-reviewable proposals use `TuningProposal` in the same module. The AI agent **never** auto-writes BACnet points — see `docs/portfolio/ai-agent-tuning.md` (3.0.19).

--- a/docs/rule-cookbook/central-plants.md
+++ b/docs/rule-cookbook/central-plants.md
@@ -1,0 +1,43 @@
+---
+title: Central plants (CHW / CTW / BLR)
+parent: Rule Cookbook
+nav_order: 20
+---
+
+# Central plant Arrow recipes
+
+Chiller plant, condenser water, cooling tower, boiler, and hot-water distribution faults use the same Arrow-native primitives as air-side rules.
+
+## Starter fault codes
+
+| Code | Primitive | Recipe |
+|------|-----------|--------|
+| `CHW-DT-001` | `low_delta_t_mask` | Low chilled-water ΔT syndrome |
+| `CHW-DP-001` | `reset_stuck_mask` | CHW differential pressure reset stuck high |
+
+## Required point roles (CHW)
+
+- `chw_supply_temp`, `chw_return_temp` — ΔT rules
+- `chw_dp`, `chw_dp_setpoint` — reset stuck rules
+- `pump_command`, `pump_feedback` — command/feedback mismatch
+
+## Synthetic test pattern
+
+```python
+import pyarrow as pa
+from open_fdd.arrow_runtime.primitives import low_delta_t_mask
+
+table = pa.table({
+    "chw_supply_temp": [44.0] * 10,
+    "chw_return_temp": [44.5] * 10,
+})
+mask = low_delta_t_mask(
+    table,
+    {"min_delta_t": 4.0},
+    supply_col="chw_supply_temp",
+    return_col="chw_return_temp",
+)
+assert mask.to_pylist()[-1] is True
+```
+
+See [Fault codes — chiller plant](../fault-codes/chiller-plant.md) (expanded in 3.0.19).

--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-# Acme operational verify: discover → learn devices → model import → FDD rules → poll check.
+# Acme operational verify: BACnet IP smoke → inventory → model → FDD → poll → building-agent.
+#
+# Default discover is **trim BACnet/IP devices only** (RTU-01 1100, hot-water 1002) — not a
+# full OT Who-Is. Use --full-discover only during initial commissioning.
 #
 #   ./scripts/acme_operational_verify.sh --host <tailscale-or-lan-ip>
+#   ./scripts/acme_operational_verify.sh --host <ip> --learn-all-trim   # point-learn all trim VAVs too
+#   ./scripts/acme_operational_verify.sh --host <ip> --full-discover    # legacy full Who-Is (slow)
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -11,11 +16,15 @@ VIBE_ROOT="${VIBE12_ROOT:-$HOME/py-bacnet-stacks-playground/vibe_code_apps_12}"
 
 HOST=""
 SKIP_DISCOVER=0
+FULL_DISCOVER=0
+LEARN_ALL_TRIM=0
 SKIP_WAIT=1
 WAIT_MINUTES="${RUN_WAIT_MINUTES:-3}"
 AUTH_ENV="${ROOT}/workspace/auth.env.local"
 ACME_SECRETS="${ANSIBLE_DIR}/secrets/acme.env.local"
-TRIM_DEVICES="${ROOT}/edge_backup/local/acme/vm-bbartling/devices_discovered.trim.csv"
+TRIM_DEVICES="${ACME_TRIM_DEVICES:-${ROOT}/edge_backup/local/acme/vm-bbartling/devices_discovered.trim.csv}"
+# BACnet/IP plant anchors on Acme (RTU AHU + hot-water boiler) — always smoke-tested.
+PLANT_INSTANCES="${ACME_PLANT_INSTANCES:-1100,1002}"
 FAILURES=0
 
 if [[ -f "$AUTH_ENV" ]]; then
@@ -42,6 +51,9 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --host) HOST="$2"; shift 2 ;;
     --skip-discover) SKIP_DISCOVER=1; shift ;;
+    --full-discover) FULL_DISCOVER=1; shift ;;
+    --learn-all-trim) LEARN_ALL_TRIM=1; shift ;;
+    --trim-devices) TRIM_DEVICES="$2"; shift 2 ;;
     --wait-minutes) WAIT_MINUTES="$2"; SKIP_WAIT=0; shift 2 ;;
     --skip-wait) SKIP_WAIT=1; shift ;;
     *) echo "Unknown: $1" >&2; exit 1 ;;
@@ -99,31 +111,93 @@ wait_job() {
   return 1
 }
 
+is_bacnet_ip_address() {
+  # IPv4 BACnet/IP (e.g. 10.200.200.27) — not MSTP router forms like 12:23.
+  [[ "$1" == *.* && "$1" != *:* ]]
+}
+
+run_point_discovery_row() {
+  local inst="$1" addr="$2" label="${3:-dev ${inst}}"
+  local body pd pj
+  body="$(python3 -c 'import json,sys; print(json.dumps({"device_instance":int(sys.argv[1]),"device_address":sys.argv[2]}))' "$inst" "$addr")"
+  pd="$(api_post "/api/bacnet/point-discovery" "$body")"
+  pj="$(echo "$pd" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("job_id",""))' 2>/dev/null || true)"
+  if [[ -n "$pj" ]]; then
+    wait_job "$pj" "Point learn ${label}" 240
+    return $?
+  fi
+  log_fail "Point discovery dev ${inst}: ${pd}"
+  return 1
+}
+
+run_trim_point_discovery() {
+  local scope="$1"  # ip | all
+  [[ -f "$TRIM_DEVICES" ]] || { log_fail "Missing trim devices CSV: ${TRIM_DEVICES}"; return 1; }
+
+  local ip_count=0 plant_ok=0
+  local -a plant_need=()
+  IFS=',' read -r -a plant_need <<< "$PLANT_INSTANCES"
+
+  if [[ "$scope" == "ip" ]]; then
+    log_info "BACnet/IP point-discovery smoke (AHU/boiler from trim CSV)"
+  else
+    log_info "Point discovery on all trim devices (AHU/VAV/boiler/tracer — skip 5xxx)"
+  fi
+
+  while IFS= read -r line; do
+    [[ "$line" == device_instance* ]] && continue
+    inst="$(echo "$line" | cut -d, -f1)"
+    addr="$(echo "$line" | cut -d, -f2)"
+    name="$(echo "$line" | cut -d, -f3)"
+    [[ -n "$inst" && -n "$addr" ]] || continue
+
+    if [[ "$scope" == "ip" ]] && ! is_bacnet_ip_address "$addr"; then
+      continue
+    fi
+    ip_count=$((ip_count + 1))
+    label="${name:-dev ${inst}} (${inst}@${addr})"
+    if run_point_discovery_row "$inst" "$addr" "$label"; then
+      for need in "${plant_need[@]}"; do
+        if [[ "$inst" == "$need" ]]; then
+          plant_ok=$((plant_ok + 1))
+        fi
+      done
+    fi
+  done < "$TRIM_DEVICES"
+
+  if [[ "$scope" == "ip" ]]; then
+    if [[ "$ip_count" -eq 0 ]]; then
+      log_fail "No BACnet/IP rows in ${TRIM_DEVICES}"
+      return 1
+    fi
+    local need_count="${#plant_need[@]}"
+    if [[ "$plant_ok" -lt "$need_count" ]]; then
+      log_fail "Plant BACnet/IP smoke incomplete (${plant_ok}/${need_count} of ${PLANT_INSTANCES} ok)"
+      return 1
+    fi
+    log_ok "BACnet/IP plant devices ok (${plant_ok}/${need_count}: ${PLANT_INSTANCES})"
+  fi
+  return 0
+}
+
 echo "Acme operational verify → ${HOST}"
 [[ -n "$LOGIN_PASS" ]] || { log_fail "No credentials in ${AUTH_ENV}"; exit 1; }
 TOKEN="$(login)"
 log_ok "Authenticated as ${LOGIN_USER}"
 
 if [[ "$SKIP_DISCOVER" -eq 0 ]]; then
-  log_info "BACnet Who-Is discover (full OT range)"
-  disc="$(api_post "/api/bacnet/discover" '{"range_low":1,"range_high":4194303}')"
-  job_id="$(echo "$disc" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("job_id",""))')"
-  [[ -n "$job_id" ]] && wait_job "$job_id" "Discover" 180 || log_fail "discover: $disc"
+  if [[ "$FULL_DISCOVER" -eq 1 ]]; then
+    log_info "BACnet Who-Is discover (full OT range — commissioning only)"
+    disc="$(api_post "/api/bacnet/discover" '{"range_low":1,"range_high":4194303}')"
+    job_id="$(echo "$disc" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("job_id",""))')"
+    [[ -n "$job_id" ]] && wait_job "$job_id" "Discover" 180 || log_fail "discover: $disc"
+    LEARN_ALL_TRIM=1
+  fi
 
-  if [[ -f "$TRIM_DEVICES" ]]; then
-    log_info "Point discovery on trim devices (AHU/VAV/boiler/tracer — skip 5xxx)"
-    while IFS= read -r line; do
-      [[ "$line" == device_instance* ]] && continue
-      inst="$(echo "$line" | cut -d, -f1)"
-      addr="$(echo "$line" | cut -d, -f2)"
-      [[ -n "$inst" && -n "$addr" ]] || continue
-      body="$(python3 -c 'import json,sys; print(json.dumps({"device_instance":int(sys.argv[1]),"device_address":sys.argv[2]}))' "$inst" "$addr")"
-      pd="$(api_post "/api/bacnet/point-discovery" "$body")"
-      pj="$(echo "$pd" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("job_id",""))' 2>/dev/null || true)"
-      if [[ -n "$pj" ]]; then
-        wait_job "$pj" "Point learn dev ${inst}" 240 || true
-      fi
-    done < "$TRIM_DEVICES"
+  if [[ "$LEARN_ALL_TRIM" -eq 1 ]]; then
+    run_trim_point_discovery all || true
+  else
+    run_trim_point_discovery ip || true
   fi
 fi
 

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.16"
+__version__ = "3.0.18"
 
 __all__ = ["__version__"]

--- a/open_fdd/arrow_runtime/evidence.py
+++ b/open_fdd/arrow_runtime/evidence.py
@@ -1,0 +1,67 @@
+"""Structured FDD evidence payloads (Arrow-native, no pandas)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def missing_columns_evidence(
+    *,
+    fault_code: str,
+    canonical_id: str,
+    missing_roles: list[str],
+    available_columns: list[str],
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "fault_code": fault_code,
+        "canonical_id": canonical_id,
+        "reason": "DATA-MISSING",
+        "missing_point_roles": list(missing_roles),
+        "available_columns": list(available_columns),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def flag_evidence(
+    *,
+    fault_code: str,
+    canonical_id: str,
+    severity: str,
+    confidence: float,
+    measured: dict[str, Any],
+    thresholds: dict[str, Any] | None = None,
+    duration_minutes: float | None = None,
+    percent_time_active: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "fault_code": fault_code,
+        "canonical_id": canonical_id,
+        "severity": severity,
+        "confidence": round(float(confidence), 3),
+        "measured": measured,
+        "thresholds": thresholds or {},
+        "duration_minutes": duration_minutes,
+        "percent_time_active": percent_time_active,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def resolve_point_roles(
+    table_columns: list[str],
+    role_map: dict[str, str],
+    required_roles: list[str],
+) -> tuple[dict[str, str], list[str]]:
+    """Map Brick/logical roles to historian column names present on table."""
+    cols = set(table_columns)
+    resolved: dict[str, str] = {}
+    missing: list[str] = []
+    for role in required_roles:
+        col = role_map.get(role) or role
+        if col in cols:
+            resolved[role] = col
+        else:
+            missing.append(role)
+    return resolved, missing

--- a/open_fdd/arrow_runtime/primitives.py
+++ b/open_fdd/arrow_runtime/primitives.py
@@ -1,0 +1,172 @@
+"""Reusable Arrow-native rule primitives (Grade-A building blocks)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from open_fdd.playground.cookbook import cfg_threshold
+
+from .cookbook import (
+    arrow_rolling_mean,
+    flatline_1h_mask,
+    mixing_envelope_mask,
+    oob_mask,
+    rate_of_change_mask,
+    sensor_bounds_mask,
+    sensor_flatline_mask,
+    value_column,
+)
+from .windows import arrow_consecutive_true
+
+
+def threshold_mask(
+    table: pa.Table,
+    cfg: dict[str, Any],
+    *,
+    col: str | None = None,
+    op: str = "gt",
+) -> pa.ChunkedArray:
+    name = value_column(table, cfg, col)
+    vals = pc.cast(table[name], pa.float64())
+    limit = cfg_threshold(cfg, str(cfg.get("threshold_key") or "threshold"))
+    if op == "lt":
+        return pc.less(vals, limit)
+    if op == "ge":
+        return pc.greater_equal(vals, limit)
+    if op == "le":
+        return pc.less_equal(vals, limit)
+    return pc.greater(vals, limit)
+
+
+def range_mask(
+    table: pa.Table,
+    cfg: dict[str, Any],
+    *,
+    col: str | None = None,
+    low_key: str = "bounds_low",
+    high_key: str = "bounds_high",
+) -> pa.ChunkedArray:
+    return oob_mask(table, {**cfg, "bounds_low": cfg.get(low_key), "bounds_high": cfg.get(high_key)}, col=col)
+
+
+def deadband_mask(
+    table: pa.Table,
+    cfg: dict[str, Any],
+    *,
+    value_col: str,
+    setpoint_col: str,
+    deadband_key: str = "deadband",
+) -> pa.ChunkedArray:
+    """True when |value - setpoint| exceeds deadband."""
+    if value_col not in table.column_names or setpoint_col not in table.column_names:
+        n = table.num_rows
+        return pa.array([False] * n, type=pa.bool_())
+    val = pc.cast(table[value_col], pa.float64())
+    sp = pc.cast(table[setpoint_col], pa.float64())
+    band = cfg_threshold(cfg, deadband_key)
+    err = pc.abs(pc.subtract(val, sp))
+    return pc.greater(err, band)
+
+
+def persistence_mask(mask: pa.Array | pa.ChunkedArray, min_samples: int) -> pa.ChunkedArray:
+    """True when condition holds for ``min_samples`` consecutive rows."""
+    return arrow_consecutive_true(mask, max(1, int(min_samples)))
+
+
+def rolling_percent_true_arrow(mask: pa.Array | pa.ChunkedArray, window: int) -> pa.ChunkedArray:
+    """Fraction of True in rolling window (0–1)."""
+    flat = mask.cast(pa.float64())
+    return arrow_rolling_mean(flat, max(1, int(window)))
+
+
+def command_feedback_mismatch(
+    table: pa.Table,
+    cfg: dict[str, Any],
+    *,
+    command_col: str,
+    feedback_col: str,
+    tolerance_key: str = "cmd_fb_tolerance",
+) -> pa.ChunkedArray:
+    if command_col not in table.column_names or feedback_col not in table.column_names:
+        n = table.num_rows
+        return pa.array([False] * n, type=pa.bool_())
+    cmd = pc.cast(table[command_col], pa.float64())
+    fb = pc.cast(table[feedback_col], pa.float64())
+    tol = cfg_threshold(cfg, tolerance_key)
+    return pc.greater(pc.abs(pc.subtract(cmd, fb)), tol)
+
+
+def setpoint_tracking_error(
+    table: pa.Table,
+    cfg: dict[str, Any],
+    *,
+    value_col: str,
+    setpoint_col: str,
+    deadband_key: str = "tracking_deadband",
+) -> pa.ChunkedArray:
+    return deadband_mask(
+        table,
+        {**cfg, "deadband": cfg.get(deadband_key)},
+        value_col=value_col,
+        setpoint_col=setpoint_col,
+        deadband_key="deadband",
+    )
+
+
+def simultaneous_heat_cool_mask(
+    table: pa.Table,
+    cfg: dict[str, Any],
+    *,
+    heat_col: str,
+    cool_col: str,
+    on_key: str = "valve_on_min",
+) -> pa.ChunkedArray:
+    if heat_col not in table.column_names or cool_col not in table.column_names:
+        n = table.num_rows
+        return pa.array([False] * n, type=pa.bool_())
+    on_min = cfg_threshold(cfg, on_key)
+    heat = pc.greater(pc.cast(table[heat_col], pa.float64()), on_min)
+    cool = pc.greater(pc.cast(table[cool_col], pa.float64()), on_min)
+    return pc.and_(heat, cool)
+
+
+def low_delta_t_mask(
+    table: pa.Table,
+    cfg: dict[str, Any],
+    *,
+    supply_col: str,
+    return_col: str,
+    min_delta_key: str = "min_delta_t",
+) -> pa.ChunkedArray:
+    if supply_col not in table.column_names or return_col not in table.column_names:
+        n = table.num_rows
+        return pa.array([False] * n, type=pa.bool_())
+    sup = pc.cast(table[supply_col], pa.float64())
+    ret = pc.cast(table[return_col], pa.float64())
+    delta = pc.abs(pc.subtract(ret, sup))
+    return pc.less(delta, cfg_threshold(cfg, min_delta_key))
+
+
+# Re-export catalog-backed sensor masks for template convenience
+flatline_mask = sensor_flatline_mask
+stale_mask = flatline_mask  # stale uses separate poll metadata — alias for template id only
+
+__all__ = [
+    "threshold_mask",
+    "range_mask",
+    "deadband_mask",
+    "persistence_mask",
+    "rolling_percent_true_arrow",
+    "command_feedback_mismatch",
+    "setpoint_tracking_error",
+    "simultaneous_heat_cool_mask",
+    "low_delta_t_mask",
+    "flatline_mask",
+    "mixing_envelope_mask",
+    "rate_of_change_mask",
+    "sensor_bounds_mask",
+    "persistence_mask",
+]

--- a/open_fdd/faults/__init__.py
+++ b/open_fdd/faults/__init__.py
@@ -1,0 +1,23 @@
+"""Grade-A canonical fault catalog — schema, YAML definitions, legacy aliases."""
+
+from .catalog import (
+    catalog_version,
+    get_fault,
+    legacy_alias,
+    list_families,
+    list_faults,
+    load_catalog,
+)
+from .schema import FaultDefinition, StandardsCrosswalk, TuningParams
+
+__all__ = [
+    "FaultDefinition",
+    "StandardsCrosswalk",
+    "TuningParams",
+    "catalog_version",
+    "get_fault",
+    "legacy_alias",
+    "list_families",
+    "list_faults",
+    "load_catalog",
+]

--- a/open_fdd/faults/catalog.py
+++ b/open_fdd/faults/catalog.py
@@ -1,0 +1,95 @@
+"""Load Grade-A fault definitions from YAML catalog files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .schema import FaultDefinition
+
+CATALOG_VERSION = 1
+_CATALOG_DIR = Path(__file__).resolve().parent / "catalog"
+_catalog_cache: dict[str, FaultDefinition] | None = None
+_alias_cache: dict[str, str] | None = None
+
+
+def _yaml_files() -> list[Path]:
+    if not _CATALOG_DIR.is_dir():
+        return []
+    return sorted(_CATALOG_DIR.glob("*.yaml"))
+
+
+def load_catalog() -> dict[str, FaultDefinition]:
+    """All faults keyed by ``code``."""
+    global _catalog_cache, _alias_cache
+    if _catalog_cache is not None:
+        return _catalog_cache
+
+    faults: dict[str, FaultDefinition] = {}
+    alias_index: dict[str, str] = {}
+
+    for path in _yaml_files():
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            continue
+        for item in raw.get("faults") or []:
+            if not isinstance(item, dict):
+                continue
+            fault = FaultDefinition.from_dict(item)
+            errors = fault.validate()
+            if errors:
+                raise ValueError(f"{path.name} fault {fault.code}: {', '.join(errors)}")
+            faults[fault.code] = fault
+            for alias in fault.legacy_aliases:
+                alias_index[str(alias).strip().upper()] = fault.code
+
+    _catalog_cache = faults
+    _alias_cache = alias_index
+    return faults
+
+
+def catalog_version() -> int:
+    return CATALOG_VERSION
+
+
+def list_faults(*, family: str | None = None) -> list[FaultDefinition]:
+    catalog = load_catalog()
+    items = list(catalog.values())
+    if family:
+        fam = family.strip().upper()
+        items = [f for f in items if f.family == fam]
+    return sorted(items, key=lambda f: f.code)
+
+
+def list_families() -> list[str]:
+    return sorted({f.family for f in load_catalog().values()})
+
+
+def get_fault(code: str) -> FaultDefinition | None:
+    key = str(code or "").strip().upper()
+    catalog = load_catalog()
+    if key in catalog:
+        return catalog[key]
+    load_catalog()
+    resolved = (_alias_cache or {}).get(key)
+    if resolved:
+        return catalog.get(resolved)
+    return None
+
+
+def legacy_alias(letter_code: str) -> str | None:
+    """Map v2 letter code (e.g. AHU-E) to Grade-A code if aliased."""
+    fault = get_fault(letter_code)
+    return fault.code if fault else None
+
+
+def catalog_export() -> dict[str, Any]:
+    """JSON-serializable catalog for API / portfolio."""
+    faults = load_catalog()
+    return {
+        "version": catalog_version(),
+        "families": list_families(),
+        "faults": [f.to_dict() for f in sorted(faults.values(), key=lambda x: x.code)],
+    }

--- a/open_fdd/faults/catalog/ahu.yaml
+++ b/open_fdd/faults/catalog/ahu.yaml
@@ -1,0 +1,105 @@
+# Grade-A AHU faults (starter set — expand per gap audit)
+faults:
+  - code: AHU-ECON-001
+    canonical_id: ahu.economizer.not_using_free_cooling
+    family: AHU
+    system_type: air_handling_unit
+    subsystem: economizer
+    component: outdoor_air_damper
+    fault_mode: missed_free_cooling
+    symptom: Free cooling available but mechanical cooling or minimum OA persists
+    title: Economizer not economizing
+    severity_default: medium
+    category: energy
+    required_point_roles: [outside_air_temperature, cooling_valve_command, damper_position_command]
+    optional_point_roles: [supply_air_temperature_setpoint, mixed_air_temperature]
+    rule_template_id: economizer_free_cooling_available
+    rule_doc_path: docs/rule-cookbook/expression-cookbook.md
+    legacy_aliases: [AHU-E]
+    standards_crosswalk:
+      ashrae_g36_reference_type: economizer_enable
+      ashrae_207_reference_type: economizer_fault
+      brick_classes: [Outside_Air_Damper, Cooling_Valve]
+    tuning_params:
+      thresholds:
+        free_cooling_margin_f: 2.0
+        damper_low_open_max: 0.5
+        cooling_cmd_on_min: 0.1
+      persistence_minutes: 60
+      occupancy_applicability: occupied
+    evidence_fields: [oat, sat_sp, damper_cmd, valve_cmd, duration_minutes]
+    related_faults: [AHU-SHC-001]
+    operator_guidance:
+      plain_english_summary: Outdoor air is cool enough for free cooling but the AHU is still using mechanical cooling.
+      why_it_matters: Energy impact proxy — unnecessary chiller/compressor load.
+      engineer_roi_notes: Check economizer lockout, damper minimums, and SAT reset.
+
+  - code: AHU-SHC-001
+    canonical_id: ahu.coils.simultaneous_heating_cooling
+    family: AHU
+    system_type: air_handling_unit
+    subsystem: coils
+    component: heating_cooling_valves
+    fault_mode: simultaneous_heat_cool
+    symptom: Heating and cooling outputs active together
+    title: Simultaneous heating and cooling
+    severity_default: critical
+    category: energy
+    required_point_roles: [heating_valve_command, cooling_valve_command]
+    optional_point_roles: [supply_air_temperature, supply_fan_status]
+    rule_template_id: simultaneous_heat_cool_mask
+    rule_doc_path: docs/rule-cookbook/expression-cookbook.md
+    legacy_aliases: [AHU-B]
+    standards_crosswalk:
+      ashrae_g36_reference_type: coil_sequencing
+      brick_classes: [Heating_Valve, Cooling_Valve]
+    tuning_params:
+      thresholds:
+        valve_on_min: 0.1
+      persistence_minutes: 15
+    evidence_fields: [heating_cmd, cooling_cmd, duration_minutes]
+    operator_guidance:
+      plain_english_summary: The AHU is heating and cooling at the same time.
+      why_it_matters: Direct energy waste and comfort fighting.
+
+  - code: AHU-SAT-001
+    canonical_id: ahu.supply_air.temperature_setpoint_not_met
+    family: AHU
+    system_type: air_handling_unit
+    subsystem: supply_air
+    component: temperature_control
+    fault_mode: setpoint_tracking_failure
+    symptom: SAT outside deadband of setpoint while fan and plant active
+    title: SAT setpoint not met
+    severity_default: medium
+    category: comfort
+    required_point_roles: [supply_air_temperature, supply_air_temperature_setpoint, supply_fan_status]
+    rule_template_id: setpoint_tracking_error
+    rule_doc_path: docs/rule-cookbook/expression-cookbook.md
+    legacy_aliases: [AHU-C]
+    tuning_params:
+      deadbands:
+        sat_deadband_f: 2.0
+      persistence_minutes: 45
+    evidence_fields: [sat, sat_sp, error, duration_minutes]
+
+  - code: AHU-MAT-001
+    canonical_id: ahu.mixed_air.inconsistent_with_oat_rat
+    family: AHU
+    system_type: air_handling_unit
+    subsystem: mixed_air
+    component: temperature_sensor
+    fault_mode: mixing_envelope_violation
+    symptom: MAT outside envelope bounded by OAT and RAT
+    title: Mixed air inconsistent with OAT/RAT
+    severity_default: medium
+    category: data_quality
+    required_point_roles: [mixed_air_temperature, outside_air_temperature, return_air_temperature, supply_fan_status]
+    rule_template_id: mixing_envelope_mask
+    rule_doc_path: docs/rule-cookbook/expression-cookbook.md
+    legacy_aliases: [AHU-D]
+    tuning_params:
+      thresholds:
+        mixing_tol_f: 1.15
+      persistence_minutes: 30
+    evidence_fields: [mat, oat, rat, mixing_tol]

--- a/open_fdd/faults/catalog/chw.yaml
+++ b/open_fdd/faults/catalog/chw.yaml
@@ -1,0 +1,48 @@
+# Grade-A chilled water plant faults (starter)
+faults:
+  - code: CHW-DT-001
+    canonical_id: chw.plant.low_delta_t
+    family: CHW
+    system_type: chilled_water_plant
+    subsystem: distribution
+    component: plant_loop
+    fault_mode: low_delta_t_syndrome
+    symptom: CHW ΔT chronically below design while load present
+    title: Low delta-T syndrome
+    severity_default: medium
+    category: energy
+    required_point_roles: [chilled_water_supply_temperature, chilled_water_return_temperature, plant_enable]
+    optional_point_roles: [chilled_water_flow, total_plant_kw]
+    rule_template_id: low_delta_t_mask
+    rule_doc_path: docs/rule-cookbook/central-plants.md
+    legacy_aliases: [CH-B]
+    standards_crosswalk:
+      ashrae_g36_reference_type: plant_efficiency
+      brick_classes: [Chilled_Water_System, Chilled_Water_Return_Temperature_Sensor]
+    tuning_params:
+      thresholds:
+        min_delta_t_f: 8.0
+      persistence_minutes: 120
+    evidence_fields: [chwst, chwrt, delta_t, duration_minutes]
+    operator_guidance:
+      plain_english_summary: The plant is moving a lot of water for little temperature lift.
+      why_it_matters: Energy impact proxy — poor plant efficiency and valve leakage.
+      engineer_roi_notes: Audit coil valves, bypass, and decoupler flow.
+
+  - code: CHW-DP-001
+    canonical_id: chw.plant.differential_pressure_reset_stuck
+    family: CHW
+    system_type: chilled_water_plant
+    subsystem: pumping
+    component: differential_pressure_setpoint
+    fault_mode: reset_stuck
+    symptom: DP setpoint remains at design maximum despite low load
+    title: CHW DP reset stuck high
+    severity_default: medium
+    category: energy
+    required_point_roles: [differential_pressure_setpoint, differential_pressure_sensor, pump_speed_command]
+    rule_template_id: reset_stuck_mask
+    rule_doc_path: docs/rule-cookbook/central-plants.md
+    tuning_params:
+      persistence_minutes: 180
+    evidence_fields: [dp_sp, dp, pump_cmd, percent_time_at_max]

--- a/open_fdd/faults/catalog/cross_cutting.yaml
+++ b/open_fdd/faults/catalog/cross_cutting.yaml
@@ -1,0 +1,132 @@
+# Grade-A cross-cutting faults: DATA, CTRL, BACNET
+faults:
+  - code: DATA-STAL-001
+    canonical_id: data.telemetry.stale_point
+    family: DATA
+    system_type: building
+    subsystem: historian
+    component: telemetry
+    fault_mode: stale
+    symptom: Point has not updated within expected poll interval
+    title: Stale telemetry point
+    severity_default: high
+    category: data_quality
+    required_point_roles: [timestamp, present_value]
+    optional_point_roles: [quality, poll_interval_s]
+    rule_template_id: stale_mask
+    rule_doc_path: docs/rule-cookbook/arrow-recipes.md
+    legacy_aliases: [BLD-D]
+    standards_crosswalk:
+      ornl_lbnl_taxonomy: sensor/data_quality/stale
+      brick_classes: []
+    tuning_params:
+      persistence_minutes: 15
+      thresholds:
+        max_age_minutes: 30
+    evidence_fields: [timestamp, last_value, age_minutes, point_id]
+    likely_causes:
+      - BACnet comm loss
+      - Poll driver down
+      - Controller offline
+    operator_guidance:
+      plain_english_summary: A trend point stopped updating; FDD cannot trust this sensor.
+      why_it_matters: Stale data causes false negatives and blocks tuning.
+      technician_checks:
+        - Verify device online on BACnet
+        - Check poll CSV freshness
+      engineer_roi_notes: Fix comm before tuning thresholds on this equipment.
+
+  - code: DATA-FLAT-001
+    canonical_id: data.sensor.flatline
+    family: DATA
+    system_type: sensor
+    subsystem: data_quality
+    component: sensor
+    fault_mode: flatline
+    symptom: Rolling spread below tolerance for extended period
+    title: Flatlined sensor
+    severity_default: medium
+    category: data_quality
+    required_point_roles: [present_value]
+    rule_template_id: flatline_mask
+    rule_doc_path: docs/rule-cookbook/expression-cookbook.md
+    legacy_aliases: [AHU-C, VAV-C, BLD-B]
+    tuning_params:
+      persistence_minutes: 60
+      thresholds:
+        flatline_tolerance: 0.1
+    evidence_fields: [spread, window_minutes, present_value]
+    operator_guidance:
+      plain_english_summary: Sensor reading is stuck; may be failed probe or comm substitution.
+      why_it_matters: Bad sensor drives wrong control and false equipment faults.
+
+  - code: DATA-OOB-001
+    canonical_id: data.sensor.out_of_range
+    family: DATA
+    system_type: sensor
+    subsystem: data_quality
+    component: sensor
+    fault_mode: out_of_range
+    symptom: Value outside physical bounds for sensor type
+    title: Sensor out of range
+    severity_default: medium
+    category: data_quality
+    required_point_roles: [present_value]
+    rule_template_id: sensor_bounds_mask
+    rule_doc_path: docs/rule-cookbook/expression-cookbook.md
+    tuning_params:
+      thresholds:
+        bounds_low: 55
+        bounds_high: 90
+    evidence_fields: [present_value, bounds_low, bounds_high]
+    operator_guidance:
+      plain_english_summary: Reading is implausible for this sensor type.
+      why_it_matters: OOB values corrupt economizer, SAT, and zone logic.
+
+  - code: CTRL-CHAT-001
+    canonical_id: controls.loop.chatter
+    family: CTRL
+    system_type: controls
+    subsystem: pid
+    component: actuator
+    fault_mode: hunting
+    symptom: Command oscillates rapidly without settling
+    title: Control loop chatter
+    severity_default: medium
+    category: controls_integrity
+    required_point_roles: [command]
+    optional_point_roles: [feedback, setpoint]
+    rule_template_id: control_chatter_mask
+    rule_doc_path: docs/rule-cookbook/arrow-recipes.md
+    tuning_params:
+      persistence_minutes: 30
+      thresholds:
+        min_reversals_per_hour: 6
+    evidence_fields: [command, reversal_count, duration_minutes]
+    operator_guidance:
+      plain_english_summary: A valve or damper is hunting — wears hardware and wastes energy.
+      why_it_matters: Chatter increases maintenance cost and comfort complaints.
+
+  - code: BACNET-P8-001
+    canonical_id: bacnet.override.operator_priority_active
+    family: BACNET
+    system_type: supervisory
+    subsystem: priority_array
+    component: override
+    fault_mode: operator_override
+    symptom: Priority-8 operator override active on point
+    title: BACnet P8 operator override
+    severity_default: medium
+    category: controls_integrity
+    required_point_roles: [priority_array]
+    rule_template_id: bacnet_p8_override
+    rule_doc_path: docs/fault-codes/sensor-quality.md
+    tuning_params:
+      persistence_minutes: 0
+    evidence_fields: [device_instance, object_identifier, value, priority_level]
+    operator_guidance:
+      plain_english_summary: An operator placed a supervisory override on a BACnet point.
+      why_it_matters: Overrides mask FDD and may hide efficiency problems.
+      technician_checks:
+        - Identify who placed override and why
+        - Clear when work complete

--- a/open_fdd/faults/catalog/crs.yaml
+++ b/open_fdd/faults/catalog/crs.yaml
@@ -1,0 +1,81 @@
+faults:
+  - code: CRS-PRESS-001
+    canonical_id: crs.pressure.relationship_lost
+    family: CRS
+    system_type: healthcare
+    subsystem: pressurization
+    component: room
+    fault_mode: pressure_relationship_lost
+    symptom: Required pressure differential not maintained
+    title: Room pressure relationship lost
+    severity_default: critical
+    category: healthcare_risk
+    required_point_roles: [room_pressure, pressure_setpoint]
+    optional_point_roles: [supply_airflow, exhaust_airflow, door_status]
+    rule_template_id: pressure_relationship_mask
+    rule_doc_path: docs/rule-cookbook/healthcare-critical-spaces.md
+    standards_crosswalk:
+      ornl_lbnl_taxonomy: healthcare/pressurization
+      brick_classes: [brick:Room, brick:Pressure_Sensor]
+    tuning_params:
+      deadbands:
+        pressure_deadband_pa: 2.5
+      persistence_minutes: 5
+    evidence_fields: [room_pressure, pressure_setpoint, duration_minutes]
+    likely_causes:
+      - Supply or exhaust fan issue
+      - Door propped open
+      - Filter loading / airflow imbalance
+    operator_guidance:
+      plain_english_summary: Critical room is not holding required positive or negative pressure.
+      why_it_matters: Infection control and regulatory risk — operational alert, not compliance certification.
+      technician_checks:
+        - Verify supply/exhaust fan status
+        - Check door seals and traffic
+
+  - code: CRS-ISO-001
+    canonical_id: crs.isolation.not_negative_when_required
+    family: CRS
+    system_type: healthcare
+    subsystem: isolation
+    component: room
+    fault_mode: isolation_not_negative
+    symptom: Isolation room pressure positive or neutral when negative required
+    title: Isolation room not negative
+    severity_default: critical
+    category: healthcare_risk
+    required_point_roles: [room_pressure]
+    optional_point_roles: [room_mode, exhaust_airflow]
+    rule_template_id: threshold_mask
+    rule_doc_path: docs/rule-cookbook/healthcare-critical-spaces.md
+    tuning_params:
+      thresholds:
+        max_pressure_pa: -2.5
+      persistence_minutes: 5
+    evidence_fields: [room_pressure, room_mode, duration_minutes]
+    operator_guidance:
+      plain_english_summary: Isolation room should be negative but pressure reading indicates it is not.
+      why_it_matters: Protects staff and adjacent spaces during infectious patient care.
+
+  - code: CRS-DATA-001
+    canonical_id: crs.sensor.critical_stale
+    family: CRS
+    system_type: healthcare
+    subsystem: data_quality
+    component: critical_sensor
+    fault_mode: stale
+    symptom: Critical pressure or environmental sensor stale
+    title: Critical sensor stale or invalid
+    severity_default: critical
+    category: healthcare_risk
+    required_point_roles: [present_value, timestamp]
+    rule_template_id: stale_mask
+    rule_doc_path: docs/fault-codes/data-quality.md
+    suppressed_by_faults: [DATA-STAL-001]
+    tuning_params:
+      thresholds:
+        max_age_minutes: 5
+    evidence_fields: [point_id, age_minutes, last_value]
+    operator_guidance:
+      plain_english_summary: A sensor protecting a critical space stopped updating.
+      why_it_matters: You cannot verify safe pressurization without valid data.

--- a/open_fdd/faults/catalog/rtu.yaml
+++ b/open_fdd/faults/catalog/rtu.yaml
@@ -1,0 +1,50 @@
+faults:
+  - code: RTU-ECON-001
+    canonical_id: rtu.economizer.not_using_free_cooling
+    family: RTU
+    system_type: packaged
+    subsystem: economizer
+    component: outdoor_air_damper
+    fault_mode: economizer_inactive
+    symptom: OA conditions favorable but economizer not providing free cooling
+    title: RTU economizer not using free cooling
+    severity_default: medium
+    category: energy
+    required_point_roles: [outdoor_air_temp, return_air_temp, mixed_air_temp, economizer_command]
+    rule_template_id: mixing_envelope_mask
+    rule_doc_path: docs/rule-cookbook/economizer-ashrae-207.md
+    legacy_aliases: [RTU-E]
+    standards_crosswalk:
+      ashrae_207_reference_type: economizer_fault_detection
+      ornl_lbnl_taxonomy: rtu/economizer
+    tuning_params:
+      thresholds:
+        oa_cooling_delta_f: 5
+      persistence_minutes: 30
+    evidence_fields: [outdoor_air_temp, mixed_air_temp, economizer_command]
+    operator_guidance:
+      plain_english_summary: Outdoor air is cool enough to help but the economizer is not doing its job.
+      engineer_roi_notes: Common summer shoulder-season savings opportunity.
+
+  - code: RTU-COMP-001
+    canonical_id: rtu.compressor.short_cycling
+    family: RTU
+    system_type: packaged
+    subsystem: refrigeration
+    component: compressor
+    fault_mode: short_cycle
+    symptom: Compressor on/off cycles faster than minimum runtime
+    title: Compressor short cycling
+    severity_default: high
+    category: reliability
+    required_point_roles: [compressor_command]
+    rule_template_id: short_cycle_mask
+    rule_doc_path: docs/rule-cookbook/python-recipes-arrow.md
+    tuning_params:
+      minimum_runtime_minutes: 5
+      thresholds:
+        min_cycle_minutes: 3
+    evidence_fields: [cycle_count, runtime_minutes, duration_minutes]
+    operator_guidance:
+      plain_english_summary: Compressor is turning on and off too quickly.
+      why_it_matters: Reduces equipment life and may indicate refrigerant or control issues.

--- a/open_fdd/faults/catalog/vav.yaml
+++ b/open_fdd/faults/catalog/vav.yaml
@@ -1,0 +1,89 @@
+faults:
+  - code: VAV-FLOW-001
+    canonical_id: vav.airflow.low_at_max_damper
+    family: VAV
+    system_type: terminal
+    subsystem: airflow
+    component: damper
+    fault_mode: low_flow_at_max
+    symptom: Damper at max command but airflow below minimum expected
+    title: Low airflow at max damper
+    severity_default: medium
+    category: comfort
+    required_point_roles: [damper_command, zone_airflow]
+    optional_point_roles: [zone_temp, zone_temp_setpoint]
+    rule_template_id: threshold_mask
+    rule_doc_path: docs/rule-cookbook/python-recipes-arrow.md
+    legacy_aliases: [VAV-A]
+    standards_crosswalk:
+      ornl_lbnl_taxonomy: terminal/airflow/low
+      ashrae_g36_reference_type: zone_airflow_request
+      brick_classes: [brick:Terminal_Unit, brick:Damper]
+    tuning_params:
+      thresholds:
+        min_flow_cfm: 50
+        max_damper_pct: 95
+      persistence_minutes: 30
+    evidence_fields: [damper_command, zone_airflow, duration_minutes]
+    likely_causes:
+      - Clogged filter or obstruction
+      - Incorrect max flow calibration
+      - Duct leakage upstream
+    operator_guidance:
+      plain_english_summary: Zone damper is wide open but not getting expected airflow.
+      why_it_matters: Comfort complaints and reheat/cooling waste.
+      technician_checks:
+        - Verify airflow sensor calibration
+        - Inspect damper linkage
+
+  - code: VAV-SHC-001
+    canonical_id: vav.reheat.simultaneous_cooling_and_reheat
+    family: VAV
+    system_type: terminal
+    subsystem: reheat
+    component: reheat_valve
+    fault_mode: simultaneous_heat_cool
+    symptom: Cooling and reheat active together
+    title: Simultaneous cooling and reheat
+    severity_default: high
+    category: energy
+    required_point_roles: [cooling_valve, reheat_valve]
+    optional_point_roles: [zone_temp, discharge_air_temp]
+    rule_template_id: simultaneous_heat_cool_mask
+    rule_doc_path: docs/rule-cookbook/python-recipes-arrow.md
+    legacy_aliases: [VAV-B]
+    tuning_params:
+      thresholds:
+        valve_on_min: 5
+      persistence_minutes: 15
+    evidence_fields: [cooling_valve, reheat_valve, percent_time_active]
+    likely_causes:
+      - SAT too low for zone
+      - Reheat valve leaking
+      - Poor minimum airflow setting
+    operator_guidance:
+      plain_english_summary: Zone is being cooled and reheated at the same time.
+      why_it_matters: Classic energy waste; often fixable by SAT reset or valve service.
+      engineer_roi_notes: High ROI when widespread across floor.
+
+  - code: VAV-ZONE-001
+    canonical_id: vav.zone.temperature_not_met
+    family: VAV
+    system_type: terminal
+    subsystem: zone
+    component: zone_temp
+    fault_mode: setpoint_not_met
+    symptom: Zone temperature outside deadband from setpoint for extended period
+    title: Zone temperature not meeting setpoint
+    severity_default: medium
+    category: comfort
+    required_point_roles: [zone_temp, zone_temp_setpoint]
+    rule_template_id: setpoint_tracking_error
+    rule_doc_path: docs/rule-cookbook/python-recipes-arrow.md
+    tuning_params:
+      deadbands:
+        tracking_deadband: 2.0
+      persistence_minutes: 60
+    evidence_fields: [zone_temp, zone_temp_setpoint, delta, duration_minutes]
+    operator_guidance:
+      plain_english_summary: Room is too hot or too cold versus its setpoint for an extended time.

--- a/open_fdd/faults/schema.py
+++ b/open_fdd/faults/schema.py
@@ -1,0 +1,222 @@
+"""Canonical fault metadata schema (Grade-A)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+SEVERITIES = frozenset({"info", "low", "medium", "high", "critical"})
+CATEGORIES = frozenset({
+    "energy",
+    "comfort",
+    "reliability",
+    "maintenance",
+    "indoor_air_quality",
+    "healthcare_risk",
+    "data_quality",
+    "controls_integrity",
+})
+FAMILIES = frozenset({
+    "AHU", "VAV", "RTU", "DOAS", "FCU", "FPU", "CHL", "CHW", "CTW", "BLR", "HWS",
+    "PMP", "HX", "ERV", "CRS", "DATA", "CTRL", "BACNET", "BUILDING", "GEO", "HP",
+})
+
+
+@dataclass
+class StandardsCrosswalk:
+    ornl_lbnl_taxonomy: str = ""
+    ashrae_g36_reference_type: str = ""
+    ashrae_207_reference_type: str = ""
+    brick_classes: list[str] = field(default_factory=list)
+    haystack_tags: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any] | None) -> StandardsCrosswalk:
+        raw = raw or {}
+        return cls(
+            ornl_lbnl_taxonomy=str(raw.get("ornl_lbnl_taxonomy") or ""),
+            ashrae_g36_reference_type=str(raw.get("ashrae_g36_reference_type") or ""),
+            ashrae_207_reference_type=str(raw.get("ashrae_207_reference_type") or ""),
+            brick_classes=list(raw.get("brick_classes") or []),
+            haystack_tags=list(raw.get("haystack_tags") or []),
+        )
+
+
+@dataclass
+class TuningParams:
+    thresholds: dict[str, float] = field(default_factory=dict)
+    deadbands: dict[str, float] = field(default_factory=dict)
+    minimum_runtime_minutes: float | None = None
+    persistence_minutes: float | None = None
+    confidence_min: float | None = None
+    seasonal_applicability: str = ""
+    occupancy_applicability: str = ""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any] | None) -> TuningParams:
+        raw = raw or {}
+        return cls(
+            thresholds={k: float(v) for k, v in (raw.get("thresholds") or {}).items()},
+            deadbands={k: float(v) for k, v in (raw.get("deadbands") or {}).items()},
+            minimum_runtime_minutes=_float_or_none(raw.get("minimum_runtime_minutes")),
+            persistence_minutes=_float_or_none(raw.get("persistence_minutes")),
+            confidence_min=_float_or_none(raw.get("confidence_min")),
+            seasonal_applicability=str(raw.get("seasonal_applicability") or ""),
+            occupancy_applicability=str(raw.get("occupancy_applicability") or ""),
+        )
+
+
+@dataclass
+class OperatorGuidance:
+    plain_english_summary: str = ""
+    why_it_matters: str = ""
+    likely_fix_by_role: dict[str, str] = field(default_factory=dict)
+    technician_checks: list[str] = field(default_factory=list)
+    engineer_roi_notes: str = ""
+    commissioning_notes: str = ""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any] | None) -> OperatorGuidance:
+        raw = raw or {}
+        return cls(
+            plain_english_summary=str(raw.get("plain_english_summary") or ""),
+            why_it_matters=str(raw.get("why_it_matters") or ""),
+            likely_fix_by_role=dict(raw.get("likely_fix_by_role") or {}),
+            technician_checks=list(raw.get("technician_checks") or []),
+            engineer_roi_notes=str(raw.get("engineer_roi_notes") or ""),
+            commissioning_notes=str(raw.get("commissioning_notes") or ""),
+        )
+
+
+@dataclass
+class FaultDefinition:
+    code: str
+    canonical_id: str
+    family: str
+    system_type: str
+    subsystem: str
+    component: str
+    fault_mode: str
+    symptom: str
+    title: str
+    likely_causes: list[str]
+    severity_default: str
+    category: str
+    required_point_roles: list[str]
+    optional_point_roles: list[str] = field(default_factory=list)
+    rule_template_id: str = ""
+    rule_doc_path: str = ""
+    related_faults: list[str] = field(default_factory=list)
+    suppresses_faults: list[str] = field(default_factory=list)
+    suppressed_by_faults: list[str] = field(default_factory=list)
+    legacy_aliases: list[str] = field(default_factory=list)
+    standards_crosswalk: StandardsCrosswalk = field(default_factory=StandardsCrosswalk)
+    tuning_params: TuningParams = field(default_factory=TuningParams)
+    evidence_fields: list[str] = field(default_factory=list)
+    operator_guidance: OperatorGuidance = field(default_factory=OperatorGuidance)
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not self.code:
+            errors.append("code required")
+        if not self.canonical_id or "." not in self.canonical_id:
+            errors.append(f"canonical_id must be dotted semantic id: {self.canonical_id!r}")
+        if self.family.upper() not in FAMILIES:
+            errors.append(f"unknown family: {self.family}")
+        if self.severity_default not in SEVERITIES:
+            errors.append(f"invalid severity: {self.severity_default}")
+        if self.category not in CATEGORIES:
+            errors.append(f"invalid category: {self.category}")
+        if not self.required_point_roles:
+            errors.append("required_point_roles must be non-empty")
+        if not self.rule_template_id:
+            errors.append("rule_template_id required")
+        return errors
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> FaultDefinition:
+        return cls(
+            code=str(raw["code"]),
+            canonical_id=str(raw["canonical_id"]),
+            family=str(raw.get("family") or raw["code"].split("-", 1)[0]).upper(),
+            system_type=str(raw.get("system_type") or ""),
+            subsystem=str(raw.get("subsystem") or ""),
+            component=str(raw.get("component") or ""),
+            fault_mode=str(raw.get("fault_mode") or ""),
+            symptom=str(raw.get("symptom") or ""),
+            title=str(raw.get("title") or raw["code"]),
+            likely_causes=list(raw.get("likely_causes") or []),
+            severity_default=str(raw.get("severity_default") or "medium"),
+            category=str(raw.get("category") or "energy"),
+            required_point_roles=list(raw.get("required_point_roles") or []),
+            optional_point_roles=list(raw.get("optional_point_roles") or []),
+            rule_template_id=str(raw.get("rule_template_id") or ""),
+            rule_doc_path=str(raw.get("rule_doc_path") or ""),
+            related_faults=list(raw.get("related_faults") or []),
+            suppresses_faults=list(raw.get("suppresses_faults") or []),
+            suppressed_by_faults=list(raw.get("suppressed_by_faults") or []),
+            legacy_aliases=list(raw.get("legacy_aliases") or []),
+            standards_crosswalk=StandardsCrosswalk.from_dict(raw.get("standards_crosswalk")),
+            tuning_params=TuningParams.from_dict(raw.get("tuning_params")),
+            evidence_fields=list(raw.get("evidence_fields") or []),
+            operator_guidance=OperatorGuidance.from_dict(raw.get("operator_guidance")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "canonical_id": self.canonical_id,
+            "family": self.family,
+            "system_type": self.system_type,
+            "subsystem": self.subsystem,
+            "component": self.component,
+            "fault_mode": self.fault_mode,
+            "symptom": self.symptom,
+            "title": self.title,
+            "likely_causes": self.likely_causes,
+            "severity_default": self.severity_default,
+            "category": self.category,
+            "required_point_roles": self.required_point_roles,
+            "optional_point_roles": self.optional_point_roles,
+            "rule_template_id": self.rule_template_id,
+            "rule_doc_path": self.rule_doc_path,
+            "related_faults": self.related_faults,
+            "suppresses_faults": self.suppresses_faults,
+            "suppressed_by_faults": self.suppressed_by_faults,
+            "legacy_aliases": self.legacy_aliases,
+            "standards_crosswalk": {
+                "ornl_lbnl_taxonomy": self.standards_crosswalk.ornl_lbnl_taxonomy,
+                "ashrae_g36_reference_type": self.standards_crosswalk.ashrae_g36_reference_type,
+                "ashrae_207_reference_type": self.standards_crosswalk.ashrae_207_reference_type,
+                "brick_classes": self.standards_crosswalk.brick_classes,
+                "haystack_tags": self.standards_crosswalk.haystack_tags,
+            },
+            "tuning_params": {
+                "thresholds": self.tuning_params.thresholds,
+                "deadbands": self.tuning_params.deadbands,
+                "minimum_runtime_minutes": self.tuning_params.minimum_runtime_minutes,
+                "persistence_minutes": self.tuning_params.persistence_minutes,
+                "confidence_min": self.tuning_params.confidence_min,
+                "seasonal_applicability": self.tuning_params.seasonal_applicability,
+                "occupancy_applicability": self.tuning_params.occupancy_applicability,
+            },
+            "evidence_fields": self.evidence_fields,
+            "operator_guidance": {
+                "plain_english_summary": self.operator_guidance.plain_english_summary,
+                "why_it_matters": self.operator_guidance.why_it_matters,
+                "likely_fix_by_role": self.operator_guidance.likely_fix_by_role,
+                "technician_checks": self.operator_guidance.technician_checks,
+                "engineer_roi_notes": self.operator_guidance.engineer_roi_notes,
+                "commissioning_notes": self.operator_guidance.commissioning_notes,
+            },
+        }
+
+
+def _float_or_none(val: Any) -> float | None:
+    if val is None or val == "":
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None

--- a/open_fdd/tests/arrow_runtime/test_primitives.py
+++ b/open_fdd/tests/arrow_runtime/test_primitives.py
@@ -1,0 +1,39 @@
+"""Arrow rule primitives — synthetic table tests."""
+
+from __future__ import annotations
+
+import pyarrow as pa
+
+from open_fdd.arrow_runtime.primitives import (
+    command_feedback_mismatch,
+    persistence_mask,
+    simultaneous_heat_cool_mask,
+    threshold_mask,
+)
+
+
+def test_threshold_mask_gt():
+    table = pa.table({"zone_temp": [70.0, 80.0, 90.0]})
+    mask = threshold_mask(table, {"threshold": 75.0, "column": "zone_temp"}, op="gt")
+    assert mask.to_pylist() == [False, True, True]
+
+
+def test_simultaneous_heat_cool():
+    table = pa.table({"heat": [0.0, 0.5, 0.0], "cool": [0.0, 0.6, 0.2]})
+    mask = simultaneous_heat_cool_mask(table, {"valve_on_min": 0.1}, heat_col="heat", cool_col="cool")
+    assert mask.to_pylist()[1] is True
+    assert mask.to_pylist()[0] is False
+
+
+def test_command_feedback_mismatch():
+    table = pa.table({"cmd": [50.0, 50.0], "fb": [50.0, 40.0]})
+    mask = command_feedback_mismatch(
+        table, {"cmd_fb_tolerance": 5.0}, command_col="cmd", feedback_col="fb"
+    )
+    assert mask.to_pylist() == [False, True]
+
+
+def test_persistence_mask():
+    mask = pa.array([False, True, True, True, False])
+    out = persistence_mask(mask, 3)
+    assert out.to_pylist()[3] is True

--- a/open_fdd/tests/faults/test_catalog.py
+++ b/open_fdd/tests/faults/test_catalog.py
@@ -1,0 +1,27 @@
+"""Grade-A fault catalog validation."""
+
+from __future__ import annotations
+
+from open_fdd.faults import get_fault, legacy_alias, list_faults, load_catalog
+
+
+def test_catalog_loads_and_validates():
+    catalog = load_catalog()
+    assert len(catalog) >= 19
+
+
+def test_legacy_alias_maps_ahu_e():
+    assert legacy_alias("AHU-E") == "AHU-ECON-001"
+
+
+def test_get_fault_by_code():
+    fault = get_fault("DATA-STAL-001")
+    assert fault is not None
+    assert fault.canonical_id == "data.telemetry.stale_point"
+    assert fault.category == "data_quality"
+
+
+def test_all_faults_have_required_metadata():
+    for fault in list_faults():
+        errors = fault.validate()
+        assert not errors, f"{fault.code}: {errors}"

--- a/portfolio/collector/collector.py
+++ b/portfolio/collector/collector.py
@@ -48,7 +48,15 @@ def load_sites_config(path: Path | None = None) -> list[SiteConfig]:
         if not site_id or not base_url:
             continue
         user = str(item.get("username") or os.environ.get("OFDD_AGENT_USER") or "agent")
-        password = str(item.get("password") or os.environ.get("OFDD_AGENT_PASSWORD") or "")
+        password = str(item.get("password") or "")
+        if not password:
+            acme_user = os.environ.get("ACME_INTEGRATOR_USER", "integrator")
+            if user == acme_user:
+                password = str(os.environ.get("ACME_INTEGRATOR_PASSWORD") or "")
+            elif user == os.environ.get("OFDD_AGENT_USER", "agent"):
+                password = str(os.environ.get("OFDD_AGENT_PASSWORD") or "")
+            else:
+                password = str(os.environ.get("OFDD_INTEGRATOR_PASSWORD") or "")
         out.append(
             SiteConfig(
                 site_id=site_id,

--- a/portfolio/dash/app.py
+++ b/portfolio/dash/app.py
@@ -8,13 +8,44 @@ import sys
 from pathlib import Path
 
 import dash
-from dash import Input, Output, dcc, html
+from dash import Input, Output, State, dcc, html
 import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
+
+THEMES: dict[str, dict[str, str]] = {
+    "dark": {
+        "page_bg": "#020617",
+        "card_bg": "#0f172a",
+        "text": "#e2e8f0",
+        "muted": "#94a3b8",
+        "accent": "#2563eb",
+        "plot_template": "plotly_dark",
+        "paper": "#0f172a",
+        "plot": "#0f172a",
+        "grid": "#1e293b",
+        "up": "#22c55e",
+        "down": "#ef4444",
+        "warn": "#f59e0b",
+    },
+    "light": {
+        "page_bg": "#f8fafc",
+        "card_bg": "#ffffff",
+        "text": "#0f172a",
+        "muted": "#64748b",
+        "accent": "#2563eb",
+        "plot_template": "plotly_white",
+        "paper": "#ffffff",
+        "plot": "#f1f5f9",
+        "grid": "#e2e8f0",
+        "up": "#16a34a",
+        "down": "#dc2626",
+        "warn": "#d97706",
+    },
+}
 
 
 def _read_csv(name: str) -> pd.DataFrame:
@@ -24,18 +55,16 @@ def _read_csv(name: str) -> pd.DataFrame:
     return pd.read_csv(path)
 
 
-def _traffic_color(traffic: str) -> str:
-    return {"green": "#22c55e", "yellow": "#eab308", "red": "#ef4444"}.get(
-        str(traffic or "").lower(), "#64748b"
-    )
+def _traffic_color(traffic: str, theme: dict[str, str]) -> str:
+    base = {"green": theme["up"], "yellow": theme["warn"], "red": theme["down"]}
+    return base.get(str(traffic or "").lower(), theme["muted"])
 
 
-def _delta_badge(current: float, prior: float) -> tuple[str, str]:
-    if prior == 0 and current == 0:
-        return "0.0", "#64748b"
+def _delta_parts(current: float, prior: float, theme: dict[str, str]) -> tuple[str, str]:
     delta = current - prior
     sign = "+" if delta >= 0 else ""
-    color = "#22c55e" if delta <= 0 else "#ef4444"
+    # Stock convention: up hours = red (bad), down hours = green (good) for energy KPIs
+    color = theme["down"] if delta > 0 else theme["up"] if delta < 0 else theme["muted"]
     return f"{sign}{delta:.1f}", color
 
 
@@ -47,107 +76,385 @@ def _latest_checkins(df: pd.DataFrame) -> pd.DataFrame:
     return df.sort_values("collected_at").groupby("site_id", as_index=False).tail(1)
 
 
-def _run_hour_series(df: pd.DataFrame, site_id: str, metric: str) -> pd.DataFrame:
+def _prior_checkins(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    df = df.copy()
+    df["collected_at"] = pd.to_datetime(df["collected_at"], errors="coerce")
+    return df.sort_values("collected_at").groupby("site_id", as_index=False).nth(-2)
+
+
+def _run_hour_series(df: pd.DataFrame, site_id: str) -> pd.DataFrame:
     if df.empty:
         return df
     sub = df[df["site_id"] == site_id].copy()
     if sub.empty:
         return sub
     sub["collected_at"] = pd.to_datetime(sub["collected_at"], errors="coerce")
-    sub = sub.sort_values(["equipment_id", "collected_at"])
-    return sub
+    return sub.sort_values(["equipment_id", "collected_at"])
 
 
-def build_layout() -> html.Div:
+def _site_cards(theme: dict[str, str]) -> list:
     checkins = _read_csv("checkins.csv")
-    sites = sorted(checkins["site_id"].dropna().unique()) if not checkins.empty else []
-    latest = _latest_checkins(checkins)
+    if checkins.empty:
+        return [html.P("No data yet — run portfolio collector.", style={"color": theme["muted"]})]
 
+    latest = _latest_checkins(checkins)
+    prior = _prior_checkins(checkins)
+    fan_df = _read_csv("run_hours_daily.csv")
     cards = []
+
     for _, row in latest.iterrows():
         sid = row.get("site_id")
-        fan_df = _read_csv("run_hours_daily.csv")
         site_runs = fan_df[fan_df["site_id"] == sid] if not fan_df.empty else fan_df
         fan_total = float(site_runs["fan_run_hours"].fillna(0).sum()) if not site_runs.empty else 0.0
-        prior = (
-            site_runs.sort_values("collected_at").groupby("equipment_id").tail(2)
-            if not site_runs.empty
-            else pd.DataFrame()
-        )
+
         prior_fan = 0.0
-        if not prior.empty:
-            last_two = prior.groupby("equipment_id").apply(
-                lambda g: g.sort_values("collected_at").iloc[-1]["fan_run_hours"]
-                - g.sort_values("collected_at").iloc[0]["fan_run_hours"]
-                if len(g) >= 2
-                else 0.0
-            )
-            prior_fan = float(last_two.sum())
-        delta_txt, delta_color = _delta_badge(fan_total, fan_total - prior_fan)
+        if not site_runs.empty:
+            last_two = site_runs.sort_values("collected_at").groupby("equipment_id").tail(2)
+
+            def _equip_delta(g: pd.DataFrame) -> float:
+                if len(g) < 2:
+                    return 0.0
+                g = g.sort_values("collected_at")
+                return float(g.iloc[-1]["fan_run_hours"]) - float(g.iloc[0]["fan_run_hours"])
+
+            prior_fan = float(last_two.groupby("equipment_id", group_keys=False).apply(_equip_delta).sum())
+
+        delta_txt, delta_color = _delta_parts(fan_total, fan_total - prior_fan, theme)
+
+        prev_row = prior[prior["site_id"] == sid]
+        prev_alerts = int(prev_row["alert_count"].iloc[0]) if not prev_row.empty else 0
+        prev_overrides = int(prev_row["operator_overrides"].iloc[0]) if not prev_row.empty else 0
+        alert_delta, alert_color = _delta_parts(
+            float(row.get("alert_count") or 0), float(prev_alerts), theme
+        )
+        ovr_delta, ovr_color = _delta_parts(
+            float(row.get("operator_overrides") or 0), float(prev_overrides), theme
+        )
+
         cards.append(
             html.Div(
-                className="site-card",
                 style={
-                    "borderLeft": f"6px solid {_traffic_color(row.get('traffic'))}",
+                    "borderLeft": f"6px solid {_traffic_color(row.get('traffic'), theme)}",
                     "padding": "12px 16px",
                     "marginBottom": "8px",
-                    "background": "#0f172a",
+                    "background": theme["card_bg"],
                     "borderRadius": "8px",
+                    "boxShadow": "0 1px 3px rgba(0,0,0,0.12)",
                 },
                 children=[
                     html.Div(
                         style={"display": "flex", "justifyContent": "space-between"},
                         children=[
-                            html.Strong(f"{row.get('site_name') or sid} ({sid})"),
+                            html.Strong(
+                                f"{row.get('site_name') or sid} ({sid})",
+                                style={"color": theme["text"]},
+                            ),
                             html.Span(
                                 str(row.get("traffic") or "—").upper(),
-                                style={"color": _traffic_color(row.get("traffic"))},
+                                style={"color": _traffic_color(row.get("traffic"), theme), "fontWeight": 600},
                             ),
                         ],
                     ),
                     html.Div(
-                        style={"fontSize": "13px", "color": "#94a3b8", "marginTop": "4px"},
+                        style={"fontSize": "13px", "color": theme["muted"], "marginTop": "4px"},
                         children=[
-                            f"Alerts {int(row.get('alert_count') or 0)} · "
-                            f"FDD {int(row.get('fdd_alert_count') or 0)} · "
-                            f"P8 overrides {int(row.get('operator_overrides') or 0)}"
+                            "Alerts ",
+                            html.Span(f"{int(row.get('alert_count') or 0)}", style={"color": theme["text"]}),
+                            html.Span(f" ({alert_delta})", style={"color": alert_color, "marginRight": "8px"}),
+                            f"· FDD {int(row.get('fdd_alert_count') or 0)} · P8 ",
+                            html.Span(f"{int(row.get('operator_overrides') or 0)}", style={"color": theme["text"]}),
+                            html.Span(f" ({ovr_delta})", style={"color": ovr_color}),
                         ],
                     ),
                     html.Div(
-                        style={"marginTop": "6px"},
+                        style={"marginTop": "6px", "fontSize": "15px"},
                         children=[
-                            html.Span("Fan hours ", style={"color": "#94a3b8"}),
-                            html.Span(f"{fan_total:.1f}h ", style={"fontWeight": 600}),
-                            html.Span(delta_txt, style={"color": delta_color, "fontWeight": 600}),
+                            html.Span("Fan hours ", style={"color": theme["muted"]}),
+                            html.Span(f"{fan_total:.1f}h ", style={"fontWeight": 700, "color": theme["text"]}),
+                            html.Span(
+                                delta_txt,
+                                style={
+                                    "color": delta_color,
+                                    "fontWeight": 700,
+                                    "fontFamily": "ui-monospace, monospace",
+                                },
+                            ),
                         ],
                     ),
                 ],
             )
         )
+    return cards
 
-    return html.Div(
+
+def _figure_layout(fig: go.Figure, theme: dict[str, str], title: str) -> go.Figure:
+    fig.update_layout(
+        template=theme["plot_template"],
+        paper_bgcolor=theme["paper"],
+        plot_bgcolor=theme["plot"],
+        title=title,
+        font={"color": theme["text"]},
+        legend={"orientation": "h", "font": {"color": theme["text"]}},
+        margin={"l": 48, "r": 24, "t": 52, "b": 40},
+        xaxis={"gridcolor": theme["grid"]},
+        yaxis={"gridcolor": theme["grid"]},
+    )
+    return fig
+
+
+def _annotate_last_delta(fig: go.Figure, x, y, delta: float, theme: dict[str, str]) -> None:
+    if pd.isna(delta) or delta == 0:
+        return
+    sign = "+" if delta > 0 else ""
+    color = theme["down"] if delta > 0 else theme["up"]
+    fig.add_annotation(
+        x=x,
+        y=y,
+        text=f"{sign}{delta:.1f}",
+        showarrow=True,
+        arrowhead=2,
+        arrowcolor=color,
+        font={"color": color, "size": 11, "family": "ui-monospace, monospace"},
+        bgcolor=theme["card_bg"],
+        bordercolor=color,
+        borderwidth=1,
+        ay=-28 if delta > 0 else 28,
+    )
+
+
+def _stock_style_figure(
+    df: pd.DataFrame,
+    metric: str,
+    title: str,
+    theme: dict[str, str],
+) -> go.Figure:
+    fig = make_subplots(specs=[[{"secondary_y": True}]])
+    if df.empty:
+        fig.add_annotation(text="No run-hour data", showarrow=False, font={"color": theme["muted"]})
+        return _figure_layout(fig, theme, title)
+
+    for equipment_id, grp in df.groupby("equipment_id"):
+        grp = grp.sort_values("collected_at")
+        y = pd.to_numeric(grp[metric], errors="coerce").fillna(0)
+        label = str(grp["equipment_name"].iloc[-1] if "equipment_name" in grp else equipment_id)
+        fig.add_trace(
+            go.Scatter(
+                x=grp["collected_at"],
+                y=y,
+                mode="lines+markers",
+                name=label,
+                line={"width": 2.5},
+            ),
+            secondary_y=False,
+        )
+        if len(y) >= 2:
+            delta = y.diff().fillna(0)
+            colors = [theme["down"] if d > 0 else theme["up"] if d < 0 else theme["muted"] for d in delta]
+            fig.add_trace(
+                go.Bar(
+                    x=grp["collected_at"],
+                    y=delta,
+                    name=f"Δ {equipment_id}",
+                    marker_color=colors,
+                    opacity=0.45,
+                    showlegend=False,
+                ),
+                secondary_y=True,
+            )
+            last_delta = float(delta.iloc[-1])
+            _annotate_last_delta(
+                fig,
+                grp["collected_at"].iloc[-1],
+                float(y.iloc[-1]),
+                last_delta,
+                theme,
+            )
+
+    fig.update_yaxes(title_text="Hours", secondary_y=False)
+    fig.update_yaxes(title_text="Δ hours (+/−)", secondary_y=True)
+    return _figure_layout(fig, theme, f"{title}  ·  green ▼ red ▲")
+
+
+def _fault_figure(site_id: str, theme: dict[str, str]) -> go.Figure:
+    df = _read_csv("faults_daily.csv")
+    fig = go.Figure()
+    if df.empty or not site_id:
+        return _figure_layout(fig, theme, "Fault codes — no data")
+
+    sub = df[df["site_id"] == site_id].copy()
+    sub["collected_at"] = pd.to_datetime(sub["collected_at"], errors="coerce")
+    for code, grp in sub.groupby("fault_code"):
+        grp = grp.sort_values("collected_at")
+        y = pd.to_numeric(grp["active_count"], errors="coerce").fillna(0)
+        fig.add_trace(
+            go.Scatter(x=grp["collected_at"], y=y, mode="lines+markers", name=str(code), line={"width": 2})
+        )
+        if len(y) >= 2:
+            delta = y.diff().fillna(0)
+            colors = [theme["down"] if d > 0 else theme["up"] if d < 0 else theme["muted"] for d in delta]
+            fig.add_trace(
+                go.Bar(
+                    x=grp["collected_at"],
+                    y=delta,
+                    opacity=0.3,
+                    marker_color=colors,
+                    showlegend=False,
+                    name=f"Δ {code}",
+                )
+            )
+
+    fig.update_layout(xaxis_title="Collection time", yaxis_title="Active alerts")
+    return _figure_layout(fig, theme, f"Fault code trends (+/−) — {site_id}")
+
+
+def _override_figure(site_id: str, theme: dict[str, str]) -> go.Figure:
+    checkins = _read_csv("checkins.csv")
+    fig = go.Figure()
+    if checkins.empty or not site_id:
+        return _figure_layout(fig, theme, "P8 overrides — no data")
+
+    sub = checkins[checkins["site_id"] == site_id].copy()
+    sub["collected_at"] = pd.to_datetime(sub["collected_at"], errors="coerce")
+    sub = sub.sort_values("collected_at")
+    y = pd.to_numeric(sub["operator_overrides"], errors="coerce").fillna(0)
+    fig.add_trace(
+        go.Scatter(
+            x=sub["collected_at"],
+            y=y,
+            mode="lines+markers",
+            name="P8 operator overrides",
+            line={"color": theme["warn"], "width": 2.5},
+            fill="tozeroy",
+        )
+    )
+    if len(y) >= 2:
+        delta = y.diff().fillna(0)
+        colors = [theme["down"] if d > 0 else theme["up"] if d < 0 else theme["muted"] for d in delta]
+        fig.add_trace(
+            go.Bar(
+                x=sub["collected_at"],
+                y=delta,
+                marker_color=colors,
+                opacity=0.4,
+                showlegend=False,
+                name="Δ overrides",
+            )
+        )
+        _annotate_last_delta(fig, sub["collected_at"].iloc[-1], float(y.iloc[-1]), float(delta.iloc[-1]), theme)
+
+    fig.update_layout(xaxis_title="Collection time", yaxis_title="Override points")
+    return _figure_layout(fig, theme, f"P8 operator overrides (+/−) — {site_id}")
+
+
+def _site_options() -> list[dict[str, str]]:
+    checkins = _read_csv("checkins.csv")
+    if checkins.empty:
+        return []
+    return [{"label": s, "value": s} for s in sorted(checkins["site_id"].dropna().unique())]
+
+
+app = dash.Dash(__name__, suppress_callback_exceptions=True)
+
+_sites = _site_options()
+
+app.layout = html.Div(
+    id="app-root",
+    children=[
+        dcc.Store(id="theme-store", data="dark"),
+        dcc.Interval(id="refresh-interval", interval=120_000, n_intervals=0),
+        html.Div(id="header-row"),
+        html.Div(id="site-cards"),
+        html.Div(
+            id="chart-grid",
+            style={"display": "grid", "gridTemplateColumns": "280px 1fr", "gap": "16px", "marginTop": "20px"},
+            children=[
+                html.Div(
+                    id="sidebar",
+                    children=[
+                        html.Label("Site", id="site-label"),
+                        dcc.Dropdown(
+                            id="site-select",
+                            options=_sites,
+                            value=_sites[0]["value"] if _sites else None,
+                            clearable=False,
+                        ),
+                        html.Label("Metric", id="metric-label", style={"marginTop": "12px"}),
+                        dcc.RadioItems(
+                            id="metric-select",
+                            options=[
+                                {"label": "Fan run hours", "value": "fan_run_hours"},
+                                {"label": "System run hours", "value": "system_run_hours"},
+                                {"label": "Unoccupied fan hours", "value": "unoccupied_fan_hours"},
+                            ],
+                            value="fan_run_hours",
+                        ),
+                        html.P(
+                            id="delta-legend",
+                            children="Δ bars: green = hours down (good) · red = hours up",
+                            style={"fontSize": "12px", "marginTop": "12px"},
+                        ),
+                    ],
+                ),
+                dcc.Graph(id="run-hours-chart"),
+            ],
+        ),
+        dcc.Graph(id="fault-trend-chart", style={"marginTop": "16px"}),
+        dcc.Graph(id="override-chart", style={"marginTop": "16px"}),
+    ],
+)
+
+
+@app.callback(
+    Output("header-row", "children"),
+    Output("app-root", "style"),
+    Input("theme-store", "data"),
+)
+def render_header(theme_key: str):
+    theme = THEMES.get(theme_key or "dark", THEMES["dark"])
+    other = "light" if theme_key == "dark" else "dark"
+    header = html.Div(
         style={
-            "fontFamily": "system-ui, sans-serif",
-            "background": "#020617",
-            "color": "#e2e8f0",
-            "minHeight": "100vh",
-            "padding": "20px",
+            "display": "flex",
+            "justifyContent": "space-between",
+            "alignItems": "flex-start",
+            "flexWrap": "wrap",
+            "gap": "12px",
+            "marginBottom": "8px",
         },
         children=[
-            html.H1("Open-FDD Portfolio", style={"marginBottom": "4px"}),
-            html.P(
-                "Central analytics for mechanical run hours, fault codes, and BACnet P8 operator overrides.",
-                style={"color": "#94a3b8", "marginTop": 0},
+            html.Div(
+                children=[
+                    html.H1("Open-FDD Portfolio", style={"margin": 0, "color": theme["text"]}),
+                    html.P(
+                        "Stock-style run-hour rollups with +/− deltas · faults · BACnet P8 overrides",
+                        style={"color": theme["muted"], "margin": "4px 0 0"},
+                    ),
+                ]
             ),
             html.Div(
-                style={"display": "flex", "gap": "12px", "margin": "16px 0", "flexWrap": "wrap"},
+                style={"display": "flex", "gap": "8px", "alignItems": "center"},
                 children=[
+                    html.Button(
+                        f"{'☀️ Light' if theme_key == 'dark' else '🌙 Dark'} mode",
+                        id="theme-toggle",
+                        n_clicks=0,
+                        style={
+                            "background": theme["card_bg"],
+                            "color": theme["text"],
+                            "border": f"1px solid {theme['grid']}",
+                            "padding": "8px 14px",
+                            "borderRadius": "6px",
+                            "cursor": "pointer",
+                        },
+                    ),
                     html.Button(
                         "Collect now",
                         id="collect-btn",
                         n_clicks=0,
                         style={
-                            "background": "#2563eb",
+                            "background": theme["accent"],
                             "color": "white",
                             "border": "none",
                             "padding": "8px 16px",
@@ -155,155 +462,56 @@ def build_layout() -> html.Div:
                             "cursor": "pointer",
                         },
                     ),
-                    html.Span(id="collect-status", style={"color": "#94a3b8", "alignSelf": "center"}),
+                    html.Span(id="collect-status", style={"color": theme["muted"]}),
                 ],
             ),
-            html.Div(id="site-cards", children=cards or [html.P("No data yet — run portfolio collector.")]),
-            html.Div(
-                style={"display": "grid", "gridTemplateColumns": "280px 1fr", "gap": "16px", "marginTop": "20px"},
-                children=[
-                    html.Div(
-                        children=[
-                            html.Label("Site"),
-                            dcc.Dropdown(
-                                id="site-select",
-                                options=[{"label": s, "value": s} for s in sites],
-                                value=sites[0] if sites else None,
-                                clearable=False,
-                            ),
-                            html.Label("Metric", style={"marginTop": "12px"}),
-                            dcc.RadioItems(
-                                id="metric-select",
-                                options=[
-                                    {"label": "Fan run hours", "value": "fan_run_hours"},
-                                    {"label": "System run hours", "value": "system_run_hours"},
-                                    {"label": "Unoccupied fan hours", "value": "unoccupied_fan_hours"},
-                                ],
-                                value="fan_run_hours",
-                                style={"color": "#e2e8f0"},
-                            ),
-                        ]
-                    ),
-                    dcc.Graph(id="run-hours-chart", style={"background": "#0f172a", "borderRadius": "8px"}),
-                ],
-            ),
-            dcc.Graph(id="fault-trend-chart", style={"marginTop": "16px", "background": "#0f172a"}),
-            dcc.Graph(id="override-chart", style={"marginTop": "16px", "background": "#0f172a"}),
-            dcc.Interval(id="refresh-interval", interval=120_000, n_intervals=0),
         ],
     )
+    root_style = {
+        "fontFamily": "system-ui, sans-serif",
+        "background": theme["page_bg"],
+        "color": theme["text"],
+        "minHeight": "100vh",
+        "padding": "20px",
+    }
+    return header, root_style
 
 
-def _stock_style_figure(df: pd.DataFrame, metric: str, title: str) -> go.Figure:
-    fig = make_subplots(specs=[[{"secondary_y": True}]])
-    if df.empty:
-        fig.add_annotation(text="No run-hour data", showarrow=False, font={"color": "#94a3b8"})
-        fig.update_layout(template="plotly_dark", paper_bgcolor="#0f172a", plot_bgcolor="#0f172a", title=title)
-        return fig
-
-    for equipment_id, grp in df.groupby("equipment_id"):
-        grp = grp.sort_values("collected_at")
-        y = pd.to_numeric(grp[metric], errors="coerce").fillna(0)
-        fig.add_trace(
-            go.Scatter(
-                x=grp["collected_at"],
-                y=y,
-                mode="lines+markers",
-                name=str(grp["equipment_name"].iloc[-1] if "equipment_name" in grp else equipment_id),
-                line={"width": 2},
-            ),
-            secondary_y=False,
-        )
-        if len(y) >= 2:
-            delta = y.diff().fillna(0)
-            colors = ["#22c55e" if d <= 0 else "#ef4444" for d in delta]
-            fig.add_trace(
-                go.Bar(
-                    x=grp["collected_at"],
-                    y=delta,
-                    name=f"Δ {equipment_id}",
-                    marker_color=colors,
-                    opacity=0.35,
-                    showlegend=False,
-                ),
-                secondary_y=True,
-            )
-
-    fig.update_layout(
-        template="plotly_dark",
-        paper_bgcolor="#0f172a",
-        plot_bgcolor="#0f172a",
-        title=title,
-        legend={"orientation": "h"},
-        margin={"l": 40, "r": 20, "t": 50, "b": 40},
-    )
-    fig.update_yaxes(title_text="Hours", secondary_y=False)
-    fig.update_yaxes(title_text="Δ hours", secondary_y=True)
-    return fig
+@app.callback(
+    Output("theme-store", "data"),
+    Input("theme-toggle", "n_clicks"),
+    State("theme-store", "data"),
+    prevent_initial_call=True,
+)
+def toggle_theme(n_clicks: int, current: str):
+    return "light" if (current or "dark") == "dark" else "dark"
 
 
-def _fault_figure(site_id: str) -> go.Figure:
-    df = _read_csv("faults_daily.csv")
-    fig = go.Figure()
-    if df.empty or not site_id:
-        fig.update_layout(template="plotly_dark", paper_bgcolor="#0f172a", title="Fault codes — no data")
-        return fig
-    sub = df[df["site_id"] == site_id].copy()
-    sub["collected_at"] = pd.to_datetime(sub["collected_at"], errors="coerce")
-    for code, grp in sub.groupby("fault_code"):
-        grp = grp.sort_values("collected_at")
-        fig.add_trace(
-            go.Scatter(
-                x=grp["collected_at"],
-                y=grp["active_count"],
-                mode="lines+markers",
-                name=str(code),
-            )
-        )
-    fig.update_layout(
-        template="plotly_dark",
-        paper_bgcolor="#0f172a",
-        plot_bgcolor="#0f172a",
-        title=f"Active fault codes — {site_id}",
-        xaxis_title="Collection time",
-        yaxis_title="Active alerts",
-        legend={"orientation": "h"},
-    )
-    return fig
+@app.callback(
+    Output("site-cards", "children"),
+    Input("theme-store", "data"),
+    Input("refresh-interval", "n_intervals"),
+    Input("collect-btn", "n_clicks"),
+)
+def refresh_cards(theme_key: str, _n: int, _btn: int):
+    theme = THEMES.get(theme_key or "dark", THEMES["dark"])
+    return _site_cards(theme)
 
 
-def _override_figure(site_id: str) -> go.Figure:
-    checkins = _read_csv("checkins.csv")
-    fig = go.Figure()
-    if checkins.empty or not site_id:
-        fig.update_layout(template="plotly_dark", paper_bgcolor="#0f172a", title="P8 overrides — no data")
-        return fig
-    sub = checkins[checkins["site_id"] == site_id].copy()
-    sub["collected_at"] = pd.to_datetime(sub["collected_at"], errors="coerce")
-    sub = sub.sort_values("collected_at")
-    fig.add_trace(
-        go.Scatter(
-            x=sub["collected_at"],
-            y=pd.to_numeric(sub["operator_overrides"], errors="coerce").fillna(0),
-            mode="lines+markers",
-            name="P8 operator overrides",
-            line={"color": "#f59e0b", "width": 2},
-            fill="tozeroy",
-        )
-    )
-    fig.update_layout(
-        template="plotly_dark",
-        paper_bgcolor="#0f172a",
-        plot_bgcolor="#0f172a",
-        title=f"BACnet priority-8 operator overrides — {site_id}",
-        xaxis_title="Collection time",
-        yaxis_title="Override points",
-    )
-    return fig
-
-
-app = dash.Dash(__name__, suppress_callback_exceptions=True)
-app.layout = build_layout
+@app.callback(
+    Output("site-label", "style"),
+    Output("metric-label", "style"),
+    Output("metric-select", "style"),
+    Output("delta-legend", "style"),
+    Input("theme-store", "data"),
+)
+def theme_sidebar(theme_key: str):
+    theme = THEMES.get(theme_key or "dark", THEMES["dark"])
+    label_style = {"color": theme["text"]}
+    metric_label_style = {"marginTop": "12px", "color": theme["text"]}
+    radio_style = {"color": theme["text"]}
+    legend_style = {"fontSize": "12px", "color": theme["muted"], "marginTop": "12px"}
+    return label_style, metric_label_style, radio_style, legend_style
 
 
 @app.callback(
@@ -315,9 +523,13 @@ def run_collect(n_clicks: int):
     if not n_clicks:
         return ""
     script = ROOT.parent / "scripts" / "portfolio_collect.py"
+    py = Path(sys.executable)
+    venv_py = ROOT.parent / ".venv" / "bin" / "python"
+    if venv_py.is_file():
+        py = venv_py
     try:
         proc = subprocess.run(
-            [sys.executable, str(script), "--json"],
+            [str(py), str(script)],
             cwd=str(ROOT.parent),
             capture_output=True,
             text=True,
@@ -326,7 +538,7 @@ def run_collect(n_clicks: int):
         )
         if proc.returncode != 0:
             return f"Collect failed: {proc.stderr[:200] or proc.stdout[:200]}"
-        return "Collect finished — refresh or wait for auto-refresh."
+        return "Collect finished — charts refresh automatically."
     except Exception as exc:
         return f"Collect error: {exc}"
 
@@ -337,18 +549,27 @@ def run_collect(n_clicks: int):
     Output("override-chart", "figure"),
     Input("site-select", "value"),
     Input("metric-select", "value"),
+    Input("theme-store", "data"),
     Input("refresh-interval", "n_intervals"),
     Input("collect-btn", "n_clicks"),
 )
-def update_charts(site_id: str | None, metric: str, _n: int, _btn: int):
+def update_charts(
+    site_id: str | None,
+    metric: str,
+    theme_key: str,
+    _n: int,
+    _btn: int,
+):
+    theme = THEMES.get(theme_key or "dark", THEMES["dark"])
     runs = _read_csv("run_hours_daily.csv")
-    if site_id and not runs.empty:
-        sub = _run_hour_series(runs, site_id, metric)
-        sub["collected_at"] = pd.to_datetime(sub["collected_at"], errors="coerce")
-    else:
-        sub = pd.DataFrame()
-    run_fig = _stock_style_figure(sub, metric or "fan_run_hours", f"Equipment run hours — {site_id or '—'}")
-    return run_fig, _fault_figure(site_id or ""), _override_figure(site_id or "")
+    sub = _run_hour_series(runs, site_id or "") if site_id and not runs.empty else pd.DataFrame()
+    run_fig = _stock_style_figure(
+        sub,
+        metric or "fan_run_hours",
+        f"Equipment run hours — {site_id or '—'}",
+        theme,
+    )
+    return run_fig, _fault_figure(site_id or "", theme), _override_figure(site_id or "", theme)
 
 
 def main() -> None:

--- a/portfolio/store/csv_store.py
+++ b/portfolio/store/csv_store.py
@@ -10,8 +10,10 @@ from typing import Any, Iterable
 
 
 def portfolio_data_dir(root: Path | None = None) -> Path:
-    base = root or Path(__file__).resolve().parents[1]
-    path = base / "data"
+    if root is not None:
+        path = root
+    else:
+        path = Path(__file__).resolve().parents[1] / "data"
     path.mkdir(parents=True, exist_ok=True)
     return path
 

--- a/portfolio/store/interval_schema.py
+++ b/portfolio/store/interval_schema.py
@@ -1,0 +1,85 @@
+"""Portable interval summary schema for central portfolio ingestion (pandas allowed here)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+OPERATOR_STATUSES = frozenset({
+    "new",
+    "acknowledged",
+    "assigned",
+    "snoozed",
+    "resolved",
+    "false_positive",
+    "tuning_needed",
+})
+
+
+@dataclass
+class FaultIntervalSummary:
+    site_id: str
+    building_id: str
+    equipment_id: str
+    equipment_family: str
+    timestamp_start: str
+    timestamp_end: str
+    rule_pack_version: str
+    open_fdd_version: str
+    fault_code: str
+    canonical_id: str
+    severity: str
+    confidence: float
+    active_minutes: float
+    percent_active: float
+    occurrence_count: int
+    first_seen: str
+    last_seen: str
+    evidence_json: dict[str, Any] = field(default_factory=dict)
+    tuning_version: str = ""
+    tuning_params_hash: str = ""
+    operator_status: str = "new"
+    estimated_energy_impact: str = ""
+    estimated_comfort_impact: str = ""
+    estimated_maintenance_impact: str = ""
+    estimated_healthcare_risk: str = ""
+    override_count_p8: int = 0
+    stale_point_count: int = 0
+    missing_point_count: int = 0
+    dashboard_url_path: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not self.fault_code:
+            errors.append("fault_code required")
+        if not self.canonical_id:
+            errors.append("canonical_id required")
+        if self.operator_status not in OPERATOR_STATUSES:
+            errors.append(f"invalid operator_status: {self.operator_status}")
+        return errors
+
+
+@dataclass
+class TuningProposal:
+    proposal_id: str
+    generated_at: str
+    site_id: str
+    equipment_id: str
+    fault_code: str
+    canonical_id: str
+    current_tuning: dict[str, Any]
+    proposed_tuning: dict[str, Any]
+    reason: str
+    supporting_evidence: dict[str, Any]
+    expected_effect: str
+    risk_level: str
+    rollback_plan: str
+    approval_status: str = "draft"
+    created_by: str = "ai_agent"
+    reviewed_by: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.16"
+version = "3.0.18"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }
@@ -73,7 +73,11 @@ include = [
     "open_fdd.schema*",
     "open_fdd.playground*",
     "open_fdd.arrow_runtime*",
+    "open_fdd.faults*",
 ]
+
+[tool.setuptools.package-data]
+"open_fdd.faults" = ["catalog/*.yaml"]
 
 [tool.black]
 line-length = 88

--- a/scripts/setup_gl36_fdd.py
+++ b/scripts/setup_gl36_fdd.py
@@ -19,6 +19,7 @@ from typing import Any
 
 REPO = Path(__file__).resolve().parents[1]
 API = REPO / "workspace" / "api"
+sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(API))
 sys.path.insert(0, str(REPO / "scripts"))
 

--- a/tests/portfolio/test_csv_store.py
+++ b/tests/portfolio/test_csv_store.py
@@ -44,7 +44,7 @@ def test_rows_from_rollup_and_append(tmp_path: Path):
 
     counts = append_rollup(rollup, site_name="Acme", base_url="http://127.0.0.1:8765", data_dir=tmp_path)
     assert counts["checkins"] == 1
-    csv_path = tmp_path / "data" / "checkins.csv"
+    csv_path = tmp_path / "checkins.csv"
     assert csv_path.is_file()
     text = csv_path.read_text(encoding="utf-8")
     assert "acme" in text

--- a/tests/test_no_pandas_edge_fdd.py
+++ b/tests/test_no_pandas_edge_fdd.py
@@ -1,0 +1,32 @@
+"""CI guard: arrow_runtime and faults packages must not import pandas."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EDGE_PACKAGES = [
+    ROOT / "open_fdd" / "arrow_runtime",
+    ROOT / "open_fdd" / "faults",
+]
+
+
+def _imports_pandas(path: Path) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "pandas" for alias in node.names):
+                return True
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.split(".")[0] == "pandas":
+            return True
+    return False
+
+
+def test_edge_packages_have_no_pandas_imports():
+    violations: list[str] = []
+    for pkg in EDGE_PACKAGES:
+        for py in pkg.rglob("*.py"):
+            if _imports_pandas(py):
+                violations.append(str(py.relative_to(ROOT)))
+    assert not violations, f"pandas found in edge FDD paths: {violations}"


### PR DESCRIPTION
## Summary
- **3.0.17 portfolio:** integrator credential priority in collector, CSV path fix, Dash light/dark theme and stock-style delta charts.
- **3.0.18 Grade-A foundation:** canonical YAML fault catalog (19 faults, 8 families), Arrow primitives/evidence helpers, portfolio interval summary schema, CI pandas edge guard.
- **Acme ops:** BACnet/IP scoped plant discover (1100/1002) instead of full Who-Is timeout; `setup_gl36_fdd.py` repo import path fix.

## Test plan
- [x] `pytest open_fdd/tests/arrow_runtime open_fdd/tests/playground open_fdd/tests/faults tests/test_no_pandas_edge_fdd.py`
- [x] `python3 scripts/build_docs_pdf.py --no-pdf`
- [x] `python3 scripts/portfolio_collect.py` (Acme 1/1 ok)
- [x] `acme_operational_verify.sh` BACnet/IP plant smoke (pre-merge; FDD setup fixed in this PR)
- [ ] CI green on PR
- [ ] Post-merge: tag `open-fdd-v3.0.18`, GHCR publish, Acme image upgrade + full verify


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme-aware portfolio dashboard with dark/light mode support
  * Grade-A fault definitions for AHU, chilled water, VAV, RTU systems
  * Healthcare and controls integrity fault detection
  * Arrow-native runtime primitives for pandas-free fault evaluation
  * Central portfolio collection with interval summaries and tuning proposals

* **Documentation**
  * Standards crosswalk mapping for fault definitions
  * Fault code naming convention guidelines
  * Central plant rule documentation
  * Grade-A gap audit and implementation roadmap

* **Improvements**
  * Enhanced site configuration credential selection
  * Version bumped to 3.0.18

<!-- end of auto-generated comment: release notes by coderabbit.ai -->