### PR TITLE
fix(ghcr): repair gh api query params for package dry-run

### DIFF
--- a/scripts/ghcr_prune_packages.py
+++ b/scripts/ghcr_prune_packages.py
@@ -151,11 +151,7 @@ def list_package_versions(owner: str, package: str, token: str | None) -> list[d
         cmd = [
             "gh",
             "api",
-            f"users/{owner}/packages/container/{package}/versions",
-            "-f",
-            f"per_page=100",
-            "-f",
-            f"page={page}",
+            f"users/{owner}/packages/container/{package}/versions?per_page=100&page={page}",
         ]
         proc = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
         if proc.returncode != 0:
@@ -350,7 +346,7 @@ def verify_packages_api_access(token: str | None) -> None:
     if token:
         env["GH_TOKEN"] = token
     proc = subprocess.run(
-        ["gh", "api", "user/packages", "-f", "package_type=container", "-f", "per_page=1"],
+        ["gh", "api", "user/packages?package_type=container&per_page=1"],
         capture_output=True,
         text=True,
         env=env,


### PR DESCRIPTION
## Summary
- Fix `gh api` calls to pass `package_type`, `per_page`, and `page` as URL query params (not `-f` form fields)
- Unblocks local dry-run preflight and **Prune old GHCR images** workflow

## Test plan
- [x] `pytest tests/scripts/test_ghcr_prune_packages.py -q`
- [ ] Re-dispatch **Prune old GHCR images** dry_run=true after merge

Made with [Cursor](https://cursor.com)