### PR TITLE
fix(validate): skip stack_health on remote Acme

### DIFF
--- a/scripts/acme_post_deploy_validate.sh
+++ b/scripts/acme_post_deploy_validate.sh
@@ -146,8 +146,9 @@ if ! "${PY_ARGS[@]}"; then
   FAIL=1
 fi
 
-if [[ "$MODE" != "quick" && "$FAIL" == "0" && -f "${ROOT}/scripts/stack_health_check.sh" ]]; then
-  echo "==> stack_health_check.sh (supplemental)"
+# stack_health_check.sh targets local compose.dev.yml and requires MCP — skip on remote edge (--limit).
+if [[ "$MODE" != "quick" && "$FAIL" == "0" && -z "$LIMIT" && -f "${ROOT}/scripts/stack_health_check.sh" ]]; then
+  echo "==> stack_health_check.sh (supplemental, local dev stack only)"
   RESOLVED_BASE="$BASE"
   if [[ -z "$RESOLVED_BASE" && -n "$LIMIT" ]]; then
     RESOLVED_BASE="$(python3 -c "


### PR DESCRIPTION
stack_health_check targets local compose.dev.yml and requires MCP; Acme disables MCP by design.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment validation to correctly skip health check step when running in remote edge environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->