### PR TITLE
3.0.24: ahu_run_hours script sandbox fix

### DIFF
--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.23"
+__version__ = "3.0.24"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.23"
+version = "3.0.24"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/workspace/data/rules_py/ahu_run_hours.py
+++ b/workspace/data/rules_py/ahu_run_hours.py
@@ -32,10 +32,14 @@ def _dt_hours(table, ts_col, max_gap_hours):
     def _to_utc(val):
         if val is None:
             return None
-        if hasattr(val, "to_pydatetime"):
-            val = val.to_pydatetime()
         if isinstance(val, datetime):
             return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+        try:
+            val = val.to_pydatetime()
+            if isinstance(val, datetime):
+                return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+        except AttributeError:
+            pass
         parsed = datetime.fromisoformat(str(val).replace("Z", "+00:00"))
         return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 


### PR DESCRIPTION
Fixes `name 'hasattr' is not defined` on Acme FDD batch for acme-ahu-run-hours.

Made with [Cursor](https://cursor.com)