### PR TITLE
fix(fdd): load web-oat-t in batch frame for OAT spread rules

### DIFF
--- a/workspace/api/openfdd_bridge/fdd_runner.py
+++ b/workspace/api/openfdd_bridge/fdd_runner.py
@@ -121,6 +121,8 @@ def _columns_for_site_rules(model: dict[str, Any], site_id: str, rules: list[dic
             "value_column",
             "column",
             "zone_avg_cols",
+            "local_oat_column",
+            "web_oat_column",
         ):
             raw = cfg.get(key)
             if isinstance(raw, str) and raw.strip():


### PR DESCRIPTION
Adds local_oat_column and web_oat_column to site column union so DataFusion SQL can reference web-oat-t.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional `local_oat_column` and `web_oat_column` rule configuration options to enable additional historian column handling for rule execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->