### PR TITLE
3.0.19: Full Arrow GL36 recipe library, portfolio Dash faults, docs cleanup

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,6 +19,7 @@ plugins:
   - jekyll-remote-theme
   - jekyll-include-cache
   - jekyll-seo-tag
+  - jekyll-redirect-from
 
 aux_links:
   "GitHub": "https://github.com/bbartling/open-fdd"

--- a/docs/expression_rule_cookbook.md
+++ b/docs/expression_rule_cookbook.md
@@ -1,0 +1,23 @@
+---
+title: Expression Rule Cookbook (retired)
+nav_exclude: true
+redirect_from:
+  - /expression_rule_cookbook/
+---
+
+# Retired — use Arrow-native cookbook
+
+The pandas **`RuleRunner`** + YAML **`type: expression`** cookbook was removed in **Open-FDD 3.x**.
+
+**Current documentation:** [Expression cookbook (Arrow-native)](rule-cookbook/expression-cookbook)
+
+Edge rules are Python modules with:
+
+```python
+def apply_faults_arrow(table, cfg, context=None):
+    ...
+```
+
+Helpers: `open_fdd.arrow_runtime.cookbook`, `open_fdd.arrow_runtime.primitives`, `open_fdd.arrow_runtime.sensor_catalog`.
+
+Legacy `open_fdd.engine` (pandas) is **not** published on PyPI for 3.x.

--- a/docs/legacy/retired-pandas-yaml-engine.md
+++ b/docs/legacy/retired-pandas-yaml-engine.md
@@ -1,0 +1,26 @@
+---
+title: Retired pandas/YAML engine
+parent: Developer Guide
+nav_exclude: true
+---
+
+# Retired: pandas RuleRunner and YAML expression rules
+
+Open-FDD **3.x** edge FDD does **not** use:
+
+- `pandas` DataFrames on the BACnet poll / Docker edge path
+- `type: expression` YAML rule files
+- `RuleRunner.run(df, column_map=…)` from `open_fdd.engine`
+
+## Use instead
+
+| Legacy | Modern (3.x) |
+|--------|----------------|
+| YAML `expression:` strings | `apply_faults_arrow()` in `workspace/data/rules_py/` |
+| `np.maximum`, `.rolling()` on Series | `pyarrow.compute`, `open_fdd.arrow_runtime.windows` |
+| `params` in YAML | Module constants + Rule Lab `cfg` + building-agent tuning |
+| `flag: rule_a_flag` | `fault_code` metadata → [Fault codes](../fault-codes/) |
+
+**Cookbook:** [Rule cookbook](../rule-cookbook/) — start at [Expression cookbook (Arrow-native)](../rule-cookbook/expression-cookbook).
+
+**Package:** PyPI `open-fdd` ships `arrow_runtime` + `playground` only. Portfolio Dash may use pandas for CSV analytics.

--- a/docs/rule-cookbook/arrow-recipes.md
+++ b/docs/rule-cookbook/arrow-recipes.md
@@ -1,14 +1,14 @@
 ---
 title: Arrow recipes
 parent: Rule Cookbook
-nav_order: 1
+nav_order: 2
 ---
 
 # Arrow recipes (default)
 
 Open-FDD 3.0 Rule Lab rules use **`apply_faults_arrow(table, cfg, context)`**, **`pyarrow.compute`**, and **module constants** (no `config.json`).
 
-For the full legacy pandas/YAML → Arrow translation, sensor bound tables, and GL36 fault-code mapping, see **[Expression cookbook (Arrow-native)](expression-cookbook)**.
+For **full GL36 A–M and plant recipes**, see **[Python recipes (full Arrow library)](python-recipes-arrow)**. Sensor tables: **[Expression cookbook](expression-cookbook)**.
 
 ## Simple threshold
 

--- a/docs/rule-cookbook/expression-cookbook.md
+++ b/docs/rule-cookbook/expression-cookbook.md
@@ -1,17 +1,21 @@
 ---
 title: Expression cookbook (Arrow-native)
 parent: Rule Cookbook
-nav_order: 0
+nav_order: 1
+redirect_from:
+  - /expression_rule_cookbook
+  - /expression_rule_cookbook.html
 ---
 
 # Expression cookbook (Arrow-native)
 
 Reference for **Open-FDD 3.x Rule Lab**: every rule is a Python module with **`apply_faults_arrow(table, cfg, context)`** using **`pyarrow.compute`** — **no pandas**, **no YAML expression files**, **no NumPy DataFrames on the IoT edge**.
 
-This page **replaces the legacy pandas `type: expression` YAML cookbook**. Each legacy recipe maps to a **fixed [fault code](../fault-codes/)** and an Arrow pattern below.
+This is the **only** expression cookbook for Open-FDD 3.x. The old pandas/YAML page is [retired](../legacy/retired-pandas-yaml-engine). Legacy GL36-style recipes map to **fixed [fault codes](../fault-codes/)** and Arrow patterns below.
 
 | Topic | Page |
 |-------|------|
+| **Full copy-paste library (GL36 A–M, VAV, plant)** | **[Python recipes (full Arrow library)](python-recipes-arrow)** |
 | Quick templates | [Arrow recipes](arrow-recipes) |
 | Shared imports | [Python recipes](python-recipes) |
 | Console window stats | [Lookback window](lookback-window) |
@@ -149,42 +153,23 @@ def apply_faults_arrow(table, cfg, context=None):
 
 ASHRAE Guideline 36-style rules from the old YAML cookbook, translated to Arrow. Assign **`fault_code`** per row in Rule Lab.
 
-| Legacy rule | Summary | Suggested code | Pattern |
-|-------------|---------|----------------|---------|
-| Rule A — duct static low @ full fan | SP below SP setpoint at high VFD | **AHU-A** | `custom_arrow` |
-| Rule B — blend below band | MAT below OAT/RAT envelope | **AHU-D** | `mixing_envelope` |
-| Rule C — blend above band | MAT above OAT/RAT envelope | **AHU-D** | `mixing_envelope` |
-| Rule D — discharge cold when heating | SAT low vs MAT, heat valve open | **AHU-B** | `custom_arrow` |
-| Rule E — SAT low, full heating | SAT below SP, valve > 90% | **AHU-C** / performance | `custom_arrow` |
-| Rule F — SAT/MAT mismatch econ | Econ mode, SAT ≠ MAT | **AHU-E** | `custom_arrow` |
-| Rule G — ambient warm free cool | OAT > SAT SP, econ open, cool off | **AHU-E** | `custom_arrow` |
-| Rule H — OAT/MAT mismatch econ+mech | Mech + econ, MAT ≠ OAT | **AHU-E** | `mixing_envelope` |
-| Rule I — OAT/MAT mismatch econ-only | Econ only, MAT ≠ OAT | **AHU-E** | `mixing_envelope` |
-| Rule J — discharge above blend cooling | SAT > MAT in cooling | **AHU-B** | `custom_arrow` |
-| Rule K — discharge above SP full cool | SAT > SP, full cooling | **AHU-C** | `custom_arrow` |
-| Rule L — cooling coil ΔT when off | CHW drop when valves closed | **CH-C** | `custom_arrow` |
-| Rule M — heating coil ΔT when off | HW rise when valves closed | **AHU-B** | `custom_arrow` |
+| Legacy rule | Summary | Code | Full Arrow module |
+|-------------|---------|------|-------------------|
+| Rule A — duct static low @ full fan | SP below SP setpoint at high VFD | **AHU-A** | [Rule A](python-recipes-arrow#rule-a--duct-static-low-at-full-fan-speed-ahu-a) |
+| Rule B — blend below band | MAT below OAT/RAT envelope | **AHU-D** | [Rules B & C](python-recipes-arrow#rules-b--c--blended-air-outside-oatr-at-band-ahu-d) |
+| Rule C — blend above band | MAT above OAT/RAT envelope | **AHU-D** | [Rules B & C](python-recipes-arrow#rules-b--c--blended-air-outside-oatr-at-band-ahu-d) |
+| Rule D — discharge cold when heating | SAT low vs MAT, heat valve open | **AHU-B** | [Rule D](python-recipes-arrow#rule-d--discharge-cold-when-heating-commanded-ahu-b) |
+| Rule E — SAT low, full heating | SAT below SP, valve > 90% | **AHU-C** | [Rule E](python-recipes-arrow#rule-e--sat-too-low-with-full-heating-ahu-c) |
+| Rule F — SAT/MAT mismatch econ | Econ mode, SAT ≠ MAT | **AHU-E** | [Rule F](python-recipes-arrow#rule-f--satmat-mismatch-in-economizer-mode-ahu-e) |
+| Rule G — ambient warm free cool | OAT > SAT SP, econ open, cool off | **AHU-E** | [Rule G](python-recipes-arrow#rule-g--ambient-too-warm-for-free-cooling-ahu-e) |
+| Rule H — OAT/MAT mismatch econ+mech | Mech + econ, MAT ≠ OAT | **AHU-E** | [Rule H](python-recipes-arrow#rule-h--oatmat-mismatch-econ--mech-cooling-ahu-e) |
+| Rule I — OAT/MAT mismatch econ-only | Econ only, MAT ≠ OAT | **AHU-E** | [Rule I](python-recipes-arrow#rule-i--oatmat-mismatch-economizer-only-ahu-e) |
+| Rule J — discharge above blend cooling | SAT > MAT in cooling | **AHU-B** | [Rule J](python-recipes-arrow#rule-j--discharge-above-blended-in-cooling-ahu-b) |
+| Rule K — discharge above SP full cool | SAT > SP, full cooling | **AHU-C** | [Rule K](python-recipes-arrow#rule-k--discharge-above-setpoint-in-full-cooling-ahu-c) |
+| Rule L — cooling coil ΔT when off | CHW drop when valves closed | **CH-C** | [Rule L](python-recipes-arrow#rule-l--cooling-coil-δt-when-inactive-ch-c) |
+| Rule M — heating coil ΔT when off | HW rise when valves closed | **AHU-B** | [Rule M](python-recipes-arrow#rule-m--heating-coil-δt-when-inactive-ahu-b) |
 
-### Rule A — duct static low at full speed (Arrow sketch)
-
-```python
-import pyarrow.compute as pc
-
-SP = "duct-static-pressure"
-SP_SP = "duct-static-pressure-sp"
-FAN = "supply-fan-speed-command"
-SP_MARGIN = 0.12
-DRV_HI = 0.93
-
-
-def apply_faults_arrow(table, cfg, context=None):
-    sp = pc.cast(table[SP], "float64")
-    sp_sp = pc.cast(table[SP_SP], "float64")
-    fan = pc.if_else(pc.greater(table[FAN], 1), pc.divide(table[FAN], 100), table[FAN])
-    low_sp = pc.less(sp, pc.subtract(sp_sp, SP_MARGIN))
-    fan_hi = pc.greater_equal(fan, DRV_HI - 0.06)
-    return pc.and_(low_sp, fan_hi)
-```
+All rules A–M have **full `apply_faults_arrow` modules** in [Python recipes (full Arrow library)](python-recipes-arrow).
 
 ---
 
@@ -198,56 +183,27 @@ Maps to legacy YAML starter filenames; use as first deploy bundle.
 | `02_vav_zone_temp_flatline_occupied` | `sensor_flatline_mask(..., "zone_temp")` + occupied | **VAV-C** |
 | `03_vav_damper_command_extreme_flatline` | `flatline_1h_mask` on damper cmd column | **VAV-D** |
 | `04_ahu_runtime_outside_schedule` | `after_hours_fan_satisfied_mask` / run-hours script | **BLD-C** |
-| `05_ahu_duct_static_pressure_not_maintained` | Rule A sketch above | **AHU-A** |
+| `05_ahu_duct_static_pressure_not_maintained` | [Rule A](python-recipes-arrow#rule-a--duct-static-low-at-full-fan-speed-ahu-a) | **AHU-A** |
 | `06_ahu_internal_temp_sensor_bounds` | `sensor_bounds_mask` on SAT/MAT | **AHU-C** |
 | `07_ahu_internal_temp_sensor_flatline` | `sensor_flatline_mask` on SAT | **AHU-C** |
 
 ### Economizer starters
 
-| Legacy name | Fault code | Key logic |
-|-------------|------------|-----------|
-| `ahu_econ_100oa_temp_tracking_fault` | **AHU-E** | OA damper ≥ 95%, \|MAT−OAT\| and \|SAT−MAT\| > tol |
-| `ahu_mech_cooling_when_free_cooling_available` | **AHU-E** | OAT ≤ SAT SP − margin, low OA damper, cooling valve on |
-| `ahu_oa_damper_excess_open_extreme_ambient` | **AHU-E** | OA ≥ 50% when OAT > 70 °F or OAT < 40 °F |
+Full modules: [economizer section](python-recipes-arrow#economizer-starters) (`ahu_econ_100oa_temp_tracking_fault`, `ahu_mech_cooling_when_free_cooling_available`, `ahu_oa_damper_excess_open_extreme_ambient`).
 
 ---
 
 ## VAV, central plant, heat pump
 
-| Legacy recipe | Fault code | Notes |
-|---------------|------------|-------|
-| `zone_reheat_warm_ambient` | **VAV-A** | Reheat open when OAT > cutoff |
-| `zone_damper_valve_full_open` | **VAV-D** | Damper > 97.5% for rolling window |
-| `dp_below_sp_pump_max` | **CH-E** | Plant DP low at max pump speed |
-| `flow_high_pump_max` | **CH-B** | High flow at max pump |
-| `plant_supply_temp_deadband` | **CH-D** | CHW SP ± band while pump on |
-| `chiller_excessive_runtime` | **CH-F** | Rolling sum of chiller on samples |
-| `hp_discharge_cold_when_heating` | **HP-D** | SAT low, zone cold, fan on |
+Full modules: [VAV](python-recipes-arrow#vav-zones) · [Central plant](python-recipes-arrow#central-plant) · [Heat pumps](python-recipes-arrow#heat-pumps).
 
-Rolling persistence in pandas `.rolling(n).min()` → `arrow_rolling_min` + `pc.and_` with current sample.
+Rolling persistence: `arrow_rolling_min` + `pc.and_` (replaces pandas `.rolling(n).min()`).
 
 ---
 
 ## Opportunistic / ventilation
 
-| Legacy recipe | Fault code |
-|---------------|------------|
-| `econ_active_warm_ambient` | **AHU-E** |
-| `mech_cool_when_econ_available` | **AHU-E** |
-| `low_oa_fraction_estimated` | **VAV-B** / **BLD-A** |
-| `preheat_excess_temp` | **AHU-B** |
-| `weather_temp_spike` | **BLD-B** (`rate_of_change`) |
-| `weather_gust_lt_wind` | **BLD-B** (custom compare) |
-
-**OA fraction estimate** (no airflow meter):
-
-```python
-# Guard: |RAT - OAT| > gap before dividing
-oa_frac = (mat - rat) / (oat - rat) * 100
-# Flag when oa_frac < oa_min_pct and fan on
-```
-
-Use `pc.and_` with gap check; skip divide where denominator near zero.
+Full modules: [Opportunistic section](python-recipes-arrow#opportunistic--ventilation) · [Weather](python-recipes-arrow#weather-station).
 
 ---
 
@@ -304,4 +260,4 @@ curl -s http://127.0.0.1:8765/api/faults/catalog | jq '.families[].codes[] | sel
 - [ ] Apply sensor_catalog defaults; tune bounds for site climate
 - [ ] Enable building-agent check-in; verify faults in portfolio rollup
 
-**Next:** [Arrow recipes](arrow-recipes) · [Fault codes](../fault-codes/) · [Rule Lab](../operator-bridge/rule-lab)
+**Next:** [Python recipes (full Arrow library)](python-recipes-arrow) · [Arrow recipes](arrow-recipes) · [Fault codes](../fault-codes/) · [Rule Lab](../operator-bridge/rule-lab)

--- a/docs/rule-cookbook/index.md
+++ b/docs/rule-cookbook/index.md
@@ -9,7 +9,8 @@ Practical patterns for **Arrow-native Rule Lab** (`apply_faults_arrow`) on feath
 
 | Page | Use when |
 |------|----------|
-| [**Expression cookbook (Arrow-native)**](expression-cookbook) | **Full reference** — legacy YAML/pandas translation, sensor bounds, GL36, fault codes |
+| [**Python recipes (full Arrow library)**](python-recipes-arrow) | **Copy-paste GL36 A–M, VAV, plant, economizer, weather** — replaces legacy YAML cookbook |
+| [**Expression cookbook (Arrow-native)**](expression-cookbook) | Sensor bounds, legacy→Arrow map, commissioning checklist |
 | [Arrow recipes](arrow-recipes) | Short templates — threshold, flatline, OOB, fan/schedule |
 | [Python recipes](python-recipes) | Shared `open_fdd.arrow_runtime.cookbook` imports |
 | [Lookback window helper](lookback-window) | `_kit_lookback_stats` — print start/stop timestamps and span |

--- a/docs/rule-cookbook/python-recipes-arrow.md
+++ b/docs/rule-cookbook/python-recipes-arrow.md
@@ -1,0 +1,651 @@
+---
+title: Python recipes (full Arrow library)
+parent: Rule Cookbook
+nav_order: 0
+---
+
+# Python recipes — full Arrow library
+
+Copy-paste **`apply_faults_arrow`** modules for Rule Lab. Replaces the legacy pandas/YAML Expression Rule Cookbook.
+
+- **No pandas** on the edge — PyArrow + `pyarrow.compute` only
+- Set **`fault_code`** in Rule Lab metadata (letter codes or Grade-A `AHU-ECON-001`)
+- Map historian column names in the data model / rule bindings (`ma-t`, `oa-t`, `stat_zn-t`, …)
+
+Quick patterns: [Arrow recipes](arrow-recipes) · Index: [Expression cookbook (Arrow-native)](expression-cookbook)
+
+---
+
+## Shared helpers (paste once per rule file)
+
+```python
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from open_fdd.arrow_runtime.cookbook import mixing_envelope_mask
+from open_fdd.arrow_runtime.windows import (
+    arrow_rolling_min,
+    arrow_rolling_max,
+    arrow_abs_diff,
+)
+
+
+def _norm_cmd(col: pa.ChunkedArray) -> pa.ChunkedArray:
+    c = pc.cast(col, pa.float64())
+    return pc.if_else(pc.greater(c, 1.0), pc.divide(c, 100.0), c)
+
+
+def _col(table, name: str) -> pa.ChunkedArray:
+    return pc.cast(table[name], pa.float64())
+
+
+def _hypot_tol(a: float, b: float) -> float:
+    return (a * a + b * b) ** 0.5
+```
+
+---
+
+## GL36 AHU Rules A–M
+
+### Rule A — duct static low at full fan speed (`AHU-A`)
+
+```python
+FAULT_CODE = "AHU-A"
+SP, SP_SP, FAN = "duct-static-pressure", "duct-static-pressure-sp", "supply-fan-speed-command"
+SP_MARGIN, DRV_HI, DRV_NEAR = 0.12, 0.93, 0.06
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    sp, sp_sp = _col(table, SP), _col(table, SP_SP)
+    fan = _norm_cmd(table[FAN])
+    return pc.and_(
+        pc.less(sp, pc.subtract(sp_sp, SP_MARGIN)),
+        pc.greater_equal(fan, DRV_HI - DRV_NEAR),
+    )
+```
+
+### Rules B & C — blended air outside OAT/RAT band (`AHU-D`)
+
+Uses `mixing_envelope_mask` (covers below-band and above-band).
+
+```python
+FAULT_CODE = "AHU-D"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    return mixing_envelope_mask(
+        table,
+        {**cfg, "mixing_tol": 1.15, "normalize_cmd_percent": 1},
+        mat_col="ma-t",
+        oat_col="oa-t",
+        rat_col="ra-t",
+        fan_col="supply-fan-speed-command",
+    )
+```
+
+### Rule D — discharge cold when heating commanded (`AHU-B`)
+
+```python
+FAULT_CODE = "AHU-B"
+BLEND_TOL, SAT_TOL, FAN_DT = 1.15, 1.15, 0.55
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    mat, sat = _col(table, "ma-t"), _col(table, "sa-t")
+    valve = _norm_cmd(table["heating-valve-command"])
+    fan = _norm_cmd(table["supply-fan-speed-command"])
+    rhs = pc.add(pc.subtract(mat, BLEND_TOL), FAN_DT)
+    cold = pc.less_equal(pc.add(sat, SAT_TOL), rhs)
+    return pc.and_(cold, pc.greater(valve, 0.01), pc.greater(fan, 0.01))
+```
+
+### Rule E — SAT too low with full heating (`AHU-C`)
+
+```python
+FAULT_CODE = "AHU-C"
+SUPPLY_ERR = 1.0
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    sat = _col(table, "sa-t")
+    sp = _col(table, "sa-t-sp") if "sa-t-sp" in table.column_names else _col(table, "supply-air-temperature-setpoint")
+    valve = _norm_cmd(table["heating-valve-command"])
+    fan = _norm_cmd(table["supply-fan-speed-command"])
+    return pc.and_(
+        pc.less(sat, pc.subtract(sp, SUPPLY_ERR)),
+        pc.greater(valve, 0.9),
+        pc.greater(fan, 0.01),
+    )
+```
+
+### Rule F — SAT/MAT mismatch in economizer mode (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+FAN_DT, BLEND_TOL, SAT_TOL, ECON_MIN = 0.55, 1.15, 1.15, 0.12
+TOL = _hypot_tol(SAT_TOL, BLEND_TOL)
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    mat, sat = _col(table, "ma-t"), _col(table, "sa-t")
+    damper = _norm_cmd(table["oa-damper-command"])
+    cool = _norm_cmd(table["cooling-valve-command"])
+    mismatch = pc.greater(pc.abs(pc.subtract(pc.subtract(sat, FAN_DT), mat)), TOL)
+    econ = pc.and_(pc.greater(damper, ECON_MIN), pc.less(cool, 0.1))
+    return pc.and_(mismatch, econ)
+```
+
+### Rule G — ambient too warm for free cooling (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+OAT_TOL, FAN_DT, SAT_TOL, ECON_MIN = 1.15, 0.55, 1.15, 0.12
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat = _col(table, "oa-t")
+    sp = _col(table, "sa-t-sp")
+    damper = _norm_cmd(table["oa-damper-command"])
+    cool = _norm_cmd(table["cooling-valve-command"])
+    warm = pc.greater(oat, pc.add(pc.subtract(sp, FAN_DT), SAT_TOL - OAT_TOL))
+    econ = pc.and_(pc.greater(damper, ECON_MIN), pc.less(cool, 0.1))
+    return pc.and_(warm, econ)
+```
+
+### Rule H — OAT/MAT mismatch (econ + mech cooling) (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+OAT_TOL, BLEND_TOL = 1.15, 1.15
+TOL = _hypot_tol(OAT_TOL, BLEND_TOL)
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat, mat = _col(table, "oa-t"), _col(table, "ma-t")
+    cool = _norm_cmd(table["cooling-valve-command"])
+    damper = _norm_cmd(table["oa-damper-command"])
+    return pc.and_(
+        pc.greater(pc.abs(pc.subtract(mat, oat)), TOL),
+        pc.greater(cool, 0.01),
+        pc.greater(damper, 0.9),
+    )
+```
+
+### Rule I — OAT/MAT mismatch (economizer only) (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+TOL = _hypot_tol(1.15, 1.15)
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat, mat = _col(table, "oa-t"), _col(table, "ma-t")
+    damper = _norm_cmd(table["oa-damper-command"])
+    return pc.and_(pc.greater(pc.abs(pc.subtract(mat, oat)), TOL), pc.greater(damper, 0.9))
+```
+
+### Rule J — discharge above blended in cooling (`AHU-B`)
+
+```python
+FAULT_CODE = "AHU-B"
+FAN_DT, BLEND_TOL, SAT_TOL, ECON_MIN = 0.55, 1.15, 1.15, 0.12
+TOL = _hypot_tol(SAT_TOL, BLEND_TOL)
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    sat, mat = _col(table, "sa-t"), _col(table, "ma-t")
+    cool = _norm_cmd(table["cooling-valve-command"])
+    damper = _norm_cmd(table["oa-damper-command"])
+    hot = pc.greater(sat, pc.add(mat, pc.add(TOL, FAN_DT)))
+    mode_a = pc.and_(pc.greater(damper, 0.9), pc.greater(cool, 0.0))
+    mode_b = pc.and_(pc.less_equal(damper, ECON_MIN), pc.greater(cool, 0.9))
+    return pc.and_(hot, pc.or_(mode_a, mode_b))
+```
+
+### Rule K — discharge above setpoint in full cooling (`AHU-C`)
+
+```python
+FAULT_CODE = "AHU-C"
+SAT_TOL, ECON_MIN = 1.15, 0.12
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    sat = _col(table, "sa-t")
+    sp = _col(table, "sa-t-sp")
+    cool = _norm_cmd(table["cooling-valve-command"])
+    damper = _norm_cmd(table["oa-damper-command"])
+    high = pc.greater(sat, pc.add(sp, SAT_TOL))
+    full = pc.or_(
+        pc.and_(pc.greater(damper, 0.9), pc.greater(cool, 0.9)),
+        pc.and_(pc.less_equal(damper, ECON_MIN), pc.greater(cool, 0.9)),
+    )
+    return pc.and_(high, full)
+```
+
+### Rule L — cooling coil ΔT when inactive (`CH-C`)
+
+```python
+FAULT_CODE = "CH-C"
+ENTER_TOL, LEAVE_TOL, ECON_MIN = 1.15, 1.15, 0.12
+TOL = _hypot_tol(ENTER_TOL, LEAVE_TOL)
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    ent = _col(table, "cooling-coil-entering-air-temperature")
+    leave = _col(table, "cooling-coil-leaving-air-temperature")
+    heat = _norm_cmd(table["heating-valve-command"])
+    cool = _norm_cmd(table["cooling-valve-command"])
+    damper = _norm_cmd(table["oa-damper-command"])
+    drop = pc.greater(pc.subtract(ent, leave), TOL)
+    mode_a = pc.and_(pc.greater(heat, 0), pc.equal(cool, 0), pc.less_equal(damper, ECON_MIN))
+    mode_b = pc.and_(pc.equal(heat, 0), pc.equal(cool, 0), pc.greater(damper, ECON_MIN))
+    return pc.and_(drop, pc.or_(mode_a, mode_b))
+```
+
+### Rule M — heating coil ΔT when inactive (`AHU-B`)
+
+```python
+FAULT_CODE = "AHU-B"
+ENTER_TOL, LEAVE_TOL, FAN_DT, ECON_MIN = 1.15, 1.15, 0.55, 0.12
+TOL = _hypot_tol(ENTER_TOL, LEAVE_TOL) + FAN_DT
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    ent = _col(table, "heating-coil-entering-air-temperature")
+    leave = _col(table, "heating-coil-leaving-air-temperature")
+    heat = _norm_cmd(table["heating-valve-command"])
+    cool = _norm_cmd(table["cooling-valve-command"])
+    damper = _norm_cmd(table["oa-damper-command"])
+    rise = pc.greater(pc.subtract(leave, ent), TOL)
+    m1 = pc.and_(pc.equal(heat, 0), pc.equal(cool, 0), pc.greater(damper, ECON_MIN))
+    m2 = pc.and_(pc.equal(heat, 0), pc.greater(cool, 0), pc.greater(damper, 0.9))
+    m3 = pc.and_(pc.equal(heat, 0), pc.greater(cool, 0), pc.less_equal(damper, ECON_MIN))
+    return pc.and_(rise, pc.or_(m1, m2, m3))
+```
+
+---
+
+## Starter pack (VAV / AHU baseline)
+
+### `01_vav_zone_temp_bounds_occupied` (`VAV-C`)
+
+```python
+from open_fdd.arrow_runtime.cookbook import sensor_bounds_mask, _unoccupied_mask
+
+FAULT_CODE = "VAV-C"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    occupied = pc.invert(_unoccupied_mask(table, cfg))
+    oob = sensor_bounds_mask(table, "zone_temp", cfg)
+    return pc.and_(oob, occupied)
+```
+
+### `02_vav_zone_temp_flatline_occupied` (`VAV-C`)
+
+```python
+from open_fdd.arrow_runtime.cookbook import sensor_flatline_mask, _unoccupied_mask
+
+FAULT_CODE = "VAV-C"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    occupied = pc.invert(_unoccupied_mask(table, cfg))
+    flat = sensor_flatline_mask(table, "zone_temp", cfg)
+    return pc.and_(flat, occupied)
+```
+
+### `03_vav_damper_command_extreme_flatline` (`VAV-D`)
+
+```python
+from open_fdd.arrow_runtime.cookbook import flatline_1h_mask
+
+FAULT_CODE = "VAV-D"
+DAMPER = "damper-position-command"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    stuck = flatline_1h_mask(table, {**cfg, "column": DAMPER})
+    wide = pc.greater(_norm_cmd(table[DAMPER]), 0.975)
+    return pc.and_(stuck, wide)
+```
+
+### `04_ahu_runtime_outside_schedule` (`BLD-C`)
+
+Use run-hours analytics script + schedule compare; boolean mask:
+
+```python
+from open_fdd.arrow_runtime.cookbook import _fan_on_mask, _unoccupied_mask
+
+FAULT_CODE = "BLD-C"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    return pc.and_(_fan_on_mask(table, cfg), _unoccupied_mask(table, cfg))
+```
+
+### `05` / `06` / `07` — see Rules A, `sensor_bounds_mask` on `sa-t` / `sensor_flatline_mask` on `sa-t`
+
+---
+
+## Economizer starters
+
+### `ahu_econ_100oa_temp_tracking_fault` (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+DAMPER_FULL, FAN_ON, TRACK_TOL, FAN_HEAT = 0.95, 0.5, 2.0, 0.5
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat, mat, sat = _col(table, "oa-t"), _col(table, "ma-t"), _col(table, "sa-t")
+    damper = _norm_cmd(table["oa-damper-command"])
+    fan = _col(table, "supply-fan-status")
+    econ = pc.and_(pc.greater(fan, FAN_ON), pc.greater_equal(damper, DAMPER_FULL))
+    mat_bad = pc.greater(pc.abs(pc.subtract(mat, oat)), TRACK_TOL)
+    sat_bad = pc.greater(pc.abs(pc.subtract(pc.subtract(sat, FAN_HEAT), mat)), TRACK_TOL)
+    return pc.and_(econ, pc.or_(mat_bad, sat_bad))
+```
+
+### `ahu_mech_cooling_when_free_cooling_available` (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+MARGIN, DAMPER_LOW, COOL_ON = 2.0, 0.50, 0.10
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat = _col(table, "oa-t")
+    sp = _col(table, "sa-t-sp")
+    damper = _norm_cmd(table["oa-damper-command"])
+    cool = _norm_cmd(table["cooling-valve-command"])
+    free = pc.less_equal(oat, pc.subtract(sp, MARGIN))
+    return pc.and_(free, pc.less(damper, DAMPER_LOW), pc.greater_equal(cool, COOL_ON))
+```
+
+### `ahu_oa_damper_excess_open_extreme_ambient` (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+DAMPER_MIN, HI_OAT, LO_OAT = 0.50, 70.0, 40.0
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat = _col(table, "oa-t")
+    damper = _norm_cmd(table["oa-damper-command"])
+    extreme = pc.or_(pc.greater_equal(oat, HI_OAT), pc.less_equal(oat, LO_OAT))
+    return pc.and_(pc.greater_equal(damper, DAMPER_MIN), extreme)
+```
+
+---
+
+## VAV zones
+
+### `zone_reheat_warm_ambient` (`VAV-A`)
+
+```python
+FAULT_CODE = "VAV-A"
+T_CUTOFF, REHEAT_MIN = 78.0, 0.52
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat = _col(table, "oa-t")
+    reheat = _norm_cmd(table["reheat-valve-command"])
+    return pc.and_(pc.greater(oat, T_CUTOFF), pc.greater(reheat, REHEAT_MIN))
+```
+
+### `zone_damper_valve_full_open` (`VAV-D`)
+
+```python
+FAULT_CODE = "VAV-D"
+FULL_OPEN, ROLL = 97.5, 105
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    d = _norm_cmd(table["damper-position-command"])
+    hi = pc.greater(d, FULL_OPEN)
+    rmin = arrow_rolling_min(d, ROLL)
+    return pc.and_(hi, pc.greater(rmin, FULL_OPEN))
+```
+
+### Zone / IAQ bounds
+
+Use `sensor_bounds_mask(table, "zone_temp", cfg)` or `sensor_bounds_mask` with CO₂ profile — see [sensor validation](expression-cookbook#sensor-validation-bounds-flatline-rate-of-change).
+
+---
+
+## Central plant
+
+### `dp_below_sp_pump_max` (`CH-E`)
+
+```python
+FAULT_CODE = "CH-E"
+DP_MARGIN, PMP_HI, PMP_NEAR = 2.2, 0.93, 0.06
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    dp = _col(table, "differential-pressure")
+    sp = _col(table, "differential-pressure-sp")
+    pump = _norm_cmd(table["pump-speed-command"])
+    return pc.and_(
+        pc.less(dp, pc.subtract(sp, DP_MARGIN)),
+        pc.greater_equal(pump, PMP_HI - PMP_NEAR),
+    )
+```
+
+### `flow_high_pump_max` (`CH-B`)
+
+```python
+FAULT_CODE = "CH-B"
+FLOW_HI, PMP_HI, PMP_NEAR = 1100.0, 0.93, 0.06
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    flow = _col(table, "water-flow")
+    pump = _norm_cmd(table["pump-speed-command"])
+    return pc.and_(pc.greater(flow, FLOW_HI), pc.greater_equal(pump, PMP_HI - PMP_NEAR))
+```
+
+### `plant_supply_temp_deadband` (`CH-D`)
+
+```python
+FAULT_CODE = "CH-D"
+SP_BAND = 2.2
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    temp = _col(table, "chilled-water-supply-temperature")
+    sp = _col(table, "chilled-water-supply-temperature-sp")
+    pump = _norm_cmd(table["pump-speed-command"])
+    low = pc.less(temp, pc.subtract(sp, SP_BAND))
+    high = pc.greater(temp, pc.add(sp, SP_BAND))
+    return pc.and_(pc.greater(pump, 0.01), pc.or_(low, high))
+```
+
+### `chiller_excessive_runtime` (`CH-F`)
+
+```python
+from open_fdd.arrow_runtime.cookbook import arrow_rolling_mean
+
+FAULT_CODE = "CH-F"
+WINDOW, MAX_ON = 276, 264  # 5-min data ≈ 23 h window, 22 h max on
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    on = pc.greater(_col(table, "chiller-status"), 0.5).cast(pa.float64())
+    roll = arrow_rolling_mean(on, WINDOW)
+    count = pc.multiply(roll, float(WINDOW))
+    return pc.greater(count, float(MAX_ON))
+```
+
+---
+
+## Heat pumps
+
+### `hp_discharge_cold_when_heating` (`HP-D`)
+
+```python
+FAULT_CODE = "HP-D"
+MIN_SAT, ZONE_COLD, FAN_ON = 85.0, 69.0, 0.01
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    sat = _col(table, "sa-t")
+    zone = _col(table, "stat_zn-t")
+    fan = _col(table, "supply-fan-status")
+    return pc.and_(
+        pc.greater(fan, FAN_ON),
+        pc.less(zone, ZONE_COLD),
+        pc.less(sat, MIN_SAT),
+    )
+```
+
+---
+
+## Opportunistic / ventilation
+
+### `econ_active_warm_ambient` (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+T_CUTOFF, DPR_MIN = 63.0, 0.42
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat = _col(table, "oa-t")
+    damper = _norm_cmd(table["oa-damper-command"])
+    return pc.and_(pc.greater(oat, T_CUTOFF), pc.greater(damper, DPR_MIN))
+```
+
+### `mech_cool_when_econ_available` (`AHU-E`)
+
+```python
+FAULT_CODE = "AHU-E"
+T_CUTOFF, DPR_MAX = 63.0, 0.32
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    oat = _col(table, "oa-t")
+    damper = _norm_cmd(table["oa-damper-command"])
+    cool = _norm_cmd(table["cooling-valve-command"])
+    return pc.and_(pc.less(oat, T_CUTOFF), pc.less(damper, DPR_MAX), pc.greater(cool, 0.01))
+```
+
+### `low_oa_fraction_estimated` (`VAV-B`)
+
+```python
+FAULT_CODE = "VAV-B"
+OA_MIN, GAP = 21.0, 2.2
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    mat, rat, oat = _col(table, "ma-t"), _col(table, "ra-t"), _col(table, "oa-t")
+    fan = _norm_cmd(table["supply-fan-speed-command"])
+    denom = pc.subtract(oat, rat)
+    safe = pc.greater(pc.abs(denom), GAP)
+    num = pc.subtract(mat, rat)
+    oa_pct = pc.multiply(pc.divide(num, denom), 100.0)
+    low = pc.less(oa_pct, OA_MIN)
+    return pc.and_(pc.greater(fan, 0.01), safe, low)
+```
+
+### `preheat_excess_temp` (`AHU-B`)
+
+```python
+FAULT_CODE = "AHU-B"
+EXCESS = 2.2
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    pre = _col(table, "preheat-coil-leaving-air-temperature")
+    sp = _col(table, "sa-t-sp")
+    oat = _col(table, "oa-t")
+    valve = _norm_cmd(table["preheat-valve-command"])
+    hot_oa = pc.and_(
+        pc.greater(oat, sp),
+        pc.greater(pc.subtract(pre, oat), EXCESS),
+    )
+    cold_oa = pc.and_(
+        pc.less(oat, sp),
+        pc.greater(pc.subtract(pre, sp), EXCESS),
+    )
+    return pc.and_(pc.greater(valve, 0.01), pc.or_(hot_oa, cold_oa))
+```
+
+---
+
+## Weather station
+
+### `weather_temp_spike` (`BLD-B`)
+
+```python
+from open_fdd.arrow_runtime.cookbook import rate_of_change_mask
+
+FAULT_CODE = "BLD-B"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    return rate_of_change_mask(
+        table,
+        {**cfg, "max_per_sample": 16.0, "column": "oa-t"},
+        col="oa-t",
+    )
+```
+
+### `weather_gust_lt_wind` (`BLD-B`)
+
+```python
+FAULT_CODE = "BLD-B"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    gust = _col(table, "wind-gust-speed")
+    wind = _col(table, "wind-speed")
+    return pc.and_(
+        pc.is_valid(gust),
+        pc.is_valid(wind),
+        pc.less(gust, wind),
+    )
+```
+
+### RH bounds
+
+```python
+from open_fdd.arrow_runtime.cookbook import sensor_bounds_mask
+
+FAULT_CODE = "DC-C"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    merged = {**cfg, "value_kind": "rh"}
+    return sensor_bounds_mask(table, "relative_humidity", merged)
+```
+
+---
+
+## Schedule + weather gating (occupied hours)
+
+```python
+from open_fdd.arrow_runtime.cookbook import _unoccupied_mask, _fan_on_mask
+
+FAULT_CODE = "BLD-C"
+
+
+def apply_faults_arrow(table, cfg, context=None):
+    """Fan running when schedule says unoccupied."""
+    return pc.and_(_fan_on_mask(table, cfg), _unoccupied_mask(table, cfg))
+```
+
+Pass `occupied_start_hour`, `occupied_end_hour`, `tz_offset_hours` in Rule Lab `cfg`.
+
+---
+
+## Next steps
+
+1. Copy a module into `workspace/data/rules_py/<site>_<rule>.py`
+2. Bind feather columns on the Rule Lab row
+3. Set `fault_code` metadata
+4. Quick-test on 3–24 h feather window
+5. Ship via `setup_gl36_fdd.py` or Rule Lab save
+
+**See also:** [Expression cookbook](expression-cookbook) · [Fault codes](../fault-codes/) · [Rule Lab](../operator-bridge/rule-lab)

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.18"
+__version__ = "3.0.19"
 
 __all__ = ["__version__"]

--- a/portfolio/collector/collector.py
+++ b/portfolio/collector/collector.py
@@ -94,6 +94,7 @@ def collect_site(site: SiteConfig, *, data_dir: Path | None = None) -> dict[str,
         site_name=site.name,
         base_url=site.base_url,
         data_dir=data_dir,
+        agent_checkin=site.run_checkin,
     )
     return {"ok": True, "site_id": site.site_id, "rollup": rollup, "csv_rows": counts}
 

--- a/portfolio/dash/app.py
+++ b/portfolio/dash/app.py
@@ -60,11 +60,21 @@ def _traffic_color(traffic: str, theme: dict[str, str]) -> str:
     return base.get(str(traffic or "").lower(), theme["muted"])
 
 
-def _delta_parts(current: float, prior: float, theme: dict[str, str]) -> tuple[str, str]:
+def _delta_parts(
+    current: float,
+    prior: float,
+    theme: dict[str, str],
+    *,
+    up_is_bad: bool = True,
+) -> tuple[str, str]:
     delta = current - prior
     sign = "+" if delta >= 0 else ""
-    # Stock convention: up hours = red (bad), down hours = green (good) for energy KPIs
-    color = theme["down"] if delta > 0 else theme["up"] if delta < 0 else theme["muted"]
+    if delta == 0:
+        color = theme["muted"]
+    elif up_is_bad:
+        color = theme["down"] if delta > 0 else theme["up"]
+    else:
+        color = theme["up"] if delta > 0 else theme["down"]
     return f"{sign}{delta:.1f}", color
 
 
@@ -277,6 +287,59 @@ def _stock_style_figure(
     return _figure_layout(fig, theme, f"{title}  ·  green ▼ red ▲")
 
 
+def _site_fault_total_figure(site_id: str, theme: dict[str, str]) -> go.Figure:
+    """Total active faults per site over portfolio collects (stock-style line + Δ bars)."""
+    checkins = _read_csv("checkins.csv")
+    fig = go.Figure()
+    if checkins.empty or not site_id:
+        return _figure_layout(fig, theme, "Site fault total — no data")
+
+    sub = checkins[checkins["site_id"] == site_id].copy()
+    sub["collected_at"] = pd.to_datetime(sub["collected_at"], errors="coerce")
+    sub = sub.sort_values("collected_at")
+    y = pd.to_numeric(sub["alert_count"], errors="coerce").fillna(0)
+
+    fig.add_trace(
+        go.Scatter(
+            x=sub["collected_at"],
+            y=y,
+            mode="lines+markers",
+            name="Active faults (total)",
+            line={"color": theme["warn"], "width": 2.5},
+        )
+    )
+    if len(y) >= 2:
+        delta = y.diff().fillna(0)
+        colors = [theme["down"] if d > 0 else theme["up"] if d < 0 else theme["muted"] for d in delta]
+        fig.add_trace(
+            go.Bar(
+                x=sub["collected_at"],
+                y=delta,
+                marker_color=colors,
+                opacity=0.35,
+                showlegend=False,
+                name="Δ faults",
+            )
+        )
+        _annotate_last_delta(fig, sub["collected_at"].iloc[-1], float(y.iloc[-1]), float(delta.iloc[-1]), theme)
+
+    if "agent_checkin" in sub.columns:
+        agent_rows = sub[sub["agent_checkin"].astype(str).str.lower().isin({"true", "1", "yes"})]
+        if not agent_rows.empty:
+            fig.add_trace(
+                go.Scatter(
+                    x=agent_rows["collected_at"],
+                    y=pd.to_numeric(agent_rows["alert_count"], errors="coerce").fillna(0),
+                    mode="markers",
+                    name="AI agent check-in",
+                    marker={"symbol": "star", "size": 14, "color": theme["accent"], "line": {"width": 1, "color": theme["text"]}},
+                )
+            )
+
+    fig.update_layout(xaxis_title="Collection time", yaxis_title="Active faults (site total)")
+    return _figure_layout(fig, theme, f"Site fault total (+/−) — {site_id}")
+
+
 def _fault_figure(site_id: str, theme: dict[str, str]) -> go.Figure:
     df = _read_csv("faults_daily.csv")
     fig = go.Figure()
@@ -306,7 +369,7 @@ def _fault_figure(site_id: str, theme: dict[str, str]) -> go.Figure:
             )
 
     fig.update_layout(xaxis_title="Collection time", yaxis_title="Active alerts")
-    return _figure_layout(fig, theme, f"Fault code trends (+/−) — {site_id}")
+    return _figure_layout(fig, theme, f"Fault codes by type (+/−) — {site_id}")
 
 
 def _override_figure(site_id: str, theme: dict[str, str]) -> go.Figure:
@@ -400,6 +463,7 @@ app.layout = html.Div(
                 dcc.Graph(id="run-hours-chart"),
             ],
         ),
+        dcc.Graph(id="site-fault-total-chart", style={"marginTop": "16px"}),
         dcc.Graph(id="fault-trend-chart", style={"marginTop": "16px"}),
         dcc.Graph(id="override-chart", style={"marginTop": "16px"}),
     ],
@@ -428,7 +492,7 @@ def render_header(theme_key: str):
                 children=[
                     html.H1("Open-FDD Portfolio", style={"margin": 0, "color": theme["text"]}),
                     html.P(
-                        "Stock-style run-hour rollups with +/− deltas · faults · BACnet P8 overrides",
+                        "Stock-style fault & run-hour trends · per-code breakdown · AI agent check-ins · P8 overrides",
                         style={"color": theme["muted"], "margin": "4px 0 0"},
                     ),
                 ]
@@ -545,6 +609,7 @@ def run_collect(n_clicks: int):
 
 @app.callback(
     Output("run-hours-chart", "figure"),
+    Output("site-fault-total-chart", "figure"),
     Output("fault-trend-chart", "figure"),
     Output("override-chart", "figure"),
     Input("site-select", "value"),
@@ -569,7 +634,13 @@ def update_charts(
         f"Equipment run hours — {site_id or '—'}",
         theme,
     )
-    return run_fig, _fault_figure(site_id or "", theme), _override_figure(site_id or "", theme)
+    sid = site_id or ""
+    return (
+        run_fig,
+        _site_fault_total_figure(sid, theme),
+        _fault_figure(sid, theme),
+        _override_figure(sid, theme),
+    )
 
 
 def main() -> None:

--- a/portfolio/store/csv_store.py
+++ b/portfolio/store/csv_store.py
@@ -46,6 +46,7 @@ CHECKIN_FIELDS = [
     "alert_count",
     "fdd_alert_count",
     "operator_overrides",
+    "agent_checkin",
     "checkin_ok",
     "poll_summary",
     "error",
@@ -91,6 +92,7 @@ def rows_from_rollup(
     base_url: str,
     collected_at: str | None = None,
     error: str = "",
+    agent_checkin: bool = False,
 ) -> dict[str, list[dict[str, Any]]]:
     ts = collected_at or datetime.now(timezone.utc).isoformat()
     day = _day_key(ts)
@@ -112,6 +114,7 @@ def rows_from_rollup(
         "alert_count": building.get("alert_count"),
         "fdd_alert_count": building.get("fdd_alert_count"),
         "operator_overrides": overrides.get("operator_override_points"),
+        "agent_checkin": agent_checkin,
         "checkin_ok": agent.get("last_checkin_ok"),
         "poll_summary": poll.get("summary_sentence"),
         "error": error,
@@ -185,9 +188,16 @@ def append_rollup(
     base_url: str,
     data_dir: Path | None = None,
     error: str = "",
+    agent_checkin: bool = False,
 ) -> dict[str, int]:
     root = portfolio_data_dir(data_dir)
-    rows = rows_from_rollup(rollup, site_name=site_name, base_url=base_url, error=error)
+    rows = rows_from_rollup(
+        rollup,
+        site_name=site_name,
+        base_url=base_url,
+        error=error,
+        agent_checkin=agent_checkin,
+    )
     return {
         "checkins": _append_rows(root / "checkins.csv", CHECKIN_FIELDS, rows["checkins"]),
         "run_hours": _append_rows(root / "run_hours_daily.csv", RUN_HOURS_FIELDS, rows["run_hours"]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.18"
+version = "3.0.19"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/daily_release.sh
+++ b/scripts/daily_release.sh
@@ -151,8 +151,8 @@ post_merge_release() {
   fi
 
   if [[ "$SKIP_DOCKER" != true ]]; then
-    echo "==> Dispatch Publish Docker addons (image_tag=${IMAGE_TAG})"
-    run gh workflow run docker-publish.yml -f "image_tag=${IMAGE_TAG}"
+    echo "==> Dispatch Publish Docker addons (:latest)"
+    run gh workflow run docker-publish.yml
     echo "    gh run list --workflow=docker-publish.yml --limit 3"
   fi
 


### PR DESCRIPTION
## Summary
- **Full Arrow cookbook:** `docs/rule-cookbook/python-recipes-arrow.md` — copy-paste `apply_faults_arrow` modules for GL36 rules A–M, starter pack, economizer, VAV, central plant, heat pump, opportunistic, and weather (replaces legacy pandas/YAML Expression Rule Cookbook depth).
- **Docs cleanup:** Legacy URL redirect, `retired-pandas-yaml-engine.md`, expression-cookbook index links to full library.
- **Portfolio Dash:** Site total fault trend chart (stock ±), per-code chart retained, AI agent check-in star markers when `run_checkin` enabled.
- **Fix:** `daily_release.sh` GHCR dispatch (remove invalid `image_tag` input).
- Version bump to **3.0.19** (chore commit on branch).

## Test plan
- [x] `pytest tests/portfolio/test_csv_store.py`
- [ ] CI green
- [ ] Docs Pages deploy after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v3.0.19

* **New Features**
  * Added site fault total chart to portfolio dashboard displaying active faults and collection deltas.
  * Introduced agent check-in tracking in portfolio data collection.

* **Documentation**
  * New Python recipes guide for Arrow-based fault detection with copy-paste examples.
  * Updated Expression Cookbook with legacy-to-Arrow migration mapping and commissioning checklist.
  * Added legacy pandas/YAML engine retirement documentation.

* **Chores**
  * Version bumped to 3.0.19.
  * Enabled documentation page redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->