### PR TITLE
fix(ci): always publish semver GHCR tags on workflow_dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,6 @@
 # Publish Open-FDD edge images to GHCR.
 # Tags: vX.Y.Z / open-fdd-vX.Y.Z → versioned + minor + latest
-# workflow_dispatch → latest (maintainer manual)
+# workflow_dispatch → pyproject.toml version + minor + latest (optional image_tag override)
 # Ordinary branch pushes do NOT publish.
 
 name: Publish Docker images to GHCR
@@ -13,9 +13,9 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Local build tag before push (default latest)"
+        description: "Optional SemVer override (default reads version from pyproject.toml)"
         required: false
-        default: "latest"
+        default: ""
       keep_versions:
         description: "GHCR versions to retain per image"
         required: false
@@ -37,20 +37,28 @@ jobs:
       build_tag: ${{ steps.meta.outputs.build_tag }}
       publish_release_tags: ${{ steps.meta.outputs.publish_release_tags }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
       - id: meta
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            ver="${GITHUB_REF_NAME#v}"
-            echo "build_tag=${ver}" >> "$GITHUB_OUTPUT"
-            echo "publish_release_tags=1" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.ref }}" == refs/tags/open-fdd-v* ]]; then
-            ver="${GITHUB_REF_NAME#open-fdd-v}"
-            echo "build_tag=${ver}" >> "$GITHUB_OUTPUT"
+          chmod +x scripts/resolve_ghcr_publish_tag.sh
+          # shellcheck source=/dev/null
+          source scripts/resolve_ghcr_publish_tag.sh
+          ref="${GITHUB_REF_NAME}"
+          ver="$(resolve_ghcr_publish_tag "${ref}" "${{ inputs.image_tag || '' }}")"
+          if [[ -z "$ver" ]]; then
+            echo "Could not resolve GHCR publish version (pyproject.toml or image_tag)" >&2
+            exit 1
+          fi
+          echo "build_tag=${ver}" >> "$GITHUB_OUTPUT"
+          if ghcr_publish_release_tags_enabled "${ref}" "${{ github.event_name }}"; then
             echo "publish_release_tags=1" >> "$GITHUB_OUTPUT"
           else
-            echo "build_tag=${{ inputs.image_tag || 'latest' }}" >> "$GITHUB_OUTPUT"
             echo "publish_release_tags=0" >> "$GITHUB_OUTPUT"
           fi
+          echo "Publishing ghcr tags: ${ver}, latest (minor alias when release tags enabled)"
 
   docker:
     needs: resolve-tag
@@ -117,8 +125,13 @@ jobs:
           dst="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${minor}"
           docker buildx imagetools create -t "$dst" "$src"
 
-      - name: Verify manifest
-        run: docker manifest inspect "${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ needs.resolve-tag.outputs.build_tag }}"
+      - name: Verify version and latest tags
+        if: needs.resolve-tag.outputs.publish_release_tags == '1'
+        run: |
+          ver="${{ needs.resolve-tag.outputs.build_tag }}"
+          img="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}"
+          docker manifest inspect "${img}:${ver}"
+          docker manifest inspect "${img}:latest"
 
   prune:
     needs: docker

--- a/docs/developer/docker-build.md
+++ b/docs/developer/docker-build.md
@@ -18,13 +18,13 @@ Images: `openfdd-bridge`, `openfdd-commission`, `openfdd-mcp-rag`.
 
 ## Publish to GHCR (maintainers)
 
-GitHub Actions workflow **Publish Docker addons** — manual dispatch; publishes **`:latest`** only and prunes GHCR (retired `openfdd-bacnet-poll` removed; keep 3 versions per image).
+GitHub Actions workflow **Publish Docker images to GHCR** — manual dispatch or git tag `vX.Y.Z`. Publishes **`pyproject.toml` version** (e.g. `3.1.3`), minor alias (`3.1`), and **`latest`**, then prunes old GHCR versions.
 
 Maintainer checklist:
 
 1. Green CI on `master`
-2. Run **Publish Docker addons** workflow
-3. Verify `ghcr.io/bbartling/openfdd-{bridge,commission,mcp-rag}:latest`
-4. Edge hosts: `docker compose pull && docker compose up -d`
+2. Run **Publish Docker images to GHCR** workflow (or push tag `vX.Y.Z`)
+3. Verify `ghcr.io/bbartling/openfdd-{bridge,commission,mcp-rag}:3.1.3` and `:latest`
+4. Edge hosts: `OPENFDD_IMAGE_TAG=3.1.3 ./scripts/upgrade_edge_ghcr.sh --limit <host>`
 
 Details live in `.github/workflows/` and `scripts/docker_build.sh` — not duplicated here.

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -65,7 +65,7 @@ docker manifest inspect ghcr.io/bbartling/openfdd-bridge:3.0.30
 ## 5. Manual workflow_dispatch
 
 - **PyPI:** `Publish open-fdd to PyPI` with `dry_run=true` (default) — build/test only
-- **Docker:** `Publish Docker images to GHCR` — publishes `:latest` (maintainer use)
+- **Docker:** `Publish Docker images to GHCR` — publishes `pyproject.toml` version + minor alias + `latest` (optional `image_tag` override)
 
 ## Package vs Docker
 

--- a/docs/ops/docker-images.md
+++ b/docs/ops/docker-images.md
@@ -36,9 +36,9 @@ docker pull ghcr.io/bbartling/openfdd-mcp-rag:${OPENFDD_IMAGE_TAG}
 
 ## Publish
 
-Triggered by git tag `vX.Y.Z` → workflow **Publish Docker images to GHCR**.
+Triggered by git tag `vX.Y.Z` → workflow **Publish Docker images to GHCR** (tags `X.Y.Z`, `X.Y`, `latest`).
 
-Manual: Actions → workflow_dispatch (publishes `latest`).
+Manual: Actions → **Publish Docker images to GHCR** (`workflow_dispatch`) — reads `version` from `pyproject.toml` and publishes the same tags (`3.1.3`, `3.1`, `latest`). Optional `image_tag` input overrides the version.
 
 ## vs PyPI
 

--- a/scripts/resolve_ghcr_publish_tag.sh
+++ b/scripts/resolve_ghcr_publish_tag.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Resolve GHCR image tags for docker-publish.yml.
+#
+# Tag push vX.Y.Z / open-fdd-vX.Y.Z → X.Y.Z (+ minor alias + latest in workflow).
+# workflow_dispatch → version from pyproject.toml (+ minor + latest); optional override.
+set -euo pipefail
+
+_read_pyproject_version() {
+  local pyproject="${1:-pyproject.toml}"
+  if [[ ! -f "$pyproject" ]]; then
+    return 1
+  fi
+  grep -E '^version\s*=' "$pyproject" | head -1 | sed -E 's/^version\s*=\s*"([^"]+)".*/\1/'
+}
+
+resolve_ghcr_publish_tag() {
+  local ref_name="${1:-}"
+  local input_tag="${2:-}"
+  local pyproject="${3:-pyproject.toml}"
+
+  if [[ "$ref_name" == v* ]]; then
+    printf '%s' "${ref_name#v}"
+    return 0
+  fi
+  if [[ "$ref_name" == open-fdd-v* ]]; then
+    printf '%s' "${ref_name#open-fdd-v}"
+    return 0
+  fi
+
+  if [[ -n "$input_tag" && "$input_tag" != "latest" ]]; then
+    printf '%s' "${input_tag#v}"
+    return 0
+  fi
+
+  _read_pyproject_version "$pyproject"
+}
+
+ghcr_publish_release_tags_enabled() {
+  local ref_name="${1:-}"
+  local event_name="${2:-}"
+
+  if [[ "$ref_name" == v* || "$ref_name" == open-fdd-v* ]]; then
+    return 0
+  fi
+  if [[ "$event_name" == "workflow_dispatch" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  resolve_ghcr_publish_tag "${1:-}" "${2:-}" "${3:-pyproject.toml}"
+fi

--- a/tests/scripts/test_resolve_ghcr_publish_tag.sh
+++ b/tests/scripts/test_resolve_ghcr_publish_tag.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=/dev/null
+source "${ROOT}/scripts/resolve_ghcr_publish_tag.sh"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+printf '%s\n' 'version = "3.1.3"' >"$tmp"
+
+ver="$(resolve_ghcr_publish_tag "master" "" "$tmp")"
+[[ "$ver" == "3.1.3" ]] || { echo "expected 3.1.3 from pyproject, got $ver"; exit 1; }
+
+ver="$(resolve_ghcr_publish_tag "v3.1.4" "" "$tmp")"
+[[ "$ver" == "3.1.4" ]] || { echo "expected 3.1.4 from tag, got $ver"; exit 1; }
+
+ver="$(resolve_ghcr_publish_tag "master" "3.2.0" "$tmp")"
+[[ "$ver" == "3.2.0" ]] || { echo "expected override 3.2.0, got $ver"; exit 1; }
+
+ghcr_publish_release_tags_enabled "v3.1.3" "push" || { echo "tag push should enable release tags"; exit 1; }
+ghcr_publish_release_tags_enabled "master" "workflow_dispatch" || { echo "dispatch should enable release tags"; exit 1; }
+ghcr_publish_release_tags_enabled "master" "push" && { echo "plain push should not enable release tags"; exit 1; }
+
+echo "resolve_ghcr_publish_tag ok"


### PR DESCRIPTION
## Summary
Manual `workflow_dispatch` Docker publishes were tagging **only** `:latest`, leaving GHCR without a pinned SemVer (e.g. `3.1.3`). Now dispatch reads `version` from `pyproject.toml` and publishes `X.Y.Z`, minor alias, and `latest` — same as tag releases.

## Test plan
- [x] `tests/scripts/test_resolve_ghcr_publish_tag.sh`
- [ ] After merge: run **Publish Docker images to GHCR** and confirm `openfdd-bridge:3.1.3` + `:latest` both exist


Made with [Cursor](https://cursor.com)