### PR TITLE
fix(fdd): enrich persisted FDD runs on API read

### DIFF
--- a/scripts/acme_overnight_fdd_validate.py
+++ b/scripts/acme_overnight_fdd_validate.py
@@ -103,6 +103,7 @@ def run_cycle(
         validate_fault_alert_schema,
         validate_fdd_run_schema,
     )
+    from openfdd_bridge.fdd_equipment import enrich_fdd_run_with_equipment  # noqa: E402
 
     user, password = resolve_credentials(auth_env, acme_secrets)
     client = ApiClient(base)
@@ -196,9 +197,12 @@ def run_cycle(
     runs = (fdd.get("runs") or []) if isinstance(fdd, dict) else []
     family_hits = []
     schema_errors: list[str] = []
-    for run in runs:
-        if not isinstance(run, dict):
+    for raw in runs:
+        if not isinstance(raw, dict):
             continue
+        run = enrich_fdd_run_with_equipment(
+            dict(raw), model_for_enrich, str(raw.get("site_id") or site_id).strip()
+        )
         rid = str(run.get("rule_id") or "")
         if any(f in rid for f in ACME_RULE_FAMILIES):
             family_hits.append(

--- a/workspace/api/openfdd_bridge/routes/fdd_routes.py
+++ b/workspace/api/openfdd_bridge/routes/fdd_routes.py
@@ -19,12 +19,19 @@ def fdd_results(
     _user: dict = _AGENT,
 ) -> dict:
     """Latest FDD batch runs with per-rule analytics (tuning feedback)."""
+    from ..fdd_equipment import enrich_fdd_run_with_equipment
+    from ..model_service import ModelService
+
     doc = load_results()
+    model = ModelService().load()
     runs = [r for r in doc.get("runs", []) if isinstance(r, dict)]
     if site_id:
         sid = site_id.strip()
         runs = [r for r in runs if str(r.get("site_id") or "") in {"", sid}]
-    runs = runs[-limit:]
+    runs = [
+        enrich_fdd_run_with_equipment(dict(r), model, str(r.get("site_id") or "").strip())
+        for r in runs[-limit:]
+    ]
     flagged = sum(1 for r in runs if int(r.get("flagged") or 0) > 0)
     errors = sum(1 for r in runs if r.get("status") == "error")
     return {


### PR DESCRIPTION
Enrich /api/fdd/results with equipment_names on read; smoke harness matches.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FDD validation results are now enriched with equipment and model context during processing and API retrieval, providing more detailed fault detection and diagnostics data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->