### PR TITLE
chore(release): 3.1.4 paired smoke hardening + README DataFusion showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ result = run_arrow_rule(high_sat, table, {"high": 85})
 print(result.true_count)  # 1
 ```
 
+**DataFusion SQL** (same telemetry table, optional `pip install 'open-fdd[datafusion]'`):
+
+```python
+from open_fdd.arrow_runtime import run_datafusion_sql_rule
+
+SQL = """
+SELECT
+  *,
+  "SAT" > 85.0 AS fault
+FROM telemetry
+"""
+
+result = run_datafusion_sql_rule(SQL, table, {"min_true_rows": 5, "poll_interval_s": 60})
+
+print(result.true_count)  # 1 — same confirmed count as PyArrow when cfg matches
+```
+
+Rule `config` fields such as `min_elapsed_minutes` and `min_true_rows` apply to **both** backends (fault confirmation / minimum duration). See [fault confirmation](docs/rule-cookbook/fault-confirmation.md).
+
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "3.1.3"
+version = "3.1.4"
 description = "Arrow-native HVAC fault detection runtime — lint, test, and run apply_faults_arrow rules on columnar telemetry (PyPI). Use GHCR Docker images for the full edge operator stack."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bump `3.1.3` → `3.1.4` for a single GHCR edge publish (no PyPI).
- README: DataFusion SQL showcase below PyArrow example; fault-confirmation config note.

## Test plan
- [x] `pytest open_fdd/tests/validation open_fdd/tests/arrow_runtime tests/workspace_bridge`
- [ ] GHCR publish `3.1.4` + Acme deploy
- [ ] `OPENFDD_LIVE_ACME=1 ./scripts/smoke_paired_fdd_harness.sh --short`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added usage documentation for DataFusion SQL functionality, including example queries and optional installation instructions with configurable parameters.

* **Chores**
  * Version bumped to 3.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->