### PR TITLE
3.0.27: async override scan-once

### DIFF
--- a/bacnet_toolshed/commission_agent.py
+++ b/bacnet_toolshed/commission_agent.py
@@ -508,6 +508,10 @@ def _unauthorized(handler: BaseHTTPRequestHandler) -> None:
     _json_response(handler, 401, {"error": "missing or invalid X-Commission-Token"})
 
 
+_override_scan_once_lock = threading.Lock()
+_override_scan_once_running = False
+
+
 class CommissionAgentHandler(BaseHTTPRequestHandler):
     server_version = "OpenFDD-BacnetToolshed/1.0"
 
@@ -679,8 +683,32 @@ class CommissionAgentHandler(BaseHTTPRequestHandler):
             return _json_response(self, 200, {"ok": bool(result.get("ok")), **result})
 
         if path == "/api/bacnet/overrides/scan-once":
-            result = run_override_scan_cycle(_run_bacnet_override_scan)
-            return _json_response(self, 200, result)
+            global _override_scan_once_running
+            with _override_scan_once_lock:
+                if _override_scan_once_running:
+                    return _json_response(
+                        self,
+                        409,
+                        {"ok": False, "error": "override scan already running", **override_scan_status()},
+                    )
+                _override_scan_once_running = True
+
+            def _bg_scan() -> None:
+                global _override_scan_once_running
+                try:
+                    run_override_scan_cycle(_run_bacnet_override_scan)
+                except Exception as exc:
+                    print(f"override scan-once failed: {exc}", file=sys.stderr)
+                finally:
+                    with _override_scan_once_lock:
+                        _override_scan_once_running = False
+
+            threading.Thread(target=_bg_scan, daemon=True, name="override-scan-once").start()
+            return _json_response(
+                self,
+                202,
+                {"ok": True, "started": True, **override_scan_status()},
+            )
 
         if path == "/api/bacnet/whois":
             low = int(body.get("range_low", _cfg().get("DISCOVER_LOW", 1)))

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -5,6 +5,6 @@ PyArrow columnar rules via ``open_fdd.arrow_runtime`` and Rule Lab ``apply_fault
 Optional graph ML (sklearn / PyG) runs outside the rule sandbox — see GitHub issue #211.
 """
 
-__version__ = "3.0.26"
+__version__ = "3.0.27"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.26"
+version = "3.0.27"
 description = "Open-FDD: Arrow-native rule-based HVAC fault detection on a columnar execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/workspace/api/openfdd_bridge/commission_client.py
+++ b/workspace/api/openfdd_bridge/commission_client.py
@@ -106,7 +106,7 @@ def commission_override_status() -> tuple[int, Any]:
 
 
 def commission_override_scan_once() -> tuple[int, Any]:
-    return _request("POST", "/api/bacnet/overrides/scan-once", {}, timeout=900.0)
+    return _request("POST", "/api/bacnet/overrides/scan-once", {}, timeout=60.0)
 
 
 def bacnet_write(

--- a/workspace/api/openfdd_bridge/routes/bacnet_routes.py
+++ b/workspace/api/openfdd_bridge/routes/bacnet_routes.py
@@ -536,7 +536,7 @@ def bacnet_override_export() -> Response:
 @router.post("/api/bacnet/overrides/scan-once", dependencies=[_READ])
 def bacnet_override_scan_once() -> dict:
     code, payload = commission_override_scan_once()
-    if code != 200:
+    if code not in (200, 202):
         raise _proxy_error(code, payload)
     return payload  # type: ignore[return-value]
 


### PR DESCRIPTION
## Summary
- Fix POST /api/bacnet/overrides/scan-once RemoteDisconnected on Acme
- Return HTTP 202 + background thread; bridge accepts 200/202

## Related
- #260 GHCR commission publish unknown blob

## Test plan
- [ ] Acme deploy + scan-once returns 202


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Override scan operations now return immediately with status confirmation instead of blocking.

* **Bug Fixes**
  * Improved concurrent request handling for scan operations to prevent multiple simultaneous scans.
  * Reduced scan request timeout for faster response times.

* **Chores**
  * Version bumped to 3.0.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->