### PR TITLE
fix(feather): cross-source column projection for OAT spread FDD

### DIFF
--- a/tests/workspace_bridge/test_feather_store.py
+++ b/tests/workspace_bridge/test_feather_store.py
@@ -48,6 +48,31 @@ def test_write_read_and_dedupe(store: FeatherStore):
     assert df["timestamp"].duplicated().sum() == 0
 
 
+def test_read_site_table_partial_column_projection(store: FeatherStore):
+    """Cross-source column lists must not drop shards missing unrelated columns."""
+    store.write_shard(
+        pd.DataFrame({"timestamp": pd.date_range("2025-01-01", periods=2, freq="1h", tz="UTC"), "oa-t": [70.0, 71.0]}),
+        source="bacnet",
+        site_id="acme",
+    )
+    store.write_shard(
+        pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2025-01-01", periods=2, freq="1h", tz="UTC"),
+                "web-oat-t": [69.0, 72.0],
+            }
+        ),
+        source="json_api",
+        site_id="acme",
+    )
+    bacnet = store.read_site_table("acme", source="bacnet", columns=["timestamp", "oa-t", "web-oat-t"])
+    assert bacnet is not None
+    assert "oa-t" in bacnet.column_names
+    web = store.read_site_table("acme", source="json_api", columns=["timestamp", "oa-t", "web-oat-t"])
+    assert web is not None
+    assert "web-oat-t" in web.column_names
+
+
 def test_list_sites(store: FeatherStore):
     store.write_shard(_frame("2025-01-01", 3), source="bacnet", site_id="s1")
     store.write_shard(_frame("2025-01-01", 3), source="weather", site_id="s2")

--- a/workspace/api/openfdd_bridge/feather_store.py
+++ b/workspace/api/openfdd_bridge/feather_store.py
@@ -78,7 +78,13 @@ def _read_df(path: Path, columns: list[str] | None = None) -> pd.DataFrame:
 
         _apply_arrow_thread_env()
         if columns:
-            table = feather.read_table(path, columns=_column_list(columns), use_threads=True)
+            col_list = _column_list(columns)
+            try:
+                table = feather.read_table(path, columns=col_list, use_threads=True)
+            except Exception:
+                table = feather.read_table(path, use_threads=True)
+                avail = [c for c in col_list if c in table.column_names]
+                table = table.select(avail) if avail else table
             return table.to_pandas()
         return pd.read_feather(path)
     df = pd.read_pickle(path)
@@ -288,7 +294,15 @@ class FeatherStore:
             tables: list[Any] = []
             for path in files:
                 try:
-                    tables.append(feather.read_table(path, columns=col_list, use_threads=True))
+                    if col_list:
+                        try:
+                            tables.append(feather.read_table(path, columns=col_list, use_threads=True))
+                        except Exception:
+                            table = feather.read_table(path, use_threads=True)
+                            avail = [c for c in col_list if c in table.column_names]
+                            tables.append(table.select(avail) if avail else table)
+                    else:
+                        tables.append(feather.read_table(path, use_threads=True))
                 except Exception as exc:  # noqa: BLE001
                     _log.warning("Skipping unreadable feather shard %s: %s", path, exc)
             if not tables:


### PR DESCRIPTION
## Summary
- Feather shard reads no longer fail when a column filter includes fields from another driver (e.g. `oa-t` on json_api shards).
- Fixes Acme demo historian fallback during OAT vs web-oat-t paired smoke rules.

## Test plan
- [x] `pytest tests/workspace_bridge/test_feather_store.py::test_read_site_table_partial_column_projection`


Made with [Cursor](https://cursor.com)