### PR TITLE
Fix post-deploy when edge MCP disabled

### DIFF
--- a/infra/ansible/scripts/post_deploy_check.sh
+++ b/infra/ansible/scripts/post_deploy_check.sh
@@ -105,6 +105,7 @@ if [[ -n "$LIMIT" && -f "$INV" ]] && command -v ansible-inventory >/dev/null 2>&
     INVENTORY_DOCKER_STACK="$(read_inv '1 if d.get("openfdd_docker_stack") else 0')"
     PROBE_SITE_ID="$(read_inv 'd.get("site_id","demo") or "demo"')"
     POST_CHECK_REQUIRE_OLLAMA="$(read_inv '1 if d.get("post_check_require_ollama") else 0')"
+    POST_CHECK_REQUIRE_MCP="$(read_inv '1 if d.get("post_check_require_mcp", True) and d.get("enable_mcp", True) else 0')"
     INV_ENABLE_OLLAMA="$(read_inv '1 if d.get("enable_ollama") else 0')"
     INV_DOCKER_OLLAMA="$(read_inv '0 if d.get("openfdd_docker_ollama") is False else 1')"
     INV_OLLAMA_REQUIRED="$(read_inv '1 if d.get("ollama_required") else 0')"

--- a/infra/ansible/tasks/post_deploy_check.yml
+++ b/infra/ansible/tasks/post_deploy_check.yml
@@ -61,7 +61,8 @@
   ansible.builtin.shell:
     cmd: |
       set -eu
-      for svc in bridge commission mcp-rag; do
+      services="$(docker compose -f "{{ openfdd_remote_dir }}/docker-compose.yml" config --services)"
+      for svc in $services; do
         cid="$(docker ps -q -f "name=${svc}" 2>/dev/null | head -1 || true)"
         echo "${svc}=${cid}"
       done


### PR DESCRIPTION
## Summary
- Read post_check_require_mcp from inventory for http probes and docker gates
- Scan only services defined in rendered docker-compose (skip mcp-rag when enable_mcp false)

## Test plan
- Acme deploy with enable_mcp: false

Made with [Cursor](https://cursor.com)