### PR TITLE
Stabilize DataFusion SQL Rules Lab (v3.1.1)

### DIFF
--- a/docs/datafusion-sql-rules.md
+++ b/docs/datafusion-sql-rules.md
@@ -45,6 +45,7 @@ SQL rules are **not** a database console. The linter rejects:
 - File paths and external URLs
 - Missing or non-boolean `fault` column
 - Row counts that differ from input telemetry
+- Wrong fault column alias (e.g. `not_fault` when `fault` is required)
 
 Server-side execution only — the Rules Lab browser editor never runs SQL locally.
 

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,6 +9,6 @@ GHCR Docker images (``openfdd-bridge``, ``openfdd-commission``, ``openfdd-mcp-ra
 not inside this wheel.
 """
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 __all__ = ["__version__"]

--- a/open_fdd/arrow_runtime/datafusion_backend.py
+++ b/open_fdd/arrow_runtime/datafusion_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import time
 import traceback
@@ -28,18 +29,33 @@ _FORBIDDEN_SQL = re.compile(
 )
 
 _FILE_OR_URL = re.compile(
-    r"(?:file://|s3://|gs://|hdfs://|/[\w./-]+\.(?:csv|parquet|json|feather|arrow)\b)",
+    r"(?:file://|s3://|gs://|hdfs://|https?://|/[\w./-]+\.(?:csv|parquet|json|feather|arrow)\b)",
     re.IGNORECASE,
 )
+
+_READ_TABLE_FUNCS = re.compile(
+    r"\bread_(?:parquet|csv|json|avro|_ndjson)\s*\(",
+    re.IGNORECASE,
+)
+
+_FROM_TABLE = re.compile(r"\bFROM\s+([`\w.-]+)", re.IGNORECASE)
+_JOIN_TABLE = re.compile(r"\bJOIN\s+([`\w.-]+)", re.IGNORECASE)
+
+
+def _debug_tracebacks_enabled() -> bool:
+    return os.environ.get("OFDD_DEBUG_TRACEBACKS", "").strip().lower() in ("1", "true", "yes")
 
 
 @dataclass
 class DataFusionSqlRule:
+    """Restricted SQL rule body executed against the registered ``telemetry`` table."""
+
     sql: str
     fault_column: str = DEFAULT_FAULT_COLUMN
 
 
 def datafusion_available() -> bool:
+    """Return True when the optional ``datafusion`` PyPI package is importable."""
     try:
         import datafusion  # noqa: F401
 
@@ -56,7 +72,7 @@ def _strip_sql(sql: str) -> str:
 
 
 def lint_datafusion_sql_rule(sql: str, *, fault_column: str = DEFAULT_FAULT_COLUMN) -> dict[str, Any]:
-    """Static SQL lint — safe without DataFusion installed."""
+    """Static SQL lint for fault-expression rules (no DataFusion install required)."""
     issues: list[dict[str, Any]] = []
     raw = str(sql or "").strip()
     if not raw:
@@ -71,14 +87,33 @@ def lint_datafusion_sql_rule(sql: str, *, fault_column: str = DEFAULT_FAULT_COLU
     if _FORBIDDEN_SQL.search(cleaned):
         issues.append({"message": "DDL/DML keywords are not allowed in SQL rules", "severity": "error"})
 
-    if _FILE_OR_URL.search(cleaned):
-        issues.append({"message": "file paths and external URLs are not allowed", "severity": "error"})
+    if _FILE_OR_URL.search(cleaned) or _READ_TABLE_FUNCS.search(cleaned):
+        issues.append({"message": "file paths, URLs, and external table reads are not allowed", "severity": "error"})
+
+    for match in _FROM_TABLE.finditer(cleaned):
+        tbl = match.group(1).strip("`")
+        if tbl.lower() != TELEMETRY_TABLE:
+            issues.append(
+                {
+                    "message": f"SQL may only read FROM {TELEMETRY_TABLE}, not {tbl!r}",
+                    "severity": "error",
+                }
+            )
+    for match in _JOIN_TABLE.finditer(cleaned):
+        tbl = match.group(1).strip("`")
+        if tbl.lower() != TELEMETRY_TABLE:
+            issues.append(
+                {
+                    "message": f"SQL may only JOIN {TELEMETRY_TABLE}, not {tbl!r}",
+                    "severity": "error",
+                }
+            )
 
     if not re.search(rf"\bFROM\s+{re.escape(TELEMETRY_TABLE)}\b", cleaned, re.IGNORECASE):
         issues.append({"message": f"SQL must read FROM {TELEMETRY_TABLE}", "severity": "error"})
 
     fault_pat = rf"\bAS\s+{re.escape(fault_column)}\b|,\s*{re.escape(fault_column)}\s*[,)]"
-    if not re.search(fault_pat, cleaned, re.IGNORECASE) and fault_column.lower() not in cleaned.lower():
+    if not re.search(fault_pat, cleaned, re.IGNORECASE):
         issues.append(
             {
                 "message": f"SQL must produce boolean column '{fault_column}'",
@@ -155,6 +190,9 @@ def run_datafusion_sql_rule(
         err = str(exc)
         mask = pa.array([False] * table.num_rows, type=pa.bool_())
         duration_ms = (time.perf_counter() - started) * 1000
+        summary: dict[str, Any] = {"error": err}
+        if _debug_tracebacks_enabled():
+            summary["trace"] = traceback.format_exc(limit=6)
         return ArrowRuleResult(
             rule_id=rule_id,
             backend="datafusion_sql",
@@ -165,7 +203,7 @@ def run_datafusion_sql_rule(
             duration_ms=duration_ms,
             fault_mask=mask,
             errors=[err],
-            summary={"error": err, "trace": traceback.format_exc(limit=6)},
+            summary=summary,
         )
 
     from .events import count_mask_values
@@ -196,8 +234,11 @@ def run_datafusion_sql_rule(
 
 
 def equivalent_pyarrow_threshold_rule(column: str, threshold: float) -> str:
-    return f'''import pyarrow.compute as pc
+    """Generate a minimal PyArrow threshold rule for compare/migration helpers."""
+    col_lit = repr(column)
+    thresh_lit = repr(float(threshold))
+    return f"""import pyarrow.compute as pc
 
 def apply_faults_arrow(table, cfg, context=None):
-    return pc.greater(table["{column}"], {threshold})
-'''
+    return pc.greater(table[{col_lit}], {thresh_lit})
+"""

--- a/open_fdd/tests/arrow_runtime/test_datafusion_backend.py
+++ b/open_fdd/tests/arrow_runtime/test_datafusion_backend.py
@@ -6,6 +6,7 @@ import pytest
 
 from open_fdd.arrow_runtime.datafusion_backend import (
     datafusion_available,
+    equivalent_pyarrow_threshold_rule,
     lint_datafusion_sql_rule,
     run_datafusion_sql_rule,
 )
@@ -103,3 +104,43 @@ def test_wrong_row_count_fails():
     bad_sql = "SELECT *, true AS fault FROM telemetry LIMIT 5"
     result = run_datafusion_sql_rule(bad_sql, table, {})
     assert result.errors
+
+
+@pytest.mark.parametrize(
+    "column",
+    ["SAT", "zone temp", 'bad"column', r"bad\column"],
+)
+def test_equivalent_pyarrow_threshold_escapes_column_names(column: str):
+    code = equivalent_pyarrow_threshold_rule(column, 65.0)
+    compile(code, "<rule>", "exec")
+    assert repr(column) in code
+    assert "65.0" in code
+
+
+def test_lint_rejects_read_parquet_path():
+    lint = lint_datafusion_sql_rule(
+        "SELECT *, true AS fault FROM read_parquet('file:///tmp/x.parquet')"
+    )
+    assert not lint["ok"]
+
+
+def test_lint_rejects_count_aggregate_as_fault():
+    lint = lint_datafusion_sql_rule("SELECT COUNT(*) AS fault FROM telemetry")
+    assert lint["ok"] is True  # lint passes; row-count guard rejects at execution
+
+
+@pytest.mark.skipif(not datafusion_available(), reason="datafusion optional extra not installed")
+def test_count_aggregate_row_mismatch_at_runtime():
+    table = sample_hvac_table(10)
+    result = run_datafusion_sql_rule("SELECT COUNT(*) AS fault FROM telemetry", table, {})
+    assert result.errors
+    assert "row count" in result.errors[0].lower()
+
+
+@pytest.mark.skipif(not datafusion_available(), reason="datafusion optional extra not installed")
+def test_run_error_summary_omits_trace_without_debug(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("OFDD_DEBUG_TRACEBACKS", raising=False)
+    table = sample_hvac_table(3)
+    result = run_datafusion_sql_rule("SELECT * FROM telemetry", table, {})
+    assert result.errors
+    assert "trace" not in result.summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.1.0"
+version = "3.1.1"
 description = "Arrow-native HVAC fault detection runtime — lint, test, and run apply_faults_arrow rules on columnar telemetry (PyPI). Use GHCR Docker images for the full edge operator stack."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/workspace_bridge/test_rules_lab_api.py
+++ b/tests/workspace_bridge/test_rules_lab_api.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
+import os
+import sys
+from pathlib import Path
+
+import pyarrow as pa
 import pytest
+from fastapi.testclient import TestClient
+
+API_ROOT = Path(__file__).resolve().parents[2] / "workspace" / "api"
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
 
 from open_fdd.arrow_runtime.datafusion_backend import lint_datafusion_sql_rule
 
@@ -8,6 +18,16 @@ GOOD_SQL = """SELECT
   *,
   zone_temp > 75.0 AS fault
 FROM telemetry"""
+
+SQL_RULE = {
+    "name": "Zone temp SQL",
+    "mode": "rule",
+    "backend": "datafusion_sql",
+    "sql": GOOD_SQL,
+    "fault_column": "fault",
+    "code": "# DataFusion SQL rule — see sql field",
+    "enabled": False,
+}
 
 
 def test_rules_lab_lint_sql_endpoint_shape():
@@ -17,4 +37,95 @@ def test_rules_lab_lint_sql_endpoint_shape():
 
 def test_rules_lab_lint_rejects_insert():
     lint = lint_datafusion_sql_rule("INSERT INTO telemetry VALUES (1)")
+    assert lint["ok"] is False
+
+
+def test_compare_fault_mask_stats_null_aware():
+    from openfdd_bridge.rules_lab import compare_fault_mask_stats
+
+    left = pa.array([None, True, None, False], type=pa.bool_())
+    right = pa.array([False, True, None, None], type=pa.bool_())
+    matching, mismatching, _mismatch = compare_fault_mask_stats(left, right)
+    assert matching == 2
+    assert mismatching == 2
+
+
+def test_sql_rule_lab_save_stores_backend(client: TestClient):
+    r = client.post("/api/rules/lab/save", json=SQL_RULE)
+    assert r.status_code == 200
+    rule = r.json()["rule"]
+    assert rule["backend"] == "datafusion_sql"
+    assert rule["sql"].strip() == GOOD_SQL.strip()
+    assert rule["fault_column"] == "fault"
+    client.delete(f"/api/rules/saved/{rule['id']}")
+
+
+def test_sql_rule_rename_preserves_sql_fields(client: TestClient):
+    created = client.post("/api/rules/lab/save", json=SQL_RULE)
+    assert created.status_code == 200
+    rule_id = created.json()["rule"]["id"]
+    original_sql = created.json()["rule"]["sql"]
+
+    renamed = client.post(
+        "/api/rules/lab/save",
+        json={
+            **SQL_RULE,
+            "id": rule_id,
+            "name": "Renamed SQL rule",
+        },
+    )
+    assert renamed.status_code == 200
+    updated = renamed.json()["rule"]
+    assert updated["name"] == "Renamed SQL rule"
+    assert updated["backend"] == "datafusion_sql"
+    assert updated["sql"] == original_sql
+    assert updated["fault_column"] == "fault"
+
+    listed = client.get("/api/rules/saved").json()["rules"]
+    found = next(r for r in listed if r["id"] == rule_id)
+    assert found["backend"] == "datafusion_sql"
+    assert found["sql"] == original_sql
+
+    client.delete(f"/api/rules/saved/{rule_id}")
+
+
+def test_validate_preview_clean_error_without_traceback(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("OFDD_DEBUG_TRACEBACKS", raising=False)
+    bad = client.post(
+        "/api/rules/lab/preview",
+        json={
+            "backend": "datafusion_sql",
+            "sql": "SELECT * FROM telemetry",
+            "fault_column": "fault",
+            "limit": 50,
+        },
+    )
+    assert bad.status_code == 200
+    body = bad.json()
+    assert body["ok"] is False
+    assert "trace" not in str(body.get("details") or "").lower() or "Traceback" not in str(body.get("details") or "")
+
+
+def test_lint_rejects_read_parquet():
+    lint = lint_datafusion_sql_rule("SELECT *, true AS fault FROM read_parquet('/tmp/x.parquet')")
+    assert lint["ok"] is False
+
+
+def test_lint_rejects_other_table():
+    lint = lint_datafusion_sql_rule("SELECT *, true AS fault FROM other_table")
+    assert lint["ok"] is False
+
+
+def test_lint_rejects_double_statement():
+    lint = lint_datafusion_sql_rule("SELECT * FROM telemetry; SELECT * FROM telemetry")
+    assert lint["ok"] is False
+
+
+def test_lint_rejects_missing_fault_projection():
+    lint = lint_datafusion_sql_rule("SELECT * FROM telemetry WHERE zone_temp > 75")
+    assert lint["ok"] is False
+
+
+def test_lint_rejects_wrong_fault_column_name():
+    lint = lint_datafusion_sql_rule("SELECT *, zone_temp > 75 AS not_fault FROM telemetry")
     assert lint["ok"] is False

--- a/workspace/api/openfdd_bridge/rules_lab.py
+++ b/workspace/api/openfdd_bridge/rules_lab.py
@@ -39,6 +39,7 @@ def load_lab_sample_table(
     limit: int = 500,
     lookback_hours: float = 24,
 ) -> tuple[pa.Table, str]:
+    """Load a bounded Arrow telemetry sample for Rules Lab validate/preview."""
     table, origin = load_arrow_table_for_run(site_id)
     if not isinstance(table, pa.Table):
         table = pa.Table.from_pandas(table)
@@ -58,6 +59,23 @@ def _result_payload(result, *, site_id: str = "", data_source: str = "") -> dict
     return payload
 
 
+def compare_fault_mask_stats(
+    left_mask: pa.Array | pa.ChunkedArray,
+    right_mask: pa.Array | pa.ChunkedArray,
+) -> tuple[int, int, pa.Array | pa.ChunkedArray]:
+    """Count matching/mismatching rows with null-aware semantics.
+
+    null vs null counts as a match; null vs true/false counts as a mismatch.
+    """
+    equal_raw = pc.equal(left_mask, right_mask)
+    both_null = pc.and_(pc.is_null(left_mask), pc.is_null(right_mask))
+    equal = pc.fill_null(pc.or_(pc.fill_null(equal_raw, False), both_null), False)
+    mismatch = pc.invert(equal)
+    mismatch_count = int(pc.sum(pc.cast(mismatch, pa.int64())).as_py() or 0)
+    matching = len(left_mask) - mismatch_count
+    return matching, mismatch_count, mismatch
+
+
 def validate_datafusion_sql(
     *,
     sql: str,
@@ -66,6 +84,7 @@ def validate_datafusion_sql(
     limit: int = 500,
     lookback_hours: float = 24,
 ) -> dict[str, Any]:
+    """Lint and optionally execute SQL against latest site telemetry."""
     lint = lint_datafusion_sql_rule(sql, fault_column=fault_column)
     if not lint["ok"]:
         msgs = [i["message"] for i in lint["issues"] if i["severity"] == "error"]
@@ -148,6 +167,7 @@ def compare_rule_backends(
     limit: int = 1000,
     lookback_hours: float = 24,
 ) -> dict[str, Any]:
+    """Compare PyArrow and DataFusion SQL fault masks on the same telemetry sample."""
     table, origin = load_lab_sample_table(site_id, limit=limit, lookback_hours=lookback_hours)
     left_backend = str(left.get("backend") or "").strip()
     right_backend = str(right.get("backend") or "").strip()
@@ -207,10 +227,7 @@ def compare_rule_backends(
             "data_source": origin,
         }
 
-    equal = pc.equal(left_mask, right_mask)
-    mismatch = pc.invert(equal)
-    mismatch_count = int(pc.sum(pc.cast(mismatch, pa.int64())).as_py() or 0)
-    matching = int(table.num_rows) - mismatch_count
+    matching, mismatch_count, mismatch = compare_fault_mask_stats(left_mask, right_mask)
 
     mismatches_preview: list[dict[str, Any]] = []
     if mismatch_count > 0:

--- a/workspace/api/static/app/index.html
+++ b/workspace/api/static/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Open-FDD Operator</title>
-    <script type="module" crossorigin src="/assets/index-PtM2R6wZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-Zav6KbEV.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DiSsWcWn.css">
   </head>
   <body>

--- a/workspace/dashboard/src/pages/RuleLabPage.tsx
+++ b/workspace/dashboard/src/pages/RuleLabPage.tsx
@@ -481,12 +481,39 @@ export default function RuleLabPage() {
       appendConsole("Upload rule.py first to create a rule.");
       return;
     }
-    if (!code.trim()) return;
+    if (ruleBackend === "datafusion_sql") {
+      if (!sql.trim()) return;
+    } else if (!code.trim()) {
+      return;
+    }
     const manageBusy = opts?.manageBusy !== false;
     if (manageBusy) setBusy(true);
     try {
       const fresh = await apiFetch<{ rules: SavedRule[] }>("/api/rules/saved");
-      const bindingsSource = fresh.rules?.find((r) => r.id === activeRuleId)?.bindings;
+      const existing = fresh.rules?.find((r) => r.id === activeRuleId);
+      const bindingsSource = existing?.bindings;
+      if (ruleBackend === "datafusion_sql") {
+        const res = await apiFetch<{ rule: SavedRule }>("/api/rules/lab/save", {
+          method: "POST",
+          body: JSON.stringify({
+            id: activeRuleId,
+            name: ruleName,
+            mode: "rule",
+            backend: "datafusion_sql",
+            sql,
+            fault_column: faultColumn,
+            code: code.trim() || "# DataFusion SQL rule — see sql field",
+            config: existing?.config ?? {},
+            severity: existing?.severity ?? "warning",
+            enabled: existing?.enabled ?? false,
+            bindings: preservedBindings(bindingsSource),
+          }),
+        });
+        setMetaDirty(false);
+        appendConsole(`>>> Saved name for ${res.rule.id}`);
+        await refreshSaved();
+        return;
+      }
       const res = await apiFetch<{ rule: SavedRule }>("/api/rules/save", {
         method: "POST",
         body: JSON.stringify({


### PR DESCRIPTION
## Summary

Follow-up stabilization pass on merged PR #302. PyArrow `apply_faults_arrow` remains first-class; DataFusion stays optional via `open-fdd[datafusion]`. SQL executes server-side only.

### Verified from PR #302 (working)
- Optional `datafusion_sql` backend with shared `ArrowRuleResult`
- Rules Lab validate/preview/compare/save API routes
- Backend selector in Rule Lab UI
- FDD runner batch path for saved SQL rules
- CI `test-datafusion` job
- Docs, ADR, and runnable example

### CodeRabbit findings — fixed
1. **SQL metadata loss on name-only save** — `saveMetadata()` now routes `datafusion_sql` rules through `/api/rules/lab/save` with `backend`, `sql`, `fault_column`, bindings, and severity preserved.
2. **Unsafe PyArrow helper generation** — `equivalent_pyarrow_threshold_rule()` uses `repr()` for column and threshold.
3. **Null-aware compare** — `compare_fault_mask_stats()` treats null↔null as match, null↔bool as mismatch.
4. **CI action pinning** — **Deferred**: repo baseline uses `@v5`/`@v6` tags everywhere; only `docker-supervisor-check.yml` pins SHAs. New DataFusion job matches existing convention (no one-off SHA drift).
5. **Docstrings** — Added on new public surfaces in `datafusion_backend.py` and `rules_lab.py` without repo-wide docstring spam.

### Hardening beyond CodeRabbit
- Stricter SQL lint: `read_parquet`/URLs, non-`telemetry` FROM/JOIN, exact `AS fault` alias (rejects `not_fault`), double statements
- Tracebacks in `run_datafusion_sql_rule` only when `OFDD_DEBUG_TRACEBACKS=1`
- Row-count guard still rejects aggregates like `SELECT COUNT(*) AS fault`

### Skipped / not applicable
- Full repo-wide GitHub Actions SHA pinning (out of scope; inconsistent with current workflows)
- CodeRabbit docstring coverage threshold — not enforced in CI; meaningful docs added only on new API surface

## Test plan
- [x] `pip install -e ".[test,dev,datafusion]"`
- [x] `pytest open_fdd/tests/arrow_runtime -q` — 48 passed, 1 skipped
- [x] `pytest tests/workspace_bridge/test_rules_lab_api.py tests/workspace_bridge/test_rules_and_fdd.py -q` — 17 passed
- [x] `npm run build` (dashboard)
- [x] Local Rules Lab SQL preview on benserver (`stat_zn-t` column)

## Acceptance
- PyArrow Rules Lab unchanged
- SQL rules: author, validate, preview, save, **rename**, compare, batch-run
- Missing DataFusion → clean API/UI message
- No pandas row-loop path added
- BACnet/Docker/MCP untouched


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation to properly handle special characters in column names
  * Corrected SQL validation to enforce proper fault column identification

* **New Features**
  * Enhanced SQL validation with stricter safety checks for unsafe database operations

* **Improvements**
  * Updated interface for saving DataFusion SQL rules
  * Improved error reporting clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->