### PR TITLE
fix(edge-ops): robust Acme SSH + remote host probe

### DIFF
--- a/infra/ansible/scripts/acme_operational_verify.sh
+++ b/infra/ansible/scripts/acme_operational_verify.sh
@@ -308,7 +308,11 @@ fi
 if [[ "$SKIP_WAIT" -eq 0 ]]; then
   log_info "Wait ${WAIT_MINUTES}m for poll samples..."
   sleep $((WAIT_MINUTES * 60))
-  ssh -o BatchMode=yes -o ConnectTimeout=10 "bbartling@${HOST}" \
+  # shellcheck source=edge_ssh_helpers.sh
+  source "${DIR}/edge_ssh_helpers.sh"
+  EDGE_SSH_CONNECT_TIMEOUT=10
+  ssh_user="${ACME_SSH_USER:-bbartling}"
+  edge_ssh_run "${ssh_user}@${HOST}" \
     "wc -l ~/open-fdd/workspace/bacnet/polls/samples.csv 2>/dev/null || true" || true
 fi
 

--- a/infra/ansible/scripts/acme_remote_host_probe.sh
+++ b/infra/ansible/scripts/acme_remote_host_probe.sh
@@ -39,12 +39,16 @@ if [[ -z "$SSH_HOST" ]]; then
   exit 1
 fi
 
-SSH_OPTS=(-o ConnectTimeout=12 -o BatchMode=yes)
-if [[ -n "${SSHPASS:-}" ]] && command -v sshpass >/dev/null 2>&1; then
-  RAW="$(SSHPASS="$SSHPASS" sshpass -e ssh "${SSH_OPTS[@]}" "${SSH_USER}@${SSH_HOST}" python3 - <"$PROBE_PY")"
-else
-  RAW="$(ssh "${SSH_OPTS[@]}" "${SSH_USER}@${SSH_HOST}" python3 - <"$PROBE_PY")"
+# shellcheck source=edge_ssh_helpers.sh
+source "${DIR}/edge_ssh_helpers.sh"
+EDGE_SSH_CONNECT_TIMEOUT=12
+build_edge_ssh_cmd
+target="${SSH_USER}@${SSH_HOST}"
+ssh_cmd=("${EDGE_SSH_CMD[@]}")
+if ! "${EDGE_SSH_CMD[@]}" "$target" true 2>/dev/null && [[ ${#EDGE_SSH_PASS_CMD[@]} -gt 0 ]]; then
+  ssh_cmd=("${EDGE_SSH_PASS_CMD[@]}")
 fi
+RAW="$("${ssh_cmd[@]}" "$target" python3 - <"$PROBE_PY")"
 
 if [[ -n "$JSON_OUT" ]]; then
   printf '%s\n' "$RAW" >"$JSON_OUT"

--- a/infra/ansible/scripts/edge_ssh_helpers.sh
+++ b/infra/ansible/scripts/edge_ssh_helpers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Shared SSH/rsync options for edge host access from bensserver (control machine).
+# shellcheck shell=bash
+#
+# Prefers key-based auth when available; falls back to SSHPASS + sshpass password auth.
+
+build_edge_ssh_cmd() {
+  local -a opts=(-o ConnectTimeout="${EDGE_SSH_CONNECT_TIMEOUT:-12}" -o BatchMode=yes)
+  EDGE_SSH_CMD=(ssh "${opts[@]}")
+  EDGE_SSH_PASS_CMD=()
+  if [[ -n "${SSHPASS:-}" ]] && command -v sshpass >/dev/null 2>&1; then
+    export SSHPASS
+    EDGE_SSH_PASS_CMD=(sshpass -e ssh "${opts[@]}" -o PreferredAuthentications=password -o PubkeyAuthentication=no)
+  fi
+}
+
+# Run remote command; tries key auth first, then password when SSHPASS is configured.
+edge_ssh_run() {
+  local target="$1"
+  shift
+  build_edge_ssh_cmd
+  if "${EDGE_SSH_CMD[@]}" "$target" "$@" 2>/dev/null; then
+    return 0
+  fi
+  if [[ ${#EDGE_SSH_PASS_CMD[@]} -gt 0 ]]; then
+    "${EDGE_SSH_PASS_CMD[@]}" "$target" "$@"
+    return $?
+  fi
+  return 255
+}
+
+build_edge_rsync_ssh() {
+  build_edge_ssh_cmd
+  local target="${EDGE_RSYNC_PROBE_TARGET:-}"
+  local -a cmd=("${EDGE_SSH_CMD[@]}")
+  if [[ -n "$target" ]] && ! "${EDGE_SSH_CMD[@]}" "$target" true 2>/dev/null; then
+    if [[ ${#EDGE_SSH_PASS_CMD[@]} -gt 0 ]]; then
+      cmd=("${EDGE_SSH_PASS_CMD[@]}")
+    fi
+  fi
+  EDGE_RSYNC_SSH=()
+  local part
+  for part in "${cmd[@]}"; do
+    EDGE_RSYNC_SSH+=("$(printf '%q' "$part")")
+  done
+}

--- a/scripts/edge_sync_ui_static.sh
+++ b/scripts/edge_sync_ui_static.sh
@@ -45,11 +45,13 @@ load_edge_secrets() {
 }
 
 build_ssh_rsync() {
-  RSYNC_SSH=(ssh -o ConnectTimeout=15)
-  if [[ -n "${SSHPASS:-}" ]] && command -v sshpass >/dev/null 2>&1; then
-    export SSHPASS
-    RSYNC_SSH=(sshpass -e ssh -o ConnectTimeout=15 -o PreferredAuthentications=password -o PubkeyAuthentication=no)
-  fi
+  # shellcheck source=../infra/ansible/scripts/edge_ssh_helpers.sh
+  source "${ROOT}/infra/ansible/scripts/edge_ssh_helpers.sh"
+  EDGE_SSH_CONNECT_TIMEOUT=15
+  EDGE_RSYNC_PROBE_TARGET="${SSH_USER}@${HOST}"
+  build_edge_rsync_ssh
+  # shellcheck disable=SC2206
+  RSYNC_SSH=($(printf '%s\n' "${EDGE_RSYNC_SSH[@]}"))
 }
 
 while [[ $# -gt 0 ]]; do

--- a/tests/scripts/test_edge_ssh_helpers.sh
+++ b/tests/scripts/test_edge_ssh_helpers.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# edge_ssh_helpers — password auth opts when SSHPASS is set.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPERS="${ROOT}/infra/ansible/scripts/edge_ssh_helpers.sh"
+# shellcheck source=/dev/null
+source "$HELPERS"
+
+unset SSHPASS
+build_edge_ssh_cmd
+[[ "${EDGE_SSH_CMD[0]}" == "ssh" ]] || { echo "expected ssh without SSHPASS"; exit 1; }
+
+export SSHPASS=test
+if command -v sshpass >/dev/null 2>&1; then
+  build_edge_ssh_cmd
+  joined="${EDGE_SSH_PASS_CMD[*]}"
+  [[ "$joined" == *PreferredAuthentications=password* ]] || { echo "missing password auth opt: $joined"; exit 1; }
+  [[ "$joined" == *PubkeyAuthentication=no* ]] || { echo "missing PubkeyAuthentication=no: $joined"; exit 1; }
+fi
+
+echo "edge_ssh_helpers ok"


### PR DESCRIPTION
## Summary
- Installed bensserver SSH key on Acme VM (key auth works; password kept as fallback in `acme.env.local`).
- Added `edge_ssh_helpers.sh`: key-first auth, SSHPASS password fallback.
- Fixed `acme_remote_host_probe.sh` stdin piping + auth selection.
- `remote_host_containers` validation check now **PASS**.

## Test plan
- [x] `./tests/scripts/test_edge_ssh_helpers.sh`
- [x] `acme_remote_host_probe.sh --limit acme_vm_bbartling`
- [x] `OPENFDD_IMAGE_TAG=3.0.32 ./scripts/acme_post_deploy_validate.sh --limit acme_vm_bbartling --full` → PASS
- [x] `post_deploy_check.sh --limit acme_vm_bbartling --full` → PASS
- [x] `acme_operational_verify.sh --host 100.122.106.124 --skip-wait` → PASS
- [x] `pytest tests/scripts/test_acme_*.py` → 12 passed


Made with [Cursor](https://cursor.com)