### PR TITLE
fix(smoke): feather dtype merge and site-level FDD context

### DIFF
--- a/scripts/acme_overnight_fdd_validate.py
+++ b/scripts/acme_overnight_fdd_validate.py
@@ -245,7 +245,10 @@ def run_cycle(
     st_ins, insight, _ = client.get_json("/openfdd-agent/building-insight")
     result["checks"]["building_insight"] = {
         "http": st_ins,
-        "ok": st_ins == 200 and not (isinstance(insight, dict) and insight.get("source") == "error"),
+        "ok": st_ins == 200
+        and isinstance(insight, dict)
+        and insight.get("ok", True) is not False
+        and insight.get("source") != "error",
         "error": str((insight or {}).get("error") or "")[:200] if isinstance(insight, dict) else "",
     }
     if st_ins >= 500:

--- a/tests/workspace_bridge/test_feather_concat.py
+++ b/tests/workspace_bridge/test_feather_concat.py
@@ -1,0 +1,37 @@
+"""Feather shard concat tolerates mixed numeric dtypes."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.feather as feather
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "workspace" / "api"))
+
+from openfdd_bridge.feather_store import FeatherStore, _concat_arrow_tables  # noqa: E402
+
+
+def test_concat_arrow_tables_promotes_int_and_float(tmp_path):
+    t1 = pa.table({"timestamp": [1, 2], "web-oat-t": pa.array([32, 33], type=pa.int64())})
+    t2 = pa.table({"timestamp": [3, 4], "web-oat-t": pa.array([34.5, 35.0], type=pa.float64())})
+    merged = _concat_arrow_tables([t1, t2])
+    assert merged.num_rows == 4
+    assert pa.types.is_floating(merged.schema.field("web-oat-t").type)
+
+
+def test_read_site_table_merges_mixed_shards(tmp_path, monkeypatch):
+    store = FeatherStore(root=tmp_path / "feather_store")
+    site = store.site_dir("json_api", "acme")
+    site.mkdir(parents=True)
+    df1 = pd.DataFrame({"timestamp": pd.to_datetime(["2025-01-01"], utc=True), "web-oat-t": [40]})
+    df2 = pd.DataFrame({"timestamp": pd.to_datetime(["2025-01-02"], utc=True), "web-oat-t": [41.2]})
+    feather.write_feather(pa.Table.from_pandas(df1), site / "shard-1.feather")
+    feather.write_feather(pa.Table.from_pandas(df2), site / "shard-2.feather")
+    out = store.read_site("acme", source="json_api")
+    assert out is not None
+    assert len(out) == 2
+    assert float(out["web-oat-t"].iloc[-1]) == 41.2

--- a/workspace/api/openfdd_bridge/building_insight.py
+++ b/workspace/api/openfdd_bridge/building_insight.py
@@ -299,8 +299,6 @@ def get_building_insight(*, force: bool = False) -> dict[str, Any]:
 
     try:
         status = collect_status()
-        zone_snapshot = get_zone_temp_snapshot(force=True)
-        device_snapshot = get_device_poll_snapshot(force=True)
     except Exception as exc:
         return {
             "ok": False,
@@ -317,6 +315,29 @@ def get_building_insight(*, force: bool = False) -> dict[str, Any]:
             "faults_linked": [],
             "brick_model": {},
             "root_cause_hints": [],
+        }
+
+    try:
+        zone_snapshot = get_zone_temp_snapshot(force=True)
+    except Exception as exc:
+        zone_snapshot = {
+            "summary_sentence": "",
+            "error": str(exc)[:200],
+            "systems": [],
+            "worst_zones": [],
+            "struggling_zones": [],
+        }
+
+    try:
+        device_snapshot = get_device_poll_snapshot(force=True)
+    except Exception as exc:
+        device_snapshot = {
+            "summary_sentence": "",
+            "error": str(exc)[:200],
+            "healthy_count": 0,
+            "offline_equipment": [],
+            "flaky_equipment": [],
+            "degraded_equipment": [],
         }
 
     fault_lines = fault_sentences_from_alerts(status.get("alerts") or [])

--- a/workspace/api/openfdd_bridge/fault_model_context.py
+++ b/workspace/api/openfdd_bridge/fault_model_context.py
@@ -11,6 +11,7 @@ from .fdd_equipment import (
     equipment_from_rule_bindings,
     equipment_labels_for_columns,
     plain_symptom_from_rule_name,
+    site_display_name,
 )
 from .timeseries_api import historian_column_candidates, plot_column_name
 
@@ -125,6 +126,12 @@ def resolve_fault_model_context(
     if not ename and cols:
         names = equipment_labels_for_columns(model, site_id, cols)
         ename = names[0] if names else ""
+
+    if not ename and not eid and site_id:
+        ename = site_display_name(model, site_id)
+        eid = site_id
+        if not eq_type:
+            eq_type = "Building"
 
     eq = eq_index.get(eid) if eid else None
     if eq:

--- a/workspace/api/openfdd_bridge/fdd_equipment.py
+++ b/workspace/api/openfdd_bridge/fdd_equipment.py
@@ -49,6 +49,14 @@ def _rules_by_id() -> dict[str, dict[str, Any]]:
     return _RULE_STORE_CACHE
 
 
+def site_display_name(model: dict[str, Any], site_id: str) -> str:
+    for site in model.get("sites") or []:
+        if isinstance(site, dict) and str(site.get("id") or "") == str(site_id or ""):
+            return str(site.get("name") or site_id or "Building").strip()
+    sid = str(site_id or "").strip()
+    return sid or "Building"
+
+
 def plain_symptom_from_rule_name(rule_name: str) -> str:
     """Source-agnostic symptom label (strip Niagara/BACnet bench prefixes)."""
     name = str(rule_name or "").strip()
@@ -187,6 +195,12 @@ def enrich_fdd_run_with_equipment(
             ids.append(eid)
     if not names and not ids:
         names, ids = equipment_from_rule_bindings(model, site_id, str(run.get("rule_id") or ""))
+    flagged = int(run.get("flagged") or run.get("fault_rows") or 0)
+    if flagged > 0 and not names and not ids:
+        label = site_display_name(model, site_id)
+        names = [label]
+        if site_id:
+            ids = [site_id]
     if not names and ids:
         eq_index = _equipment_index(model, site_id)
         for eid in ids:

--- a/workspace/api/openfdd_bridge/feather_store.py
+++ b/workspace/api/openfdd_bridge/feather_store.py
@@ -166,6 +166,26 @@ class StorageChunk:
     size_bytes: int
 
 
+def _concat_arrow_tables(tables: list[Any]) -> Any:
+    """Merge feather shards; promote mixed int/float columns (e.g. web-oat-t)."""
+    import pyarrow as pa
+
+    if len(tables) == 1:
+        return tables[0]
+    try:
+        return pa.concat_tables(tables, promote_options="permissive")
+    except (pa.ArrowInvalid, TypeError, ValueError) as exc:
+        _log.warning("Arrow permissive concat failed (%s); falling back to pandas unify", exc)
+    frames = [t.to_pandas() for t in tables]
+    combined = pd.concat(frames, ignore_index=True, sort=False)
+    for col in combined.columns:
+        if col in {"timestamp", "site_id"}:
+            continue
+        if combined[col].dtype == object or str(combined[col].dtype).startswith(("int", "float", "Int", "Float")):
+            combined[col] = pd.to_numeric(combined[col], errors="coerce")
+    return pa.Table.from_pandas(combined, preserve_index=False)
+
+
 @dataclass
 class FeatherStore:
     root: Path = field(default_factory=lambda: data_dir() / "feather_store")
@@ -262,7 +282,6 @@ class FeatherStore:
             return None
         col_list = _column_list(columns)
         if _USE_FEATHER:
-            import pyarrow as pa
             import pyarrow.feather as feather
 
             _apply_arrow_thread_env()
@@ -274,9 +293,7 @@ class FeatherStore:
                     _log.warning("Skipping unreadable feather shard %s: %s", path, exc)
             if not tables:
                 return None
-            if len(tables) == 1:
-                return tables[0]
-            return pa.concat_tables(tables, promote_options="default")
+            return _concat_arrow_tables(tables)
 
         frames: list[pd.DataFrame] = []
         for path in files:
@@ -286,7 +303,13 @@ class FeatherStore:
                 _log.warning("Skipping unreadable feather shard %s: %s", path, exc)
         if not frames:
             return None
-        return pd.concat(frames, ignore_index=True)
+        combined = pd.concat(frames, ignore_index=True, sort=False)
+        for col in combined.columns:
+            if col in {"timestamp", "site_id"}:
+                continue
+            if combined[col].dtype == object or str(combined[col].dtype).startswith(("int", "float", "Int", "Float")):
+                combined[col] = pd.to_numeric(combined[col], errors="coerce")
+        return combined
 
     def write_shard(self, df: pd.DataFrame, *, source: str, site_id: str) -> Path:
         site = self.site_dir(source, site_id)


### PR DESCRIPTION
## Summary
- Fix pyarrow feather shard concat when columns mix int64/float64 (web-oat-t on Acme)
- Site-level FDD equipment fallback for building/OAT rules missing bindings
- Building insight degrades when zone/device analytics fail instead of HTTP 500

## Test plan
- [x] pytest tests/workspace_bridge/test_feather_concat.py + acme audit tests
- [ ] OPENFDD_LIVE_ACME=1 ./scripts/smoke_sites_parity.sh --short after deploy


Made with [Cursor](https://cursor.com)