### PR TITLE
fix(smoke): single Acme OAT point binding for arrow/SQL parity

### DIFF
--- a/open_fdd/tests/validation/test_paired_fdd_contract.py
+++ b/open_fdd/tests/validation/test_paired_fdd_contract.py
@@ -29,8 +29,8 @@ def test_bench_bounds_sql_matches_phases():
 def test_acme_spread_sql_tight_vs_normal():
     loose = oat_spread_sql(10.0)
     tight = oat_spread_sql(0.001)
-    assert "> 10.0" in loose
-    assert "> 0.001" in tight
+    assert "10.0" in loose and "IS NOT NULL" in loose
+    assert "0.001" in tight
 
 
 def test_bench_rules_include_both_backends():

--- a/open_fdd/tests/validation/test_paired_fdd_contract.py
+++ b/open_fdd/tests/validation/test_paired_fdd_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from open_fdd.validation.paired_fdd_contract import (
+    ACME_LOCAL_OAT_POINT_ID,
     ACME_SPREAD_CFG,
     CONFIRMATION_CFG,
     PHASE_BLATANT,
@@ -46,4 +47,5 @@ def test_bench_rules_include_both_backends():
 def test_acme_rules_pair():
     rules = acme_rules_for_phase(PHASE_BLATANT)
     assert len(rules) == 2
+    assert rules[0]["bindings"]["point_ids"] == [ACME_LOCAL_OAT_POINT_ID]
     assert float(rules[0]["config"]["max_spread_f"]) == float(ACME_SPREAD_CFG[PHASE_BLATANT]["max_spread_f"])

--- a/open_fdd/validation/paired_fdd_contract.py
+++ b/open_fdd/validation/paired_fdd_contract.py
@@ -28,7 +28,7 @@ BENCH_BOUNDS: dict[str, dict[str, float | str]] = {
     PHASE_BLATANT: {"low": 99.0, "high": 100.0, "value_column": BENCH_VALUE_COLUMN},
 }
 
-# Acme local OAT vs OpenWeather web-oat-t
+ACME_LOCAL_OAT_POINT_ID = "1100-unknown-2"
 ACME_SITE_ID = "acme"
 ACME_SPREAD_CFG: dict[str, dict[str, float | str]] = {
     PHASE_NORMAL: {
@@ -194,7 +194,7 @@ def acme_rules_for_phase(phase: str) -> list[dict[str, Any]]:
             "backend": "arrow",
             "code": OAT_SPREAD_ARROW_CODE,
             "config": cfg,
-            "bindings": {"brick_types": ["Outside_Air_Temperature_Sensor"]},
+            "bindings": {"point_ids": [ACME_LOCAL_OAT_POINT_ID]},
             "severity": "warning",
             "enabled": True,
         },
@@ -207,7 +207,7 @@ def acme_rules_for_phase(phase: str) -> list[dict[str, Any]]:
             "fault_column": "fault",
             "code": OAT_SPREAD_ARROW_CODE,
             "config": cfg,
-            "bindings": {"brick_types": ["Outside_Air_Temperature_Sensor"]},
+            "bindings": {"point_ids": [ACME_LOCAL_OAT_POINT_ID]},
             "severity": "warning",
             "enabled": True,
         },

--- a/open_fdd/validation/paired_fdd_contract.py
+++ b/open_fdd/validation/paired_fdd_contract.py
@@ -104,8 +104,14 @@ def zn_t_bounds_sql(low: float, high: float, column: str = BENCH_VALUE_COLUMN) -
 
 
 def oat_spread_sql(max_spread_f: float, local: str = "oa-t", web: str = "web-oat-t") -> str:
+    l = _sql_quote(local)
+    w = _sql_quote(web)
+    spread = float(max_spread_f)
     return (
-        f"SELECT *, abs({_sql_quote(local)} - {_sql_quote(web)}) > {float(max_spread_f)} AS fault "
+        "SELECT *, CASE "
+        f'WHEN {l} IS NOT NULL AND {w} IS NOT NULL '
+        f"AND abs({l} - {w}) > {spread} THEN true "
+        "ELSE false END AS fault "
         "FROM telemetry"
     )
 


### PR DESCRIPTION
Binds smoke OAT spread to 1100-unknown-2 only; avoids multi-column brick sweep.

Made with [Cursor](https://cursor.com)