### PR TITLE
fix(release): 3.1.6 version alignment and CI probe test

### DIFF
--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,6 +9,6 @@ GHCR Docker images (``openfdd-bridge``, ``openfdd-commission``, ``openfdd-mcp-ra
 not inside this wheel.
 """
 
-__version__ = "3.1.5"
+__version__ = "3.1.6"
 
 __all__ = ["__version__"]

--- a/open_fdd/tests/validation/test_smoke_health_probes.py
+++ b/open_fdd/tests/validation/test_smoke_health_probes.py
@@ -47,6 +47,8 @@ def test_probe_bacnet_override_scan_interval(mock_fetch):
         "operator_priority": 8,
         "full_rotation_hours": 3.0,
         "last_scan_device": 5007,
+        "last_scan_at": "2026-06-19T14:00:00+00:00",
+        "scan_health": {"ok": True, "status": "healthy", "detail": "ok"},
     }
     mock_fetch.side_effect = [
         (200, body),


### PR DESCRIPTION
## Summary
- Bump `open_fdd.__version__` to **3.1.6** (matches `pyproject.toml`)
- Fix smoke health probe test for stricter BACnet override scan validation

## Test plan
- [x] CI green on patch branch
- [ ] Merge then tag `v3.1.6` and publish GHCR images
- [ ] Merge multi-arch `docker-publish.yml` via GitHub UI (OAuth workflow scope)


Made with [Cursor](https://cursor.com)