### PR TITLE
fix(acme): RTU roles, FDD run equipment_names, 3.0.34

### DIFF
--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,6 +9,6 @@ GHCR Docker images (``openfdd-bridge``, ``openfdd-commission``, ``openfdd-mcp-ra
 not inside this wheel.
 """
 
-__version__ = "3.0.33"
+__version__ = "3.0.34"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.33"
+version = "3.0.34"
 description = "Arrow-native HVAC fault detection runtime — lint, test, and run apply_faults_arrow rules on columnar telemetry (PyPI). Use GHCR Docker images for the full edge operator stack."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/workspace_bridge/test_acme_fdd_audit.py
+++ b/tests/workspace_bridge/test_acme_fdd_audit.py
@@ -100,3 +100,18 @@ def test_acme_gl36_model_no_duplicates_if_present():
     model = json.loads(path.read_text(encoding="utf-8"))
     out = duplicate_audit(model)
     assert out["duplicate_point_ids"] == 0
+
+
+def test_acme_rtu_role_audit_covers_sat_and_fan_command():
+    path = REPO / "workspace/data/acme_gl36_model.json"
+    if not path.is_file():
+        pytest.skip("fixture missing")
+    model = json.loads(path.read_text(encoding="utf-8"))
+    out = equipment_point_role_audit(model)
+    rtu = next((r for r in out["rtu_reports"] if r["equipment_id"] == "acme-vm-bbartling-rtu-01"), None)
+    assert rtu is not None
+    assert rtu["equipment_class"] == "RTU"
+    assert "supply_air_temperature" in rtu["roles_found"]
+    assert "supply_fan_command" in rtu["roles_found"]
+    assert "duct_static_pressure" in rtu["roles_found"]
+    assert "supply_air_temperature_setpoint" in rtu["roles_missing_optional"]

--- a/tests/workspace_bridge/test_fdd_run_equipment.py
+++ b/tests/workspace_bridge/test_fdd_run_equipment.py
@@ -1,0 +1,45 @@
+"""FDD run equipment enrichment tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "workspace" / "api"))
+
+from openfdd_bridge.fdd_equipment import enrich_fdd_run_with_equipment  # noqa: E402
+
+
+def test_enrich_fdd_run_uses_fault_code_when_columns_empty():
+    model = {"sites": [{"id": "acme"}], "equipment": [], "points": []}
+    run = {"site_id": "acme", "fault_code": "AHU-C", "flagged": 1, "analytics": {}}
+    out = enrich_fdd_run_with_equipment(run, model, "acme")
+    assert out["equipment_names"] == ["AHU-C"]
+    assert out["equipment_name"] == "AHU-C"
+
+
+def test_save_results_persists_equipment_names(tmp_path, monkeypatch):
+    import openfdd_bridge.fdd_results as mod
+
+    model = {
+        "sites": [{"id": "acme"}],
+        "equipment": [{"id": "ahu-c", "name": "AHU-C", "site_id": "acme"}],
+        "points": [],
+    }
+
+    monkeypatch.setattr(mod, "fdd_results_path", lambda: tmp_path / "fdd_results.json")
+    monkeypatch.setattr(mod, "_model_for_fdd", lambda: model)
+    out = mod.save_results(
+        [
+            {
+                "rule_id": "acme-sat-flatline-1h",
+                "rule_name": "SAT flatline",
+                "site_id": "acme",
+                "flagged": 1,
+                "fault_code": "AHU-C",
+            }
+        ]
+    )
+    assert out["runs"][0]["equipment_names"] == ["AHU-C"]
+    assert (tmp_path / "fdd_results.json").is_file()

--- a/workspace/api/openfdd_bridge/acme_fdd_audit.py
+++ b/workspace/api/openfdd_bridge/acme_fdd_audit.py
@@ -42,12 +42,50 @@ def _point_text(pt: dict[str, Any]) -> str:
         pt.get("name"),
         pt.get("external_id"),
         pt.get("fdd_input"),
+        pt.get("brick_tag"),
     ]
     return _norm(" ".join(str(p) for p in parts if p))
 
 
+# RTU/AHU packaged units may lack setpoints or discrete fan status points.
+RTU_OPTIONAL_AHU_ROLES: frozenset[str] = frozenset(
+    {
+        "supply_air_temperature_setpoint",
+        "supply_fan_status",
+        "return_air_temperature",
+    }
+)
+
+# Extra keyword aliases for packaged RTU points (Acme device 1100).
+RTU_AHU_ROLE_ALIASES: dict[str, tuple[str, ...]] = {
+    "supply_fan_command": ("supply_fan_speed", "fan_start", "sf_cmd", "fan_speed"),
+    "supply_fan_status": ("fan_start", "fan_stop", "fan_stat"),
+    "duct_static_pressure": ("static_pressure", "sap", "duct_static"),
+}
+
+
 def _equipment_type(eq: dict[str, Any]) -> str:
-    return _norm(str(eq.get("equipment_type") or eq.get("brick_type") or eq.get("name") or ""))
+    parts = [
+        eq.get("equipment_type"),
+        eq.get("brick_type"),
+        eq.get("name"),
+        eq.get("id"),
+    ]
+    return _norm(" ".join(str(p) for p in parts if p))
+
+
+def _is_rtu_equipment(eq: dict[str, Any]) -> bool:
+    return "rtu" in _equipment_type(eq)
+
+
+def _role_map_for_equipment(eq: dict[str, Any]) -> dict[str, tuple[str, ...]]:
+    if not _is_rtu_equipment(eq):
+        return AHU_POINT_ROLES
+    merged: dict[str, tuple[str, ...]] = {}
+    for role, keywords in AHU_POINT_ROLES.items():
+        extra = RTU_AHU_ROLE_ALIASES.get(role, ())
+        merged[role] = keywords + extra
+    return merged
 
 
 def duplicate_audit(model: dict[str, Any]) -> dict[str, Any]:
@@ -97,23 +135,34 @@ def equipment_point_role_audit(model: dict[str, Any], *, site_id: str = "acme") 
     """Report AHU/VAV point role coverage and equipment assignment sanity."""
     equipment = [e for e in model.get("equipment") or [] if isinstance(e, dict)]
     points = [p for p in model.get("points") or [] if isinstance(p, dict)]
-    ahurs = [e for e in equipment if "ahu" in _equipment_type(e) or "rtu" in _equipment_type(e)]
+    ahurs = [e for e in equipment if "ahu" in _equipment_type(e) and not _is_rtu_equipment(e)]
+    rtus = [e for e in equipment if _is_rtu_equipment(e)]
     vavs = [e for e in equipment if "vav" in _equipment_type(e)]
     ahu_reports: list[dict[str, Any]] = []
-    for eq in ahurs:
+    rtu_reports: list[dict[str, Any]] = []
+
+    def _audit_row(eq: dict[str, Any], *, equipment_class: str) -> dict[str, Any]:
         eid = str(eq.get("id") or "")
         eq_pts = [p for p in points if str(p.get("equipment_id") or "") == eid]
-        roles = _roles_present(eq_pts, AHU_POINT_ROLES)
+        role_map = _role_map_for_equipment(eq)
+        roles = _roles_present(eq_pts, role_map)
         missing = [r for r, ok in roles.items() if not ok]
-        ahu_reports.append(
-            {
-                "equipment_id": eid,
-                "name": eq.get("name"),
-                "point_count": len(eq_pts),
-                "roles_found": [r for r, ok in roles.items() if ok],
-                "roles_missing": missing,
-            }
-        )
+        optional_missing = [r for r in missing if equipment_class == "RTU" and r in RTU_OPTIONAL_AHU_ROLES]
+        required_missing = [r for r in missing if r not in optional_missing]
+        return {
+            "equipment_id": eid,
+            "name": eq.get("name"),
+            "equipment_class": equipment_class,
+            "point_count": len(eq_pts),
+            "roles_found": [r for r, ok in roles.items() if ok],
+            "roles_missing": required_missing,
+            "roles_missing_optional": optional_missing,
+        }
+
+    for eq in ahurs:
+        ahu_reports.append(_audit_row(eq, equipment_class="AHU"))
+    for eq in rtus:
+        rtu_reports.append(_audit_row(eq, equipment_class="RTU"))
     vav_reports: list[dict[str, Any]] = []
     for eq in vavs:
         eid = str(eq.get("id") or "")
@@ -136,8 +185,10 @@ def equipment_point_role_audit(model: dict[str, Any], *, site_id: str = "acme") 
     ]
     return {
         "ahu_count": len(ahurs),
+        "rtu_count": len(rtus),
         "vav_count": len(vavs),
         "ahu_reports": ahu_reports,
+        "rtu_reports": rtu_reports,
         "vav_reports": vav_reports,
         "orphan_point_count": len(orphan_pts),
         "orphan_point_samples": orphan_pts[:10],
@@ -173,4 +224,10 @@ def validate_fdd_run_schema(run: dict[str, Any]) -> list[str]:
             errors.append(f"run missing {key}")
     if run.get("flagged") is None and run.get("fault_rows") is None:
         errors.append("run missing flagged/fault_rows count")
+    flagged = int(run.get("flagged") or run.get("fault_rows") or 0)
+    if flagged > 0:
+        names = run.get("equipment_names") or []
+        eq_name = str(run.get("equipment_name") or "").strip()
+        if not names and not eq_name:
+            errors.append("run missing equipment_names for flagged row")
     return errors

--- a/workspace/api/openfdd_bridge/fdd_equipment.py
+++ b/workspace/api/openfdd_bridge/fdd_equipment.py
@@ -80,10 +80,23 @@ def enrich_fdd_run_with_equipment(
         eid = str((col_map.get(str(col)) or {}).get("equipment_id") or "").strip()
         if eid and eid not in ids:
             ids.append(eid)
+    if not names and ids:
+        eq_index = _equipment_index(model, site_id)
+        for eid in ids:
+            eq = eq_index.get(eid) or {}
+            label = str(eq.get("name") or eid).strip()
+            if label and label not in names:
+                names.append(label)
+    if not names:
+        fc = str(run.get("fault_code") or "").strip()
+        if fc and (fc.upper().startswith(("AHU", "VAV", "RTU", "BLD"))):
+            names = [fc]
     if names:
         run = {**run, "equipment_names": names}
     if ids:
         run = {**run, "equipment_id": ids[0], "equipment_ids": ids}
         if len(ids) == 1:
             run.setdefault("equipment_name", names[0] if names else None)
+    elif names:
+        run = {**run, "equipment_name": names[0]}
     return run

--- a/workspace/api/openfdd_bridge/fdd_results.py
+++ b/workspace/api/openfdd_bridge/fdd_results.py
@@ -77,7 +77,16 @@ def load_results() -> dict[str, Any]:
 
 
 def save_results(runs: list[dict[str, Any]]) -> dict[str, Any]:
-    doc = {"version": 1, "generated_at": _now(), "runs": runs}
+    from .fdd_equipment import enrich_fdd_run_with_equipment
+
+    model = _model_for_fdd()
+    enriched: list[dict[str, Any]] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        site_id = str(run.get("site_id") or "").strip()
+        enriched.append(enrich_fdd_run_with_equipment(dict(run), model, site_id))
+    doc = {"version": 1, "generated_at": _now(), "runs": enriched}
     path = fdd_results_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(doc, indent=2)


### PR DESCRIPTION
## Summary
- RTU normalized role mapping for `acme-vm-bbartling-rtu-01` (closes #284)
- Persist `equipment_names` on FDD batch runs (closes #283)
- Bump package version to **3.0.34** for ACME deploy

## Changes
- `acme_fdd_audit.py`: separate RTU reports, `brick_tag` matching, optional RTU roles
- `fdd_equipment.py` / `fdd_results.py`: enrich runs at save time with fault-code fallback
- Tests: RTU regression on GL36 model, FDD run equipment persistence

## Safety
Read-only validation only; no BACnet writes.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v3.0.34

* **New Features**
  * Equipment names are now automatically derived from fault codes when historian data is unavailable
  * RTU role auditing now includes RTU-specific role support with optional role handling

* **Bug Fixes**
  * Improved equipment information completeness in FDD run results through model-based backfilling

* **Tests**
  * Added test coverage for RTU role auditing and equipment enrichment workflows

* **Chores**
  * Version updated to 3.0.34

<!-- end of auto-generated comment: release notes by coderabbit.ai -->