### PR TITLE
docs(edge): ARM/x86 GHCR platform auto-detect and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,32 @@
 | [`ghcr.io/bbartling/openfdd-commission`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-commission) | BACnet discover, read, poll |
 | [`ghcr.io/bbartling/openfdd-mcp-rag`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mcp-rag) | MCP + doc-search |
 
+GHCR publishes **multi-arch** images (`linux/amd64` + `linux/arm64`) from release **3.1.6** onward. Edge scripts **auto-detect** the host CPU and pull the matching manifest — no manual platform flag on a normal x86 or 64-bit Raspberry Pi install.
+
+| Host CPU (`uname -m`) | Docker platform | Typical hardware |
+|-----------------------|-----------------|------------------|
+| `x86_64`, `amd64` | `linux/amd64` | Intel/AMD servers, VMs |
+| `aarch64`, `arm64` | `linux/arm64` | Raspberry Pi 4/5 (64-bit OS) |
+
+Verify before pull (optional but recommended on Pi):
+
+```bash
+cd ~/open-fdd
+./scripts/openfdd_check_ghcr_platform.sh
+```
+
+Override platform (lab / QEMU emulation only):
+
+```bash
+# Force amd64 images on ARM64 (slow — see docs/quick-start/raspberry-pi-edge.md)
+OPENFDD_DOCKER_PLATFORM=linux/amd64 docker compose pull
+
+# Bootstrap or update with explicit platform
+bash /tmp/openfdd_edge_bootstrap.sh --start --platform linux/arm64
+NEW_TAG=3.1.6 OPENFDD_DOCKER_PLATFORM=linux/amd64 ./scripts/openfdd_site_update.sh
+```
+
+Pi-specific troubleshooting: [Raspberry Pi edge bootstrap](docs/quick-start/raspberry-pi-edge.md).
 
 ### Manual Installation
 
@@ -66,7 +92,7 @@ cd ~/open-fdd
 
 | Area | Examples |
 |------|----------|
-| **Edge deploy** | `openfdd_edge_bootstrap.sh`, `openfdd_site_backup.sh`, `openfdd_site_update.sh`, health checks |
+| **Edge deploy** | `openfdd_edge_bootstrap.sh`, `openfdd_site_backup.sh`, `openfdd_site_update.sh`, `openfdd_check_ghcr_platform.sh`, health checks |
 | **Drivers** | BACnet discover/poll/bind, Niagara station setup, JSON API endpoints |
 | **Model & rules** | BRICK sites/equipment/points, Rule Lab save/bind, batch FDD, tuning brief/apply |
 | **Operations** | Building check-in, zone temps, device poll health, BACnet P8 override scans |
@@ -425,6 +451,7 @@ Restore ALL historian data (no cap):
 
 Useful env vars:
   NEW_TAG=latest                    GHCR tag (or OPENFDD_IMAGE_TAG)
+  OPENFDD_DOCKER_PLATFORM=auto      linux/arm64 | linux/amd64 (default: auto-detect host)
   BACKUP_INCLUDE_POLL_SAMPLES=0     fast backup (skip poll CSV history)
   SKIP_DOCKER_MAINTENANCE=1         skip prune
   PURGE_BACKUP_AFTER_SUCCESS=0      keep backup after successful upgrade

--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -21,6 +21,7 @@ Open-FDD is an **edge FDD platform**: BACnet / Niagara / JSON API drivers ingest
 | **`workspace/`** | Model, rules, feather store, auth env — persist across image upgrades |
 | **Auth** | `workspace/auth.env.local` (gitignored); JWT via `POST /api/auth/login` |
 | **Update** | [Edge site lifecycle]({{ "/quick-start/site-lifecycle/" | relative_url }}) · [Updating the stack]({{ "/quick-start/updating/" | relative_url }}) · pin `OPENFDD_IMAGE_TAG` |
+| **CPU / platform** | Auto-detect: `x86_64` → `linux/amd64`, `aarch64` → `linux/arm64`. Check: `./scripts/openfdd_check_ghcr_platform.sh`. Override: `OPENFDD_DOCKER_PLATFORM` or bootstrap `--platform`. Pi: [Raspberry Pi edge]({{ "/quick-start/raspberry-pi-edge/" | relative_url }}) |
 
 Rebuild MCP index after doc changes: `./scripts/build_mcp_rag_index.sh`.
 

--- a/docs/quick-start/docker.md
+++ b/docs/quick-start/docker.md
@@ -18,6 +18,34 @@ Deploy Open-FDD on a Linux edge host using **three published GHCR images**. No g
 
 Edge hosts pull **`latest`** from GHCR (three images: bridge, commission, mcp-rag). The retired **`openfdd-bacnet-poll`** image is no longer published.
 
+## CPU architecture (auto-detect)
+
+Open-FDD GHCR images are **multi-arch** (`linux/amd64` + `linux/arm64`) from release **3.1.6** onward. Bootstrap and site-update scripts detect the host CPU and set `DOCKER_DEFAULT_PLATFORM` automatically:
+
+| `uname -m` | Platform pulled |
+|------------|-----------------|
+| `x86_64`, `amd64` | `linux/amd64` |
+| `aarch64`, `arm64` | `linux/arm64` |
+
+Verify manifests before pull (especially on Raspberry Pi):
+
+```bash
+cd ~/open-fdd
+./scripts/openfdd_check_ghcr_platform.sh
+./scripts/openfdd_check_ghcr_platform.sh --platform linux/arm64   # explicit check
+OPENFDD_IMAGE_TAG=3.1.6 ./scripts/openfdd_check_ghcr_platform.sh
+```
+
+Override (QEMU / lab only):
+
+| Variable / flag | Example |
+|-----------------|---------|
+| `OPENFDD_DOCKER_PLATFORM` | `OPENFDD_DOCKER_PLATFORM=linux/amd64 docker compose pull` |
+| Bootstrap `--platform` | `bash …/openfdd_edge_bootstrap.sh --start --platform linux/arm64` |
+| Site update | `OPENFDD_DOCKER_PLATFORM=linux/amd64 ./scripts/openfdd_site_update.sh` |
+
+ARM64 pull errors → [Raspberry Pi edge bootstrap]({{ "/quick-start/raspberry-pi-edge/" | relative_url }}).
+
 ## 1. Install and validate Docker
 
 ```bash
@@ -109,6 +137,7 @@ Options:
 |------|---------|
 | `--start` | `docker compose pull && up -d` after layout; curls `http://127.0.0.1:8765/health` |
 | `--image-tag TAG` | default `latest` |
+| `--platform PLAT` | `auto` (default), `linux/arm64`, `linux/amd64` — or set `OPENFDD_DOCKER_PLATFORM` |
 | `--repo-ref BRANCH` | branch for `compose.edge.yml` if not on `master` yet |
 | `--force-auth` | regenerate `auth.env.local` (restarts bridge if stack is up) |
 | `--restart` | recreate bridge to reload `auth.env.local`; curls `/health` after |
@@ -131,6 +160,7 @@ Use this only if you ran bootstrap **without** `--start` and want to bring the s
 
 ```bash
 cd ~/open-fdd
+./scripts/openfdd_check_ghcr_platform.sh
 docker compose pull
 docker compose up -d
 docker compose ps

--- a/docs/quick-start/raspberry-pi-edge.md
+++ b/docs/quick-start/raspberry-pi-edge.md
@@ -8,6 +8,8 @@ nav_order: 5
 
 Open-FDD edge deploy on **Raspberry Pi 4/5 (64-bit)** uses the same bootstrap as x86 Linux. Docker must be installed; the host must be **aarch64 / arm64** (not 32-bit Raspberry Pi OS).
 
+Bootstrap and update scripts **auto-detect** `linux/arm64` on Pi hosts. No `--platform` flag is required when GHCR publishes ARM64 manifests for your tag (3.1.6+).
+
 ## One-liner
 
 ```bash
@@ -29,6 +31,7 @@ Error response from daemon: no matching manifest for linux/arm64/v8 in the manif
 ```bash
 cd ~/open-fdd
 ./scripts/openfdd_check_ghcr_platform.sh
+# explicit: ./scripts/openfdd_check_ghcr_platform.sh --platform linux/arm64
 ```
 
 Or manually:
@@ -57,8 +60,8 @@ sudo apt install -y qemu-user-static binfmt-support
 docker run --privileged --rm tonistiigi/binfmt --install amd64
 
 cd ~/open-fdd
-DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose pull
-DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose up -d
+OPENFDD_DOCKER_PLATFORM=linux/amd64 docker compose pull
+OPENFDD_DOCKER_PLATFORM=linux/amd64 docker compose up -d
 
 docker compose ps
 curl -sf http://127.0.0.1:8765/health | jq .

--- a/docs/quick-start/site-lifecycle.md
+++ b/docs/quick-start/site-lifecycle.md
@@ -40,7 +40,14 @@ Creates:
 | `~/open-fdd/workspace/` | Persistent site state (historian, model, auth) |
 | `~/open-fdd/scripts/openfdd_site_*.sh` | Backup and update helpers |
 
-Options: `--image-tag`, `--root`, `--force-auth`, `--restart`. See script header (`--help`).
+Options: `--image-tag`, `--platform`, `--root`, `--force-auth`, `--restart`. See script header (`--help`).
+
+Scripts auto-detect CPU (`x86_64` → `linux/amd64`, `aarch64` → `linux/arm64`). Verify GHCR manifests:
+
+```bash
+cd ~/open-fdd
+./scripts/openfdd_check_ghcr_platform.sh
+```
 
 After bootstrap → [Health check]({{ "/quick-start/health-check/" | relative_url }}).
 
@@ -92,6 +99,7 @@ export NEW_TAG=3.1.6
 | Variable | Default | Meaning |
 |----------|---------|---------|
 | `NEW_TAG` / `OPENFDD_IMAGE_TAG` | `latest` | GHCR image tag |
+| `OPENFDD_DOCKER_PLATFORM` | `auto` | `linux/arm64`, `linux/amd64`, or auto-detect from `uname -m` |
 | `BACKUP_ROOT` | `~/openfdd-backups/latest` | Backup used for validation / restore |
 | `SKIP_DOCKER_MAINTENANCE` | `0` | Set `1` to skip prune |
 | `PURGE_BACKUP_AFTER_SUCCESS` | `1` | Set `0` to keep backup after upgrade |
@@ -138,7 +146,7 @@ If scripts are missing:
 ```bash
 mkdir -p ~/open-fdd/scripts
 BASE=https://github.com/bbartling/open-fdd/raw/refs/heads/master/scripts
-for f in openfdd_site_lib.sh openfdd_site_backup.sh openfdd_site_update.sh; do
+for f in openfdd_site_lib.sh openfdd_site_backup.sh openfdd_site_update.sh openfdd_check_ghcr_platform.sh; do
   curl -fsSL -o ~/open-fdd/scripts/"$f" "$BASE/$f"
 done
 chmod +x ~/open-fdd/scripts/openfdd_site_*.sh

--- a/scripts/openfdd_check_ghcr_platform.sh
+++ b/scripts/openfdd_check_ghcr_platform.sh
@@ -1,29 +1,42 @@
 #!/usr/bin/env bash
-# Verify GHCR Open-FDD images publish a manifest for this host CPU.
+# Verify GHCR Open-FDD images publish a manifest for this host CPU (or a chosen platform).
 #
 #   ./scripts/openfdd_check_ghcr_platform.sh
+#   ./scripts/openfdd_check_ghcr_platform.sh --platform linux/amd64
 #   OPENFDD_IMAGE_TAG=3.1.6 ./scripts/openfdd_check_ghcr_platform.sh
+#   OPENFDD_DOCKER_PLATFORM=linux/arm64 ./scripts/openfdd_check_ghcr_platform.sh
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=openfdd_site_lib.sh
+source "${SCRIPT_DIR}/openfdd_site_lib.sh"
 
 TAG="${OPENFDD_IMAGE_TAG:-latest}"
 OWNER="${OPENFDD_GHCR_OWNER:-bbartling}"
 
-_detect_platform() {
-  case "$(uname -m)" in
-    aarch64|arm64) echo "linux/arm64" ;;
-    x86_64|amd64) echo "linux/amd64" ;;
-    *) echo "linux/$(uname -m)" ;;
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform) OPENFDD_DOCKER_PLATFORM="$2"; shift 2 ;;
+    --image-tag) OPENFDD_IMAGE_TAG="$2"; TAG="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
-}
+done
 
-PLATFORM="$(_detect_platform)"
-ARCH="${PLATFORM#linux/}"
+PLATFORM="$(openfdd_export_docker_platform)"
+ARCH="$(openfdd_platform_arch "$PLATFORM")"
+HOST_ARCH="$(uname -m)"
 
 IMAGES=(
   openfdd-bridge
   openfdd-commission
   openfdd-mcp-rag
 )
+
+echo "Host CPU: ${HOST_ARCH} → checking GHCR manifests for ${PLATFORM} (tag=${TAG})"
 
 missing=()
 for img in "${IMAGES[@]}"; do
@@ -34,7 +47,7 @@ for img in "${IMAGES[@]}"; do
     continue
   fi
   if ! docker manifest inspect "$ref" 2>/dev/null | grep -q "\"architecture\": \"${ARCH}\""; then
-    missing+=("$ref (no ${ARCH} — Pi needs linux/arm64)")
+    missing+=("$ref (no ${ARCH})")
   else
     echo "OK  $ref → ${ARCH}"
   fi
@@ -43,7 +56,7 @@ done
 if [[ ${#missing[@]} -gt 0 ]]; then
   echo "" >&2
   echo "Open-FDD GHCR images are not published for ${PLATFORM} (tag=${TAG})." >&2
-  echo "This host: $(uname -m) / ${PLATFORM}" >&2
+  echo "This host: ${HOST_ARCH} / ${PLATFORM}" >&2
   echo "" >&2
   for m in "${missing[@]}"; do
     echo "  ✗ $m" >&2
@@ -53,19 +66,23 @@ if [[ ${#missing[@]} -gt 0 ]]; then
     cat >&2 <<'EOF'
 Raspberry Pi / ARM64 options:
 
-  1. RECOMMENDED — Wait for native ARM64 images (after next Open-FDD release publish).
+  1. RECOMMENDED — Use a tag with native ARM64 images (3.1.6+ multi-arch publish).
      Re-run: bash /tmp/openfdd_edge_bootstrap.sh --start
 
   2. WORKAROUND — QEMU emulation (slow; lab only):
      sudo apt install -y qemu-user-static binfmt-support
      docker run --privileged --rm tonistiigi/binfmt --install amd64
      cd ~/open-fdd
-     DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose pull
-     DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose up -d
+     OPENFDD_DOCKER_PLATFORM=linux/amd64 ./scripts/openfdd_site_update.sh
 
   3. BUILD ON PI — clone repo and: ./scripts/docker_build.sh (needs ~30–60 min on Pi 5)
 
 Docs: https://bbartling.github.io/open-fdd/quick-start/raspberry-pi-edge/
+EOF
+  elif [[ "$ARCH" == "amd64" && "$HOST_ARCH" =~ ^(aarch64|arm64)$ ]]; then
+    cat >&2 <<'EOF'
+You requested linux/amd64 on an ARM64 host (QEMU emulation). Ensure binfmt is installed:
+  docker run --privileged --rm tonistiigi/binfmt --install amd64
 EOF
   fi
   exit 1

--- a/scripts/openfdd_edge_bootstrap.sh
+++ b/scripts/openfdd_edge_bootstrap.sh
@@ -8,6 +8,7 @@
 # Options:
 #   --start          docker compose pull && up -d after bootstrap
 #   --image-tag TAG  default: latest
+#   --platform PLAT  auto (default), linux/arm64, linux/amd64 — or OPENFDD_DOCKER_PLATFORM
 #   --repo-ref REF   GitHub branch for compose.edge.yml (tries master, then this ref)
 #   --root PATH      default: ~/open-fdd
 #   --force-auth     regenerate workspace/auth.env.local
@@ -28,6 +29,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --start) DO_START=true; shift ;;
     --image-tag) OPENFDD_IMAGE_TAG="$2"; shift 2 ;;
+    --platform) OPENFDD_DOCKER_PLATFORM="$2"; shift 2 ;;
     --repo-ref) OPENFDD_REPO_REF="$2"; shift 2 ;;
     --root) OPENFDD_ROOT="$2"; shift 2 ;;
     --force-auth) FORCE_AUTH=true; shift ;;
@@ -266,7 +268,10 @@ _check_docker() {
   echo "    Host CPU: ${arch}"
   case "$arch" in
     aarch64|arm64)
-      echo "    Raspberry Pi / ARM64 — requires GHCR images with linux/arm64 manifest"
+      echo "    Raspberry Pi / ARM64 — auto-selects linux/arm64 GHCR manifests"
+      ;;
+    x86_64|amd64)
+      echo "    x86_64 — auto-selects linux/amd64 GHCR manifests"
       ;;
   esac
   if ! groups | grep -q '\bdocker\b'; then
@@ -281,11 +286,22 @@ _check_docker() {
 _pull_and_start() {
   cd "$OPENFDD_ROOT"
   export OPENFDD_IMAGE_TAG
-  if [[ -x "${OPENFDD_ROOT}/scripts/openfdd_check_ghcr_platform.sh" ]]; then
-    echo "==> Verifying GHCR images for $(uname -m)"
-    OPENFDD_IMAGE_TAG="$OPENFDD_IMAGE_TAG" "${OPENFDD_ROOT}/scripts/openfdd_check_ghcr_platform.sh"
+  local platform
+  if [[ -f "${OPENFDD_ROOT}/scripts/openfdd_site_lib.sh" ]]; then
+    # shellcheck source=openfdd_site_lib.sh
+    source "${OPENFDD_ROOT}/scripts/openfdd_site_lib.sh"
+    platform="$(openfdd_export_docker_platform)"
+  else
+    platform="${OPENFDD_DOCKER_PLATFORM:-linux/$(uname -m)}"
+    export OPENFDD_DOCKER_PLATFORM="$platform"
+    export DOCKER_DEFAULT_PLATFORM="$platform"
   fi
-  echo "==> Pulling images (tag=${OPENFDD_IMAGE_TAG})"
+  if [[ -x "${OPENFDD_ROOT}/scripts/openfdd_check_ghcr_platform.sh" ]]; then
+    echo "==> Verifying GHCR images for ${platform} (host $(uname -m))"
+    OPENFDD_IMAGE_TAG="$OPENFDD_IMAGE_TAG" OPENFDD_DOCKER_PLATFORM="$platform" \
+      "${OPENFDD_ROOT}/scripts/openfdd_check_ghcr_platform.sh"
+  fi
+  echo "==> Pulling images (tag=${OPENFDD_IMAGE_TAG}, platform=${platform})"
   docker compose pull
   docker compose up -d
   docker compose ps
@@ -369,6 +385,7 @@ echo "=== Bootstrap complete ==="
 echo "  Site root:     ${OPENFDD_ROOT}"
 echo "  Compose file:  ${COMPOSE_PATH}"
 echo "  Image tag:     ${OPENFDD_IMAGE_TAG}"
+echo "  Platform:      ${OPENFDD_DOCKER_PLATFORM:-auto (host $(uname -m))}"
 echo "  BACnet NIC:    ${BACNET_IFACE:-unknown}"
 echo "  BACnet bind:   ${BACNET_BIND}"
 echo "  Auth file:     ${AUTH_PATH}"
@@ -388,7 +405,7 @@ fi
 echo ""
 if [[ "$DO_START" != true ]]; then
   echo "Start stack:"
-  echo "  cd ${OPENFDD_ROOT} && docker compose pull && docker compose up -d"
+  echo "  cd ${OPENFDD_ROOT} && ./scripts/openfdd_check_ghcr_platform.sh && docker compose pull && docker compose up -d"
   echo "Or re-run: bash $0 --start"
 fi
 echo ""

--- a/scripts/openfdd_site_lib.sh
+++ b/scripts/openfdd_site_lib.sh
@@ -8,6 +8,50 @@ openfdd_site_root_from_caller() {
   cd "$(dirname "$caller")/.." && pwd
 }
 
+# Docker image platform: auto-detect host CPU unless OPENFDD_DOCKER_PLATFORM is set.
+# Values: auto (default), linux/arm64, linux/amd64, or aliases arm64|amd64|aarch64|x86_64.
+openfdd_detect_docker_platform() {
+  case "$(uname -m)" in
+    aarch64|arm64) echo "linux/arm64" ;;
+    x86_64|amd64) echo "linux/amd64" ;;
+    *) echo "linux/$(uname -m)" ;;
+  esac
+}
+
+openfdd_normalize_docker_platform() {
+  local raw="${1:-auto}"
+  case "$raw" in
+    ""|auto) openfdd_detect_docker_platform ;;
+    linux/arm64|arm64|aarch64) echo "linux/arm64" ;;
+    linux/amd64|amd64|x86_64) echo "linux/amd64" ;;
+    linux/*) echo "$raw" ;;
+    *)
+      echo "ERROR: unknown platform: $raw (use auto, linux/arm64, or linux/amd64)" >&2
+      return 1
+      ;;
+  esac
+}
+
+openfdd_resolve_docker_platform() {
+  openfdd_normalize_docker_platform "${OPENFDD_DOCKER_PLATFORM:-auto}"
+}
+
+openfdd_platform_arch() {
+  local platform="${1:-}"
+  if [[ -z "$platform" ]]; then
+    platform="$(openfdd_resolve_docker_platform)" || return 1
+  fi
+  printf '%s' "${platform#linux/}"
+}
+
+openfdd_export_docker_platform() {
+  local platform
+  platform="$(openfdd_resolve_docker_platform)" || return 1
+  export OPENFDD_DOCKER_PLATFORM="$platform"
+  export DOCKER_DEFAULT_PLATFORM="$platform"
+  printf '%s' "$platform"
+}
+
 openfdd_resolve_compose_file() {
   local root="$1"
   local compose="${COMPOSE_FILE:-}"

--- a/scripts/openfdd_site_update.sh
+++ b/scripts/openfdd_site_update.sh
@@ -14,6 +14,7 @@
 #
 # Env:
 #   NEW_TAG / OPENFDD_IMAGE_TAG     Image tag (default: latest)
+#   OPENFDD_DOCKER_PLATFORM         auto (default), linux/arm64, linux/amd64
 #   BACKUP_ROOT                     Backup dir (default: ~/openfdd-backups/latest)
 #   SKIP_DOCKER_MAINTENANCE=1         Skip image/container prune
 #   RESTORE_WORKSPACE=0|1           Extract backup over workspace/ (default: 0)
@@ -55,7 +56,9 @@ IMAGES=(
 ARCHIVE="$(openfdd_backup_archive_path "$BACKUP_ROOT")"
 
 echo "=== Open-FDD site update → ${NEW_TAG} ==="
+PLATFORM="$(openfdd_export_docker_platform)"
 echo "Compose file:     $COMPOSE_FILE"
+echo "Docker platform:  ${PLATFORM} (host $(uname -m))"
 echo "Backup root:        $BACKUP_ROOT"
 echo "Restore workspace: $RESTORE_WORKSPACE"
 echo "Feather cap (GiB):  $([[ "$RESTORE_WORKSPACE" == "1" ]] && echo "${RESTORE_FEATHER_MAX_GIB} (0=all)" || echo n/a)"
@@ -80,11 +83,16 @@ if [[ "$SKIP_DOCKER_MAINTENANCE" != "1" ]]; then
   echo ""
 fi
 
-echo "==> Verify images exist on GHCR"
-for img in "${IMAGES[@]}"; do
-  docker manifest inspect "$img" >/dev/null
-  echo "  OK $img"
-done
+echo "==> Verify images exist on GHCR (${PLATFORM})"
+if [[ -x "$ROOT/scripts/openfdd_check_ghcr_platform.sh" ]]; then
+  OPENFDD_IMAGE_TAG="$NEW_TAG" OPENFDD_DOCKER_PLATFORM="$PLATFORM" \
+    "$ROOT/scripts/openfdd_check_ghcr_platform.sh"
+else
+  for img in "${IMAGES[@]}"; do
+    docker manifest inspect "$img" >/dev/null
+    echo "  OK $img"
+  done
+fi
 
 if [[ -f "$ROOT/docker-compose.yml" ]] && grep -q 'OPENFDD_IMAGE_TAG\|2026\.[0-9]' "$ROOT/docker-compose.yml" 2>/dev/null; then
   cp "$ROOT/docker-compose.yml" "$ROOT/docker-compose.yml.bak.$(date +%Y%m%d-%H%M%S)"


### PR DESCRIPTION
## Summary
- Document multi-arch GHCR images (`linux/amd64` + `linux/arm64` from 3.1.6+) in README and quick-start docs.
- Add shared `OPENFDD_DOCKER_PLATFORM` helpers in `openfdd_site_lib.sh` — scripts auto-detect host CPU and export `DOCKER_DEFAULT_PLATFORM` before pull.
- Extend `openfdd_check_ghcr_platform.sh`, bootstrap (`--platform`), and site update with optional manual platform override for QEMU/lab use.
- Update AI agent context with platform detection guidance.

## Test plan
- [x] `bash -n` on updated shell scripts
- [x] `openfdd_detect_docker_platform` / `openfdd_normalize_docker_platform` smoke on x86_64 host
- [ ] `./scripts/openfdd_check_ghcr_platform.sh` on edge host (amd64 + arm64)
- [ ] `bash scripts/openfdd_edge_bootstrap.sh --help` shows `--platform`
- [ ] `OPENFDD_DOCKER_PLATFORM=linux/amd64 ./scripts/openfdd_site_update.sh` dry-run on Pi lab (QEMU path only)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture Docker image support with automatic CPU architecture detection (x86_64 → AMD64, ARM64).
  * Added platform override capability via `OPENFDD_DOCKER_PLATFORM` environment variable for manual control (e.g., QEMU emulation scenarios).

* **Documentation**
  * Expanded deployment guidance for multi-architecture environments and Raspberry Pi.
  * Added platform verification and auto-detection instructions to installation and upgrade procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->