### PR TITLE
Rename portfolio dashboard to RCx Central and add Edge-authenticated RCx analytics/report workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,7 @@ edge_backup/local/acme/vm-bbartling/*
 
 # Central portfolio analytics (analyst clone — not edge)
 portfolio/data/
+portfolio/config/
 portfolio/sites.json
 portfolio/agent/MEMORY.md
 portfolio/agent/SKILLS.md

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ print(result.true_count)
 |------|-----|
 | Run FDD in your Python / cloud pipeline | **PyPI** `open-fdd` |
 | BACnet + UI + bridge on an edge host | **GHCR** Docker images |
-| Portfolio / MCP agent over Tailscale | Docker stack + [portfolio docs](https://bbartling.github.io/open-fdd/portfolio/) |
+| **OpenFDD Edge** on OT LAN | **GHCR** Docker images |
+| **OpenFDD RCx Central** (analyst PC) | [RCx Central docs](docs/rcx-central/index.md) · `./scripts/run_rcx_central_docker.sh` |
+| Portfolio collect / MCP over Tailscale | Edge stack + [portfolio docs](https://bbartling.github.io/open-fdd/portfolio/) |
 
 Examples: [`examples/`](examples/). Release: [developer/release-process](https://bbartling.github.io/open-fdd/developer/release-process/).
 

--- a/docker/rcx-central/Dockerfile
+++ b/docker/rcx-central/Dockerfile
@@ -1,0 +1,35 @@
+# OpenFDD RCx Central — analyst workstation / Docker Desktop image
+# docker build -f docker/rcx-central/Dockerfile -t openfdd-rcx-central:local .
+
+FROM python:3.12-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    OPENFDD_RCX_CENTRAL_DATA=/app/portfolio/data \
+    OPENFDD_RCX_CENTRAL_CONFIG=/app/portfolio/config \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY open_fdd ./open_fdd
+COPY portfolio ./portfolio
+
+RUN pip install --upgrade pip \
+    && pip install -e . \
+    && pip install -r portfolio/requirements.txt
+
+RUN mkdir -p /app/portfolio/data /app/portfolio/config /app/portfolio/data/reports
+
+EXPOSE 8050 8060
+
+COPY docker/rcx-central/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=25s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8060/health')" || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["api"]

--- a/docker/rcx-central/docker-compose.yml
+++ b/docker/rcx-central/docker-compose.yml
@@ -1,0 +1,49 @@
+# OpenFDD RCx Central — Docker Desktop / analyst workstation
+# docker compose -f docker/rcx-central/docker-compose.yml up --build
+
+services:
+  rcx-central-api:
+    image: ghcr.io/bbartling/openfdd-rcx-central:${OPENFDD_IMAGE_TAG:-local}
+    build:
+      context: ../..
+      dockerfile: docker/rcx-central/Dockerfile
+    command: ["api"]
+    ports:
+      - "8060:8060"
+    environment:
+      OPENFDD_CENTRAL_API_HOST: 0.0.0.0
+      OPENFDD_CENTRAL_API_PORT: "8060"
+      OPENFDD_RCX_CENTRAL_DATA: /app/portfolio/data
+      OPENFDD_RCX_CENTRAL_CONFIG: /app/portfolio/config
+    volumes:
+      - rcx-central-data:/app/portfolio/data
+      - rcx-central-config:/app/portfolio/config
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8060/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  rcx-central-dash:
+    image: ghcr.io/bbartling/openfdd-rcx-central:${OPENFDD_IMAGE_TAG:-local}
+    build:
+      context: ../..
+      dockerfile: docker/rcx-central/Dockerfile
+    command: ["dash"]
+    ports:
+      - "8050:8050"
+    environment:
+      OPENFDD_CENTRAL_API_URL: http://rcx-central-api:8060
+      OPENFDD_RCX_CENTRAL_DATA: /app/portfolio/data
+      OPENFDD_RCX_CENTRAL_CONFIG: /app/portfolio/config
+    volumes:
+      - rcx-central-data:/app/portfolio/data
+      - rcx-central-config:/app/portfolio/config
+    depends_on:
+      rcx-central-api:
+        condition: service_healthy
+
+volumes:
+  rcx-central-data:
+  rcx-central-config:

--- a/docker/rcx-central/entrypoint.sh
+++ b/docker/rcx-central/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+MODE="${1:-api}"
+case "$MODE" in
+  api)
+    exec python3 -m portfolio.central
+    ;;
+  dash)
+    exec python3 -m portfolio.dash
+    ;;
+  both)
+    python3 -m portfolio.central &
+    exec python3 -m portfolio.dash
+    ;;
+  *)
+    echo "Usage: entrypoint.sh [api|dash|both]" >&2
+    exit 1
+    ;;
+esac

--- a/docs/dev/rcx-central-current-state.md
+++ b/docs/dev/rcx-central-current-state.md
@@ -1,0 +1,69 @@
+# OpenFDD RCx Central — current state
+
+Branch: `feature/rcx-central-edge-analytics-docx`  
+Updated: 2026-05-30
+
+## Product names
+
+| User-facing | Internal path |
+|-------------|----------------|
+| **OpenFDD Edge** | `workspace/`, `docker/`, GHCR images |
+| **OpenFDD RCx Central** | `portfolio/` (Dash + Central API) |
+
+## Entrypoints
+
+| Service | Command | Port |
+|---------|---------|------|
+| RCx Central Dash | `python -m portfolio.dash` / `./scripts/run_portfolio_dash.sh` | 8050 |
+| RCx Central API | `./scripts/run_central_api.sh` → `python scripts/run_central_api.py` | 8060 |
+| Docker (both) | `./scripts/run_rcx_central_docker.sh` | 8050, 8060 |
+
+## Central API (new/changed)
+
+- `GET/POST/PUT/DELETE /api/central/edges`, `POST /api/central/edges/test`
+- `GET /api/central/mechanical-summary/{site_id}`
+- `GET /api/central/fdd-analytics/{site_id}`
+- `POST /api/central/rcx/preview`, `/charts/preview`, `/report`
+- `POST /api/central/rcx/report-legacy` (backward compatible)
+
+## Edge REST (read-only)
+
+Model: `/api/model/tree`, `/api/model/health`, SPARQL, `/api/model/fdd-query-presets`  
+Trends: `/api/timeseries/readings`, `/api/timeseries/series`  
+Analytics: `/api/analytics/overview`, `/api/analytics/faults`  
+Faults: `/api/faults/status`  
+Collect: `/api/building/portfolio-rollup`
+
+## Dash UI tabs
+
+Overview · Edge Connections · Mechanical Summary · FDD Analytics · Trend Explorer · RCx Report Builder · Validation Runs · Settings
+
+Header: **OpenFDD RCx Central**
+
+## RCx / charts
+
+- `portfolio/central/chart_preview.py` — matplotlib base64 previews, fault overlay bands from timeseries fault flags
+- `portfolio/central/trend_charts.py` — role→column mapping, trend fetch
+- `portfolio/central/fdd_analytics.py` — rules + chart packs
+- `open_fdd/reports/rcx_docx.py` — DOCX when installed
+
+## Docker
+
+`docker/rcx-central/` — Dockerfile, compose, volumes `rcx-central-data`, `rcx-central-config`  
+Smoke: `scripts/test_rcx_central_docker.sh`, `scripts/test_rcx_central_docker.ps1`
+
+## Tests
+
+`tests/portfolio/test_central.py`, `test_edge_registry.py`, `test_chart_preview.py`
+
+## Remaining gaps
+
+- GHCR publish for `openfdd-rcx-central` image tag
+- Trend Explorer tab (placeholder; Overview Plotly charts use local CSV collect)
+- Live ACME opt-in manual workflow doc section in CI
+- Deeper equipment-tree scope in RCx builder UI
+- More chart types (economizer, VAV worst zones)
+
+## Recommended next PR
+
+Publish RCx Central image + expand chart catalog + equipment-tree report scope.

--- a/docs/portfolio/central-api.md
+++ b/docs/portfolio/central-api.md
@@ -1,54 +1,66 @@
 ---
-title: Open-FDD Central API
+title: OpenFDD RCx Central API
 parent: Portfolio
 nav_order: 2
 ---
 
-# Open-FDD Central API
+# OpenFDD RCx Central API
 
-Multi-building desk over Tailscale/VPN. **Read-only toward edges** — no BACnet, no commands.
+Local analyst API for multi-edge RCx workflows over Tailscale/VPN. **Read-only toward OpenFDD Edge** — no BACnet, no commands.
+
+> Package path: `portfolio/central/api.py` — service name **openfdd-rcx-central**.
 
 ## Start
 
 ```bash
 pip install -r portfolio/requirements.txt
-cp portfolio/sites.json.example portfolio/sites.json   # edit base URLs
-./scripts/run_central_api.sh                           # http://127.0.0.1:8060
+./scripts/run_central_api.sh   # http://127.0.0.1:8060/health
 ```
 
-## Endpoints
+Docker Desktop: [docs/rcx-central/docker-desktop-windows.md](../rcx-central/docker-desktop-windows.md)
+
+## Edge registry (browser auth)
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/health` | Central service health |
-| GET | `/api/central/sites` | Edge registry + last check-in |
-| POST | `/api/central/sites/{site_id}/collect-validate` | Portfolio collect + read-only validation |
-| POST | `/api/central/validation/run` | One-off (`duration_hours=0`) or 24h plan |
-| GET | `/api/central/validation/jobs` | Stored validation jobs |
-| GET | `/api/central/validation/jobs/{id}` | Job detail + cycles |
-| POST | `/api/central/rcx/report` | Download RCx `.docx` report |
+| GET | `/api/central/edges` | Saved Edge instances (secrets masked) |
+| POST | `/api/central/edges` | Add/update Edge |
+| POST | `/api/central/edges/test` | Test connection (health + model) |
+| PUT | `/api/central/edges/{site_id}` | Update Edge |
+| DELETE | `/api/central/edges/{site_id}` | Remove Edge |
 
-## Validation plan body
+## Analytics & RCx
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/central/mechanical-summary/{site_id}` | Equipment counts, BACnet, readiness |
+| GET | `/api/central/fdd-analytics/{site_id}` | FDD rules + chart packs |
+| POST | `/api/central/rcx/preview` | Data readiness + chart catalog |
+| POST | `/api/central/rcx/charts/preview` | Matplotlib PNG previews (base64) |
+| POST | `/api/central/rcx/report` | Download DOCX report |
+
+## Validation (legacy collect workflow)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/central/sites` | Edge registry + last check-in |
+| POST | `/api/central/sites/{site_id}/collect-validate` | Collect rollup + validation |
+| POST | `/api/central/validation/run` | One-off or scheduled plan |
+| GET | `/api/central/validation/jobs` | Stored jobs |
+| GET | `/api/central/validation/jobs/{id}` | Job detail |
+
+## RCx report body
 
 ```json
 {
   "site_id": "acme",
-  "interval_hours": 2,
-  "duration_hours": 24,
-  "sleep_seconds": 0
+  "hours": 24,
+  "charts": ["fault_hours_by_severity", "ahu_sat_vs_setpoint"],
+  "sections": ["executive_summary", "mechanical_summary"],
+  "save_to_volume": true
 }
 ```
 
-Set `sleep_seconds` to `7200` for true 2-hour wall-clock spacing. Use `duration_hours: 0` for a one-off probe.
+Reports save under `portfolio/data/reports/` (configurable via `OPENFDD_RCX_CENTRAL_DATA`).
 
-## RCx report
-
-POST `/api/central/rcx/report` with `{"site_id": "acme"}`. Includes:
-
-- Active faults **with equipment name** (never severity-only)
-- Fault-hour estimates from rollup history
-- Missing-data / validation warnings
-
-## Safety
-
-Central never writes to BACnet devices or edge schedules. All edge calls use authenticated GET probes only.
+Legacy endpoint: `POST /api/central/rcx/report-legacy`

--- a/docs/portfolio/central-collection.md
+++ b/docs/portfolio/central-collection.md
@@ -4,9 +4,11 @@ parent: Portfolio
 nav_order: 1
 ---
 
-# Portfolio central collection
+# OpenFDD RCx Central — collection
 
-Edge Open-FDD sites emit **interval summaries** (not raw historian by default). Central portfolio ingests, stores, and aggregates for Dash and the AI tuning agent.
+**OpenFDD Edge** sites emit **interval summaries** (not raw historian by default). **OpenFDD RCx Central** ingests rollups over Tailscale/VPN, stores them locally, and feeds the Dash overview and validation jobs.
+
+RCx Central is read-only toward Edge/BACnet. It runs on an analyst workstation or Docker Desktop — not on the OT edge by default.
 
 ## Interval summary schema
 

--- a/docs/rcx-central/ai-agent-workflow.md
+++ b/docs/rcx-central/ai-agent-workflow.md
@@ -1,0 +1,24 @@
+# AI agent workflow vs runtime use
+
+## Runtime analyst (no git clone)
+
+1. `docker compose -f docker/rcx-central/docker-compose.yml up`
+2. Open http://localhost:8050
+3. Add ACME Edge via Tailscale URL in Edge Connections
+4. Test → Save → Mechanical Summary → RCx Report Builder → DOCX
+
+Kill container when done. Data persists in Docker volumes.
+
+## Developer / coding agent (git working tree)
+
+Use Cursor or Codex against the `open-fdd` repo to change Central code, tests, and docs. This requires a clone or working tree — **not** the runtime Docker image alone.
+
+## Secrets
+
+- Never commit `portfolio/config/credentials.json` or `sites.json` with passwords
+- Use env vars for CI: `OFDD_AGENT_PASSWORD`, etc.
+- Live ACME tests: `OPENFDD_LIVE_ACME=1` only
+
+## Model routing (test triage)
+
+See `AGENTS.md` — classify CI failures as SIMPLE (primary model) vs COMPLEX (thinking model) before processing.

--- a/docs/rcx-central/docker-desktop-windows.md
+++ b/docs/rcx-central/docker-desktop-windows.md
@@ -1,0 +1,43 @@
+# RCx Central on Docker Desktop (Windows)
+
+## Prerequisites
+
+- Docker Desktop for Windows
+- Edge reachable from the host (e.g. Tailscale)
+
+## Run
+
+```powershell
+cd open-fdd
+docker compose -f docker/rcx-central/docker-compose.yml up --build
+```
+
+Open:
+
+- Dash: http://localhost:8050
+- API health: http://localhost:8060/health
+
+No git clone required at runtime if you pull `ghcr.io/bbartling/openfdd-rcx-central` (when published). Build locally with `OPENFDD_IMAGE_TAG=local`.
+
+## Volumes
+
+| Volume | Purpose |
+|--------|---------|
+| `rcx-central-data` | Rollups, reports (`portfolio/data/reports/`) |
+| `rcx-central-config` | `sites.json`, masked credentials |
+
+## Tailscale networking
+
+If Edge is reachable on the Windows host but not from inside the Linux container:
+
+1. Test from host: `curl https://<tailscale-ip>:8765/health`
+2. Test from container: `docker compose exec rcx-central-api curl -s http://<tailscale-ip>:8765/health`
+3. If container cannot route, use the host's Tailscale IP (Docker Desktop often routes LAN correctly) or document `host.docker.internal` proxy for dev.
+
+## Smoke test
+
+```bash
+./scripts/test_rcx_central_docker.sh
+```
+
+Windows PowerShell variant: run compose up, then curl health URLs manually per steps above.

--- a/docs/rcx-central/edge-auth.md
+++ b/docs/rcx-central/edge-auth.md
@@ -1,0 +1,31 @@
+# Edge authentication (RCx Central)
+
+## Browser flow
+
+1. Open RCx Central → **Edge Connections**
+2. Enter site_id, name, Edge base URL (`https://<tailscale-ip>:8765`)
+3. Enter username/password (or bearer token via API)
+4. **Test Connection** — probes `/health`, `/api/model/health`, `/api/faults/status`
+5. **Save Edge** — writes to `portfolio/config/sites.json` + `credentials.json` (Docker volume)
+
+## API
+
+```text
+GET  /api/central/edges
+POST /api/central/edges
+POST /api/central/edges/test
+PUT  /api/central/edges/{site_id}
+DELETE /api/central/edges/{site_id}
+```
+
+Secrets are **never** returned in API responses or committed to git. Passwords are masked in UI after save.
+
+## Auth types
+
+- `password` — `POST /api/auth/login` on Edge
+- `bearer` — static token in credentials store
+- `none` — public Edge endpoints only (dev)
+
+## Rejected URLs
+
+`file://`, `ftp://`, and hosts without scheme are rejected.

--- a/docs/rcx-central/index.md
+++ b/docs/rcx-central/index.md
@@ -1,0 +1,44 @@
+# OpenFDD RCx Central
+
+**OpenFDD RCx Central** is the local analyst / RCx engineer dashboard. It runs on an analyst workstation or **Docker Desktop (Windows/Linux)** — not on the OT edge by default.
+
+| Product | Role |
+|---------|------|
+| **OpenFDD Edge** | Arrow-native, no-pandas OT-LAN FDD machine at the building |
+| **OpenFDD RCx Central** | Read-only multi-edge analytics, chart preview, DOCX reports |
+
+Internal source path: `portfolio/` (package name unchanged).
+
+## Quick start (host Python)
+
+```bash
+pip install -r portfolio/requirements.txt
+./scripts/run_central_api.sh   # :8060
+./scripts/run_portfolio_dash.sh # :8050
+```
+
+## Docker Desktop
+
+```bash
+./scripts/run_rcx_central_docker.sh
+# Dash http://localhost:8050  API http://localhost:8060/health
+```
+
+See [docker-desktop-windows.md](docker-desktop-windows.md).
+
+## Pages
+
+- Overview — collected rollup trends (Plotly, light/dark theme)
+- Edge Connections — add/test/save Edge URLs (secrets in local volume)
+- Mechanical Summary — BRICK equipment counts from Edge APIs
+- FDD Rules & Analytics — configured rules, chart packs
+- Trend Explorer — pointer to Overview Plotly charts (local collect CSVs)
+- RCx Report Builder — matplotlib preview, fault overlays, DOCX download
+- Validation Runs — one-off read-only Edge probes
+- Settings — API URL and volume paths
+
+Model query details: [model-queries.md](model-queries.md)
+
+## Safety
+
+RCx Central is **read-only** toward Edge and BACnet. No writes, commands, or setpoint changes.

--- a/docs/rcx-central/model-queries.md
+++ b/docs/rcx-central/model-queries.md
@@ -1,0 +1,41 @@
+# Model queries (RCx Central → OpenFDD Edge)
+
+OpenFDD RCx Central reuses the **same read-only Edge REST APIs** as the Edge operator React **Data model** tab. RCx Central does not scrape the React UI.
+
+## Primary endpoints
+
+| Method | Edge path | Purpose |
+|--------|-----------|---------|
+| GET | `/api/model/tree` | Equipment + points (BRICK roles, timeseries columns) |
+| GET | `/api/model/health` | Point/equipment counts, model issues |
+| GET | `/api/model/sparql/predefined` | Prebuilt SPARQL query list |
+| POST | `/api/model/sparql` | Run SPARQL (`{"query": "..."}`) |
+| GET | `/api/model/fdd-query-presets` | FDD commissioning query presets |
+| GET | `/api/model/fdd-query-presets/{id}` | Run preset by id |
+
+## Trends (matplotlib preview + fault overlays)
+
+| Method | Edge path | Purpose |
+|--------|-----------|---------|
+| GET | `/api/timeseries/series?site_id=` | Plottable columns per site |
+| GET | `/api/timeseries/readings?site_id=&columns=&hours=` | Trend samples + optional FDD fault flags |
+
+RCx Central maps BRICK **point roles** (e.g. `supply_air_temperature`) to historian columns via `/api/model/tree`, then calls `/api/timeseries/readings` with `include_faults=true` for overlay bands.
+
+## Analytics
+
+| Method | Edge path | Purpose |
+|--------|-----------|---------|
+| GET | `/api/analytics/overview` | KPIs, fault hours by severity/equipment |
+| GET | `/api/analytics/faults?hours=` | Fault rows for selected window |
+| GET | `/api/analytics/model-health` | Stale/missing roles |
+
+## RCx Central API wrappers
+
+| Method | Central path |
+|--------|----------------|
+| GET | `/api/central/mechanical-summary/{site_id}` |
+| GET | `/api/central/fdd-analytics/{site_id}` |
+| POST | `/api/central/rcx/preview` |
+
+All calls are **read-only** toward Edge.

--- a/docs/rcx-central/report-builder.md
+++ b/docs/rcx-central/report-builder.md
@@ -1,0 +1,22 @@
+# RCx Report Builder (RCx Central)
+
+## Flow
+
+1. Select saved Edge site
+2. Choose date range (2h / 24h / 7d)
+3. **Collect Data / Preview** — `POST /api/central/rcx/preview`
+4. **Preview Charts** — matplotlib PNG as base64 in browser
+5. Select chart/section checkboxes
+6. **Generate DOCX** — `POST /api/central/rcx/report`
+
+Reports save to `portfolio/data/reports/` when `save_to_volume=true`.
+
+## Fault overlays
+
+Preview charts include severity-colored bands when fault rows exist and overlay toggle is on.
+
+## DOCX
+
+Uses `open_fdd/reports/rcx_docx.py` when available (selectable sections/charts). Falls back to `portfolio/central/rcx_report.py`.
+
+Read-only safety note is included in every report.

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -1,37 +1,40 @@
-# Open-FDD Portfolio (central desk)
+# OpenFDD RCx Central
 
-**benserver / analyst workstation** — multi-site rollup, CSV history, and Plotly Dash. Not deployed on edge VMs.
+**Local analyst / RCx engineer tool** — multi-edge analytics, matplotlib chart preview, and DOCX reports. Runs on an analyst workstation or **Docker Desktop**; **not** deployed on the OT edge by default.
+
+> Internal package path remains `portfolio/` for import stability.
+
+| Product | Where it runs |
+|---------|----------------|
+| **OpenFDD Edge** | Building OT LAN — Arrow-native FDD, BACnet, read-only APIs |
+| **OpenFDD RCx Central** | Analyst PC / Docker — queries Edge over Tailscale/VPN |
 
 | Path | Role |
 |------|------|
-| `sites.json` | Site registry (`base_url`, credentials via env or inline) |
-| `sites.json.example` | Template |
+| `sites.json` / `config/sites.json` | Edge registry (URL; credentials in `config/credentials.json`) |
 | `collector/` | Poll `GET /api/building/portfolio-rollup` per site |
-| `store/` | CSV append + `FaultIntervalSummary` / `TuningProposal` schema |
-| `dash/app.py` | Central portfolio dashboard (`:8050`) |
-| `agent/MEMORY.md`, `agent/SKILLS.md` | Agent desk notes for Acme tuning loops |
-| `data/` | Runtime CSV + `latest/*.json` (gitignored) |
+| `central/` | FastAPI API — edges, mechanical summary, RCx preview/report |
+| `dash/app.py` | Dash UI (`:8050`) — **OpenFDD RCx Central** |
+| `data/` | Runtime CSV, rollups, generated reports (gitignored) |
+| `config/` | Browser-saved edges + secrets (gitignored) |
 
-## Commands
-
-```bash
-source infra/ansible/secrets/acme.env.local   # integrator password for Acme
-python3 scripts/portfolio_collect.py
-python3 scripts/portfolio_collect.py --json
-./scripts/run_portfolio_dash.sh               # http://127.0.0.1:8050
-```
-
-Edge API: `workspace/api/openfdd_bridge/portfolio_rollup.py` → `GET /api/building/portfolio-rollup`.
-
-Published docs: [docs/portfolio/central-collection.md](../docs/portfolio/central-collection.md), [Central API](../docs/portfolio/central-api.md).
-
-## Central API (validation + RCx)
+## Commands (host)
 
 ```bash
 pip install -r portfolio/requirements.txt
-./scripts/run_central_api.sh    # :8060
-curl http://127.0.0.1:8060/api/central/sites
-curl -X POST http://127.0.0.1:8060/api/central/validation/run \
-  -H 'Content-Type: application/json' \
-  -d '{"site_id":"acme","duration_hours":0}'
+./scripts/run_central_api.sh    # http://127.0.0.1:8060/health
+./scripts/run_portfolio_dash.sh # http://127.0.0.1:8050
+python3 scripts/portfolio_collect.py
 ```
+
+## Docker Desktop
+
+```bash
+./scripts/run_rcx_central_docker.sh
+```
+
+Docs: [docs/rcx-central/index.md](../docs/rcx-central/index.md)
+
+## Safety
+
+RCx Central is **read-only** toward OpenFDD Edge and BACnet.

--- a/portfolio/central/__main__.py
+++ b/portfolio/central/__main__.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-"""Launch OpenFDD RCx Central API (uvicorn)."""
+"""Run OpenFDD RCx Central API: python -m portfolio.central"""
 
 from __future__ import annotations
 

--- a/portfolio/central/api.py
+++ b/portfolio/central/api.py
@@ -1,4 +1,4 @@
-"""FastAPI Central desk — edge registry, validation jobs, RCx reports."""
+"""FastAPI OpenFDD RCx Central — edge registry, analytics preview, RCx reports."""
 
 from __future__ import annotations
 
@@ -9,56 +9,157 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
-from portfolio.central.registry import list_edge_sites
+from portfolio.central.chart_preview import build_rcx_preview, generate_rcx_docx
+from portfolio.central.edge_registry import (
+    add_or_update_edge,
+    delete_edge,
+    list_edges_public,
+    test_edge_connection,
+)
+from portfolio.central.fdd_analytics import build_fdd_analytics
+from portfolio.central.mechanical_summary import build_mechanical_summary
+from portfolio.central.paths import data_dir, reports_dir, sites_path
+from portfolio.central.registry import list_edge_sites, site_config_for, touch_site
 from portfolio.central.validation import (
     collect_and_validate,
     run_one_off_validation,
     run_validation_plan,
 )
 from portfolio.central.job_store import list_jobs, load_job
-from portfolio.central.rcx_report import build_rcx_docx
-from portfolio.central.registry import site_config_for
 
-ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_SITES = ROOT / "sites.json"
-DEFAULT_DATA = ROOT / "data"
+app = FastAPI(title="OpenFDD RCx Central", version="0.2.0")
 
-app = FastAPI(title="Open-FDD Central", version="0.1.0")
+_DATA = data_dir()
+_SITES = sites_path()
 
 
 class ValidationPlanBody(BaseModel):
     site_id: str = Field(min_length=1)
     interval_hours: float = Field(default=2.0, gt=0, le=24)
     duration_hours: float = Field(default=24.0, gt=0, le=168)
-    sleep_seconds: float = Field(
-        default=0.0,
-        ge=0,
-        description="Wall-clock sleep between cycles (0=try-out)",
-    )
+    sleep_seconds: float = Field(default=0.0, ge=0)
 
 
-class RcxReportBody(BaseModel):
+class EdgeBody(BaseModel):
     site_id: str = Field(min_length=1)
-    include_validation: bool = True
+    name: str = ""
+    base_url: str = Field(min_length=8)
+    auth_type: str = "password"
+    username: str = "agent"
+    password: str = ""
+    token: str = ""
+
+
+class EdgeTestBody(BaseModel):
+    site_id: str = ""
+    base_url: str = ""
+    auth_type: str = "password"
+    username: str = "agent"
+    password: str = ""
+    token: str = ""
+
+
+class RcxPreviewBody(BaseModel):
+    site_id: str = Field(min_length=1)
+    hours: int = Field(default=24, ge=2, le=168)
+    chart_ids: list[str] = Field(default_factory=list)
+    show_fault_overlays: bool = True
+
+
+class RcxReportBody(RcxPreviewBody):
+    sections: list[str] = Field(default_factory=list)
+    charts: list[str] = Field(default_factory=list)
+    save_to_volume: bool = True
 
 
 @app.get("/health")
 def health() -> dict[str, str]:
-    return {"status": "ok", "service": "openfdd-central"}
+    return {"status": "ok", "service": "openfdd-rcx-central"}
 
+
+# --- Edge registry (browser auth) ---
+
+@app.get("/api/central/edges")
+def get_edges() -> dict[str, Any]:
+    return {"edges": list_edges_public(), "count": len(list_edges_public())}
+
+
+@app.post("/api/central/edges")
+def post_edge(body: EdgeBody) -> dict[str, Any]:
+    try:
+        edges = add_or_update_edge(
+            site_id=body.site_id,
+            name=body.name,
+            base_url=body.base_url,
+            auth_type=body.auth_type,
+            username=body.username,
+            password=body.password,
+            token=body.token,
+        )
+        return {"ok": True, "edges": edges}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/central/edges/test")
+def post_edge_test(body: EdgeTestBody) -> dict[str, Any]:
+    try:
+        return test_edge_connection(
+            site_id=body.site_id or None,
+            base_url=body.base_url or None,
+            auth_type=body.auth_type,
+            username=body.username,
+            password=body.password,
+            token=body.token,
+        )
+    except (ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.put("/api/central/edges/{site_id}")
+def put_edge(site_id: str, body: EdgeBody) -> dict[str, Any]:
+    body.site_id = site_id
+    return post_edge(body)
+
+
+@app.delete("/api/central/edges/{site_id}")
+def remove_edge(site_id: str) -> dict[str, Any]:
+    delete_edge(site_id)
+    return {"ok": True, "site_id": site_id}
+
+
+# --- Sites (legacy + state) ---
 
 @app.get("/api/central/sites")
 def get_sites() -> dict[str, Any]:
-    sites = [s.to_dict() for s in list_edge_sites(sites_path=DEFAULT_SITES, data_dir=DEFAULT_DATA)]
+    sites = [s.to_dict() for s in list_edge_sites(sites_path=_SITES, data_dir=_DATA)]
     return {"sites": sites, "count": len(sites)}
+
+
+@app.get("/api/central/fdd-analytics/{site_id}")
+def get_fdd_analytics(site_id: str, hours: int = 24) -> dict[str, Any]:
+    try:
+        return build_fdd_analytics(site_id, hours=hours)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@app.get("/api/central/mechanical-summary/{site_id}")
+def get_mechanical_summary(site_id: str, hours: int = 24) -> dict[str, Any]:
+    try:
+        return build_mechanical_summary(site_id, hours=hours)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
 @app.post("/api/central/sites/{site_id}/collect-validate")
 def post_collect_validate(site_id: str) -> dict[str, Any]:
     try:
-        return collect_and_validate(
-            site_id, sites_path=DEFAULT_SITES, data_dir=DEFAULT_DATA
-        )
+        return collect_and_validate(site_id, sites_path=_SITES, data_dir=_DATA)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -67,16 +168,14 @@ def post_collect_validate(site_id: str) -> dict[str, Any]:
 def post_validation_run(body: ValidationPlanBody) -> dict[str, Any]:
     try:
         if body.duration_hours <= 0:
-            return run_one_off_validation(
-                body.site_id, sites_path=DEFAULT_SITES, data_dir=DEFAULT_DATA
-            )
+            return run_one_off_validation(body.site_id, sites_path=_SITES, data_dir=_DATA)
         return run_validation_plan(
             body.site_id,
             interval_hours=body.interval_hours,
             duration_hours=body.duration_hours,
             sleep_seconds=body.sleep_seconds,
-            sites_path=DEFAULT_SITES,
-            data_dir=DEFAULT_DATA,
+            sites_path=_SITES,
+            data_dir=_DATA,
         )
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -84,44 +183,99 @@ def post_validation_run(body: ValidationPlanBody) -> dict[str, Any]:
 
 @app.get("/api/central/validation/jobs")
 def get_validation_jobs() -> dict[str, Any]:
-    jobs = list_jobs(data_dir=DEFAULT_DATA)
+    jobs = list_jobs(data_dir=_DATA)
     return {"jobs": jobs, "count": len(jobs)}
 
 
 @app.get("/api/central/validation/jobs/{job_id}")
 def get_validation_job(job_id: str) -> dict[str, Any]:
     try:
-        return load_job(job_id, data_dir=DEFAULT_DATA)
+        return load_job(job_id, data_dir=_DATA)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="job not found") from exc
+
+
+# --- RCx preview + report ---
+
+@app.post("/api/central/rcx/preview")
+def post_rcx_preview(body: RcxPreviewBody) -> dict[str, Any]:
+    try:
+        return build_rcx_preview(
+            site_id=body.site_id,
+            hours=body.hours,
+            chart_ids=body.chart_ids or None,
+            show_fault_overlays=body.show_fault_overlays,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@app.post("/api/central/rcx/charts/preview")
+def post_charts_preview(body: RcxPreviewBody) -> dict[str, Any]:
+    return post_rcx_preview(body)
 
 
 @app.post("/api/central/rcx/report")
 def post_rcx_report(body: RcxReportBody) -> Response:
     try:
-        cfg = site_config_for(body.site_id, sites_path=DEFAULT_SITES)
+        blob, fname = generate_rcx_docx(
+            site_id=body.site_id,
+            hours=body.hours,
+            sections=body.sections or None,
+            charts=body.charts or body.chart_ids or None,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ModuleNotFoundError as exc:
+        raise HTTPException(status_code=503, detail="python-docx required") from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    if body.save_to_volume:
+        out = reports_dir() / fname
+        out.write_bytes(blob)
+
+    return Response(
+        content=blob,
+        media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        headers={"Content-Disposition": f'attachment; filename="{fname}"'},
+    )
+
+
+# Legacy RCx endpoint (backward compatible)
+class RcxReportBodyLegacy(BaseModel):
+    site_id: str = Field(min_length=1)
+    include_validation: bool = True
+
+
+@app.post("/api/central/rcx/report-legacy")
+def post_rcx_report_legacy(body: RcxReportBodyLegacy) -> Response:
+    from portfolio.central.rcx_report import build_rcx_docx as legacy_build
+
+    try:
+        cfg = site_config_for(body.site_id, sites_path=_SITES)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     validation = None
     warnings: list[str] = []
     if body.include_validation:
-        validation = run_one_off_validation(
-            body.site_id, sites_path=DEFAULT_SITES, data_dir=DEFAULT_DATA
-        )
+        validation = run_one_off_validation(body.site_id, sites_path=_SITES, data_dir=_DATA)
         if not validation.get("ok"):
             warnings.extend(validation.get("errors") or [])
 
-    latest_path = DEFAULT_DATA / "latest" / f"{body.site_id}.json"
+    latest_path = _DATA / "latest" / f"{body.site_id}.json"
     rollups: list[dict[str, Any]] = []
     if latest_path.is_file():
         import json
 
         rollups.append(json.loads(latest_path.read_text(encoding="utf-8")))
     else:
-        warnings.append("No latest rollup JSON — run portfolio collect first.")
+        warnings.append("No latest rollup JSON — run collect first.")
 
-    blob = build_rcx_docx(
+    blob = legacy_build(
         site_id=body.site_id,
         site_name=cfg.name,
         validation=validation,

--- a/portfolio/central/chart_preview.py
+++ b/portfolio/central/chart_preview.py
@@ -1,0 +1,273 @@
+"""Matplotlib chart previews with fault overlays (BytesIO → base64)."""
+
+from __future__ import annotations
+
+import base64
+import io
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from portfolio.central.chart_specs import CHART_SPECS, SECTION_SPECS, chart_readiness
+from portfolio.central.edge_registry import resolve_site_config, resolve_token
+from portfolio.central.mechanical_summary import build_mechanical_summary
+from portfolio.central.trend_charts import (
+    columns_for_roles,
+    overlays_from_readings,
+    render_trend_ax,
+)
+from portfolio.collector.edge_client import EdgeClient
+
+TREND_CHARTS = {
+    "ahu_sat_vs_setpoint": ["supply_air_temperature", "supply_air_temperature_setpoint"],
+    "ahu_duct_static_vs_setpoint": ["duct_static_pressure", "duct_static_pressure_setpoint"],
+    "vav_zone_temp": ["zone_temperature", "zone_cooling_setpoint", "zone_heating_setpoint"],
+}
+
+SEVERITY_COLORS = {
+    "critical": (0.86, 0.15, 0.15, 0.25),
+    "warning": (0.96, 0.62, 0.04, 0.22),
+    "high": (0.95, 0.45, 0.1, 0.22),
+    "medium": (0.98, 0.75, 0.15, 0.18),
+    "info": (0.4, 0.5, 0.7, 0.15),
+}
+
+
+def _window(hours: int) -> tuple[str, str]:
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(hours=hours)
+    return start.isoformat(), end.isoformat()
+
+
+def _png_base64(title: str, render_fn) -> str:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(6.5, 3.2))
+    render_fn(ax)
+    ax.set_title(title, fontsize=11)
+    fig.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=120)
+    plt.close(fig)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _fault_overlays(ax, overlays: list[dict[str, Any]]) -> None:
+    for ov in overlays:
+        color = SEVERITY_COLORS.get(str(ov.get("severity") or "warning").lower(), SEVERITY_COLORS["warning"])
+        ax.axvspan(float(ov.get("x0", 0)), float(ov.get("x1", 1)), color=color, label=ov.get("label"))
+
+
+def build_rcx_preview(
+    *,
+    site_id: str,
+    hours: int = 24,
+    chart_ids: list[str] | None = None,
+    show_fault_overlays: bool = True,
+) -> dict[str, Any]:
+    start, end = _window(hours)
+    mech = build_mechanical_summary(site_id, hours=hours)
+    site = resolve_site_config(site_id)
+    client = EdgeClient(site.base_url)
+    token = resolve_token(site)
+    analytics = client.get_analytics_overview(token=token)
+    faults_data = client.get_analytics_faults(hours=hours, token=token)
+
+    roles_present: set[str] = set()
+    tree = client.get_model_tree(token=token)
+    for pt in tree.get("points") or []:
+        if isinstance(pt, dict):
+            role = str(pt.get("brick_type") or pt.get("role") or "").strip()
+            if role:
+                roles_present.add(role)
+
+    fault_rows = faults_data.get("faults") if isinstance(faults_data.get("faults"), list) else []
+    has_faults = bool(fault_rows)
+    trend_cache: dict[str, dict[str, Any]] = {}
+
+    def _readings_for_chart(chart_id: str) -> dict[str, Any]:
+        if chart_id in trend_cache:
+            return trend_cache[chart_id]
+        roles = TREND_CHARTS.get(chart_id)
+        if not roles:
+            trend_cache[chart_id] = {}
+            return {}
+        cols = columns_for_roles(tree, roles)
+        if not cols:
+            trend_cache[chart_id] = {}
+            return {}
+        try:
+            data = client.get_timeseries_readings(
+                site_id,
+                cols,
+                hours=hours,
+                token=token,
+                include_faults=show_fault_overlays,
+            )
+        except RuntimeError:
+            data = {}
+        trend_cache[chart_id] = data
+        return data
+
+    has_trends = any((_readings_for_chart(cid).get("row_count") or 0) > 0 for cid in TREND_CHARTS)
+
+    available: list[dict[str, Any]] = []
+    disabled: list[dict[str, Any]] = []
+    previews: list[dict[str, Any]] = []
+
+    for spec in CHART_SPECS:
+        if chart_ids and spec["chart_id"] not in chart_ids:
+            continue
+        cid = spec["chart_id"]
+        trend_ok = (_readings_for_chart(cid).get("row_count") or 0) > 0 if cid in TREND_CHARTS else has_trends
+        ok, reason = chart_readiness(
+            spec,
+            roles_present=roles_present,
+            has_fault_data=has_faults,
+            has_trend_data=trend_ok if cid in TREND_CHARTS else True,
+        )
+        if ok:
+            available.append(spec)
+        else:
+            disabled.append({**spec, "reason": reason})
+
+    by_sev = analytics.get("faults_by_severity") or []
+    if has_faults and (not chart_ids or "fault_hours_by_severity" in (chart_ids or [])):
+        labels = [r.get("group", "") for r in by_sev]
+        values = [float(r.get("elapsed_hours") or 0) for r in by_sev]
+
+        def render(ax):
+            ax.bar(labels, values, color="#2563eb")
+            ax.set_ylabel("Hours (est.)")
+
+        previews.append(
+            {
+                "chart_id": "fault_hours_by_severity",
+                "title": "Fault hours by severity",
+                "image_base64": _png_base64("Fault hours by severity", render),
+                "warnings": [],
+            }
+        )
+
+    by_eq = analytics.get("fault_hours_by_equipment") or []
+    if has_faults and (not chart_ids or "fault_hours_by_equipment" in (chart_ids or [])):
+        labels = [str(r.get("group", ""))[:20] for r in by_eq[:12]]
+        values = [float(r.get("elapsed_hours") or 0) for r in by_eq[:12]]
+
+        def render_eq(ax):
+            ax.bar(labels, values, color="#2563eb")
+            ax.tick_params(axis="x", rotation=45, labelsize=7)
+            ax.set_ylabel("Hours (est.)")
+
+        previews.append(
+            {
+                "chart_id": "fault_hours_by_equipment",
+                "title": "Fault hours by equipment",
+                "image_base64": _png_base64("Fault hours by equipment", render_eq),
+                "warnings": [],
+            }
+        )
+
+    for chart_id, roles in TREND_CHARTS.items():
+        if chart_ids and chart_id not in chart_ids:
+            continue
+        if chart_id not in [p["chart_id"] for p in previews] and chart_id in [s["chart_id"] for s in available]:
+            readings = _readings_for_chart(chart_id)
+            if (readings.get("row_count") or 0) <= 0:
+                continue
+            title = next((s["title"] for s in CHART_SPECS if s["chart_id"] == chart_id), chart_id)
+            overlays = overlays_from_readings(readings, show=show_fault_overlays)
+
+            def _make_render(rd, ov, rl):
+                def render(ax):
+                    render_trend_ax(ax, rd, title_cols=rl, overlays=ov, overlay_fn=_fault_overlays)
+
+                return render
+
+            previews.append(
+                {
+                    "chart_id": chart_id,
+                    "title": title,
+                    "image_base64": _png_base64(title, _make_render(readings, overlays, roles)),
+                    "warnings": [],
+                }
+            )
+
+    fault_overlays: list[dict[str, Any]] = []
+    if show_fault_overlays:
+        for chart_id in TREND_CHARTS:
+            rd = _readings_for_chart(chart_id)
+            fault_overlays.extend(overlays_from_readings(rd, show=True)[:8])
+
+    return {
+        "site_id": site_id,
+        "site_name": site.name,
+        "window": {"start": start, "end": end, "hours": hours},
+        "mechanical_summary": mech,
+        "available_charts": available,
+        "disabled_charts": disabled,
+        "sections": SECTION_SPECS,
+        "fault_summary": {
+            "active_faults": len(fault_rows),
+            "total_fault_hours": (analytics.get("kpis") or {}).get("total_fault_hours"),
+        },
+        "fault_rows": fault_rows[:50],
+        "fault_overlays": fault_overlays,
+        "chart_previews": previews,
+        "warnings": mech.get("warnings") or [],
+        "missing_roles": [
+            str(i.get("title") or "") for i in (mech.get("model_issues") or [])[:10]
+        ],
+    }
+
+
+def generate_rcx_docx(
+    *,
+    site_id: str,
+    hours: int = 24,
+    sections: list[str] | None = None,
+    charts: list[str] | None = None,
+) -> tuple[bytes, str]:
+    preview = build_rcx_preview(site_id=site_id, hours=hours, chart_ids=charts)
+    site = resolve_site_config(site_id)
+    fault_rows = preview.get("fault_rows") or []
+
+    try:
+        from open_fdd.reports.rcx_docx import build_rcx_docx
+    except ImportError:
+        from portfolio.central.rcx_report import build_rcx_docx as legacy_build
+
+        blob = legacy_build(
+            site_id=site_id,
+            site_name=site.name,
+            validation=None,
+            rollups=[],
+            warnings=preview.get("warnings"),
+        )
+        fname = f"openfdd-rcx-{site_id}.docx"
+        return blob, fname
+
+    overview = {
+        "active_faults": preview["fault_summary"]["active_faults"],
+        "total_fault_hours": preview["fault_summary"]["total_fault_hours"],
+        "missing_roles": preview.get("missing_roles"),
+    }
+    if preview.get("mechanical_summary"):
+        overview["mechanical_summary"] = preview["mechanical_summary"]
+
+    blob = build_rcx_docx(
+        site_id=site_id,
+        site_name=site.name,
+        window=preview.get("window") or {},
+        fault_rows=fault_rows,
+        overview=overview,
+        sections=sections,
+        charts=charts,
+        warnings=preview.get("warnings"),
+    )
+    start = (preview.get("window") or {}).get("start", "")[:10]
+    end = (preview.get("window") or {}).get("end", "")[:10]
+    fname = f"openfdd-rcx-{site_id}-{start}-{end}.docx"
+    return blob, fname

--- a/portfolio/central/chart_specs.py
+++ b/portfolio/central/chart_specs.py
@@ -1,0 +1,97 @@
+"""RCx chart catalog — required roles, fault overlay support."""
+
+from __future__ import annotations
+
+from typing import Any
+
+CHART_SPECS: list[dict[str, Any]] = [
+    {
+        "chart_id": "fault_hours_by_severity",
+        "title": "Fault hours by severity",
+        "equipment_type": "building",
+        "required_roles": [],
+        "supports_fault_overlay": False,
+        "supports_preview": True,
+        "supports_docx": True,
+    },
+    {
+        "chart_id": "fault_hours_by_equipment",
+        "title": "Fault hours by equipment",
+        "equipment_type": "building",
+        "required_roles": [],
+        "supports_fault_overlay": False,
+        "supports_preview": True,
+        "supports_docx": True,
+    },
+    {
+        "chart_id": "ahu_sat_vs_setpoint",
+        "title": "Supply air temperature vs setpoint",
+        "equipment_type": "AHU",
+        "required_roles": ["supply_air_temperature", "supply_air_temperature_setpoint"],
+        "related_fault_codes": ["SAT", "flatline"],
+        "supports_fault_overlay": True,
+        "supports_preview": True,
+        "supports_docx": True,
+    },
+    {
+        "chart_id": "ahu_duct_static_vs_setpoint",
+        "title": "Duct static pressure vs setpoint",
+        "equipment_type": "AHU",
+        "required_roles": ["duct_static_pressure", "duct_static_pressure_setpoint"],
+        "supports_fault_overlay": True,
+        "supports_preview": True,
+        "supports_docx": True,
+    },
+    {
+        "chart_id": "vav_zone_temp",
+        "title": "Zone temperature vs setpoints",
+        "equipment_type": "VAV",
+        "required_roles": ["zone_temperature", "zone_cooling_setpoint"],
+        "supports_fault_overlay": True,
+        "supports_preview": True,
+        "supports_docx": True,
+    },
+    {
+        "chart_id": "model_health_summary",
+        "title": "BACnet / model health summary",
+        "equipment_type": "building",
+        "required_roles": [],
+        "supports_fault_overlay": False,
+        "supports_preview": True,
+        "supports_docx": True,
+    },
+]
+
+SECTION_SPECS = [
+    {"id": "executive_summary", "label": "Executive summary"},
+    {"id": "mechanical_summary", "label": "Mechanical summary"},
+    {"id": "fault_analytics", "label": "Fault analytics"},
+    {"id": "ahu_analytics", "label": "AHU analytics"},
+    {"id": "vav_analytics", "label": "VAV zone analytics"},
+    {"id": "runtime_analytics", "label": "Runtime analytics"},
+    {"id": "model_health", "label": "BACnet / model health"},
+    {"id": "recommendations", "label": "Recommendations"},
+    {"id": "appendix_faults", "label": "Appendix: raw fault table"},
+]
+
+
+def chart_readiness(
+    spec: dict[str, Any],
+    *,
+    roles_present: set[str],
+    has_fault_data: bool,
+    has_trend_data: bool,
+) -> tuple[bool, str]:
+    cid = spec["chart_id"]
+    if cid in ("fault_hours_by_severity", "fault_hours_by_equipment"):
+        return (has_fault_data, "No active faults in selected window")
+    if cid == "model_health_summary":
+        return (True, "")
+    needed = spec.get("required_roles") or []
+    if needed:
+        missing = [r for r in needed if r not in roles_present]
+        if missing:
+            return (False, f"Missing {', '.join(missing)}")
+        if not has_trend_data:
+            return (False, "No trend samples in selected window")
+    return (True, "")

--- a/portfolio/central/edge_registry.py
+++ b/portfolio/central/edge_registry.py
@@ -1,0 +1,230 @@
+"""Edge registry CRUD + connection test (local config volume, secrets masked)."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from portfolio.central.paths import config_dir, credentials_path, sites_path
+from portfolio.collector.collector import SiteConfig, load_sites_config
+from portfolio.collector.edge_client import EdgeClient
+
+
+_BLOCKED_SCHEMES = {"file", "ftp", "gopher"}
+
+
+def _validate_base_url(url: str) -> str:
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("base_url must use http or https")
+    if parsed.scheme in _BLOCKED_SCHEMES:
+        raise ValueError("base_url scheme not allowed")
+    if not parsed.netloc:
+        raise ValueError("base_url must include host")
+    return url.rstrip("/")
+
+
+def _load_credentials() -> dict[str, Any]:
+    path = credentials_path()
+    if not path.is_file():
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return raw if isinstance(raw, dict) else {}
+
+
+def _save_credentials(data: dict[str, Any]) -> None:
+    credentials_path().write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _mask_secret(value: str) -> str:
+    if not value:
+        return ""
+    if len(value) <= 4:
+        return "****"
+    return value[:2] + "****" + value[-2:]
+
+
+@dataclass
+class EdgeRecordPublic:
+    site_id: str
+    name: str
+    base_url: str
+    auth_type: str
+    username: str
+    has_password: bool
+    has_token: bool
+    enabled: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def list_edges_public() -> list[dict[str, Any]]:
+    creds = _load_credentials()
+    out: list[dict[str, Any]] = []
+    for cfg in load_sites_config(sites_path()):
+        c = creds.get(cfg.site_id) if isinstance(creds.get(cfg.site_id), dict) else {}
+        auth_type = str(c.get("auth_type") or ("bearer" if c.get("token") else "password"))
+        out.append(
+            EdgeRecordPublic(
+                site_id=cfg.site_id,
+                name=cfg.name,
+                base_url=cfg.base_url,
+                auth_type=auth_type,
+                username=cfg.username,
+                has_password=bool(c.get("password") or cfg.password),
+                has_token=bool(c.get("token")),
+            ).to_dict()
+        )
+    return out
+
+
+def _write_sites(sites: list[dict[str, Any]]) -> None:
+    path = config_dir() / "sites.json"
+    path.write_text(json.dumps({"sites": sites}, indent=2), encoding="utf-8")
+
+
+def _all_site_dicts() -> list[dict[str, Any]]:
+    path = sites_path()
+    if not path.is_file():
+        return []
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    sites = raw.get("sites") if isinstance(raw, dict) else raw
+    return list(sites) if isinstance(sites, list) else []
+
+
+def add_or_update_edge(
+    *,
+    site_id: str,
+    name: str,
+    base_url: str,
+    auth_type: str = "password",
+    username: str = "agent",
+    password: str = "",
+    token: str = "",
+) -> dict[str, Any]:
+    site_id = site_id.strip()
+    if not re.match(r"^[a-z0-9][a-z0-9._-]{0,63}$", site_id):
+        raise ValueError("site_id must be lowercase alphanumeric with ._-")
+    base_url = _validate_base_url(base_url)
+    sites = _all_site_dicts()
+    row = {
+        "site_id": site_id,
+        "name": name.strip() or site_id,
+        "base_url": base_url,
+        "username": username.strip() or "agent",
+    }
+    updated = False
+    for i, s in enumerate(sites):
+        if isinstance(s, dict) and s.get("site_id") == site_id:
+            sites[i] = {**s, **row}
+            updated = True
+            break
+    if not updated:
+        sites.append(row)
+    _write_sites(sites)
+
+    creds = _load_credentials()
+    entry: dict[str, Any] = {"auth_type": auth_type}
+    if auth_type == "bearer" and token:
+        entry["token"] = token
+    elif auth_type == "password" and password:
+        entry["password"] = password
+    elif auth_type == "none":
+        entry["auth_type"] = "none"
+    if entry.get("password") or entry.get("token") or auth_type == "none":
+        creds[site_id] = entry
+        _save_credentials(creds)
+    return list_edges_public()
+
+
+def delete_edge(site_id: str) -> None:
+    sites = [s for s in _all_site_dicts() if isinstance(s, dict) and s.get("site_id") != site_id]
+    _write_sites(sites)
+    creds = _load_credentials()
+    creds.pop(site_id, None)
+    _save_credentials(creds)
+
+
+def resolve_site_config(site_id: str) -> SiteConfig:
+    creds = _load_credentials()
+    for cfg in load_sites_config(sites_path()):
+        if cfg.site_id != site_id:
+            continue
+        c = creds.get(site_id) if isinstance(creds.get(site_id), dict) else {}
+        if c.get("password"):
+            return SiteConfig(
+                site_id=cfg.site_id,
+                name=cfg.name,
+                base_url=cfg.base_url,
+                username=cfg.username,
+                password=str(c["password"]),
+            )
+        if c.get("token"):
+            return SiteConfig(
+                site_id=cfg.site_id,
+                name=cfg.name,
+                base_url=cfg.base_url,
+                username=cfg.username,
+                password="",
+            )
+        return cfg
+    raise KeyError(f"unknown site_id {site_id!r}")
+
+
+def resolve_token(site: SiteConfig) -> str:
+    creds = _load_credentials()
+    c = creds.get(site.site_id) if isinstance(creds.get(site.site_id), dict) else {}
+    if c.get("token"):
+        return str(c["token"])
+    if c.get("auth_type") == "none":
+        return ""
+    if site.password:
+        return EdgeClient(site.base_url).login(username=site.username, password=site.password)
+    raise RuntimeError(f"{site.site_id}: missing credentials")
+
+
+def test_edge_connection(
+    *,
+    site_id: str | None = None,
+    base_url: str | None = None,
+    auth_type: str = "password",
+    username: str = "agent",
+    password: str = "",
+    token: str = "",
+) -> dict[str, Any]:
+    if site_id:
+        site = resolve_site_config(site_id)
+        client = EdgeClient(site.base_url)
+        tok = resolve_token(site)
+    else:
+        if not base_url:
+            raise ValueError("base_url required when site_id omitted")
+        base_url = _validate_base_url(base_url)
+        client = EdgeClient(base_url)
+        if auth_type == "bearer" and token:
+            tok = token
+        elif auth_type == "none":
+            tok = ""
+        else:
+            tok = client.login(username=username, password=password)
+
+    result: dict[str, Any] = {"ok": False, "base_url": client.base_url}
+    try:
+        health = client.get_health(token=tok)
+        result["health"] = health
+        result["edge_version"] = health.get("openfdd_version") or health.get("version")
+        stack = client.api_get("/health/stack", token=tok)
+        result["stack"] = {"image_tag": stack.get("image_tag")}
+        model = client.api_get("/api/model/health", token=tok)
+        result["model_health"] = model
+        faults = client.api_get("/api/faults/status", token=tok)
+        result["traffic"] = faults.get("traffic")
+        result["fault_count"] = faults.get("alert_count")
+        result["ok"] = True
+    except Exception as exc:
+        result["error"] = str(exc)[:500]
+    return result

--- a/portfolio/central/fdd_analytics.py
+++ b/portfolio/central/fdd_analytics.py
@@ -1,0 +1,87 @@
+"""FDD rules & analytics visibility for RCx Central (read-only Edge queries)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from portfolio.central.chart_specs import CHART_SPECS
+from portfolio.central.edge_registry import resolve_site_config, resolve_token
+from portfolio.collector.edge_client import EdgeClient
+
+
+def _charts_for_rule(rule: dict[str, Any]) -> list[str]:
+    code = str(rule.get("fault_code") or rule.get("code") or "").upper()
+    name = str(rule.get("name") or "").lower()
+    out: list[str] = []
+    for spec in CHART_SPECS:
+        related = [str(c).upper() for c in (spec.get("related_fault_codes") or [])]
+        if code and any(code in r or r in code for r in related):
+            out.append(spec["chart_id"])
+        elif "sat" in name and "sat" in spec["chart_id"]:
+            out.append(spec["chart_id"])
+        elif "duct" in name and "duct" in spec["chart_id"]:
+            out.append(spec["chart_id"])
+        elif "zone" in name and "vav" in spec["chart_id"]:
+            out.append(spec["chart_id"])
+    return out
+
+
+def build_fdd_analytics(site_id: str, *, hours: int = 24) -> dict[str, Any]:
+    site = resolve_site_config(site_id)
+    client = EdgeClient(site.base_url)
+    token = resolve_token(site)
+
+    rules_raw = client.get_fdd_rules(token=token)
+    rules_list = rules_raw.get("rules") if isinstance(rules_raw.get("rules"), list) else []
+    if not rules_list and isinstance(rules_raw.get("saved"), list):
+        rules_list = rules_raw["saved"]
+
+    faults = client.get_analytics_faults(hours=hours, token=token)
+    fault_rows = faults.get("faults") if isinstance(faults.get("faults"), list) else []
+    by_rule: dict[str, dict[str, Any]] = {}
+    for row in fault_rows:
+        if not isinstance(row, dict):
+            continue
+        rid = str(row.get("rule_id") or row.get("fault_code") or "")
+        if not rid:
+            continue
+        bucket = by_rule.setdefault(rid, {"active_count": 0, "elapsed_hours": 0.0})
+        bucket["active_count"] += 1
+        bucket["elapsed_hours"] += float(row.get("elapsed_hours") or 0)
+
+    rules_out: list[dict[str, Any]] = []
+    for rule in rules_list:
+        if not isinstance(rule, dict):
+            continue
+        rid = str(rule.get("id") or rule.get("rule_id") or rule.get("name") or "")
+        stats = by_rule.get(rid) or by_rule.get(str(rule.get("fault_code") or "")) or {}
+        cfg = rule.get("config") if isinstance(rule.get("config"), dict) else {}
+        rules_out.append(
+            {
+                "rule_id": rid,
+                "fault_code": rule.get("fault_code") or rule.get("code"),
+                "fault_name": rule.get("name") or rule.get("title"),
+                "equipment_type": rule.get("equipment_type") or cfg.get("equipment_type"),
+                "severity": rule.get("severity") or cfg.get("severity"),
+                "required_roles": cfg.get("required_roles") or rule.get("required_roles") or [],
+                "optional_roles": cfg.get("optional_roles") or [],
+                "enabled": rule.get("enabled", True),
+                "active_fault_count": stats.get("active_count", 0),
+                "elapsed_fault_hours": stats.get("elapsed_hours", 0.0),
+                "chart_pack": _charts_for_rule(rule),
+            }
+        )
+
+    presets = client.get_fdd_query_presets(token=token)
+    preset_list = presets.get("presets") if isinstance(presets.get("presets"), list) else []
+
+    return {
+        "site_id": site_id,
+        "site_name": site.name,
+        "lookback_hours": hours,
+        "rules": rules_out,
+        "rules_configured": len(rules_out),
+        "active_faults": len(fault_rows),
+        "model_query_presets": preset_list[:30],
+        "warnings": [] if rules_out else ["No FDD rules returned from Edge — check Rule Lab export."],
+    }

--- a/portfolio/central/mechanical_summary.py
+++ b/portfolio/central/mechanical_summary.py
@@ -1,0 +1,76 @@
+"""Mechanical summary from Edge model queries (read-only)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from portfolio.central.edge_registry import resolve_site_config, resolve_token
+from portfolio.collector.edge_client import EdgeClient
+
+
+def build_mechanical_summary(site_id: str, *, hours: int = 24) -> dict[str, Any]:
+    site = resolve_site_config(site_id)
+    client = EdgeClient(site.base_url)
+    token = resolve_token(site)
+    warnings: list[str] = []
+
+    tree = client.get_model_tree(token=token)
+    model_health = client.get_model_health(token=token)
+    faults = client.get_faults_status(token=token)
+    analytics = client.get_analytics_overview(token=token)
+    bacnet = client.get_bacnet_poll_status(token=token)
+
+    equipment = tree.get("equipment") if isinstance(tree.get("equipment"), list) else []
+    by_type: dict[str, int] = {}
+    ahus: list[str] = []
+    vavs: list[str] = []
+    rtus: list[str] = []
+    for eq in equipment:
+        if not isinstance(eq, dict):
+            continue
+        etype = str(eq.get("type") or eq.get("equipment_type") or "unknown").upper()
+        by_type[etype] = by_type.get(etype, 0) + 1
+        name = str(eq.get("name") or eq.get("id") or "")
+        if "AHU" in etype and name:
+            ahus.append(name)
+        elif "VAV" in etype and name:
+            vavs.append(name)
+        elif "RTU" in etype and name:
+            rtus.append(name)
+
+    counts = model_health.get("counts") if isinstance(model_health.get("counts"), dict) else {}
+    issues = model_health.get("issues") if isinstance(model_health.get("issues"), list) else []
+    kpis = analytics.get("kpis") if isinstance(analytics.get("kpis"), dict) else {}
+
+    if not equipment:
+        warnings.append("Edge model tree returned no equipment — check BRICK model import.")
+
+    readiness = 100
+    if issues:
+        readiness = max(0, 100 - min(len(issues) * 5, 60))
+    if not kpis.get("active_faults") and faults.get("traffic") not in ("green", None):
+        readiness = min(readiness, 70)
+
+    return {
+        "site_id": site_id,
+        "site_name": site.name,
+        "base_url": site.base_url,
+        "equipment_counts": by_type,
+        "ahus": sorted(ahus)[:50],
+        "vavs": sorted(vavs)[:100],
+        "rtus": sorted(rtus)[:50],
+        "point_count": counts.get("points"),
+        "equipment_count": counts.get("equipment"),
+        "model_warnings": len(issues),
+        "model_issues": issues[:20],
+        "active_faults": kpis.get("active_faults") or faults.get("alert_count"),
+        "total_fault_hours": kpis.get("total_fault_hours"),
+        "bacnet_poll": {
+            "enabled_points": bacnet.get("enabled_points"),
+            "last_poll_at": bacnet.get("last_poll_at"),
+        },
+        "traffic": faults.get("traffic"),
+        "data_readiness_score": readiness,
+        "warnings": warnings,
+        "lookback_hours": hours,
+    }

--- a/portfolio/central/paths.py
+++ b/portfolio/central/paths.py
@@ -1,0 +1,48 @@
+"""Configurable paths for OpenFDD RCx Central (Docker volume friendly)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def portfolio_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def data_dir() -> Path:
+    raw = os.environ.get("OPENFDD_RCX_CENTRAL_DATA")
+    path = Path(raw) if raw else portfolio_root() / "data"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def config_dir() -> Path:
+    raw = os.environ.get("OPENFDD_RCX_CENTRAL_CONFIG")
+    path = Path(raw) if raw else portfolio_root() / "config"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def sites_path() -> Path:
+    cfg = config_dir() / "sites.json"
+    if cfg.is_file():
+        return cfg
+    legacy = portfolio_root() / "sites.json"
+    if legacy.is_file():
+        return legacy
+    return cfg
+
+
+def credentials_path() -> Path:
+    return config_dir() / "credentials.json"
+
+
+def reports_dir() -> Path:
+    path = data_dir() / "reports"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def central_api_url() -> str:
+    return os.environ.get("OPENFDD_CENTRAL_API_URL", "http://127.0.0.1:8060").rstrip("/")

--- a/portfolio/central/trend_charts.py
+++ b/portfolio/central/trend_charts.py
@@ -1,0 +1,164 @@
+"""Matplotlib trend charts from Edge /api/timeseries/readings (read-only)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from portfolio.collector.edge_client import EdgeClient
+
+ROLE_ALIASES: dict[str, list[str]] = {
+    "supply_air_temperature": ["supply_air_temperature", "Supply_Air_Temperature", "SAT"],
+    "supply_air_temperature_setpoint": [
+        "supply_air_temperature_setpoint",
+        "Supply_Air_Temperature_Setpoint",
+        "SAT_Setpoint",
+    ],
+    "duct_static_pressure": ["duct_static_pressure", "Duct_Static_Pressure"],
+    "duct_static_pressure_setpoint": ["duct_static_pressure_setpoint", "Duct_Static_Setpoint"],
+    "zone_temperature": ["zone_temperature", "Zone_Temperature"],
+    "zone_cooling_setpoint": ["zone_cooling_setpoint", "Zone_Cooling_Setpoint"],
+    "zone_heating_setpoint": ["zone_heating_setpoint", "Zone_Heating_Setpoint"],
+}
+
+
+def _role_matches(point: dict[str, Any], role: str) -> bool:
+    candidates = {role.lower()}
+    candidates.update(a.lower() for a in ROLE_ALIASES.get(role, []))
+    for key in ("brick_type", "role", "point_role", "semantic_role"):
+        val = str(point.get(key) or "").strip().lower()
+        if val in candidates or role.lower() in val:
+            return True
+    return False
+
+
+def columns_for_roles(tree: dict[str, Any], roles: list[str]) -> list[str]:
+    """Map BRICK roles to historian column names from model tree points."""
+    points = tree.get("points") if isinstance(tree.get("points"), list) else []
+    cols: list[str] = []
+    for role in roles:
+        for pt in points:
+            if not isinstance(pt, dict) or not _role_matches(pt, role):
+                continue
+            col = (
+                pt.get("timeseries_column")
+                or pt.get("historian_column")
+                or pt.get("column")
+                or pt.get("name")
+            )
+            if col and str(col) not in cols:
+                cols.append(str(col))
+                break
+    return cols
+
+
+def fetch_trend_readings(
+    client: EdgeClient,
+    *,
+    site_id: str,
+    columns: list[str],
+    hours: int,
+    token: str,
+    include_faults: bool = True,
+) -> dict[str, Any]:
+    if not columns:
+        return {}
+    col_param = ",".join(columns)
+    path = (
+        f"/api/timeseries/readings?site_id={site_id}"
+        f"&columns={col_param}&hours={hours}&include_faults={'true' if include_faults else 'false'}"
+    )
+    return client.api_get(path, token=token)
+
+
+def _parse_dt(ts: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def fault_overlay_spans(
+    timestamps: list[str],
+    flags: list[int],
+    *,
+    label: str = "",
+    severity: str = "warning",
+) -> list[dict[str, Any]]:
+    """Contiguous fault=1 regions as matplotlib axvspan specs (datetime x-axis)."""
+    xs = [_parse_dt(t) for t in timestamps]
+    spans: list[dict[str, Any]] = []
+    start: datetime | None = None
+    for i, flag in enumerate(flags):
+        x = xs[i] if i < len(xs) else None
+        if x is None:
+            continue
+        if flag:
+            if start is None:
+                start = x
+        elif start is not None:
+            spans.append({"x0": start, "x1": x, "label": label, "severity": severity})
+            start = None
+    if start is not None and xs:
+        last = next((x for x in reversed(xs) if x is not None), None)
+        if last is not None:
+            spans.append({"x0": start, "x1": last, "label": label, "severity": severity})
+    return spans
+
+
+def overlays_from_readings(readings: dict[str, Any], *, show: bool = True) -> list[dict[str, Any]]:
+    if not show:
+        return []
+    timestamps = readings.get("timestamps") or []
+    fault_plots = readings.get("fault_plots") or {}
+    panels = {str(p.get("key")): p for p in (readings.get("fault_panels") or []) if isinstance(p, dict)}
+    out: list[dict[str, Any]] = []
+    for key, flags in fault_plots.items():
+        panel = panels.get(key) or {}
+        spans = fault_overlay_spans(
+            timestamps,
+            flags,
+            label=str(panel.get("title") or key),
+            severity="warning",
+        )
+        out.extend(spans)
+    return out
+
+
+def render_trend_ax(
+    ax,
+    readings: dict[str, Any],
+    *,
+    title_cols: list[str] | None = None,
+    overlays: list[dict[str, Any]] | None = None,
+    overlay_fn=None,
+) -> None:
+    timestamps = readings.get("timestamps") or []
+    series = readings.get("series") or {}
+    labels = readings.get("labels") or {}
+    xs = [datetime.fromisoformat(str(t).replace("Z", "+00:00")) for t in timestamps]
+
+    for col, vals in series.items():
+        label = str(labels.get(col) or col)
+        ax.plot(xs, vals, label=label, linewidth=1.2)
+
+    if overlays:
+        colors = {
+            "critical": (0.86, 0.15, 0.15, 0.25),
+            "warning": (0.96, 0.62, 0.04, 0.22),
+            "high": (0.95, 0.45, 0.1, 0.22),
+            "medium": (0.98, 0.75, 0.15, 0.18),
+            "info": (0.4, 0.5, 0.7, 0.15),
+        }
+        if overlay_fn:
+            overlay_fn(ax, overlays)
+        else:
+            for ov in overlays:
+                sev = str(ov.get("severity") or "warning").lower()
+                color = colors.get(sev, colors["warning"])
+                ax.axvspan(ov["x0"], ov["x1"], color=color, label=ov.get("label"))
+
+    ax.set_xlabel("Time (UTC)")
+    ax.legend(loc="upper right", fontsize=7)
+    if title_cols:
+        ax.set_ylabel(" / ".join(title_cols))

--- a/portfolio/collector/collector.py
+++ b/portfolio/collector/collector.py
@@ -29,7 +29,15 @@ def _portfolio_root() -> Path:
 
 
 def load_sites_config(path: Path | None = None) -> list[SiteConfig]:
-    cfg_path = path or (_portfolio_root() / "sites.json")
+    if path is None:
+        try:
+            from portfolio.central.paths import sites_path as _sites_path
+
+            cfg_path = _sites_path()
+        except ImportError:
+            cfg_path = _portfolio_root() / "sites.json"
+    else:
+        cfg_path = path
     if not cfg_path.is_file():
         example = _portfolio_root() / "sites.json.example"
         raise FileNotFoundError(

--- a/portfolio/collector/edge_client.py
+++ b/portfolio/collector/edge_client.py
@@ -1,4 +1,4 @@
-"""Minimal HTTP client for edge Operator Bridge (stdlib only)."""
+"""HTTP client for OpenFDD Edge Operator Bridge (stdlib only, read-only)."""
 
 from __future__ import annotations
 
@@ -26,9 +26,12 @@ def login(base_url: str, *, username: str, password: str, timeout: int = 30) -> 
 
 
 def api_get(base_url: str, token: str, path: str, *, timeout: int = 120) -> dict[str, Any]:
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(
         f"{base_url.rstrip('/')}{path}",
-        headers={"Authorization": f"Bearer {token}"},
+        headers=headers,
         method="GET",
     )
     try:
@@ -50,14 +53,14 @@ def api_post(
     *,
     timeout: int = 600,
 ) -> dict[str, Any]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
         f"{base_url.rstrip('/')}{path}",
         data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
-        },
+        headers=headers,
         method="POST",
     )
     try:
@@ -81,3 +84,81 @@ def fetch_portfolio_rollup(
     if site_id:
         path = f"{path}?site_id={urllib.parse.quote(site_id)}"
     return api_get(base_url, token, path)
+
+
+class EdgeClient:
+    """Read-only Edge REST client for OpenFDD RCx Central."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def login(self, *, username: str, password: str) -> str:
+        return login(self.base_url, username=username, password=password)
+
+    def api_get(self, path: str, *, token: str = "") -> dict[str, Any]:
+        return api_get(self.base_url, token, path)
+
+    def api_post(self, path: str, body: dict[str, Any], *, token: str = "") -> dict[str, Any]:
+        return api_post(self.base_url, token, path, body)
+
+    def get_health(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/health", token=token)
+
+    def get_version(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/health/stack", token=token)
+
+    def get_model_health(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/model/health", token=token)
+
+    def get_model_tree(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/model/tree", token=token)
+
+    def get_model_queries(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/model/sparql/predefined", token=token)
+
+    def run_model_query(self, query: str, *, token: str = "") -> dict[str, Any]:
+        return self.api_post("/api/model/sparql", {"query": query}, token=token)
+
+    def get_faults_status(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/faults/status", token=token)
+
+    def get_analytics_overview(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/analytics/overview", token=token)
+
+    def get_analytics_faults(self, hours: int = 24, *, token: str = "") -> dict[str, Any]:
+        return self.api_get(f"/api/analytics/faults?hours={hours}", token=token)
+
+    def get_bacnet_poll_status(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/bacnet/poll/status", token=token)
+
+    def get_fdd_rules(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/rules/saved", token=token)
+
+    def get_fdd_query_presets(self, *, token: str = "") -> dict[str, Any]:
+        return self.api_get("/api/model/fdd-query-presets", token=token)
+
+    def get_timeseries_series(self, site_id: str, *, token: str = "", source: str = "bacnet") -> dict[str, Any]:
+        return self.api_get(f"/api/timeseries/series?site_id={site_id}&source={source}", token=token)
+
+    def get_timeseries_readings(
+        self,
+        site_id: str,
+        columns: list[str],
+        *,
+        hours: int = 24,
+        token: str = "",
+        include_faults: bool = True,
+        source: str = "bacnet",
+    ) -> dict[str, Any]:
+        import urllib.parse
+
+        col_param = urllib.parse.quote(",".join(columns), safe=",")
+        inc = "true" if include_faults else "false"
+        path = (
+            f"/api/timeseries/readings?site_id={urllib.parse.quote(site_id)}"
+            f"&columns={col_param}&hours={hours}&source={source}&include_faults={inc}"
+        )
+        return self.api_get(path, token=token)
+
+    def get_portfolio_rollup(self, *, site_id: str | None = None, token: str = "") -> dict[str, Any]:
+        return fetch_portfolio_rollup(self.base_url, token, site_id=site_id)

--- a/portfolio/dash/__main__.py
+++ b/portfolio/dash/__main__.py
@@ -1,0 +1,4 @@
+from portfolio.dash.app import main
+
+if __name__ == "__main__":
+    main()

--- a/portfolio/dash/app.py
+++ b/portfolio/dash/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Open-FDD central portfolio dashboard — run-hour & fault rollups across sites."""
+"""OpenFDD RCx Central — multi-edge analytics and RCx report builder (Dash)."""
 
 from __future__ import annotations
 
@@ -418,9 +418,55 @@ def _site_options() -> list[dict[str, str]]:
     return [{"label": s, "value": s} for s in sorted(checkins["site_id"].dropna().unique())]
 
 
-app = dash.Dash(__name__, suppress_callback_exceptions=True)
+app = dash.Dash(__name__, title="OpenFDD RCx Central", suppress_callback_exceptions=True)
 
 _sites = _site_options()
+
+def _overview_tab() -> html.Div:
+    return html.Div(
+        children=[
+            html.Div(id="overview-intro"),
+            html.Div(id="site-cards"),
+            html.Div(
+                id="chart-grid",
+                style={"display": "grid", "gridTemplateColumns": "280px 1fr", "gap": "16px", "marginTop": "20px"},
+                children=[
+                    html.Div(
+                        id="sidebar",
+                        children=[
+                            html.Label("Site", id="site-label"),
+                            dcc.Dropdown(
+                                id="site-select",
+                                options=_sites,
+                                value=_sites[0]["value"] if _sites else None,
+                                clearable=False,
+                            ),
+                            html.Label("Metric", id="metric-label", style={"marginTop": "12px"}),
+                            dcc.RadioItems(
+                                id="metric-select",
+                                options=[
+                                    {"label": "Fan run hours", "value": "fan_run_hours"},
+                                    {"label": "System run hours", "value": "system_run_hours"},
+                                    {"label": "Unoccupied fan hours", "value": "unoccupied_fan_hours"},
+                                ],
+                                value="fan_run_hours",
+                            ),
+                            html.P(
+                                id="delta-legend",
+                                children="Δ bars: green = hours down (good) · red = hours up",
+                                style={"fontSize": "12px", "marginTop": "12px"},
+                            ),
+                        ],
+                    ),
+                    dcc.Graph(id="run-hours-chart"),
+                ],
+            ),
+            dcc.Graph(id="site-fault-total-chart", style={"marginTop": "16px"}),
+            dcc.Graph(id="fault-trend-chart", style={"marginTop": "16px"}),
+            dcc.Graph(id="override-chart", style={"marginTop": "16px"}),
+        ]
+    )
+
 
 app.layout = html.Div(
     id="app-root",
@@ -428,44 +474,20 @@ app.layout = html.Div(
         dcc.Store(id="theme-store", data="dark"),
         dcc.Interval(id="refresh-interval", interval=120_000, n_intervals=0),
         html.Div(id="header-row"),
-        html.Div(id="site-cards"),
-        html.Div(
-            id="chart-grid",
-            style={"display": "grid", "gridTemplateColumns": "280px 1fr", "gap": "16px", "marginTop": "20px"},
+        dcc.Tabs(
+            id="main-tabs",
+            value="overview",
             children=[
-                html.Div(
-                    id="sidebar",
-                    children=[
-                        html.Label("Site", id="site-label"),
-                        dcc.Dropdown(
-                            id="site-select",
-                            options=_sites,
-                            value=_sites[0]["value"] if _sites else None,
-                            clearable=False,
-                        ),
-                        html.Label("Metric", id="metric-label", style={"marginTop": "12px"}),
-                        dcc.RadioItems(
-                            id="metric-select",
-                            options=[
-                                {"label": "Fan run hours", "value": "fan_run_hours"},
-                                {"label": "System run hours", "value": "system_run_hours"},
-                                {"label": "Unoccupied fan hours", "value": "unoccupied_fan_hours"},
-                            ],
-                            value="fan_run_hours",
-                        ),
-                        html.P(
-                            id="delta-legend",
-                            children="Δ bars: green = hours down (good) · red = hours up",
-                            style={"fontSize": "12px", "marginTop": "12px"},
-                        ),
-                    ],
-                ),
-                dcc.Graph(id="run-hours-chart"),
+                dcc.Tab(label="Overview", value="overview", children=[_overview_tab()]),
+                dcc.Tab(label="Edge Connections", value="edges", children=[html.Div(id="edges-tab")]),
+                dcc.Tab(label="Mechanical Summary", value="mechanical", children=[html.Div(id="mech-tab")]),
+                dcc.Tab(label="FDD Analytics", value="fdd", children=[html.Div(id="fdd-tab")]),
+                dcc.Tab(label="Trend Explorer", value="trends", children=[html.Div(id="trends-tab")]),
+                dcc.Tab(label="RCx Report Builder", value="rcx", children=[html.Div(id="rcx-tab")]),
+                dcc.Tab(label="Validation Runs", value="validation", children=[html.Div(id="val-tab")]),
+                dcc.Tab(label="Settings", value="settings", children=[html.Div(id="settings-tab")]),
             ],
         ),
-        dcc.Graph(id="site-fault-total-chart", style={"marginTop": "16px"}),
-        dcc.Graph(id="fault-trend-chart", style={"marginTop": "16px"}),
-        dcc.Graph(id="override-chart", style={"marginTop": "16px"}),
     ],
 )
 
@@ -490,9 +512,9 @@ def render_header(theme_key: str):
         children=[
             html.Div(
                 children=[
-                    html.H1("Open-FDD Portfolio", style={"margin": 0, "color": theme["text"]}),
+                    html.H1("OpenFDD RCx Central", style={"margin": 0, "color": theme["text"]}),
                     html.P(
-                        "Stock-style fault & run-hour trends · per-code breakdown · AI agent check-ins · P8 overrides",
+                        "Local analyst tool · multi-edge RCx analytics · read-only toward OpenFDD Edge",
                         style={"color": theme["muted"], "margin": "4px 0 0"},
                     ),
                 ]
@@ -643,7 +665,46 @@ def update_charts(
     )
 
 
+@app.callback(
+    Output("overview-intro", "children"),
+    Output("edges-tab", "children"),
+    Output("mech-tab", "children"),
+    Output("fdd-tab", "children"),
+    Output("trends-tab", "children"),
+    Output("rcx-tab", "children"),
+    Output("val-tab", "children"),
+    Output("settings-tab", "children"),
+    Input("theme-store", "data"),
+)
+def render_tab_shells(theme_key: str):
+    from portfolio.dash.rcx_pages import (
+        edge_connections_layout,
+        fdd_analytics_layout,
+        mechanical_layout,
+        overview_intro,
+        rcx_builder_layout,
+        settings_layout,
+        trend_explorer_layout,
+        validation_layout,
+    )
+
+    theme = THEMES.get(theme_key or "dark", THEMES["dark"])
+    return (
+        overview_intro(theme),
+        edge_connections_layout(theme),
+        mechanical_layout(theme),
+        fdd_analytics_layout(theme),
+        trend_explorer_layout(theme),
+        rcx_builder_layout(theme),
+        validation_layout(theme),
+        settings_layout(theme),
+    )
+
+
 def main() -> None:
+    from portfolio.dash.rcx_callbacks import register_rcx_callbacks
+
+    register_rcx_callbacks(app)
     app.run(host="0.0.0.0", port=8050, debug=False)
 
 

--- a/portfolio/dash/rcx_callbacks.py
+++ b/portfolio/dash/rcx_callbacks.py
@@ -1,0 +1,269 @@
+"""Callbacks for RCx Central tabs (Edge, Mechanical, Report Builder)."""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib import error, request
+
+from dash import Input, Output, State, dcc, html, no_update
+
+CENTRAL_API = os.environ.get("OPENFDD_CENTRAL_API_URL", "http://127.0.0.1:8060").rstrip("/")
+
+
+def _api(method: str, path: str, body: dict | None = None) -> dict:
+    url = f"{CENTRAL_API}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if body is not None else {}
+    req = request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with request.urlopen(req, timeout=120) as resp:
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw else {}
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"HTTP {exc.code}: {detail}") from exc
+
+
+def register_rcx_callbacks(app) -> None:
+    @app.callback(
+        Output("edge-list", "children"),
+        Output("mech-site", "options"),
+        Output("rcx-site", "options"),
+        Output("fdd-site", "options"),
+        Output("val-site", "options"),
+        Input("main-tabs", "value"),
+        Input("edge-save-btn", "n_clicks"),
+    )
+    def refresh_edge_lists(tab, _save):
+        try:
+            data = _api("GET", "/api/central/edges")
+            edges = data.get("edges") or []
+            opts = [{"label": f"{e.get('name')} ({e.get('site_id')})", "value": e.get("site_id")} for e in edges]
+            rows = [html.Li(f"{e.get('name')} — {e.get('base_url')} [{e.get('auth_type')}]") for e in edges]
+            return html.Ul(rows), opts, opts, opts, opts
+        except Exception as exc:
+            return html.P(str(exc)), [], [], [], []
+
+    @app.callback(
+        Output("edge-test-result", "children"),
+        Input("edge-test-btn", "n_clicks"),
+        State("edge-url", "value"),
+        State("edge-user", "value"),
+        State("edge-password", "value"),
+        prevent_initial_call=True,
+    )
+    def test_edge(_n, url, user, password):
+        if not url:
+            return "Enter Edge base URL."
+        try:
+            out = _api(
+                "POST",
+                "/api/central/edges/test",
+                {"base_url": url, "username": user or "agent", "password": password or "", "auth_type": "password"},
+            )
+            return json.dumps(out, indent=2)
+        except Exception as exc:
+            return str(exc)
+
+    @app.callback(
+        Output("edge-test-result", "children", allow_duplicate=True),
+        Input("edge-save-btn", "n_clicks"),
+        State("edge-site-id", "value"),
+        State("edge-name", "value"),
+        State("edge-url", "value"),
+        State("edge-user", "value"),
+        State("edge-password", "value"),
+        prevent_initial_call=True,
+    )
+    def save_edge(_n, site_id, name, url, user, password):
+        if not site_id or not url:
+            return "site_id and base_url required."
+        try:
+            _api(
+                "POST",
+                "/api/central/edges",
+                {
+                    "site_id": site_id,
+                    "name": name or site_id,
+                    "base_url": url,
+                    "username": user or "agent",
+                    "password": password or "",
+                    "auth_type": "password",
+                },
+            )
+            return f"Saved Edge {site_id}."
+        except Exception as exc:
+            return str(exc)
+
+    @app.callback(
+        Output("mech-summary", "children"),
+        Input("mech-refresh-btn", "n_clicks"),
+        State("mech-site", "value"),
+        State("mech-hours", "value"),
+        prevent_initial_call=True,
+    )
+    def refresh_mech(_n, site_id, hours):
+        if not site_id:
+            return "Select a site."
+        try:
+            out = _api("GET", f"/api/central/mechanical-summary/{site_id}?hours={hours or 24}")
+            return json.dumps(out, indent=2)
+        except Exception as exc:
+            return str(exc)
+
+    @app.callback(
+        Output("rcx-readiness", "children"),
+        Output("rcx-chart-checkboxes", "children"),
+        Output("rcx-section-checkboxes", "children"),
+        Input("rcx-preview-btn", "n_clicks"),
+        State("rcx-site", "value"),
+        State("rcx-hours", "value"),
+        State("rcx-overlays", "value"),
+        prevent_initial_call=True,
+    )
+    def rcx_preview(_n, site_id, hours, overlays):
+        if not site_id:
+            return "Select a site.", no_update, no_update
+        try:
+            out = _api(
+                "POST",
+                "/api/central/rcx/preview",
+                {
+                    "site_id": site_id,
+                    "hours": hours or 24,
+                    "show_fault_overlays": "on" in (overlays or []),
+                },
+            )
+            fs = out.get("fault_summary") or {}
+            text = (
+                f"Active faults: {fs.get('active_faults')} · "
+                f"Fault hours: {fs.get('total_fault_hours')} · "
+                f"Disabled charts: {len(out.get('disabled_charts') or [])}"
+            )
+            charts = dcc.Checklist(
+                id="rcx-charts-selected",
+                options=[
+                    {"label": c.get("title"), "value": c.get("chart_id")}
+                    for c in (out.get("available_charts") or [])
+                ],
+                value=[c.get("chart_id") for c in (out.get("available_charts") or [])],
+            )
+            disabled = html.Ul(
+                [html.Li(f"{c.get('title')}: {c.get('reason')}") for c in (out.get("disabled_charts") or [])]
+            )
+            sections = dcc.Checklist(
+                id="rcx-sections-selected",
+                options=[{"label": s.get("label"), "value": s.get("id")} for s in (out.get("sections") or [])],
+                value=[s.get("id") for s in (out.get("sections") or [])],
+            )
+            return html.Div([html.P(text), disabled]), charts, sections
+        except Exception as exc:
+            return str(exc), no_update, no_update
+
+    @app.callback(
+        Output("rcx-chart-previews", "children"),
+        Input("rcx-charts-btn", "n_clicks"),
+        State("rcx-site", "value"),
+        State("rcx-hours", "value"),
+        State("rcx-charts-selected", "value"),
+        State("rcx-overlays", "value"),
+        prevent_initial_call=True,
+    )
+    def rcx_chart_previews(_n, site_id, hours, chart_ids, overlays):
+        if not site_id:
+            return "Select a site."
+        try:
+            out = _api(
+                "POST",
+                "/api/central/rcx/charts/preview",
+                {
+                    "site_id": site_id,
+                    "hours": hours or 24,
+                    "chart_ids": chart_ids or [],
+                    "show_fault_overlays": "on" in (overlays or []),
+                },
+            )
+            imgs = []
+            for p in out.get("chart_previews") or []:
+                b64 = p.get("image_base64")
+                if b64:
+                    imgs.append(
+                        html.Div(
+                            [
+                                html.H4(p.get("title")),
+                                html.Img(src=f"data:image/png;base64,{b64}", style={"maxWidth": "100%"}),
+                            ]
+                        )
+                    )
+            return imgs or "No chart previews (missing data or python-docx/matplotlib)."
+        except Exception as exc:
+            return str(exc)
+
+    @app.callback(
+        Output("fdd-rules-table", "children"),
+        Input("fdd-refresh-btn", "n_clicks"),
+        State("fdd-site", "value"),
+        State("fdd-hours", "value"),
+        prevent_initial_call=True,
+    )
+    def refresh_fdd(_n, site_id, hours):
+        if not site_id:
+            return "Select a site."
+        try:
+            out = _api("GET", f"/api/central/fdd-analytics/{site_id}?hours={hours or 24}")
+            return json.dumps(out, indent=2)
+        except Exception as exc:
+            return str(exc)
+
+    @app.callback(
+        Output("val-result", "children"),
+        Output("val-jobs", "children"),
+        Input("val-run-btn", "n_clicks"),
+        State("val-site", "value"),
+        prevent_initial_call=True,
+    )
+    def run_validation(_n, site_id):
+        if not site_id:
+            return "Select a site.", no_update
+        try:
+            out = _api(
+                "POST",
+                "/api/central/validation/run",
+                {"site_id": site_id, "interval_hours": 2, "duration_hours": 0, "sleep_seconds": 0},
+            )
+            jobs = _api("GET", "/api/central/validation/jobs")
+            return json.dumps(out, indent=2), json.dumps(jobs, indent=2)
+        except Exception as exc:
+            return str(exc), no_update
+
+    @app.callback(
+        Output("rcx-download", "data"),
+        Output("rcx-status", "children"),
+        Input("rcx-docx-btn", "n_clicks"),
+        State("rcx-site", "value"),
+        State("rcx-hours", "value"),
+        State("rcx-charts-selected", "value"),
+        State("rcx-sections-selected", "value"),
+        prevent_initial_call=True,
+    )
+    def rcx_download(_n, site_id, hours, charts, sections):
+        if not site_id:
+            return no_update, "Select a site."
+        try:
+            url = f"{CENTRAL_API}/api/central/rcx/report"
+            body = json.dumps(
+                {
+                    "site_id": site_id,
+                    "hours": hours or 24,
+                    "charts": charts or [],
+                    "sections": sections or [],
+                }
+            ).encode("utf-8")
+            req = request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+            with request.urlopen(req, timeout=180) as resp:
+                blob = resp.read()
+            fname = f"openfdd-rcx-{site_id}.docx"
+            return dcc.send_bytes(blob, fname), "Report generated — download started."
+        except Exception as exc:
+            return no_update, str(exc)

--- a/portfolio/dash/rcx_pages.py
+++ b/portfolio/dash/rcx_pages.py
@@ -1,0 +1,141 @@
+"""OpenFDD RCx Central — additional Dash tab layouts."""
+
+from __future__ import annotations
+
+import os
+
+from dash import dcc, html
+
+CENTRAL_API = os.environ.get("OPENFDD_CENTRAL_API_URL", "http://127.0.0.1:8060").rstrip("/")
+
+HOUR_OPTS = [
+    {"label": "Last 2 hours", "value": 2},
+    {"label": "Last 24 hours", "value": 24},
+    {"label": "Last 7 days", "value": 168},
+]
+
+
+def edge_connections_layout(theme: dict) -> html.Div:
+    return html.Div(
+        className="rcx-panel",
+        children=[
+            html.H2("Edge Connections", style={"color": theme["text"]}),
+            html.P(
+                "Add OpenFDD Edge instances (Tailscale/VPN URL). Credentials stay in local config volume only.",
+                style={"color": theme["muted"]},
+            ),
+            html.Div(
+                style={"display": "grid", "gridTemplateColumns": "1fr 1fr", "gap": "12px"},
+                children=[
+                    dcc.Input(id="edge-site-id", placeholder="site_id (e.g. acme)", style={"padding": "8px"}),
+                    dcc.Input(id="edge-name", placeholder="Site name", style={"padding": "8px"}),
+                    dcc.Input(id="edge-url", placeholder="https://edge.example:8765", style={"padding": "8px", "gridColumn": "1 / -1"}),
+                    dcc.Input(id="edge-user", placeholder="username", value="agent", style={"padding": "8px"}),
+                    dcc.Input(id="edge-password", type="password", placeholder="password", style={"padding": "8px"}),
+                ],
+            ),
+            html.Div(
+                style={"marginTop": "12px", "display": "flex", "gap": "8px"},
+                children=[
+                    html.Button("Test Connection", id="edge-test-btn", n_clicks=0),
+                    html.Button("Save Edge", id="edge-save-btn", n_clicks=0),
+                ],
+            ),
+            html.Pre(id="edge-test-result", style={"color": theme["muted"], "whiteSpace": "pre-wrap"}),
+            html.Div(id="edge-list"),
+        ],
+    )
+
+
+def mechanical_layout(theme: dict) -> html.Div:
+    return html.Div(
+        children=[
+            html.H2("Mechanical Summary", style={"color": theme["text"]}),
+            dcc.Dropdown(id="mech-site", placeholder="Select Edge site"),
+            dcc.RadioItems(id="mech-hours", options=HOUR_OPTS, value=24, inline=True),
+            html.Button("Refresh Mechanical Summary", id="mech-refresh-btn", n_clicks=0, style={"marginTop": "8px"}),
+            html.Pre(id="mech-summary", style={"color": theme["text"], "whiteSpace": "pre-wrap"}),
+        ]
+    )
+
+
+def rcx_builder_layout(theme: dict) -> html.Div:
+    return html.Div(
+        children=[
+            html.H2("RCx Report Builder", style={"color": theme["text"]}),
+            dcc.Dropdown(id="rcx-site", placeholder="Select Edge site"),
+            dcc.RadioItems(id="rcx-hours", options=HOUR_OPTS, value=24, inline=True),
+            dcc.Checklist(id="rcx-overlays", options=[{"label": "Show fault overlays", "value": "on"}], value=["on"]),
+            html.Div(
+                style={"display": "flex", "gap": "8px", "marginTop": "8px", "flexWrap": "wrap"},
+                children=[
+                    html.Button("Collect Data / Preview", id="rcx-preview-btn", n_clicks=0),
+                    html.Button("Preview Charts", id="rcx-charts-btn", n_clicks=0),
+                    html.Button("Generate DOCX", id="rcx-docx-btn", n_clicks=0),
+                ],
+            ),
+            html.Div(id="rcx-readiness", style={"color": theme["muted"]}),
+            html.Div(id="rcx-chart-checkboxes"),
+            html.Div(id="rcx-section-checkboxes"),
+            html.Div(id="rcx-chart-previews"),
+            dcc.Download(id="rcx-download"),
+            html.Pre(id="rcx-status", style={"color": theme["muted"]}),
+        ]
+    )
+
+
+def fdd_analytics_layout(theme: dict) -> html.Div:
+    return html.Div(
+        children=[
+            html.H2("FDD Rules & Analytics", style={"color": theme["text"]}),
+            dcc.Dropdown(id="fdd-site", placeholder="Select Edge site"),
+            dcc.RadioItems(id="fdd-hours", options=HOUR_OPTS, value=24, inline=True),
+            html.Button("Refresh FDD rules", id="fdd-refresh-btn", n_clicks=0, style={"marginTop": "8px"}),
+            html.Pre(id="fdd-rules-table", style={"color": theme["text"], "whiteSpace": "pre-wrap"}),
+        ]
+    )
+
+
+def trend_explorer_layout(theme: dict) -> html.Div:
+    return html.Div(
+        children=[
+            html.H2("Trend Explorer", style={"color": theme["text"]}),
+            html.P("Plotly view of collected portfolio rollups (interactive).", style={"color": theme["muted"]}),
+            dcc.Dropdown(id="trend-site", placeholder="Site (overview tab charts)"),
+            html.P("Use Overview charts for interactive Plotly trends from local collect CSVs.", style={"color": theme["muted"]}),
+        ]
+    )
+
+
+def validation_layout(theme: dict) -> html.Div:
+    return html.Div(
+        children=[
+            html.H2("Validation Runs", style={"color": theme["text"]}),
+            dcc.Dropdown(id="val-site", placeholder="Select Edge site"),
+            html.Button("Run one-off validation", id="val-run-btn", n_clicks=0, style={"marginTop": "8px"}),
+            html.Pre(id="val-result", style={"color": theme["text"], "whiteSpace": "pre-wrap"}),
+            html.H3("Stored jobs", style={"color": theme["text"]}),
+            html.Pre(id="val-jobs", style={"color": theme["muted"], "whiteSpace": "pre-wrap"}),
+        ]
+    )
+
+
+def settings_layout(theme: dict) -> html.Div:
+    return html.Div(
+        children=[
+            html.H2("Settings", style={"color": theme["text"]}),
+            html.P(f"Central API: {CENTRAL_API}", style={"color": theme["muted"]}),
+            html.P(
+                "Data and credentials persist under portfolio/data and portfolio/config (Docker volumes in compose).",
+                style={"color": theme["muted"]},
+            ),
+            html.P("Read-only toward OpenFDD Edge — no BACnet writes.", style={"color": theme.get("warn", theme["muted"])}),
+        ]
+    )
+
+
+def overview_intro(theme: dict) -> html.P:
+    return html.P(
+        "Multi-edge fault & run-hour rollups from collected Edge snapshots. Use Edge Connections to register sites.",
+        style={"color": theme["muted"], "margin": "4px 0 12px"},
+    )

--- a/scripts/build_rcx_central_image.sh
+++ b/scripts/build_rcx_central_image.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG="${OPENFDD_IMAGE_TAG:-local}"
+docker build -f "$ROOT/docker/rcx-central/Dockerfile" -t "ghcr.io/bbartling/openfdd-rcx-central:${TAG}" "$ROOT"
+echo "Built ghcr.io/bbartling/openfdd-rcx-central:${TAG}"

--- a/scripts/run_central_api.sh
+++ b/scripts/run_central_api.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+export PYTHONPATH="${ROOT}:${PYTHONPATH:-}"
 exec python3 "$ROOT/scripts/run_central_api.py" "$@"

--- a/scripts/run_rcx_central_docker.sh
+++ b/scripts/run_rcx_central_docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export OPENFDD_IMAGE_TAG="${OPENFDD_IMAGE_TAG:-local}"
+exec docker compose -f "$ROOT/docker/rcx-central/docker-compose.yml" up --build "$@"

--- a/scripts/test_rcx_central_docker.ps1
+++ b/scripts/test_rcx_central_docker.ps1
@@ -1,0 +1,27 @@
+# Smoke test OpenFDD RCx Central Docker stack (Windows Docker Desktop)
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$Compose = "docker compose -f `"$Root/docker/rcx-central/docker-compose.yml`""
+
+if (-not $env:OPENFDD_IMAGE_TAG) { $env:OPENFDD_IMAGE_TAG = "local" }
+
+Invoke-Expression "$Compose build"
+Invoke-Expression "$Compose up -d"
+
+try {
+    $ok = $false
+    for ($i = 0; $i -lt 30; $i++) {
+        try {
+            $r = Invoke-WebRequest -Uri "http://127.0.0.1:8060/health" -UseBasicParsing -TimeoutSec 5
+            if ($r.Content -match "ok") { $ok = $true; break }
+        } catch { Start-Sleep -Seconds 2 }
+    }
+    if (-not $ok) { throw "API health did not respond" }
+
+    Invoke-WebRequest -Uri "http://127.0.0.1:8050/" -UseBasicParsing -TimeoutSec 10 | Out-Null
+    Invoke-Expression "$Compose exec -T rcx-central-api python -c `"from pathlib import Path; p=Path('/app/portfolio/data/reports'); p.mkdir(exist_ok=True); (p/'_write_test').write_text('ok'); assert (p/'_write_test').read_text()=='ok'`""
+    Write-Host "RCx Central Docker smoke: PASS"
+}
+finally {
+    Invoke-Expression "$Compose down"
+}

--- a/scripts/test_rcx_central_docker.sh
+++ b/scripts/test_rcx_central_docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Smoke test OpenFDD RCx Central Docker stack (cross-platform)
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="docker compose -f $ROOT/docker/rcx-central/docker-compose.yml"
+
+export OPENFDD_IMAGE_TAG="${OPENFDD_IMAGE_TAG:-local}"
+$COMPOSE build
+$COMPOSE up -d
+trap '$COMPOSE down' EXIT
+
+for i in $(seq 1 30); do
+  if curl -fsS http://127.0.0.1:8060/health >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+curl -fsS http://127.0.0.1:8060/health | grep -q ok
+curl -fsS http://127.0.0.1:8050/ | head -c 200 >/dev/null
+$COMPOSE exec -T rcx-central-api python -c "from pathlib import Path; p=Path('/app/portfolio/data/reports'); p.mkdir(exist_ok=True); (p/'_write_test').write_text('ok'); assert (p/'_write_test').read_text()=='ok'"
+echo "RCx Central Docker smoke: PASS"

--- a/tests/portfolio/test_central.py
+++ b/tests/portfolio/test_central.py
@@ -179,4 +179,6 @@ def test_central_api_health():
     from portfolio.central.api import app
 
     client = TestClient(app)
-    assert client.get("/health").json()["status"] == "ok"
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    assert body["service"] == "openfdd-rcx-central"

--- a/tests/portfolio/test_chart_preview.py
+++ b/tests/portfolio/test_chart_preview.py
@@ -1,0 +1,57 @@
+"""Offline tests for RCx chart preview and fault overlays."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from portfolio.central.trend_charts import fault_overlay_spans, overlays_from_readings
+
+
+def test_fault_overlay_spans_contiguous():
+    ts = ["2026-01-01T00:00:00Z", "2026-01-01T01:00:00Z", "2026-01-01T02:00:00Z", "2026-01-01T03:00:00Z"]
+    flags = [0, 1, 1, 0]
+    spans = fault_overlay_spans(ts, flags, label="SAT flatline", severity="warning")
+    assert len(spans) == 1
+    assert spans[0]["label"] == "SAT flatline"
+
+
+def test_overlays_from_readings():
+    readings = {
+        "timestamps": ["2026-01-01T00:00:00Z", "2026-01-01T01:00:00Z"],
+        "fault_plots": {"rule-1": [1, 0]},
+        "fault_panels": [{"key": "rule-1", "title": "AHU SAT"}],
+    }
+    ovs = overlays_from_readings(readings)
+    assert ovs
+
+
+@pytest.mark.skipif(
+    __import__("importlib").util.find_spec("matplotlib") is None,
+    reason="matplotlib not installed",
+)
+@patch("portfolio.central.chart_preview.build_mechanical_summary")
+@patch("portfolio.central.chart_preview.resolve_token", return_value="tok")
+@patch("portfolio.central.chart_preview.resolve_site_config")
+@patch("portfolio.central.chart_preview.EdgeClient")
+def test_build_rcx_preview_fault_bars(mock_client_cls, mock_site, _tok, mock_mech):
+    mock_site.return_value = MagicMock(name="ACME", base_url="http://edge.test")
+    mock_mech.return_value = {"warnings": [], "model_issues": []}
+    client = mock_client_cls.return_value
+    client.get_model_tree.return_value = {"points": []}
+    client.get_analytics_overview.return_value = {
+        "kpis": {"active_faults": 2, "total_fault_hours": 5.0},
+        "faults_by_severity": [{"group": "warning", "elapsed_hours": 3}],
+        "fault_hours_by_equipment": [{"group": "AHU-C", "elapsed_hours": 2}],
+    }
+    client.get_analytics_faults.return_value = {
+        "faults": [{"fault_name": "SAT", "severity": "warning", "equipment": "AHU-C"}]
+    }
+
+    from portfolio.central.chart_preview import build_rcx_preview
+
+    out = build_rcx_preview(site_id="acme", hours=24)
+    assert out["fault_summary"]["active_faults"] == 1
+    assert len(out["chart_previews"]) >= 1
+    assert out["chart_previews"][0]["image_base64"]

--- a/tests/portfolio/test_edge_registry.py
+++ b/tests/portfolio/test_edge_registry.py
@@ -1,0 +1,74 @@
+"""Tests for RCx Central edge registry and API extensions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from portfolio.central.edge_registry import (
+    _validate_base_url,
+    add_or_update_edge,
+    delete_edge,
+    list_edges_public,
+)
+
+
+def test_validate_base_url_rejects_file_scheme():
+    with pytest.raises(ValueError):
+        _validate_base_url("file:///etc/passwd")
+
+
+def test_add_list_delete_edge(tmp_path, monkeypatch):
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    monkeypatch.setenv("OPENFDD_RCX_CENTRAL_CONFIG", str(cfg))
+    monkeypatch.setenv("OPENFDD_RCX_CENTRAL_DATA", str(tmp_path / "data"))
+
+    add_or_update_edge(
+        site_id="demo",
+        name="Demo Edge",
+        base_url="http://127.0.0.1:8765",
+        auth_type="password",
+        username="agent",
+        password="secret",
+    )
+    edges = list_edges_public()
+    assert any(e["site_id"] == "demo" for e in edges)
+    assert edges[0]["has_password"]
+    assert "secret" not in json.dumps(edges)
+
+    delete_edge("demo")
+    assert not any(e["site_id"] == "demo" for e in list_edges_public())
+
+
+def test_central_edges_api(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    monkeypatch.setenv("OPENFDD_RCX_CENTRAL_CONFIG", str(cfg))
+    monkeypatch.setenv("OPENFDD_RCX_CENTRAL_DATA", str(tmp_path / "data"))
+
+    from portfolio.central.api import app
+
+    client = TestClient(app)
+    assert client.get("/health").json()["service"] == "openfdd-rcx-central"
+    bad = client.post("/api/central/edges", json={"site_id": "x", "base_url": "ftp://bad"})
+    assert bad.status_code == 400
+    ok = client.post(
+        "/api/central/edges",
+        json={"site_id": "acme", "name": "Acme", "base_url": "http://127.0.0.1:8765", "password": "x"},
+    )
+    assert ok.status_code == 200
+    assert client.get("/api/central/edges").json()["count"] >= 1
+
+
+def test_dash_title():
+    text = (Path(__file__).resolve().parents[2] / "portfolio" / "dash" / "app.py").read_text()
+    assert 'title="OpenFDD RCx Central"' in text
+    assert "OpenFDD RCx Central" in text
+    for tab in ("Edge Connections", "Mechanical Summary", "FDD Analytics", "RCx Report Builder"):
+        assert tab in text


### PR DESCRIPTION
## Summary
- Renames the local portfolio dashboard into **OpenFDD RCx Central** and turns it into a Docker Desktop-friendly analyst tool for querying OpenFDD Edge instances, previewing RCx analytics, and generating DOCX reports.
- Adds browser Edge registry (add/test/save), mechanical summary, FDD analytics visibility, matplotlib chart preview with fault overlays, and RCx report builder flow.
- Adds `docker/rcx-central/` runtime (no git clone required when image is pulled).

## Product Boundary
- **OpenFDD Edge** remains the Arrow-native, no-pandas, OT-LAN FDD deployment.
- **OpenFDD RCx Central** is the local analyst/RCx dashboard that connects to one or more Edge instances over Tailscale/VPN/private network.
- RCx Central is **read-only** toward Edge/BACnet.

## Safety
All RCx Central operations are read-only. No BACnet writes, commands, overrides, priority-array edits, schedules, setpoints, or BAS changes are performed. Credentials stay in local `portfolio/config/` (gitignored).

## Tests
- `pytest tests/portfolio/` — 14 passed, 2 skipped (optional matplotlib/python-docx)
- Docker smoke: API health + volume write (`scripts/test_rcx_central_docker.sh`); dash bind fails if host `:8050` is already in use

## Manual Windows Docker Desktop Test
```powershell
docker compose -f docker/rcx-central/docker-compose.yml up --build
# http://localhost:8050
# http://localhost:8060/health
# Add ACME Edge via Tailscale → Test Connection → Mechanical Summary → Preview Charts → Generate DOCX
```

## Known Limitations
- GHCR image `openfdd-rcx-central` not published yet (local build works)
- Trend Explorer tab is a stub; Plotly trends remain on Overview (local collect CSVs)
- RCx builder lacks full equipment-tree scope UI
- Chart catalog has 6 specs; more FDD chart packs follow-up

## Follow-Up Work
- Publish RCx Central GHCR image tag
- Equipment-tree report scope + more chart packs
- Configurable compose ports for smoke CI when 8050 is occupied

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Docker Compose support for RCx Central deployment
  * Edge management interface for configuring site connections
  * RCx Report Builder with chart preview and DOCX generation
  * FDD analytics dashboard and mechanical summary views
  * Tabbed interface for improved navigation

* **Documentation**
  * Comprehensive guides for Docker Desktop setup, edge authentication, API endpoints, and report generation
  * AI agent workflow documentation
  * Model query and analytics documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->