### PR TITLE
Release 3.1.3: bench historian evaluate patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,21 @@ Use **GHCR** ([GitHub Container Registry](https://docs.github.com/en/packages/wo
 | [`ghcr.io/bbartling/openfdd-commission`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-commission) | BACnet discover, read, poll |
 | [`ghcr.io/bbartling/openfdd-mcp-rag`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mcp-rag) | MCP + doc-search |
 
-**Prefer pinned release tags in production** (not floating `latest`). Set `OPENFDD_IMAGE_TAG` / `--image-tag` / `NEW_TAG` to the current release (today **3.1.2** — bump these on every release):
+**Prefer pinned release tags in production** (not floating `latest`). Set `OPENFDD_IMAGE_TAG` / `--image-tag` / `NEW_TAG` to the current release (today **3.1.3** — bump these on every release):
 
 ```bash
 # Bootstrap a new edge host (no git clone) — creates ~/open-fdd, auth.env.local, BACnet bind
 curl -fsSL -o /tmp/openfdd_edge_bootstrap.sh \
   https://github.com/bbartling/open-fdd/raw/refs/heads/master/scripts/openfdd_edge_bootstrap.sh
-OPENFDD_IMAGE_TAG=3.1.2 bash /tmp/openfdd_edge_bootstrap.sh --start --image-tag 3.1.2
+OPENFDD_IMAGE_TAG=3.1.3 bash /tmp/openfdd_edge_bootstrap.sh --start --image-tag 3.1.3
 
 # Update an existing site — backup workspace, pull pinned GHCR tags, recreate containers
 cd ~/open-fdd
 ./scripts/openfdd_site_backup.sh
-NEW_TAG=3.1.2 ./scripts/openfdd_site_update.sh
+NEW_TAG=3.1.3 ./scripts/openfdd_site_update.sh
 ```
 
-From a repo checkout: `./scripts/openfdd_edge_bootstrap.sh --start --image-tag 3.1.2`
+From a repo checkout: `./scripts/openfdd_edge_bootstrap.sh --start --image-tag 3.1.3`
 
 Edge bootstrap: [Run with Docker images](https://bbartling.github.io/open-fdd/quick-start/docker/) · Site updates: [Updating the stack](https://bbartling.github.io/open-fdd/quick-start/updating/)
 

--- a/docs/releases/3.1.3.md
+++ b/docs/releases/3.1.3.md
@@ -1,0 +1,24 @@
+# Open-FDD 3.1.3
+
+Release date: 2026-06-15
+
+## Patch fixes
+
+- **Bench long FDD evaluate** — when wall-clock `run_started_at` / lookback filtering would empty a non-empty historian table (demo CSV fallback or stale feather replay), evaluate now uses the full loaded table and sets `time_filter_relaxed: true`. Strict smoke freshness gates still FAIL/WARN honestly on non-fresh samples.
+- **Live smoke lookback** — final matrix evaluate uses the same 24h minimum lookback as cycle evaluates.
+
+## GHCR tags
+
+- `ghcr.io/bbartling/openfdd-bridge:3.1.3`
+- `ghcr.io/bbartling/openfdd-commission:3.1.3`
+- `ghcr.io/bbartling/openfdd-mcp-rag:3.1.3`
+
+## Validation
+
+```bash
+python scripts/smoke_bench_5007_long_fdd.py --synthetic --dry-run
+python scripts/smoke_bench_5007_long_fdd.py --live --duration-minutes 35 \
+  --baseline-minutes 10 --confirmation-rows 10 --confirmation-minutes 10 \
+  --poll-seconds 60 --strict-live-freshness
+python scripts/inspect_bench_5007_long_fdd_report.py workspace/reports/bench_5007_long_fdd_*.json
+```

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,6 +9,6 @@ GHCR Docker images (``openfdd-bridge``, ``openfdd-commission``, ``openfdd-mcp-ra
 not inside this wheel.
 """
 
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.1.2"
+version = "3.1.3"
 description = "Arrow-native HVAC fault detection runtime — lint, test, and run apply_faults_arrow rules on columnar telemetry (PyPI). Use GHCR Docker images for the full edge operator stack."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/smoke_bench_5007_long_fdd.py
+++ b/scripts/smoke_bench_5007_long_fdd.py
@@ -443,7 +443,7 @@ def run_live(cfg: SmokeConfig) -> ValidationReport:
         report.errors.append("fault phase never reached — increase duration_minutes")
 
     # Final snapshot with full lookback for fault-phase evidence
-    lookback_h = max(1.0, (cfg.duration_minutes + 10) / 60.0)
+    lookback_h = max(24.0, (cfg.duration_minutes + 10) / 60.0)
     for source in sources:
         for backend in backends:
             if backend == "datafusion_sql" and not datafusion_available():

--- a/tests/workspace_bridge/test_bench_long_fdd_api.py
+++ b/tests/workspace_bridge/test_bench_long_fdd_api.py
@@ -81,6 +81,41 @@ def test_bench_long_fdd_evaluate_missing_alignment():
     assert "no model alignment" in out["error"]
 
 
+def test_bench_long_fdd_evaluate_historical_replay_relaxed_filter(monkeypatch: pytest.MonkeyPatch):
+    """Stale/demo historian must still evaluate; freshness is a smoke verdict concern."""
+    from datetime import datetime, timezone
+
+    from openfdd_bridge.bench_long_fdd_eval import BenchLongFddEvaluateBody, evaluate_long_fdd
+
+    timestamps = [f"2025-01-15T08:{i:02d}:00Z" for i in range(0, 24, 5)]
+    table = pa.table(
+        {
+            "timestamp": timestamps,
+            "duct-t": [68.0 + i * 0.2 for i in range(len(timestamps))],
+            "site_id": ["demo"] * len(timestamps),
+        }
+    )
+
+    def _fake_load(site_id, *, source="bacnet", columns=None):
+        return table, "demo"
+
+    monkeypatch.setattr("openfdd_bridge.data_loader.load_arrow_table_for_run", _fake_load)
+
+    body = BenchLongFddEvaluateBody(
+        site_id="demo",
+        source="bacnet_direct",
+        semantic_key="duct-t",
+        backend="pyarrow",
+        threshold=80.0,
+        lookback_hours=2.0,
+        run_started_at=datetime.now(timezone.utc).isoformat(),
+    )
+    out = evaluate_long_fdd(body, _BENCH_MODEL)
+    assert out["ok"] is True
+    assert out.get("time_filter_relaxed") is True
+    assert out["metrics"]["row_count"] == len(timestamps)
+
+
 def test_bench_long_fdd_evaluate_missing_historian(monkeypatch: pytest.MonkeyPatch):
     from openfdd_bridge.bench_long_fdd_eval import BenchLongFddEvaluateBody, evaluate_long_fdd
 

--- a/workspace/api/openfdd_bridge/bench_long_fdd_eval.py
+++ b/workspace/api/openfdd_bridge/bench_long_fdd_eval.py
@@ -63,7 +63,13 @@ def evaluate_long_fdd(body: BenchLongFddEvaluateBody, model: dict[str, Any]) -> 
         run_start = _parse_ts(body.run_started_at)
         if run_start:
             cutoff = max(cutoff, run_start - timedelta(minutes=5))
-    table = arrow_time_filter(table, "timestamp", cutoff, None)
+    filtered = arrow_time_filter(table, "timestamp", cutoff, None)
+    time_filter_relaxed = False
+    if filtered.num_rows == 0 and table.num_rows > 0:
+        # Demo fallback or stale feather replay — evaluate full table; freshness gates decide verdict.
+        filtered = table
+        time_filter_relaxed = True
+    table = filtered
     if table.num_rows == 0:
         return {"ok": False, "error": f"no historian rows within lookback/window", "origin": origin}
 
@@ -90,6 +96,7 @@ def evaluate_long_fdd(body: BenchLongFddEvaluateBody, model: dict[str, Any]) -> 
     return {
         "ok": not metrics.errors,
         "origin": origin,
+        "time_filter_relaxed": time_filter_relaxed,
         "metrics": {
             "source": metrics.source,
             "point_id": metrics.point_id,


### PR DESCRIPTION
## Summary
- Fix bench long-FDD evaluate when wall-clock `run_started_at`/lookback would empty a loaded historian table (demo CSV fallback or stale feather replay). Response includes `time_filter_relaxed: true`; strict smoke freshness gates still reject non-fresh live sign-off.
- Align final live smoke evaluate lookback with 24h minimum (from prior master commit on this branch).
- Bump `open-fdd` package and README examples to **3.1.3**.

## Test plan
- [x] `pytest open_fdd/tests/validation tests/workspace_bridge/test_bench_long_fdd_api.py -q`
- [x] `python scripts/release/check_version.py`
- [x] Live preflight evaluate returns rows with `time_filter_relaxed: true` on demo historian


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Open-FDD 3.1.3 released with updated image tags and deployment instructions.

* **Bug Fixes**
  * Fixed long FDD evaluation to relax time filtering constraints when historian data would become empty, while preserving smoke freshness validation.
  * Standardized live smoke lookback window to 24-hour minimum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->