### PR TITLE
3.0.21: brick column resolution + AHU run-hours fix

### DIFF
--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.20"
+__version__ = "3.0.21"
 
 __all__ = ["__version__"]

--- a/open_fdd/arrow_runtime/cookbook.py
+++ b/open_fdd/arrow_runtime/cookbook.py
@@ -172,6 +172,8 @@ def _unoccupied_mask(table: pa.Table, cfg: dict[str, Any]) -> pa.ChunkedArray:
         if val is None:
             out.append(False)
             continue
+        if hasattr(val, "to_pydatetime"):
+            val = val.to_pydatetime()
         if isinstance(val, datetime):
             utc = val if val.tzinfo else val.replace(tzinfo=timezone.utc)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.20"
+version = "3.0.21"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/acme_wake_orchestrator.sh
+++ b/scripts/acme_wake_orchestrator.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Acme FDD tuning + patch orchestrator for agent wake cycles.
+#
+# Schedule (default):
+#   1. patch cycle (smoke → deploy → verify → tune → collect)
+#   2. tuning wake × 3 (6 h apart)
+#   3. patch cycle
+#   4. tuning wake × 3 (6 h apart)
+#   5. patch cycle (final)
+#
+#   ./scripts/acme_wake_orchestrator.sh run          # execute current phase
+#   ./scripts/acme_wake_orchestrator.sh status
+#   ./scripts/acme_wake_orchestrator.sh arm-sleep    # sleep 6h then emit wake sentinel
+#   ACME_WAKE_TUNING_CYCLES=3 ACME_WAKE_PATCH_CYCLES=2 ./scripts/acme_wake_orchestrator.sh run
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+STATE_DIR="${ACME_WAKE_STATE_DIR:-$ROOT/.acme_wake}"
+STATE_FILE="$STATE_DIR/state.json"
+SLEEP_HOURS="${ACME_WAKE_SLEEP_HOURS:-6}"
+TUNING_PER_BLOCK="${ACME_WAKE_TUNING_CYCLES:-3}"
+PATCH_CYCLES="${ACME_WAKE_PATCH_CYCLES:-2}"
+SENTINEL="${ACME_WAKE_SENTINEL:-AGENT_ACME_WAKE}"
+
+mkdir -p "$STATE_DIR"
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+now_epoch() { date -u +%s; }
+
+init_state() {
+  if [[ ! -f "$STATE_FILE" ]]; then
+    python3 - <<PY
+import json
+from pathlib import Path
+p = Path("$STATE_FILE")
+p.write_text(json.dumps({
+    "started_at": "$(now_iso)",
+    "phase": "patch",
+    "patch_num": 1,
+    "tuning_in_block": 0,
+    "patches_done": 0,
+    "tuning_wakes_done": 0,
+    "last_run_at": "",
+    "last_result": "",
+    "history": [],
+}, indent=2))
+PY
+  fi
+}
+
+read_state() { python3 -c "import json; print(json.load(open('$STATE_FILE')))"; }
+
+save_note() {
+  local note="$1"
+  python3 - <<PY
+import json
+from pathlib import Path
+p = Path("$STATE_FILE")
+s = json.loads(p.read_text())
+s["last_run_at"] = "$(now_iso)"
+s["last_result"] = """$note"""
+s.setdefault("history", []).append({"at": "$(now_iso)", "note": """$note"""})
+p.write_text(json.dumps(s, indent=2))
+PY
+}
+
+advance_state() {
+  python3 - <<PY
+import json
+from pathlib import Path
+
+tuning_per = int("$TUNING_PER_BLOCK")
+patch_total = 1 + int("$PATCH_CYCLES")  # initial patch + N more after tuning blocks
+
+p = Path("$STATE_FILE")
+s = json.loads(p.read_text())
+phase = s.get("phase", "patch")
+patch_num = int(s.get("patch_num") or 1)
+tuning_in = int(s.get("tuning_in_block") or 0)
+
+if phase == "patch":
+    s["patches_done"] = int(s.get("patches_done") or 0) + 1
+    if patch_num >= patch_total:
+        s["phase"] = "complete"
+    else:
+        s["phase"] = "tuning"
+        s["tuning_in_block"] = 0
+elif phase == "tuning":
+    tuning_in += 1
+    s["tuning_wakes_done"] = int(s.get("tuning_wakes_done") or 0) + 1
+    s["tuning_in_block"] = tuning_in
+    if tuning_in >= tuning_per:
+        s["phase"] = "patch"
+        s["patch_num"] = patch_num + 1
+        s["tuning_in_block"] = 0
+
+p.write_text(json.dumps(s, indent=2))
+print(json.dumps(s))
+PY
+}
+
+run_patch_cycle() {
+  echo "==> patch cycle smokes"
+  python3 -m pytest open_fdd/tests/arrow_runtime open_fdd/tests/faults tests/test_no_pandas_edge_fdd.py \
+    tests/workspace_bridge/test_fdd_brick_column_sweep.py -q
+
+  if [[ -f infra/ansible/secrets/acme.env.local ]]; then
+    # shellcheck disable=SC1091
+    source infra/ansible/secrets/acme.env.local
+    echo "==> Acme operational verify"
+    ./infra/ansible/scripts/acme_operational_verify.sh --host "${ACME_SSH_HOST}"
+  else
+    echo "WARN: no acme.env.local — skip edge verify"
+  fi
+}
+
+run_tuning_collect() {
+  echo "==> portfolio collect + FDD audit"
+  python3 scripts/portfolio_collect.py --json 2>&1 | tail -30
+
+  if [[ -f infra/ansible/secrets/acme.env.local ]]; then
+    # shellcheck disable=SC1091
+    source infra/ansible/secrets/acme.env.local
+    python3 <<'PY'
+import json, os, urllib.request
+base = f"http://{os.environ['ACME_SSH_HOST']}"
+login = urllib.request.Request(
+    f"{base}/api/auth/login",
+    data=json.dumps({"username": os.environ["ACME_INTEGRATOR_USER"],
+                      "password": os.environ["ACME_INTEGRATOR_PASSWORD"]}).encode(),
+    headers={"Content-Type": "application/json"}, method="POST",
+)
+with urllib.request.urlopen(login, timeout=30) as r:
+    token = json.load(r).get("token")
+hdr = {"Authorization": f"Bearer {token}"}
+for path, method, body in [
+    ("/api/building-agent/checkin", "POST", {"site_id": "acme", "run_fdd_batch": True}),
+    ("/api/building-agent/tuning-brief?site_id=acme&window_minutes=180", "GET", None),
+]:
+    req = urllib.request.Request(
+        f"{base}{path}",
+        data=json.dumps(body).encode() if body else None,
+        headers={**hdr, **({"Content-Type": "application/json"} if body else {})},
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        d = json.load(r)
+    print(path, json.dumps(d, indent=2)[:2500])
+PY
+  fi
+}
+
+cmd_status() {
+  init_state
+  echo "state: $STATE_FILE"
+  read_state | python3 -m json.tool
+}
+
+cmd_arm_sleep() {
+  local secs=$((SLEEP_HOURS * 3600))
+  echo "Arming ${SLEEP_HOURS}h sleep (${secs}s) → sentinel ${SENTINEL}"
+  (
+    sleep "$secs"
+    echo "${SENTINEL} $(now_iso) phase=$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('phase','?'))")"
+  ) &
+  echo "sleep_pid=$!"
+}
+
+cmd_run() {
+  init_state
+  local phase patch_num
+  phase="$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('phase','patch'))")"
+  patch_num="$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('patch_num',1))")"
+
+  echo "acme_wake: phase=$phase patch_num=$patch_num"
+  case "$phase" in
+    patch)
+      run_patch_cycle
+      save_note "patch $patch_num verify OK"
+      ;;
+    tuning)
+      run_tuning_collect
+      save_note "tuning wake collect OK"
+      ;;
+    complete)
+      echo "acme_wake: schedule complete"
+      exit 0
+      ;;
+    *)
+      echo "unknown phase: $phase" >&2
+      exit 1
+      ;;
+  esac
+
+  advance_state | python3 -m json.tool
+  local next_phase
+  next_phase="$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('phase','?'))")"
+  if [[ "$next_phase" != "complete" ]]; then
+    cmd_arm_sleep
+  fi
+  echo "${SENTINEL}_DONE $(now_iso) next=$next_phase"
+}
+
+case "${1:-}" in
+  run) cmd_run ;;
+  status) cmd_status ;;
+  arm-sleep) cmd_arm_sleep ;;
+  -h|--help)
+    sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    echo "Usage: $0 {run|status|arm-sleep}" >&2
+    exit 1
+    ;;
+esac

--- a/workspace/api/openfdd_bridge/data_loader.py
+++ b/workspace/api/openfdd_bridge/data_loader.py
@@ -186,7 +186,13 @@ def enrich_rows_with_column_map(rows: list[dict[str, Any]], column_map: dict[str
     return out
 
 
-def historian_columns_for_rule(model: dict, site_id: str, rule: dict) -> list[str]:
+def historian_columns_for_rule(
+    model: dict,
+    site_id: str,
+    rule: dict,
+    *,
+    available_columns: set[str] | list[str] | None = None,
+) -> list[str]:
     """Historian column names for all points matched by rule bindings (brick / equipment / point)."""
     from .model_point_utils import point_site_id
     from .timeseries_api import plot_column_name
@@ -200,6 +206,7 @@ def historian_columns_for_rule(model: dict, site_id: str, rule: dict) -> list[st
 
     cols: list[str] = []
     sid = str(site_id or "").strip()
+    available = set(available_columns) if available_columns is not None else None
     for pt in model.get("points") or []:
         if not isinstance(pt, dict):
             continue
@@ -217,10 +224,32 @@ def historian_columns_for_rule(model: dict, site_id: str, rule: dict) -> list[st
             matched = True
         if not matched:
             continue
-        col = plot_column_name(pt)
+        from .timeseries_api import historian_column_candidates, resolve_historian_column
+
+        if available is not None:
+            col = resolve_historian_column(pt, available)
+            if col not in available:
+                continue
+        else:
+            col = plot_column_name(pt)
         if col:
             cols.append(col)
     return sorted(set(cols))
+
+
+def historian_columns_for_rule_resolved(
+    model: dict,
+    site_id: str,
+    rule: dict,
+    available_columns: set[str] | list[str],
+) -> list[str]:
+    """Binding-matched historian columns that exist in a loaded frame."""
+    return historian_columns_for_rule(
+        model,
+        site_id,
+        rule,
+        available_columns=available_columns,
+    )
 
 
 def column_map_for_rule(model: dict, site_id: str, rule: dict) -> dict[str, str]:

--- a/workspace/api/openfdd_bridge/fdd_runner.py
+++ b/workspace/api/openfdd_bridge/fdd_runner.py
@@ -250,7 +250,14 @@ def _run_one(
                 table = table.slice(max(0, table.num_rows - limit), min(limit, table.num_rows))
             cfg = dict(rule.get("config") or {})
             cfg.setdefault("site_id", site_id)
-            bound_cols = historian_columns_for_rule(model, site_id, rule)
+            avail_cols = (
+                set(table.column_names)
+                if hasattr(table, "column_names")
+                else set(getattr(frame, "columns", []))
+            )
+            bound_cols = historian_columns_for_rule(
+                model, site_id, rule, available_columns=avail_cols
+            )
             if bound_cols:
                 if len(bound_cols) == 1:
                     cfg.setdefault("value_column", bound_cols[0])

--- a/workspace/data/rules_py/ahu_run_hours.py
+++ b/workspace/data/rules_py/ahu_run_hours.py
@@ -32,9 +32,12 @@ def _dt_hours(table, ts_col, max_gap_hours):
     def _to_utc(val):
         if val is None:
             return None
+        if hasattr(val, "to_pydatetime"):
+            val = val.to_pydatetime()
         if isinstance(val, datetime):
             return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
-        return datetime.fromisoformat(str(val).replace("Z", "+00:00")).replace(tzinfo=timezone.utc)
+        parsed = datetime.fromisoformat(str(val).replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
     ts_list = [_to_utc(v) for v in table[ts_col].to_pylist()]
     capped = float(max_gap_hours or 2.0)
@@ -73,11 +76,6 @@ if ts_col is None:
         "metrics": {},
     }
 else:
-    ts_type = table[ts_col].type
-    if pa.types.is_timestamp(ts_type) and ts_type.tz is not None:
-        ts_naive = pc.cast(pc.cast(table[ts_col], pa.int64()), pa.timestamp("us"))
-        col_idx = table.column_names.index(ts_col)
-        table = table.set_column(col_idx, ts_col, ts_naive)
     fan_on = _fan_on_mask(table, cfg)
     system_on = _system_on_mask(table, cfg, fan_on)
     dt = _dt_hours(table, ts_col, cfg.get("max_gap_hours", 2.0))


### PR DESCRIPTION
## Summary
- Resolve brick-bound FDD columns against columns actually present in the feather frame (Acme zone sweep).
- Fix `acme-ahu-run-hours` script for pandas timestamps without pytz on edge.
- Add `scripts/acme_wake_orchestrator.sh` for patch + 6h tuning wake schedule.

## Test plan
- [x] pytest arrow_runtime + test_fdd_brick_column_sweep + test_ahu_run_hours_script
- [ ] GHCR `:latest` → `upgrade_edge_ghcr.sh --limit acme_vm_bbartling`
- [ ] `acme_operational_verify.sh` PASS; `acme-ahu-run-hours` error_runs=0
- [ ] portfolio_collect + tuning-brief


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v3.0.21

* **Chores**
  * Version bumped to 3.0.21

* **Bug Fixes**
  * Fixed timestamp handling for PyArrow timestamp-like objects
  * Improved timezone handling to preserve timezone information in ISO-8601 string parsing

* **New Features**
  * Added new orchestration script for managing agent wake cycles with persistent state tracking across patch, tuning, and completion phases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->