### PR TITLE
fix(ops): edge backup tar timeout

### DIFF
--- a/scripts/openfdd_site_backup.sh
+++ b/scripts/openfdd_site_backup.sh
@@ -83,20 +83,12 @@ if [[ "$BACKUP_INCLUDE_POLL_SAMPLES" != "1" ]]; then
 fi
 
 echo "Archiving workspace/…"
-run_tar() {
-  tar "${TAR_OPTS[@]}" workspace 2>"$BACKUP_ROOT/tar.stderr"
-}
-
-run_tar_with_timeout() {
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "${BACKUP_TIMEOUT_SECS}" run_tar
-  else
-    run_tar
-  fi
-}
-
 set +e
-run_tar_with_timeout
+if command -v timeout >/dev/null 2>&1; then
+  timeout "${BACKUP_TIMEOUT_SECS}" tar "${TAR_OPTS[@]}" workspace 2>"$BACKUP_ROOT/tar.stderr"
+else
+  tar "${TAR_OPTS[@]}" workspace 2>"$BACKUP_ROOT/tar.stderr"
+fi
 rc=$?
 set -e
 

--- a/scripts/upgrade_edge_site.sh
+++ b/scripts/upgrade_edge_site.sh
@@ -97,7 +97,7 @@ if [[ "$SKIP_BACKUP" == "0" ]]; then
   if [[ "$FAST_BACKUP" == "1" ]]; then
     BACKUP_ENV+=" BACKUP_INCLUDE_POLL_SAMPLES=0"
   fi
-  BACKUP_ENV+=" ./scripts/openfdd_site_backup.sh"
+  BACKUP_ENV+=" && ./scripts/openfdd_site_backup.sh"
   echo "    async budget: ${BACKUP_ASYNC_SECS}s (poll every 15s)"
   if ! "${APB}" -i "$INV" "$LIMIT" "${ANSIBLE_SSH_OPTS[@]}" "${ANSIBLE_ASYNC_OPTS[@]}" \
     -m shell -a "$BACKUP_ENV"; then


### PR DESCRIPTION
Quick follow-up to #312 — timeout(1) cannot run bash functions; fix upgrade env chain.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backup script reliability and timeout handling
  * Optimized remote backup command execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->