### PR TITLE
Open-FDD 3.1.0: optional DataFusion SQL rule backend + Rules Lab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,23 @@ jobs:
           /tmp/ofdd-wheel-smoke/bin/pip install "$wheel"
           /tmp/ofdd-wheel-smoke/bin/python -c "from open_fdd.arrow_runtime import run_arrow_rule; from open_fdd.arrow_runtime.column_map_from_model import build_column_map_from_model_points; import open_fdd; assert open_fdd.__version__"
 
+  test-datafusion:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install with DataFusion extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,datafusion]"
+      - name: DataFusion SQL backend tests
+        run: python -m pytest open_fdd/tests/arrow_runtime/test_datafusion_backend.py -q
+
   agent-shell:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 <p align="center">
   Open-source <strong>supervisory fault detection</strong> for buildings — Arrow-native rules,
+  optional DataFusion SQL rules for Rust-ready migration,
   optional <strong>PyPI</strong> embeddable runtime, and a full <strong>Docker/GHCR</strong> edge operator stack
   (BACnet, bridge API, dashboard, MCP).
 </p>

--- a/docs/adr/adr-datafusion-rust-ready-rule-backend.md
+++ b/docs/adr/adr-datafusion-rust-ready-rule-backend.md
@@ -1,0 +1,59 @@
+# ADR: DataFusion as optional Rust-ready rule backend
+
+## Status
+
+Accepted — Open-FDD 3.1.0
+
+## Context
+
+Open-FDD v3 executes FDD rules over **Apache Arrow** tables. The primary contract is:
+
+```python
+apply_faults_arrow(table, cfg, context=None) -> BooleanArray | ChunkedArray
+```
+
+Operators and integrators author rules in Python/PyArrow. BACnet polling, bridge APIs, dashboard, MCP, and Docker deployment all consume normalized `ArrowRuleResult` payloads.
+
+We want a migration path toward Rust/DataFusion components **without** rewriting the project in Rust or weakening the PyArrow contract.
+
+## Decision
+
+Add an **optional** second rule backend:
+
+| Backend | Entry |
+| --- | --- |
+| `arrow` | `apply_faults_arrow(...)` (default, first-class) |
+| `datafusion_sql` | Restricted `SELECT` over registered `telemetry` |
+
+DataFusion is Apache Arrow-native and implemented in Rust. The Python `datafusion` package gives Open-FDD a clean seam where a future Rust service can replace or accelerate the wrapper while preserving the same result schema.
+
+## Why
+
+- Same Arrow memory model end-to-end
+- SQL expressions are easy to read for simple threshold/CASE rules
+- Compare mode can prove SQL masks match PyArrow before migration
+- Optional extra — normal `pip install open-fdd` unchanged
+
+## Non-goals (this milestone)
+
+- No Rust rewrite
+- No replacing PyArrow rules
+- No pandas on edge runtime
+- No arbitrary SQL console (injection-safe subset only)
+- No changes to BACnet, bridge auth, or MCP unless required for tests
+
+## Future path
+
+**Phase A** — PyArrow + optional DataFusion Python backend (this ADR)
+
+**Phase B** — Shared Arrow rule result contract across batch, Rules Lab, and reporting
+
+**Phase C** — Optional Rust DataFusion crate/service replaces Python wrapper
+
+**Phase D** — ML/graph analytics consume Arrow/Parquet outputs without changing the FDD rule contract
+
+## Consequences
+
+- CI adds a job with `pip install -e ".[test,dev,datafusion]"` for backend validation
+- Rule store persists `sql` and `fault_column` separately from Python `code`
+- Rules Lab gains backend selector; SQL executes server-side only

--- a/docs/datafusion-sql-rules.md
+++ b/docs/datafusion-sql-rules.md
@@ -1,0 +1,59 @@
+# DataFusion SQL rules (optional)
+
+Open-FDD v3 remains **PyArrow-first**. Rules implement `apply_faults_arrow(table, cfg, context=None)` and return a boolean Arrow mask.
+
+The optional **DataFusion SQL** backend (`backend: datafusion_sql`) is a future-Rust-prep seam:
+
+- Input: PyArrow `Table` registered as `telemetry`
+- Rule body: a restricted `SELECT` that adds a boolean `fault` column
+- Output: the same `ArrowRuleResult` shape as PyArrow rules
+
+Install:
+
+```bash
+pip install 'open-fdd[datafusion]'
+```
+
+## When to use SQL vs PyArrow
+
+| Use DataFusion SQL | Use PyArrow |
+| --- | --- |
+| Simple thresholds, `CASE WHEN`, boolean logic | Custom HVAC helpers, rolling windows, ML prep |
+| SQL-readable expressions for operators | Complex graph/feature work |
+| Proving parity before Rust migration | Primary supported authoring path |
+
+## Rule metadata
+
+```yaml
+id: zone_temp_high_sql
+name: Zone temperature high — SQL
+backend: datafusion_sql
+fault_column: fault
+sql: |
+  SELECT
+    *,
+    zone_temp > 75.0 AS fault
+  FROM telemetry
+```
+
+## Safety
+
+SQL rules are **not** a database console. The linter rejects:
+
+- Multiple statements, DDL/DML
+- Reads other than `FROM telemetry`
+- File paths and external URLs
+- Missing or non-boolean `fault` column
+- Row counts that differ from input telemetry
+
+Server-side execution only — the Rules Lab browser editor never runs SQL locally.
+
+## Rules Lab
+
+In **Rule Lab**, choose **PyArrow** or **DataFusion SQL**:
+
+- **Validate SQL** — lint + optional server preview on latest historian sample
+- **Run Preview** — bounded sample against site telemetry
+- **Compare backends** — prove an equivalent SQL rule matches a PyArrow rule mask
+
+See [ADR: DataFusion Rust-ready backend](adr/adr-datafusion-rust-ready-rule-backend.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,10 +5,11 @@ These examples use **`pip install open-fdd`** — the embeddable FDD runtime. Th
 | Example | Purpose |
 |---------|---------|
 | [arrow_minimal/](arrow_minimal/) | Smallest `apply_faults_arrow` + `run_arrow_rule` |
+| [datafusion_sql_rule/](datafusion_sql_rule/) | Optional DataFusion SQL backend (`pip install open-fdd[datafusion]`) |
 | [feather_rule_run/](feather_rule_run/) | Run a rule against a Feather file |
 | [cloud_pipeline/generic_iot_pipeline/](cloud_pipeline/generic_iot_pipeline/) | IoT rows → Arrow → FDD → fake fault sink |
 
-**Rule contract:** rules define `apply_faults_arrow(table, cfg, context=None)` and return a PyArrow boolean mask (or documented `ArrowRuleResult` from `run_arrow_rule`).
+**Rule contract:** rules define `apply_faults_arrow(table, cfg, context=None)` and return a PyArrow boolean mask (or documented `ArrowRuleResult` from `run_arrow_rule`). An optional **DataFusion SQL** backend (`backend: datafusion_sql`) uses the same result shape for simple expression-style rules — see [docs/datafusion-sql-rules.md](../docs/datafusion-sql-rules.md).
 
 **Not included here:** pandas/YAML `RuleRunner` notebooks — archived under `_archive/examples_pandas_yaml/`.
 

--- a/examples/datafusion_sql_rule/README.md
+++ b/examples/datafusion_sql_rule/README.md
@@ -1,0 +1,15 @@
+# DataFusion SQL rule example (optional extra)
+
+Install:
+
+```bash
+pip install -e ".[datafusion]"
+```
+
+Run against synthetic telemetry:
+
+```bash
+python examples/datafusion_sql_rule/run_example.py
+```
+
+The SQL reads from the registered Arrow table `telemetry` and must return a boolean column named `fault`.

--- a/examples/datafusion_sql_rule/run_example.py
+++ b/examples/datafusion_sql_rule/run_example.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Minimal DataFusion SQL rule against synthetic HVAC telemetry."""
+
+from __future__ import annotations
+
+from open_fdd.arrow_runtime.datafusion_backend import datafusion_available, run_datafusion_sql_rule
+from open_fdd.arrow_runtime.testing import sample_hvac_table
+
+SQL = """SELECT
+  *,
+  zone_temp > 75.0 AS fault
+FROM telemetry"""
+
+
+def main() -> None:
+    if not datafusion_available():
+        raise SystemExit("Install optional extra: pip install 'open-fdd[datafusion]'")
+    table = sample_hvac_table(100, seed=7)
+    result = run_datafusion_sql_rule(SQL, table, rule_id="sat_high_sql")
+    print(f"rows={result.row_count} true={result.true_count} backend={result.backend}")
+    if result.errors:
+        raise SystemExit(result.errors[0])
+
+
+if __name__ == "__main__":
+    main()

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,6 +9,6 @@ GHCR Docker images (``openfdd-bridge``, ``openfdd-commission``, ``openfdd-mcp-ra
 not inside this wheel.
 """
 
-__version__ = "3.0.34"
+__version__ = "3.1.0"
 
 __all__ = ["__version__"]

--- a/open_fdd/arrow_runtime/__init__.py
+++ b/open_fdd/arrow_runtime/__init__.py
@@ -3,6 +3,11 @@
 from .backend import ArrowRuleResult, run_arrow_rule
 from .column_map_from_model import build_column_map_from_model_points
 from .config import ArrowRuntimeConfig, configure_arrow_runtime, get_arrow_runtime_config
+from .datafusion_backend import (
+    datafusion_available,
+    lint_datafusion_sql_rule,
+    run_datafusion_sql_rule,
+)
 from .rules import detect_rule_backend, legacy_row_allowed, migrate_legacy_threshold_hint
 
 __all__ = [
@@ -10,9 +15,12 @@ __all__ = [
     "ArrowRuntimeConfig",
     "build_column_map_from_model_points",
     "configure_arrow_runtime",
+    "datafusion_available",
     "detect_rule_backend",
     "get_arrow_runtime_config",
     "legacy_row_allowed",
+    "lint_datafusion_sql_rule",
     "migrate_legacy_threshold_hint",
     "run_arrow_rule",
+    "run_datafusion_sql_rule",
 ]

--- a/open_fdd/arrow_runtime/datafusion_backend.py
+++ b/open_fdd/arrow_runtime/datafusion_backend.py
@@ -1,0 +1,203 @@
+"""Optional DataFusion SQL rule backend — Arrow in, Arrow fault mask out."""
+
+from __future__ import annotations
+
+import re
+import time
+import traceback
+from dataclasses import dataclass
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from .backend import ArrowRuleResult, normalize_fault_mask
+from .summary import preview_fault_rows, summarize_arrow_run
+
+TELEMETRY_TABLE = "telemetry"
+DEFAULT_FAULT_COLUMN = "fault"
+
+_DATAFUSION_INSTALL_MSG = (
+    "DataFusion SQL backend is not installed. Install with: pip install 'open-fdd[datafusion]'"
+)
+
+_FORBIDDEN_SQL = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|COPY|ATTACH|DETACH|EXPLAIN|TRUNCATE|GRANT|REVOKE|"
+    r"CALL|EXECUTE|PREPARE|MERGE|REPLACE|LOAD|UNLOAD|EXPORT|IMPORT)\b",
+    re.IGNORECASE,
+)
+
+_FILE_OR_URL = re.compile(
+    r"(?:file://|s3://|gs://|hdfs://|/[\w./-]+\.(?:csv|parquet|json|feather|arrow)\b)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class DataFusionSqlRule:
+    sql: str
+    fault_column: str = DEFAULT_FAULT_COLUMN
+
+
+def datafusion_available() -> bool:
+    try:
+        import datafusion  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _strip_sql(sql: str) -> str:
+    text = str(sql or "").strip()
+    if text.endswith(";"):
+        text = text[:-1].strip()
+    return text
+
+
+def lint_datafusion_sql_rule(sql: str, *, fault_column: str = DEFAULT_FAULT_COLUMN) -> dict[str, Any]:
+    """Static SQL lint — safe without DataFusion installed."""
+    issues: list[dict[str, Any]] = []
+    raw = str(sql or "").strip()
+    if not raw:
+        return {"ok": False, "issues": [{"message": "SQL is required", "severity": "error"}]}
+
+    cleaned = _strip_sql(raw)
+    if ";" in cleaned:
+        issues.append({"message": "multiple SQL statements are not allowed", "severity": "error"})
+    if not re.match(r"^\s*SELECT\b", cleaned, re.IGNORECASE):
+        issues.append({"message": "SQL must be a single SELECT query", "severity": "error"})
+
+    if _FORBIDDEN_SQL.search(cleaned):
+        issues.append({"message": "DDL/DML keywords are not allowed in SQL rules", "severity": "error"})
+
+    if _FILE_OR_URL.search(cleaned):
+        issues.append({"message": "file paths and external URLs are not allowed", "severity": "error"})
+
+    if not re.search(rf"\bFROM\s+{re.escape(TELEMETRY_TABLE)}\b", cleaned, re.IGNORECASE):
+        issues.append({"message": f"SQL must read FROM {TELEMETRY_TABLE}", "severity": "error"})
+
+    fault_pat = rf"\bAS\s+{re.escape(fault_column)}\b|,\s*{re.escape(fault_column)}\s*[,)]"
+    if not re.search(fault_pat, cleaned, re.IGNORECASE) and fault_column.lower() not in cleaned.lower():
+        issues.append(
+            {
+                "message": f"SQL must produce boolean column '{fault_column}'",
+                "severity": "error",
+            }
+        )
+
+    return {"ok": not any(i["severity"] == "error" for i in issues), "issues": issues}
+
+
+def _import_datafusion():
+    try:
+        from datafusion import SessionContext
+    except ImportError as exc:
+        raise RuntimeError(_DATAFUSION_INSTALL_MSG) from exc
+    return SessionContext
+
+
+def _extract_fault_mask(result: pa.Table, *, fault_column: str, expected_len: int) -> pa.ChunkedArray:
+    if fault_column not in result.column_names:
+        raise ValueError(f"SQL must return a boolean column named '{fault_column}'")
+    if result.num_rows != expected_len:
+        raise ValueError(f"SQL row count {result.num_rows} != input rows {expected_len}")
+    col = result.column(fault_column)
+    return normalize_fault_mask(col, expected_len=expected_len)
+
+
+def run_datafusion_sql_rule(
+    sql: str,
+    table: pa.Table,
+    cfg: dict[str, Any] | None = None,
+    *,
+    context: dict[str, Any] | None = None,
+    rule_id: str = "",
+    fault_column: str = DEFAULT_FAULT_COLUMN,
+    preview_columns: list[str] | None = None,
+    preview_limit: int = 20,
+) -> ArrowRuleResult:
+    """Execute restricted DataFusion SQL against registered ``telemetry`` table."""
+    started = time.perf_counter()
+    cfg = dict(cfg or {})
+    _ = context or {}
+    fault_column = str(fault_column or DEFAULT_FAULT_COLUMN).strip() or DEFAULT_FAULT_COLUMN
+    lint = lint_datafusion_sql_rule(sql, fault_column=fault_column)
+    if not lint["ok"]:
+        msgs = [i["message"] for i in lint["issues"] if i["severity"] == "error"]
+        err = "DataFusion SQL invalid:\n" + "\n".join(msgs)
+        mask = pa.array([False] * table.num_rows, type=pa.bool_())
+        duration_ms = (time.perf_counter() - started) * 1000
+        return ArrowRuleResult(
+            rule_id=rule_id,
+            backend="datafusion_sql",
+            row_count=table.num_rows,
+            true_count=0,
+            false_count=table.num_rows,
+            null_count=0,
+            duration_ms=duration_ms,
+            fault_mask=mask,
+            errors=[err],
+            summary={"error": err},
+        )
+
+    try:
+        SessionContext = _import_datafusion()
+        import pyarrow.dataset as ds
+
+        ctx = SessionContext()
+        ctx.register_table(TELEMETRY_TABLE, ds.InMemoryDataset(table))
+        cleaned = _strip_sql(sql)
+        df = ctx.sql(cleaned)
+        result = df.to_arrow_table()
+        mask = _extract_fault_mask(result, fault_column=fault_column, expected_len=table.num_rows)
+    except Exception as exc:  # noqa: BLE001
+        err = str(exc)
+        mask = pa.array([False] * table.num_rows, type=pa.bool_())
+        duration_ms = (time.perf_counter() - started) * 1000
+        return ArrowRuleResult(
+            rule_id=rule_id,
+            backend="datafusion_sql",
+            row_count=table.num_rows,
+            true_count=0,
+            false_count=table.num_rows,
+            null_count=0,
+            duration_ms=duration_ms,
+            fault_mask=mask,
+            errors=[err],
+            summary={"error": err, "trace": traceback.format_exc(limit=6)},
+        )
+
+    from .events import count_mask_values
+
+    counts = count_mask_values(mask)
+    duration_ms = (time.perf_counter() - started) * 1000
+    summary = summarize_arrow_run(
+        table,
+        mask,
+        rule_id=rule_id,
+        site_id=str(cfg.get("site_id") or ""),
+        duration_ms=duration_ms,
+        backend="datafusion_sql",
+    )
+    preview = preview_fault_rows(table, mask, columns=preview_columns, limit=preview_limit)
+    return ArrowRuleResult(
+        rule_id=rule_id,
+        backend="datafusion_sql",
+        row_count=counts["row_count"],
+        true_count=counts["true_count"],
+        false_count=counts["false_count"],
+        null_count=counts["null_count"],
+        duration_ms=duration_ms,
+        fault_mask=mask,
+        summary=summary,
+        preview=preview,
+    )
+
+
+def equivalent_pyarrow_threshold_rule(column: str, threshold: float) -> str:
+    return f'''import pyarrow.compute as pc
+
+def apply_faults_arrow(table, cfg, context=None):
+    return pc.greater(table["{column}"], {threshold})
+'''

--- a/open_fdd/arrow_runtime/rules.py
+++ b/open_fdd/arrow_runtime/rules.py
@@ -17,13 +17,15 @@ def _has_function(code: str, name: str) -> bool:
 
 
 def detect_rule_backend(code: str, rule: dict[str, Any] | None = None) -> str:
-    """Return ``arrow``, ``legacy_row``, or ``script``."""
+    """Return ``arrow``, ``datafusion_sql``, ``legacy_row``, or ``script``."""
     rule = rule or {}
     if rule.get("mode") == "script":
         return "script"
     explicit = str(rule.get("backend") or "").strip()
-    if explicit in {"arrow", "legacy_row"}:
+    if explicit in {"arrow", "legacy_row", "datafusion_sql"}:
         return explicit
+    if str(rule.get("sql") or "").strip():
+        return "datafusion_sql"
     if _has_function(code, "apply_faults_arrow"):
         return "arrow"
     if _has_function(code, "evaluate"):

--- a/open_fdd/tests/arrow_runtime/test_datafusion_backend.py
+++ b/open_fdd/tests/arrow_runtime/test_datafusion_backend.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+
+from open_fdd.arrow_runtime.datafusion_backend import (
+    datafusion_available,
+    lint_datafusion_sql_rule,
+    run_datafusion_sql_rule,
+)
+from open_fdd.arrow_runtime.backend import run_arrow_rule
+from open_fdd.arrow_runtime.rules import detect_rule_backend
+from open_fdd.arrow_runtime.testing import sample_hvac_table
+
+THRESHOLD_SQL = """SELECT
+  *,
+  zone_temp > 75.0 AS fault
+FROM telemetry"""
+
+CASE_SQL = """SELECT
+  *,
+  CASE
+    WHEN fan_cmd > 0.5 AND airflow_cfm < 1000.0 THEN true
+    ELSE false
+  END AS fault
+FROM telemetry"""
+
+ARROW_THRESHOLD = """import pyarrow.compute as pc
+
+def apply_faults_arrow(table, cfg, context=None):
+    return pc.greater(table["zone_temp"], 75.0)
+"""
+
+
+def test_detect_rule_backend_datafusion_explicit():
+    assert detect_rule_backend("", {"backend": "datafusion_sql", "sql": THRESHOLD_SQL}) == "datafusion_sql"
+
+
+def test_detect_rule_backend_datafusion_from_sql_field():
+    assert detect_rule_backend("", {"sql": THRESHOLD_SQL}) == "datafusion_sql"
+
+
+def test_detect_rule_backend_arrow_unchanged():
+    assert detect_rule_backend(ARROW_THRESHOLD, {}) == "arrow"
+
+
+def test_lint_rejects_unsafe_sql():
+    lint = lint_datafusion_sql_rule("DROP TABLE telemetry")
+    assert not lint["ok"]
+    assert any("SELECT" in i["message"] for i in lint["issues"])
+
+
+def test_lint_rejects_missing_telemetry():
+    lint = lint_datafusion_sql_rule("SELECT 1 AS fault")
+    assert not lint["ok"]
+
+
+def test_lint_rejects_dml():
+    lint = lint_datafusion_sql_rule("INSERT INTO telemetry SELECT 1")
+    assert not lint["ok"]
+
+
+def test_missing_datafusion_clean_error():
+    if datafusion_available():
+        pytest.skip("datafusion installed")
+    table = sample_hvac_table(5)
+    result = run_datafusion_sql_rule(THRESHOLD_SQL, table)
+    assert result.backend == "datafusion_sql"
+    assert result.errors
+    assert "open-fdd[datafusion]" in result.errors[0]
+
+
+@pytest.mark.skipif(not datafusion_available(), reason="datafusion optional extra not installed")
+def test_simple_sql_threshold_matches_pyarrow():
+    table = sample_hvac_table(80, seed=3)
+    arrow = run_arrow_rule(ARROW_THRESHOLD, table, {})
+    sql = run_datafusion_sql_rule(THRESHOLD_SQL, table, {})
+    assert not arrow.errors
+    assert not sql.errors
+    assert sql.true_count == arrow.true_count
+    assert sql.row_count == arrow.row_count
+
+
+@pytest.mark.skipif(not datafusion_available(), reason="datafusion optional extra not installed")
+def test_case_when_sql_rule():
+    table = pa.table({"fan_cmd": [1.0, 0.0, 1.0], "airflow_cfm": [100.0, 5000.0, 8000.0]})
+    result = run_datafusion_sql_rule(CASE_SQL, table, {})
+    assert not result.errors
+    assert result.true_count == 1
+
+
+@pytest.mark.skipif(not datafusion_available(), reason="datafusion optional extra not installed")
+def test_missing_fault_column_fails():
+    table = sample_hvac_table(5)
+    result = run_datafusion_sql_rule("SELECT * FROM telemetry", table, {})
+    assert result.errors
+
+
+@pytest.mark.skipif(not datafusion_available(), reason="datafusion optional extra not installed")
+def test_wrong_row_count_fails():
+    table = sample_hvac_table(10)
+    bad_sql = "SELECT *, true AS fault FROM telemetry LIMIT 5"
+    result = run_datafusion_sql_rule(bad_sql, table, {})
+    assert result.errors

--- a/open_fdd/tests/arrow_runtime/test_detect_rule_backend.py
+++ b/open_fdd/tests/arrow_runtime/test_detect_rule_backend.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from open_fdd.arrow_runtime.datafusion_backend import lint_datafusion_sql_rule
+from open_fdd.arrow_runtime.rules import detect_rule_backend, legacy_row_allowed
+
+
+def test_legacy_row_still_gated():
+    code = "def evaluate(row, cfg):\n    return True\n"
+    assert detect_rule_backend(code, {}) == "legacy_row"
+    assert not legacy_row_allowed({})
+
+
+def test_detect_backends_matrix():
+    assert detect_rule_backend("", {"backend": "arrow"}) == "arrow"
+    assert detect_rule_backend("", {"backend": "datafusion_sql", "sql": "SELECT 1 AS fault FROM telemetry"}) == "datafusion_sql"
+    assert detect_rule_backend("", {"mode": "script"}) == "script"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.0.34"
+version = "3.1.0"
 description = "Arrow-native HVAC fault detection runtime — lint, test, and run apply_faults_arrow rules on columnar telemetry (PyPI). Use GHCR Docker images for the full edge operator stack."
 readme = "README.md"
 license = { text = "MIT" }
@@ -74,6 +74,9 @@ portfolio = [
     "dash>=2.17",
     "plotly>=5.22",
     "pandas>=2.2",
+]
+datafusion = [
+    "datafusion>=40.0.0",
 ]
 
 [project.urls]

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -387,7 +387,7 @@ start_bridge() {
   mkdir -p "$PID_DIR" workspace/data workspace/bacnet/commissioning workspace/bacnet/polls
   restart_if_running "$BRIDGE_PID" "uvicorn openfdd_bridge.main:app" "bridge"
   ensure_build
-  "${VENV}/bin/pip" install -q -e ".[dev,engine]" -r workspace/api/requirements.txt
+  "${VENV}/bin/pip" install -q -e ".[dev,engine,datafusion]" -r workspace/api/requirements.txt
   nohup "${VENV}/bin/uvicorn" openfdd_bridge.main:app \
     --app-dir workspace/api \
     --host "$OFDD_BRIDGE_HOST" --port "$OFDD_BRIDGE_PORT" \
@@ -499,7 +499,7 @@ start_ollama() {
 start_fdd_loop() {
   mkdir -p "$PID_DIR"
   restart_if_running "$FDD_PID" "openfdd_bridge.fdd_runner" "FDD loop"
-  "${VENV}/bin/pip" install -q -e ".[dev,engine]" -r workspace/api/requirements.txt
+  "${VENV}/bin/pip" install -q -e ".[dev,engine,datafusion]" -r workspace/api/requirements.txt
   (
     cd "${ROOT}/workspace/api"
     nohup "${VENV}/bin/python" -m openfdd_bridge.fdd_runner \

--- a/tests/workspace_bridge/test_rules_lab_api.py
+++ b/tests/workspace_bridge/test_rules_lab_api.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from open_fdd.arrow_runtime.datafusion_backend import lint_datafusion_sql_rule
+
+GOOD_SQL = """SELECT
+  *,
+  zone_temp > 75.0 AS fault
+FROM telemetry"""
+
+
+def test_rules_lab_lint_sql_endpoint_shape():
+    lint = lint_datafusion_sql_rule(GOOD_SQL)
+    assert lint["ok"] is True
+
+
+def test_rules_lab_lint_rejects_insert():
+    lint = lint_datafusion_sql_rule("INSERT INTO telemetry VALUES (1)")
+    assert lint["ok"] is False

--- a/workspace/api/openfdd_bridge/fdd_runner.py
+++ b/workspace/api/openfdd_bridge/fdd_runner.py
@@ -230,6 +230,53 @@ def _run_one(
         from open_fdd.arrow_runtime.rules import detect_rule_backend, legacy_row_allowed
 
         backend = detect_rule_backend(code, rule)
+        if backend == "datafusion_sql":
+            from .data_loader import load_arrow_table_for_run
+            from open_fdd.arrow_runtime.datafusion_backend import run_datafusion_sql_rule
+
+            import pyarrow as pa
+
+            if frame is not None:
+                table = frame if hasattr(frame, "num_rows") else pa.Table.from_pandas(frame)
+            else:
+                table, origin = load_arrow_table_for_run(site_id)
+                frame = table
+            if lookback_hours > 0 and table is not None and "timestamp" in table.column_names:
+                from open_fdd.arrow_runtime.features import arrow_time_filter
+                import datetime as _dt
+
+                cutoff = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=lookback_hours)
+                table = arrow_time_filter(table, "timestamp", cutoff, None)
+            if limit and table.num_rows > limit:
+                table = table.slice(max(0, table.num_rows - limit), min(limit, table.num_rows))
+            cfg = dict(rule.get("config") or {})
+            cfg.setdefault("site_id", site_id)
+            sql = str(rule.get("sql") or "").strip()
+            fault_column = str(rule.get("fault_column") or "fault")
+            arrow_result = run_datafusion_sql_rule(
+                sql,
+                table,
+                cfg,
+                rule_id=str(rule.get("id") or ""),
+                fault_column=fault_column,
+            )
+            if arrow_result.errors:
+                return {
+                    **base,
+                    "status": "error",
+                    "rows": arrow_result.row_count,
+                    "flagged": 0,
+                    "error": arrow_result.errors[0],
+                    "backend": "datafusion_sql",
+                }
+            return {
+                **base,
+                "status": "ok",
+                "rows": arrow_result.row_count,
+                "flagged": arrow_result.true_count,
+                "backend": "datafusion_sql",
+                "duration_ms": arrow_result.duration_ms,
+            }
         if backend == "arrow":
             from .data_loader import load_arrow_table_for_run
 

--- a/workspace/api/openfdd_bridge/main.py
+++ b/workspace/api/openfdd_bridge/main.py
@@ -34,6 +34,7 @@ from .routes import (
     playground_routes,
     reports_routes,
     rules_routes,
+    rules_lab_routes,
     sites_routes,
     timeseries_routes,
 )
@@ -87,6 +88,7 @@ def create_app() -> FastAPI:
     app.include_router(audit_routes.router)
     app.include_router(playground_routes.router)
     app.include_router(rules_routes.router)
+    app.include_router(rules_lab_routes.router)
     app.include_router(model_routes.router)
     app.include_router(timeseries_routes.router)
     app.include_router(building_routes.router)

--- a/workspace/api/openfdd_bridge/routes/rules_lab_routes.py
+++ b/workspace/api/openfdd_bridge/routes/rules_lab_routes.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..deps import require_roles
+from ..model_service import ModelService
+from ..rule_store import RuleStore
+from ..rules_lab import (
+    compare_rule_backends,
+    detect_backend_from_payload,
+    preview_datafusion_sql,
+    validate_datafusion_sql,
+)
+from ..site_defaults import ensure_default_site
+from ..ttl_service import TtlService
+from open_fdd.arrow_runtime.datafusion_backend import lint_datafusion_sql_rule
+
+router = APIRouter(
+    prefix="/api/rules/lab",
+    tags=["rules-lab"],
+    dependencies=[Depends(require_roles("integrator", "agent"))],
+)
+
+
+class LabSqlBody(BaseModel):
+    backend: str = "datafusion_sql"
+    sql: str = ""
+    fault_column: str = "fault"
+    sample_source: str = "latest"
+    site_id: str | None = None
+    limit: int = Field(default=500, ge=1, le=10000)
+    lookback_hours: float = Field(default=24, ge=0, le=720)
+
+
+class CompareSide(BaseModel):
+    backend: str
+    rule_id: str = ""
+    code: str = ""
+    sql: str = ""
+    fault_column: str = "fault"
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class LabCompareBody(BaseModel):
+    left: CompareSide
+    right: CompareSide
+    sample_source: str = "latest"
+    site_id: str | None = None
+    limit: int = Field(default=1000, ge=1, le=10000)
+    lookback_hours: float = Field(default=24, ge=0, le=720)
+
+
+class LabSaveBody(BaseModel):
+    id: str | None = None
+    name: str = "Untitled rule"
+    short_description: str = ""
+    description: str = ""
+    mode: str = "rule"
+    backend: str = "arrow"
+    code: str = ""
+    sql: str = ""
+    fault_column: str = "fault"
+    config: dict[str, Any] = Field(default_factory=dict)
+    column_map: dict[str, str] = Field(default_factory=dict)
+    applies_to: dict[str, Any] = Field(default_factory=dict)
+    bindings: dict[str, list[str]] = Field(default_factory=dict)
+    severity: str = "warning"
+    enabled: bool = True
+
+
+def _resolve_site_id(site_id: str | None) -> str:
+    svc = ModelService()
+    return (site_id or "").strip() or ensure_default_site(svc, TtlService())
+
+
+@router.post("/validate")
+def lab_validate(body: LabSqlBody) -> dict:
+    backend = str(body.backend or "").strip()
+    if backend != "datafusion_sql":
+        raise HTTPException(status_code=400, detail=f"validate supports datafusion_sql only, got {backend!r}")
+    site_id = _resolve_site_id(body.site_id)
+    return validate_datafusion_sql(
+        sql=body.sql,
+        fault_column=body.fault_column,
+        site_id=site_id,
+        limit=body.limit,
+        lookback_hours=body.lookback_hours,
+    )
+
+
+@router.post("/preview")
+def lab_preview(body: LabSqlBody) -> dict:
+    backend = str(body.backend or "").strip()
+    if backend != "datafusion_sql":
+        raise HTTPException(status_code=400, detail=f"preview supports datafusion_sql only, got {backend!r}")
+    site_id = _resolve_site_id(body.site_id)
+    return preview_datafusion_sql(
+        sql=body.sql,
+        fault_column=body.fault_column,
+        site_id=site_id,
+        limit=body.limit,
+        lookback_hours=body.lookback_hours,
+    )
+
+
+@router.post("/compare")
+def lab_compare(body: LabCompareBody) -> dict:
+    site_id = _resolve_site_id(body.site_id)
+    return compare_rule_backends(
+        left=body.left.model_dump(),
+        right=body.right.model_dump(),
+        site_id=site_id,
+        limit=body.limit,
+        lookback_hours=body.lookback_hours,
+    )
+
+
+@router.post("/lint-sql")
+def lab_lint_sql(body: LabSqlBody) -> dict:
+    """Static SQL lint — no execution."""
+    return lint_datafusion_sql_rule(body.sql, fault_column=body.fault_column)
+
+
+@router.post("/save")
+def lab_save(body: LabSaveBody, user: dict = Depends(require_roles("integrator", "agent"))) -> dict:
+    saved_by = str(user.get("sub") or user.get("role") or "operator")
+    backend = str(body.backend or "").strip() or detect_backend_from_payload(body.model_dump())
+    payload = body.model_dump()
+    payload["backend"] = backend
+    if backend == "datafusion_sql":
+        if not str(payload.get("sql") or "").strip():
+            raise HTTPException(status_code=400, detail="datafusion_sql rules require sql")
+        payload.setdefault("code", "# DataFusion SQL rule — see sql field")
+    elif not str(payload.get("code") or "").strip():
+        raise HTTPException(status_code=400, detail="arrow rules require code")
+    if not str(payload.get("short_description") or "").strip():
+        payload["short_description"] = str(body.name or "Fault detected").strip()[:240]
+    try:
+        entry = RuleStore().upsert(payload, saved_by=saved_by)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"ok": True, "rule": entry}

--- a/workspace/api/openfdd_bridge/routes/rules_routes.py
+++ b/workspace/api/openfdd_bridge/routes/rules_routes.py
@@ -36,7 +36,9 @@ class SaveRuleBody(BaseModel):
     description: str = ""
     mode: str = "rule"
     backend: str = ""
-    code: str
+    code: str = ""
+    sql: str = ""
+    fault_column: str = "fault"
     config: dict[str, Any] = Field(default_factory=dict)
     column_map: dict[str, str] = Field(default_factory=dict)
     applies_to: AppliesTo = Field(default_factory=AppliesTo)
@@ -242,6 +244,13 @@ def infer_fault_codes_route(
 def save_rule(body: SaveRuleBody, user: dict = Depends(require_roles("integrator", "agent"))) -> dict:
     saved_by = str(user.get("sub") or user.get("role") or "operator")
     payload = body.model_dump()
+    backend = str(payload.get("backend") or "").strip()
+    if backend == "datafusion_sql":
+        if not str(payload.get("sql") or "").strip():
+            raise HTTPException(status_code=400, detail="datafusion_sql rules require sql")
+        payload.setdefault("code", "# DataFusion SQL rule — see sql field")
+    elif not str(payload.get("code") or "").strip():
+        raise HTTPException(status_code=400, detail="rule code is required")
     if not str(payload.get("short_description") or "").strip():
         payload["short_description"] = str(body.name or "Fault detected").strip()[:240]
     try:

--- a/workspace/api/openfdd_bridge/rule_store.py
+++ b/workspace/api/openfdd_bridge/rule_store.py
@@ -200,12 +200,23 @@ class RuleStore:
         return True
 
 
-def _lint_rule_code(code: str, *, mode: str) -> None:
+def _lint_rule_code(code: str, *, mode: str, backend: str = "", sql: str = "", fault_column: str = "fault") -> None:
     """Reject pandas/legacy patterns before persisting a rule."""
+    from open_fdd.arrow_runtime.datafusion_backend import lint_datafusion_sql_rule
     from open_fdd.arrow_runtime.rules import detect_rule_backend
 
     from . import playground
 
+    if backend == "datafusion_sql" or str(sql or "").strip():
+        lint = lint_datafusion_sql_rule(sql, fault_column=fault_column or "fault")
+        if lint.get("ok"):
+            return
+        msgs = [
+            str(i.get("message") or "lint failed")
+            for i in lint.get("issues", [])
+            if i.get("severity") == "error"
+        ]
+        raise ValueError("SQL lint failed:\n" + "\n".join(msgs) if msgs else "SQL lint failed")
     if mode == "script":
         lint = playground.lint_python(
             code,
@@ -235,14 +246,25 @@ def normalize_rule(entry: dict[str, Any], *, saved_by: str = "operator") -> dict
     if severity not in VALID_SEVERITIES:
         severity = "warning"
     code = str(entry.get("code") or "")
+    sql = str(entry.get("sql") or "").strip()
+    fault_column = str(entry.get("fault_column") or "fault").strip() or "fault"
     path = str(entry.get("source_path") or "")
-    if path:
-        disk = read_source(path)
-        if disk.strip():
-            code = disk
-    if not code.strip():
-        raise ValueError("rule code is required")
-    _lint_rule_code(code, mode=mode)
+    resolved_backend = backend
+    if backend == "datafusion_sql" or sql:
+        if not sql:
+            raise ValueError("datafusion_sql rules require sql field")
+        _lint_rule_code(code, mode=mode, backend="datafusion_sql", sql=sql, fault_column=fault_column)
+        if not code.strip():
+            code = "# DataFusion SQL rule — see sql field"
+        resolved_backend = "datafusion_sql"
+    else:
+        if path:
+            disk = read_source(path)
+            if disk.strip():
+                code = disk
+        if not code.strip():
+            raise ValueError("rule code is required")
+        _lint_rule_code(code, mode=mode)
     config = entry.get("config")
     if not isinstance(config, dict):
         config = {}
@@ -252,23 +274,22 @@ def normalize_rule(entry: dict[str, Any], *, saved_by: str = "operator") -> dict
     applies_to = entry.get("applies_to")
     if not isinstance(applies_to, dict):
         applies_to = {}
-    backend = str(entry.get("backend") or "").strip()
-    if backend not in {"arrow", "legacy_row"}:
+    if resolved_backend not in {"arrow", "legacy_row", "datafusion_sql"}:
         try:
             from open_fdd.arrow_runtime.rules import detect_rule_backend
 
-            backend = detect_rule_backend(code, {"mode": mode})
-            if backend == "script":
-                backend = ""
+            resolved_backend = detect_rule_backend(code, {"mode": mode, "sql": sql, "backend": resolved_backend})
+            if resolved_backend == "script":
+                resolved_backend = ""
         except Exception:
-            backend = ""
-    return {
+            resolved_backend = ""
+    out = {
         "id": str(entry.get("id") or uuid4()),
         "name": str(entry.get("name") or "Untitled rule")[:200],
         "short_description": _short_description(entry),
         "description": str(entry.get("description") or "")[:1000],
         "mode": mode,
-        "backend": backend,
+        "backend": resolved_backend,
         "code": code,
         "config": config,
         "column_map": column_map,
@@ -285,3 +306,7 @@ def normalize_rule(entry: dict[str, Any], *, saved_by: str = "operator") -> dict
         "created_at": str(entry.get("created_at") or _now()),
         "updated_at": _now(),
     }
+    if resolved_backend == "datafusion_sql":
+        out["sql"] = sql
+        out["fault_column"] = fault_column
+    return out

--- a/workspace/api/openfdd_bridge/rule_store.py
+++ b/workspace/api/openfdd_bridge/rule_store.py
@@ -249,6 +249,7 @@ def normalize_rule(entry: dict[str, Any], *, saved_by: str = "operator") -> dict
     sql = str(entry.get("sql") or "").strip()
     fault_column = str(entry.get("fault_column") or "fault").strip() or "fault"
     path = str(entry.get("source_path") or "")
+    backend = str(entry.get("backend") or "").strip()
     resolved_backend = backend
     if backend == "datafusion_sql" or sql:
         if not sql:

--- a/workspace/api/openfdd_bridge/rules_lab.py
+++ b/workspace/api/openfdd_bridge/rules_lab.py
@@ -1,0 +1,240 @@
+"""Rules Lab helpers — server-side DataFusion SQL validate/preview/compare."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from open_fdd.arrow_runtime.backend import run_arrow_rule
+from open_fdd.arrow_runtime.datafusion_backend import (
+    datafusion_available,
+    lint_datafusion_sql_rule,
+    run_datafusion_sql_rule,
+)
+from open_fdd.arrow_runtime.rules import detect_rule_backend
+
+from .data_loader import load_arrow_table_for_run
+from .rule_store import RuleStore
+from .security import debug_tracebacks_enabled
+
+
+def _trim_table(table: pa.Table, *, limit: int, lookback_hours: float) -> pa.Table:
+    if lookback_hours > 0 and "timestamp" in table.column_names:
+        from open_fdd.arrow_runtime.features import arrow_time_filter
+        import datetime as _dt
+
+        cutoff = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=lookback_hours)
+        table = arrow_time_filter(table, "timestamp", cutoff, None)
+    if limit and table.num_rows > limit:
+        table = table.slice(max(0, table.num_rows - limit), min(limit, table.num_rows))
+    return table
+
+
+def load_lab_sample_table(
+    site_id: str,
+    *,
+    limit: int = 500,
+    lookback_hours: float = 24,
+) -> tuple[pa.Table, str]:
+    table, origin = load_arrow_table_for_run(site_id)
+    if not isinstance(table, pa.Table):
+        table = pa.Table.from_pandas(table)
+    table = _trim_table(table, limit=limit, lookback_hours=lookback_hours)
+    return table, origin
+
+
+def _result_payload(result, *, site_id: str = "", data_source: str = "") -> dict[str, Any]:
+    payload = result.as_dict()
+    payload["ok"] = not result.errors
+    payload["site_id"] = site_id
+    payload["data_source"] = data_source
+    if result.errors:
+        payload["error"] = result.errors[0]
+        if debug_tracebacks_enabled() and isinstance(result.summary, dict):
+            payload["details"] = result.summary.get("trace") or result.summary.get("error")
+    return payload
+
+
+def validate_datafusion_sql(
+    *,
+    sql: str,
+    fault_column: str = "fault",
+    site_id: str,
+    limit: int = 500,
+    lookback_hours: float = 24,
+) -> dict[str, Any]:
+    lint = lint_datafusion_sql_rule(sql, fault_column=fault_column)
+    if not lint["ok"]:
+        msgs = [i["message"] for i in lint["issues"] if i["severity"] == "error"]
+        return {
+            "ok": False,
+            "backend": "datafusion_sql",
+            "error": msgs[0] if msgs else "SQL validation failed",
+            "details": "\n".join(msgs),
+            "issues": lint["issues"],
+        }
+    if not datafusion_available():
+        return {
+            "ok": False,
+            "backend": "datafusion_sql",
+            "error": "DataFusion SQL backend is not installed on this Open-FDD runtime.",
+            "details": "Install the optional extra: pip install 'open-fdd[datafusion]'",
+            "datafusion_installed": False,
+        }
+    table, origin = load_lab_sample_table(site_id, limit=limit, lookback_hours=lookback_hours)
+    result = run_datafusion_sql_rule(
+        sql,
+        table,
+        {"site_id": site_id},
+        rule_id="lab-validate",
+        fault_column=fault_column,
+    )
+    if result.errors:
+        return {
+            "ok": False,
+            "backend": "datafusion_sql",
+            "error": result.errors[0],
+            "details": result.summary.get("trace") if debug_tracebacks_enabled() else result.errors[0],
+            "row_count": result.row_count,
+        }
+    return {
+        "ok": True,
+        "backend": "datafusion_sql",
+        "columns": list(table.column_names),
+        "fault_column": fault_column,
+        "row_count": result.row_count,
+        "true_count": result.true_count,
+        "false_count": result.false_count,
+        "null_count": result.null_count,
+        "preview": result.preview,
+        "data_source": origin,
+        "duration_ms": result.duration_ms,
+        "datafusion_installed": True,
+    }
+
+
+def preview_datafusion_sql(
+    *,
+    sql: str,
+    fault_column: str = "fault",
+    site_id: str,
+    limit: int = 500,
+    lookback_hours: float = 24,
+) -> dict[str, Any]:
+    started = time.time()
+    out = validate_datafusion_sql(
+        sql=sql,
+        fault_column=fault_column,
+        site_id=site_id,
+        limit=limit,
+        lookback_hours=lookback_hours,
+    )
+    out["ms"] = int((time.time() - started) * 1000)
+    if out.get("ok"):
+        total = int(out.get("row_count") or 0)
+        true_n = int(out.get("true_count") or 0)
+        out["fault_rate_pct"] = round(100.0 * true_n / total, 2) if total else 0.0
+    return out
+
+
+def compare_rule_backends(
+    *,
+    left: dict[str, Any],
+    right: dict[str, Any],
+    site_id: str,
+    limit: int = 1000,
+    lookback_hours: float = 24,
+) -> dict[str, Any]:
+    table, origin = load_lab_sample_table(site_id, limit=limit, lookback_hours=lookback_hours)
+    left_backend = str(left.get("backend") or "").strip()
+    right_backend = str(right.get("backend") or "").strip()
+
+    def _run_side(side: dict[str, Any], backend: str):
+        if backend == "datafusion_sql":
+            if not datafusion_available():
+                raise ValueError(
+                    "DataFusion SQL backend is not installed. Install with: pip install 'open-fdd[datafusion]'"
+                )
+            sql = str(side.get("sql") or "").strip()
+            fault_column = str(side.get("fault_column") or "fault")
+            return run_datafusion_sql_rule(
+                sql,
+                table,
+                {"site_id": site_id},
+                rule_id="lab-compare",
+                fault_column=fault_column,
+            )
+        if backend == "arrow":
+            code = str(side.get("code") or "").strip()
+            rule_id = str(side.get("rule_id") or "").strip()
+            if rule_id and not code:
+                rule = RuleStore().get(rule_id) or {}
+                code = str(rule.get("code") or "")
+            if not code:
+                raise ValueError("arrow compare requires code or rule_id")
+            return run_arrow_rule(code, table, dict(side.get("config") or {}), rule_id=rule_id or "compare")
+        raise ValueError(f"unsupported compare backend: {backend}")
+
+    try:
+        left_result = _run_side(left, left_backend)
+        right_result = _run_side(right, right_backend)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "error": str(exc),
+            "details": str(exc) if debug_tracebacks_enabled() else None,
+            "data_source": origin,
+        }
+
+    if left_result.errors or right_result.errors:
+        return {
+            "ok": False,
+            "error": (left_result.errors or right_result.errors)[0],
+            "left_backend": left_backend,
+            "right_backend": right_backend,
+            "data_source": origin,
+        }
+
+    left_mask = left_result.fault_mask
+    right_mask = right_result.fault_mask
+    if len(left_mask) != len(right_mask):
+        return {
+            "ok": False,
+            "error": f"mask length mismatch {len(left_mask)} vs {len(right_mask)}",
+            "data_source": origin,
+        }
+
+    equal = pc.equal(left_mask, right_mask)
+    mismatch = pc.invert(equal)
+    mismatch_count = int(pc.sum(pc.cast(mismatch, pa.int64())).as_py() or 0)
+    matching = int(table.num_rows) - mismatch_count
+
+    mismatches_preview: list[dict[str, Any]] = []
+    if mismatch_count > 0:
+        idx = pc.indices_nonzero(mismatch).to_pylist()[:20]
+        for i in idx:
+            row: dict[str, Any] = {"row_index": i, "left_fault": left_mask[i].as_py(), "right_fault": right_mask[i].as_py()}
+            for col in ("timestamp", "equipment_id", "site_id"):
+                if col in table.column_names:
+                    row[col] = table.column(col)[i].as_py()
+            mismatches_preview.append(row)
+
+    return {
+        "ok": True,
+        "left_backend": left_backend,
+        "right_backend": right_backend,
+        "left_true_count": left_result.true_count,
+        "right_true_count": right_result.true_count,
+        "matching_rows": matching,
+        "mismatching_rows": mismatch_count,
+        "mismatches_preview": mismatches_preview,
+        "row_count": table.num_rows,
+        "data_source": origin,
+    }
+
+
+def detect_backend_from_payload(payload: dict[str, Any]) -> str:
+    return detect_rule_backend(str(payload.get("code") or ""), payload)

--- a/workspace/api/static/app/index.html
+++ b/workspace/api/static/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Open-FDD Operator</title>
-    <script type="module" crossorigin src="/assets/index-5bZTawnE.js"></script>
+    <script type="module" crossorigin src="/assets/index-PtM2R6wZ.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DiSsWcWn.css">
   </head>
   <body>

--- a/workspace/dashboard/src/pages/RuleLabPage.tsx
+++ b/workspace/dashboard/src/pages/RuleLabPage.tsx
@@ -17,16 +17,34 @@ import {
 
 const NEW_RULE_VALUE = "__new__";
 
+type RuleBackend = "arrow" | "datafusion_sql";
+
+const SQL_THRESHOLD_TEMPLATE = `SELECT
+  *,
+  zone_temp > 75.0 AS fault
+FROM telemetry`;
+
+const SQL_CASE_TEMPLATE = `SELECT
+  *,
+  CASE
+    WHEN fan_cmd > 0.5 AND airflow_cfm < 1000.0 THEN true
+    ELSE false
+  END AS fault
+FROM telemetry`;
+
 type SavedRule = {
   id: string;
   name: string;
   mode: "rule" | "script";
+  backend?: RuleBackend | string;
   severity: string;
   enabled: boolean;
   source_path?: string;
   fault_code?: string;
   fault_codes?: string[];
   code?: string;
+  sql?: string;
+  fault_column?: string;
   config?: Record<string, unknown>;
   bindings?: {
     point_ids?: string[];
@@ -45,6 +63,12 @@ function syntaxPillClass(ok: boolean | null, busy: boolean): string {
 export default function RuleLabPage() {
   const activeSiteId = useActiveSiteId();
   const [code, setCode] = useState("");
+  const [sql, setSql] = useState(SQL_THRESHOLD_TEMPLATE);
+  const [ruleBackend, setRuleBackend] = useState<RuleBackend>("arrow");
+  const [faultColumn, setFaultColumn] = useState("fault");
+  const [sqlLintIssues, setSqlLintIssues] = useState<LintIssue[]>([]);
+  const [sqlSyntaxOk, setSqlSyntaxOk] = useState<boolean | null>(null);
+  const [sqlPreview, setSqlPreview] = useState<Record<string, unknown> | null>(null);
   const [sourcePath, setSourcePath] = useState("");
   const [consoleText, setConsoleText] = useState("");
   const [busy, setBusy] = useState(false);
@@ -81,6 +105,17 @@ export default function RuleLabPage() {
     setActiveRuleId(rule.id);
     setRuleName(displayRuleName(rule.name));
     setMetaDirty(false);
+    const backend = (rule.backend === "datafusion_sql" ? "datafusion_sql" : "arrow") as RuleBackend;
+    setRuleBackend(backend);
+    setFaultColumn(rule.fault_column || "fault");
+    if (backend === "datafusion_sql") {
+      setSql(rule.sql?.trim() || SQL_THRESHOLD_TEMPLATE);
+      setCode(rule.code?.trim() || "# DataFusion SQL rule — see sql field");
+      setSourcePath("");
+      setHelperSource("");
+      setHelperWarnings([]);
+      return;
+    }
     try {
       const res = await apiFetch<{ code: string; path: string }>(`/api/rules/saved/${rule.id}/source`);
       setCode(res.code?.trim() || rule.code?.trim() || "");
@@ -156,12 +191,43 @@ export default function RuleLabPage() {
     }, 400);
   }, []);
 
+  const runDebouncedSqlLint = useCallback((source: string) => {
+    if (!source.trim()) {
+      setSqlSyntaxOk(null);
+      setSqlLintIssues([]);
+      return;
+    }
+    if (lintTimer.current) window.clearTimeout(lintTimer.current);
+    lintTimer.current = window.setTimeout(() => {
+      setLintBusy(true);
+      apiFetch<{ ok: boolean; issues: LintIssue[] }>("/api/rules/lab/lint-sql", {
+        method: "POST",
+        body: JSON.stringify({ backend: "datafusion_sql", sql: source, fault_column: faultColumn }),
+      })
+        .then((res) => {
+          setSqlSyntaxOk(res.ok);
+          setSqlLintIssues(res.issues || []);
+        })
+        .catch(() => {
+          setSqlSyntaxOk(null);
+          setSqlLintIssues([]);
+        })
+        .finally(() => setLintBusy(false));
+    }, 400);
+  }, [faultColumn]);
+
   useEffect(() => {
+    if (ruleBackend === "datafusion_sql") {
+      runDebouncedSqlLint(sql);
+      return () => {
+        if (lintTimer.current) window.clearTimeout(lintTimer.current);
+      };
+    }
     runDebouncedLint(code);
     return () => {
       if (lintTimer.current) window.clearTimeout(lintTimer.current);
     };
-  }, [code, runDebouncedLint]);
+  }, [code, sql, ruleBackend, runDebouncedLint, runDebouncedSqlLint]);
 
   function appendConsole(text: string) {
     setConsoleText((prev) => (prev ? `${prev}\n${text}` : text));
@@ -175,7 +241,157 @@ export default function RuleLabPage() {
     };
   }
 
+  async function validateSql() {
+    if (!sql.trim()) {
+      appendConsole("Enter SQL before validating.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await apiFetch<{
+        ok: boolean;
+        error?: string;
+        details?: string;
+        true_count?: number;
+        false_count?: number;
+        row_count?: number;
+        datafusion_installed?: boolean;
+      }>("/api/rules/lab/validate", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "datafusion_sql",
+          sql,
+          fault_column: faultColumn,
+          site_id: activeSiteId || undefined,
+          limit: 500,
+        }),
+      });
+      setSqlSyntaxOk(res.ok);
+      if (res.ok) {
+        appendConsole(
+          `>>> SQL valid · rows=${res.row_count} true=${res.true_count} false=${res.false_count}`,
+        );
+      } else {
+        appendConsole([res.error, res.details].filter(Boolean).join("\n"));
+      }
+    } catch (e) {
+      appendConsole(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function previewSql() {
+    if (!sql.trim()) return;
+    setBusy(true);
+    setConsoleText("");
+    try {
+      const res = await apiFetch<Record<string, unknown>>("/api/rules/lab/preview", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "datafusion_sql",
+          sql,
+          fault_column: faultColumn,
+          site_id: activeSiteId || undefined,
+          limit: 500,
+        }),
+      });
+      setSqlPreview(res);
+      if (res.ok) {
+        setConsoleText(
+          [
+            ">>> DataFusion SQL preview",
+            `backend: datafusion_sql · rows=${res.row_count} · true=${res.true_count} (${res.fault_rate_pct}%)`,
+            `null=${res.null_count} · ${res.ms ?? res.duration_ms} ms · ${res.data_source}`,
+            Array.isArray(res.preview) && res.preview.length
+              ? `fault preview: ${JSON.stringify(res.preview.slice(0, 5), null, 2)}`
+              : "",
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        );
+      } else {
+        setConsoleText(String(res.error || res.details || "SQL preview failed"));
+      }
+    } catch (e) {
+      setConsoleText(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function compareBackends() {
+    if (ruleBackend !== "datafusion_sql" || !sql.trim() || !code.trim()) {
+      appendConsole("Compare needs a PyArrow code buffer and DataFusion SQL rule.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await apiFetch<{
+        ok: boolean;
+        left_true_count?: number;
+        right_true_count?: number;
+        matching_rows?: number;
+        mismatching_rows?: number;
+        error?: string;
+      }>("/api/rules/lab/compare", {
+        method: "POST",
+        body: JSON.stringify({
+          left: { backend: "arrow", code },
+          right: { backend: "datafusion_sql", sql, fault_column: faultColumn },
+          site_id: activeSiteId || undefined,
+          limit: 1000,
+        }),
+      });
+      if (res.ok) {
+        appendConsole(
+          `>>> Compare arrow vs SQL · left=${res.left_true_count} right=${res.right_true_count} mismatches=${res.mismatching_rows}`,
+        );
+      } else {
+        appendConsole(res.error || "Compare failed");
+      }
+    } catch (e) {
+      appendConsole(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function saveSqlRule() {
+    setBusy(true);
+    try {
+      const res = await apiFetch<{ rule: SavedRule }>("/api/rules/lab/save", {
+        method: "POST",
+        body: JSON.stringify({
+          id: creatingNew ? undefined : activeRuleId || undefined,
+          name: ruleName,
+          mode: "rule",
+          backend: "datafusion_sql",
+          sql,
+          fault_column: faultColumn,
+          code: "# DataFusion SQL rule — see sql field",
+          config: {},
+          severity: "warning",
+          enabled: false,
+        }),
+      });
+      setActiveRuleId(res.rule.id);
+      setCreatingNew(false);
+      setMetaDirty(false);
+      appendConsole(`>>> Saved DataFusion SQL rule ${res.rule.id}`);
+      await refreshSaved();
+    } catch (e) {
+      appendConsole(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function lintNow() {
+    if (ruleBackend === "datafusion_sql") {
+      await validateSql();
+      return;
+    }
     if (!code.trim()) {
       appendConsole("No rule loaded — upload rule.py or select a saved rule.");
       return;
@@ -197,6 +413,10 @@ export default function RuleLabPage() {
   }
 
   async function testRun() {
+    if (ruleBackend === "datafusion_sql") {
+      await previewSql();
+      return;
+    }
     if (!code.trim()) {
       appendConsole("Upload rule.py before testing.");
       return;
@@ -403,9 +623,19 @@ export default function RuleLabPage() {
     setActiveRuleId("");
     setRuleName("New rule");
     setCode("");
+    setSql(SQL_THRESHOLD_TEMPLATE);
+    setRuleBackend("arrow");
     setSourcePath("");
     setMetaDirty(false);
-    appendConsole("Download a blank kit or upload rule.py to create a new Arrow rule.");
+    appendConsole("Download a blank kit, upload rule.py (PyArrow), or switch to DataFusion SQL.");
+  }
+
+  function onBackendChange(next: RuleBackend) {
+    setRuleBackend(next);
+    setMetaDirty(true);
+    if (next === "datafusion_sql" && !sql.trim()) {
+      setSql(SQL_THRESHOLD_TEMPLATE);
+    }
   }
 
   async function removeRule() {
@@ -442,12 +672,17 @@ export default function RuleLabPage() {
 
   const selectValue = creatingNew ? NEW_RULE_VALUE : activeRuleId || saved[0]?.id || "";
 
+  const activeLintIssues = ruleBackend === "datafusion_sql" ? sqlLintIssues : lintIssues;
+  const activeSyntaxOk = ruleBackend === "datafusion_sql" ? sqlSyntaxOk : syntaxOk;
+
   const syntaxTitle = useMemo(() => {
     if (lintBusy) return "Checking syntax…";
-    if (syntaxOk === true) return "Arrow lint OK";
-    if (syntaxOk === false) return lintIssues.find((i) => i.severity === "error")?.message || "Lint error";
-    return code.trim() ? "Lint pending" : "No rule loaded";
-  }, [lintBusy, syntaxOk, lintIssues, code]);
+    if (activeSyntaxOk === true) return ruleBackend === "datafusion_sql" ? "SQL lint OK" : "Arrow lint OK";
+    if (activeSyntaxOk === false)
+      return activeLintIssues.find((i) => i.severity === "error")?.message || "Lint error";
+    const hasSource = ruleBackend === "datafusion_sql" ? sql.trim() : code.trim();
+    return hasSource ? "Lint pending" : "No rule loaded";
+  }, [lintBusy, activeSyntaxOk, activeLintIssues, code, sql, ruleBackend]);
 
   const consoleLines = useMemo(() => consoleTextToLines(consoleText), [consoleText]);
 
@@ -457,7 +692,8 @@ export default function RuleLabPage() {
         title="Rule Lab"
         subtitle={
           <>
-            Arrow-only rules: <strong>download kit</strong> → edit locally → <strong>upload rule.py</strong>.
+            Arrow-only rules: <strong>download kit</strong> → edit locally → <strong>upload rule.py</strong>, or author{" "}
+            <strong>DataFusion SQL</strong> (server-side, optional extra).
             Pin rules on the <a href="/model">Data Model</a> commissioning JSON or test by equipment below.
           </>
         }
@@ -512,12 +748,26 @@ export default function RuleLabPage() {
               +
             </button>
           </div>
-          <span className={syntaxPillClass(syntaxOk, lintBusy)} title={syntaxTitle}>
-            {lintBusy ? "…" : syntaxOk === true ? "arrow ok" : syntaxOk === false ? "lint err" : "arrow —"}
+          <span className={syntaxPillClass(activeSyntaxOk, lintBusy)} title={syntaxTitle}>
+            {lintBusy ? "…" : activeSyntaxOk === true ? (ruleBackend === "datafusion_sql" ? "sql ok" : "arrow ok") : activeSyntaxOk === false ? "lint err" : ruleBackend === "datafusion_sql" ? "sql —" : "arrow —"}
           </span>
         </div>
 
         <div className="form-grid">
+          <div className="field">
+            <label className="field-label" htmlFor="rule-backend">
+              Rule backend
+            </label>
+            <select
+              id="rule-backend"
+              value={ruleBackend}
+              disabled={busy}
+              onChange={(e) => onBackendChange(e.target.value as RuleBackend)}
+            >
+              <option value="arrow">PyArrow</option>
+              <option value="datafusion_sql">DataFusion SQL</option>
+            </select>
+          </div>
           <div className="field">
             <label className="field-label" htmlFor="rule-name">
               Name
@@ -535,30 +785,75 @@ export default function RuleLabPage() {
         </div>
 
         <p className="muted rule-lab-hint">
-          Tune thresholds in <code>rule.py</code> constants (<code>VALUE_COLUMN</code>, limits) — download kit, edit locally,
-          upload.
+          {ruleBackend === "datafusion_sql" ? (
+            <>
+              DataFusion SQL rules run <strong>server-side</strong> against the Arrow table <code>telemetry</code>. The query
+              must return one boolean column named <code>{faultColumn}</code>. Install optional extra:{" "}
+              <code>open-fdd[datafusion]</code>.
+            </>
+          ) : (
+            <>
+              Tune thresholds in <code>rule.py</code> constants (<code>VALUE_COLUMN</code>, limits) — download kit, edit
+              locally, upload.
+            </>
+          )}
         </p>
 
         <div className="toolbar rule-lab-actions">
-          <button type="button" className="secondary" disabled={busy} onClick={() => void downloadKit()}>
-            Download kit (.zip)
-          </button>
-          <button
-            type="button"
-            className="secondary"
-            disabled={busy || authRole === "operator"}
-            onClick={() => void downloadAllRulesKit()}
-          >
-            Export all rules
-          </button>
-          <button
-            type="button"
-            className="secondary"
-            disabled={busy || authRole === "operator"}
-            onClick={() => uploadRef.current?.click()}
-          >
-            Upload rule.py
-          </button>
+          {ruleBackend === "arrow" ? (
+            <>
+              <button type="button" className="secondary" disabled={busy} onClick={() => void downloadKit()}>
+                Download kit (.zip)
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                disabled={busy || authRole === "operator"}
+                onClick={() => void downloadAllRulesKit()}
+              >
+                Export all rules
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                disabled={busy || authRole === "operator"}
+                onClick={() => uploadRef.current?.click()}
+              >
+                Upload rule.py
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="secondary"
+                disabled={busy}
+                onClick={() => {
+                  setSql(SQL_THRESHOLD_TEMPLATE);
+                  setMetaDirty(true);
+                }}
+              >
+                Threshold template
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                disabled={busy}
+                onClick={() => {
+                  setSql(SQL_CASE_TEMPLATE);
+                  setMetaDirty(true);
+                }}
+              >
+                CASE template
+              </button>
+              <button type="button" className="secondary" disabled={busy || authRole === "operator"} onClick={() => void saveSqlRule()}>
+                Save SQL rule
+              </button>
+              <button type="button" className="secondary" disabled={busy || !code.trim() || !sql.trim()} onClick={() => void compareBackends()}>
+                Compare backends
+              </button>
+            </>
+          )}
           <input
             ref={uploadRef}
             type="file"
@@ -566,11 +861,24 @@ export default function RuleLabPage() {
             hidden
             onChange={(e) => void onUploadFile(e.target.files?.[0] ?? null)}
           />
-          <button type="button" className="secondary" disabled={busy || !code.trim()} onClick={() => void lintNow()}>
-            Lint
+          <button
+            type="button"
+            className="secondary"
+            disabled={busy || (ruleBackend === "arrow" ? !code.trim() : !sql.trim())}
+            onClick={() => void lintNow()}
+          >
+            {ruleBackend === "datafusion_sql" ? "Validate SQL" : "Lint"}
           </button>
-          <button type="button" disabled={busy || syntaxOk === false || !code.trim()} onClick={() => void testRun()}>
-            Quick test
+          <button
+            type="button"
+            disabled={
+              busy ||
+              activeSyntaxOk === false ||
+              (ruleBackend === "arrow" ? !code.trim() : !sql.trim())
+            }
+            onClick={() => void testRun()}
+          >
+            {ruleBackend === "datafusion_sql" ? "Run Preview" : "Quick test"}
           </button>
           <button
             type="button"
@@ -582,7 +890,7 @@ export default function RuleLabPage() {
           <button
             type="button"
             className="primary"
-            disabled={busy || authRole === "operator" || !code.trim()}
+            disabled={busy || authRole === "operator" || (ruleBackend === "arrow" ? !code.trim() : false)}
             onClick={() => void updateAllRecords()}
           >
             Update all records
@@ -601,8 +909,40 @@ export default function RuleLabPage() {
       <FddRuleTestPanel rules={saved} disabled={busy || authRole === "operator"} />
 
       <div className="panel rule-lab-readonly-panel">
-        <h3 className="panel-title">Rule source</h3>
-        {code.trim() ? (
+        <h3 className="panel-title">{ruleBackend === "datafusion_sql" ? "SQL rule editor" : "Rule source"}</h3>
+        {ruleBackend === "datafusion_sql" ? (
+          <>
+            <label className="field-label" htmlFor="fault-column">
+              Fault column
+            </label>
+            <input
+              id="fault-column"
+              value={faultColumn}
+              disabled={busy}
+              onChange={(e) => {
+                setFaultColumn(e.target.value);
+                setMetaDirty(true);
+              }}
+            />
+            <textarea
+              className="sql-rule-editor"
+              rows={14}
+              value={sql}
+              disabled={busy || authRole === "operator"}
+              onChange={(e) => {
+                setSql(e.target.value);
+                setMetaDirty(true);
+              }}
+              spellCheck={false}
+            />
+            {sqlPreview?.ok === false && sqlPreview.datafusion_installed === false ? (
+              <p className="error panel">
+                DataFusion SQL backend is not installed on this Open-FDD runtime. Install{" "}
+                <code>open-fdd[datafusion]</code>.
+              </p>
+            ) : null}
+          </>
+        ) : code.trim() ? (
           <div className="rule-readonly-editor">
             <PythonCodeEditor
               value={code}
@@ -618,21 +958,28 @@ export default function RuleLabPage() {
             <code>pip install open-fdd pyarrow</code>, then upload when lint passes.
           </p>
         )}
-        {lintIssues.length > 0 && syntaxOk === false ? (
+        {activeLintIssues.length > 0 && activeSyntaxOk === false ? (
           <ul className="rule-lint-list">
-            {lintIssues
+            {activeLintIssues
               .filter((i) => i.severity === "error")
               .slice(0, 6)
               .map((i, idx) => (
                 <li key={`${i.line}-${idx}`}>
-                  line {i.line}: {i.message}
+                  {i.line ? `line ${i.line}: ` : ""}
+                  {i.message}
                 </li>
               ))}
           </ul>
         ) : null}
+        {ruleBackend === "datafusion_sql" && sqlPreview?.ok ? (
+          <p className="muted">
+            Backend: <strong>DataFusion SQL</strong> · rows={String(sqlPreview.row_count)} · fault rate{" "}
+            {String(sqlPreview.fault_rate_pct)}%
+          </p>
+        ) : null}
       </div>
 
-      {helperSource || helperWarnings.length ? (
+      {ruleBackend === "arrow" && (helperSource || helperWarnings.length) ? (
         <details className="panel rule-lab-readonly-panel">
           <summary>Helper libraries (Open-FDD + PyArrow)</summary>
           {helperSource ? (


### PR DESCRIPTION
## Summary
- Adds optional `datafusion_sql` rule backend (`pip install open-fdd[datafusion]`) as a Rust/DataFusion migration seam while keeping PyArrow `apply_faults_arrow` first-class
- Restricted SQL lint + execution over registered `telemetry` Arrow tables; results normalize to existing `ArrowRuleResult`
- Bridge Rules Lab APIs: `/api/rules/lab/validate`, `/preview`, `/compare`, `/save`, `/lint-sql`
- Rules Lab UI: PyArrow vs DataFusion SQL backend selector, SQL templates, validate/preview/compare, save metadata with `backend: datafusion_sql`
- Docs/ADR/examples + dedicated CI job for DataFusion tests
- Version bump **3.1.0** (minor feature milestone)

## Test plan
- [x] `pip install -e ".[test,dev,datafusion]"` + `pytest open_fdd/tests/arrow_runtime -q` (40 passed, 1 skipped without datafusion in default matrix)
- [x] CI-equivalent package + bridge lint tests
- [x] `npm run build` dashboard + static bundle updated
- [x] Local smoke: DataFusion SQL threshold on synthetic table matches PyArrow mask
- [ ] Merge + tag `v3.1.0` + GHCR publish
- [ ] benserver stack restart with new image/tag


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional DataFusion SQL backend for authoring and running rules in SQL
  * Introduced Rules Lab support for DataFusion SQL validation, preview, and cross-backend comparison
  * Added a runnable DataFusion SQL rule example

* **Documentation**
  * Updated project tagline and added DataFusion SQL rule guidance, including safety constraints
  * Added an ADR describing the optional DataFusion SQL backend approach

* **Tests / CI**
  * Added a targeted CI job and expanded automated coverage for linting and execution

* **Chores**
  * Bumped version to 3.1.0 and added `datafusion` as an optional dependency extra
<!-- end of auto-generated comment: release notes by coderabbit.ai -->