### PR TITLE
Fix PyPI publish test_cookbook clash

### DIFF
--- a/.github/workflows/publish-open-fdd.yml
+++ b/.github/workflows/publish-open-fdd.yml
@@ -56,7 +56,9 @@ jobs:
 
       - name: Run package tests
         run: |
-          python -m pytest open_fdd/tests/arrow_runtime open_fdd/tests/playground open_fdd/tests/faults -q
+          python -m pytest open_fdd/tests/arrow_runtime -q
+          python -m pytest open_fdd/tests/playground -q
+          python -m pytest open_fdd/tests/faults -q
           python -m pytest open_fdd/tests/test_version_consistency.py open_fdd/tests/test_package_import.py open_fdd/tests/test_cli_smoke.py -q
           python -m pytest tests/test_no_pandas_edge_fdd.py -q
 


### PR DESCRIPTION
Split pytest dirs in publish-open-fdd.yml (same as CI). Required to re-run v3.0.30 publish.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test execution in the build pipeline by splitting test runs into separate, more granular invocations for better organization and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->