### PR TITLE
fix(docs): repair broken GitHub Pages internal links

### DIFF
--- a/docs/DOCUMENTATION_CHECKLIST.md
+++ b/docs/DOCUMENTATION_CHECKLIST.md
@@ -8,6 +8,8 @@ nav_exclude: true
 Run before merging docs PRs:
 
 - [ ] `cd docs && bundle exec jekyll build` succeeds
+- [ ] `python3 scripts/check_docs_internal_links.py --site _site` passes (catches missing `/open-fdd/` on body links)
+- [ ] Internal doc links use `{{ "/path/" | relative_url }}` — not bare `{% link %}` (no baseurl on GitHub Pages project sites)
 - [ ] No broken `parent:` titles (must match parent page `title` exactly)
 - [ ] `rg -i 'acme|bensserver' docs --glob '*.md' | grep -v docs_cleanup_plan | grep -v DOCUMENTATION_CHECKLIST | grep -v '^docs/examples/'` is empty (Acme names allowed under `docs/examples/` only)
 - [ ] GHCR commands use real image names (`ghcr.io/bbartling/openfdd-*`)

--- a/docs/DOCUMENTATION_CHECKLIST.md
+++ b/docs/DOCUMENTATION_CHECKLIST.md
@@ -9,7 +9,7 @@ Run before merging docs PRs:
 
 - [ ] `cd docs && bundle exec jekyll build` succeeds
 - [ ] `python3 scripts/check_docs_internal_links.py --site _site` passes (catches missing `/open-fdd/` on body links)
-- [ ] Internal doc links use `{{ "/path/" | relative_url }}` — not bare `{% link %}` (no baseurl on GitHub Pages project sites)
+- [ ] Internal doc links use `{{ "/path/" | relative_url }}` — not bare {% raw %}`{% link %}`{% endraw %} (no baseurl on GitHub Pages project sites)
 - [ ] No broken `parent:` titles (must match parent page `title` exactly)
 - [ ] `rg -i 'acme|bensserver' docs --glob '*.md' | grep -v docs_cleanup_plan | grep -v DOCUMENTATION_CHECKLIST | grep -v '^docs/examples/'` is empty (Acme names allowed under `docs/examples/` only)
 - [ ] GHCR commands use real image names (`ghcr.io/bbartling/openfdd-*`)

--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -7,6 +7,6 @@ has_children: true
 
 # AI agents and MCP
 
-- [MCP server]({% link ai/mcp-server.md %}) — FastMCP tools over the operator bridge
+- [MCP server]({{ "/ai/mcp-server/" | relative_url }}) — FastMCP tools over the operator bridge
 - Skills under `skills/openfdd-*-agent/` and `skills/openfdd-mcp-server/`
 - Operator memory: `workspace/MEMORY.md` (see `workspace/MEMORY.md.example`)

--- a/docs/appendix/bridge_api.md
+++ b/docs/appendix/bridge_api.md
@@ -10,7 +10,7 @@ REST API served by **`openfdd-bridge`** (default `http://127.0.0.1:8765`). Produ
 
 **OpenAPI:** `GET /docs` and `GET /redoc` when the bridge runs.
 
-**Auth:** JWT via `POST /api/auth/login`. Most routes require `Authorization: Bearer <token>`. Roles: `viewer`, `operator`, `integrator`, `commission`, `agent`, `admin`. BACnet writes require commission role + [write safety]({% link bacnet/write-safety.md %}). Dev: `OFDD_AUTH_DISABLED` on loopback only.
+**Auth:** JWT via `POST /api/auth/login`. Most routes require `Authorization: Bearer <token>`. Roles: `viewer`, `operator`, `integrator`, `commission`, `agent`, `admin`. BACnet writes require commission role + [write safety]({{ "/bacnet/write-safety/" | relative_url }}). Dev: `OFDD_AUTH_DISABLED` on loopback only.
 
 **WebSocket:** `WS /ws/dashboard` — `POST /api/auth/ws-ticket`, then pass the ticket via `Sec-WebSocket-Protocol: ofdd.ws, <ticket>`. Query `?ticket=` is dev-only when `OFDD_WS_ALLOW_QUERY_TICKET=1`. Tickets are short-lived and not interchangeable with the Bearer token.
 
@@ -105,7 +105,7 @@ REST API served by **`openfdd-bridge`** (default `http://127.0.0.1:8765`). Produ
 | GET | `/api/bacnet/poll/status` | read | Poll worker status |
 | POST | `/ingest/bacnet` | read | Ingest samples into feather |
 
-Bind address: `BACNET_BIND` in commission env — see [BACnet network setup]({% link bacnet/network-setup.md %}). Operator guide: [Discover and read]({% link bacnet/discover-read.md %}).
+Bind address: `BACNET_BIND` in commission env — see [BACnet network setup]({{ "/bacnet/network-setup/" | relative_url }}). Operator guide: [Discover and read]({{ "/bacnet/discover-read/" | relative_url }}).
 
 | PATCH | `/api/bacnet/driver/point` | commission | Enable poll + interval on point |
 | PATCH | `/api/bacnet/driver/device` | commission | Enable poll for all points on device |
@@ -164,7 +164,7 @@ Prefix **`/openfdd-agent`**. Role **`agent`** for tool execution.
 | GET | `/openfdd-agent/zone-temps` | Zone temperature insight |
 | POST | `/openfdd-agent/chat` | Chat completion (catalog-bound) |
 
-Optional host Ollama for building insight — not required for core FDD. Configure via compose profile or host service; see [Architecture overview]({% link architecture/overview.md %}).
+Optional host Ollama for building insight — not required for core FDD. Configure via compose profile or host service; see [Architecture overview]({{ "/architecture/overview/" | relative_url }}).
 
 ---
 
@@ -180,7 +180,7 @@ Optional host Ollama for building insight — not required for core FDD. Configu
 | POST | `/api/modbus/refresh` | operator+ | Re-read one register |
 | PATCH | `/api/modbus/register/poll` | integrator+ | Enable poll interval |
 
-See [Driver framework]({% link drivers/index.md %}).
+See [Driver framework]({{ "/drivers/" | relative_url }}).
 
 ---
 
@@ -199,16 +199,16 @@ See [Driver framework]({% link drivers/index.md %}).
 | PATCH | `/api/json-api/endpoint/poll` | integrator+ | Enable poll interval |
 | DELETE | `/api/json-api/endpoint/{point_id}` | integrator+ | Remove endpoint |
 
-**Outbound auth:** `auth_type` = `none` \| `bearer` \| `basic`; optional `verify_tls` (default true). See [JSON API driver]({% link drivers/json-api.md %}).
+**Outbound auth:** `auth_type` = `none` \| `bearer` \| `basic`; optional `verify_tls` (default true). See [JSON API driver]({{ "/drivers/json-api/" | relative_url }}).
 
 ---
 
 ## PyPI package (separate)
 
-Library-only HTTP is **not** bundled. See [Python package]({% link appendix/python-package.md %}) for `open_fdd.arrow_runtime` (Arrow rules offline).
+Library-only HTTP is **not** bundled. See [Python package]({{ "/appendix/python-package/" | relative_url }}) for `open_fdd.arrow_runtime` (Arrow rules offline).
 
 ---
 
 ## Errors
 
-JSON error bodies; stack traces hidden unless `OFDD_DEBUG_TRACEBACKS=1`. See [LAN hardening]({% link security/lan-hardening.md %}).
+JSON error bodies; stack traces hidden unless `OFDD_DEBUG_TRACEBACKS=1`. See [LAN hardening]({{ "/security/lan-hardening/" | relative_url }}).

--- a/docs/appendix/index.md
+++ b/docs/appendix/index.md
@@ -10,8 +10,8 @@ Reference material for integrators and library users.
 
 | Page | Content |
 |------|---------|
-| [API routes]({% link appendix/bridge_api.md %}) | Operator Bridge REST/WebSocket |
-| [Python package]({% link appendix/python-package.md %}) | PyPI `open-fdd` |
-| [Configuration reference]({% link appendix/configuration.md %}) | Key env variables |
-| [Workspace env files]({% link appendix/workspace-env-files.md %}) | `workspace/*.env.local` inventory |
-| [Glossary]({% link appendix/glossary.md %}) | Terms |
+| [API routes]({{ "/appendix/bridge_api/" | relative_url }}) | Operator Bridge REST/WebSocket |
+| [Python package]({{ "/appendix/python-package/" | relative_url }}) | PyPI `open-fdd` |
+| [Configuration reference]({{ "/appendix/configuration/" | relative_url }}) | Key env variables |
+| [Workspace env files]({{ "/appendix/workspace-env-files/" | relative_url }}) | `workspace/*.env.local` inventory |
+| [Glossary]({{ "/appendix/glossary/" | relative_url }}) | Terms |

--- a/docs/appendix/python-package.md
+++ b/docs/appendix/python-package.md
@@ -33,7 +33,7 @@ Retired in 3.0.1+: `open_fdd.engine` (YAML/pandas `RuleRunner`) is **not** shipp
 
 ## Versioning
 
-Publish: git tag `vX.Y.Z` (or legacy `open-fdd-vX.Y.Z`) → GitHub Actions **Publish open-fdd to PyPI**. See [Release process]({% link developer/release-process.md %}).
+Publish: git tag `vX.Y.Z` (or legacy `open-fdd-vX.Y.Z`) → GitHub Actions **Publish open-fdd to PyPI**. See [Release process]({{ "/developer/release-process/" | relative_url }}).
 
 ```python
 import open_fdd
@@ -58,4 +58,4 @@ result = run_arrow_rule(code, table, {"high": 85})
 print(result.flagged_count)
 ```
 
-API surface: `open_fdd/arrow_runtime` docstrings and [Arrow recipes]({% link rule-cookbook/arrow-recipes.md %}).
+API surface: `open_fdd/arrow_runtime` docstrings and [Arrow recipes]({{ "/rule-cookbook/arrow-recipes/" | relative_url }}).

--- a/docs/appendix/workspace-env-files.md
+++ b/docs/appendix/workspace-env-files.md
@@ -13,7 +13,7 @@ All live under `workspace/`. Copy from `*.example` templates; committed `*.local
 | `auth.env.local` | `run_local.sh`, Docker compose, Ansible | JWT secret (`OFDD_AUTH_SECRET`), integrator/operator/agent passwords, `OFDD_AUTH_DISABLED` for localhost dev only |
 | `data.env.local` | `run_local.sh`, bridge, feather maintain | Feather historian caps (`OFDD_FEATHER_*`), audit/error log rotation (`OFDD_LOG_*`), BACnet discovery mutation toggle |
 | `json_api.env.local` | bridge, Ansible edge sync | API keys for JSON API driver `${ENV:VAR}` substitution (e.g. `OPENWEATHER_API_KEY`) |
-| `ollama.env.local` | `run_local.sh`, bridge | Ollama base URL, model name, RAM tier, GPU mode, timeouts — see [Ollama and analytics]({% link operator-bridge/ollama-analytics.md %}) |
+| `ollama.env.local` | `run_local.sh`, bridge | Ollama base URL, model name, RAM tier, GPU mode, timeouts — see [Ollama and analytics]({{ "/operator-bridge/ollama-analytics/" | relative_url }}) |
 | `mcp.env.local` | `run_local.sh`, MCP sidecar | Enable MCP RAG REST (`OFDD_MCP_*`), index path |
 | `caddy.env.local` | `run_local.sh`, Ansible edge | Reverse proxy mode (`http` / `tls` / `off`), TLS CN, port overrides |
 | `pentest.env.local` | `pentest_production_stack.sh` | Production-like LAN scan stack: CORS, auth, passive BACnet defaults |
@@ -26,7 +26,7 @@ All live under `workspace/`. Copy from `*.example` templates; committed `*.local
 
 ## Related docs
 
-- [Secrets and auth]({% link security/secrets-auth.md %}) — required production variables
-- [Logging and audit]({% link ops/logging.md %}) — `OFDD_LOG_*` detail
-- [JSON API driver]({% link drivers/json-api.md %}) — `${ENV:VAR}` pattern
-- [Configuration reference]({% link appendix/configuration.md %}) — bridge runtime flags not in env files
+- [Secrets and auth]({{ "/security/secrets-auth/" | relative_url }}) — required production variables
+- [Logging and audit]({{ "/ops/logging/" | relative_url }}) — `OFDD_LOG_*` detail
+- [JSON API driver]({{ "/drivers/json-api/" | relative_url }}) — `${ENV:VAR}` pattern
+- [Configuration reference]({{ "/appendix/configuration/" | relative_url }}) — bridge runtime flags not in env files

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -77,7 +77,7 @@ cd ~/open-fdd && docker compose ps
 
 If containers are down: `docker compose up -d` (idempotent).
 
-See [Run with Docker images]({% link quick-start/docker.md %}).
+See [Run with Docker images]({{ "/quick-start/docker/" | relative_url }}).
 
 ## Persistent data
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -38,7 +38,7 @@ OT REST / weather API → bridge JSON API worker → samples.csv → feather_sto
                                                       ↘ merged into FDD frame with bacnet/modbus
 ```
 
-Showcase: [OpenWeatherMap bundle]({% link drivers/json-api.md %}#openweathermap-showcase-recommended-demo). Details: [Driver framework]({% link drivers/index.md %}), [BACnet polling]({% link bacnet/polling.md %}), [JSON API driver]({% link drivers/json-api.md %}), [Containers]({% link architecture/containers.md %}).
+Showcase: [OpenWeatherMap bundle]({{ "/drivers/json-api/" | relative_url }}#openweathermap-showcase-recommended-demo). Details: [Driver framework]({{ "/drivers/" | relative_url }}), [BACnet polling]({{ "/bacnet/polling/" | relative_url }}), [JSON API driver]({{ "/drivers/json-api/" | relative_url }}), [Containers]({{ "/architecture/containers/" | relative_url }}).
 
 ## Rule evaluation
 
@@ -54,4 +54,4 @@ Showcase: [OpenWeatherMap bundle]({% link drivers/json-api.md %}#openweathermap-
 
 ## Retention
 
-Feather files grow on disk; retention is configurable (`workspace/data.env.local`). Image upgrades must **preserve** `workspace/data/` — backup before `docker compose up -d --force-recreate`. See [Updating the stack]({% link quick-start/updating.md %}).
+Feather files grow on disk; retention is configurable (`workspace/data.env.local`). Image upgrades must **preserve** `workspace/data/` — backup before `docker compose up -d --force-recreate`. See [Updating the stack]({{ "/quick-start/updating/" | relative_url }}).

--- a/docs/architecture/deployment-modes.md
+++ b/docs/architecture/deployment-modes.md
@@ -27,7 +27,7 @@ How Open-FDD is typically run: local development, lab LAN trials, and production
 {: .note }
 > **`openfdd-bacnet-poll` is retired.** BACnet polling runs inside **commission** only. Do not run the legacy poll container or `openfdd-bacnet-poll` systemd unit alongside Docker commission — that double-polls the OT network.
 
-See [Containers]({% link architecture/containers.md %}) for ports, networks, and persistence.
+See [Containers]({{ "/architecture/containers/" | relative_url }}) for ports, networks, and persistence.
 
 ## Caddy HTTP (typical edge)
 
@@ -35,7 +35,7 @@ See [Containers]({% link architecture/containers.md %}) for ports, networks, and
 - Reverse-proxies to bridge at `127.0.0.1:8765`
 - Bridge stays loopback-only; operators bookmark `http://<edge-ip>/`
 
-Bootstrap and compose: [Quick Start — Docker]({% link quick-start/docker.md %}).
+Bootstrap and compose: [Quick Start — Docker]({{ "/quick-start/docker/" | relative_url }}).
 
 ## Caddy TLS (OT LAN)
 
@@ -45,7 +45,7 @@ For HTTPS on the edge LAN (self-signed or site CA):
 2. Start with `OFDD_CADDY_MODE=tls`
 3. Trust the CA on operator PCs
 
-Details: [TLS and certificates]({% link security/tls-and-certs.md %}). Security headers are set by the **Operator Bridge**; Caddy adds **HSTS** only in TLS mode.
+Details: [TLS and certificates]({{ "/security/tls-and-certs/" | relative_url }}). Security headers are set by the **Operator Bridge**; Caddy adds **HSTS** only in TLS mode.
 
 ## BACnet data path
 
@@ -68,7 +68,7 @@ The bridge thread named `bacnet_poll_worker` is **ingest only** — it does not 
 
 | Topic | Page |
 |-------|------|
-| First deploy | [Quick Start — Docker]({% link quick-start/docker.md %}) |
-| Upgrade | [Updating the stack]({% link quick-start/updating.md %}) |
-| LAN security | [LAN hardening]({% link security/lan-hardening.md %}) |
-| Lab example site | [Examples — GL36 lab note]({% link examples/acme-gl36-lab.md %}) |
+| First deploy | [Quick Start — Docker]({{ "/quick-start/docker/" | relative_url }}) |
+| Upgrade | [Updating the stack]({{ "/quick-start/updating/" | relative_url }}) |
+| LAN security | [LAN hardening]({{ "/security/lan-hardening/" | relative_url }}) |
+| Lab example site | [Examples — GL36 lab note]({{ "/examples/acme-gl36-lab/" | relative_url }}) |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -10,12 +10,12 @@ Open-FDD v3 edge: **three Docker containers** (`bridge`, `commission`, `mcp-rag`
 
 | Page | Topic |
 |------|-------|
-| [System overview]({% link architecture/overview.md %}) | Components and diagram |
-| [Deployment modes]({% link architecture/deployment-modes.md %}) | Local dev, lab LAN, edge production, Caddy HTTP/TLS |
-| [Data flow]({% link architecture/data-flow.md %}) | BACnet / Modbus / JSON API → feather → FDD → dashboard |
-| [Containers]({% link architecture/containers.md %}) | GHCR images, ports, persistence, retired poll image |
-| [Driver framework]({% link drivers/index.md %}) | Shared commissioning pattern for OT sources |
+| [System overview]({{ "/architecture/overview/" | relative_url }}) | Components and diagram |
+| [Deployment modes]({{ "/architecture/deployment-modes/" | relative_url }}) | Local dev, lab LAN, edge production, Caddy HTTP/TLS |
+| [Data flow]({{ "/architecture/data-flow/" | relative_url }}) | BACnet / Modbus / JSON API → feather → FDD → dashboard |
+| [Containers]({{ "/architecture/containers/" | relative_url }}) | GHCR images, ports, persistence, retired poll image |
+| [Driver framework]({{ "/drivers/" | relative_url }}) | Shared commissioning pattern for OT sources |
 
-**Operators:** [Quick Start — Docker]({% link quick-start/docker.md %}) — no git clone on the edge host.
+**Operators:** [Quick Start — Docker]({{ "/quick-start/docker/" | relative_url }}) — no git clone on the edge host.
 
-**BACnet polling:** [Polling]({% link bacnet/polling.md %}) — commission container only.
+**BACnet polling:** [Polling]({{ "/bacnet/polling/" | relative_url }}) — commission container only.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -28,7 +28,7 @@ nav_order: 1
 
 ## Docker edge stack (production)
 
-Three GHCR images — see [Containers]({% link architecture/containers.md %}):
+Three GHCR images — see [Containers]({{ "/architecture/containers/" | relative_url }}):
 
 | Container | BACnet OT | Operator LAN |
 |-----------|-----------|--------------|
@@ -53,8 +53,8 @@ BACnet **polling** is not a separate container — it runs inside **commission**
 
 ## Deployment
 
-IT operators: [Quick Start — Docker]({% link quick-start/docker.md %}). Modes and Caddy: [Deployment modes]({% link architecture/deployment-modes.md %}).
+IT operators: [Quick Start — Docker]({{ "/quick-start/docker/" | relative_url }}). Modes and Caddy: [Deployment modes]({{ "/architecture/deployment-modes/" | relative_url }}).
 
 ## Optional PyPI-only path
 
-`pip install open-fdd` ships Arrow runtime + playground lint helpers **without** the Operator Bridge UI. Use for offline rule tests or CI. See [Appendix — Python package]({% link appendix/python-package.md %}).
+`pip install open-fdd` ships Arrow runtime + playground lint helpers **without** the Operator Bridge UI. Use for offline rule tests or CI. See [Appendix — Python package]({{ "/appendix/python-package/" | relative_url }}).

--- a/docs/bacnet/discover-read.md
+++ b/docs/bacnet/discover-read.md
@@ -13,13 +13,13 @@ The **commission** container exposes HTTP APIs for discovery and read-property w
 | Who-Is / I-Am | Device discovery on OT subnet |
 | Read property | Present value, object name, units |
 | RPM | Bulk reads for inventory export |
-| Write property | **Gated** — see [Write safety]({% link bacnet/write-safety.md %}) |
+| Write property | **Gated** — see [Write safety]({{ "/bacnet/write-safety/" | relative_url }}) |
 
 Exported inventory feeds `points_discovered.csv` and the Brick point registry.
 
 ## Operator workflow
 
-1. Confirm [network setup]({% link bacnet/network-setup.md %}).
+1. Confirm [network setup]({{ "/bacnet/network-setup/" | relative_url }}).
 2. Run discover from dashboard or API.
 3. Review discovered objects; enable points for poll profiles.
 4. Sync model bindings for FDD inputs.

--- a/docs/bacnet/index.md
+++ b/docs/bacnet/index.md
@@ -10,8 +10,8 @@ Open-FDD integrates with field controllers via BACnet/IP (and bench MSTP overlay
 
 | Page | Topic |
 |------|-------|
-| [Network setup]({% link bacnet/network-setup.md %}) | Bind address and NIC |
-| [Discover and read]({% link bacnet/discover-read.md %}) | Commission agent |
-| [Polling]({% link bacnet/polling.md %}) | Historian driver |
-| [Operator override scans]({% link bacnet/override-scans.md %}) | Hourly P8 supervisory rotation |
-| [Write safety]({% link bacnet/write-safety.md %}) | Defaults and allowlists |
+| [Network setup]({{ "/bacnet/network-setup/" | relative_url }}) | Bind address and NIC |
+| [Discover and read]({{ "/bacnet/discover-read/" | relative_url }}) | Commission agent |
+| [Polling]({{ "/bacnet/polling/" | relative_url }}) | Historian driver |
+| [Operator override scans]({{ "/bacnet/override-scans/" | relative_url }}) | Hourly P8 supervisory rotation |
+| [Write safety]({{ "/bacnet/write-safety/" | relative_url }}) | Defaults and allowlists |

--- a/docs/bacnet/override-scans.md
+++ b/docs/bacnet/override-scans.md
@@ -58,4 +58,4 @@ Expect `device_count` > 0, `last_scan_at` within the last few hours on a healthy
 | `workspace/bacnet/overrides/registry.json` | Per-device last scan + override points |
 | `workspace/bacnet/overrides/overrides_export.csv` | Flat export for spreadsheets |
 
-Preserved across Docker upgrades when `workspace/` is on the edge volume — see [Backup & restore]({% link ops/backup-restore.md %}).
+Preserved across Docker upgrades when `workspace/` is on the edge volume — see [Backup & restore]({{ "/ops/backup-restore/" | relative_url }}).

--- a/docs/bacnet/polling.md
+++ b/docs/bacnet/polling.md
@@ -42,7 +42,7 @@ Inside **bridge**, a background thread watches `samples.csv` and ingests new row
 
 Dashboard stack health (`GET /health/stack`) reports `bacnet_poll` status from the commission agent — not a separate container.
 
-Stale points trigger data-quality fault patterns — see [Sensor quality faults]({% link fault-codes/sensor-quality.md %}).
+Stale points trigger data-quality fault patterns — see [Sensor quality faults]({{ "/fault-codes/sensor-quality/" | relative_url }}).
 
 ## Poll strategy (edge)
 
@@ -66,11 +66,11 @@ Acme ships **FDD-minimal polling** (~76 points on a typical GL36 lab when 8 rule
 | RPM batching | Present-value reads chunked (25 objects) to cut APDUs |
 | Poll loop | Sequential per-device RPM when `interruptible=True` so operator UI can preempt |
 | Operator UI | **INTERACTIVE** priority — cancels in-flight background work |
-| Override scans | **BACKGROUND**, 15 min timeout — see [Operator override scans]({% link bacnet/override-scans.md %}) |
+| Override scans | **BACKGROUND**, 15 min timeout — see [Operator override scans]({{ "/bacnet/override-scans/" | relative_url }}) |
 | Bridge ingest | Async notify after each poll cycle → feather historian |
 
-Do **not** run a second BACnet bind on 47808 (no parallel `openfdd-bacnet-poll` container). See [Containers]({% link architecture/containers.md %}).
+Do **not** run a second BACnet bind on 47808 (no parallel `openfdd-bacnet-poll` container). See [Containers]({{ "/architecture/containers/" | relative_url }}).
 
 ## Operator override scans
 
-Hourly P8 supervisory scans rotate one device at a time. Documented in [Operator override scans]({% link bacnet/override-scans.md %}).
+Hourly P8 supervisory scans rotate one device at a time. Documented in [Operator override scans]({{ "/bacnet/override-scans/" | relative_url }}).

--- a/docs/bacnet/write-safety.md
+++ b/docs/bacnet/write-safety.md
@@ -19,7 +19,7 @@ nav_order: 4
 
 ## Enable writes (commission role)
 
-1. Set env flag documented in [Security]({% link security/index.md %}) (`OFDD_BACNET_WRITE_ENABLED` or site equivalent).
+1. Set env flag documented in [Security]({{ "/security/" | relative_url }}) (`OFDD_BACNET_WRITE_ENABLED` or site equivalent).
 2. Populate write allowlist CSV / config with explicit object IDs.
 3. Use **commission** role JWT; every write should include reason/note where API supports it.
 4. Test on bench hardware before production OT.

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -36,7 +36,7 @@ nav_order: 4
 
 The site is a **project page** at `https://bbartling.github.io/open-fdd/` (`baseurl: /open-fdd` in `docs/_config.yml`).
 
-- **Do not** use Jekyll `{% link path.md %}` in Markdown body text — it omits `baseurl` and 404s on GitHub Pages.
+- **Do not** use {% raw %}`{% link path.md %}`{% endraw %} in Markdown body text — it omits `baseurl` and 404s on GitHub Pages.
 - **Do** use `[label]({{ "/section/page/" | relative_url }})` for internal links.
 - After `bundle exec jekyll build`, run `python3 scripts/check_docs_internal_links.py --site _site` from the repo root.
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -19,7 +19,7 @@ nav_order: 4
 - [ ] Docs updated if user-facing behavior changed
 - [ ] `docs/` Jekyll build succeeds
 - [ ] No credentials in diff
-- [ ] Auth/Caddy/header changes: re-run [pentest verify + LAN ZAP]({% link developer/security-testing.md %}) and update [ZAP baseline]({% link security/zap-baseline.md %}) if expectations changed
+- [ ] Auth/Caddy/header changes: re-run [pentest verify + LAN ZAP]({{ "/developer/security-testing/" | relative_url }}) and update [ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}) if expectations changed
 
 ## Repository layout (short)
 
@@ -31,6 +31,14 @@ nav_order: 4
 | `docker/` | Compose files and image contexts |
 | `infra/ansible/` | Edge deploy playbooks |
 | `docs/` | This site (Jekyll + Just the Docs) |
+
+## Docs links (GitHub Pages)
+
+The site is a **project page** at `https://bbartling.github.io/open-fdd/` (`baseurl: /open-fdd` in `docs/_config.yml`).
+
+- **Do not** use Jekyll `{% link path.md %}` in Markdown body text — it omits `baseurl` and 404s on GitHub Pages.
+- **Do** use `[label]({{ "/section/page/" | relative_url }})` for internal links.
+- After `bundle exec jekyll build`, run `python3 scripts/check_docs_internal_links.py --site _site` from the repo root.
 
 ## Security issues
 

--- a/docs/developer/health-check.md
+++ b/docs/developer/health-check.md
@@ -8,7 +8,7 @@ nav_order: 5
 
 Extended validation for engineers with a **full git checkout** — CI, compose overlays, and pre-release gates.
 
-IT operators on edge hosts should use [Quick Start — health check]({% link quick-start/health-check.md %}) and [Deployment validation]({% link ops/deployment-validation.md %}) instead.
+IT operators on edge hosts should use [Quick Start — health check]({{ "/quick-start/health-check/" | relative_url }}) and [Deployment validation]({{ "/ops/deployment-validation/" | relative_url }}) instead.
 
 ## Clone and local stack
 
@@ -76,7 +76,7 @@ Then from a **LAN workstation**, run the packaged scan:
 - Windows: `scripts/security/Run-OpenFddSecurityScan.ps1`
 - macOS/Linux: `scripts/security/run_openfdd_security_scan.sh`
 
-See [scripts/security/README.md](https://github.com/bbartling/open-fdd/blob/master/scripts/security/README.md), [Security — ZAP baseline]({% link security/zap-baseline.md %}), and the full [security testing cycle]({% link developer/security-testing.md %}). Host-side notes: `workspace/deploy/PENTEST.md`.
+See [scripts/security/README.md](https://github.com/bbartling/open-fdd/blob/master/scripts/security/README.md), [Security — ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}), and the full [security testing cycle]({{ "/developer/security-testing/" | relative_url }}). Host-side notes: `workspace/deploy/PENTEST.md`.
 
 ## Post-deploy insurance (inventory hosts)
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -10,11 +10,11 @@ Clone, build, test, and contribute to Open-FDD.
 
 | Topic | Page |
 |-------|------|
-| Local setup | [Local development]({% link developer/local-setup.md %}) |
-| Docker builds | [Build Docker images]({% link developer/docker-build.md %}) |
-| Health checks | [Health checks (developer)]({% link developer/health-check.md %}) |
-| Tests & CI | [Tests and CI]({% link developer/tests-ci.md %}) |
-| Security testing | [Release & LAN scan cycle]({% link developer/security-testing.md %}) |
-| PRs | [Contributing]({% link developer/contributing.md %}) |
+| Local setup | [Local development]({{ "/developer/local-setup/" | relative_url }}) |
+| Docker builds | [Build Docker images]({{ "/developer/docker-build/" | relative_url }}) |
+| Health checks | [Health checks (developer)]({{ "/developer/health-check/" | relative_url }}) |
+| Tests & CI | [Tests and CI]({{ "/developer/tests-ci/" | relative_url }}) |
+| Security testing | [Release & LAN scan cycle]({{ "/developer/security-testing/" | relative_url }}) |
+| PRs | [Contributing]({{ "/developer/contributing/" | relative_url }}) |
 
 AI-assisted contributors: see repository `AGENTS.md` for workspace layout, skill routing, and agent policy (one paragraph in public docs; details stay internal).

--- a/docs/developer/local-setup.md
+++ b/docs/developer/local-setup.md
@@ -48,7 +48,7 @@ Same shape as an Acme edge deploy: **prod React UI**, **Caddy on :80**, bridge o
 
 Credentials: `workspace/auth.pentest.local` (generated on first start). ZAP target is usually `http://<lan-ip>/` (benserver example: `http://192.168.204.18/`). If LAN clients cannot reach :80, run `sudo ./scripts/open_lan_port.sh 80`.
 
-See also [Health checks (developer)]({% link developer/health-check.md %}) for probe details and [ZAP baseline expectations]({% link security/zap-baseline.md %}) for accepted Medium/Low findings.
+See also [Health checks (developer)]({{ "/developer/health-check/" | relative_url }}) for probe details and [ZAP baseline expectations]({{ "/security/zap-baseline/" | relative_url }}) for accepted Medium/Low findings.
 
 ## Docs preview
 

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -69,4 +69,4 @@ docker manifest inspect ghcr.io/bbartling/openfdd-bridge:3.0.30
 
 ## Package vs Docker
 
-See [PyPI package](pypi-package.md) and [Docker images](../ops/docker-images.md).
+See [PyPI package]({{ "/developer/pypi-package/" | relative_url }}) and [Docker images]({{ "/ops/docker-images/" | relative_url }}).

--- a/docs/developer/security-testing.md
+++ b/docs/developer/security-testing.md
@@ -8,7 +8,7 @@ nav_order: 6
 
 How Open-FDD validates each **patch revision** before it ships to the live Acme HVAC bench — local automation, AI-assisted PR review, LAN passive scans, and edge post-deploy checks.
 
-Related security docs: [ZAP baseline]({% link security/zap-baseline.md %}), [TLS and certificates]({% link security/tls-and-certs.md %}), [LAN hardening]({% link security/lan-hardening.md %}), [Linux host hardening]({% link security/linux-host-hardening.md %}), [Tenable remediation]({% link security/tenable-remediation.md %}), [Authenticated scanning (roadmap)]({% link security/authenticated-scanning.md %}).
+Related security docs: [ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}), [TLS and certificates]({{ "/security/tls-and-certs/" | relative_url }}), [LAN hardening]({{ "/security/lan-hardening/" | relative_url }}), [Linux host hardening]({{ "/security/linux-host-hardening/" | relative_url }}), [Tenable remediation]({{ "/security/tenable-remediation/" | relative_url }}), [Authenticated scanning (roadmap)]({{ "/security/authenticated-scanning/" | relative_url }}).
 
 ## Who owns what
 
@@ -20,7 +20,7 @@ Related security docs: [ZAP baseline]({% link security/zap-baseline.md %}), [TLS
 | Pentest credentials | Generated per stack | `workspace/auth.pentest.local` (never commit) |
 | LAN ZAP + Nmap scans | **Developer workstation** on test LAN | `scripts/security/` |
 
-See [TLS and certificate ownership]({% link security/tls-and-certs.md %}) for cert lifecycle.
+See [TLS and certificate ownership]({{ "/security/tls-and-certs/" | relative_url }}) for cert lifecycle.
 
 ## Per-revision workflow
 
@@ -53,7 +53,7 @@ infra/ansible/scripts/bench_5007_arrow_battery.sh   # when FDD/Arrow paths chang
 ./scripts/pentest_production_stack.sh verify
 ```
 
-Confirms Caddy `:80` fronts the bridge, auth is enabled, BACnet writes disabled, and security headers are singular (no Caddy duplicates). Details: [Health checks — pentest]({% link developer/health-check.md %}#pentest-production-stack-lan-zap).
+Confirms Caddy `:80` fronts the bridge, auth is enabled, BACnet writes disabled, and security headers are singular (no Caddy duplicates). Details: [Health checks — pentest]({{ "/developer/health-check/" | relative_url }}#pentest-production-stack-lan-zap).
 
 ### 3. Host + exposure checks (on edge VM)
 
@@ -79,7 +79,7 @@ Setup (Docker Desktop, Nmap): [scripts/security/README.md](https://github.com/bb
 
 Target URL is usually **`http://<lan-ip>/`** (Caddy), not `:8765`.
 
-Review `openfdd-security-report/90-quick-findings-summary.txt` and compare against [ZAP baseline expectations]({% link security/zap-baseline.md %}).
+Review `openfdd-security-report/90-quick-findings-summary.txt` and compare against [ZAP baseline expectations]({{ "/security/zap-baseline/" | relative_url }}).
 
 ### 5. Pull request + automated review
 
@@ -107,7 +107,7 @@ OPENFDD_IMAGE_TAG=latest ./scripts/upgrade_edge_full.sh --limit <inventory_host>
 infra/ansible/scripts/post_deploy_check.sh --limit <inventory_host> --full
 ```
 
-Re-run LAN ZAP + Nmap against the edge LAN IP if Caddy or auth behavior changed. Site-specific example: [GL36 lab note]({% link examples/acme-gl36-lab.md %}).
+Re-run LAN ZAP + Nmap against the edge LAN IP if Caddy or auth behavior changed. Site-specific example: [GL36 lab note]({{ "/examples/acme-gl36-lab/" | relative_url }}).
 
 ### 8. Next cycle
 
@@ -121,10 +121,10 @@ Bump patch version locally (`pyproject.toml`, `open_fdd/__init__.py`) on `master
 | Stack smoke | `pentest_production_stack.sh verify` | Live headers, health, auth file |
 | Passive web | ZAP baseline | Public routes, CSP, cookies, CORS |
 | Port exposure | Nmap scoped | One host, known service ports |
-| Authenticated API/dashboard | ZAP full + login | **Roadmap** — [Authenticated scanning]({% link security/authenticated-scanning.md %}) |
+| Authenticated API/dashboard | ZAP full + login | **Roadmap** — [Authenticated scanning]({{ "/security/authenticated-scanning/" | relative_url }}) |
 
 Baseline ZAP does **not** exercise integrator login or protected `/api/*` routes deeply.
 
 ## Open-source contributors
 
-The `scripts/security/` folder is part of the public repo so any fork can run the same LAN smoke against their bench. PRs that change Caddy, auth, or `security_headers.py` should update [ZAP baseline]({% link security/zap-baseline.md %}) and re-run the scan scripts.
+The `scripts/security/` folder is part of the public repo so any fork can run the same LAN smoke against their bench. PRs that change Caddy, auth, or `security_headers.py` should update [ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}) and re-run the scan scripts.

--- a/docs/developer/tests-ci.md
+++ b/docs/developer/tests-ci.md
@@ -33,4 +33,4 @@ Fix any template or link errors before opening a PR that touches `docs/`.
 
 ## Security-related CI
 
-`ci.yml` includes bridge security tests (`tests/workspace_bridge/test_security.py`). That complements — but does not replace — LAN [ZAP + Nmap scans]({% link security/zap-baseline.md %}) on each patch revision. See [Security testing cycle]({% link developer/security-testing.md %}).
+`ci.yml` includes bridge security tests (`tests/workspace_bridge/test_security.py`). That complements — but does not replace — LAN [ZAP + Nmap scans]({{ "/security/zap-baseline/" | relative_url }}) on each patch revision. See [Security testing cycle]({{ "/developer/security-testing/" | relative_url }}).

--- a/docs/drivers/index.md
+++ b/docs/drivers/index.md
@@ -12,9 +12,9 @@ Open-FDD edge commissioning uses a **shared driver pattern** for OT data sources
 
 | Driver | Protocol | Feather `source` | Commissioning tab |
 |--------|----------|------------------|-------------------|
-| [BACnet]({% link bacnet/index.md %}) | MS/TP / IP (`:47808`) | `bacnet` | BACnet |
+| [BACnet]({{ "/bacnet/" | relative_url }}) | MS/TP / IP (`:47808`) | `bacnet` | BACnet |
 | Modbus | Modbus TCP | `modbus` | Modbus |
-| [JSON API]({% link drivers/json-api.md %}) | HTTP/HTTPS REST (+ [OpenWeather showcase]({% link drivers/json-api.md %}#openweathermap-showcase-recommended-demo)) | `json_api` | JSON API |
+| [JSON API]({{ "/drivers/json-api/" | relative_url }}) | HTTP/HTTPS REST (+ [OpenWeather showcase]({{ "/drivers/json-api/" | relative_url }}#openweathermap-showcase-recommended-demo)) | `json_api` | JSON API |
 
 All three drivers share the same operator workflow:
 
@@ -44,7 +44,7 @@ workspace/
 
 - **Plot tab** — numeric columns from `bacnet` and `modbus` sources (`GET /api/timeseries/plot?source=…`).
 - **String JSON fields** — stored in feather under `json_api`; use the JSON API tree or feather directly (plot is numeric-only).
-- **FDD batch** — merges `bacnet` + `modbus` + `json_api` historian columns by nearest timestamp; rules use BRICK-bound `external_id` names (e.g. compare BACnet `oa-t` vs JSON API `web-oat-t` — see [JSON API]({% link drivers/json-api.md %})).
+- **FDD batch** — merges `bacnet` + `modbus` + `json_api` historian columns by nearest timestamp; rules use BRICK-bound `external_id` names (e.g. compare BACnet `oa-t` vs JSON API `web-oat-t` — see [JSON API]({{ "/drivers/json-api/" | relative_url }})).
 - **BRICK model** — bind points in **Model & assignments** commissioning JSON; sync TTL for SPARQL scope.
 
 ## Rule Lab (Arrow upload/download)
@@ -67,6 +67,6 @@ python3 scripts/validate_modbus_temp_e2e.py --no-server
 
 ## Related docs
 
-- [Data flow]({% link architecture/data-flow.md %}) — poll → CSV → feather → FDD
-- [API routes]({% link appendix/bridge_api.md %}) — REST reference
-- [BACnet polling]({% link bacnet/polling.md %}) — commission container loop
+- [Data flow]({{ "/architecture/data-flow/" | relative_url }}) — poll → CSV → feather → FDD
+- [API routes]({{ "/appendix/bridge_api/" | relative_url }}) — REST reference
+- [BACnet polling]({{ "/bacnet/polling/" | relative_url }}) — commission container loop

--- a/docs/drivers/json-api.md
+++ b/docs/drivers/json-api.md
@@ -199,7 +199,7 @@ Credentials in `endpoints.csv` are redacted in API responses (`***`). Prefer `${
 | PATCH | `/api/json-api/endpoint/poll` | integrator+ | Enable/disable poll interval |
 | DELETE | `/api/json-api/endpoint/{point_id}` | integrator+ | Remove endpoint |
 
-Full route list: [API routes]({% link appendix/bridge_api.md %}).
+Full route list: [API routes]({{ "/appendix/bridge_api/" | relative_url }}).
 
 ## Typical OT URLs
 
@@ -226,7 +226,7 @@ curl -X PATCH http://127.0.0.1:8765/api/json-api/endpoint/poll \
   -d '{"point_id":"ja-api-openweathermap-org-get-web-oat-t","enabled":false,"poll_interval_s":0}'
 ```
 
-API keys live in `json_api.env.local` (gitignored) — never committed; audit logs do not record expanded URLs with `appid=`. See [Logging and audit]({% link ops/logging.md %}).
+API keys live in `json_api.env.local` (gitignored) — never committed; audit logs do not record expanded URLs with `appid=`. See [Logging and audit]({{ "/ops/logging/" | relative_url }}).
 
 ## Smoke test
 

--- a/docs/edge_deploy_docker.md
+++ b/docs/edge_deploy_docker.md
@@ -9,7 +9,7 @@ This page has moved.
 
 | Task | Doc |
 |------|-----|
-| First deploy | [Quick Start — Run with Docker]({% link quick-start/docker.md %}) |
-| Upgrade | [Quick Start — Updating the stack]({% link quick-start/updating.md %}) |
-| Architecture | [Containers]({% link architecture/containers.md %}) |
-| Deployment modes | [Deployment modes]({% link architecture/deployment-modes.md %}) |
+| First deploy | [Quick Start — Run with Docker]({{ "/quick-start/docker/" | relative_url }}) |
+| Upgrade | [Quick Start — Updating the stack]({{ "/quick-start/updating/" | relative_url }}) |
+| Architecture | [Containers]({{ "/architecture/containers/" | relative_url }}) |
+| Deployment modes | [Deployment modes]({{ "/architecture/deployment-modes/" | relative_url }}) |

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -10,6 +10,6 @@ Site-specific commissioning notes, GL36 examples, and maintainer lab workflows. 
 
 | Page | Description |
 |------|-------------|
-| [GL36 lab site (Acme)]({% link examples/acme-gl36-lab.md %}) | Example real-building poll scope, Arrow rule stubs, Ansible deploy commands |
+| [GL36 lab site (Acme)]({{ "/examples/acme-gl36-lab/" | relative_url }}) | Example real-building poll scope, Arrow rule stubs, Ansible deploy commands |
 
-For production IT operators, start with [Quick Start]({% link quick-start/index.md %}) and [Operations]({% link ops/index.md %}).
+For production IT operators, start with [Quick Start]({{ "/quick-start/" | relative_url }}) and [Operations]({{ "/ops/" | relative_url }}).

--- a/docs/expression_rule_cookbook.md
+++ b/docs/expression_rule_cookbook.md
@@ -9,7 +9,7 @@ redirect_from:
 
 The pandas **`RuleRunner`** + YAML **`type: expression`** cookbook was removed in **Open-FDD 3.x**.
 
-**Current documentation:** [Expression cookbook (Arrow-native)]({% link rule-cookbook/expression-cookbook.md %})
+**Current documentation:** [Expression cookbook (Arrow-native)]({{ "/rule-cookbook/expression-cookbook/" | relative_url }})
 
 Edge rules are Python modules with:
 

--- a/docs/fault-codes/ahu.md
+++ b/docs/fault-codes/ahu.md
@@ -17,4 +17,4 @@ Air handling unit codes (sample from catalog).
 | **AHU-E** | Economizer not economizing | warning | Free cool available, OA minimum | Stuck damper, lockout | OA damper vs OAT trend |
 | **AHU-F** | Damper command vs feedback mismatch | warning | Cmd ≠ feedback | Stuck actuator, linkage | Compare cmd/feedback trends |
 
-**Example rule:** `flatline_1h` on SAT → tag **AHU-C**. Recipe: [Python recipes]({% link rule-cookbook/python-recipes.md %}).
+**Example rule:** `flatline_1h` on SAT → tag **AHU-C**. Recipe: [Python recipes]({{ "/rule-cookbook/python-recipes/" | relative_url }}).

--- a/docs/fault-codes/convention.md
+++ b/docs/fault-codes/convention.md
@@ -52,6 +52,6 @@ In Rule Lab, set `fault_code` on the rule metadata. Batch FDD aggregates hits in
 
 ## Cookbook mapping
 
-Each catalog entry lists `cookbook_patterns` (e.g. `flatline_1h`, `mixing_envelope`, `rate_of_change`) — see [Expression cookbook (Arrow-native)]({% link rule-cookbook/expression-cookbook.md %}).
+Each catalog entry lists `cookbook_patterns` (e.g. `flatline_1h`, `mixing_envelope`, `rate_of_change`) — see [Expression cookbook (Arrow-native)]({{ "/rule-cookbook/expression-cookbook/" | relative_url }}).
 
 Legacy pandas `type: expression` YAML rules are **not** used on the edge in 3.x; translate to `rules_py` Arrow modules and bind **`fault_code`** in Rule Lab.

--- a/docs/fault-codes/index.md
+++ b/docs/fault-codes/index.md
@@ -10,10 +10,10 @@ Open-FDD uses a **check-engine** model: one building-level status (green / yello
 
 | Page | Content |
 |------|---------|
-| [Convention]({% link fault-codes/convention.md %}) | Naming, severity, categories |
-| [AHU faults]({% link fault-codes/ahu.md %}) | Air handling units |
-| [VAV faults]({% link fault-codes/vav.md %}) | Terminal units |
-| [RTU faults]({% link fault-codes/rtu.md %}) | Packaged rooftops |
-| [Sensor & data quality]({% link fault-codes/sensor-quality.md %}) | Stale, flatline, comms |
+| [Convention]({{ "/fault-codes/convention/" | relative_url }}) | Naming, severity, categories |
+| [AHU faults]({{ "/fault-codes/ahu/" | relative_url }}) | Air handling units |
+| [VAV faults]({{ "/fault-codes/vav/" | relative_url }}) | Terminal units |
+| [RTU faults]({{ "/fault-codes/rtu/" | relative_url }}) | Packaged rooftops |
+| [Sensor & data quality]({{ "/fault-codes/sensor-quality/" | relative_url }}) | Stale, flatline, comms |
 
 Live catalog API: `GET /api/faults/catalog` on the Operator Bridge.

--- a/docs/fault-codes/sensor-quality.md
+++ b/docs/fault-codes/sensor-quality.md
@@ -6,7 +6,7 @@ nav_order: 5
 
 # Sensor and data quality
 
-Sensor faults use cookbook patterns **`flatline_1h`**, **`oob_rolling`**, **`rate_of_change`**, and **`mixing_envelope`**. Full thresholds: [Expression cookbook — sensor validation]({% link rule-cookbook/expression-cookbook.md %}#sensor-validation-bounds-flatline-rate-of-change).
+Sensor faults use cookbook patterns **`flatline_1h`**, **`oob_rolling`**, **`rate_of_change`**, and **`mixing_envelope`**. Full thresholds: [Expression cookbook — sensor validation]({{ "/rule-cookbook/expression-cookbook/" | relative_url }}#sensor-validation-bounds-flatline-rate-of-change).
 
 ## Catalog codes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,9 @@ Open-FDD is an open-source **building edge platform** for BACnet integration, fe
 
 | Path | Go to |
 |------|-------|
-| **Try it** | [Quick Start — Run with Docker]({% link quick-start/docker.md %}) |
-| **Operate it** | [Updating the stack]({% link quick-start/updating.md %}) · [Operations]({% link ops/index.md %}) |
-| **Develop it** | [Developer Guide]({% link developer/index.md %}) · [Architecture]({% link architecture/index.md %}) |
+| **Try it** | [Quick Start — Run with Docker]({{ "/quick-start/docker/" | relative_url }}) |
+| **Operate it** | [Updating the stack]({{ "/quick-start/updating/" | relative_url }}) · [Operations]({{ "/ops/" | relative_url }}) |
+| **Develop it** | [Developer Guide]({{ "/developer/" | relative_url }}) · [Architecture]({{ "/architecture/" | relative_url }}) |
 
 ## v3 edge stack
 
@@ -36,10 +36,10 @@ Three primary containers on a Linux edge host:
 
 Host **Caddy** on `:80` or `:443` is the normal LAN front door. BACnet UDP `:47808` is bound by **commission** only — the bridge ingests `samples.csv` into the feather historian.
 
-Details: [Containers]({% link architecture/containers.md %}) · [Deployment modes]({% link architecture/deployment-modes.md %})
+Details: [Containers]({{ "/architecture/containers/" | relative_url }}) · [Deployment modes]({{ "/architecture/deployment-modes/" | relative_url }})
 
 {: .warning }
-> **LAN / OT edge only.** Do not expose the Operator Bridge to the public internet without TLS, strong auth, and site review. BACnet writes are disabled by default — see [BACnet write guard]({% link security/bacnet-writes.md %}).
+> **LAN / OT edge only.** Do not expose the Operator Bridge to the public internet without TLS, strong auth, and site review. BACnet writes are disabled by default — see [BACnet write guard]({{ "/security/bacnet-writes/" | relative_url }}).
 
 ## Distribution
 

--- a/docs/operations/acme_vav_ahu_rule_guidance.md
+++ b/docs/operations/acme_vav_ahu_rule_guidance.md
@@ -94,7 +94,7 @@ Before enabling more rules:
 
 ## BACnet override scans
 
-Commission agent rotates **one device/hour** through P8 priority-array reads. Status: `GET /api/bacnet/overrides/status`. See [Operator override scans]({% link bacnet/override-scans.md %}).
+Commission agent rotates **one device/hour** through P8 priority-array reads. Status: `GET /api/bacnet/overrides/status`. See [Operator override scans]({{ "/bacnet/override-scans/" | relative_url }}).
 
 ## Docker backup / recovery
 

--- a/docs/operator-bridge/algorithms.md
+++ b/docs/operator-bridge/algorithms.md
@@ -15,7 +15,7 @@ The **Algorithms** dashboard tab (`/algorithms`) is a placeholder for **supervis
 | Output | Boolean fault mask | Numeric outputs / structured dict |
 | Historian | Same `feather_store` PyArrow tables | Same |
 
-Until the tab ships, draft patterns live in this doc and in [GL36 algorithm stubs]({% link rule-cookbook/gl36-algorithm-stubs.md %}).
+Until the tab ships, draft patterns live in this doc and in [GL36 algorithm stubs]({{ "/rule-cookbook/gl36-algorithm-stubs/" | relative_url }}).
 
 ## GL36 Trim & Respond reference
 
@@ -39,11 +39,11 @@ Porting those blocks to PyArrow is in progress; the dashboard tab shows **COMING
 3. Run `python run_test.py` locally against `sample.feather`
 4. Upload `algorithm.py` when satisfied
 
-Kit files will match the Rule Lab zip layout (see [Rule Lab — dev kit zip]({% link operator-bridge/rule-lab.md %}#dev-kit-zip-download)).
+Kit files will match the Rule Lab zip layout (see [Rule Lab — dev kit zip]({{ "/operator-bridge/rule-lab/" | relative_url }}#dev-kit-zip-download)).
 
 ## Lookback windows
 
-Rules and algorithms that need multi-hour history should use the shared **lookback stats helper** documented in [Lookback window helper]({% link rule-cookbook/lookback-window.md %}). Pass `hours=1`, `3`, `6`, `12`, or `24` to print row count, timestamp start/stop, and span for console validation.
+Rules and algorithms that need multi-hour history should use the shared **lookback stats helper** documented in [Lookback window helper]({{ "/rule-cookbook/lookback-window/" | relative_url }}). Pass `hours=1`, `3`, `6`, `12`, or `24` to print row count, timestamp start/stop, and span for console validation.
 
 Scheduled batch defaults: **1 h** lookback on the FDD loop; **Update all records** in Rule Lab uses **24 h** with 6 h chunks.
 
@@ -117,10 +117,10 @@ def apply_faults_arrow(table, cfg, context=None):
 
 ## Plant supervisory checks (doc-only)
 
-See [GL36 algorithm stubs]({% link rule-cookbook/gl36-algorithm-stubs.md %}) for chiller plant enable, HWST trim & respond, and CHW DP/CHWST reset patterns aligned with the Niagara README.
+See [GL36 algorithm stubs]({{ "/rule-cookbook/gl36-algorithm-stubs/" | relative_url }}) for chiller plant enable, HWST trim & respond, and CHW DP/CHWST reset patterns aligned with the Niagara README.
 
 ## Related
 
-- [Rule Lab]({% link operator-bridge/rule-lab.md %}) — live FDD authoring
-- [Model workflow]({% link operator-bridge/model-workflow.md %}) — point bindings
-- [Windowing & debugging]({% link rule-cookbook/windowing-debugging.md %}) — rolling windows
+- [Rule Lab]({{ "/operator-bridge/rule-lab/" | relative_url }}) — live FDD authoring
+- [Model workflow]({{ "/operator-bridge/model-workflow/" | relative_url }}) — point bindings
+- [Windowing & debugging]({{ "/rule-cookbook/windowing-debugging/" | relative_url }}) — rolling windows

--- a/docs/operator-bridge/auth-roles.md
+++ b/docs/operator-bridge/auth-roles.md
@@ -26,4 +26,4 @@ Login: `POST /api/auth/login` → Bearer JWT on API calls.
 
 `OFDD_BRIDGE_HOST=127.0.0.1` with `OFDD_AUTH_DISABLED=1` is acceptable on a single machine. **Never** use auth-disabled mode on a building LAN.
 
-Full hardening: [Security]({% link security/index.md %}).
+Full hardening: [Security]({{ "/security/" | relative_url }}).

--- a/docs/operator-bridge/dashboard.md
+++ b/docs/operator-bridge/dashboard.md
@@ -25,4 +25,4 @@ Dashboard tiles use REST polling and `WS /ws/dashboard` for selected live views 
 
 ## Roles
 
-Read-only operators see trends and faults; integrators access Rule Lab and model import. See [Auth and roles]({% link operator-bridge/auth-roles.md %}).
+Read-only operators see trends and faults; integrators access Rule Lab and model import. See [Auth and roles]({{ "/operator-bridge/auth-roles/" | relative_url }}).

--- a/docs/operator-bridge/fdd-assignments.md
+++ b/docs/operator-bridge/fdd-assignments.md
@@ -91,6 +91,6 @@ After import, verify in **Trend plot** with `?fdd=1` — fault lanes appear on t
 
 ## Related
 
-- [Model workflow]({% link operator-bridge/model-workflow.md %})
-- [Rule Lab]({% link operator-bridge/rule-lab.md %})
-- [Trend plot / fault overlays]({% link operator-bridge/dashboard.md %}#trend-plot)
+- [Model workflow]({{ "/operator-bridge/model-workflow/" | relative_url }})
+- [Rule Lab]({{ "/operator-bridge/rule-lab/" | relative_url }})
+- [Trend plot / fault overlays]({{ "/operator-bridge/dashboard/" | relative_url }}#trend-plot)

--- a/docs/operator-bridge/index.md
+++ b/docs/operator-bridge/index.md
@@ -10,12 +10,12 @@ The Operator Bridge is the FastAPI service and React dashboard operators use dai
 
 | Page | Topic |
 |------|-------|
-| [Dashboard overview]({% link operator-bridge/dashboard.md %}) | Main UI areas |
-| [Auth and roles]({% link operator-bridge/auth-roles.md %}) | Login and permissions |
-| [Rule Lab]({% link operator-bridge/rule-lab.md %}) | Python FDD rule authoring (PyArrow kit zip) |
-| [Algorithms]({% link operator-bridge/algorithms.md %}) | Supervisory GL36 sequences (coming soon) |
-| [Model workflow]({% link operator-bridge/model-workflow.md %}) | Brick bindings and imports |
-| [FDD and assignments]({% link operator-bridge/fdd-assignments.md %}) | Rule bindings, BRICK classes, commissioning JSON |
-| [Ollama and analytics]({% link operator-bridge/ollama-analytics.md %}) | Home briefing, zone levers, model RAM tiers |
+| [Dashboard overview]({{ "/operator-bridge/dashboard/" | relative_url }}) | Main UI areas |
+| [Auth and roles]({{ "/operator-bridge/auth-roles/" | relative_url }}) | Login and permissions |
+| [Rule Lab]({{ "/operator-bridge/rule-lab/" | relative_url }}) | Python FDD rule authoring (PyArrow kit zip) |
+| [Algorithms]({{ "/operator-bridge/algorithms/" | relative_url }}) | Supervisory GL36 sequences (coming soon) |
+| [Model workflow]({{ "/operator-bridge/model-workflow/" | relative_url }}) | Brick bindings and imports |
+| [FDD and assignments]({{ "/operator-bridge/fdd-assignments/" | relative_url }}) | Rule bindings, BRICK classes, commissioning JSON |
+| [Ollama and analytics]({{ "/operator-bridge/ollama-analytics/" | relative_url }}) | Home briefing, zone levers, model RAM tiers |
 
-REST details: [Appendix — API routes]({% link appendix/bridge_api.md %}). Env files: [Workspace env files]({% link appendix/workspace-env-files.md %}).
+REST details: [Appendix — API routes]({{ "/appendix/bridge_api/" | relative_url }}). Env files: [Workspace env files]({{ "/appendix/workspace-env-files/" | relative_url }}).

--- a/docs/operator-bridge/model-workflow.md
+++ b/docs/operator-bridge/model-workflow.md
@@ -21,6 +21,6 @@ nav_order: 4
 5. Run `POST /api/model/sync-ttl` after bulk imports.
 6. Validate on **Trend plot** with FDD overlays (`?fdd=1`) — faults render on a right-hand 0/1 axis per device scope.
 
-AI Agent and commissioning JSON import can bulk-apply steps 2–4; integrator should review model health before production FDD. See [FDD and assignments]({% link operator-bridge/fdd-assignments.md %}) and [Ollama and analytics]({% link operator-bridge/ollama-analytics.md %}).
+AI Agent and commissioning JSON import can bulk-apply steps 2–4; integrator should review model health before production FDD. See [FDD and assignments]({{ "/operator-bridge/fdd-assignments/" | relative_url }}) and [Ollama and analytics]({{ "/operator-bridge/ollama-analytics/" | relative_url }}).
 
-Export: `GET /api/model/export` (TTL/JSON). Commissioning bundle: `GET /api/model/commissioning-export` — includes per-point `fdd_rules_linked` (Rule Lab names) plus `fdd_rules[]` catalog. Use **Import / export** tab preview table or **Point → FDD rule pins** before editing raw JSON. API detail in [Appendix]({% link appendix/bridge_api.md %}).
+Export: `GET /api/model/export` (TTL/JSON). Commissioning bundle: `GET /api/model/commissioning-export` — includes per-point `fdd_rules_linked` (Rule Lab names) plus `fdd_rules[]` catalog. Use **Import / export** tab preview table or **Point → FDD rule pins** before editing raw JSON. API detail in [Appendix]({{ "/appendix/bridge_api/" | relative_url }}).

--- a/docs/operator-bridge/rule-lab.md
+++ b/docs/operator-bridge/rule-lab.md
@@ -115,16 +115,16 @@ flagged=…
 
 ## Lookback windows
 
-Rules that need multi-hour history should call `_kit_lookback_stats(table)` (see [Lookback window helper]({% link rule-cookbook/lookback-window.md %})). Pass `hours=1`, `3`, `6`, `12`, or `24` to validate timestamp span in the console.
+Rules that need multi-hour history should call `_kit_lookback_stats(table)` (see [Lookback window helper]({{ "/rule-cookbook/lookback-window/" | relative_url }})). Pass `hours=1`, `3`, `6`, `12`, or `24` to validate timestamp span in the console.
 
-Rolling-window rules (flatline, spread) use `WINDOW_SAMPLES` (~12 samples ≈ 1 h at 5 min poll) — see [Windowing & debugging]({% link rule-cookbook/windowing-debugging.md %}).
+Rolling-window rules (flatline, spread) use `WINDOW_SAMPLES` (~12 samples ≈ 1 h at 5 min poll) — see [Windowing & debugging]({{ "/rule-cookbook/windowing-debugging/" | relative_url }}).
 
 ## Algorithms (supervisory — coming soon)
 
-GL36 trim & respond and plant reset sequences will live on the **[Algorithms]({% link operator-bridge/algorithms.md %})** tab with the same zip kit shape but `apply_algorithm_arrow` outputs. Reference: [README_TRIM_RESPOND](https://github.com/bbartling/niagara4-vibe-code-addict/blob/develop/README_TRIM_RESPOND.md).
+GL36 trim & respond and plant reset sequences will live on the **[Algorithms]({{ "/operator-bridge/algorithms/" | relative_url }})** tab with the same zip kit shape but `apply_algorithm_arrow` outputs. Reference: [README_TRIM_RESPOND](https://github.com/bbartling/niagara4-vibe-code-addict/blob/develop/README_TRIM_RESPOND.md).
 
 ## Related
 
-- [Model workflow]({% link operator-bridge/model-workflow.md %})
-- [Arrow recipes]({% link rule-cookbook/arrow-recipes.md %})
-- [GL36 algorithm stubs]({% link rule-cookbook/gl36-algorithm-stubs.md %}) (doc-only)
+- [Model workflow]({{ "/operator-bridge/model-workflow/" | relative_url }})
+- [Arrow recipes]({{ "/rule-cookbook/arrow-recipes/" | relative_url }})
+- [GL36 algorithm stubs]({{ "/rule-cookbook/gl36-algorithm-stubs/" | relative_url }}) (doc-only)

--- a/docs/ops/acme-live-validation.md
+++ b/docs/ops/acme-live-validation.md
@@ -96,7 +96,7 @@ OPENFDD_LIVE_ACME=1 OPENFDD_IMAGE_TAG=3.0.32 ACME_OVERNIGHT_CYCLES=4 \
 | `ACME_WINDOW_HOURS` | `2` | Historian lookback per cycle |
 | `ACME_CYCLE_SLEEP_MINUTES` | `0` | Set `120` for true 2-hour wall-clock spacing |
 
-Reports are written under `reports/` (gitignored). See [ACME validation follow-ups]({% link ops/acme-validation-follow-ups.md %}) and [ACME deploy 3.0.33 validation plan]({% link ops/acme-deploy-3.0.33-validation.md %}).
+Reports are written under `reports/` (gitignored). See [ACME validation follow-ups]({{ "/ops/acme-validation-follow-ups/" | relative_url }}) and [ACME deploy 3.0.33 validation plan]({{ "/ops/acme-deploy-3.0.33-validation/" | relative_url }}).
 
 ### Live bridge vs branch fix
 

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -60,7 +60,7 @@ du -h "$BACKUP_ROOT/workspace-full.tgz"
 2. Restore `docker-compose.yml` from backup
 3. If data corruption: extract selective files from `workspace-full.tgz` — model, rules, feather shards
 4. `docker compose pull && docker compose up -d --force-recreate`
-5. Verify: [Deployment validation]({% link ops/deployment-validation.md %})
+5. Verify: [Deployment validation]({{ "/ops/deployment-validation/" | relative_url }})
 
 ## Safe cleanup
 
@@ -73,5 +73,5 @@ docker image prune -f
 
 ## Related
 
-- [Updating the stack]({% link quick-start/updating.md %})
-- [Live site update]({% link ops/live_site_update.md %})
+- [Updating the stack]({{ "/quick-start/updating/" | relative_url }})
+- [Live site update]({{ "/ops/live_site_update/" | relative_url }})

--- a/docs/ops/deployment-validation.md
+++ b/docs/ops/deployment-validation.md
@@ -6,7 +6,7 @@ nav_order: 4
 
 # Deployment validation
 
-For the **live Acme site** after GHCR updates, use the dedicated harness documented in [Acme live validation]({% link ops/acme-live-validation.md %}) (`acme_post_deploy_validate.sh`).
+For the **live Acme site** after GHCR updates, use the dedicated harness documented in [Acme live validation]({{ "/ops/acme-live-validation/" | relative_url }}) (`acme_post_deploy_validate.sh`).
 
 Non-destructive checks after deploy or image upgrade. Run from the **edge host** (smoke) or from a **control machine** with the full repo (insurance suite).
 
@@ -58,7 +58,7 @@ Or by IP:
 Checks include: Caddy → React dashboard, `/health/stack`, MCP RAG, BACnet tree, BRICK/SPARQL, Docker log scan.
 
 {: .warning }
-> **Do not run on live commissioned sites without approval:** `acme_operational_verify.sh` with BACnet rediscover — use `--skip-discover` for smoke only. See [Examples — GL36 lab]({% link examples/acme-gl36-lab.md %}).
+> **Do not run on live commissioned sites without approval:** `acme_operational_verify.sh` with BACnet rediscover — use `--skip-discover` for smoke only. See [Examples — GL36 lab]({{ "/examples/acme-gl36-lab/" | relative_url }}).
 
 ## LAN security smoke (optional)
 
@@ -67,7 +67,7 @@ From a workstation on the same LAN as the edge:
 - Windows: `scripts/security/Run-OpenFddSecurityScan.ps1`
 - macOS/Linux: `scripts/security/run_openfdd_security_scan.sh`
 
-Expected findings: [ZAP baseline]({% link security/zap-baseline.md %}).
+Expected findings: [ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}).
 
 ## Arrow / FDD rules (3.0+)
 
@@ -85,5 +85,5 @@ grep -R "apply_faults_arrow" workspace/data/rules_py | wc -l
 
 ## Related
 
-- [Health check]({% link quick-start/health-check.md %})
-- [Security testing cycle]({% link developer/security-testing.md %}) (maintainers)
+- [Health check]({{ "/quick-start/health-check/" | relative_url }})
+- [Security testing cycle]({{ "/developer/security-testing/" | relative_url }}) (maintainers)

--- a/docs/ops/docker-images.md
+++ b/docs/ops/docker-images.md
@@ -47,4 +47,4 @@ Manual: Actions → workflow_dispatch (publishes `latest`).
 | Embed FDD in your Python/cloud job | `pip install open-fdd` |
 | BACnet + UI + bridge on an edge host | GHCR images |
 
-See [Release process](../developer/release-process.md).
+See [Release process]({{ "/developer/release-process/" | relative_url }}).

--- a/docs/ops/index.md
+++ b/docs/ops/index.md
@@ -6,18 +6,18 @@ has_children: true
 
 # Operations
 
-Runbooks for live edge hosts after the initial [Quick Start]({% link quick-start/index.md %}) deploy.
+Runbooks for live edge hosts after the initial [Quick Start]({{ "/quick-start/" | relative_url }}) deploy.
 
 | Page | When to use |
 |------|-------------|
-| [Live site update]({% link ops/live_site_update.md %}) | Pull new GHCR tags, preserve `workspace/` |
-| [Backup and restore]({% link ops/backup-restore.md %}) | Archive `workspace/` before upgrades |
-| [Logging and audit]({% link ops/logging.md %}) | Auth audit trail, rotation, Docker log caps |
-| [Deployment validation]({% link ops/deployment-validation.md %}) | Post-upgrade smoke and insurance checks |
-| [Acme live validation]({% link ops/acme-live-validation.md %}) | Read-only harness after GHCR upgrades |
-| [Acme deploy 3.0.33 plan]({% link ops/acme-deploy-3.0.33-validation.md %}) | Post-merge deploy and re-validation |
-| [Acme validation follow-ups]({% link ops/acme-validation-follow-ups.md %}) | Run-history equipment, RTU roles, true overnight |
+| [Live site update]({{ "/ops/live_site_update/" | relative_url }}) | Pull new GHCR tags, preserve `workspace/` |
+| [Backup and restore]({{ "/ops/backup-restore/" | relative_url }}) | Archive `workspace/` before upgrades |
+| [Logging and audit]({{ "/ops/logging/" | relative_url }}) | Auth audit trail, rotation, Docker log caps |
+| [Deployment validation]({{ "/ops/deployment-validation/" | relative_url }}) | Post-upgrade smoke and insurance checks |
+| [Acme live validation]({{ "/ops/acme-live-validation/" | relative_url }}) | Read-only harness after GHCR upgrades |
+| [Acme deploy 3.0.33 plan]({{ "/ops/acme-deploy-3.0.33-validation/" | relative_url }}) | Post-merge deploy and re-validation |
+| [Acme validation follow-ups]({{ "/ops/acme-validation-follow-ups/" | relative_url }}) | Run-history equipment, RTU roles, true overnight |
 
-Site-specific lab notes (example BACnet scope, GL36 rules): [Examples & lab notes]({% link examples/index.md %}).
+Site-specific lab notes (example BACnet scope, GL36 rules): [Examples & lab notes]({{ "/examples/" | relative_url }}).
 
-For first-time deploy: [Quick Start — Docker]({% link quick-start/docker.md %}).
+For first-time deploy: [Quick Start — Docker]({{ "/quick-start/docker/" | relative_url }}).

--- a/docs/ops/live_site_update.md
+++ b/docs/ops/live_site_update.md
@@ -9,7 +9,7 @@ nav_order: 1
 Upgrade GHCR images on a **live edge host** that already has `~/open-fdd/` — no `git pull` on the host.
 
 {: .note }
-> **IT operators:** prefer [Quick Start — Updating the stack]({% link quick-start/updating.md %}) and `openfdd_site_backup.sh` / `openfdd_site_update.sh` on the edge host. This page adds control-machine UI deploy and Ansible paths.
+> **IT operators:** prefer [Quick Start — Updating the stack]({{ "/quick-start/updating/" | relative_url }}) and `openfdd_site_backup.sh` / `openfdd_site_update.sh` on the edge host. This page adds control-machine UI deploy and Ansible paths.
 
 ## Layout on the edge host
 
@@ -21,7 +21,7 @@ Upgrade GHCR images on a **live edge host** that already has `~/open-fdd/` — n
 
 `workspace/` holds BACnet commissioning, poll CSV, feather historian, BRICK model, FDD rules, and `auth.env.local`. Image upgrades must **preserve** it.
 
-See [Backup and restore]({% link ops/backup-restore.md %}) before any upgrade.
+See [Backup and restore]({{ "/ops/backup-restore/" | relative_url }}) before any upgrade.
 
 ## Concepts
 
@@ -96,13 +96,13 @@ OPENFDD_IMAGE_TAG=latest RUN_POST_CHECK=1 ./scripts/upgrade_edge_ghcr.sh --limit
 
 ## 5. Validate
 
-→ [Deployment validation]({% link ops/deployment-validation.md %})
+→ [Deployment validation]({{ "/ops/deployment-validation/" | relative_url }})
 
 ## Rollback
 
-Restore `docker-compose.yml` from backup, pull previous tag, `docker compose up -d --force-recreate`. `workspace/` is unchanged. Details: [Backup and restore]({% link ops/backup-restore.md %}).
+Restore `docker-compose.yml` from backup, pull previous tag, `docker compose up -d --force-recreate`. `workspace/` is unchanged. Details: [Backup and restore]({{ "/ops/backup-restore/" | relative_url }}).
 
 ## Related
 
-- [Updating the stack]({% link quick-start/updating.md %}) — edge-host helper scripts
-- [Containers]({% link architecture/containers.md %}) — three-image architecture
+- [Updating the stack]({{ "/quick-start/updating/" | relative_url }}) — edge-host helper scripts
+- [Containers]({{ "/architecture/containers/" | relative_url }}) — three-image architecture

--- a/docs/ops/logging.md
+++ b/docs/ops/logging.md
@@ -160,10 +160,10 @@ docker compose logs bridge --tail 50
 | Log rotation / size caps | Yes — defaults above + Docker `max-size` |
 | SIEM-ready export | Yes — file tail / Filebeat on `workspace/logs/` |
 
-For BACnet write safety and credential generation, see [SECURITY.md](https://github.com/bbartling/open-fdd/blob/master/workspace/deploy/SECURITY.md) and [Secrets and auth]({% link security/secrets-auth.md %}).
+For BACnet write safety and credential generation, see [SECURITY.md](https://github.com/bbartling/open-fdd/blob/master/workspace/deploy/SECURITY.md) and [Secrets and auth]({{ "/security/secrets-auth/" | relative_url }}).
 
 ## Related
 
-- [JSON API driver]({% link drivers/json-api.md %}) — OpenWeatherMap showcase, env-based API keys (`json_api.env.local`)
-- [Live site update]({% link ops/live_site_update.md %}) — `docker compose logs` after upgrades
-- [Data flow]({% link architecture/data-flow.md %}) — historian retention (`OFDD_FEATHER_*`) is separate from audit logs
+- [JSON API driver]({{ "/drivers/json-api/" | relative_url }}) — OpenWeatherMap showcase, env-based API keys (`json_api.env.local`)
+- [Live site update]({{ "/ops/live_site_update/" | relative_url }}) — `docker compose logs` after upgrades
+- [Data flow]({{ "/architecture/data-flow/" | relative_url }}) — historian retention (`OFDD_FEATHER_*`) is separate from audit logs

--- a/docs/portfolio/index.md
+++ b/docs/portfolio/index.md
@@ -10,6 +10,6 @@ Multi-site analytics on **benserver** — not part of the edge Docker stack.
 
 | Topic | Page |
 |-------|------|
-| Collect rollups from edge sites | [Central collection]({% link portfolio/central-collection.md %}) |
+| Collect rollups from edge sites | [Central collection]({{ "/portfolio/central-collection/" | relative_url }}) |
 
 Repo layout: `portfolio/` (collector, Dash, `sites.json`). Maintainer tuning API flow: `skills/openfdd-edge-deploy-tune/SKILL.md`.

--- a/docs/quick-start/docker.md
+++ b/docs/quick-start/docker.md
@@ -74,7 +74,7 @@ OFDD_AGENT_USER=agent
 OFDD_AGENT_PASSWORD=<random>
 ```
 
-Sign in as **integrator** with the password from that file → [First login and health check]({% link quick-start/health-check.md %}).
+Sign in as **integrator** with the password from that file → [First login and health check]({{ "/quick-start/health-check/" | relative_url }}).
 
 | Action | Touches `auth.env.local`? |
 |--------|---------------------------|
@@ -123,7 +123,7 @@ nano ~/open-fdd/workspace/bacnet/commissioning/commission.env
 ```
 
 {: .note }
-> If you used `--start`, the stack is already up. Next step → [First login and health check]({% link quick-start/health-check.md %}).
+> If you used `--start`, the stack is already up. Next step → [First login and health check]({{ "/quick-start/health-check/" | relative_url }}).
 
 ### Manual start (optional)
 
@@ -137,7 +137,7 @@ docker compose ps
 curl -sf http://127.0.0.1:8765/health && echo
 ```
 
-Expected: **bridge**, **commission**, **mcp-rag** — all `Up`. Then → [First login and health check]({% link quick-start/health-check.md %}).
+Expected: **bridge**, **commission**, **mcp-rag** — all `Up`. Then → [First login and health check]({{ "/quick-start/health-check/" | relative_url }}).
 
 ## Long-term operation
 
@@ -172,12 +172,12 @@ Put **Caddy** (or nginx) on port 80 → `127.0.0.1:8765`, or expose 8765 through
 | Mode | Compose services | When to use |
 |------|------------------|-------------|
 | **Standard OT / BACnet** | `bridge` + `commission` + `mcp-rag` | Real buildings — commission polls BACnet into `samples.csv`; bridge ingests to feather |
-| **Non-BACnet / demo** | `bridge` + `mcp-rag` (omit `commission`) | JSON API, Modbus-only, or lab without field BACnet — see [Driver framework]({% link drivers/index.md %}) |
+| **Non-BACnet / demo** | `bridge` + `mcp-rag` (omit `commission`) | JSON API, Modbus-only, or lab without field BACnet — see [Driver framework]({{ "/drivers/" | relative_url }}) |
 | **TLS on OT LAN** | Same stack + **host Caddy** `OFDD_CADDY_MODE=tls` | Encrypt browser↔edge; trust self-signed CA on operator PCs — not for public internet |
 
 Do **not** run the retired `openfdd-bacnet-poll` image or legacy `openfdd-bacnet-poll` systemd unit alongside Docker **commission** — that double-polls BACnet.
 
 ## Next steps
 
-→ [First login and health check]({% link quick-start/health-check.md %})  
-→ [Updating the stack]({% link quick-start/updating.md %}) — `./scripts/openfdd_site_update.sh`
+→ [First login and health check]({{ "/quick-start/health-check/" | relative_url }})  
+→ [Updating the stack]({{ "/quick-start/updating/" | relative_url }}) — `./scripts/openfdd_site_update.sh`

--- a/docs/quick-start/health-check.md
+++ b/docs/quick-start/health-check.md
@@ -6,7 +6,7 @@ nav_order: 2
 
 # First login and health check
 
-Quick checks after `docker compose up -d` on the edge host. Services use `restart: unless-stopped` — after a reboot, run `docker compose ps` once Docker is up (see [Run with Docker]({% link quick-start/docker.md %}#survive-power-cycles)).
+Quick checks after `docker compose up -d` on the edge host. Services use `restart: unless-stopped` — after a reboot, run `docker compose ps` once Docker is up (see [Run with Docker]({{ "/quick-start/docker/" | relative_url }}#survive-power-cycles)).
 
 ## Public health
 
@@ -61,8 +61,8 @@ Look for `bacnet_poll` green/yellow in the services list.
 | Symptom | Fix |
 |---------|-----|
 | 401 everywhere | Configure `workspace/auth.env.local` |
-| Empty BACnet discover | Fix `BACNET_BIND` in `commission.env` — [network setup]({% link bacnet/network-setup.md %}) |
+| Empty BACnet discover | Fix `BACNET_BIND` in `commission.env` — [network setup]({{ "/bacnet/network-setup/" | relative_url }}) |
 | No poll rows | Commission container running? `points.csv` has enabled rows? |
 | LAN browser timeout | Open firewall port 80 or 8765 |
 
-Advanced probes (model graph, Rule Lab, compose profiles): [Developer health check]({% link developer/health-check.md %}).
+Advanced probes (model graph, Rule Lab, compose profiles): [Developer health check]({{ "/developer/health-check/" | relative_url }}).

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -10,9 +10,9 @@ Run Open-FDD on a Linux edge host using **three GHCR Docker images**. No git clo
 
 | Step | Page |
 |------|------|
-| 1 | [Run with Docker images]({% link quick-start/docker.md %}) — bootstrap script + `docker compose up` |
-| 2 | [First login and health check]({% link quick-start/health-check.md %}) |
-| 3 | [Updating the stack]({% link quick-start/updating.md %}) — backup + pull |
+| 1 | [Run with Docker images]({{ "/quick-start/docker/" | relative_url }}) — bootstrap script + `docker compose up` |
+| 2 | [First login and health check]({{ "/quick-start/health-check/" | relative_url }}) |
+| 3 | [Updating the stack]({{ "/quick-start/updating/" | relative_url }}) — backup + pull |
 
 **One-liner bootstrap** (edge host):
 
@@ -25,6 +25,6 @@ bash /tmp/openfdd_edge_bootstrap.sh --start
 **Prerequisites:** Linux, Docker enabled on boot, BACnet LAN if polling OT equipment.
 
 {: .warning }
-> **BACnet writes are disabled by default.** See [Write safety]({% link bacnet/write-safety.md %}).
+> **BACnet writes are disabled by default.** See [Write safety]({{ "/bacnet/write-safety/" | relative_url }}).
 
-**Stack:** `bridge` + `commission` (BACnet + poll) + `mcp-rag`. Details: [Containers]({% link architecture/containers.md %}).
+**Stack:** `bridge` + `commission` (BACnet + poll) + `mcp-rag`. Details: [Containers]({{ "/architecture/containers/" | relative_url }}).

--- a/docs/quick-start/updating.md
+++ b/docs/quick-start/updating.md
@@ -91,7 +91,7 @@ tail -1 workspace/bacnet/polls/samples.csv
 ls -lah workspace/data/feather_store/
 ```
 
-→ [Health check]({% link quick-start/health-check.md %})
+→ [Health check]({{ "/quick-start/health-check/" | relative_url }})
 
 ## Dashboard UI updates
 
@@ -114,5 +114,5 @@ docker image prune -f
 
 ## Next steps
 
-→ [Run with Docker images]({% link quick-start/docker.md %}) — bootstrap a new host  
-→ [Health check]({% link quick-start/health-check.md %})
+→ [Run with Docker images]({{ "/quick-start/docker/" | relative_url }}) — bootstrap a new host  
+→ [Health check]({{ "/quick-start/health-check/" | relative_url }})

--- a/docs/roadmap/openfdd-central-portfolio-rcx.md
+++ b/docs/roadmap/openfdd-central-portfolio-rcx.md
@@ -46,7 +46,7 @@ Existing code to extend (do not rewrite):
 ## Prerequisites
 
 - ACME validation PR merged and **3.0.33** deployed (equipment context on live FDD alerts).
-- Follow-ups: FDD run-history equipment grouping, RTU role mapping (see [ACME validation follow-ups]({% link ops/acme-validation-follow-ups.md %})).
+- Follow-ups: FDD run-history equipment grouping, RTU role mapping (see [ACME validation follow-ups]({{ "/ops/acme-validation-follow-ups/" | relative_url }})).
 
 ## Safety
 

--- a/docs/rule-cookbook/arrow-recipes.md
+++ b/docs/rule-cookbook/arrow-recipes.md
@@ -8,7 +8,7 @@ nav_order: 2
 
 Open-FDD 3.0 Rule Lab rules use **`apply_faults_arrow(table, cfg, context)`**, **`pyarrow.compute`**, and **module constants** (no `config.json`).
 
-For **full GL36 A–M and plant recipes**, see **[Python recipes (full Arrow library)]({% link rule-cookbook/python-recipes-arrow.md %})**. Sensor tables: **[Expression cookbook]({% link rule-cookbook/expression-cookbook.md %})**.
+For **full GL36 A–M and plant recipes**, see **[Python recipes (full Arrow library)]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }})**. Sensor tables: **[Expression cookbook]({{ "/rule-cookbook/expression-cookbook/" | relative_url }})**.
 
 ## Simple threshold
 
@@ -93,10 +93,10 @@ def apply_faults_arrow(table, cfg, context=None):
     return pc.or_(flat, spike)  # import pyarrow.compute as pc
 ```
 
-Bounds table: [Expression cookbook — sensor validation]({% link rule-cookbook/expression-cookbook.md %}#sensor-validation-bounds-flatline-rate-of-change).
+Bounds table: [Expression cookbook — sensor validation]({{ "/rule-cookbook/expression-cookbook/" | relative_url }}#sensor-validation-bounds-flatline-rate-of-change).
 
 More templates ship in `open_fdd.playground.arrow_templates` and via `GET /api/playground/arrow-templates`.
 
 Bench examples: `workspace/data/rules_py/bench_*.py`.
 
-Dev kit zip layout: [Rule Lab — dev kit zip]({% link operator-bridge/rule-lab.md %}#dev-kit-zip-download).
+Dev kit zip layout: [Rule Lab — dev kit zip]({{ "/operator-bridge/rule-lab/" | relative_url }}#dev-kit-zip-download).

--- a/docs/rule-cookbook/central-plants.md
+++ b/docs/rule-cookbook/central-plants.md
@@ -40,4 +40,4 @@ mask = low_delta_t_mask(
 assert mask.to_pylist()[-1] is True
 ```
 
-See [Fault codes — chiller plant]({% link fault-codes/index.md %}) (expanded in 3.0.19).
+See [Fault codes — chiller plant]({{ "/fault-codes/" | relative_url }}) (expanded in 3.0.19).

--- a/docs/rule-cookbook/expression-cookbook.md
+++ b/docs/rule-cookbook/expression-cookbook.md
@@ -11,15 +11,15 @@ redirect_from:
 
 Reference for **Open-FDD 3.x Rule Lab**: every rule is a Python module with **`apply_faults_arrow(table, cfg, context)`** using **`pyarrow.compute`** — **no pandas**, **no YAML expression files**, **no NumPy DataFrames on the IoT edge**.
 
-This is the **only** expression cookbook for Open-FDD 3.x. The pandas/YAML `RuleRunner` path is retired — use Arrow `apply_faults_arrow` and the operator bridge Rule Lab. Legacy GL36-style recipes map to **fixed [fault codes]({% link fault-codes/index.md %})** and Arrow patterns below.
+This is the **only** expression cookbook for Open-FDD 3.x. The pandas/YAML `RuleRunner` path is retired — use Arrow `apply_faults_arrow` and the operator bridge Rule Lab. Legacy GL36-style recipes map to **fixed [fault codes]({{ "/fault-codes/" | relative_url }})** and Arrow patterns below.
 
 | Topic | Page |
 |-------|------|
-| **Full copy-paste library (GL36 A–M, VAV, plant)** | **[Python recipes (full Arrow library)]({% link rule-cookbook/python-recipes-arrow.md %})** |
-| Quick templates | [Arrow recipes]({% link rule-cookbook/arrow-recipes.md %}) |
-| Shared imports | [Python recipes]({% link rule-cookbook/python-recipes.md %}) |
-| Console window stats | [Lookback window]({% link rule-cookbook/lookback-window.md %}) |
-| Fault code catalog | [Fault codes]({% link fault-codes/index.md %}) |
+| **Full copy-paste library (GL36 A–M, VAV, plant)** | **[Python recipes (full Arrow library)]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }})** |
+| Quick templates | [Arrow recipes]({{ "/rule-cookbook/arrow-recipes/" | relative_url }}) |
+| Shared imports | [Python recipes]({{ "/rule-cookbook/python-recipes/" | relative_url }}) |
+| Console window stats | [Lookback window]({{ "/rule-cookbook/lookback-window/" | relative_url }}) |
+| Fault code catalog | [Fault codes]({{ "/fault-codes/" | relative_url }}) |
 | Programmatic defaults | `open_fdd.arrow_runtime.sensor_catalog` |
 
 ---
@@ -155,21 +155,21 @@ ASHRAE Guideline 36-style rules from the old YAML cookbook, translated to Arrow.
 
 | Legacy rule | Summary | Code | Full Arrow module |
 |-------------|---------|------|-------------------|
-| Rule A — duct static low @ full fan | SP below SP setpoint at high VFD | **AHU-A** | [Rule A]({% link rule-cookbook/python-recipes-arrow.md %}#rule-a--duct-static-low-at-full-fan-speed-ahu-a) |
-| Rule B — blend below band | MAT below OAT/RAT envelope | **AHU-D** | [Rules B & C]({% link rule-cookbook/python-recipes-arrow.md %}#rules-b--c--blended-air-outside-oatr-at-band-ahu-d) |
-| Rule C — blend above band | MAT above OAT/RAT envelope | **AHU-D** | [Rules B & C]({% link rule-cookbook/python-recipes-arrow.md %}#rules-b--c--blended-air-outside-oatr-at-band-ahu-d) |
-| Rule D — discharge cold when heating | SAT low vs MAT, heat valve open | **AHU-B** | [Rule D]({% link rule-cookbook/python-recipes-arrow.md %}#rule-d--discharge-cold-when-heating-commanded-ahu-b) |
-| Rule E — SAT low, full heating | SAT below SP, valve > 90% | **AHU-C** | [Rule E]({% link rule-cookbook/python-recipes-arrow.md %}#rule-e--sat-too-low-with-full-heating-ahu-c) |
-| Rule F — SAT/MAT mismatch econ | Econ mode, SAT ≠ MAT | **AHU-E** | [Rule F]({% link rule-cookbook/python-recipes-arrow.md %}#rule-f--satmat-mismatch-in-economizer-mode-ahu-e) |
-| Rule G — ambient warm free cool | OAT > SAT SP, econ open, cool off | **AHU-E** | [Rule G]({% link rule-cookbook/python-recipes-arrow.md %}#rule-g--ambient-too-warm-for-free-cooling-ahu-e) |
-| Rule H — OAT/MAT mismatch econ+mech | Mech + econ, MAT ≠ OAT | **AHU-E** | [Rule H]({% link rule-cookbook/python-recipes-arrow.md %}#rule-h--oatmat-mismatch-econ--mech-cooling-ahu-e) |
-| Rule I — OAT/MAT mismatch econ-only | Econ only, MAT ≠ OAT | **AHU-E** | [Rule I]({% link rule-cookbook/python-recipes-arrow.md %}#rule-i--oatmat-mismatch-economizer-only-ahu-e) |
-| Rule J — discharge above blend cooling | SAT > MAT in cooling | **AHU-B** | [Rule J]({% link rule-cookbook/python-recipes-arrow.md %}#rule-j--discharge-above-blended-in-cooling-ahu-b) |
-| Rule K — discharge above SP full cool | SAT > SP, full cooling | **AHU-C** | [Rule K]({% link rule-cookbook/python-recipes-arrow.md %}#rule-k--discharge-above-setpoint-in-full-cooling-ahu-c) |
-| Rule L — cooling coil ΔT when off | CHW drop when valves closed | **CH-C** | [Rule L]({% link rule-cookbook/python-recipes-arrow.md %}#rule-l--cooling-coil-δt-when-inactive-ch-c) |
-| Rule M — heating coil ΔT when off | HW rise when valves closed | **AHU-B** | [Rule M]({% link rule-cookbook/python-recipes-arrow.md %}#rule-m--heating-coil-δt-when-inactive-ahu-b) |
+| Rule A — duct static low @ full fan | SP below SP setpoint at high VFD | **AHU-A** | [Rule A]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-a--duct-static-low-at-full-fan-speed-ahu-a) |
+| Rule B — blend below band | MAT below OAT/RAT envelope | **AHU-D** | [Rules B & C]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rules-b--c--blended-air-outside-oatr-at-band-ahu-d) |
+| Rule C — blend above band | MAT above OAT/RAT envelope | **AHU-D** | [Rules B & C]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rules-b--c--blended-air-outside-oatr-at-band-ahu-d) |
+| Rule D — discharge cold when heating | SAT low vs MAT, heat valve open | **AHU-B** | [Rule D]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-d--discharge-cold-when-heating-commanded-ahu-b) |
+| Rule E — SAT low, full heating | SAT below SP, valve > 90% | **AHU-C** | [Rule E]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-e--sat-too-low-with-full-heating-ahu-c) |
+| Rule F — SAT/MAT mismatch econ | Econ mode, SAT ≠ MAT | **AHU-E** | [Rule F]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-f--satmat-mismatch-in-economizer-mode-ahu-e) |
+| Rule G — ambient warm free cool | OAT > SAT SP, econ open, cool off | **AHU-E** | [Rule G]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-g--ambient-too-warm-for-free-cooling-ahu-e) |
+| Rule H — OAT/MAT mismatch econ+mech | Mech + econ, MAT ≠ OAT | **AHU-E** | [Rule H]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-h--oatmat-mismatch-econ--mech-cooling-ahu-e) |
+| Rule I — OAT/MAT mismatch econ-only | Econ only, MAT ≠ OAT | **AHU-E** | [Rule I]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-i--oatmat-mismatch-economizer-only-ahu-e) |
+| Rule J — discharge above blend cooling | SAT > MAT in cooling | **AHU-B** | [Rule J]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-j--discharge-above-blended-in-cooling-ahu-b) |
+| Rule K — discharge above SP full cool | SAT > SP, full cooling | **AHU-C** | [Rule K]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-k--discharge-above-setpoint-in-full-cooling-ahu-c) |
+| Rule L — cooling coil ΔT when off | CHW drop when valves closed | **CH-C** | [Rule L]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-l--cooling-coil-δt-when-inactive-ch-c) |
+| Rule M — heating coil ΔT when off | HW rise when valves closed | **AHU-B** | [Rule M]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-m--heating-coil-δt-when-inactive-ahu-b) |
 
-All rules A–M have **full `apply_faults_arrow` modules** in [Python recipes (full Arrow library)]({% link rule-cookbook/python-recipes-arrow.md %}).
+All rules A–M have **full `apply_faults_arrow` modules** in [Python recipes (full Arrow library)]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}).
 
 ---
 
@@ -183,19 +183,19 @@ Maps to legacy YAML starter filenames; use as first deploy bundle.
 | `02_vav_zone_temp_flatline_occupied` | `sensor_flatline_mask(..., "zone_temp")` + occupied | **VAV-C** |
 | `03_vav_damper_command_extreme_flatline` | `flatline_1h_mask` on damper cmd column | **VAV-D** |
 | `04_ahu_runtime_outside_schedule` | `after_hours_fan_satisfied_mask` / run-hours script | **BLD-C** |
-| `05_ahu_duct_static_pressure_not_maintained` | [Rule A]({% link rule-cookbook/python-recipes-arrow.md %}#rule-a--duct-static-low-at-full-fan-speed-ahu-a) | **AHU-A** |
+| `05_ahu_duct_static_pressure_not_maintained` | [Rule A]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#rule-a--duct-static-low-at-full-fan-speed-ahu-a) | **AHU-A** |
 | `06_ahu_internal_temp_sensor_bounds` | `sensor_bounds_mask` on SAT/MAT | **AHU-C** |
 | `07_ahu_internal_temp_sensor_flatline` | `sensor_flatline_mask` on SAT | **AHU-C** |
 
 ### Economizer starters
 
-Full modules: [economizer section]({% link rule-cookbook/python-recipes-arrow.md %}#economizer-starters) (`ahu_econ_100oa_temp_tracking_fault`, `ahu_mech_cooling_when_free_cooling_available`, `ahu_oa_damper_excess_open_extreme_ambient`).
+Full modules: [economizer section]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#economizer-starters) (`ahu_econ_100oa_temp_tracking_fault`, `ahu_mech_cooling_when_free_cooling_available`, `ahu_oa_damper_excess_open_extreme_ambient`).
 
 ---
 
 ## VAV, central plant, heat pump
 
-Full modules: [VAV]({% link rule-cookbook/python-recipes-arrow.md %}#vav-zones) · [Central plant]({% link rule-cookbook/python-recipes-arrow.md %}#central-plant) · [Heat pumps]({% link rule-cookbook/python-recipes-arrow.md %}#heat-pumps).
+Full modules: [VAV]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#vav-zones) · [Central plant]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#central-plant) · [Heat pumps]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#heat-pumps).
 
 Rolling persistence: `arrow_rolling_min` + `pc.and_` (replaces pandas `.rolling(n).min()`).
 
@@ -203,7 +203,7 @@ Rolling persistence: `arrow_rolling_min` + `pc.and_` (replaces pandas `.rolling(
 
 ## Opportunistic / ventilation
 
-Full modules: [Opportunistic section]({% link rule-cookbook/python-recipes-arrow.md %}#opportunistic--ventilation) · [Weather]({% link rule-cookbook/python-recipes-arrow.md %}#weather-station).
+Full modules: [Opportunistic section]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#opportunistic--ventilation) · [Weather]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}#weather-station).
 
 ---
 
@@ -217,7 +217,7 @@ Full modules: [Opportunistic section]({% link rule-cookbook/python-recipes-arrow
 | No new samples | `stale_points` | **BLD-D** | Equipment fault |
 | MAT ∉ [OAT, RAT] | `mixing_envelope` | **AHU-D** | Stratification during startup |
 
-Always gate sensor faults with **fan on**, **valve open**, or **occupied** where appropriate — see [Sensor & data quality]({% link fault-codes/sensor-quality.md %}).
+Always gate sensor faults with **fan on**, **valve open**, or **occupied** where appropriate — see [Sensor & data quality]({{ "/fault-codes/sensor-quality/" | relative_url }}).
 
 ---
 
@@ -240,7 +240,7 @@ Set `cfg["temp_unit"] = "metric"` in Rule Lab or scale constants:
 
 ## Binding rules to the fault catalog
 
-1. Pick a **letter code** from [Fault codes]({% link fault-codes/index.md %}) — never invent suffixes.
+1. Pick a **letter code** from [Fault codes]({{ "/fault-codes/" | relative_url }}) — never invent suffixes.
 2. In Rule Lab, set **fault_code** on the rule row.
 3. Batch FDD aggregates into `GET /api/faults/status` and portfolio rollup.
 4. Legacy numeric codes (`AHU-03`) migrate via `LEGACY_CODE_MAP` in the bridge.
@@ -260,4 +260,4 @@ curl -s http://127.0.0.1:8765/api/faults/catalog | jq '.families[].codes[] | sel
 - [ ] Apply sensor_catalog defaults; tune bounds for site climate
 - [ ] Enable building-agent check-in; verify faults in portfolio rollup
 
-**Next:** [Python recipes (full Arrow library)]({% link rule-cookbook/python-recipes-arrow.md %}) · [Arrow recipes]({% link rule-cookbook/arrow-recipes.md %}) · [Fault codes]({% link fault-codes/index.md %}) · [Rule Lab]({% link operator-bridge/rule-lab.md %})
+**Next:** [Python recipes (full Arrow library)]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}) · [Arrow recipes]({{ "/rule-cookbook/arrow-recipes/" | relative_url }}) · [Fault codes]({{ "/fault-codes/" | relative_url }}) · [Rule Lab]({{ "/operator-bridge/rule-lab/" | relative_url }})

--- a/docs/rule-cookbook/index.md
+++ b/docs/rule-cookbook/index.md
@@ -9,13 +9,13 @@ Practical patterns for **Arrow-native Rule Lab** (`apply_faults_arrow`) on feath
 
 | Page | Use when |
 |------|----------|
-| [**Python recipes (full Arrow library)**]({% link rule-cookbook/python-recipes-arrow.md %}) | **Copy-paste GL36 A–M, VAV, plant, economizer, weather** — replaces legacy YAML cookbook |
-| [**Expression cookbook (Arrow-native)**]({% link rule-cookbook/expression-cookbook.md %}) | Sensor bounds, legacy→Arrow map, commissioning checklist |
-| [Arrow recipes]({% link rule-cookbook/arrow-recipes.md %}) | Short templates — threshold, flatline, OOB, fan/schedule |
-| [Python recipes]({% link rule-cookbook/python-recipes.md %}) | Shared `open_fdd.arrow_runtime.cookbook` imports |
-| [Lookback window helper]({% link rule-cookbook/lookback-window.md %}) | `_kit_lookback_stats` — print start/stop timestamps and span |
-| [Windowing & debugging]({% link rule-cookbook/windowing-debugging.md %}) | Rolling windows, batch runtime, Rule Lab console |
-| [GL36 algorithm stubs]({% link rule-cookbook/gl36-algorithm-stubs.md %}) | Doc-only supervisory patterns (trim & respond, plant resets) |
+| [**Python recipes (full Arrow library)**]({{ "/rule-cookbook/python-recipes-arrow/" | relative_url }}) | **Copy-paste GL36 A–M, VAV, plant, economizer, weather** — replaces legacy YAML cookbook |
+| [**Expression cookbook (Arrow-native)**]({{ "/rule-cookbook/expression-cookbook/" | relative_url }}) | Sensor bounds, legacy→Arrow map, commissioning checklist |
+| [Arrow recipes]({{ "/rule-cookbook/arrow-recipes/" | relative_url }}) | Short templates — threshold, flatline, OOB, fan/schedule |
+| [Python recipes]({{ "/rule-cookbook/python-recipes/" | relative_url }}) | Shared `open_fdd.arrow_runtime.cookbook` imports |
+| [Lookback window helper]({{ "/rule-cookbook/lookback-window/" | relative_url }}) | `_kit_lookback_stats` — print start/stop timestamps and span |
+| [Windowing & debugging]({{ "/rule-cookbook/windowing-debugging/" | relative_url }}) | Rolling windows, batch runtime, Rule Lab console |
+| [GL36 algorithm stubs]({{ "/rule-cookbook/gl36-algorithm-stubs/" | relative_url }}) | Doc-only supervisory patterns (trim & respond, plant resets) |
 
 Programmatic sensor defaults: `open_fdd.arrow_runtime.sensor_catalog.SENSOR_PROFILES`.
 

--- a/docs/rule-cookbook/lookback-window.md
+++ b/docs/rule-cookbook/lookback-window.md
@@ -76,4 +76,4 @@ Always call `_kit_lookback_stats(table)` first so operators can confirm the tabl
 | Rule Lab **Update all records** | 24 h (`chunk_hours: 6`, `use_chunks: true`) |
 | Rule Lab Quick test | 3 h (UI default) |
 
-See [Windowing & debugging]({% link rule-cookbook/windowing-debugging.md %}) for `arrow_rolling_min` / `arrow_consecutive_true`.
+See [Windowing & debugging]({{ "/rule-cookbook/windowing-debugging/" | relative_url }}) for `arrow_rolling_min` / `arrow_consecutive_true`.

--- a/docs/rule-cookbook/python-recipes-arrow.md
+++ b/docs/rule-cookbook/python-recipes-arrow.md
@@ -12,7 +12,7 @@ Copy-paste **`apply_faults_arrow`** modules for Rule Lab. Replaces the legacy pa
 - Set **`fault_code`** in Rule Lab metadata (letter codes or Grade-A `AHU-ECON-001`)
 - Map historian column names in the data model / rule bindings (`ma-t`, `oa-t`, `stat_zn-t`, …)
 
-Quick patterns: [Arrow recipes]({% link rule-cookbook/arrow-recipes.md %}) · Index: [Expression cookbook (Arrow-native)]({% link rule-cookbook/expression-cookbook.md %})
+Quick patterns: [Arrow recipes]({{ "/rule-cookbook/arrow-recipes/" | relative_url }}) · Index: [Expression cookbook (Arrow-native)]({{ "/rule-cookbook/expression-cookbook/" | relative_url }})
 
 ---
 
@@ -410,7 +410,7 @@ def apply_faults_arrow(table, cfg, context=None):
 
 ### Zone / IAQ bounds
 
-Use `sensor_bounds_mask(table, "zone_temp", cfg)` or `sensor_bounds_mask` with CO₂ profile — see [sensor validation]({% link rule-cookbook/expression-cookbook.md %}#sensor-validation-bounds-flatline-rate-of-change).
+Use `sensor_bounds_mask(table, "zone_temp", cfg)` or `sensor_bounds_mask` with CO₂ profile — see [sensor validation]({{ "/rule-cookbook/expression-cookbook/" | relative_url }}#sensor-validation-bounds-flatline-rate-of-change).
 
 ---
 
@@ -648,4 +648,4 @@ Pass `occupied_start_hour`, `occupied_end_hour`, `tz_offset_hours` in Rule Lab `
 4. Quick-test on 3–24 h feather window
 5. Ship via `setup_gl36_fdd.py` or Rule Lab save
 
-**See also:** [Expression cookbook]({% link rule-cookbook/expression-cookbook.md %}) · [Fault codes]({% link fault-codes/index.md %}) · [Rule Lab]({% link operator-bridge/rule-lab.md %})
+**See also:** [Expression cookbook]({{ "/rule-cookbook/expression-cookbook/" | relative_url }}) · [Fault codes]({{ "/fault-codes/" | relative_url }}) · [Rule Lab]({{ "/operator-bridge/rule-lab/" | relative_url }})

--- a/docs/rule-cookbook/python-recipes.md
+++ b/docs/rule-cookbook/python-recipes.md
@@ -8,9 +8,9 @@ nav_order: 2
 
 All Rule Lab Python rules use **`apply_faults_arrow(table, cfg, context)`** on PyArrow tables with **`pyarrow.compute`** and **module constants**.
 
-See **[Arrow recipes]({% link rule-cookbook/arrow-recipes.md %})** for the canonical cookbook (flatline, spread, OOB, schedule faults).
+See **[Arrow recipes]({{ "/rule-cookbook/arrow-recipes/" | relative_url }})** for the canonical cookbook (flatline, spread, OOB, schedule faults).
 
-Shared helpers live in `open_fdd.arrow_runtime.cookbook` and `open_fdd.arrow_runtime.windows`. For console validation, copy **`_kit_lookback_stats`** from [Lookback window helper]({% link rule-cookbook/lookback-window.md %}).
+Shared helpers live in `open_fdd.arrow_runtime.cookbook` and `open_fdd.arrow_runtime.windows`. For console validation, copy **`_kit_lookback_stats`** from [Lookback window helper]({{ "/rule-cookbook/lookback-window/" | relative_url }}).
 
 ```python
 from open_fdd.arrow_runtime.windows import arrow_rolling_min, arrow_rolling_max

--- a/docs/rule-cookbook/windowing-debugging.md
+++ b/docs/rule-cookbook/windowing-debugging.md
@@ -12,7 +12,7 @@ nav_order: 4
 |---|------------------------|-------------------|
 | Set by | Batch `lookback_hours`, FDD loop, Quick test UI | `WINDOW_SAMPLES` constant in `rule.py` |
 | Typical | 1 h scheduled; 24 h Update all | 12 samples ≈ 1 h @ 5 min poll |
-| Validate with | `_kit_lookback_stats(table)` — see [Lookback window helper]({% link rule-cookbook/lookback-window.md %}) | Rule logic + console `flagged` count |
+| Validate with | `_kit_lookback_stats(table)` — see [Lookback window helper]({{ "/rule-cookbook/lookback-window/" | relative_url }}) | Rule logic + console `flagged` count |
 
 ## Rolling windows (Arrow)
 

--- a/docs/security/authenticated-scanning.md
+++ b/docs/security/authenticated-scanning.md
@@ -6,11 +6,11 @@ nav_order: 4
 
 # Authenticated scanning (roadmap)
 
-[ZAP baseline]({% link security/zap-baseline.md %}) is **unauthenticated** — it checks public pages, response headers, and a handful of routes reachable without login. That is the right default for every docker image / patch revision smoke on a test LAN.
+[ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}) is **unauthenticated** — it checks public pages, response headers, and a handful of routes reachable without login. That is the right default for every docker image / patch revision smoke on a test LAN.
 
 For **deep** coverage of integrator dashboards, `/api/*` routes, WebSocket sessions, and role-gated writes, plan a separate **authenticated** scan — only on fake/bench stacks with explicit approval.
 
-Release context: [Security testing cycle]({% link developer/security-testing.md %}).
+Release context: [Security testing cycle]({{ "/developer/security-testing/" | relative_url }}).
 
 ## Current state (3.0.x)
 
@@ -54,5 +54,5 @@ Do **not** run active scans against production Acme without a maintenance window
 ## Related
 
 - [scripts/security/README.md](https://github.com/bbartling/open-fdd/blob/master/scripts/security/README.md) — baseline setup
-- [Secrets and auth]({% link security/secrets-auth.md %}) — env file layout
-- [LAN hardening]({% link security/lan-hardening.md %}) — bind and auth modes
+- [Secrets and auth]({{ "/security/secrets-auth/" | relative_url }}) — env file layout
+- [LAN hardening]({{ "/security/lan-hardening/" | relative_url }}) — bind and auth modes

--- a/docs/security/bacnet-writes.md
+++ b/docs/security/bacnet-writes.md
@@ -9,7 +9,7 @@ nav_order: 6
 Supervisory writes require:
 
 1. **Feature flag** enabled in environment (off by default).
-2. **Allowlist** file at `workspace/bacnet/write_allowlist.json` (copy from [`write_allowlist.example.json`](write_allowlist.example.json)). If the flag is on but the allowlist is missing, writes are **denied**.
+2. **Allowlist** file at `workspace/bacnet/write_allowlist.json` (copy from [`write_allowlist.example.json`](https://github.com/bbartling/open-fdd/blob/master/docs/security/write_allowlist.example.json)). If the flag is on but the allowlist is missing, writes are **denied**.
 3. **Integrator** role on API calls.
 4. **Audit** log review after commissioning sessions.
 
@@ -17,6 +17,6 @@ Allowlist entries support `device_instance`, `object_identifier`, `property_iden
 
 Lab-only override: `OFDD_BACNET_WRITE_ALLOW_ANY=1` (audited; not for production edges).
 
-See operator guide: [BACnet write safety]({% link bacnet/write-safety.md %}).
+See operator guide: [BACnet write safety]({{ "/bacnet/write-safety/" | relative_url }}).
 
 Never enable blanket write access for agent or integrator automation without human approval per site.

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -10,13 +10,13 @@ LAN deployment security for the Operator Bridge and BACnet write guard. Open-FDD
 
 | Page | Topic |
 |------|-------|
-| [LAN hardening]({% link security/lan-hardening.md %}) | Auth and bind modes |
-| [ZAP baseline (local bench)]({% link security/zap-baseline.md %}) | Pentest stack, expected warnings |
-| [TLS and certificates]({% link security/tls-and-certs.md %}) | Cert ownership, bench TLS mode |
-| [Linux host hardening]({% link security/linux-host-hardening.md %}) | Ubuntu edge VM, SSH, kernel, Ollama bind |
-| [Tenable / Nessus remediation]({% link security/tenable-remediation.md %}) | IT scan findings, operator runbook |
-| [Authenticated scanning (roadmap)]({% link security/authenticated-scanning.md %}) | Deep ZAP / protected API |
-| [Secrets and auth]({% link security/secrets-auth.md %}) | Env files |
-| [BACnet write allowlists]({% link security/bacnet-writes.md %}) | Supervisory write gates |
-| [Release & LAN scan cycle]({% link developer/security-testing.md %}) | Per-revision ZAP + CI workflow |
-| [Logging and audit]({% link ops/logging.md %}) | Auth audit trail, rotation, SIEM |
+| [LAN hardening]({{ "/security/lan-hardening/" | relative_url }}) | Auth and bind modes |
+| [ZAP baseline (local bench)]({{ "/security/zap-baseline/" | relative_url }}) | Pentest stack, expected warnings |
+| [TLS and certificates]({{ "/security/tls-and-certs/" | relative_url }}) | Cert ownership, bench TLS mode |
+| [Linux host hardening]({{ "/security/linux-host-hardening/" | relative_url }}) | Ubuntu edge VM, SSH, kernel, Ollama bind |
+| [Tenable / Nessus remediation]({{ "/security/tenable-remediation/" | relative_url }}) | IT scan findings, operator runbook |
+| [Authenticated scanning (roadmap)]({{ "/security/authenticated-scanning/" | relative_url }}) | Deep ZAP / protected API |
+| [Secrets and auth]({{ "/security/secrets-auth/" | relative_url }}) | Env files |
+| [BACnet write allowlists]({{ "/security/bacnet-writes/" | relative_url }}) | Supervisory write gates |
+| [Release & LAN scan cycle]({{ "/developer/security-testing/" | relative_url }}) | Per-revision ZAP + CI workflow |
+| [Logging and audit]({{ "/ops/logging/" | relative_url }}) | Auth audit trail, rotation, SIEM |

--- a/docs/security/lan-hardening.md
+++ b/docs/security/lan-hardening.md
@@ -8,7 +8,7 @@ nav_order: 1
 
 Open-FDD targets **trusted building LAN / OT edge** deployment. The Operator Bridge is not intended for direct public internet exposure.
 
-Full mode matrix: [Deployment modes]({% link architecture/deployment-modes.md %}).
+Full mode matrix: [Deployment modes]({{ "/architecture/deployment-modes/" | relative_url }}).
 
 ## Auth and bind
 
@@ -25,7 +25,7 @@ Startup **fails** on non-loopback bind without credentials (unless insecure lab 
 - Put **Caddy** on `:80` / `:443`; keep bridge `:8765` on loopback when possible.
 - Do not port-forward the Operator Bridge to the public internet without TLS and strong auth.
 - Keep BACnet on OT VLANs; management UI on IT VLAN with firewall rules.
-- BACnet **writes** are gated by default — [BACnet write guard]({% link security/bacnet-writes.md %}).
+- BACnet **writes** are gated by default — [BACnet write guard]({{ "/security/bacnet-writes/" | relative_url }}).
 
 ## Rule Lab
 
@@ -35,10 +35,10 @@ Rule Lab runs **operator-authored Python** in a sandbox. Restrict integrator acc
 
 | Topic | Page |
 |-------|------|
-| Certificates (self-signed / site CA) | [TLS and certificates]({% link security/tls-and-certs.md %}) |
-| ZAP + Nmap bench smoke | [ZAP baseline]({% link security/zap-baseline.md %}) · `scripts/security/` |
-| Ubuntu host + Tenable/Nessus | [Linux host hardening]({% link security/linux-host-hardening.md %}) · [Tenable remediation]({% link security/tenable-remediation.md %}) |
-| Release test cycle (maintainers) | [Security testing]({% link developer/security-testing.md %}) |
+| Certificates (self-signed / site CA) | [TLS and certificates]({{ "/security/tls-and-certs/" | relative_url }}) |
+| ZAP + Nmap bench smoke | [ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}) · `scripts/security/` |
+| Ubuntu host + Tenable/Nessus | [Linux host hardening]({{ "/security/linux-host-hardening/" | relative_url }}) · [Tenable remediation]({{ "/security/tenable-remediation/" | relative_url }}) |
+| Release test cycle (maintainers) | [Security testing]({{ "/developer/security-testing/" | relative_url }}) |
 
 ## Ollama on the edge
 

--- a/docs/security/linux-host-hardening.md
+++ b/docs/security/linux-host-hardening.md
@@ -6,9 +6,9 @@ nav_order: 7
 
 # Linux host hardening
 
-Generic **Ubuntu edge VM** guidance for Open-FDD deployments scanned by IT tools (Tenable/Nessus, Qualys, etc.). This complements application-level [LAN hardening]({% link security/lan-hardening.md %}) and [TLS]({% link security/tls-and-certs.md %}).
+Generic **Ubuntu edge VM** guidance for Open-FDD deployments scanned by IT tools (Tenable/Nessus, Qualys, etc.). This complements application-level [LAN hardening]({{ "/security/lan-hardening/" | relative_url }}) and [TLS]({{ "/security/tls-and-certs/" | relative_url }}).
 
-Nessus-specific finding tables: [Tenable remediation]({% link security/tenable-remediation.md %}).
+Nessus-specific finding tables: [Tenable remediation]({{ "/security/tenable-remediation/" | relative_url }}).
 
 ## Scope
 
@@ -17,7 +17,7 @@ Nessus-specific finding tables: [Tenable remediation]({% link security/tenable-r
 | Ubuntu kernel, OpenSSH, apt packages | **Site IT / integrator** | `scripts/security/remediate_ubuntu_host.sh` |
 | Docker engine, compose, Caddy | **Integrator** | Ansible + `check_openfdd_exposure.sh` |
 | Open-FDD containers (pip/pyOpenSSL) | **Open-FDD maintainers** | `docker/python-security-constraints.txt`, GHCR images |
-| Self-signed TLS on OT LAN | **Expected lab finding** | Enterprise CA path in [TLS]({% link security/tls-and-certs.md %}) |
+| Self-signed TLS on OT LAN | **Expected lab finding** | Enterprise CA path in [TLS]({{ "/security/tls-and-certs/" | relative_url }}) |
 
 ## Quick operator workflow
 
@@ -135,7 +135,7 @@ sudo nft add rule inet filter input icmp type timestamp-request drop
 
 ## TLS and certificate scans
 
-Self-signed or internal CA certificates produce **Medium** Nessus SSL findings (untrusted, self-signed, expiry). That is **expected** for lab/OT encryption-in-transit. For clean SSL plugin results, install a **site enterprise CA** certificate on Caddy — [TLS and certificates]({% link security/tls-and-certs.md %}#enterprise-ca-production).
+Self-signed or internal CA certificates produce **Medium** Nessus SSL findings (untrusted, self-signed, expiry). That is **expected** for lab/OT encryption-in-transit. For clean SSL plugin results, install a **site enterprise CA** certificate on Caddy — [TLS and certificates]({{ "/security/tls-and-certs/" | relative_url }}#enterprise-ca-production).
 
 ## Maintainer security audits (CI parity)
 

--- a/docs/security/secrets-auth.md
+++ b/docs/security/secrets-auth.md
@@ -19,7 +19,7 @@ nav_order: 5
 | `workspace/pentest.env.local` | LAN security scan stack |
 | `infra/ansible/secrets/<host>.env.local` | SSH deploy secrets (maintainers) |
 
-Copy from `*.example` templates only. Full inventory: [Workspace env files]({% link appendix/workspace-env-files.md %}).
+Copy from `*.example` templates only. Full inventory: [Workspace env files]({{ "/appendix/workspace-env-files/" | relative_url }}).
 
 ## Required variables (production)
 
@@ -37,4 +37,4 @@ Use read-only registry credentials on edge if images are private; rotate tokens 
 
 Back up `workspace/data/` and auth env in secure operator vault — not in git.
 
-Audit JSONL under `workspace/logs/` may contain client IPs and usernames — treat like security logs. See [Logging and audit]({% link ops/logging.md %}).
+Audit JSONL under `workspace/logs/` may contain client IPs and usernames — treat like security logs. See [Logging and audit]({{ "/ops/logging/" | relative_url }}).

--- a/docs/security/tenable-remediation.md
+++ b/docs/security/tenable-remediation.md
@@ -8,7 +8,7 @@ nav_order: 8
 
 Remediation plan for **IT/Tenable.io Nessus** findings on an Open-FDD **OT/LAN edge** deployment (e.g. Acme GL36 lab VM). Open-FDD runs behind a building firewall on Ubuntu with Docker Compose, Caddy, and optional host Ollama.
 
-Related: [Linux host hardening]({% link security/linux-host-hardening.md %}), [TLS and certificates]({% link security/tls-and-certs.md %}), [LAN hardening]({% link security/lan-hardening.md %}), [Security testing cycle]({% link developer/security-testing.md %}).
+Related: [Linux host hardening]({{ "/security/linux-host-hardening/" | relative_url }}), [TLS and certificates]({{ "/security/tls-and-certs/" | relative_url }}), [LAN hardening]({{ "/security/lan-hardening/" | relative_url }}), [Security testing cycle]({{ "/developer/security-testing/" | relative_url }}).
 
 ## Prioritized action plan
 
@@ -119,7 +119,7 @@ CI `pip-audit` runs against bridge + bacnet requirements with the same constrain
 | Caddy self-signed `:443` | Medium: untrusted, self-signed, expiry | OT LAN encryption, lab |
 | Enterprise CA cert on Caddy | Clean SSL plugins (if chain trusted) | IT mandates clean Nessus |
 
-See [TLS — enterprise CA]({% link security/tls-and-certs.md %}#enterprise-ca-on-caddy-edge).
+See [TLS — enterprise CA]({{ "/security/tls-and-certs/" | relative_url }}#enterprise-ca-on-caddy-edge).
 
 ## Residual findings after remediation
 
@@ -136,7 +136,7 @@ Even with a patched host and loopback-only Ollama, IT may still see:
 3. **BACnet UDP 47808** on commission is expected OT traffic — out of scope for web/plugin remediation.
 4. Do not expose Ollama **11434** to the building LAN; agent chat is server-side only.
 5. Kernel CVEs require **host reboot** — schedule with operations.
-6. For authenticated web/API depth, see roadmap [Authenticated scanning]({% link security/authenticated-scanning.md %}).
+6. For authenticated web/API depth, see roadmap [Authenticated scanning]({{ "/security/authenticated-scanning/" | relative_url }}).
 
 ## Repo-owned fixes (this document’s release)
 

--- a/docs/security/tls-and-certs.md
+++ b/docs/security/tls-and-certs.md
@@ -8,7 +8,7 @@ nav_order: 3
 
 Who generates, stores, and renews TLS material for Open-FDD on OT LANs — and how that ties into ZAP/Nmap bench testing.
 
-Developer release cycle: [Security testing cycle]({% link developer/security-testing.md %}).
+Developer release cycle: [Security testing cycle]({{ "/developer/security-testing/" | relative_url }}).
 
 ## Ownership
 
@@ -34,7 +34,7 @@ OFDD_CADDY_MODE=tls ./scripts/run_local.sh
 # or pentest stack with OFDD_CADDY_MODE=tls
 ```
 
-Caddy serves `:443` and redirects `:80` → HTTPS. Caddy adds **`Strict-Transport-Security`** only; all other security headers remain on the **bridge** ([ZAP baseline]({% link security/zap-baseline.md %}#header-ownership)).
+Caddy serves `:443` and redirects `:80` → HTTPS. Caddy adds **`Strict-Transport-Security`** only; all other security headers remain on the **bridge** ([ZAP baseline]({{ "/security/zap-baseline/" | relative_url }}#header-ownership)).
 
 ## ZAP / Nmap with TLS bench
 
@@ -89,7 +89,7 @@ openssl x509 -in /etc/openfdd/caddy/cert.pem -noout -dates
 }
 ```
 
-Lab/self-signed mode still produces expected **Medium** Tenable findings — document as accepted risk or switch to enterprise CA. See [Tenable remediation]({% link security/tenable-remediation.md %}).
+Lab/self-signed mode still produces expected **Medium** Tenable findings — document as accepted risk or switch to enterprise CA. See [Tenable remediation]({{ "/security/tenable-remediation/" | relative_url }}).
 
 ## Caddy internal CA mode (lab)
 

--- a/docs/security/zap-baseline.md
+++ b/docs/security/zap-baseline.md
@@ -8,7 +8,7 @@ nav_order: 2
 
 Passive [OWASP ZAP baseline](https://www.zaproxy.org/docs/docker/baseline-scan/) against the **pentest production stack** on benserver is the standard LAN security smoke before Acme edge deploys.
 
-Full per-revision workflow (pytest → PR → GHCR → Acme): [Developer — security testing cycle]({% link developer/security-testing.md %}).
+Full per-revision workflow (pytest → PR → GHCR → Acme): [Developer — security testing cycle]({{ "/developer/security-testing/" | relative_url }}).
 
 Packaged scan scripts (Windows + Mac/Linux): [scripts/security/README.md](https://github.com/bbartling/open-fdd/blob/master/scripts/security/README.md).
 
@@ -33,7 +33,7 @@ Packaged scan scripts (Windows + Mac/Linux): [scripts/security/README.md](https:
 ./scripts/security/run_openfdd_security_scan.sh --url http://192.168.204.18
 ```
 
-ZAP target (example): `http://192.168.204.18/` — Caddy on `:80` only; bridge `:8765` stays loopback. TLS bench: see [TLS and certificates]({% link security/tls-and-certs.md %}).
+ZAP target (example): `http://192.168.204.18/` — Caddy on `:80` only; bridge `:8765` stays loopback. TLS bench: see [TLS and certificates]({{ "/security/tls-and-certs/" | relative_url }}).
 
 ## Expected results (HTTP bench mode)
 
@@ -56,7 +56,7 @@ ZAP target (example): `http://192.168.204.18/` — Caddy on `:80` only; bridge `
 
 ## Authenticated scan (later)
 
-Baseline scan hits ~4 public endpoints (`/health`, public agent insight routes). Deep API/dashboard coverage requires ZAP with integrator login — see [Authenticated scanning (roadmap)]({% link security/authenticated-scanning.md %}).
+Baseline scan hits ~4 public endpoints (`/health`, public agent insight routes). Deep API/dashboard coverage requires ZAP with integrator login — see [Authenticated scanning (roadmap)]({{ "/security/authenticated-scanning/" | relative_url }}).
 
 ## After fixes
 

--- a/scripts/check_docs_internal_links.py
+++ b/scripts/check_docs_internal_links.py
@@ -43,6 +43,18 @@ def _skip_href(href: str) -> bool:
     return False
 
 
+def _missing_baseurl(href: str) -> bool:
+    """Root-absolute paths must include GitHub Pages project baseurl."""
+    if not href.startswith("/"):
+        return False
+    if href.startswith(BASEURL + "/") or href == BASEURL + "/" or href == BASEURL:
+        return False
+    # Allow root-only anchors and asset paths that Jekyll may emit at repo root (rare).
+    if href.startswith("/assets/"):
+        return True
+    return True
+
+
 def _site_path_for_href(href: str, site_dir: Path) -> Path | None:
     """Map published href to expected file under _site."""
     path = unquote(urlparse(href).path)
@@ -86,8 +98,11 @@ def check_site(site_dir: Path) -> tuple[list[str], list[str]]:
                 continue
             resolved = _site_path_for_href(href, site_dir)
             if resolved is None:
-                # Only flag paths under baseurl or root-relative site paths
-                if href.startswith(BASEURL) or href.startswith("/"):
+                if _missing_baseurl(href):
+                    errors.append(
+                        f"{page_url}: href missing {BASEURL} prefix (use relative_url) → {href}"
+                    )
+                elif href.startswith(BASEURL) or href.startswith("/"):
                     errors.append(f"{page_url}: broken internal link → {href}")
             elif "github.com" in href:
                 skipped.append(href)

--- a/scripts/fix_docs_link_tags.py
+++ b/scripts/fix_docs_link_tags.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Rewrite Jekyll {% link path.md %} tags to use relative_url (GitHub Pages baseurl)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DOCS = REPO / "docs"
+LINK_RE = re.compile(r"\{%\s*link\s+([^%]+?)\s*%\}")
+
+
+def md_path_to_site_path(md_path: str) -> str:
+    path = md_path.strip().replace("\\", "/")
+    if path.endswith("/index.md"):
+        path = path[: -len("index.md")].rstrip("/")
+        return f"/{path}/" if path else "/"
+    if path.endswith(".md"):
+        return f"/{path[:-3]}/"
+    return f"/{path}/"
+
+
+def rewrite(text: str) -> tuple[str, int]:
+    count = 0
+
+    def _repl(match: re.Match[str]) -> str:
+        nonlocal count
+        count += 1
+        site_path = md_path_to_site_path(match.group(1))
+        return f'{{{{ "{site_path}" | relative_url }}}}'
+
+    return LINK_RE.sub(_repl, text), count
+
+
+def main() -> int:
+    total = 0
+    for path in sorted(DOCS.rglob("*.md")):
+        if "_site" in path.parts:
+            continue
+        original = path.read_text(encoding="utf-8")
+        updated, n = rewrite(original)
+        if n:
+            path.write_text(updated, encoding="utf-8")
+            total += n
+            print(f"{path.relative_to(REPO)}: {n} link(s)")
+    print(f"Rewrote {total} link tag(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- **Root cause:** Jekyll `{% link path.md %}` emits root-absolute URLs (`/quick-start/docker/`) that 404 on the GitHub Pages **project site** (`https://bbartling.github.io/open-fdd/`). Sidebar nav was correct (`/open-fdd/...`); body/table links were not.
- Rewrote **296** internal doc links to `{{ "/path/" | relative_url }}` across `docs/`.
- Hardened `scripts/check_docs_internal_links.py` to fail CI when built HTML contains root-absolute hrefs missing the `/open-fdd` prefix.
- Added contributor guidance in `docs/developer/contributing.md` and checklist items in `DOCUMENTATION_CHECKLIST.md`.
- Added `scripts/fix_docs_link_tags.py` for future bulk migrations.

## Test plan
- [ ] CI **Docs (GitHub Pages)** workflow green (Jekyll build + internal link check)
- [ ] After deploy, home page “Start here” table links resolve (e.g. `/open-fdd/quick-start/docker/` → 200)
- [ ] Spot-check Operations and Rule Cookbook cross-links from page body text


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized internal documentation links across 80+ pages to use GitHub Pages-compatible `relative_url` format instead of legacy Jekyll `link` tags, ensuring consistent navigation across project sites.

* **Chores**
  * Added `scripts/fix_docs_link_tags.py` to automate link format conversion.
  * Enhanced `scripts/check_docs_internal_links.py` to detect and report missing `baseurl` prefixes in links.
  * Updated documentation checklist with link validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->