### PR TITLE
chore(scripts): GHCR multi-arch publish installer

### DIFF
--- a/scripts/ghcr-multiarch-publish.workflow.yml
+++ b/scripts/ghcr-multiarch-publish.workflow.yml
@@ -1,0 +1,30 @@
+# Copy to .github/workflows/ghcr-multiarch-publish.yml (requires workflow OAuth scope to push).
+# Then: gh workflow run "Publish multi-arch GHCR images" -f image_tag=3.1.6
+name: Publish multi-arch GHCR images
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "GHCR tag (e.g. 3.1.6)"
+        required: true
+        default: "3.1.6"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Build dashboard for bridge image
+        run: ./scripts/build_operator_dashboard.sh prod
+
+      - uses: ./.github/actions/publish-multiarch
+        with:
+          image_tag: ${{ inputs.image_tag }}

--- a/scripts/install_and_publish_ghcr_multiarch.sh
+++ b/scripts/install_and_publish_ghcr_multiarch.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Install multi-arch GHCR publish workflow, push, dispatch, verify arm64 manifests.
+# Requires: gh CLI logged in with `workflow` scope (gh auth refresh -h github.com -s workflow)
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+TAG="${1:-3.1.6}"
+WF_SRC="$ROOT/scripts/ghcr-multiarch-publish.workflow.yml"
+WF_DST="$ROOT/.github/workflows/ghcr-multiarch-publish.yml"
+
+scopes="$(gh auth status 2>&1 | grep -o "Token scopes:.*" || true)"
+if [[ "$scopes" != *workflow* ]]; then
+  echo "ERROR: gh token needs workflow scope. Run:" >&2
+  echo "  gh auth refresh -h github.com -s workflow" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$WF_DST")"
+cp "$WF_SRC" "$WF_DST"
+git add "$WF_DST"
+if git diff --cached --quiet; then
+  echo "Workflow already installed."
+else
+  git commit -m "ci: add multi-arch GHCR publish workflow"
+  git push origin HEAD:master
+fi
+
+gh workflow run "Publish multi-arch GHCR images" -f "image_tag=${TAG}"
+echo "Dispatched publish for tag=${TAG}. Waiting for run…"
+sleep 15
+RUN_ID="$(gh run list --workflow ghcr-multiarch-publish.yml --limit 1 --json databaseId -q '.[0].databaseId')"
+gh run watch "$RUN_ID" --exit-status
+
+verify() {
+  local image="$1"
+  local token
+  token="$(curl -fsSL "https://ghcr.io/token?service=ghcr.io&scope=repository:bbartling/${image}:pull" | python3 -c "import json,sys; print(json.load(sys.stdin)['token'])")"
+  curl -fsSL -H "Authorization: Bearer ${token}" -H "Accept: application/vnd.oci.image.index.v1+json" \
+    "https://ghcr.io/v2/bbartling/${image}/manifests/${TAG}" \
+    | python3 -c "import json,sys; m=json.load(sys.stdin); plats=[p.get('platform',{}) for p in m.get('manifests',[])]; print('${image}:${TAG}', plats); assert any(p.get('architecture')=='arm64' and p.get('os')=='linux' for p in plats), 'missing linux/arm64'"
+}
+
+for img in openfdd-bridge openfdd-commission openfdd-mcp-rag; do
+  verify "$img"
+done
+echo "OK: linux/arm64 manifests present for ${TAG}"


### PR DESCRIPTION
Workflow template + one-shot install/publish/verify script.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for automated multi-architecture container image publishing to GHCR
  * Added automation script to install the workflow and verify successful multi-architecture image deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->