### PR TITLE
fix(smoke): OAT spread SQL null parity with PyArrow

### DIFF
--- a/open_fdd/tests/validation/test_paired_fdd_contract.py
+++ b/open_fdd/tests/validation/test_paired_fdd_contract.py
@@ -29,8 +29,8 @@ def test_bench_bounds_sql_matches_phases():
 def test_acme_spread_sql_tight_vs_normal():
     loose = oat_spread_sql(10.0)
     tight = oat_spread_sql(0.001)
-    assert "> 10.0" in loose
-    assert "> 0.001" in tight
+    assert "10.0" in loose and "IS NOT NULL" in loose
+    assert "0.001" in tight
 
 
 def test_bench_rules_include_both_backends():

--- a/open_fdd/validation/paired_fdd_contract.py
+++ b/open_fdd/validation/paired_fdd_contract.py
@@ -104,8 +104,14 @@ def zn_t_bounds_sql(low: float, high: float, column: str = BENCH_VALUE_COLUMN) -
 
 
 def oat_spread_sql(max_spread_f: float, local: str = "oa-t", web: str = "web-oat-t") -> str:
+    l = _sql_quote(local)
+    w = _sql_quote(web)
+    spread = float(max_spread_f)
     return (
-        f"SELECT *, abs({_sql_quote(local)} - {_sql_quote(web)}) > {float(max_spread_f)} AS fault "
+        "SELECT *, CASE "
+        f'WHEN {l} IS NOT NULL AND {w} IS NOT NULL '
+        f"AND abs({l} - {w}) > {spread} THEN true "
+        "ELSE false END AS fault "
         "FROM telemetry"
     )
 


### PR DESCRIPTION
CASE WHEN guards for null oa-t/web-oat-t so blatant-phase arrow and SQL flagged counts match.

Made with [Cursor](https://cursor.com)