### PR TITLE
3.0.26: Weather OAT cross-check + BACnet override scans

### DIFF
--- a/bacnet_toolshed/bacnet_override_scan_loop.py
+++ b/bacnet_toolshed/bacnet_override_scan_loop.py
@@ -72,7 +72,10 @@ def _override_scan_loop(run_bacnet_sync: Callable[..., Any]) -> None:
     while True:
         interval = scan_interval_s()
         if list_devices_for_scan():
-            run_override_scan_cycle(run_bacnet_sync)
+            try:
+                run_override_scan_cycle(run_bacnet_sync)
+            except Exception as exc:
+                print(f"BACnet override scan loop error: {exc}", file=sys.stderr)
         time.sleep(interval)
 
 

--- a/bacnet_toolshed/commission_agent.py
+++ b/bacnet_toolshed/commission_agent.py
@@ -321,6 +321,11 @@ def _run_bacnet_background(coro_factory, timeout: float = 180.0) -> Any:
     return _run_bacnet_sync(coro_factory, priority=BacnetPriority.BACKGROUND, timeout=timeout)
 
 
+def _run_bacnet_override_scan(coro_factory, timeout: float = 900.0) -> Any:
+    """Supervisory override scans may read many priority arrays — allow up to 15 min."""
+    return _run_bacnet_sync(coro_factory, priority=BacnetPriority.BACKGROUND, timeout=timeout)
+
+
 def _run_async_bacnet_job(job_id: str, kind: str, coro_factory) -> None:
     log_file = _log_path(job_id)
     meta = {
@@ -674,7 +679,7 @@ class CommissionAgentHandler(BaseHTTPRequestHandler):
             return _json_response(self, 200, {"ok": bool(result.get("ok")), **result})
 
         if path == "/api/bacnet/overrides/scan-once":
-            result = run_override_scan_cycle(_run_bacnet_background)
+            result = run_override_scan_cycle(_run_bacnet_override_scan)
             return _json_response(self, 200, result)
 
         if path == "/api/bacnet/whois":
@@ -741,7 +746,7 @@ def main() -> int:
         flush=True,
     )
     start_poll_loop(_run_bacnet_background)
-    start_override_scan_loop(_run_bacnet_background)
+    start_override_scan_loop(_run_bacnet_override_scan)
     print(
         f"BACnet poll loop started (enabled points={enabled_point_count()}, interval={poll_interval_s()}s)",
         flush=True,

--- a/docs/bacnet/index.md
+++ b/docs/bacnet/index.md
@@ -13,4 +13,5 @@ Open-FDD integrates with field controllers via BACnet/IP (and bench MSTP overlay
 | [Network setup](network-setup) | Bind address and NIC |
 | [Discover and read](discover-read) | Commission agent |
 | [Polling](polling) | Historian driver |
+| [Operator override scans](override-scans) | Hourly P8 supervisory rotation |
 | [Write safety](write-safety) | Defaults and allowlists |

--- a/docs/bacnet/override-scans.md
+++ b/docs/bacnet/override-scans.md
@@ -1,0 +1,61 @@
+---
+title: Operator override scans
+parent: BACnet
+nav_order: 4
+---
+
+# Operator override scans (P8)
+
+The commission agent rotates **one BACnet device per hour** (default) through a supervisory priority-array scan. Results are persisted for operator review and portfolio rollup — not for automatic writes.
+
+## Schedule
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `OFDD_OVERRIDE_SCAN_INTERVAL_S` | `3600` | Seconds between single-device scans |
+| `OFDD_OPERATOR_OVERRIDE_PRIORITY` | `8` | BACnet priority counted as “operator override” |
+| Device list | `points_discovered.csv` | Unique `device_instance` rows |
+| Rotation | `registry.json` cursor | Full plant rotation ≈ `device_count × interval` |
+
+Example: **33 devices × 1 h** ≈ **33 h** for a full pass. Dashboard shows **next device** and **last scan** time.
+
+## What each scan does
+
+1. `point_discovery` on the target device (commandable objects).
+2. `read_property` on each object’s **priority-array** (not RPM — RPM loses priority slots).
+3. Merge into `workspace/bacnet/overrides/registry.json` and append `overrides_export.csv`.
+4. Advance cursor to the next device.
+
+Fault code **operator_override** (P8) surfaces active overrides on the BACnet tree and building status.
+
+## BACnet I/O priority
+
+Override scans run at **BACKGROUND** priority on the single shared BACnet stack (UDP 47808). Operator reads/writes use **INTERACTIVE** and preempt background work. Scheduled RPM polling also uses BACKGROUND and shares the same asyncio lock — polls and override scans take turns; neither starves the other indefinitely.
+
+Override scans allow up to **15 minutes** per device (`_run_bacnet_override_scan` timeout). Bridge `POST /api/bacnet/overrides/scan-once` proxies with a matching 900 s timeout.
+
+## Manual trigger
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  http://EDGE:8765/api/bacnet/overrides/scan-once
+```
+
+Dashboard: BACnet page → **Scan next device now**.
+
+## Health checks
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://EDGE:8765/api/bacnet/overrides/status
+```
+
+Expect `device_count` > 0, `last_scan_at` within the last few hours on a healthy edge, and `export_row_count` growing over time.
+
+## Data paths
+
+| Path | Content |
+|------|---------|
+| `workspace/bacnet/overrides/registry.json` | Per-device last scan + override points |
+| `workspace/bacnet/overrides/overrides_export.csv` | Flat export for spreadsheets |
+
+Preserved across Docker upgrades when `workspace/` is on the edge volume — see [Backup & restore](../ops/backup-restore).

--- a/docs/bacnet/polling.md
+++ b/docs/bacnet/polling.md
@@ -43,3 +43,31 @@ Inside **bridge**, a background thread watches `samples.csv` and ingests new row
 Dashboard stack health (`GET /health/stack`) reports `bacnet_poll` status from the commission agent — not a separate container.
 
 Stale points trigger data-quality fault patterns — see [Sensor quality faults](../fault-codes/sensor-quality).
+
+## Poll strategy (edge)
+
+Open-FDD intentionally keeps BACnet field traffic **minimal**:
+
+- **One enabled row per object** in `points.csv` — poll only what the model/FDD needs.
+- **Uniform cycle** — every enabled point is RPM-polled each cycle; the loop sleeps `max(15, min(poll_interval_s))` (typically **60 s** on Acme).
+- Per-point `poll_interval_s` in the UI is the **commissioned target**; throughput analytics compare configured vs observed samples.
+- **Unit conversion** (e.g. Trane °C → °F) uses `device_poll_profiles.csv` at ingest — not a poll-rate file.
+
+Acme ships ~**340 points / 60 s** ≈ one full plant read per minute. Disable unneeded objects in BACnet commissioning rather than raising global poll rates.
+
+## Async driver and single-stack I/O
+
+| Layer | Behavior |
+|-------|----------|
+| Dedicated `bacnet-io` thread | One asyncio loop + serial lock for all field I/O |
+| RPM batching | Present-value reads chunked (25 objects) to cut APDUs |
+| Poll loop | Sequential per-device RPM when `interruptible=True` so operator UI can preempt |
+| Operator UI | **INTERACTIVE** priority — cancels in-flight background work |
+| Override scans | **BACKGROUND**, 15 min timeout — see [Operator override scans](override-scans) |
+| Bridge ingest | Async notify after each poll cycle → feather historian |
+
+Do **not** run a second BACnet bind on 47808 (no parallel `openfdd-bacnet-poll` container). See [Containers](../architecture/containers).
+
+## Operator override scans
+
+Hourly P8 supervisory scans rotate one device at a time. Documented in [Operator override scans](override-scans).

--- a/docs/development/patch_cycle_3.0.26_acme.md
+++ b/docs/development/patch_cycle_3.0.26_acme.md
@@ -1,0 +1,35 @@
+# Patch cycle 3.0.26 — Weather OAT + BACnet override scans (2026-06-10)
+
+## Shipped (`fix/3.0.26-acme-weather-bacnet`)
+
+| Item | Change |
+|------|--------|
+| Override scans | 15 min BACnet timeout; bridge proxy 900 s; loop try/except so thread survives errors |
+| Weather FDD | `acme-oat-vs-web-spread` in `setup_gl36_fdd.py`; configurable columns in `oat_vs_web_spread_1h.py` |
+| OAT alias | `scripts/acme_patch_oat_column.py` → `1100-unknown-2` as `oa-t` |
+| Portfolio | Fix `override_status` import → `scan_status` |
+| Docs | `docs/bacnet/override-scans.md`, polling strategy, JSON API weather section |
+| Verify | `acme_operational_verify.sh` — OpenWeather + override status + OAT patch |
+
+## Post-merge deploy
+
+```bash
+gh workflow run "Publish Docker addons" --ref master
+source infra/ansible/secrets/acme.env.local
+OPENFDD_IMAGE_TAG=latest ./scripts/upgrade_edge_ghcr.sh --limit acme_vm_bbartling
+python3 scripts/acme_patch_oat_column.py --host "$ACME_SSH_HOST" --token "$TOKEN"
+python3 scripts/setup_gl36_fdd.py --site-id acme --building-id vm-bbartling \
+  --host "$ACME_SSH_HOST" --token "$TOKEN" \
+  --ahu-equipment-id acme-vm-bbartling-rtu-01 --fan-point-id 1100-analog-output-1
+./infra/ansible/scripts/acme_operational_verify.sh --host "${ACME_SSH_HOST}"
+```
+
+## Validate live
+
+```bash
+curl -s "$BASE/health" | jq .openfdd_version   # 3.0.26
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/json-api/endpoints" | jq '.endpoints[]|select(.label=="web-oat-t")'
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/bacnet/overrides/status" | jq '{devices:.device_count,last:.last_scan_at}'
+# Optional: trigger one override scan (may take several minutes)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" "$BASE/api/bacnet/overrides/scan-once"
+```

--- a/docs/drivers/json-api.md
+++ b/docs/drivers/json-api.md
@@ -79,11 +79,28 @@ python3 scripts/openweather_json_api_example.py --register --base http://127.0.0
 
 ### 4. FDD: local OA-T vs web weather
 
-With BACnet `oa-t` and JSON API `web-oat-t` in the same site, scheduled FDD merges both sources. Example rule:
+With BACnet `oa-t` and JSON API `web-oat-t` in the merged site frame, scheduled FDD compares local outdoor air to the weather service.
 
-`workspace/data/rules_py/oat_vs_web_spread_1h.py` — flags when `|oa-t − web-oat-t| > 8 °F` (stuck or drifting outdoor-air sensor).
+| Item | Detail |
+|------|--------|
+| Rule module | `oat_vs_web_spread_1h.py` |
+| Fault code | **BLD-B** (outdoor air sensor fault) |
+| Default threshold | `|oa-t − web-oat-t| > 8 °F` (`max_spread_f` in rule cfg) |
+| Acme rule id | `acme-oat-vs-web-spread` (via `setup_gl36_fdd.py`) |
+| Local OAT source | RTU `1100-unknown-2` (Outdoor Air Temperature Local) — same value as boiler/AHU networked OAT |
+| Web column | `web-oat-t` from OpenWeather bundle |
 
-Enable it in Rule Lab, bind to your OA-T BACnet point, and run **Update all records**.
+**Model alias:** local BACnet historian column must be `oa-t`:
+
+```bash
+python3 scripts/acme_patch_oat_column.py --point-id 1100-unknown-2 --host "$ACME_HOST" --token "$TOKEN"
+```
+
+Or set `external_id` / `fdd_input` to `oa-t` on the chosen `Outside_Air_Temperature_Sensor` in the model.
+
+**Units:** keep `OPENWEATHER_UNITS=imperial` when BACnet OAT is °F.
+
+Enable the rule in Rule Lab (or `setup_gl36_fdd.py` push) and run an FDD batch. Missing either column → rule returns all-false (no crash).
 
 ## Commissioning (UI)
 

--- a/docs/operations/acme_vav_ahu_rule_guidance.md
+++ b/docs/operations/acme_vav_ahu_rule_guidance.md
@@ -42,6 +42,7 @@ Poll interval: Acme BACnet poll loop is **60 s**. Flatline windows use `poll_int
 | 0 | 1 | `oat-bounds` | `oat_sensor_bounds.py` | BLD-B | Building | OAT | — | — | OAT sensor stuck high/low | Extreme weather; sensor in sun/wind |
 | 0 | 2 | `oat-flatline-1h` | `oat_sensor_flatline.py` | BLD-B | Building | OAT | — | 1 h @ 60 s poll | OAT not updating | Equipment powered off (rare for OAT) |
 | 0 | 3 | `oat-spike` | `oat_sensor_spike.py` | BLD-B | Building | OAT | — | **Disabled** — enable after spike tuning | Bad OAT spike | Fast legitimate weather fronts |
+| 0 | 3b | `oat-vs-web-spread` | `oat_vs_web_spread_1h.py` | BLD-B | Building | `oa-t` + `web-oat-t` | OpenWeather JSON API | Enabled when both columns present | Local OAT diverges from weather | Microclimate; wrong city in `OPENWEATHER_CITY` |
 | 0 | 4 | `zn-t-oob-occupied` | `vav_zone_temp_bounds_occupied.py` | VAV-C | VAV | ZN-T | schedule | Occupied 8–17 | Zone too hot/cold when occupied | Wide default bounds (65–78 °F); tune per site |
 | 0 | 5 | `zn-t-flatline-1h` | `vav_zone_temp_flatline_occupied.py` | VAV-C | VAV | ZN-T | schedule | Occupied + 1 h flatline | Zone sensor failed | Long steady occupied periods |
 | 0 | 6 | `da-t-flatline-1h` | `flatline_1h.py` | VAV-E | VAV | DA-T | — | 1 h flatline | DAT sensor stuck | Box off / no airflow |
@@ -84,6 +85,16 @@ Before enabling more rules:
 - **`acme-zn-t-oob-occupied`**: if flag rate &gt; ~70%, use tuning brief / bounds auto-tune (needs ≥85% flagged + analytics on Arrow sweep).
 - Disable noisy rules via `enabled: false` in `setup_gl36_fdd.py` rather than deleting modules.
 - Economizer and reheat-leak rules stay off until OAT/MAT/SAT columns are confirmed on the 7-day feather window.
+
+## JSON API weather + BACnet OAT
+
+- OpenWeather registered on edge JSON API tab (`web-oat-t`, `web-rh`, ~20–30 min poll).
+- Local OAT: bind **`1100-unknown-2`** (RTU outdoor air local) with `external_id: oa-t` — `scripts/acme_patch_oat_column.py`.
+- Rule `acme-oat-vs-web-spread` flags when local vs web spread exceeds 8 °F.
+
+## BACnet override scans
+
+Commission agent rotates **one device/hour** through P8 priority-array reads. Status: `GET /api/bacnet/overrides/status`. See [Operator override scans](../bacnet/override-scans).
 
 ## Docker backup / recovery
 

--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -256,8 +256,36 @@ model_pts="$(echo "$tree" | python3 -c 'import json,sys; print(len(json.load(sys
 zat="$(echo "$tree" | python3 -c 'import json,sys; print(sum(1 for p in json.load(sys.stdin).get("points",[]) if p.get("brick_type")=="Zone_Air_Temperature_Sensor"))')"
 log_ok "Model tree points=${model_pts} zone_temp=${zat}"
 
-log_info "Setup default zone-temp FDD rules (brick-scoped)"
+log_info "JSON API OpenWeather scrape"
+json_env="$(api_get "/api/json-api/env/status")"
+if echo "$json_env" | python3 -c 'import json,sys; d=json.load(sys.stdin); v=d.get("variables") or {}; sys.exit(0 if v.get("OPENWEATHER_API_KEY") else 1)' 2>/dev/null; then
+  log_ok "OpenWeather env configured"
+else
+  log_fail "OpenWeather API key missing in json_api.env.local"
+fi
+json_eps="$(api_get "/api/json-api/endpoints")"
+web_oat="$(echo "$json_eps" | python3 -c 'import json,sys; d=json.load(sys.stdin); eps=d.get("endpoints") or []; w=[e for e in eps if e.get("label")=="web-oat-t"]; print(w[0].get("last_value","") if w else "")' 2>/dev/null || true)"
+if [[ -n "${web_oat}" ]]; then
+  log_ok "JSON API web-oat-t last_value=${web_oat}"
+else
+  log_fail "JSON API web-oat-t not polling (register OpenWeather bundle)"
+fi
+
+log_info "BACnet operator override scan status"
+ov="$(api_get "/api/bacnet/overrides/status")"
+ov_dev="$(echo "$ov" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("device_count",0))' 2>/dev/null || echo 0)"
+ov_last="$(echo "$ov" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("last_scan_at",""))' 2>/dev/null || true)"
+if [[ "${ov_dev:-0}" -ge 5 ]]; then
+  log_ok "Override scan devices=${ov_dev} last_scan=${ov_last:-—}"
+else
+  log_fail "Override scan device_count=${ov_dev}"
+fi
+
+log_info "Setup GL36 FDD rules + OAT alias"
 export OFDD_DESKTOP_DATA_DIR="${ROOT}/workspace/data"
+python3 "${ROOT}/scripts/acme_patch_oat_column.py" \
+  --point-id "${OAT_POINT_ID:-1100-unknown-2}" \
+  --host "$HOST" --token "$TOKEN" || log_fail "OAT column patch"
 python3 "${ROOT}/scripts/setup_gl36_fdd.py" \
   --site-id "${SITE_ID:-acme}" \
   --building-id "${BUILDING_ID:-vm-bbartling}" \

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.25"
+__version__ = "3.0.26"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.25"
+version = "3.0.26"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/acme_patch_oat_column.py
+++ b/scripts/acme_patch_oat_column.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Ensure Acme local OAT historian column is ``oa-t`` for weather cross-check rules.
+
+Sets ``external_id`` and ``fdd_input`` on the RTU local outdoor-air point
+(``1100-unknown-2`` by default). Boiler-wired OAT can be substituted via
+``--point-id`` when that BACnet object is commissioned instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+API = REPO / "workspace" / "api"
+sys.path.insert(0, str(API))
+sys.path.insert(0, str(REPO))
+
+os.environ.setdefault("OPENFDD_REPO_ROOT", str(REPO))
+os.environ.setdefault("OFDD_DESKTOP_DATA_DIR", str(REPO / "workspace" / "data"))
+
+
+def _patch_local(model: dict, point_id: str, alias: str) -> bool:
+    changed = False
+    for pt in model.get("points") or []:
+        if str(pt.get("id") or "") != point_id:
+            continue
+        if str(pt.get("external_id") or "") != alias:
+            pt["external_id"] = alias
+            changed = True
+        if str(pt.get("fdd_input") or "") != alias:
+            pt["fdd_input"] = alias
+            changed = True
+        break
+    return changed
+
+
+def _push_model(base: str, token: str, model: dict) -> None:
+    body = json.dumps({"payload": model, "replace": False}).encode()
+    req = urllib.request.Request(
+        f"{base.rstrip('/')}/api/model/import",
+        data=body,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        print(f"Model import HTTP {resp.status}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Patch Acme OAT point alias to oa-t")
+    parser.add_argument("--point-id", default="1100-unknown-2", help="BACnet point id for local OAT")
+    parser.add_argument("--alias", default="oa-t")
+    parser.add_argument("--host", default="")
+    parser.add_argument("--token", default="")
+    args = parser.parse_args()
+
+    from openfdd_bridge.model_service import ModelService  # noqa: E402
+
+    svc = ModelService()
+    model = svc.load()
+    if not _patch_local(model, args.point_id, args.alias):
+        print(f"No change needed for {args.point_id} (already {args.alias})")
+        return 0
+    svc.import_json(model, replace=True)
+    print(f"Patched local model: {args.point_id} → external_id/fdd_input={args.alias}")
+    if args.host and args.token:
+        _push_model(f"http://{args.host}", args.token, model)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup_gl36_fdd.py
+++ b/scripts/setup_gl36_fdd.py
@@ -129,6 +129,21 @@ def gl36_rule_specs(
             "enabled": False,
         },
         {
+            "id": f"{p}-oat-vs-web-spread",
+            "name": "Local OAT vs OpenWeather spread",
+            "fault_code": "BLD-B",
+            "code_file": "oat_vs_web_spread_1h.py",
+            "config": _cfg(
+                extra={
+                    "local_oat_column": "oa-t",
+                    "web_oat_column": "web-oat-t",
+                    "max_spread_f": 8.0,
+                }
+            ),
+            "bindings": {"point_ids": [], "equipment_ids": [], "brick_types": []},
+            "applies_to": applies,
+        },
+        {
             "id": f"{p}-zn-t-flatline-1h",
             "name": "Zone temp flatline 1h occupied",
             "fault_code": "VAV-C",

--- a/tests/workspace_bridge/test_acme_vav_arrow_rules.py
+++ b/tests/workspace_bridge/test_acme_vav_arrow_rules.py
@@ -96,6 +96,26 @@ def test_vav_zone_bounds_occupied_gates_unoccupied():
     assert True in mask.to_pylist()
 
 
+def test_oat_vs_web_spread_flags_divergence():
+    mod = _load_rule("oat_vs_web_spread_1h.py")
+    table = pa.table(
+        {
+            "timestamp": _ts(3),
+            "oa-t": [70.0, 70.0, 90.0],
+            "web-oat-t": [71.0, 72.0, 70.0],
+        }
+    )
+    mask = mod.apply_faults_arrow(table, {})
+    assert mask.to_pylist() == [False, False, True]
+
+
+def test_oat_vs_web_spread_missing_column_safe():
+    mod = _load_rule("oat_vs_web_spread_1h.py")
+    table = pa.table({"timestamp": _ts(2), "oa-t": [70.0, 71.0]})
+    mask = mod.apply_faults_arrow(table, {})
+    assert mask.to_pylist() == [False, False]
+
+
 def test_flatline_1h_occupied_only_flag():
     mod = _load_rule("flatline_1h.py")
     table = pa.table({"timestamp": _ts(4), "zone_temp": [70.0, 70.0, 70.0, 70.0]})

--- a/workspace/api/openfdd_bridge/commission_client.py
+++ b/workspace/api/openfdd_bridge/commission_client.py
@@ -106,7 +106,7 @@ def commission_override_status() -> tuple[int, Any]:
 
 
 def commission_override_scan_once() -> tuple[int, Any]:
-    return _request("POST", "/api/bacnet/overrides/scan-once", {})
+    return _request("POST", "/api/bacnet/overrides/scan-once", {}, timeout=900.0)
 
 
 def bacnet_write(

--- a/workspace/api/openfdd_bridge/portfolio_rollup.py
+++ b/workspace/api/openfdd_bridge/portfolio_rollup.py
@@ -17,7 +17,7 @@ try:
     from bacnet_toolshed.override_registry import (
         load_registry,
         operator_override_priority,
-        override_status,
+        scan_status as override_status,
     )
 except ImportError:
 

--- a/workspace/data/rules_py/oat_vs_web_spread_1h.py
+++ b/workspace/data/rules_py/oat_vs_web_spread_1h.py
@@ -1,8 +1,8 @@
-"""Local OA-T vs OpenWeather web-oat-t spread (Arrow).
+"""Local OA-T vs OpenWeather web-oat-t spread (Arrow, BLD-B).
 
-Requires BACnet historian column ``oa-t`` and JSON API column ``web-oat-t``
-(register via JSON API tab → OpenWeather bundle). Flags stuck or drifting
-outdoor-air sensors when local readings diverge from the weather service.
+Requires BACnet historian ``oa-t`` (or ``local_oat_column`` in cfg) and JSON API
+``web-oat-t``. Register OpenWeather via JSON API tab; bind RTU/boiler OAT in model
+with ``external_id: oa-t`` or set ``local_oat_column`` to the BACnet feather column.
 """
 
 import pyarrow as pa
@@ -13,33 +13,22 @@ WEB_OAT = "web-oat-t"
 MAX_SPREAD_F = 8.0
 
 
-def _kit_fmt(scalar):
-    v = scalar.as_py() if scalar is not None else None
-    return "nan" if v is None else f"{v:.2f}"
+def _false_mask(table):
+    return pa.array([False] * table.num_rows, type=pa.bool_())
 
 
-def _kit_value_stats(table):
-    if LOCAL_OAT not in table.column_names or WEB_OAT not in table.column_names:
-        print(
-            f"rows={table.num_rows} missing columns "
-            f"(need {LOCAL_OAT} + {WEB_OAT}); available={table.column_names}"
-        )
-        return
-    local = pc.cast(table[LOCAL_OAT], "float64")
-    web = pc.cast(table[WEB_OAT], "float64")
-    spread = pc.abs(pc.subtract(local, web))
-    print(
-        f"rows={table.num_rows} spread "
-        f"min={_kit_fmt(pc.min(spread))} max={_kit_fmt(pc.max(spread))} "
-        f"mean={_kit_fmt(pc.mean(spread))} threshold={MAX_SPREAD_F}"
-    )
+def _col_names(cfg):
+    local = str(cfg.get("local_oat_column") or cfg.get("value_column") or LOCAL_OAT)
+    web = str(cfg.get("web_oat_column") or WEB_OAT)
+    spread = float(cfg.get("max_spread_f") or cfg.get("max_spread") or MAX_SPREAD_F)
+    return local, web, spread
 
 
 def apply_faults_arrow(table, cfg, context=None):
-    _kit_value_stats(table)
-    if LOCAL_OAT not in table.column_names or WEB_OAT not in table.column_names:
-        return pa.array([False] * table.num_rows)
-    local = pc.cast(table[LOCAL_OAT], "float64")
-    web = pc.cast(table[WEB_OAT], "float64")
+    local_col, web_col, max_spread = _col_names(cfg)
+    if local_col not in table.column_names or web_col not in table.column_names:
+        return _false_mask(table)
+    local = pc.cast(table[local_col], pa.float64())
+    web = pc.cast(table[web_col], pa.float64())
     spread = pc.abs(pc.subtract(local, web))
-    return pc.greater(spread, MAX_SPREAD_F)
+    return pc.greater(spread, max_spread)


### PR DESCRIPTION
## Summary
- Fix hourly P8 override scans: 15 min BACnet timeout, 900 s bridge proxy, resilient scan loop
- Add `acme-oat-vs-web-spread` (BLD-B) comparing local `oa-t` to OpenWeather `web-oat-t`
- `scripts/acme_patch_oat_column.py` sets RTU OAT (`1100-unknown-2`) historian alias
- Document BACnet minimal polling + override rotation; extend Acme operational verify

## Test plan
- [x] `pytest tests/workspace_bridge/test_acme_vav_arrow_rules.py tests/bacnet_toolshed/test_override_registry.py`
- [x] `python3 scripts/acme_validate_fdd_bundle.py` — 12 enabled rules incl. oat-vs-web
- [ ] CI green
- [ ] Acme deploy + operational verify


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New rule for detecting outdoor air temperature divergence from weather data integration.

* **Bug Fixes**
  * Improved error resilience in BACnet override scan loop to prevent termination on unexpected exceptions.
  * Extended timeout for override scan operations.

* **Documentation**
  * Added comprehensive guides for BACnet override scans workflow and polling strategy.
  * Updated configuration guidance for outdoor air temperature mapping and spread detection rules.

* **Tests**
  * Added coverage for OAT spread rule with missing column safety validation.

* **Chores**
  * Version 3.0.26 release with enhanced operational verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->