### PR TITLE
fix(edge-ops): close Acme #276 patch cycle

### DIFF
--- a/docs/ops/acme-live-validation.md
+++ b/docs/ops/acme-live-validation.md
@@ -21,7 +21,9 @@ export OPENFDD_IMAGE_TAG=v3.0.32
   --json-out reports/acme-live-validate.json
 ```
 
-Use **`upgrade_edge_full.sh`**, not `upgrade_edge_ghcr.sh` alone, when the Operator Bridge UI changed — the edge bind-mount serves `workspace/api/static/app/` **before** image-baked assets.
+Use **`upgrade_edge_full.sh`**, not `upgrade_edge_ghcr.sh` alone, when the Operator Bridge UI changed — the edge bind-mount serves `workspace/api/static/app/` **before** image-baked assets (`edge_sync_ui_static.sh` rsyncs the bundle; `deploy.sh ui` was removed).
+
+GHCR SemVer tags omit the leading `v` (`3.0.32`, not `v3.0.32`). `upgrade_edge_ghcr.sh` normalizes `OPENFDD_IMAGE_TAG` automatically.
 
 ## Modes
 

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,6 +9,6 @@ GHCR Docker images (``openfdd-bridge``, ``openfdd-commission``, ``openfdd-mcp-ra
 not inside this wheel.
 """
 
-__version__ = "3.0.32"
+__version__ = "3.0.33"
 
 __all__ = ["__version__"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,8 @@
 | **`build_docs_pdf.sh`** / **`build_docs_pdf.py`** | Combined Markdown → `pdf/open-fdd-docs.pdf` (+ `.txt`). Needs system **pandoc** + `pip install weasyprint` (or `pip install -e ".[docs]"`). CI opens a PR on `master`/`main` doc changes — merge `chore/docs-pdf-refresh`. |
 | **`openfdd_edge_validate.sh`** | Bensserver / edge gate: backup → BACnet+model reset → bench setup → stack → **public check-engine (no auth)** → SPARQL/http probes → operational verify → pytest → health → log scan. `--quick` (no resets), `--full` / `--long` (full bench), `--pre-update-backup`, `--rebuild`. |
 | **`docker_maintenance.sh`** | Safe prune/rebuild; never prunes bind-mounted workspace volumes. |
-| **`upgrade_edge_full.sh`** | Build UI + `deploy.sh ui` + GHCR image upgrade + post-deploy check (fixes stale `static/app` on edge). |
+| **`upgrade_edge_full.sh`** | Build UI + `edge_sync_ui_static.sh` + GHCR image upgrade + post-deploy check (fixes stale `static/app` on edge). |
+| **`edge_sync_ui_static.sh`** | Rsync `workspace/api/static/app/` to edge bind mount via inventory SSH. |
 | **`acme_post_deploy_validate.sh`** | **Live Acme** read-only validation after GHCR updates — image tag, UI bundle, duplicates, BACnet, trends, FDD, Rule Lab, logs. `--quick` \| `--full`. |
 | **`acme_live_validate.py`** | Python API probe engine used by `acme_post_deploy_validate.sh`; JSON/JUnit/Markdown reports. |
 | **`daily_release.sh`** | Daily easy button: merge PR → tag `open-fdd-v*` (PyPI) → GHCR publish → prune branches → `--prep-next 3.0.1` for next cycle. |

--- a/scripts/acme_patch_oat_column.py
+++ b/scripts/acme_patch_oat_column.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 import sys
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -39,8 +40,25 @@ def _patch_local(model: dict, point_id: str, alias: str) -> bool:
     return changed
 
 
+def _api_base(host: str) -> str:
+    host = host.strip()
+    if host.startswith("http://") or host.startswith("https://"):
+        return host.rstrip("/")
+    return f"http://{host}".rstrip("/")
+
+
+def _fetch_model(base: str, token: str) -> dict:
+    req = urllib.request.Request(
+        f"{base}/api/model/export",
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode())
+
+
 def _push_model(base: str, token: str, model: dict) -> None:
-    body = json.dumps({"payload": model, "replace": False}).encode()
+    body = json.dumps({"payload": model, "replace": True}).encode()
     req = urllib.request.Request(
         f"{base.rstrip('/')}/api/model/import",
         data=body,
@@ -59,6 +77,24 @@ def main() -> int:
     parser.add_argument("--token", default="")
     args = parser.parse_args()
 
+    if args.host and args.token:
+        base = _api_base(args.host)
+        try:
+            model = _fetch_model(base, args.token)
+        except urllib.error.HTTPError as exc:
+            print(f"Model export failed: HTTP {exc.code}", file=sys.stderr)
+            return 1
+        if not _patch_local(model, args.point_id, args.alias):
+            print(f"No change needed for {args.point_id} on edge (already {args.alias})")
+            return 0
+        try:
+            _push_model(base, args.token, model)
+        except urllib.error.HTTPError as exc:
+            print(f"Model import failed: HTTP {exc.code}", file=sys.stderr)
+            return 1
+        print(f"Patched edge model: {args.point_id} → external_id/fdd_input={args.alias}")
+        return 0
+
     from openfdd_bridge.model_service import ModelService  # noqa: E402
 
     svc = ModelService()
@@ -68,8 +104,6 @@ def main() -> int:
         return 0
     svc.import_json(model, replace=True)
     print(f"Patched local model: {args.point_id} → external_id/fdd_input={args.alias}")
-    if args.host and args.token:
-        _push_model(f"http://{args.host}", args.token, model)
     return 0
 
 

--- a/scripts/acme_post_deploy_validate.sh
+++ b/scripts/acme_post_deploy_validate.sh
@@ -93,6 +93,12 @@ if [[ -z "$BASE" && -z "$LIMIT" ]]; then
 fi
 
 TAG="${OPENFDD_IMAGE_TAG:-}"
+if [[ -n "$TAG" ]]; then
+  # shellcheck source=scripts/openfdd_normalize_image_tag.sh
+  source "${ROOT}/scripts/openfdd_normalize_image_tag.sh"
+  TAG="$(normalize_openfdd_image_tag "$TAG")"
+  export OPENFDD_IMAGE_TAG="$TAG"
+fi
 if [[ -z "$TAG" ]]; then
   echo "warn: OPENFDD_IMAGE_TAG not set — Docker image tag checks are best-effort" >&2
 fi

--- a/scripts/edge_sync_ui_static.sh
+++ b/scripts/edge_sync_ui_static.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Rsync operator dashboard static bundle to edge workspace bind mount.
+#
+# Bridge prefers ~/open-fdd/workspace/api/static/app over image-baked assets when
+# index.html exists (static_dashboard_dir). Use after build_operator_dashboard.sh
+# when GHCR image pull alone leaves a stale hash on disk.
+#
+#   ./scripts/edge_sync_ui_static.sh --limit acme_vm_bbartling
+#   ./scripts/edge_sync_ui_static.sh --host 100.x.x.x --ssh-user bbartling
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+LIMIT=""
+HOST=""
+SSH_USER="${ANSIBLE_REMOTE_USER:-ben}"
+REMOTE_DIR="${OPENFDD_REMOTE_DIR:-~/open-fdd}"
+SRC="${ROOT}/workspace/api/static/app/"
+DEST_SUFFIX="/workspace/api/static/app/"
+
+usage() {
+  sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+load_edge_secrets() {
+  local limit="${1:-}"
+  local secrets_dir="${ROOT}/infra/ansible/secrets"
+  local secrets_file=""
+  if [[ -n "$limit" && -f "${secrets_dir}/${limit}.env.local" ]]; then
+    secrets_file="${secrets_dir}/${limit}.env.local"
+  else
+    case "$limit" in
+      acme_vm_bbartling) secrets_file="${secrets_dir}/acme.env.local" ;;
+      bacnet_pi) secrets_file="${secrets_dir}/bacnet_pi.env.local" ;;
+    esac
+  fi
+  if [[ -n "$secrets_file" && -f "$secrets_file" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$secrets_file"
+    set +a
+    export SSHPASS="${SSHPASS:-}"
+  fi
+}
+
+build_ssh_rsync() {
+  RSYNC_SSH=(ssh -o ConnectTimeout=15)
+  if [[ -n "${SSHPASS:-}" ]] && command -v sshpass >/dev/null 2>&1; then
+    export SSHPASS
+    RSYNC_SSH=(sshpass -e ssh -o ConnectTimeout=15 -o PreferredAuthentications=password -o PubkeyAuthentication=no)
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --limit) LIMIT="$2"; shift 2 ;;
+    --host) HOST="$2"; shift 2 ;;
+    --ssh-user) SSH_USER="$2"; shift 2 ;;
+    --remote-dir) REMOTE_DIR="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+[[ -f "${SRC}index.html" ]] || {
+  echo "Missing ${SRC}index.html — run ./scripts/build_operator_dashboard.sh prod first" >&2
+  exit 1
+}
+
+INV="${ANSIBLE_INVENTORY:-${ROOT}/infra/ansible/inventory.yml}"
+if [[ -n "$LIMIT" ]]; then
+  load_edge_secrets "$LIMIT"
+  if [[ -z "$HOST" && -f "$INV" ]] && command -v ansible-inventory >/dev/null 2>&1; then
+    inv_json="$(ansible-inventory -i "$INV" --host "$LIMIT" 2>/dev/null || true)"
+    if [[ -n "$inv_json" ]]; then
+      HOST="$(echo "$inv_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("ansible_host",""))' 2>/dev/null || true)"
+      inv_user="$(echo "$inv_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("ansible_user",""))' 2>/dev/null || true)"
+      [[ -n "$inv_user" ]] && SSH_USER="$inv_user"
+    fi
+  fi
+fi
+
+[[ -n "$HOST" ]] || { echo "Need --limit <inventory_host> or --host <ip>" >&2; exit 1; }
+
+build_ssh_rsync
+REMOTE="${SSH_USER}@${HOST}:${REMOTE_DIR%/}${DEST_SUFFIX}"
+echo "==> Rsync UI static bundle → ${REMOTE}"
+rsync -az --delete -e "$(printf '%q ' "${RSYNC_SSH[@]}")" "${SRC}" "${REMOTE}"
+asset="$(grep -oE 'index-[^"]+\.js' "${SRC}index.html" | head -1 || true)"
+echo "OK — edge UI bundle ${asset:-?} synced to ${HOST}"

--- a/scripts/openfdd_normalize_image_tag.sh
+++ b/scripts/openfdd_normalize_image_tag.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# GHCR SemVer tags omit the leading "v" (workflow publishes 3.0.32, not v3.0.32).
+# Normalize OPENFDD_IMAGE_TAG for docker compose / validation probes.
+normalize_openfdd_image_tag() {
+  local raw="${1:-}"
+  raw="${raw#v}"
+  printf '%s' "$raw"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  normalize_openfdd_image_tag "${OPENFDD_IMAGE_TAG:-}"
+fi

--- a/scripts/upgrade_edge_full.sh
+++ b/scripts/upgrade_edge_full.sh
@@ -36,9 +36,13 @@ done
 
 TAG="${OPENFDD_IMAGE_TAG:-}"
 if [[ -z "$TAG" || "$TAG" == "local" ]]; then
-  echo "Set OPENFDD_IMAGE_TAG to the GHCR tag published by CI (e.g. 2026.06.08-edge)." >&2
+  echo "Set OPENFDD_IMAGE_TAG to the GHCR tag published by CI (e.g. 3.0.32 or latest)." >&2
   exit 1
 fi
+# shellcheck source=scripts/openfdd_normalize_image_tag.sh
+source "${ROOT}/scripts/openfdd_normalize_image_tag.sh"
+TAG="$(normalize_openfdd_image_tag "$TAG")"
+export OPENFDD_IMAGE_TAG="$TAG"
 
 LOCAL_ASSET=""
 if [[ -f workspace/api/static/app/index.html ]]; then
@@ -61,11 +65,8 @@ else
 fi
 
 if [[ "$SKIP_UI_DEPLOY" == "0" ]]; then
-  echo "==> Deploy UI static bundle to edge (workspace/api/static/app/)"
-  cd "${ROOT}/infra/ansible"
-  # UI deploy runs Ansible only; defer insurance check until GHCR pull completes.
-  RUN_POST_CHECK=0 ./deploy.sh ui --limit "$LIMIT" "${EXTRA[@]}"
-  cd "$ROOT"
+  echo "==> Sync UI static bundle to edge (workspace/api/static/app/ bind mount)"
+  "${ROOT}/scripts/edge_sync_ui_static.sh" --limit "$LIMIT"
 else
   echo "==> Skipping UI deploy (--skip-ui-deploy)"
 fi

--- a/scripts/upgrade_edge_ghcr.sh
+++ b/scripts/upgrade_edge_ghcr.sh
@@ -35,7 +35,9 @@ if [[ -z "$TAG" || "$TAG" == "local" ]]; then
   echo "Set OPENFDD_IMAGE_TAG to the GHCR tag to pull." >&2
   exit 1
 fi
-
+# shellcheck source=../scripts/openfdd_normalize_image_tag.sh
+source "${ROOT}/scripts/openfdd_normalize_image_tag.sh"
+TAG="$(normalize_openfdd_image_tag "$TAG")"
 export OPENFDD_IMAGE_TAG="$TAG"
 export RUN_POST_CHECK="${RUN_POST_CHECK:-1}"
 

--- a/tests/scripts/test_acme_patch_oat_column.py
+++ b/tests/scripts/test_acme_patch_oat_column.py
@@ -1,0 +1,60 @@
+"""acme_patch_oat_column — API-first path when --host and --token are set."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "acme_patch_oat_column.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("acme_patch_oat_column", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_api_path_patches_and_imports(monkeypatch):
+    mod = _load_module()
+    model = {"points": [{"id": "1100-unknown-2", "external_id": "", "fdd_input": ""}]}
+    calls: list[str] = []
+
+    def fake_fetch(base, token):
+        calls.append(f"fetch:{base}")
+        return json.loads(json.dumps(model))
+
+    def fake_push(base, token, payload):
+        calls.append(f"push:{base}")
+        assert payload["points"][0]["external_id"] == "oa-t"
+
+    monkeypatch.setattr(mod, "_fetch_model", fake_fetch)
+    monkeypatch.setattr(mod, "_push_model", fake_push)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["acme_patch_oat_column.py", "--host", "100.1.2.3", "--token", "tok"],
+    )
+    assert mod.main() == 0
+    assert calls == ["fetch:http://100.1.2.3", "push:http://100.1.2.3"]
+
+
+def test_api_path_no_change_skips_import(monkeypatch):
+    mod = _load_module()
+    model = {"points": [{"id": "1100-unknown-2", "external_id": "oa-t", "fdd_input": "oa-t"}]}
+    pushed = []
+
+    monkeypatch.setattr(mod, "_fetch_model", lambda *_: model)
+    monkeypatch.setattr(mod, "_push_model", lambda *_a, **_k: pushed.append(1))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["acme_patch_oat_column.py", "--host", "edge", "--token", "t"],
+    )
+    assert mod.main() == 0
+    assert pushed == []


### PR DESCRIPTION
## Summary
- Replace broken `deploy.sh ui` path in `upgrade_edge_full.sh` with `edge_sync_ui_static.sh` (SSH rsync of `workspace/api/static/app/`).
- Normalize `OPENFDD_IMAGE_TAG` (`3.0.32` not `v3.0.32`) in upgrade and validation scripts — fixes GHCR commission pull failures from issue #276.
- `acme_patch_oat_column.py` patches via API when `--host` + `--token` are set (no local `model.json` read).
- Bump `3.0.33`.

Closes #276.

## Test plan
- [x] `pytest tests/scripts/test_acme_patch_oat_column.py`
- [ ] `OPENFDD_IMAGE_TAG=3.0.32 ./scripts/upgrade_edge_full.sh --limit acme_vm_bbartling`
- [ ] `OPENFDD_IMAGE_TAG=3.0.32 ./scripts/acme_post_deploy_validate.sh --limit acme_vm_bbartling --full`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 3.0.33

* **New Features**
  * Added remote HTTP API support for model patching with token authentication
  * Implemented edge UI static asset synchronization capability during deployments

* **Documentation**
  * Enhanced deployment guidance clarifying upgrade workflow options and image tag format requirements

* **Chores**
  * Version bumped to 3.0.33
  * Improved image tag normalization for deployment consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->