### PR TITLE
ci: composite action for multi-arch GHCR publish

### DIFF
--- a/.github/actions/publish-multiarch/action.yml
+++ b/.github/actions/publish-multiarch/action.yml
@@ -1,0 +1,31 @@
+name: Publish multi-arch to GHCR
+description: Build and push amd64+arm64 Open-FDD edge images
+inputs:
+  image_tag:
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    - shell: bash
+      run: |
+        set -euo pipefail
+        TAG="${{ inputs.image_tag }}"
+        for spec in "bridge:openfdd-bridge" "commission:openfdd-commission" "mcp-rag:openfdd-mcp-rag"; do
+          target="${spec%%:*}"
+          image="${spec##*:}"
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            -f docker/Dockerfile --target "$target" \
+            -t "ghcr.io/bbartling/${image}:${TAG}" -t "ghcr.io/bbartling/${image}:latest" \
+            --build-arg "OPENFDD_IMAGE_TAG=${TAG}" \
+            --build-arg "OPENFDD_BUILD_GIT_SHA=${GITHUB_SHA}" \
+            --build-arg "OPENFDD_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --push .
+          docker buildx imagetools inspect "ghcr.io/bbartling/${image}:${TAG}" | grep -E 'linux/amd64|linux/arm64'
+        done


### PR DESCRIPTION
Adds reusable publish-multiarch composite action. Pair with workflow in follow-up.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added multi-architecture container image publishing to support `linux/amd64` and `linux/arm64` platforms, enabling broader deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->