### PR TITLE
Harden Acme live post-deploy validation

### DIFF
--- a/docs/ops/acme-live-validation.md
+++ b/docs/ops/acme-live-validation.md
@@ -1,0 +1,98 @@
+---
+title: Acme live validation
+parent: Operations
+nav_order: 25
+---
+
+# Acme live validation
+
+Acme (`vm-bbartling`) is the **live Open-FDD test site** on the OT LAN (reachable over Tailscale from the control machine). After every GHCR image update, run the read-only validation harness before closing a patch cycle.
+
+## Recommended flow
+
+```bash
+export OPENFDD_IMAGE_TAG=v3.0.32
+
+# Full upgrade: React static bundle + GHCR containers (not image-only)
+./scripts/upgrade_edge_full.sh --limit acme_vm_bbartling
+
+# Rigorous live validation
+./scripts/acme_post_deploy_validate.sh --limit acme_vm_bbartling --full \
+  --json-out reports/acme-live-validate.json
+```
+
+Use **`upgrade_edge_full.sh`**, not `upgrade_edge_ghcr.sh` alone, when the Operator Bridge UI changed — the edge bind-mount serves `workspace/api/static/app/` **before** image-baked assets.
+
+## Modes
+
+| Flag | What runs |
+|------|-----------|
+| `--quick` | Health, auth, UI bundle, Docker tag, model health, **duplicate device/point checks**, BACnet poll, trends, FDD summary |
+| `--full` | Quick + SPARQL presets, Rule Lab export, local bundle/PyPI rule smoke, `stack_health_check.sh` |
+| `--long` | Same depth as `--full` (reserved for extended soak hooks) |
+
+## What counts as pass
+
+- Bridge `/health` OK and reports expected `openfdd_version`
+- Running GHCR image tag matches `OPENFDD_IMAGE_TAG` (when set)
+- Dashboard serves current `index-*.js` bundle (matches control machine build when available)
+- **No duplicate BACnet device instances** in model (`duplicate_bacnet_device_instances == 0`)
+- **No duplicate point IDs** in commissioning export
+- Model equipment/point counts above profile thresholds (default ≥10 / ≥50)
+- BACnet poll heartbeat recent; enabled point count above threshold
+- Historian/trend API returns chartable data (or explicit warm-up warning)
+- FDD rules saved and lint-clean; Building Status faults include equipment/point context
+- Recent ops logs free of `Traceback` / fatal import errors
+- Host disk/memory within thresholds (when Ansible remote probe succeeds)
+
+Warnings (e.g. MCP/Ollama disabled, single stale BACnet point) do not fail the run unless paired with hard errors.
+
+## Configuration (no secrets in git)
+
+Copy and customize locally:
+
+```bash
+cp scripts/acme_validation_profile.example.json scripts/acme_validation_profile.local.json
+```
+
+Point the harness at it:
+
+```bash
+./scripts/acme_post_deploy_validate.sh --limit acme_vm_bbartling --full \
+  --profile scripts/acme_validation_profile.local.json
+```
+
+Credentials load from gitignored files only:
+
+- `workspace/auth.env.local`
+- `infra/ansible/secrets/acme.env.local`
+
+Quote passwords that contain `$` or `&` in `auth.env.local`.
+
+## Optional live pytest
+
+```bash
+ACME_VALIDATE_LIVE=1 python -m pytest tests/live/test_acme_live.py -q
+```
+
+Requires Tailscale/inventory reachability and local secrets. CI skips this test by default.
+
+## Safety
+
+Normal validation is **read-only**. It does not:
+
+- Reset BACnet, model, rules, or historian data
+- Run Easy Pooge or bench resets
+- Write setpoints or BACnet values
+- Start packet captures
+
+Destructive actions require explicit operator tooling outside this harness.
+
+## Reports
+
+JSON reports redact tokens and private hostnames. Example fields:
+
+- `summary.ok`, `summary.failed`, `summary.warnings`
+- `checks[].id`, `checks[].category`, `checks[].status`, `checks[].message`
+
+On failure, the console output lists suggested next steps (re-run full upgrade, check static bind mount, run `stack_health_check.sh`).

--- a/docs/ops/deployment-validation.md
+++ b/docs/ops/deployment-validation.md
@@ -6,6 +6,8 @@ nav_order: 4
 
 # Deployment validation
 
+For the **live Acme site** after GHCR updates, use the dedicated harness documented in [Acme live validation]({% link ops/acme-live-validation.md %}) (`acme_post_deploy_validate.sh`).
+
 Non-destructive checks after deploy or image upgrade. Run from the **edge host** (smoke) or from a **control machine** with the full repo (insurance suite).
 
 ## Edge host smoke (5 minutes)

--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -29,7 +29,9 @@ FAILURES=0
 
 if [[ -f "$AUTH_ENV" ]]; then
   # shellcheck disable=SC1090
+  set +u
   set -a && source "$AUTH_ENV" && set +a
+  set -u
 fi
 if [[ -f "$ACME_SECRETS" ]]; then
   # shellcheck disable=SC1090

--- a/infra/ansible/scripts/acme_remote_host_probe.py
+++ b/infra/ansible/scripts/acme_remote_host_probe.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Emit read-only host/container JSON for Acme edge (run locally or over SSH)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _run(cmd: str) -> str:
+    try:
+        return subprocess.check_output(cmd, shell=True, text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        return ""
+
+
+def collect() -> dict:
+    home = Path.home()
+    compose = home / "open-fdd" / "docker-compose.yml"
+    data: dict = {
+        "probe_at": datetime.now(timezone.utc).isoformat(),
+        "hostname": _run("hostname -s") or _run("hostname"),
+        "compose_file": str(compose) if compose.is_file() else None,
+        "services": [],
+        "exited_openfdd": [],
+        "disk_usage_percent": None,
+        "mem_available_mb": None,
+        "load_average": _run("uptime | sed 's/.*load average: //'"),
+        "max_restart_count": 0,
+    }
+    if _run("command -v docker"):
+        data["docker_ps"] = _run("docker ps --format '{{.Names}}|{{.Image}}|{{.Status}}'")
+        exited = [
+            x
+            for x in _run("docker ps -a --filter status=exited --format '{{.Names}}'").splitlines()
+            if "openfdd" in x.lower()
+        ]
+        data["exited_openfdd"] = exited
+        if compose.is_file():
+            lines = _run(f"docker compose -f {compose} ps --format json")
+            for line in lines.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                svc = row.get("Service") or row.get("Name") or ""
+                data["services"].append(
+                    {"service": svc, "state": row.get("State"), "image": row.get("Image")}
+                )
+    df = _run(f"df -P {home}/open-fdd 2>/dev/null | awk 'NR==2{{gsub(/%/,\"\",$5); print $5}}'")
+    if df:
+        try:
+            data["disk_usage_percent"] = float(df)
+        except ValueError:
+            pass
+    mem = _run("free -m | awk '/^Mem:/{print $7}'")
+    if mem:
+        try:
+            data["mem_available_mb"] = int(mem)
+        except ValueError:
+            pass
+    return data
+
+
+def main() -> int:
+    print(json.dumps(collect(), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/ansible/scripts/acme_remote_host_probe.sh
+++ b/infra/ansible/scripts/acme_remote_host_probe.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Read-only remote host/container probe for Acme edge (via SSH).
+#
+#   ./infra/ansible/scripts/acme_remote_host_probe.sh --limit acme_vm_bbartling --json-out /tmp/host.json
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ANSIBLE_DIR="$(cd "$DIR/.." && pwd)"
+SECRETS="${ANSIBLE_DIR}/secrets/acme.env.local"
+PROBE_PY="${DIR}/acme_remote_host_probe.py"
+
+LIMIT=""
+JSON_OUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --limit) LIMIT="$2"; shift 2 ;;
+    --json-out) JSON_OUT="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,5p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "$LIMIT" ]] || { echo "Need --limit" >&2; exit 1; }
+
+if [[ -f "$SECRETS" ]]; then
+  set +u
+  # shellcheck disable=SC1090
+  set -a && source "$SECRETS" && set +a
+  set -u
+fi
+
+SSH_USER="${ACME_SSH_USER:-ben}"
+SSH_HOST="${ACME_SSH_HOST:-}"
+if [[ -z "$SSH_HOST" ]]; then
+  echo '{"error":"ACME_SSH_HOST not configured"}' >"${JSON_OUT:-/dev/stdout}"
+  exit 1
+fi
+
+SSH_OPTS=(-o ConnectTimeout=12 -o BatchMode=yes)
+if [[ -n "${SSHPASS:-}" ]] && command -v sshpass >/dev/null 2>&1; then
+  RAW="$(SSHPASS="$SSHPASS" sshpass -e ssh "${SSH_OPTS[@]}" "${SSH_USER}@${SSH_HOST}" python3 - <"$PROBE_PY")"
+else
+  RAW="$(ssh "${SSH_OPTS[@]}" "${SSH_USER}@${SSH_HOST}" python3 - <"$PROBE_PY")"
+fi
+
+if [[ -n "$JSON_OUT" ]]; then
+  printf '%s\n' "$RAW" >"$JSON_OUT"
+else
+  printf '%s\n' "$RAW"
+fi

--- a/infra/ansible/scripts/post_deploy_check.sh
+++ b/infra/ansible/scripts/post_deploy_check.sh
@@ -143,7 +143,9 @@ BASE="${scheme}://${HOST}"
 
 if [[ -f "$AUTH_ENV" ]]; then
   # shellcheck disable=SC1090
+  set +u
   set -a && source "$AUTH_ENV" && set +a
+  set -u
 fi
 LOGIN_USER="${OFDD_INTEGRATOR_USER:-${OFDD_OPERATOR_USER:-}}"
 LOGIN_PASS="${OFDD_INTEGRATOR_PASSWORD:-${OFDD_OPERATOR_PASSWORD:-}}"

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,6 +9,6 @@ GHCR Docker images (``openfdd-bridge``, ``openfdd-commission``, ``openfdd-mcp-ra
 not inside this wheel.
 """
 
-__version__ = "3.0.31"
+__version__ = "3.0.32"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.31"
+version = "3.0.32"
 description = "Arrow-native HVAC fault detection runtime — lint, test, and run apply_faults_arrow rules on columnar telemetry (PyPI). Use GHCR Docker images for the full edge operator stack."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,8 @@
 | **`openfdd_edge_validate.sh`** | Bensserver / edge gate: backup → BACnet+model reset → bench setup → stack → **public check-engine (no auth)** → SPARQL/http probes → operational verify → pytest → health → log scan. `--quick` (no resets), `--full` / `--long` (full bench), `--pre-update-backup`, `--rebuild`. |
 | **`docker_maintenance.sh`** | Safe prune/rebuild; never prunes bind-mounted workspace volumes. |
 | **`upgrade_edge_full.sh`** | Build UI + `deploy.sh ui` + GHCR image upgrade + post-deploy check (fixes stale `static/app` on edge). |
+| **`acme_post_deploy_validate.sh`** | **Live Acme** read-only validation after GHCR updates — image tag, UI bundle, duplicates, BACnet, trends, FDD, Rule Lab, logs. `--quick` \| `--full`. |
+| **`acme_live_validate.py`** | Python API probe engine used by `acme_post_deploy_validate.sh`; JSON/JUnit/Markdown reports. |
 | **`daily_release.sh`** | Daily easy button: merge PR → tag `open-fdd-v*` (PyPI) → GHCR publish → prune branches → `--prep-next 3.0.1` for next cycle. |
 | **`validate_fdd_backends.sh`** | Verify all enabled rules use `apply_faults_arrow` (`--docker` uses bridge container). |
 | **`edge_site_backup.sh`** / **`edge_site_apply.sh`** | Site data backup/restore for remote updates (preserves model, BACnet bind, trends). |

--- a/scripts/acme_live_validate.py
+++ b/scripts/acme_live_validate.py
@@ -1,0 +1,808 @@
+#!/usr/bin/env python3
+"""Deep live API validation for Acme Open-FDD edge (read-only by default)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from collections import Counter
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Callable
+
+REPO = Path(__file__).resolve().parents[1]
+ANSIBLE_SCRIPTS = REPO / "infra" / "ansible" / "scripts"
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "workspace" / "api"))
+sys.path.insert(0, str(ANSIBLE_SCRIPTS))
+
+from scripts.acme_validation_report import (  # noqa: E402
+    ValidationCheck,
+    ValidationReport,
+    print_console_summary,
+    write_json_report,
+    write_junit_report,
+    write_markdown_report,
+)
+
+DEFAULT_PROFILE = {
+    "site_id": "acme",
+    "building_id": "vm-bbartling",
+    "min_equipment_count": 10,
+    "min_point_count": 50,
+    "min_enabled_bacnet_points": 50,
+    "max_recent_data_age_minutes": 30,
+    "max_api_latency_ms": 3000,
+    "max_container_restarts": 2,
+    "max_disk_usage_percent": 85,
+    "required_free_disk_gb": 5,
+    "required_services": ["bridge", "commission"],
+    "optional_services": ["mcp-rag", "cloud-exporter"],
+    "required_rule_id_patterns": ["ahu", "vav"],
+    "max_duplicate_bacnet_devices": 0,
+    "max_duplicate_point_ids": 0,
+}
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:]
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        out[k.strip()] = v.strip().strip("'\"").strip()
+    return out
+
+
+def resolve_credentials(auth_env: Path, acme_secrets: Path | None) -> tuple[str, str]:
+    auth = load_env_file(auth_env)
+    acme = load_env_file(acme_secrets) if acme_secrets and acme_secrets.is_file() else {}
+    user = acme.get("ACME_INTEGRATOR_USER") or auth.get("OFDD_INTEGRATOR_USER") or auth.get("OFDD_OPERATOR_USER") or ""
+    password = (
+        acme.get("ACME_INTEGRATOR_PASSWORD")
+        or auth.get("OFDD_INTEGRATOR_PASSWORD")
+        or auth.get("OFDD_OPERATOR_PASSWORD")
+        or ""
+    )
+    return user, password
+
+
+class ApiClient:
+    def __init__(self, base: str, token: str | None = None, timeout: float = 30.0) -> None:
+        self.base = base.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+
+    def _headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        h = {"Content-Type": "application/json"}
+        if self.token:
+            h["Authorization"] = f"Bearer {self.token}"
+        if extra:
+            h.update(extra)
+        return h
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        *,
+        auth: bool = True,
+    ) -> tuple[int, str, float]:
+        url = f"{self.base}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        headers = self._headers() if auth and self.token else {"Content-Type": "application/json"}
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        t0 = time.perf_counter()
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                text = resp.read().decode("utf-8", errors="replace")
+                return resp.status, text, (time.perf_counter() - t0) * 1000
+        except urllib.error.HTTPError as exc:
+            text = exc.read().decode("utf-8", errors="replace")
+            return exc.code, text, (time.perf_counter() - t0) * 1000
+        except urllib.error.URLError as exc:
+            raise RuntimeError(str(exc.reason)) from exc
+
+    def get_json(self, path: str, *, auth: bool = True) -> tuple[int, Any, float]:
+        status, text, ms = self.request("GET", path, auth=auth)
+        try:
+            return status, json.loads(text) if text.strip() else {}, ms
+        except json.JSONDecodeError:
+            return status, {"_raw": text[:500]}, ms
+
+    def post_json(self, path: str, body: dict[str, Any], *, auth: bool = True) -> tuple[int, Any, float]:
+        status, text, ms = self.request("POST", path, body, auth=auth)
+        try:
+            return status, json.loads(text) if text.strip() else {}, ms
+        except json.JSONDecodeError:
+            return status, {"_raw": text[:500]}, ms
+
+
+def scan_logs_for_fatal(text: str) -> list[str]:
+    fatal_patterns = (
+        "Traceback",
+        "Unhandled exception",
+        "ModuleNotFoundError",
+        "ImportError",
+        "SyntaxError",
+        "database is locked",
+        "Address already in use",
+    )
+    hits: list[str] = []
+    for pat in fatal_patterns:
+        if pat in text:
+            hits.append(pat)
+    return hits
+
+
+class AcmeLiveValidator:
+    def __init__(
+        self,
+        *,
+        base: str,
+        site_id: str,
+        building_id: str,
+        profile: dict[str, Any],
+        expected_image_tag: str = "",
+        auth_env: Path,
+        acme_secrets: Path | None = None,
+        mode: str = "quick",
+        skip_ui: bool = False,
+        skip_bacnet: bool = False,
+        skip_fdd: bool = False,
+        skip_rulelab: bool = False,
+        skip_logs: bool = False,
+        fail_fast: bool = False,
+        local_ui_index: Path | None = None,
+        remote_host_json: dict[str, Any] | None = None,
+    ) -> None:
+        self.base = base.rstrip("/")
+        self.site_id = site_id
+        self.building_id = building_id
+        self.profile = {**DEFAULT_PROFILE, **profile}
+        self.expected_image_tag = expected_image_tag.strip()
+        self.auth_env = auth_env
+        self.acme_secrets = acme_secrets
+        self.mode = mode
+        self.skip_ui = skip_ui
+        self.skip_bacnet = skip_bacnet
+        self.skip_fdd = skip_fdd
+        self.skip_rulelab = skip_rulelab
+        self.skip_logs = skip_logs
+        self.fail_fast = fail_fast
+        self.local_ui_index = local_ui_index or (REPO / "workspace/api/static/app/index.html")
+        self.remote_host_json = remote_host_json or {}
+        self.token: str | None = None
+        self.client = ApiClient(self.base)
+        self.report = ValidationReport(
+            target={
+                "base_url": "redacted",
+                "site_id": site_id,
+                "building_id": building_id,
+                "expected_image_tag": expected_image_tag,
+                "mode": mode,
+            },
+            started_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    def _run_check(self, check_id: str, category: str, fn: Callable[[], tuple[str, str, dict[str, Any]]]) -> None:
+        t0 = time.perf_counter()
+        try:
+            status, message, details = fn()
+        except Exception as exc:  # noqa: BLE001
+            status, message, details = "fail", str(exc), {}
+        ms = int((time.perf_counter() - t0) * 1000)
+        self.report.add(
+            ValidationCheck(
+                id=check_id,
+                category=category,
+                status=status,  # type: ignore[arg-type]
+                duration_ms=ms,
+                message=message,
+                details=details,
+            )
+        )
+        if self.fail_fast and status == "fail":
+            raise SystemExit(1)
+
+    def login(self) -> None:
+        user, password = resolve_credentials(self.auth_env, self.acme_secrets)
+        if not user or not password:
+            self.report.add(
+                ValidationCheck(
+                    id="auth_credentials",
+                    category="auth",
+                    status="fail",
+                    message="No integrator credentials in auth env or acme secrets",
+                )
+            )
+            return
+        status, body, ms = self.client.request(
+            "POST",
+            "/api/auth/login",
+            {"username": user, "password": password},
+            auth=False,
+        )
+        if status != 200:
+            self.report.add(
+                ValidationCheck(
+                    id="auth_login",
+                    category="auth",
+                    status="fail",
+                    duration_ms=int(ms),
+                    message=f"Login failed HTTP {status}",
+                    details={"body_preview": body[:200]},
+                )
+            )
+            return
+        self.token = json.loads(body)["token"]
+        self.client = ApiClient(self.base, self.token)
+        self.report.add(
+            ValidationCheck(
+                id="auth_login",
+                category="auth",
+                status="pass",
+                duration_ms=int(ms),
+                message="Authenticated as integrator",
+            )
+        )
+
+    def validate_all(self) -> ValidationReport:
+        self.login()
+        if not self.token:
+            self.report.finalize()
+            return self.report
+
+        self._run_check("bridge_health", "api", self._check_bridge_health)
+        self._run_check("auth_required_routes", "auth", self._check_auth_required)
+        if not self.skip_ui:
+            self._run_check("ui_bundle_freshness", "ui", self._check_ui_bundle)
+        self._run_check("docker_image_tag", "docker", self._check_docker_image_tag)
+        if self.remote_host_json:
+            self._run_check("remote_host_containers", "docker", self._check_remote_host)
+        self._run_check("model_health", "model", self._check_model_health)
+        self._run_check("no_duplicate_devices", "model", self._check_no_duplicate_devices)
+        self._run_check("commissioning_export", "model", self._check_commissioning_export)
+        if self.mode in {"full", "long"}:
+            self._run_check("sparql_presets", "model", self._check_sparql)
+        if not self.skip_bacnet:
+            self._run_check("bacnet_poll", "bacnet", self._check_bacnet_poll)
+        self._run_check("historian_trends", "historian", self._check_trends)
+        if not self.skip_fdd:
+            self._run_check("fdd_rules_batch", "fdd", self._check_fdd)
+            self._run_check("building_status_context", "building", self._check_building_status)
+        if not self.skip_rulelab and self.mode in {"full", "long"}:
+            self._run_check("rule_lab_export", "rulelab", self._check_rule_lab)
+        self._run_check("host_resources", "host", self._check_host_resources)
+        self._run_check("security_redaction", "security", self._check_security)
+        if not self.skip_logs:
+            self._run_check("logs_scan", "logs", self._check_logs)
+        if self.mode in {"full", "long"}:
+            self._run_check("bundle_validator", "local", self._check_local_bundle)
+            self._run_check("pypi_rules_smoke", "local", self._check_pypi_rules)
+
+        self.report.finalize()
+        return self.report
+
+    def _check_bridge_health(self) -> tuple[str, str, dict[str, Any]]:
+        status, body, ms = self.client.request("GET", "/health", auth=False)
+        if status != 200:
+            return "fail", f"/health HTTP {status}", {"latency_ms": ms}
+        data = json.loads(body)
+        latency_limit = float(self.profile.get("max_api_latency_ms", 3000))
+        if ms > latency_limit:
+            return "warn", f"Health latency {ms:.0f}ms > {latency_limit:.0f}ms", data
+        ver = data.get("openfdd_version") or data.get("version")
+        return "pass", f"Bridge health OK (version={ver})", {**data, "latency_ms": ms}
+
+    def _check_auth_required(self) -> tuple[str, str, dict[str, Any]]:
+        status, _, _ = self.client.get_json("/api/model/health", auth=False)
+        if status == 401:
+            return "pass", "Model health requires auth", {}
+        return "fail", f"Expected 401 without token, got {status}", {}
+
+    def _check_ui_bundle(self) -> tuple[str, str, dict[str, Any]]:
+        status, html, _ = self.client.request("GET", "/", auth=False)
+        if status != 200:
+            return "fail", f"Dashboard HTML HTTP {status}", {}
+        m = re.search(r'src="([^"]*index-[^"]+\.js)"', html)
+        if not m:
+            return "fail", "No index-*.js bundle in dashboard HTML", {}
+        remote_asset = m.group(1)
+        if not remote_asset.startswith("/"):
+            remote_asset = "/" + remote_asset.lstrip("/")
+        a_status, _, _ = self.client.request("GET", remote_asset, auth=False)
+        if a_status != 200:
+            return "fail", f"JS bundle {remote_asset} HTTP {a_status}", {}
+        local_asset = ""
+        if self.local_ui_index.is_file():
+            local_html = self.local_ui_index.read_text(encoding="utf-8")
+            lm = re.search(r'src="([^"]*index-[^"]+\.js)"', local_html)
+            if lm:
+                local_asset = lm.group(1).split("/")[-1]
+        remote_name = remote_asset.split("/")[-1]
+        details = {"remote_bundle": remote_name, "local_bundle": local_asset or None}
+        if local_asset and local_asset != remote_name:
+            return (
+                "fail",
+                f"Stale UI bundle on edge: remote={remote_name} local={local_asset} — run upgrade_edge_full.sh",
+                details,
+            )
+        return "pass", f"UI bundle {remote_name} reachable", details
+
+    def _check_docker_image_tag(self) -> tuple[str, str, dict[str, Any]]:
+        from http_probes import check_stack_revision  # type: ignore[import-untyped]
+
+        rev = check_stack_revision(self.base, self.token or "", expected_image_tag=self.expected_image_tag)
+        tag = str(rev.get("image_tag") or "")
+        details = {"image_tag": tag, "git_sha": rev.get("git_sha")}
+        expected = self.expected_image_tag
+        if expected and expected != "latest":
+            norm_expected = expected.removeprefix("v").strip()
+            norm_tag = tag.removeprefix("v").strip()
+            if tag and norm_tag and norm_tag != norm_expected:
+                return "fail", f"Running tag {tag!r} != expected {expected!r}", details
+        if rev.get("errors"):
+            return "fail", "; ".join(rev["errors"]), details
+        if rev.get("warnings"):
+            return "warn", "; ".join(rev["warnings"]), details
+        return "pass", f"Bridge image tag {tag or 'unknown'}", details
+
+    def _check_remote_host(self) -> tuple[str, str, dict[str, Any]]:
+        data = self.remote_host_json
+        services = data.get("compose_services") or data.get("services") or []
+        required = set(self.profile.get("required_services") or [])
+        running = {str(s.get("service") or s.get("name") or "") for s in services if isinstance(s, dict)}
+        missing = [s for s in required if s not in running and not any(s in r for r in running)]
+        restarts = int(data.get("max_restart_count") or 0)
+        max_restarts = int(self.profile.get("max_container_restarts", 2))
+        if missing:
+            return "fail", f"Missing services: {missing}", data
+        if restarts > max_restarts:
+            return "fail", f"Container restarts {restarts} > {max_restarts}", data
+        disk_pct = data.get("disk_usage_percent")
+        if disk_pct is not None and float(disk_pct) > float(self.profile.get("max_disk_usage_percent", 85)):
+            return "warn", f"Disk usage {disk_pct}% high", data
+        return "pass", f"Remote host OK ({len(services)} services)", data
+
+    def _check_model_health(self) -> tuple[str, str, dict[str, Any]]:
+        status, data, ms = self.client.get_json("/api/model/health")
+        if status != 200:
+            return "fail", f"/api/model/health HTTP {status}", {}
+        counts = data.get("counts") or {}
+        eq = int(counts.get("equipment") or 0)
+        pts = int(counts.get("points") or 0)
+        min_eq = int(self.profile.get("min_equipment_count", 10))
+        min_pts = int(self.profile.get("min_point_count", 50))
+        details = {"counts": counts, "score": data.get("score"), "latency_ms": ms}
+        if eq < min_eq or pts < min_pts:
+            return "fail", f"Model counts low: equipment={eq} points={pts}", details
+        dup = int(counts.get("duplicate_bacnet_device_instances") or 0)
+        dup_pts = int(counts.get("duplicate_point_ids") or 0)
+        if dup > int(self.profile.get("max_duplicate_bacnet_devices", 0)):
+            return "fail", f"{dup} duplicate BACnet device instance(s) in model", details
+        if dup_pts > int(self.profile.get("max_duplicate_point_ids", 0)):
+            return "fail", f"{dup_pts} duplicate point id(s) in model", details
+        if data.get("status") == "error":
+            return "fail", f"Model health status=error score={data.get('score')}", details
+        return "pass", f"Model health OK (equipment={eq}, points={pts}, score={data.get('score')})", details
+
+    def _check_no_duplicate_devices(self) -> tuple[str, str, dict[str, Any]]:
+        """Explicit duplicate BACnet device + point ID gate (model + poll inventory)."""
+        status, bundle, _ = self.client.get_json("/api/model/commissioning-export")
+        details: dict[str, Any] = {}
+        if status == 200:
+            equipment = bundle.get("equipment") or []
+            points = bundle.get("points") or []
+            dev_ids = [e.get("bacnet_device_id") for e in equipment if e.get("bacnet_device_id") is not None]
+            dup_dev = {k: v for k, v in Counter(dev_ids).items() if v > 1}
+            pid = Counter(str(p.get("id")) for p in points if p.get("id"))
+            dup_pid = {k: v for k, v in pid.items() if v > 1}
+            details["duplicate_bacnet_device_ids"] = dup_dev
+            details["duplicate_point_ids"] = dup_pid
+            max_dev = int(self.profile.get("max_duplicate_bacnet_devices", 0))
+            max_pid = int(self.profile.get("max_duplicate_point_ids", 0))
+            if dup_dev:
+                return "fail", f"Duplicate BACnet device IDs in model: {dup_dev}", details
+            if dup_pid:
+                return "fail", f"Duplicate point IDs in model: {list(dup_pid.keys())[:5]}", details
+        if not self.skip_bacnet:
+            st, inv, _ = self.client.get_json("/api/bacnet/inventory")
+            if st == 200:
+                devices = inv.get("devices") or []
+                inst = [str(d.get("device_instance") or d.get("instance") or "") for d in devices]
+                inst = [i for i in inst if i]
+                dup_inst = {k: v for k, v in Counter(inst).items() if v > 1}
+                details["poll_inventory_duplicate_instances"] = dup_inst
+                if dup_inst:
+                    return "fail", f"Duplicate BACnet instances in poll inventory: {dup_inst}", details
+                details["poll_device_count"] = len(devices)
+        if details:
+            return "pass", "No duplicate BACnet devices or point IDs", details
+        return "warn", "Could not verify duplicates (export/inventory unavailable)", details
+
+    def _check_commissioning_export(self) -> tuple[str, str, dict[str, Any]]:
+        status, bundle, _ = self.client.get_json("/api/model/commissioning-export")
+        if status != 200:
+            return "fail", f"commissioning-export HTTP {status}", {}
+        sites = bundle.get("sites") or []
+        eq = bundle.get("equipment") or []
+        pts = bundle.get("points") or []
+        site_ids = {s.get("id") for s in sites}
+        if self.site_id not in site_ids:
+            return "fail", f"Site {self.site_id!r} missing from export", {"sites": list(site_ids)}
+        rule_ids = {r.get("id") for r in (bundle.get("fdd_rules") or []) if r.get("id")}
+        bad_refs = 0
+        for p in pts:
+            for rid in p.get("fdd_rule_ids") or []:
+                if rid not in rule_ids:
+                    bad_refs += 1
+        details = {
+            "equipment_count": len(eq),
+            "point_count": len(pts),
+            "fdd_rules_count": len(rule_ids),
+            "invalid_rule_refs": bad_refs,
+        }
+        if bad_refs:
+            return "fail", f"{bad_refs} point(s) reference missing fdd_rule_ids", details
+        return "pass", f"Commissioning export OK ({len(eq)} equipment, {len(pts)} points)", details
+
+    def _check_sparql(self) -> tuple[str, str, dict[str, Any]]:
+        status, presets, _ = self.client.get_json("/api/model/fdd-query-presets")
+        if status != 200:
+            return "warn", f"fdd-query-presets HTTP {status}", {}
+        preset_list = presets if isinstance(presets, list) else presets.get("presets") or []
+        if not preset_list:
+            return "warn", "No FDD SPARQL presets returned", {}
+        pid = str(preset_list[0].get("id") or preset_list[0].get("preset_id") or "")
+        if not pid:
+            return "warn", "Could not run SPARQL preset probe", {}
+        st, result, _ = self.client.get_json(f"/api/model/fdd-query-presets/{urllib.parse.quote(pid)}")
+        if st != 200:
+            return "fail", f"SPARQL preset {pid} HTTP {st}", {}
+        rows = len(result.get("rows") or result.get("results") or [])
+        return "pass", f"SPARQL preset {pid} returned {rows} row(s)", {"preset_id": pid, "rows": rows}
+
+    def _check_bacnet_poll(self) -> tuple[str, str, dict[str, Any]]:
+        from http_probes import check_bacnet_driver  # type: ignore[import-untyped]
+
+        min_dev = 1
+        min_pts = int(self.profile.get("min_enabled_bacnet_points", 50))
+        out = check_bacnet_driver(self.base, self.token or "", min_devices=min_dev, min_enabled_points=min_pts)
+        if out.get("errors"):
+            return "fail", "; ".join(out["errors"]), out
+        if out.get("warnings"):
+            return "warn", "; ".join(out["warnings"]), out
+        return "pass", "BACnet poll pipeline healthy", out
+
+    def _check_trends(self) -> tuple[str, str, dict[str, Any]]:
+        from http_probes import check_integrator_ui_api  # type: ignore[import-untyped]
+
+        ui = check_integrator_ui_api(self.base, self.token or "", site_id=self.site_id)
+        if ui.get("errors"):
+            return "fail", "; ".join(ui["errors"]), ui
+        if ui.get("warnings"):
+            return "warn", "; ".join(ui["warnings"]), ui
+        return "pass", "Historian/trend API OK", ui
+
+    def _check_fdd(self) -> tuple[str, str, dict[str, Any]]:
+        from http_probes import check_fdd_operational  # type: ignore[import-untyped]
+
+        min_rules = 5
+        out = check_fdd_operational(
+            self.base,
+            self.token or "",
+            site_id=self.site_id,
+            min_saved_rules=min_rules,
+        )
+        patterns = [p.lower() for p in (self.profile.get("required_rule_id_patterns") or [])]
+        status, saved, _ = self.client.get_json("/api/rules/saved")
+        if status == 200:
+            rules = saved.get("rules") or []
+            enabled_ids = [str(r.get("id") or "") for r in rules if r.get("enabled") is not False]
+            for pat in patterns:
+                if not any(pat in rid.lower() for rid in enabled_ids):
+                    out.setdefault("warnings", []).append(f"No enabled rule matching pattern {pat!r}")
+        st, results, _ = self.client.get_json("/api/fdd/results?limit=20")
+        if st == 200:
+            runs = results.get("runs") or results if isinstance(results, list) else []
+            if isinstance(results, dict):
+                runs = results.get("runs") or []
+            out["fdd_result_runs"] = len(runs)
+        if out.get("errors"):
+            return "fail", "; ".join(out["errors"]), out
+        if out.get("warnings"):
+            return "warn", "; ".join(out["warnings"]), out
+        return "pass", f"FDD rules operational ({out.get('rules_enabled_count', '?')} enabled)", out
+
+    def _check_building_status(self) -> tuple[str, str, dict[str, Any]]:
+        from http_probes import check_building_dashboard_health  # type: ignore[import-untyped]
+
+        dash = check_building_dashboard_health(self.base, self.token or "", site_id=self.site_id)
+        st, faults, _ = self.client.get_json("/api/faults/status")
+        missing_ctx = 0
+        fdd_without_equipment = 0
+        if st == 200:
+            for fam in faults.get("families") or []:
+                for alert in fam.get("faults") or []:
+                    if alert.get("source") != "fdd":
+                        continue
+                    ctx = alert.get("model_context") or {}
+                    if not (ctx.get("equipment") or alert.get("equipment_name")):
+                        fdd_without_equipment += 1
+                    if not (ctx.get("point") or ctx.get("historian_column") or alert.get("point_id")):
+                        missing_ctx += 1
+        dash["fdd_missing_equipment_context"] = fdd_without_equipment
+        dash["fdd_missing_point_context"] = missing_ctx
+        if fdd_without_equipment or missing_ctx:
+            return (
+                "fail",
+                f"Building Status: {fdd_without_equipment} FDD alert(s) missing equipment, "
+                f"{missing_ctx} missing point context",
+                dash,
+            )
+        if dash.get("errors"):
+            return "fail", "; ".join(dash["errors"]), dash
+        if dash.get("warnings"):
+            return "warn", "; ".join(dash["warnings"]), dash
+        return "pass", "Building Status fault context OK", dash
+
+    def _check_rule_lab(self) -> tuple[str, str, dict[str, Any]]:
+        st, _, _ = self.client.post_json(
+            "/api/playground/lint",
+            {"code": "def apply_faults_arrow(table, cfg, context):\n    return table", "mode": "rule"},
+        )
+        if st != 200:
+            return "fail", f"playground lint HTTP {st}", {}
+        st, saved, _ = self.client.get_json("/api/rules/saved")
+        rules = (saved.get("rules") or []) if st == 200 else []
+        enabled = [r for r in rules if isinstance(r, dict) and r.get("enabled") is not False]
+        if not enabled:
+            return "warn", "No enabled rules for Rule Lab export probe", {}
+        rid = str(enabled[0].get("id") or "")
+        details: dict[str, Any] = {"rule_id": rid}
+        st2, body, _ = self.client.request(
+            "GET",
+            f"/api/playground/rules/{urllib.parse.quote(rid)}/source-expanded",
+        )
+        if st2 == 200:
+            try:
+                expanded = json.loads(body)
+                if expanded.get("source") or expanded.get("expanded_source"):
+                    details["source_expanded"] = True
+            except json.JSONDecodeError:
+                pass
+        eq_id = f"{self.site_id}-{self.building_id}-rtu-01".replace("_", "-")
+        url = f"{self.base}/api/rules/export-equipment-kit?equipment_id={urllib.parse.quote(eq_id)}"
+        req = urllib.request.Request(url, headers=self.client._headers())
+        try:
+            with urllib.request.urlopen(req, timeout=self.client.timeout) as resp:
+                blob = resp.read()
+                if resp.status == 200 and blob[:2] == b"PK":
+                    with zipfile.ZipFile(BytesIO(blob)) as zf:
+                        details["zip_entries"] = zf.namelist()[:10]
+                    return "pass", "Equipment rule kit zip export OK", details
+        except urllib.error.HTTPError as exc:
+            details["export_http"] = exc.code
+        return "warn", "Rule Lab export probe incomplete (lint OK)", details
+
+    def _check_host_resources(self) -> tuple[str, str, dict[str, Any]]:
+        st, stats, _ = self.client.get_json("/api/host/stats")
+        if st != 200:
+            return "fail", f"/api/host/stats HTTP {st}", {}
+        disk = stats.get("disk") or {}
+        free_gb = float(disk.get("free_gb") or disk.get("free_gib") or 0)
+        used_pct = float(disk.get("used_percent") or disk.get("usage_percent") or 0)
+        req_free = float(self.profile.get("required_free_disk_gb", 5))
+        if free_gb and free_gb < req_free:
+            return "warn", f"Low workspace disk free {free_gb:.1f}GB", stats
+        if used_pct > float(self.profile.get("max_disk_usage_percent", 85)):
+            return "warn", f"Disk usage {used_pct}%", stats
+        st2, preview, _ = self.client.post_json(
+            "/api/host/pooge/preview",
+            {"dry_run": True, "confirmation": ""},
+        )
+        if st2 == 200 and preview.get("would_run"):
+            return "fail", "Pooge preview would run without confirmation (unsafe)", preview
+        return "pass", "Host resources OK", stats
+
+    def _check_security(self) -> tuple[str, str, dict[str, Any]]:
+        st, body, _ = self.client.request("GET", "/api/auth/login", auth=False)
+        if st not in (401, 405):
+            pass
+        st2, inv, _ = self.client.get_json("/api/bacnet/inventory")
+        text = json.dumps(inv) if isinstance(inv, dict) else ""
+        if "password" in text.lower() or "secret" in text.lower():
+            return "fail", "BACnet inventory may expose secrets", {}
+        invalid_st, _, _ = self.client.get_json("/api/model/health", auth=False)
+        if invalid_st != 401:
+            return "fail", f"Unauthenticated model health returned {invalid_st}", {}
+        return "pass", "Auth and redaction checks OK", {}
+
+    def _check_logs(self) -> tuple[str, str, dict[str, Any]]:
+        st, logs, _ = self.client.get_json("/api/ops/logs?tail=80&include_docker=true")
+        if st != 200:
+            return "warn", f"ops/logs HTTP {st} (skipped)", {}
+        text = json.dumps(logs) if isinstance(logs, dict) else str(logs)
+        hits = scan_logs_for_fatal(text)
+        if hits:
+            return "fail", f"Fatal log patterns: {hits}", {"patterns": hits}
+        return "pass", "No fatal log patterns in recent ops logs", {}
+
+    def _check_local_bundle(self) -> tuple[str, str, dict[str, Any]]:
+        script = REPO / "scripts/acme_validate_fdd_bundle.py"
+        if not script.is_file():
+            return "skip", "acme_validate_fdd_bundle.py missing", {}
+        out_path = REPO / "reports" / ".acme-bundle-check.json"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        proc = subprocess.run(
+            [sys.executable, str(script), "--json-out", str(out_path), "--site-id", self.site_id],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO),
+            timeout=120,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return "fail", "Local FDD bundle validation failed", {"stderr": proc.stderr[:400]}
+        return "pass", "Local Acme FDD bundle validation OK", {}
+
+    def _check_pypi_rules(self) -> tuple[str, str, dict[str, Any]]:
+        script = REPO / "scripts/validate_acme_rules_pypi.py"
+        if not script.is_file():
+            return "skip", "validate_acme_rules_pypi.py missing", {}
+        try:
+            import open_fdd.arrow_runtime  # noqa: F401
+        except ModuleNotFoundError:
+            proc = subprocess.run(
+                [sys.executable, "-m", "pip", "install", "-q", "-e", str(REPO)],
+                capture_output=True,
+                text=True,
+                timeout=180,
+                check=False,
+            )
+            if proc.returncode != 0:
+                return "warn", "PyPI rule smoke skipped (open-fdd package not installed)", {}
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO),
+            env={**os.environ, "PYTHONPATH": ""},
+            timeout=120,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return "warn", "PyPI-style rule smoke failed (non-blocking on live edge)", {
+                "stderr": proc.stderr[:400]
+            }
+        return "pass", "PyPI-style Acme rule smoke OK", {}
+
+
+def load_profile(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    p = Path(path)
+    if not p.is_file():
+        raise SystemExit(f"Profile not found: {path}")
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def resolve_base_from_ansible(limit: str) -> str:
+    secrets = REPO / "infra/ansible/secrets/acme.env.local"
+    if limit == "acme_vm_bbartling" and secrets.is_file():
+        env = load_env_file(secrets)
+        host = env.get("ACME_SSH_HOST") or env.get("ACME_DASHBOARD_URL", "").replace("http://", "").replace("https://", "").split("/")[0]
+        if host:
+            return f"http://{host}"
+    inv = REPO / "infra/ansible/inventory.yml"
+    if inv.is_file():
+        text = inv.read_text(encoding="utf-8")
+        m = re.search(rf"{re.escape(limit)}:\s*\n\s*ansible_host:\s*(\S+)", text)
+        if m:
+            return f"http://{m.group(1)}"
+    raise SystemExit(
+        f"Cannot resolve base URL for --limit {limit!r}. "
+        "Set --base or configure infra/ansible/secrets/acme.env.local (gitignored)."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="")
+    parser.add_argument("--limit", default="")
+    parser.add_argument("--site-id", default="acme")
+    parser.add_argument("--building-id", default="vm-bbartling")
+    parser.add_argument("--expected-image-tag", default=os.environ.get("OPENFDD_IMAGE_TAG", ""))
+    parser.add_argument("--auth-env", default=str(REPO / "workspace/auth.env.local"))
+    parser.add_argument("--acme-secrets", default=str(REPO / "infra/ansible/secrets/acme.env.local"))
+    parser.add_argument("--profile", default="")
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--full", action="store_true")
+    parser.add_argument("--long", action="store_true")
+    parser.add_argument("--json-out", default="")
+    parser.add_argument("--junit-out", default="")
+    parser.add_argument("--markdown-out", default="")
+    parser.add_argument("--remote-host-json", default="")
+    parser.add_argument("--skip-ui", action="store_true")
+    parser.add_argument("--skip-bacnet", action="store_true")
+    parser.add_argument("--skip-fdd", action="store_true")
+    parser.add_argument("--skip-rulelab", action="store_true")
+    parser.add_argument("--skip-logs", action="store_true")
+    parser.add_argument("--fail-fast", action="store_true")
+    parser.add_argument("--allow-write", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.allow_write:
+        print("error: --allow-write not used in read-only validation harness", file=sys.stderr)
+        return 2
+
+    mode = "quick"
+    if args.full:
+        mode = "full"
+    elif args.long:
+        mode = "long"
+
+    base = args.base.strip()
+    if not base:
+        if args.limit:
+            base = resolve_base_from_ansible(args.limit)
+        else:
+            parser.error("Provide --base or --limit")
+
+    profile = load_profile(args.profile or None)
+    remote_host: dict[str, Any] | None = None
+    if args.remote_host_json:
+        remote_host = json.loads(Path(args.remote_host_json).read_text(encoding="utf-8"))
+
+    t0 = time.perf_counter()
+    validator = AcmeLiveValidator(
+        base=base,
+        site_id=args.site_id,
+        building_id=args.building_id,
+        profile=profile,
+        expected_image_tag=args.expected_image_tag,
+        auth_env=Path(args.auth_env),
+        acme_secrets=Path(args.acme_secrets) if args.acme_secrets else None,
+        mode=mode,
+        skip_ui=args.skip_ui,
+        skip_bacnet=args.skip_bacnet,
+        skip_fdd=args.skip_fdd,
+        skip_rulelab=args.skip_rulelab,
+        skip_logs=args.skip_logs,
+        fail_fast=args.fail_fast,
+        remote_host_json=remote_host,
+    )
+    report = validator.validate_all()
+    report.duration_seconds = time.perf_counter() - t0
+    print_console_summary(report)
+    if args.json_out:
+        write_json_report(report, args.json_out)
+        print(f"\nReport: {args.json_out}")
+    if args.junit_out:
+        write_junit_report(report, args.junit_out)
+    if args.markdown_out:
+        write_markdown_report(report, args.markdown_out)
+    return 0 if report.summary.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/acme_post_deploy_validate.sh
+++ b/scripts/acme_post_deploy_validate.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Live Acme post-deploy validation after GHCR image updates (read-only by default).
+#
+#   OPENFDD_IMAGE_TAG=v3.0.32 ./scripts/acme_post_deploy_validate.sh --limit acme_vm_bbartling --full
+#   OPENFDD_IMAGE_TAG=latest ./scripts/acme_post_deploy_validate.sh --base http://100.x.x.x --quick
+#   ./scripts/acme_post_deploy_validate.sh --limit acme_vm_bbartling --full --json-out reports/acme-validate.json
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+LIMIT=""
+BASE=""
+SITE_ID="${ACME_SITE_ID:-acme}"
+BUILDING_ID="${ACME_BUILDING_ID:-vm-bbartling}"
+MODE="quick"
+JSON_OUT=""
+JUNIT_OUT=""
+MARKDOWN_OUT=""
+PROFILE=""
+REMOTE_JSON=""
+SKIP_UI=0
+SKIP_BACNET=0
+SKIP_FDD=0
+SKIP_RULELAB=0
+SKIP_LOGS=0
+NO_ANSIBLE=0
+FAIL_FAST=0
+ALLOW_WRITE=0
+TIMEOUT_SECONDS="${ACME_VALIDATE_TIMEOUT:-600}"
+EXTRA_PY=()
+
+usage() {
+  sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+
+Options:
+  --limit <ansible-host>     Acme inventory limit (preferred)
+  --base <url>               Direct bridge URL (skip inventory resolution)
+  --site-id <id>             Default: acme
+  --building-id <id>         Default: vm-bbartling
+  --quick | --full | --long  Validation depth (default: --quick)
+  --profile <json>           Threshold profile JSON
+  --json-out <path>          Machine-readable report
+  --junit-out <path>         JUnit XML report
+  --markdown-out <path>      Markdown summary
+  --skip-ui | --skip-bacnet | --skip-fdd | --skip-rulelab | --skip-logs
+  --no-ansible               Skip remote host/container probes
+  --fail-fast                Stop Python validator on first failure
+  --timeout-seconds <n>      Remote probe timeout (default 600)
+  --allow-write              Not supported (validation is read-only)
+
+Reuses: stack_health_check.sh, acme_validate_fdd_bundle.py, validate_acme_rules_pypi.py,
+        infra/ansible/scripts/http_probes.py, acme_operational_verify.sh (optional).
+EOF
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --limit) LIMIT="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    --site-id) SITE_ID="$2"; shift 2 ;;
+    --building-id) BUILDING_ID="$2"; shift 2 ;;
+    --quick) MODE="quick"; shift ;;
+    --full) MODE="full"; shift ;;
+    --long) MODE="long"; shift ;;
+    --profile) PROFILE="$2"; shift 2 ;;
+    --json-out) JSON_OUT="$2"; shift 2 ;;
+    --junit-out) JUNIT_OUT="$2"; shift 2 ;;
+    --markdown-out) MARKDOWN_OUT="$2"; shift 2 ;;
+    --skip-ui) SKIP_UI=1; shift ;;
+    --skip-bacnet) SKIP_BACNET=1; shift ;;
+    --skip-fdd) SKIP_FDD=1; shift ;;
+    --skip-rulelab) SKIP_RULELAB=1; shift ;;
+    --skip-logs) SKIP_LOGS=1; shift ;;
+    --no-ansible) NO_ANSIBLE=1; shift ;;
+    --fail-fast) FAIL_FAST=1; shift ;;
+    --timeout-seconds) TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --allow-write) ALLOW_WRITE=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown: $1" >&2; usage 1 ;;
+  esac
+done
+
+if [[ "$ALLOW_WRITE" == "1" ]]; then
+  echo "error: --allow-write is not supported for live Acme validation" >&2
+  exit 2
+fi
+
+if [[ -z "$BASE" && -z "$LIMIT" ]]; then
+  echo "error: provide --base <url> or --limit <inventory_host>" >&2
+  usage 1
+fi
+
+TAG="${OPENFDD_IMAGE_TAG:-}"
+if [[ -z "$TAG" ]]; then
+  echo "warn: OPENFDD_IMAGE_TAG not set — Docker image tag checks are best-effort" >&2
+fi
+
+REMOTE_JSON="$(mktemp)"
+trap 'rm -f "$REMOTE_JSON"' EXIT
+
+if [[ "$NO_ANSIBLE" == "0" && -n "$LIMIT" ]]; then
+  echo "==> Remote host probe (--limit ${LIMIT})"
+  if ! timeout "${TIMEOUT_SECONDS}" "${ROOT}/infra/ansible/scripts/acme_remote_host_probe.sh" \
+    --limit "$LIMIT" --json-out "$REMOTE_JSON"; then
+    echo "warn: remote host probe failed (continuing with API-only checks)" >&2
+    echo '{}' >"$REMOTE_JSON"
+  fi
+else
+  echo '{}' >"$REMOTE_JSON"
+fi
+
+PY_ARGS=(
+  python3 "${ROOT}/scripts/acme_live_validate.py"
+  --site-id "$SITE_ID"
+  --building-id "$BUILDING_ID"
+  --expected-image-tag "$TAG"
+  --auth-env "${ROOT}/workspace/auth.env.local"
+  --acme-secrets "${ROOT}/infra/ansible/secrets/acme.env.local"
+  --remote-host-json "$REMOTE_JSON"
+  "--${MODE}"
+)
+[[ -n "$BASE" ]] && PY_ARGS+=(--base "$BASE")
+[[ -z "$BASE" && -n "$LIMIT" ]] && PY_ARGS+=(--limit "$LIMIT")
+[[ -n "$PROFILE" ]] && PY_ARGS+=(--profile "$PROFILE")
+[[ -n "$JSON_OUT" ]] && PY_ARGS+=(--json-out "$JSON_OUT")
+[[ -n "$JUNIT_OUT" ]] && PY_ARGS+=(--junit-out "$JUNIT_OUT")
+[[ -n "$MARKDOWN_OUT" ]] && PY_ARGS+=(--markdown-out "$MARKDOWN_OUT")
+[[ "$SKIP_UI" == "1" ]] && PY_ARGS+=(--skip-ui)
+[[ "$SKIP_BACNET" == "1" ]] && PY_ARGS+=(--skip-bacnet)
+[[ "$SKIP_FDD" == "1" ]] && PY_ARGS+=(--skip-fdd)
+[[ "$SKIP_RULELAB" == "1" ]] && PY_ARGS+=(--skip-rulelab)
+[[ "$SKIP_LOGS" == "1" ]] && PY_ARGS+=(--skip-logs)
+[[ "$FAIL_FAST" == "1" ]] && PY_ARGS+=(--fail-fast)
+
+echo "==> Acme live API validation (${MODE})"
+FAIL=0
+if ! "${PY_ARGS[@]}"; then
+  FAIL=1
+fi
+
+if [[ "$MODE" != "quick" && "$FAIL" == "0" && -f "${ROOT}/scripts/stack_health_check.sh" ]]; then
+  echo "==> stack_health_check.sh (supplemental)"
+  RESOLVED_BASE="$BASE"
+  if [[ -z "$RESOLVED_BASE" && -n "$LIMIT" ]]; then
+    RESOLVED_BASE="$(python3 -c "
+from pathlib import Path
+import re, sys
+sys.path.insert(0, '${ROOT}')
+from scripts.acme_live_validate import resolve_base_from_ansible
+print(resolve_base_from_ansible('${LIMIT}'))
+" 2>/dev/null || true)"
+  fi
+  if [[ -n "$RESOLVED_BASE" ]]; then
+    OPENFDD_BASE_URL="$RESOLVED_BASE" OPENFDD_HEALTH_MIN_MODEL_EQUIPMENT="${ACME_MIN_EQUIPMENT:-10}" \
+      OPENFDD_HEALTH_MIN_MODEL_POINTS="${ACME_MIN_POINTS:-50}" \
+      ./scripts/stack_health_check.sh --base "$RESOLVED_BASE" || FAIL=1
+  fi
+fi
+
+if [[ "$FAIL" == "1" ]]; then
+  echo ""
+  echo "ACME POST-DEPLOY VALIDATION — FAIL"
+  echo "See report above. For UI bundle staleness, run: OPENFDD_IMAGE_TAG=${TAG:-latest} ./scripts/upgrade_edge_full.sh --limit ${LIMIT:-<host>}"
+  exit 1
+fi
+
+echo ""
+echo "ACME POST-DEPLOY VALIDATION — PASS"
+exit 0

--- a/scripts/acme_validate_fdd_bundle.py
+++ b/scripts/acme_validate_fdd_bundle.py
@@ -90,14 +90,21 @@ def main() -> int:
     parser.add_argument("--building-id", default="vm-bbartling")
     parser.add_argument("--model", default=str(REPO / "edge_config/acme/vm-bbartling/model.json"))
     parser.add_argument("--profiles", default=str(REPO / "edge_config/acme/vm-bbartling/device_poll_profiles.csv"))
+    parser.add_argument("--json-out", default="", help="Write report JSON to path (- for stdout only)")
     args = parser.parse_args()
 
     report = {
+        "site_id": args.site_id,
+        "building_id": args.building_id,
         "model": audit_model(Path(args.model)),
         "poll_profiles": audit_poll_profiles(Path(args.profiles)),
         "rules": lint_bundle(args.site_id, args.building_id),
     }
-    print(json.dumps(report, indent=2))
+    text = json.dumps(report, indent=2)
+    if args.json_out and args.json_out != "-":
+        Path(args.json_out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
     ok = report["model"]["ok"] and report["poll_profiles"]["ok"] and report["rules"]["lint_ok"]
     return 0 if ok else 1
 

--- a/scripts/acme_validation_profile.example.json
+++ b/scripts/acme_validation_profile.example.json
@@ -1,0 +1,25 @@
+{
+  "site_id": "acme",
+  "building_id": "vm-bbartling",
+  "min_equipment_count": 10,
+  "min_point_count": 50,
+  "min_enabled_bacnet_points": 50,
+  "max_recent_data_age_minutes": 30,
+  "max_api_latency_ms": 3000,
+  "max_container_restarts": 2,
+  "max_disk_usage_percent": 85,
+  "required_free_disk_gb": 5,
+  "max_duplicate_bacnet_devices": 0,
+  "max_duplicate_point_ids": 0,
+  "required_services": ["bridge", "commission"],
+  "optional_services": ["mcp-rag", "cloud-exporter"],
+  "required_rule_id_patterns": ["ahu", "vav"],
+  "required_pages": [
+    "/",
+    "/building-status",
+    "/rule-lab",
+    "/data-model",
+    "/trends",
+    "/bacnet"
+  ]
+}

--- a/scripts/acme_validation_report.py
+++ b/scripts/acme_validation_report.py
@@ -1,0 +1,180 @@
+"""Shared report schema helpers for Acme live validation."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+from xml.sax.saxutils import escape
+
+CheckStatus = Literal["pass", "fail", "warn", "skip"]
+
+
+@dataclass
+class ValidationCheck:
+    id: str
+    category: str
+    status: CheckStatus
+    duration_ms: int = 0
+    message: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ValidationReport:
+    target: dict[str, Any]
+    started_at: str
+    finished_at: str = ""
+    duration_seconds: float = 0.0
+    summary: dict[str, Any] = field(default_factory=dict)
+    checks: list[ValidationCheck] = field(default_factory=list)
+
+    def add(self, check: ValidationCheck) -> None:
+        self.checks.append(check)
+
+    def finalize(self) -> None:
+        self.finished_at = datetime.now(timezone.utc).isoformat()
+        passed = sum(1 for c in self.checks if c.status == "pass")
+        failed = sum(1 for c in self.checks if c.status == "fail")
+        warnings = sum(1 for c in self.checks if c.status == "warn")
+        skipped = sum(1 for c in self.checks if c.status == "skip")
+        self.summary = {
+            "ok": failed == 0,
+            "passed": passed,
+            "failed": failed,
+            "warnings": warnings,
+            "skipped": skipped,
+        }
+
+    def to_dict(self, *, redact: bool = True) -> dict[str, Any]:
+        data = {
+            "target": dict(self.target),
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "duration_seconds": self.duration_seconds,
+            "summary": dict(self.summary),
+            "checks": [asdict(c) for c in self.checks],
+        }
+        if redact:
+            data = redact_report(data)
+        return data
+
+
+_REDACT_PATTERNS = (
+    (re.compile(r"Bearer\s+[A-Za-z0-9._\-]+"), "Bearer [REDACTED]"),
+    (re.compile(r'"token"\s*:\s*"[^"]+"'), '"token": "[REDACTED]"'),
+    (re.compile(r"https?://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d+"), "http://[REDACTED-HOST]"),
+    (re.compile(r"100\.\d{1,3}\.\d{1,3}\.\d+"), "[REDACTED-TAILSCALE]"),
+)
+
+
+def redact_text(text: str) -> str:
+    out = text
+    for pattern, repl in _REDACT_PATTERNS:
+        out = pattern.sub(repl, out)
+    return out
+
+
+def redact_report(data: dict[str, Any]) -> dict[str, Any]:
+    """Redact tokens and private hostnames in report JSON."""
+
+    def _walk(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            out: dict[str, Any] = {}
+            for k, v in obj.items():
+                if k in {"token", "password", "secret", "authorization"}:
+                    out[k] = "[REDACTED]"
+                elif k == "base_url":
+                    out[k] = "redacted"
+                else:
+                    out[k] = _walk(v)
+            return out
+        if isinstance(obj, list):
+            return [_walk(x) for x in obj]
+        if isinstance(obj, str):
+            return redact_text(obj)
+        return obj
+
+    return _walk(data)
+
+
+def write_json_report(report: ValidationReport, path: str) -> None:
+    from pathlib import Path
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(report.to_dict(redact=True), indent=2), encoding="utf-8")
+
+
+def write_junit_report(report: ValidationReport, path: str) -> None:
+    from pathlib import Path
+
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<testsuite name="acme-live-validate" tests="{len(report.checks)}" '
+        f'failures="{report.summary.get("failed", 0)}" '
+        f'time="{report.duration_seconds:.3f}">',
+    ]
+    for check in report.checks:
+        cls = f"{check.category}.{check.id}"
+        lines.append(f'  <testcase classname="{escape(cls)}" name="{escape(check.id)}" time="{check.duration_ms / 1000.0:.3f}">')
+        if check.status == "fail":
+            lines.append(f"    <failure message=\"{escape(check.message)}\"/>")
+        elif check.status == "warn":
+            lines.append(f"    <skipped message=\"{escape(check.message)}\"/>")
+        lines.append("  </testcase>")
+    lines.append("</testsuite>")
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_markdown_report(report: ValidationReport, path: str) -> None:
+    from pathlib import Path
+
+    ok = report.summary.get("ok")
+    title = "PASS" if ok else "FAIL"
+    lines = [
+        f"# ACME LIVE VALIDATION — {title}",
+        "",
+        f"- **Site:** {report.target.get('site_id', '?')} / {report.target.get('building_id', '?')}",
+        f"- **Expected image tag:** {report.target.get('expected_image_tag') or '(not set)'}",
+        f"- **Duration:** {report.duration_seconds:.1f}s",
+        f"- **Passed:** {report.summary.get('passed', 0)} | "
+        f"**Failed:** {report.summary.get('failed', 0)} | "
+        f"**Warnings:** {report.summary.get('warnings', 0)}",
+        "",
+        "## Checks",
+        "",
+    ]
+    for check in report.checks:
+        icon = {"pass": "PASS", "fail": "FAIL", "warn": "WARN", "skip": "SKIP"}.get(check.status, "?")
+        lines.append(f"- **{icon}** `{check.category}/{check.id}` — {check.message}")
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def print_console_summary(report: ValidationReport) -> None:
+    ok = report.summary.get("ok")
+    title = "PASS" if ok else "FAIL"
+    print(f"\nACME LIVE VALIDATION — {title}\n")
+    tgt = report.target
+    print(f"Target: {tgt.get('site_id')} / {tgt.get('building_id')}")
+    if tgt.get("expected_image_tag"):
+        print(f"Image tag expected: {tgt.get('expected_image_tag')}")
+    print(f"Duration: {report.duration_seconds:.1f}s\n")
+    for check in report.checks:
+        if check.status == "fail":
+            print(f"FAIL {check.category}/{check.id}: {check.message}")
+        elif check.status == "warn":
+            print(f"WARN {check.category}/{check.id}: {check.message}")
+        else:
+            print(f"PASS {check.category}/{check.id}")
+    if not ok:
+        print("\nSuggested next steps:")
+        print("1. Re-run upgrade_edge_full.sh (UI static + GHCR), not image-only upgrade.")
+        print("2. Check workspace/api/static/app bind mount on edge.")
+        print("3. Run ./scripts/stack_health_check.sh against the edge base URL.")

--- a/tests/live/test_acme_live.py
+++ b/tests/live/test_acme_live.py
@@ -1,0 +1,44 @@
+"""Optional live Acme validation (skipped unless ACME_VALIDATE_LIVE=1)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.skipif(os.environ.get("ACME_VALIDATE_LIVE") != "1", reason="Set ACME_VALIDATE_LIVE=1")
+def test_live_acme_quick_validation():
+    base = os.environ.get("ACME_BASE_URL", "").strip()
+    if not base:
+        secrets = REPO / "infra/ansible/secrets/acme.env.local"
+        if secrets.is_file():
+            for line in secrets.read_text(encoding="utf-8").splitlines():
+                if "ACME_SSH_HOST=" in line:
+                    host = line.split("=", 1)[1].strip().strip("'\"")
+                    base = f"http://{host}"
+                    break
+    if not base:
+        pytest.skip("ACME_BASE_URL or acme.env.local required")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO / "scripts/acme_live_validate.py"),
+            "--base",
+            base,
+            "--quick",
+            "--site-id",
+            os.environ.get("ACME_SITE_ID", "acme"),
+        ],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr

--- a/tests/scripts/test_acme_live_validate.py
+++ b/tests/scripts/test_acme_live_validate.py
@@ -1,0 +1,140 @@
+"""Offline tests for Acme live validator logic (mocked HTTP)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.acme_live_validate import (
+    AcmeLiveValidator,
+    load_env_file,
+    scan_logs_for_fatal,
+)
+
+
+def test_load_env_file_parses_export_and_quotes(tmp_path):
+    p = tmp_path / "env"
+    p.write_text(
+        "export ACME_SSH_HOST=10.0.0.1\nOFDD_INTEGRATOR_USER=integrator\n"
+        "OFDD_INTEGRATOR_PASSWORD='p$w&d'\n",
+        encoding="utf-8",
+    )
+    env = load_env_file(p)
+    assert env["ACME_SSH_HOST"] == "10.0.0.1"
+    assert env["OFDD_INTEGRATOR_PASSWORD"] == "p$w&d"
+
+
+def test_scan_logs_for_fatal():
+    assert "Traceback" in scan_logs_for_fatal("foo Traceback bar")
+    assert not scan_logs_for_fatal("normal log line")
+
+
+def test_no_duplicate_devices_fails_on_dup_bacnet():
+    validator = AcmeLiveValidator(
+        base="http://127.0.0.1:8765",
+        site_id="acme",
+        building_id="vm-bbartling",
+        profile={"max_duplicate_bacnet_devices": 0},
+        auth_env=Path("/nonexistent"),
+        mode="quick",
+    )
+    validator.token = "tok"
+    bundle = {
+        "sites": [{"id": "acme"}],
+        "equipment": [
+            {"id": "e1", "bacnet_device_id": 1100},
+            {"id": "e2", "bacnet_device_id": 1100},
+        ],
+        "points": [],
+        "fdd_rules": [],
+    }
+
+    def fake_get(path, auth=True):
+        if "commissioning-export" in path:
+            return 200, bundle, 1.0
+        if "inventory" in path:
+            return 200, {"devices": []}, 1.0
+        return 404, {}, 1.0
+
+    validator.client.get_json = fake_get  # type: ignore[method-assign]
+    status, msg, details = validator._check_no_duplicate_devices()
+    assert status == "fail"
+    assert "Duplicate BACnet" in msg
+    assert details["duplicate_bacnet_device_ids"]
+
+
+def test_empty_model_fails_health_threshold():
+    validator = AcmeLiveValidator(
+        base="http://127.0.0.1:8765",
+        site_id="acme",
+        building_id="vm-bbartling",
+        profile={"min_equipment_count": 10, "min_point_count": 50},
+        auth_env=Path("/nonexistent"),
+    )
+    validator.token = "tok"
+    validator.client.get_json = lambda path, auth=True: (  # type: ignore[method-assign]
+        200,
+        {"counts": {"equipment": 2, "points": 5}, "score": 10, "status": "warning"},
+        1.0,
+    )
+    status, msg, _ = validator._check_model_health()
+    assert status == "fail"
+    assert "counts low" in msg
+
+
+def test_building_status_missing_context_fails():
+    validator = AcmeLiveValidator(
+        base="http://127.0.0.1:8765",
+        site_id="acme",
+        building_id="vm-bbartling",
+        profile={},
+        auth_env=Path("/nonexistent"),
+    )
+    validator.token = "tok"
+
+    def fake_get(path, auth=True):
+        if path.startswith("/api/faults/status"):
+            return 200, {
+                "families": [
+                    {
+                        "faults": [
+                            {
+                                "source": "fdd",
+                                "title": "Fault only code",
+                                "code": "acme-test",
+                            }
+                        ]
+                    }
+                ]
+            }, 1.0
+        return 200, {}, 1.0
+
+    validator.client.get_json = fake_get  # type: ignore[method-assign]
+    with patch(
+        "http_probes.check_building_dashboard_health",
+        return_value={"errors": [], "warnings": []},
+    ):
+        status, msg, _ = validator._check_building_status()
+    assert status == "fail"
+    assert "missing" in msg.lower()
+
+
+def test_trend_empty_fails_via_http_probes_errors():
+    validator = AcmeLiveValidator(
+        base="http://127.0.0.1:8765",
+        site_id="acme",
+        building_id="vm-bbartling",
+        profile={},
+        auth_env=Path("/nonexistent"),
+    )
+    validator.token = "tok"
+    with patch(
+        "http_probes.check_integrator_ui_api",
+        return_value={"errors": ["/api/timeseries/readings HTTP 422"], "warnings": []},
+    ):
+        status, msg, _ = validator._check_trends()
+    assert status == "fail"
+    assert "422" in msg

--- a/tests/scripts/test_acme_validation_report.py
+++ b/tests/scripts/test_acme_validation_report.py
@@ -1,0 +1,59 @@
+"""Offline tests for Acme validation report schema."""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+
+from scripts.acme_validation_report import (
+    ValidationCheck,
+    ValidationReport,
+    redact_report,
+    redact_text,
+    write_junit_report,
+    write_json_report,
+)
+
+
+def test_report_summary_ok_when_no_failures(tmp_path):
+    report = ValidationReport(target={"site_id": "acme"}, started_at="2026-01-01T00:00:00Z")
+    report.add(ValidationCheck(id="a", category="api", status="pass", message="ok"))
+    report.add(ValidationCheck(id="b", category="api", status="warn", message="slow"))
+    report.finalize()
+    assert report.summary["ok"] is True
+    assert report.summary["passed"] == 1
+    assert report.summary["warnings"] == 1
+
+
+def test_report_fails_when_check_fails():
+    report = ValidationReport(target={}, started_at="t")
+    report.add(ValidationCheck(id="dup", category="model", status="fail", message="duplicate devices"))
+    report.finalize()
+    assert report.summary["ok"] is False
+    assert report.summary["failed"] == 1
+
+
+def test_redact_token_and_tailscale():
+    text = redact_text('Bearer abc.def-123 at http://100.122.106.124/api')
+    assert "REDACTED" in text
+    assert "100.122" not in text
+    data = redact_report({"token": "secret", "base_url": "http://100.1.2.3", "nested": {"password": "x"}})
+    assert data["token"] == "[REDACTED]"
+    assert data["base_url"] == "redacted"
+
+
+def test_json_and_junit_output(tmp_path):
+    report = ValidationReport(target={"site_id": "acme"}, started_at="t", duration_seconds=1.5)
+    report.add(ValidationCheck(id="health", category="api", status="pass", message="OK", duration_ms=10))
+    report.add(ValidationCheck(id="dup", category="model", status="fail", message="duplicate", duration_ms=5))
+    report.finalize()
+    jp = tmp_path / "r.json"
+    write_json_report(report, str(jp))
+    loaded = json.loads(jp.read_text(encoding="utf-8"))
+    assert loaded["summary"]["failed"] == 1
+    assert loaded["checks"][0]["id"] == "health"
+    junit = tmp_path / "r.xml"
+    write_junit_report(report, str(junit))
+    root = ET.parse(junit).getroot()
+    assert root.tag == "testsuite"
+    assert int(root.attrib["failures"]) == 1

--- a/tests/workspace_bridge/test_bacnet_poll_model_sync.py
+++ b/tests/workspace_bridge/test_bacnet_poll_model_sync.py
@@ -203,3 +203,16 @@ def test_repair_duplicate_bacnet_equipment(model_env):
     assert len(eq) == 1
     assert eq[0]["id"] == "acme-vav-39"
     assert pts[0]["equipment_id"] == "acme-vav-39"
+
+
+def test_repair_duplicate_point_ids_keeps_richest_row():
+    from openfdd_bridge.bacnet_poll_model_sync import repair_duplicate_point_ids  # noqa: E402
+
+    points = [
+        {"id": "12035-analog-input-1", "equipment_id": "vav", "external_id": "ZN-T"},
+        {"id": "12035-analog-input-1", "equipment_id": "vav"},
+    ]
+    repaired, n = repair_duplicate_point_ids(points)
+    assert n == 1
+    assert len(repaired) == 1
+    assert repaired[0]["external_id"] == "ZN-T"

--- a/workspace/api/openfdd_bridge/bacnet_poll_model_sync.py
+++ b/workspace/api/openfdd_bridge/bacnet_poll_model_sync.py
@@ -130,6 +130,46 @@ def duplicate_bacnet_equipment_report(model: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def duplicate_point_id_report(model: dict[str, Any]) -> dict[str, Any]:
+    """Detect multiple model rows sharing one point id (commissioning export double-count)."""
+    from collections import Counter
+
+    points = [p for p in (model.get("points") or []) if isinstance(p, dict)]
+    ids = [str(p.get("id") or "").strip() for p in points if str(p.get("id") or "").strip()]
+    dup = {k: v for k, v in Counter(ids).items() if v > 1}
+    return {"duplicate_point_ids": len(dup), "instances": dup}
+
+
+def _point_row_richness(row: dict[str, Any]) -> int:
+    score = 0
+    for key in ("external_id", "series_id", "fdd_input", "brick_type", "description"):
+        if str(row.get(key) or "").strip():
+            score += 1
+    return score
+
+
+def repair_duplicate_point_ids(points: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    """Keep the richest row per point id; drop sparse BACnet poll duplicates."""
+    best: dict[str, dict[str, Any]] = {}
+    no_id: list[dict[str, Any]] = []
+    pruned = 0
+    for pt in points:
+        if not isinstance(pt, dict):
+            continue
+        pid = str(pt.get("id") or "").strip()
+        if not pid:
+            no_id.append(dict(pt))
+            continue
+        prev = best.get(pid)
+        if prev is None:
+            best[pid] = dict(pt)
+            continue
+        if _point_row_richness(pt) >= _point_row_richness(prev):
+            best[pid] = dict(pt)
+        pruned += 1
+    return list(best.values()) + no_id, pruned
+
+
 def repair_duplicate_bacnet_equipment(
     equipment: list[dict[str, Any]],
     points: list[dict[str, Any]],
@@ -286,6 +326,8 @@ def sync_enabled_polling_to_model(*, site_id: str | None = None, sync_ttl: bool 
         removed = before_pts - len(model["points"])
         equipment, model["points"], pruned = repair_duplicate_bacnet_equipment(equipment, model["points"])
         repaired += pruned
+        model["points"], pt_pruned = repair_duplicate_point_ids(model["points"])
+        repaired += pt_pruned
         remaining_eq_ids = {str(p.get("equipment_id") or "") for p in model["points"] if isinstance(p, dict)}
         model["equipment"] = [
             e

--- a/workspace/api/openfdd_bridge/bacnet_poll_model_sync.py
+++ b/workspace/api/openfdd_bridge/bacnet_poll_model_sync.py
@@ -236,6 +236,7 @@ def sync_enabled_polling_to_model(*, site_id: str | None = None, sync_ttl: bool 
     updated = 0
     removed = 0
     repaired = 0
+    points_deduplicated = 0
     sid = ""
 
     with svc.transaction() as model:
@@ -243,6 +244,8 @@ def sync_enabled_polling_to_model(*, site_id: str | None = None, sync_ttl: bool 
         equipment = model.setdefault("equipment", [])
         points = model.setdefault("points", [])
         equipment, points, repaired = repair_duplicate_bacnet_equipment(equipment, points)
+        points, pt_pruned = repair_duplicate_point_ids(points)
+        points_deduplicated += pt_pruned
         by_key = _model_bacnet_keys(points)
 
         devices_touched: set[str] = set()
@@ -327,7 +330,7 @@ def sync_enabled_polling_to_model(*, site_id: str | None = None, sync_ttl: bool 
         equipment, model["points"], pruned = repair_duplicate_bacnet_equipment(equipment, model["points"])
         repaired += pruned
         model["points"], pt_pruned = repair_duplicate_point_ids(model["points"])
-        repaired += pt_pruned
+        points_deduplicated += pt_pruned
         remaining_eq_ids = {str(p.get("equipment_id") or "") for p in model["points"] if isinstance(p, dict)}
         model["equipment"] = [
             e
@@ -337,7 +340,7 @@ def sync_enabled_polling_to_model(*, site_id: str | None = None, sync_ttl: bool 
         ]
 
     ttl_path = None
-    if sync_ttl and (added or updated or removed or repaired):
+    if sync_ttl and (added or updated or removed or repaired or points_deduplicated):
         ttl_path = str(TtlService().sync())
 
     return {
@@ -347,6 +350,7 @@ def sync_enabled_polling_to_model(*, site_id: str | None = None, sync_ttl: bool 
         "points_updated": updated,
         "points_removed": removed,
         "equipment_stubs_repaired": repaired,
+        "points_deduplicated": points_deduplicated,
         "devices": sorted(devices_touched),
         "ttl_path": ttl_path,
     }

--- a/workspace/api/openfdd_bridge/model_health.py
+++ b/workspace/api/openfdd_bridge/model_health.py
@@ -27,6 +27,7 @@ def model_health_summary(model: dict[str, Any]) -> dict[str, Any]:
                 "missing_fdd_input": 0,
                 "duplicate_external_ids": 0,
                 "duplicate_bacnet_device_instances": 0,
+                "duplicate_point_ids": 0,
             },
             "issues": [],
             "summary": "",
@@ -73,13 +74,21 @@ def model_health_summary(model: dict[str, Any]) -> dict[str, Any]:
         duplicate_map[key] = duplicate_map.get(key, 0) + 1
     duplicate_external_ids = sum(1 for count in duplicate_map.values() if count > 1)
 
-    from .bacnet_poll_model_sync import duplicate_bacnet_equipment_report
+    from .bacnet_poll_model_sync import duplicate_bacnet_equipment_report, duplicate_point_id_report
 
     dup_bacnet = duplicate_bacnet_equipment_report(model)
     duplicate_bacnet_device_instances = int(dup_bacnet.get("duplicate_device_instances") or 0)
+    dup_points = duplicate_point_id_report(model)
+    duplicate_point_ids = int(dup_points.get("duplicate_point_ids") or 0)
 
     critical = orphan_equipment + orphan_points_site + orphan_points_equipment
-    warning = missing_brick_type + missing_fdd_input + duplicate_external_ids + duplicate_bacnet_device_instances
+    warning = (
+        missing_brick_type
+        + missing_fdd_input
+        + duplicate_external_ids
+        + duplicate_bacnet_device_instances
+        + duplicate_point_ids
+    )
     score = max(0, 100 - (critical * 10) - (warning * 2))
 
     issues: list[dict[str, str]] = []
@@ -139,6 +148,14 @@ def model_health_summary(model: dict[str, Any]) -> dict[str, Any]:
                 "detail": "Often bacnet-{instance} stubs duplicate GL36 equipment — run POST /api/model/bacnet-sync or repair.",
             }
         )
+    if duplicate_point_ids:
+        issues.append(
+            {
+                "severity": "warning",
+                "title": f"{duplicate_point_ids} duplicate point id(s) in model",
+                "detail": "Run POST /api/model/bacnet-sync to prune duplicate BACnet poll rows.",
+            }
+        )
 
     status = "ok"
     if critical:
@@ -161,6 +178,7 @@ def model_health_summary(model: dict[str, Any]) -> dict[str, Any]:
             "missing_fdd_input": missing_fdd_input,
             "duplicate_external_ids": duplicate_external_ids,
             "duplicate_bacnet_device_instances": duplicate_bacnet_device_instances,
+            "duplicate_point_ids": duplicate_point_ids,
         },
         "issues": issues,
         "summary": (


### PR DESCRIPTION
## Summary
- Adds `acme_post_deploy_validate.sh` + `acme_live_validate.py` — rigorous read-only Acme validation after GHCR/Docker updates (image tag, UI bundle freshness, duplicates, BACnet, trends, FDD, Rule Lab, logs, JSON/JUnit reports).
- Repairs duplicate BACnet point IDs during `bacnet-sync` and surfaces `duplicate_point_ids` in model health.
- Bumps version to **3.0.32**; fixes auth env sourcing for passwords containing `$`/`&`.

## Test plan
- [x] `pytest tests/scripts/test_acme_* -q`
- [x] `pytest tests/workspace_bridge/test_bacnet_poll_model_sync.py::test_repair_duplicate_point_ids_keeps_richest_row -q`
- [ ] `OPENFDD_IMAGE_TAG=v3.0.32 ./scripts/acme_post_deploy_validate.sh --limit acme_vm_bbartling --full` after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive live ACME post-deployment validation harness with health checks, API probes, and security redaction.
  * Added duplicate point ID detection and repair for BACnet polling synchronization.
  * Added remote host probe utility for edge environment diagnostics.

* **Bug Fixes**
  * Fixed unbound variable errors in shell scripts during authentication environment sourcing.

* **Documentation**
  * Added ACME live validation operational guide with procedure steps and validation modes.
  * Updated deployment validation documentation with references to new validation tools.
  * Added validation profile configuration example.

* **Tests**
  * Added comprehensive test suite for validation tools, reporting, and BACnet duplicate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->