### PR TITLE
FDD Wires: rule graph, SQL builder, DataFusion execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
             -d '{"sql":"SELECT timestamp, equipment_id, oa_t, CASE WHEN oa_t > 110.0 THEN true ELSE false END AS fault_raw FROM telemetry_pivot WHERE equipment_id = '\''AHU-1'\''","confirmation_seconds":300}' \
             | jq -e '.ok == true and (.engine | type == "string") and (.engine | contains("DataFusion"))'
 
-          curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/oa_temp_out_of_range/activate \
+          curl -sS -X POST http://127.0.0.1:8080/api/fdd-rules/oa_temp_out_of_range/activate \
             -H "Authorization: Bearer $AGENT" -H 'Content-Type: application/json' -d '{}' \
             | jq -e '.ok == false'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/oa_temp_out_of_range/test-sql \
             -H "Authorization: Bearer $INT" -H 'Content-Type: application/json' \
             -d '{"sql":"SELECT timestamp, equipment_id, oa_t, CASE WHEN oa_t > 110.0 THEN true ELSE false END AS fault_raw FROM telemetry_pivot WHERE equipment_id = '\''AHU-1'\''","confirmation_seconds":300}' \
-            | jq -e '.ok == true and .engine | test("DataFusion")'
+            | jq -e '.ok == true and (.engine | type == "string") and (.engine | contains("DataFusion"))'
 
           curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/oa_temp_out_of_range/activate \
             -H "Authorization: Bearer $AGENT" -H 'Content-Type: application/json' -d '{}' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,16 @@ jobs:
           node-version: "22"
 
       - name: Frontend syntax
-        run: node --check frontend/app.js
+        run: |
+          node --check frontend/app.js
+          node --check frontend/fdd-wires.js
+
+      - name: FDD Wires UI guards
+        run: |
+          grep -q "FDD Wires" frontend/app.js
+          grep -q "Rule Assignment Workspace" frontend/fdd-wires.js
+          grep -q "Raw DataFusion SQL" frontend/fdd-wires.js
+          ! grep -Ri "grafana\|rubix\|nubeio\|nubedev\|niagara" frontend/app.js frontend/fdd-wires.js frontend/index.html
 
       - name: New driver-tree UI is default
         run: |
@@ -166,6 +175,38 @@ jobs:
             -H "Authorization: Bearer $TOKEN" \
             -H 'Content-Type: application/json' \
             -d '{"register":40001,"function":"holding_register"}' | grep -q simulated
+
+      - name: FDD Wires and DataFusion SQL smoke
+        run: |
+          INTEGRATOR_PW="$(grep '^OFDD_INTEGRATOR_PASSWORD=' workspace/auth.env.local | cut -d= -f2- | tr -d '\r')"
+          AGENT_PW="$(grep '^OFDD_AGENT_PASSWORD=' workspace/auth.env.local | cut -d= -f2- | tr -d '\r')"
+          INT="$(curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -nc --arg p "$INTEGRATOR_PW" '{username:"integrator",password:$p}')" | jq -r '.token // .access_token')"
+          AGENT="$(curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -nc --arg p "$AGENT_PW" '{username:"agent",password:$p}')" | jq -r '.token // .access_token')"
+
+          curl -fsS http://127.0.0.1:8080/api/fdd-wires/graphs?site_id=site:demo \
+            -H "Authorization: Bearer $INT" | jq -e '.ok == true'
+
+          curl -fsS http://127.0.0.1:8080/api/fdd-wires/graphs/graph:bench-5007-fdd?site_id=site:demo \
+            -H "Authorization: Bearer $INT" | jq -e '.graph.nodes | length >= 4'
+
+          curl -fsS -X POST http://127.0.0.1:8080/api/fdd-wires/propose-assignments \
+            -H "Authorization: Bearer $AGENT" -H 'Content-Type: application/json' \
+            -d '{"site_id":"site:demo","equipment_type":"ahu"}' | jq -e '.review_status == "needs_review"'
+
+          curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/oa_temp_out_of_range/test-sql \
+            -H "Authorization: Bearer $INT" -H 'Content-Type: application/json' \
+            -d '{"sql":"SELECT timestamp, equipment_id, oa_t, CASE WHEN oa_t > 110.0 THEN true ELSE false END AS fault_raw FROM telemetry_pivot WHERE equipment_id = '\''AHU-1'\''","confirmation_seconds":300}' \
+            | jq -e '.ok == true and .engine | test("DataFusion")'
+
+          curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/oa_temp_out_of_range/activate \
+            -H "Authorization: Bearer $AGENT" -H 'Content-Type: application/json' -d '{}' \
+            | jq -e '.ok == false'
+
+          curl -fsS http://127.0.0.1:8080/fdd-wires.js | grep -q "FDD Wires"
 
       - name: CSV files created in workspace
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 edge/workspace/
 workspace/auth.env.local
 workspace/data.env.local
+workspace/data/fdd_wires/
 **/*.db
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,53 +68,270 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
+name = "arrayref"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "arrow"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a3ec4fe573f9d1f59d99c085197ef669b00b088ba1d7bb75224732d9357a74"
 dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
-name = "anstyle"
-version = "1.0.14"
+name = "arrow-arith"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "6dcf19f07792d8c7f91086c67b574a79301e367029b17fcf63fb854332246a10"
 dependencies = [
- "utf8parse",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "num",
 ]
 
 [[package]]
-name = "anstyle-query"
-version = "1.1.5"
+name = "arrow-array"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+checksum = "7845c32b41f7053e37a075b3c2f29c6f5ea1b3ca6e5df7a2d325ee6e1b4a63cf"
 dependencies = [
- "windows-sys",
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
+name = "arrow-buffer"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+checksum = "5b5c681a99606f3316f2a99d9c8b6fa3aad0b1d34d8f6d7a1b471893940219d8"
 dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365f8527d4f87b133eeb862f9b8093c009d41a210b8f101f91aa2392f61daac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30dac4d23ac769300349197b845e0fd18c7f9f15d260d4659ae6b5a9ca06f586"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3527365b24372f9c948f16e53738eb098720eea2093ae73c7af04ac5e30a39b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+ "lz4_flex",
+]
+
+[[package]]
+name = "arrow-json"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdec0024749fc0d95e025c0b0266d78613727b3b3a5d4cf8ea47eb6d38afdd1"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af2db0e62a508d34ddf4f76bfd6109b6ecc845257c9cba6f939653668f89ac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da30e9d10e9c52f09ea0cf15086d6d785c11ae8dcc3ea5f16d402221b6ac7735"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+
+[[package]]
+name = "arrow-select"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fc337f01635218493c23da81a364daf38c694b05fc20569c3193c11c561984"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d596a9fc25dae556672d5069b090331aca8acb93cae426d8b7dcdf1c558fa0ce"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+dependencies = [
+ "bzip2 0.5.2",
+ "flate2",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "xz2",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -142,7 +415,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975f24ce6506f2906d08bec590272f0001de67cf1090f1f149bb3ce58c494c3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "smallvec",
  "thiserror",
 ]
@@ -155,9 +428,38 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -169,10 +471,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -181,12 +510,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -198,63 +558,64 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.45"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets",
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.1"
+name = "chrono-tz"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
- "clap_builder",
- "clap_derive",
+ "chrono",
+ "phf",
 ]
 
 [[package]]
-name = "clap_builder"
-version = "4.6.0"
+name = "comfy-table"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.6.1"
+name = "const-random"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "const-random-macro",
 ]
 
 [[package]]
-name = "clap_lex"
-version = "1.1.0"
+name = "const-random-macro"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
+name = "constant_time_eq"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -272,6 +633,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +670,446 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "datafusion"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbba0799cf6913b456ed07a94f0f3b6e12c62a5d88b10809e2284a0f2b915c05"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-compression",
+ "async-trait",
+ "bytes",
+ "bzip2 0.4.4",
+ "chrono",
+ "dashmap",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-sql",
+ "flate2",
+ "futures",
+ "glob",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "itertools",
+ "log",
+ "num_cpus",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "paste",
+ "pin-project-lite",
+ "rand",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+ "xz2",
+ "zstd",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7493c5c2d40eec435b13d92e5703554f4efc7059451fcb8d3a79580ff0e45560"
+dependencies = [
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24953049ebbd6f8964f91f60aa3514e121b5e81e068e33b60e77815ab369b25c"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "instant",
+ "libc",
+ "num_cpus",
+ "object_store",
+ "parquet",
+ "paste",
+ "sqlparser",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f06df4ef76872e11c924d3c814fd2a8dd09905ed2e2195f71c857d78abd19685"
+dependencies = [
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-execution"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbdcb628d690f3ce5fea7de81642b514486d58ff9779a51f180a69a4eadb361"
+dependencies = [
+ "arrow",
+ "chrono",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "futures",
+ "hashbrown 0.14.5",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8036495980e3131f706b7d33ab00b4492d73dc714e3cb74d11b50f9602a73246"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
+ "indexmap",
+ "paste",
+ "serde_json",
+ "sqlparser",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da0f3cb4669f9523b403d6b5a0ec85023e0ab3bf0183afd1517475b3e64fdd2"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "itertools",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52c4012648b34853e40a2c6bcaa8772f837831019b68aca384fb38436dba162"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "base64",
+ "blake2",
+ "blake3",
+ "chrono",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools",
+ "log",
+ "md-5",
+ "rand",
+ "regex",
+ "sha2",
+ "unicode-segmentation",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b8bb624597ba28ed7446df4a9bd7c7a7bde7c578b6b527da3f47371d5f6741"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "half",
+ "indexmap",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb06208fc470bc8cf1ce2d9a1159d42db591f2c7264a8c1776b53ad8f675143"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+ "rand",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca25bbb87323716d05e54114666e942172ccca23c5a507e9c7851db6e965317"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-physical-expr-common",
+ "itertools",
+ "log",
+ "paste",
+ "rand",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ae23356c634e54c59f7c51acb7a5b9f6240ffb2cf997049a1a24a8a88598dbe"
+dependencies = [
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b3d6ff7794acea026de36007077a06b18b89e4f9c3fea7f2215f9f7dd9059b"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec6241eb80c595fa0e1a8a6b69686b5cf3bd5fdacb8319582a0943b0bd788aa"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "itertools",
+ "log",
+ "paste",
+ "regex-syntax",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3370357b8fc75ec38577700644e5d1b0bc78f38babab99c0b8bd26bafb3e4335"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-string",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "itertools",
+ "log",
+ "paste",
+ "petgraph",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7734d94bf2fa6f6e570935b0ddddd8421179ce200065be97874e13d46a47b"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "hashbrown 0.14.5",
+ "rand",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eee8c479522df21d7b395640dff88c5ed05361852dce6544d7c98e9dbcebffe"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "itertools",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1fc2e2c239d14e8556f2622b19a726bf6bc6962cc00c71fc52626274bee24"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "itertools",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e3a4ed41dbee20a5d947a59ca035c225d67dc9cbe869c10f66dcdf25e7ce51"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-expr",
+ "indexmap",
+ "log",
+ "regex",
+ "sqlparser",
+ "strum",
 ]
 
 [[package]]
@@ -293,16 +1124,132 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -316,6 +1263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,9 +1280,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -356,10 +1313,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -375,6 +1401,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "iana-time-zone"
@@ -401,16 +1433,160 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
+name = "icu_collections"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -424,10 +1600,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -436,10 +1702,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash 2.1.2",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -453,12 +1759,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object_store"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "itertools",
+ "parking_lot",
+ "percent-encoding",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -468,29 +1870,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "open_fdd_edge_prototype"
 version = "3.2.0"
 dependencies = [
+ "arrow",
  "bacnet-client",
  "bacnet-encoding",
  "bacnet-transport",
  "bacnet-types",
  "base64",
  "chrono",
- "clap",
+ "datafusion",
  "hex",
  "hmac",
- "rand",
+ "serde",
  "serde_json",
  "sha2",
- "subtle",
  "tokio",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8cf58b29782a7add991f655ff42929e31a7859f5319e53db9e39a714cb113c"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half",
+ "hashbrown 0.15.5",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "object_store",
+ "paste",
+ "seq-macro",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash 1.6.3",
+ "zstd",
+ "zstd-sys",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -498,6 +2002,21 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -527,6 +2046,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,7 +2084,67 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -563,12 +2154,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -611,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -620,6 +2245,18 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -634,6 +2271,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,10 +2308,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
+name = "sqlparser"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -664,6 +2377,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -687,11 +2424,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -709,6 +2477,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -743,6 +2524,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,10 +2552,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "utf8parse"
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -767,10 +2599,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -815,6 +2666,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -886,6 +2756,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,7 +2884,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -23,3 +23,4 @@ These documents describe **how to confirm** Open-FDD Rust edge behavior on a rea
 - [Modbus live reads](modbus-live.md)
 - [UI smoke](ui-smoke.md)
 - [Auth and login](auth-and-login.md)
+- [FDD Wires and SQL rules](fdd-wires.md)

--- a/docs/verification/fdd-wires.md
+++ b/docs/verification/fdd-wires.md
@@ -1,0 +1,103 @@
+# FDD Wires and SQL rules verification
+
+Validates the **FDD Wires** graph workspace, DataFusion SQL rule builder, AI assignment proposals, and activation RBAC.
+
+## Prerequisites
+
+```bash
+docker compose up -d --build
+curl -fsS http://127.0.0.1:8080/api/health
+```
+
+Sign in with credentials from `workspace/auth.env.local` (integrator for writes, agent for read-only proposals).
+
+```bash
+INTEGRATOR_PW="$(grep '^OFDD_INTEGRATOR_PASSWORD=' workspace/auth.env.local | cut -d= -f2- | tr -d '\r')"
+TOKEN="$(curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg p "$INTEGRATOR_PW" '{username:"integrator",password:$p}')" \
+  | jq -r '.token // .access_token')"
+```
+
+## FDD Wires graph API
+
+List graphs and load the seeded demo graph (replace `GRAPH_ID` with your site graph):
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  'http://127.0.0.1:8080/api/fdd-wires/graphs?site_id=site:demo' | jq .
+
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  'http://127.0.0.1:8080/api/fdd-wires/graphs/GRAPH_ID?site_id=site:demo' \
+  | jq '.graph.review_status, (.graph.nodes | length)'
+```
+
+## UI smoke
+
+1. Open `http://127.0.0.1:8080` and sign in.
+2. **FDD Wires** tab loads the rule graph canvas.
+3. Right-click canvas → Validate graph / Propose assignments.
+4. Right-click a node → settings / copy JSON.
+5. **SQL Rules** tab: toggle Builder / Raw DataFusion SQL; Ctrl/Cmd+Enter runs a query.
+6. Product UI must not mention third-party BMS or analytics brands.
+
+## SQL rule builder
+
+```bash
+curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/builder-sql \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"input":"oa_t","operator":">","value":110,"equipment_id":"AHU-1"}' \
+  | jq '.sql, .validation.safe'
+
+curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/RULE_ID/test-sql \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"sql":"SELECT timestamp, equipment_id, oa_t FROM telemetry_pivot LIMIT 5","confirmation_seconds":300}' \
+  | jq '.ok, .engine'
+
+curl -fsS -X POST http://127.0.0.1:8080/api/fdd-rules/RULE_ID/validate-sql \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"sql":"DROP TABLE telemetry"}' | jq '.safe, .errors'
+```
+
+## AI assignment proposals (draft only)
+
+```bash
+AGENT_PW="$(grep '^OFDD_AGENT_PASSWORD=' workspace/auth.env.local | cut -d= -f2- | tr -d '\r')"
+AGENT="$(curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg p "$AGENT_PW" '{username:"agent",password:$p}')" \
+  | jq -r '.token // .access_token')"
+
+curl -fsS -X POST http://127.0.0.1:8080/api/fdd-wires/propose-assignments \
+  -H "Authorization: Bearer $AGENT" -H 'Content-Type: application/json' \
+  -d '{"site_id":"site:demo","equipment_type":"ahu"}' \
+  | jq '.review_status, .proposals[0].review_status'
+```
+
+Expected: `review_status` is `needs_review`; proposals are `ai_suggested`; integrator approval required before activation.
+
+## Activation RBAC
+
+Agent must not activate rules:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/api/fdd-rules/RULE_ID/activate \
+  -H "Authorization: Bearer $AGENT" -H 'Content-Type: application/json' -d '{}' | jq '.ok, .error'
+```
+
+Integrator activates only after graph approval:
+
+```bash
+curl -fsS -X POST "http://127.0.0.1:8080/api/fdd-wires/graphs/GRAPH_ID/approve?site_id=site:demo" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{}' | jq '.ok'
+
+curl -fsS -X POST "http://127.0.0.1:8080/api/fdd-wires/graphs/GRAPH_ID/activate?site_id=site:demo" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{}' | jq '.ok, .activated'
+```
+
+## Pass criteria
+
+- Graph schema version present; node chain includes driver → model → FDD input → SQL rule → confirmation → fault output.
+- DataFusion executes in Rust; DDL/DML rejected.
+- Agent proposals stay draft; integrator-only activation.
+- Import/export JSON works from the UI.

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -12,6 +12,7 @@ name = "openfdd_edge"
 path = "src/bin/openfdd_edge.rs"
 
 [dependencies]
+arrow = "53"
 base64 = "0.22"
 bacnet-client = "0.9"
 bacnet-encoding = "0.9"
@@ -19,9 +20,11 @@ bacnet-transport = "0.9"
 bacnet-types = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+datafusion = "43"
 hex = "0.4"
 hmac = "0.12"
 rand = "0.8"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 subtle = "2"

--- a/edge/src/fdd/confirmation.rs
+++ b/edge/src/fdd/confirmation.rs
@@ -1,0 +1,92 @@
+//! Confirmation duration logic for raw faults → confirmed faults.
+
+use serde_json::{json, Value};
+
+pub fn apply_confirmation(raw_rows: &[Value], confirmation_seconds: i64) -> Value {
+    if raw_rows.is_empty() {
+        return json!({
+            "ok": true,
+            "raw_fault_count": 0,
+            "confirmed_fault_count": 0,
+            "confirmation_seconds": confirmation_seconds,
+            "confirmed": []
+        });
+    }
+
+    let mut confirmed = Vec::new();
+    let mut streak_start: Option<i64> = None;
+    let mut last_ts: Option<i64> = None;
+    let mut raw_count = 0_i64;
+
+    for row in raw_rows {
+        let fault = row
+            .get("fault_raw")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if fault {
+            raw_count += 1;
+        }
+        let ts = parse_ts(row.get("timestamp").or_else(|| row.get("ts")));
+        if fault {
+            if streak_start.is_none() {
+                streak_start = Some(ts);
+            }
+            last_ts = Some(ts);
+        } else {
+            if let (Some(start), Some(end)) = (streak_start, last_ts) {
+                if end - start >= confirmation_seconds {
+                    confirmed.push(json!({
+                        "start": start,
+                        "end": end,
+                        "duration_seconds": end - start,
+                        "equipment_id": row.get("equipment_id").cloned().unwrap_or(json!(null)),
+                    }));
+                }
+            }
+            streak_start = None;
+            last_ts = None;
+        }
+    }
+    if let (Some(start), Some(end)) = (streak_start, last_ts) {
+        if end - start >= confirmation_seconds {
+            confirmed.push(json!({
+                "start": start,
+                "end": end,
+                "duration_seconds": end - start,
+                "confirmed_at_end": true
+            }));
+        }
+    }
+
+    json!({
+        "ok": true,
+        "raw_fault_count": raw_count,
+        "confirmed_fault_count": confirmed.len(),
+        "confirmation_seconds": confirmation_seconds,
+        "confirmed": confirmed
+    })
+}
+
+fn parse_ts(value: Option<&Value>) -> i64 {
+    value
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confirms_after_duration() {
+        let rows = vec![
+            json!({"timestamp":"2026-06-21T00:00:00Z","fault_raw":true,"equipment_id":"AHU-1"}),
+            json!({"timestamp":"2026-06-21T00:06:00Z","fault_raw":true,"equipment_id":"AHU-1"}),
+            json!({"timestamp":"2026-06-21T00:11:00Z","fault_raw":false,"equipment_id":"AHU-1"}),
+        ];
+        let out = apply_confirmation(&rows, 300);
+        assert_eq!(out["confirmed_fault_count"].as_u64(), Some(1));
+    }
+}

--- a/edge/src/fdd/execution.rs
+++ b/edge/src/fdd/execution.rs
@@ -1,0 +1,401 @@
+//! DataFusion SQL execution against Arrow telemetry tables.
+
+use crate::fdd::confirmation;
+use crate::fdd::sql_safety;
+use crate::historian::arrow_table;
+use arrow::array::{BooleanArray, Float64Array, StringArray, TimestampMillisecondArray};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use chrono::{DateTime, Utc};
+use datafusion::prelude::*;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+pub fn schema_tables_json() -> Value {
+    json!({
+        "ok": true,
+        "tables": [
+            {
+                "name": "telemetry",
+                "description": "Normalized long-format telemetry rows",
+                "columns": ["timestamp","site_id","building_id","equipment_id","point_id","fdd_input","value","unit","quality","source","source_driver","source_device","source_object","is_simulated"]
+            },
+            {
+                "name": "telemetry_pivot",
+                "description": "Wide pivoted view for rule SQL",
+                "columns": ["timestamp","equipment_id","oa_t","oa_h","sat","duct_t","zn_t","sat_sp","fan_cmd","occ"]
+            },
+            {
+                "name": "hvac",
+                "description": "Legacy HVAC demo table",
+                "columns": ["ts","equip","sat","sat_sp","duct_static","duct_static_sp","oat","fan_cmd"]
+            }
+        ]
+    })
+}
+
+pub fn fdd_inputs_json() -> Value {
+    json!({
+        "ok": true,
+        "fdd_inputs": [
+            {"id":"oa_t","label":"Outside Air Temp","unit":"degF","equipment_types":["ahu","bench"]},
+            {"id":"oa_h","label":"Outside Air Humidity","unit":"%RH","equipment_types":["ahu"]},
+            {"id":"sat","label":"Supply Air Temp","unit":"degF","equipment_types":["ahu","vav"]},
+            {"id":"duct_t","label":"Discharge/Duct Temp","unit":"degF","equipment_types":["ahu","vav"]},
+            {"id":"zn_t","label":"Zone Temp","unit":"degF","equipment_types":["vav","zone"]},
+            {"id":"sat_sp","label":"SAT Setpoint","unit":"degF","equipment_types":["ahu"]},
+            {"id":"fan_cmd","label":"Fan Command","unit":"bool","equipment_types":["ahu"]},
+            {"id":"occ","label":"Occupancy","unit":"bool","equipment_types":["ahu","zone"]}
+        ]
+    })
+}
+
+pub fn equipment_types_json() -> Value {
+    json!({
+        "ok": true,
+        "equipment_types": [
+            {"id":"ahu","label":"Air Handling Unit"},
+            {"id":"vav","label":"VAV Box"},
+            {"id":"bench","label":"Bench Controller"},
+            {"id":"plant","label":"Central Plant"}
+        ]
+    })
+}
+
+pub fn run_rule_sql(sql: &str, confirmation_seconds: i64, params: &Value) -> Value {
+    if !sql_safety::is_sql_safe(sql) {
+        return json!({
+            "ok": false,
+            "error": "unsafe SQL rejected",
+            "validation": sql_safety::validate_sql(sql)
+        });
+    }
+
+    let bound = bind_params(sql, params);
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    match rt.block_on(execute_query(&bound)) {
+        Ok(rows) => {
+            let confirmation = confirmation::apply_confirmation(&rows, confirmation_seconds);
+            json!({
+                "ok": true,
+                "sql": bound,
+                "row_count": rows.len(),
+                "rows": rows,
+                "confirmation": confirmation,
+                "engine": "Apache Arrow + DataFusion SQL (Rust)"
+            })
+        }
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+fn bind_params(sql: &str, params: &Value) -> String {
+    let mut out = sql.to_string();
+    if let Some(map) = params.as_object() {
+        for (k, v) in map {
+            let placeholder = format!("${{{k}}}");
+            let replacement = match v {
+                Value::String(s) => format!("'{s}'"),
+                Value::Number(n) => n.to_string(),
+                Value::Bool(b) => b.to_string(),
+                _ => v.to_string(),
+            };
+            out = out.replace(&placeholder, &replacement);
+        }
+    }
+    out
+}
+
+async fn execute_query(sql: &str) -> Result<Vec<Value>, String> {
+    let ctx = SessionContext::new();
+    register_demo_tables(&ctx).await?;
+    let df = ctx.sql(sql).await.map_err(|e| e.to_string())?;
+    let batches = df.collect().await.map_err(|e| e.to_string())?;
+    let mut rows = Vec::new();
+    for batch in batches {
+        rows.extend(batch_to_json_rows(&batch)?);
+    }
+    Ok(rows)
+}
+
+async fn register_demo_tables(ctx: &SessionContext) -> Result<(), String> {
+    let telemetry = build_telemetry_batch().map_err(|e| e.to_string())?;
+    let pivot = build_pivot_batch().map_err(|e| e.to_string())?;
+    let hvac = build_hvac_batch().map_err(|e| e.to_string())?;
+    ctx.register_batch("telemetry", telemetry)
+        .map_err(|e| e.to_string())?;
+    ctx.register_batch("telemetry_pivot", pivot)
+        .map_err(|e| e.to_string())?;
+    ctx.register_batch("hvac", hvac)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn build_hvac_batch() -> Result<RecordBatch, arrow::error::ArrowError> {
+    let rows: Vec<Value> = serde_json::from_str(arrow_table::demo_rows_json()).unwrap_or_default();
+    let schema = Schema::new(vec![
+        Field::new("ts", DataType::Utf8, false),
+        Field::new("equip", DataType::Utf8, false),
+        Field::new("sat", DataType::Float64, true),
+        Field::new("sat_sp", DataType::Float64, true),
+        Field::new("duct_static", DataType::Float64, true),
+        Field::new("duct_static_sp", DataType::Float64, true),
+        Field::new("oat", DataType::Float64, true),
+        Field::new("fan_cmd", DataType::Float64, true),
+    ]);
+    let ts: StringArray = rows
+        .iter()
+        .map(|r| r.get("ts").and_then(|v| v.as_str()).unwrap_or(""))
+        .collect::<Vec<_>>()
+        .into();
+    let equip: StringArray = rows
+        .iter()
+        .map(|r| r.get("equip").and_then(|v| v.as_str()).unwrap_or(""))
+        .collect::<Vec<_>>()
+        .into();
+    let f64 = |key: &str| -> Float64Array {
+        rows.iter()
+            .map(|r| r.get(key).and_then(|v| v.as_f64()))
+            .collect::<Float64Array>()
+    };
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(ts),
+            Arc::new(equip),
+            Arc::new(f64("sat")),
+            Arc::new(f64("sat_sp")),
+            Arc::new(f64("duct_static")),
+            Arc::new(f64("duct_static_sp")),
+            Arc::new(f64("oat")),
+            Arc::new(f64("fan_cmd")),
+        ],
+    )
+}
+
+fn build_telemetry_batch() -> Result<RecordBatch, arrow::error::ArrowError> {
+    let rows: Vec<Value> = serde_json::from_str(arrow_table::demo_rows_json()).unwrap_or_default();
+    let schema = Schema::new(vec![
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
+        Field::new("site_id", DataType::Utf8, false),
+        Field::new("building_id", DataType::Utf8, false),
+        Field::new("equipment_id", DataType::Utf8, false),
+        Field::new("point_id", DataType::Utf8, false),
+        Field::new("fdd_input", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, true),
+        Field::new("unit", DataType::Utf8, false),
+        Field::new("quality", DataType::Utf8, false),
+        Field::new("source", DataType::Utf8, false),
+        Field::new("source_driver", DataType::Utf8, false),
+        Field::new("source_device", DataType::Utf8, false),
+        Field::new("source_object", DataType::Utf8, false),
+        Field::new("is_simulated", DataType::Boolean, false),
+    ]);
+    let mut ts = Vec::new();
+    let mut equipment = Vec::new();
+    let mut fdd_input = Vec::new();
+    let mut value = Vec::new();
+    for row in &rows {
+        let t = row.get("ts").and_then(|v| v.as_str()).unwrap_or("");
+        ts.push(parse_ts_ms(t));
+        equipment.push(
+            row.get("equip")
+                .and_then(|v| v.as_str())
+                .unwrap_or("AHU-1")
+                .to_string(),
+        );
+        for (input, key) in [
+            ("sat", "sat"),
+            ("sat_sp", "sat_sp"),
+            ("fan_cmd", "fan_cmd"),
+            ("oat", "oa_t"),
+        ] {
+            fdd_input.push(input.to_string());
+            value.push(row.get(key).and_then(|v| v.as_f64()));
+        }
+    }
+    let n = ts.len();
+    let site: StringArray = std::iter::repeat("site:demo")
+        .take(n)
+        .collect::<Vec<_>>()
+        .into();
+    let building: StringArray = std::iter::repeat("building:main")
+        .take(n)
+        .collect::<Vec<_>>()
+        .into();
+    let equip_arr: StringArray = equipment.into();
+    let point: StringArray = std::iter::repeat("point:demo")
+        .take(n)
+        .collect::<Vec<_>>()
+        .into();
+    let fdd_arr: StringArray = fdd_input.into();
+    let val_arr: Float64Array = value.into();
+    let unit: StringArray = std::iter::repeat("degF").take(n).collect::<Vec<_>>().into();
+    let quality: StringArray = std::iter::repeat("good").take(n).collect::<Vec<_>>().into();
+    let source: StringArray = std::iter::repeat("simulated")
+        .take(n)
+        .collect::<Vec<_>>()
+        .into();
+    let driver: StringArray = std::iter::repeat("bacnet")
+        .take(n)
+        .collect::<Vec<_>>()
+        .into();
+    let device: StringArray = std::iter::repeat("5007").take(n).collect::<Vec<_>>().into();
+    let object: StringArray = std::iter::repeat("ai:1173")
+        .take(n)
+        .collect::<Vec<_>>()
+        .into();
+    let simulated = BooleanArray::from(vec![true; n]);
+    let ts_arr = TimestampMillisecondArray::from(ts);
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(ts_arr),
+            Arc::new(site),
+            Arc::new(building),
+            Arc::new(equip_arr),
+            Arc::new(point),
+            Arc::new(fdd_arr),
+            Arc::new(val_arr),
+            Arc::new(unit),
+            Arc::new(quality),
+            Arc::new(source),
+            Arc::new(driver),
+            Arc::new(device),
+            Arc::new(object),
+            Arc::new(simulated),
+        ],
+    )
+}
+
+fn build_pivot_batch() -> Result<RecordBatch, arrow::error::ArrowError> {
+    let rows: Vec<Value> = serde_json::from_str(arrow_table::demo_rows_json()).unwrap_or_default();
+    let schema = Schema::new(vec![
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
+        Field::new("equipment_id", DataType::Utf8, false),
+        Field::new("oa_t", DataType::Float64, true),
+        Field::new("oa_h", DataType::Float64, true),
+        Field::new("sat", DataType::Float64, true),
+        Field::new("duct_t", DataType::Float64, true),
+        Field::new("zn_t", DataType::Float64, true),
+        Field::new("sat_sp", DataType::Float64, true),
+        Field::new("fan_cmd", DataType::Float64, true),
+        Field::new("occ", DataType::Float64, true),
+    ]);
+    let mut ts = Vec::new();
+    let mut equip = Vec::new();
+    let mut sat = Vec::new();
+    let mut sat_sp = Vec::new();
+    let mut fan = Vec::new();
+    let mut oat = Vec::new();
+    for row in &rows {
+        ts.push(parse_ts_ms(
+            row.get("ts").and_then(|v| v.as_str()).unwrap_or(""),
+        ));
+        equip.push(
+            row.get("equip")
+                .and_then(|v| v.as_str())
+                .unwrap_or("AHU-1")
+                .to_string(),
+        );
+        sat.push(row.get("sat").and_then(|v| v.as_f64()));
+        sat_sp.push(row.get("sat_sp").and_then(|v| v.as_f64()));
+        fan.push(row.get("fan_cmd").and_then(|v| v.as_f64()));
+        oat.push(row.get("oat").and_then(|v| v.as_f64()));
+    }
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(TimestampMillisecondArray::from(ts)),
+            Arc::new(StringArray::from(equip)),
+            Arc::new(Float64Array::from(oat)),
+            Arc::new(Float64Array::from(vec![None; rows.len()])),
+            Arc::new(Float64Array::from(sat)),
+            Arc::new(Float64Array::from(vec![None; rows.len()])),
+            Arc::new(Float64Array::from(vec![None; rows.len()])),
+            Arc::new(Float64Array::from(sat_sp)),
+            Arc::new(Float64Array::from(fan)),
+            Arc::new(Float64Array::from(vec![Some(1.0); rows.len()])),
+        ],
+    )
+}
+
+fn parse_ts_ms(s: &str) -> i64 {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc).timestamp_millis())
+        .unwrap_or(0)
+}
+
+fn batch_to_json_rows(batch: &RecordBatch) -> Result<Vec<Value>, String> {
+    let mut out = Vec::new();
+    for row_idx in 0..batch.num_rows() {
+        let mut obj = serde_json::Map::new();
+        for (col_idx, field) in batch.schema().fields().iter().enumerate() {
+            let col = batch.column(col_idx);
+            let val = json_cell(col, row_idx, field.data_type());
+            obj.insert(field.name().clone(), val);
+        }
+        out.push(Value::Object(obj));
+    }
+    Ok(out)
+}
+
+fn json_cell(col: &Arc<dyn arrow::array::Array>, idx: usize, dtype: &DataType) -> Value {
+    if col.is_null(idx) {
+        return Value::Null;
+    }
+    match dtype {
+        DataType::Utf8 => {
+            let arr = col.as_any().downcast_ref::<StringArray>().unwrap();
+            json!(arr.value(idx))
+        }
+        DataType::Float64 => {
+            let arr = col.as_any().downcast_ref::<Float64Array>().unwrap();
+            json!(arr.value(idx))
+        }
+        DataType::Boolean => {
+            let arr = col.as_any().downcast_ref::<BooleanArray>().unwrap();
+            json!(arr.value(idx))
+        }
+        DataType::Timestamp(_, _) => {
+            let arr = col
+                .as_any()
+                .downcast_ref::<TimestampMillisecondArray>()
+                .unwrap();
+            let ms = arr.value(idx);
+            let dt = DateTime::<Utc>::from_timestamp_millis(ms).unwrap_or_else(Utc::now);
+            json!(dt.to_rfc3339())
+        }
+        _ => json!(null),
+    }
+}
+
+pub fn builder_to_sql(builder: &Value) -> String {
+    let input = builder
+        .get("input")
+        .and_then(|v| v.as_str())
+        .unwrap_or("oa_t");
+    let op = builder
+        .get("operator")
+        .and_then(|v| v.as_str())
+        .unwrap_or(">");
+    let value = builder
+        .get("value")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(100.0);
+    let equipment = builder
+        .get("equipment_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("AHU-1");
+    format!(
+        "SELECT timestamp, equipment_id, {input}, CASE WHEN {input} IS NULL THEN false WHEN {input} {op} {value} THEN true ELSE false END AS fault_raw FROM telemetry_pivot WHERE equipment_id = '{equipment}'"
+    )
+}

--- a/edge/src/fdd/execution.rs
+++ b/edge/src/fdd/execution.rs
@@ -201,19 +201,20 @@ fn build_telemetry_batch() -> Result<RecordBatch, arrow::error::ArrowError> {
     let mut value = Vec::new();
     for row in &rows {
         let t = row.get("ts").and_then(|v| v.as_str()).unwrap_or("");
-        ts.push(parse_ts_ms(t));
-        equipment.push(
-            row.get("equip")
-                .and_then(|v| v.as_str())
-                .unwrap_or("AHU-1")
-                .to_string(),
-        );
+        let ts_ms = parse_ts_ms(t);
+        let equip = row
+            .get("equip")
+            .and_then(|v| v.as_str())
+            .unwrap_or("AHU-1")
+            .to_string();
         for (input, key) in [
             ("sat", "sat"),
             ("sat_sp", "sat_sp"),
             ("fan_cmd", "fan_cmd"),
             ("oat", "oa_t"),
         ] {
+            ts.push(ts_ms);
+            equipment.push(equip.clone());
             fdd_input.push(input.to_string());
             value.push(row.get(key).and_then(|v| v.as_f64()));
         }

--- a/edge/src/fdd/mod.rs
+++ b/edge/src/fdd/mod.rs
@@ -1,6 +1,8 @@
-//! Fault detection layer.
-//!
-//! FDD in this Rust-only baseline is DataFusion SQL oriented. Driver data lands
-//! in Arrow-shaped historian tables, then rules are SQL over those tables.
+//! Fault detection layer — DataFusion SQL over Apache Arrow telemetry.
 
+pub mod confirmation;
 pub mod datafusion_sql;
+pub mod execution;
+pub mod rules;
+pub mod sql_safety;
+pub mod wires;

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -1,0 +1,173 @@
+//! DataFusion SQL rule model persistence and lifecycle.
+
+use crate::fdd::execution;
+use crate::fdd::sql_safety;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+pub fn rules_dir() -> PathBuf {
+    workspace_dir().join("data/fdd_wires/rules")
+}
+
+pub fn list_rules() -> Value {
+    ensure_dirs();
+    let mut rules = Vec::new();
+    if let Ok(entries) = fs::read_dir(rules_dir()) {
+        for entry in entries.flatten() {
+            if entry.path().extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if let Ok(text) = fs::read_to_string(entry.path()) {
+                if let Ok(rule) = serde_json::from_str::<Value>(&text) {
+                    rules.push(rule);
+                }
+            }
+        }
+    }
+    if rules.is_empty() {
+        rules.push(default_oa_rule());
+    }
+    json!({"ok": true, "rules": rules})
+}
+
+pub fn get_rule(rule_id: &str) -> Value {
+    let path = rules_dir().join(format!("{rule_id}.json"));
+    if let Ok(text) = fs::read_to_string(&path) {
+        if let Ok(rule) = serde_json::from_str::<Value>(&text) {
+            return json!({"ok": true, "rule": rule});
+        }
+    }
+    if rule_id == "oa_temp_out_of_range" {
+        return json!({"ok": true, "rule": default_oa_rule()});
+    }
+    json!({"ok": false, "error": "rule not found", "rule_id": rule_id})
+}
+
+pub fn save_rule(payload: &Value, actor: &str) -> Value {
+    ensure_dirs();
+    let rule_id = payload
+        .get("rule_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("rule-new");
+    let mut rule = payload.clone();
+    if rule.get("created_at").is_none() {
+        rule["created_at"] = json!(Utc::now().to_rfc3339());
+        rule["created_by"] = json!(actor);
+    }
+    rule["updated_at"] = json!(Utc::now().to_rfc3339());
+    rule["updated_by"] = json!(actor);
+    if rule.get("review_status").is_none() {
+        rule["review_status"] = json!("draft");
+    }
+    if rule.get("source").is_none() {
+        rule["source"] = json!("human_created");
+    }
+    let path = rules_dir().join(format!("{rule_id}.json"));
+    if let Err(err) = fs::write(
+        &path,
+        serde_json::to_string_pretty(&rule).unwrap_or_default(),
+    ) {
+        return json!({"ok": false, "error": err.to_string()});
+    }
+    json!({"ok": true, "saved": true, "rule_id": rule_id, "path": path.display().to_string(), "review_status": rule["review_status"]})
+}
+
+pub fn validate_rule_sql(payload: &Value) -> Value {
+    let sql = payload.get("sql").and_then(|v| v.as_str()).unwrap_or("");
+    let mut validation = sql_safety::validate_sql(sql);
+    if let Some(obj) = validation.as_object_mut() {
+        obj.insert(
+            "rule_id".into(),
+            payload.get("rule_id").cloned().unwrap_or(json!(null)),
+        );
+    }
+    validation
+}
+
+pub fn test_rule_sql(payload: &Value) -> Value {
+    let sql = payload.get("sql").and_then(|v| v.as_str()).unwrap_or("");
+    let confirmation = payload
+        .get("confirmation_seconds")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(300);
+    let params = payload.get("params").cloned().unwrap_or(json!({}));
+    execution::run_rule_sql(sql, confirmation, &params)
+}
+
+pub fn activate_rule(rule_id: &str, actor: &str, role: &str) -> Value {
+    if role != "integrator" {
+        return json!({"ok": false, "error": "integrator role required to activate rules", "role": role});
+    }
+    let mut rule = get_rule(rule_id);
+    if rule.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return rule;
+    }
+    let review = rule["rule"]["review_status"].as_str().unwrap_or("draft");
+    if review != "approved" && review != "active" {
+        return json!({
+            "ok": false,
+            "error": "rule must be approved before activation",
+            "review_status": review
+        });
+    }
+    let sql = rule["rule"]["sql"].as_str().unwrap_or("");
+    if !sql_safety::is_sql_safe(sql) {
+        return json!({"ok": false, "error": "unsafe SQL", "validation": sql_safety::validate_sql(sql)});
+    }
+    let mut updated = rule["rule"].clone();
+    updated["review_status"] = json!("active");
+    updated["updated_at"] = json!(Utc::now().to_rfc3339());
+    updated["updated_by"] = json!(actor);
+    let save = save_rule(&updated, actor);
+    json!({
+        "ok": true,
+        "activated": true,
+        "rule_id": rule_id,
+        "activated_by": actor,
+        "save": save
+    })
+}
+
+fn default_oa_rule() -> Value {
+    json!({
+        "rule_id": "oa_temp_out_of_range",
+        "name": "OA Temperature Out Of Range",
+        "description": "Outside air temperature below low limit or above high limit",
+        "equipment_types": ["ahu", "bench"],
+        "required_inputs": ["oa_t"],
+        "optional_inputs": [],
+        "sql": "SELECT timestamp, equipment_id, oa_t, CASE WHEN oa_t IS NULL THEN false WHEN oa_t < 40.0 THEN true WHEN oa_t > 110.0 THEN true ELSE false END AS fault_raw FROM telemetry_pivot WHERE equipment_id = 'AHU-1'",
+        "builder_config": {"input":"oa_t","operator":"range","low":40,"high":110},
+        "confirmation_seconds": 300,
+        "clear_behavior": "immediate",
+        "severity": "medium",
+        "output_fault_code": "OA_TEMP_OUT_OF_RANGE",
+        "source": "human_created",
+        "review_status": "approved",
+        "sql_mode": "builder"
+    })
+}
+
+fn workspace_dir() -> PathBuf {
+    env::var("OPENFDD_WORKSPACE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("workspace"))
+}
+
+fn ensure_dirs() {
+    let _ = fs::create_dir_all(rules_dir());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_cannot_activate() {
+        let out = activate_rule("oa_temp_out_of_range", "agent", "agent");
+        assert_eq!(out["ok"].as_bool(), Some(false));
+    }
+}

--- a/edge/src/fdd/sql_safety.rs
+++ b/edge/src/fdd/sql_safety.rs
@@ -1,0 +1,92 @@
+//! SQL safety validator for DataFusion rule execution.
+//!
+//! Blocks DDL/DML and restricts queries to read-only SELECT against allowed views.
+
+use serde_json::{json, Value};
+
+const BLOCKED: &[&str] = &[
+    "DROP", "DELETE", "INSERT", "UPDATE", "ALTER", "CREATE", "COPY", "ATTACH", "PRAGMA",
+    "TRUNCATE", "GRANT", "REVOKE", "EXEC", "EXECUTE", "CALL", "MERGE", "REPLACE",
+];
+
+const ALLOWED_TABLES: &[&str] = &["telemetry", "telemetry_pivot", "hvac"];
+
+pub fn validate_sql(sql: &str) -> Value {
+    let upper = normalize_for_scan(sql);
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    if !upper.contains("SELECT") {
+        errors.push("SQL must be a SELECT query".to_string());
+    }
+    for kw in BLOCKED {
+        if contains_keyword(&upper, kw) {
+            errors.push(format!("Blocked SQL operation: {kw}"));
+        }
+    }
+    if upper.contains(';') && upper.matches(';').count() > 1 {
+        warnings
+            .push("Multiple statements detected; only the first SELECT is executed".to_string());
+    }
+    let table_ok = ALLOWED_TABLES.iter().any(|t| {
+        let tu = t.to_uppercase();
+        upper.contains(&format!("FROM {tu}")) || upper.contains(&format!("JOIN {tu}"))
+    });
+    if !table_ok {
+        errors.push(format!(
+            "SQL must read from allowed tables/views: {}",
+            ALLOWED_TABLES.join(", ")
+        ));
+    }
+    if !upper.contains("FAULT_RAW") && !upper.contains(" AS FAULT_RAW") {
+        warnings.push(
+            "Missing fault_raw output alias; rules should expose fault_raw boolean".to_string(),
+        );
+    }
+    json!({
+        "ok": errors.is_empty(),
+        "safe": errors.is_empty(),
+        "errors": errors,
+        "warnings": warnings,
+        "allowed_tables": ALLOWED_TABLES,
+    })
+}
+
+pub fn is_sql_safe(sql: &str) -> bool {
+    validate_sql(sql)
+        .get("safe")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+fn normalize_for_scan(sql: &str) -> String {
+    sql.replace(['\n', '\r', '\t'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_uppercase()
+}
+
+fn contains_keyword(upper: &str, kw: &str) -> bool {
+    upper
+        .split(' ')
+        .any(|token| token == kw || token.starts_with(&format!("{kw}(")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_drop_delete() {
+        assert!(!is_sql_safe("DROP TABLE telemetry"));
+        assert!(!is_sql_safe("DELETE FROM telemetry_pivot"));
+        assert!(!is_sql_safe("INSERT INTO telemetry VALUES (1)"));
+    }
+
+    #[test]
+    fn allows_select_from_telemetry_pivot() {
+        let sql = "SELECT timestamp, equipment_id, oa_t, CASE WHEN oa_t > 100 THEN true ELSE false END AS fault_raw FROM telemetry_pivot WHERE equipment_id = 'AHU-1'";
+        assert!(is_sql_safe(sql));
+    }
+}

--- a/edge/src/fdd/wires/api.rs
+++ b/edge/src/fdd/wires/api.rs
@@ -1,0 +1,230 @@
+//! HTTP API handlers for FDD Wires and SQL rules.
+
+use super::assignments;
+use super::persistence;
+use super::validation;
+use crate::fdd::execution;
+use crate::fdd::rules;
+use chrono::Utc;
+use serde_json::{json, Value};
+
+pub fn list_graphs(site_id: Option<&str>) -> String {
+    let site = site_id
+        .map(String::from)
+        .unwrap_or_else(persistence::default_site_id);
+    persistence::seed_demo_graph(&site, "system");
+    serde_json::to_string(&persistence::list_graphs(&site)).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn get_graph(site_id: &str, graph_id: &str) -> String {
+    persistence::seed_demo_graph(site_id, "system");
+    match persistence::read_graph(site_id, graph_id) {
+        Some(graph) => serde_json::to_string(&json!({"ok": true, "graph": graph})).unwrap(),
+        None => serde_json::to_string(&json!({"ok": false, "error": "graph not found"})).unwrap(),
+    }
+}
+
+pub fn create_graph(payload: &Value, actor: &str) -> Value {
+    let site_id = payload
+        .get("site_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&persistence::default_site_id())
+        .to_string();
+    let graph_id = payload
+        .get("graph_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&format!("graph:{}", Utc::now().timestamp()))
+        .to_string();
+    let mut graph = if payload.get("nodes").is_some() {
+        payload.clone()
+    } else {
+        super::schema::empty_graph(&site_id, &graph_id, actor)
+    };
+    graph["graph_id"] = json!(graph_id);
+    graph["site_id"] = json!(site_id);
+    graph["updated_at"] = json!(Utc::now().to_rfc3339());
+    graph["updated_by"] = json!(actor);
+    if graph.get("review_status").is_none() {
+        graph["review_status"] = json!("draft");
+    }
+    match persistence::write_graph(&site_id, &graph) {
+        Ok(path) => json!({"ok": true, "graph": graph, "path": path.display().to_string()}),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn update_graph(site_id: &str, graph_id: &str, payload: &Value, actor: &str) -> Value {
+    let mut graph = persistence::read_graph(site_id, graph_id)
+        .unwrap_or_else(|| super::schema::empty_graph(site_id, graph_id, actor));
+    if let Some(nodes) = payload.get("nodes") {
+        graph["nodes"] = nodes.clone();
+    }
+    if let Some(edges) = payload.get("edges") {
+        graph["edges"] = edges.clone();
+    }
+    if let Some(review) = payload.get("review_status") {
+        graph["review_status"] = review.clone();
+    }
+    graph["updated_at"] = json!(Utc::now().to_rfc3339());
+    graph["updated_by"] = json!(actor);
+    if payload.get("source").and_then(|v| v.as_str()) == Some("ai_generated") {
+        graph["review_status"] = json!("needs_review");
+    }
+    match persistence::write_graph(site_id, &graph) {
+        Ok(path) => json!({"ok": true, "graph": graph, "path": path.display().to_string()}),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn validate_graph(site_id: &str, graph_id: &str) -> Value {
+    let graph = persistence::read_graph(site_id, graph_id);
+    match graph {
+        Some(g) => {
+            let result = validation::validate_graph(&g);
+            json!({"ok": result["ok"], "validation": result, "graph_id": graph_id})
+        }
+        None => json!({"ok": false, "error": "graph not found"}),
+    }
+}
+
+pub fn test_graph(site_id: &str, graph_id: &str) -> Value {
+    let graph = match persistence::read_graph(site_id, graph_id) {
+        Some(g) => g,
+        None => return json!({"ok": false, "error": "graph not found"}),
+    };
+    let validation = validation::validate_graph(&graph);
+    let sql_node = graph
+        .get("nodes")
+        .and_then(|n| n.as_array())
+        .and_then(|nodes| {
+            nodes
+                .iter()
+                .find(|n| n.get("type").and_then(|t| t.as_str()) == Some("sql_rule"))
+        });
+    let confirm_secs = graph
+        .get("nodes")
+        .and_then(|n| n.as_array())
+        .and_then(|nodes| {
+            nodes
+                .iter()
+                .find(|n| n.get("type").and_then(|t| t.as_str()) == Some("confirmation_timer"))
+        })
+        .and_then(|n| n.get("config"))
+        .and_then(|c| c.get("confirmation_seconds"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(300);
+    let sql = sql_node
+        .and_then(|n| n.get("config"))
+        .and_then(|c| c.get("sql"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(
+            "SELECT timestamp, equipment_id, oa_t, CASE WHEN oa_t IS NULL THEN false WHEN oa_t < 40.0 OR oa_t > 110.0 THEN true ELSE false END AS fault_raw FROM telemetry_pivot WHERE equipment_id = 'AHU-1'",
+        );
+    let exec = execution::run_rule_sql(sql, confirm_secs, &json!({}));
+    json!({
+        "ok": validation["ok"].as_bool().unwrap_or(false) && exec.get("ok").and_then(|v| v.as_bool()).unwrap_or(false),
+        "validation": validation,
+        "execution": exec,
+        "graph_id": graph_id,
+        "site_id": site_id
+    })
+}
+
+pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
+    if role != "integrator" {
+        return json!({"ok": false, "error": "integrator role required to approve graphs", "role": role});
+    }
+    let mut graph = match persistence::read_graph(site_id, graph_id) {
+        Some(g) => g,
+        None => return json!({"ok": false, "error": "graph not found"}),
+    };
+    let validation = validation::validate_graph(&graph);
+    if validation.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return json!({"ok": false, "error": "graph validation failed", "validation": validation});
+    }
+    graph["review_status"] = json!("approved");
+    graph["updated_at"] = json!(Utc::now().to_rfc3339());
+    graph["updated_by"] = json!(actor);
+    let _ = persistence::write_graph(site_id, &graph);
+    json!({"ok": true, "approved": true, "graph_id": graph_id, "approved_by": actor})
+}
+
+pub fn activate_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
+    if role != "integrator" {
+        return json!({"ok": false, "error": "integrator role required to activate graphs", "role": role});
+    }
+    let mut graph = match persistence::read_graph(site_id, graph_id) {
+        Some(g) => g,
+        None => return json!({"ok": false, "error": "graph not found"}),
+    };
+    let status = graph
+        .get("review_status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("draft");
+    if status != "approved" {
+        return json!({"ok": false, "error": "graph must be approved before activation", "review_status": status});
+    }
+    let validation = validation::validate_graph(&graph);
+    if validation.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return json!({"ok": false, "error": "graph validation failed", "validation": validation});
+    }
+    graph["review_status"] = json!("active");
+    graph["execution_status"] = json!("scheduled");
+    graph["updated_at"] = json!(Utc::now().to_rfc3339());
+    graph["updated_by"] = json!(actor);
+    let _ = persistence::write_graph(site_id, &graph);
+    json!({"ok": true, "activated": true, "graph_id": graph_id, "activated_by": actor})
+}
+
+pub fn propose_assignments(payload: &Value, role: &str) -> Value {
+    if !["integrator", "agent"].contains(&role) {
+        return json!({"ok": false, "error": "integrator or agent role required"});
+    }
+    assignments::propose_assignments(payload)
+}
+
+pub fn schema_tables_json() -> String {
+    serde_json::to_string(&execution::schema_tables_json()).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn schema_fdd_inputs_json() -> String {
+    serde_json::to_string(&execution::fdd_inputs_json()).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn schema_equipment_types_json() -> String {
+    serde_json::to_string(&execution::equipment_types_json()).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn list_rules_json() -> String {
+    serde_json::to_string(&rules::list_rules()).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn get_rule_json(rule_id: &str) -> String {
+    serde_json::to_string(&rules::get_rule(rule_id)).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn save_rule(payload: &Value, actor: &str) -> Value {
+    rules::save_rule(payload, actor)
+}
+
+pub fn validate_rule_sql(payload: &Value) -> Value {
+    rules::validate_rule_sql(payload)
+}
+
+pub fn test_rule_sql(payload: &Value) -> Value {
+    rules::test_rule_sql(payload)
+}
+
+pub fn activate_rule(rule_id: &str, actor: &str, role: &str) -> Value {
+    rules::activate_rule(rule_id, actor, role)
+}
+
+pub fn builder_sql(payload: &Value) -> Value {
+    let sql = execution::builder_to_sql(payload);
+    json!({
+        "ok": true,
+        "sql": sql,
+        "sql_mode": "builder",
+        "validation": crate::fdd::sql_safety::validate_sql(&sql)
+    })
+}

--- a/edge/src/fdd/wires/assignments.rs
+++ b/edge/src/fdd/wires/assignments.rs
@@ -1,0 +1,150 @@
+//! Deterministic model-to-rule assignment proposal engine.
+
+use serde_json::{json, Value};
+
+const AHU_MAPPINGS: &[(&str, &str, &str, f64)] = &[
+    ("Outside Air Temp", "oa_t", "point:oa-t", 0.95),
+    ("Supply Air Temp", "sat", "point:sat", 0.93),
+    ("Discharge Air Temp", "duct_t", "point:duct-t", 0.90),
+    ("Zone Temp", "zn_t", "point:zn-t", 0.88),
+    ("Outside Air Humidity", "oa_h", "point:oa-h", 0.86),
+    ("SAT Setpoint", "sat_sp", "point:sat-sp", 0.92),
+    ("Fan Command", "fan_cmd", "point:fan-cmd", 0.94),
+];
+
+pub fn propose_assignments(payload: &Value) -> Value {
+    let site_id = payload
+        .get("site_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("site:demo");
+    let equipment_type = payload
+        .get("equipment_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("ahu");
+
+    let driver_points = collect_driver_points(payload);
+    let mut proposals = Vec::new();
+    let mut missing = Vec::new();
+    let mut ambiguous = Vec::new();
+
+    for (label, fdd_input, haystack_id, confidence) in AHU_MAPPINGS {
+        let matches: Vec<&Value> = driver_points
+            .iter()
+            .filter(|p| point_matches(p, label, fdd_input))
+            .collect();
+        if matches.is_empty() {
+            missing.push(
+                json!({"fdd_input": fdd_input, "label": label, "expected_haystack": haystack_id}),
+            );
+            continue;
+        }
+        if matches.len() > 1 {
+            ambiguous.push(json!({
+                "fdd_input": fdd_input,
+                "candidates": matches.len(),
+                "note": "multiple driver points match; human review required"
+            }));
+        }
+        let chosen = matches[0];
+        proposals.push(json!({
+            "fdd_input": fdd_input,
+            "label": label,
+            "haystack_id": haystack_id,
+            "driver_ref": chosen.get("ref").or_else(|| chosen.get("id")).cloned().unwrap_or(json!(null)),
+            "confidence": confidence,
+            "explanation": format!("Mapped {label} to FDD input {fdd_input} via name/tag similarity"),
+            "source": "ai_generated",
+            "review_status": "ai_suggested"
+        }));
+    }
+
+    let rule_bindings = vec![json!({
+        "rule_id": "oa_temp_out_of_range",
+        "name": "OA Temperature Out Of Range",
+        "required_inputs": ["oa_t"],
+        "confidence": 0.91,
+        "source": "ai_generated",
+        "review_status": "ai_suggested"
+    })];
+
+    json!({
+        "ok": true,
+        "site_id": site_id,
+        "equipment_type": equipment_type,
+        "source": "ai_generated",
+        "review_status": "needs_review",
+        "proposals": proposals,
+        "rule_bindings": rule_bindings,
+        "missing_points": missing,
+        "ambiguous_points": ambiguous,
+        "validation_warnings": if ambiguous.is_empty() { json!([]) } else { json!(["ambiguous driver point matches require human review"]) },
+        "note": "AI suggestions are draft-only until integrator approval"
+    })
+}
+
+fn collect_driver_points(payload: &Value) -> Vec<Value> {
+    if let Some(points) = payload.get("driver_points").and_then(|v| v.as_array()) {
+        return points.clone();
+    }
+    if let Some(drivers) = payload.get("drivers").and_then(|v| v.as_array()) {
+        let mut out = Vec::new();
+        for driver in drivers {
+            if let Some(devices) = driver.get("devices").and_then(|v| v.as_array()) {
+                for device in devices {
+                    if let Some(points) = device.get("points").and_then(|v| v.as_array()) {
+                        for point in points {
+                            let mut p = point.clone();
+                            if p.get("ref").is_none() {
+                                p["ref"] = point.get("id").cloned().unwrap_or(json!(null));
+                            }
+                            out.push(p);
+                        }
+                    }
+                }
+            }
+        }
+        return out;
+    }
+    demo_driver_points()
+}
+
+fn point_matches(point: &Value, label: &str, fdd_input: &str) -> bool {
+    let name = point.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let haystack = point
+        .get("haystack_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let input = point
+        .get("fdd_input")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    name.to_ascii_lowercase()
+        .contains(&label.to_ascii_lowercase())
+        || haystack.contains(fdd_input)
+        || input == fdd_input
+        || (fdd_input == "oa_t" && (name.contains("OA") || name.contains("Outside Air")))
+        || (fdd_input == "sat" && name.contains("SAT"))
+        || (fdd_input == "fan_cmd" && name.to_ascii_lowercase().contains("fan"))
+}
+
+fn demo_driver_points() -> Vec<Value> {
+    vec![
+        json!({"id":"bacnet:5007:analog-input:1173","name":"Outside Air Temp","haystack_id":"point:oa-t","fdd_input":"oa_t","source_label":"simulated"}),
+        json!({"id":"bacnet:5007:analog-input:1174","name":"Supply Air Temp","haystack_id":"point:sat","fdd_input":"sat","source_label":"simulated"}),
+        json!({"id":"bacnet:5007:analog-value:1175","name":"SAT Setpoint","haystack_id":"point:sat-sp","fdd_input":"sat_sp","source_label":"simulated"}),
+        json!({"id":"bacnet:5007:binary-output:1176","name":"Fan Command","haystack_id":"point:fan-cmd","fdd_input":"fan_cmd","source_label":"simulated"}),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposes_oa_t_assignment() {
+        let out = propose_assignments(&json!({"equipment_type":"ahu"}));
+        let proposals = out["proposals"].as_array().unwrap();
+        assert!(proposals.iter().any(|p| p["fdd_input"] == "oa_t"));
+        assert_eq!(out["review_status"], "needs_review");
+    }
+}

--- a/edge/src/fdd/wires/mod.rs
+++ b/edge/src/fdd/wires/mod.rs
@@ -1,0 +1,5 @@
+pub mod api;
+pub mod assignments;
+pub mod persistence;
+pub mod schema;
+pub mod validation;

--- a/edge/src/fdd/wires/persistence.rs
+++ b/edge/src/fdd/wires/persistence.rs
@@ -1,0 +1,139 @@
+//! JSON persistence for FDD Wires graphs and assignments.
+
+use super::schema;
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn workspace_dir() -> PathBuf {
+    env::var("OPENFDD_WORKSPACE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("workspace"))
+}
+
+pub fn wires_root() -> PathBuf {
+    workspace_dir().join("data/fdd_wires")
+}
+
+pub fn graphs_dir(site_id: &str) -> PathBuf {
+    wires_root().join("graphs").join(site_id)
+}
+
+pub fn graph_path(site_id: &str, graph_id: &str) -> PathBuf {
+    graphs_dir(site_id).join(format!("{graph_id}.json"))
+}
+
+pub fn assignments_path(site_id: &str) -> PathBuf {
+    wires_root()
+        .join("assignments")
+        .join(format!("{site_id}.json"))
+}
+
+pub fn ensure_layout(site_id: &str) {
+    let _ = fs::create_dir_all(graphs_dir(site_id));
+    let _ = fs::create_dir_all(wires_root().join("assignments"));
+    let _ = fs::create_dir_all(wires_root().join("rules"));
+}
+
+pub fn list_graphs(site_id: &str) -> Value {
+    ensure_layout(site_id);
+    let mut graphs = Vec::new();
+    let dir = graphs_dir(site_id);
+    if let Ok(entries) = fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            if let Ok(text) = fs::read_to_string(entry.path()) {
+                if let Ok(g) = serde_json::from_str::<Value>(&text) {
+                    graphs.push(json!({
+                        "graph_id": g.get("graph_id"),
+                        "site_id": g.get("site_id"),
+                        "review_status": g.get("review_status"),
+                        "updated_at": g.get("updated_at"),
+                        "node_count": g.get("nodes").and_then(|n| n.as_array()).map(|a| a.len()).unwrap_or(0),
+                    }));
+                }
+            }
+        }
+    }
+    json!({"ok": true, "site_id": site_id, "graphs": graphs})
+}
+
+pub fn read_graph(site_id: &str, graph_id: &str) -> Option<Value> {
+    read_json_file(&graph_path(site_id, graph_id))
+}
+
+pub fn write_graph(site_id: &str, graph: &Value) -> Result<PathBuf, String> {
+    ensure_layout(site_id);
+    let graph_id = graph
+        .get("graph_id")
+        .and_then(|v| v.as_str())
+        .ok_or("graph_id required")?;
+    let path = graph_path(site_id, graph_id);
+    write_json_file(&path, graph)
+}
+
+pub fn read_assignments(site_id: &str) -> Value {
+    ensure_layout(site_id);
+    read_json_file(&assignments_path(site_id)).unwrap_or_else(|| {
+        json!({
+            "ok": true,
+            "site_id": site_id,
+            "assignments": [],
+            "review_status": "draft"
+        })
+    })
+}
+
+pub fn write_assignments(site_id: &str, doc: &Value) -> Result<PathBuf, String> {
+    ensure_layout(site_id);
+    write_json_file(&assignments_path(site_id), doc)
+}
+
+pub fn default_site_id() -> String {
+    env::var("OPENFDD_SITE_ID").unwrap_or_else(|_| "site:demo".to_string())
+}
+
+fn read_json_file(path: &Path) -> Option<Value> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|t| serde_json::from_str(&t).ok())
+}
+
+fn write_json_file(path: &Path, value: &Value) -> Result<PathBuf, String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    fs::write(
+        path,
+        serde_json::to_string_pretty(value).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(path.to_path_buf())
+}
+
+pub fn seed_demo_graph(site_id: &str, actor: &str) -> Value {
+    let graph_id = "graph:bench-5007-fdd";
+    if read_graph(site_id, graph_id).is_some() {
+        return read_graph(site_id, graph_id).unwrap();
+    }
+    let mut graph = schema::empty_graph(site_id, graph_id, actor);
+    graph["review_status"] = json!("needs_review");
+    graph["source"] = json!("ai_generated");
+    graph["nodes"] = json!([
+        {"id":"n-driver-oa","type":"driver_point","label":"BACnet OA-T","position":{"x":40,"y":80},"config":{"ref":"bacnet:5007:analog-input:1173","source_label":"simulated"},"source":"ai_generated","provenance":{"confidence":0.92},"validation":{"status":"ok"}},
+        {"id":"n-model-oa","type":"model_point","label":"point:oa-t","position":{"x":220,"y":80},"config":{"haystack_id":"point:oa-t"},"source":"ai_generated","validation":{"status":"ok"}},
+        {"id":"n-fdd-input","type":"fdd_input","label":"oa_t","position":{"x":400,"y":80},"config":{"fdd_input":"oa_t","unit":"degF"},"source":"ai_generated","validation":{"status":"ok"}},
+        {"id":"n-sql-rule","type":"sql_rule","label":"OA Temperature Out Of Range","position":{"x":580,"y":80},"config":{"rule_id":"oa_temp_out_of_range","sql_mode":"builder"},"source":"ai_generated","validation":{"status":"ok"}},
+        {"id":"n-confirm","type":"confirmation_timer","label":"5 min confirmation","position":{"x":760,"y":80},"config":{"confirmation_seconds":300},"source":"human_created","validation":{"status":"ok"}},
+        {"id":"n-fault","type":"fault_output","label":"OA_TEMP_OUT_OF_RANGE","position":{"x":940,"y":80},"config":{"fault_code":"OA_TEMP_OUT_OF_RANGE","severity":"medium"},"source":"human_created","validation":{"status":"ok"}}
+    ]);
+    graph["edges"] = json!([
+        {"id":"e1","type":"maps_to","from":"n-driver-oa","to":"n-model-oa"},
+        {"id":"e2","type":"feeds","from":"n-model-oa","to":"n-fdd-input"},
+        {"id":"e3","type":"rule_input","from":"n-fdd-input","to":"n-sql-rule"},
+        {"id":"e4","type":"confirms","from":"n-sql-rule","to":"n-confirm"},
+        {"id":"e5","type":"rule_output","from":"n-confirm","to":"n-fault"}
+    ]);
+    let _ = write_graph(site_id, &graph);
+    graph
+}

--- a/edge/src/fdd/wires/schema.rs
+++ b/edge/src/fdd/wires/schema.rs
@@ -1,0 +1,66 @@
+//! Versioned FDD Wires graph schema constants.
+
+pub const SCHEMA_VERSION: &str = "1.0.0";
+
+pub const NODE_TYPES: &[&str] = &[
+    "model_site",
+    "model_equipment",
+    "model_point",
+    "driver_point",
+    "fdd_input",
+    "unit_conversion",
+    "quality_check",
+    "sql_rule",
+    "confirmation_timer",
+    "fault_output",
+    "recommendation",
+    "report_section",
+    "comment",
+    "group",
+];
+
+pub const EDGE_TYPES: &[&str] = &[
+    "maps_to",
+    "feeds",
+    "converts_to",
+    "validates",
+    "assigned_to",
+    "rule_input",
+    "rule_output",
+    "confirms",
+    "reports_to",
+];
+
+pub const REVIEW_STATUSES: &[&str] = &[
+    "draft",
+    "needs_review",
+    "approved",
+    "rejected",
+    "active",
+    "ai_suggested",
+    "human_modified",
+    "disabled",
+];
+
+pub fn empty_graph(site_id: &str, graph_id: &str, actor: &str) -> serde_json::Value {
+    let now = chrono::Utc::now().to_rfc3339();
+    serde_json::json!({
+        "schema_version": SCHEMA_VERSION,
+        "graph_id": graph_id,
+        "site_id": site_id,
+        "building_id": format!("building:{site_id}"),
+        "created_at": now,
+        "updated_at": now,
+        "created_by": actor,
+        "updated_by": actor,
+        "source": "human_created",
+        "review_status": "draft",
+        "nodes": [],
+        "edges": [],
+        "validation_errors": [],
+        "validation_warnings": [],
+        "execution_status": "idle",
+        "last_test_result": null,
+        "provenance": {"product": "Open-FDD FDD Wires", "inspiration_note": "Internal dev notes only — flow/wiresheet UX patterns"}
+    })
+}

--- a/edge/src/fdd/wires/validation.rs
+++ b/edge/src/fdd/wires/validation.rs
@@ -1,0 +1,165 @@
+//! Graph and assignment validation for FDD Wires workspace.
+
+use super::schema::{EDGE_TYPES, NODE_TYPES};
+use crate::fdd::sql_safety;
+use serde_json::{json, Value};
+
+pub fn validate_graph(graph: &Value) -> Value {
+    let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    if graph.get("schema_version").is_none() {
+        errors.push("missing schema_version".into());
+    }
+    let nodes = graph.get("nodes").and_then(|v| v.as_array());
+    let edges = graph.get("edges").and_then(|v| v.as_array());
+    if nodes.is_none() {
+        errors.push("nodes array required".into());
+    }
+    if edges.is_none() {
+        errors.push("edges array required".into());
+    }
+
+    let node_ids: Vec<String> = nodes
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|n| {
+            let id = n.get("id")?.as_str()?.to_string();
+            let ty = n.get("type")?.as_str()?;
+            if !NODE_TYPES.contains(&ty) {
+                errors.push(format!("unknown node type: {ty}"));
+            }
+            if n.get("source").and_then(|s| s.as_str()) == Some("ai_generated")
+                && graph.get("review_status").and_then(|s| s.as_str()) == Some("active")
+            {
+                errors.push("AI-generated graph cannot be active without human approval".into());
+            }
+            if let Some(label) = n
+                .get("config")
+                .and_then(|c| c.get("source_label"))
+                .and_then(|v| v.as_str())
+            {
+                if label == "simulated"
+                    && graph.get("review_status").and_then(|s| s.as_str()) == Some("active")
+                {
+                    warnings.push(format!(
+                        "node {id} uses simulated source in active graph — confirm explicitly"
+                    ));
+                }
+            }
+            Some(id)
+        })
+        .collect();
+
+    for edge in edges.cloned().unwrap_or_default() {
+        let ty = edge.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if !EDGE_TYPES.contains(&ty) {
+            errors.push(format!("unknown edge type: {ty}"));
+        }
+        let from = edge.get("from").and_then(|v| v.as_str()).unwrap_or("");
+        let to = edge.get("to").and_then(|v| v.as_str()).unwrap_or("");
+        if !node_ids.contains(&from.to_string()) {
+            errors.push(format!("edge from missing node: {from}"));
+        }
+        if !node_ids.contains(&to.to_string()) {
+            errors.push(format!("edge to missing node: {to}"));
+        }
+    }
+
+    let node_list = nodes.cloned().unwrap_or_default();
+    let sql_nodes: Vec<Value> = node_list
+        .iter()
+        .filter(|n| n.get("type").and_then(|t| t.as_str()) == Some("sql_rule"))
+        .cloned()
+        .collect();
+    for node in &sql_nodes {
+        let sql = node
+            .get("config")
+            .and_then(|c| c.get("sql"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if !sql.is_empty() && !sql_safety::is_sql_safe(sql) {
+            errors.push(format!(
+                "unsafe SQL on node {}",
+                node.get("id").and_then(|v| v.as_str()).unwrap_or("?")
+            ));
+        }
+    }
+
+    let has_confirm = node_list
+        .iter()
+        .any(|n| n.get("type").and_then(|t| t.as_str()) == Some("confirmation_timer"));
+    if !sql_nodes.is_empty() && !has_confirm {
+        warnings.push("SQL rule nodes present without confirmation timer".into());
+    }
+
+    let fault_codes: Vec<String> = nodes
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter(|n| n.get("type").and_then(|t| t.as_str()) == Some("fault_output"))
+        .filter_map(|n| {
+            n.get("config")
+                .and_then(|c| c.get("fault_code"))
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        })
+        .collect();
+    let mut seen = std::collections::HashSet::new();
+    for code in fault_codes {
+        if !seen.insert(code.clone()) {
+            warnings.push(format!("duplicate fault code on graph: {code}"));
+        }
+    }
+
+    json!({
+        "ok": errors.is_empty(),
+        "errors": errors,
+        "warnings": warnings,
+        "node_count": node_ids.len(),
+        "edge_count": edges.as_ref().map(|e| e.len()).unwrap_or(0)
+    })
+}
+
+pub fn validate_rule_object(rule: &Value) -> Value {
+    let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+    let sql = rule.get("sql").and_then(|v| v.as_str()).unwrap_or("");
+    if sql.is_empty() {
+        errors.push("sql required".into());
+    } else {
+        let safety = sql_safety::validate_sql(sql);
+        if safety.get("safe").and_then(|v| v.as_bool()) != Some(true) {
+            errors.push("unsafe or invalid SQL".into());
+        }
+        if let Some(w) = safety.get("warnings").and_then(|v| v.as_array()) {
+            for item in w {
+                warnings.push(item.as_str().unwrap_or("").to_string());
+            }
+        }
+    }
+    if rule.get("confirmation_seconds").is_none() {
+        warnings.push("confirmation_seconds not set".into());
+    }
+    if rule.get("output_fault_code").is_none() {
+        errors.push("output_fault_code required".into());
+    }
+    json!({"ok": errors.is_empty(), "errors": errors, "warnings": warnings})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fdd::wires::persistence;
+
+    #[test]
+    fn ai_graph_cannot_activate_without_approval() {
+        let site = "site:test";
+        let mut graph = persistence::seed_demo_graph(site, "tester");
+        graph["review_status"] = json!("active");
+        graph["source"] = json!("ai_generated");
+        let out = validate_graph(&graph);
+        assert_eq!(out["ok"].as_bool(), Some(false));
+    }
+}

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -212,6 +212,45 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             serde_json::from_str::<Value>(fdd::datafusion_sql::batch_json()).unwrap(),
         ),
+
+        ("GET", "/api/fdd-schema/tables") => {
+            raw_json(&mut stream, &fdd::wires::api::schema_tables_json())
+        }
+        ("GET", "/api/fdd-schema/fdd-inputs") => {
+            raw_json(&mut stream, &fdd::wires::api::schema_fdd_inputs_json())
+        }
+        ("GET", "/api/fdd-schema/equipment-types") => {
+            raw_json(&mut stream, &fdd::wires::api::schema_equipment_types_json())
+        }
+        ("GET", "/api/fdd-rules") => raw_json(&mut stream, &fdd::wires::api::list_rules_json()),
+        ("POST", "/api/fdd-rules") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator"],
+            fdd::wires::api::save_rule(&parse_json_body(&body), &principal.sub),
+        ),
+        ("POST", "/api/fdd-rules/builder-sql") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            fdd::wires::api::builder_sql(&parse_json_body(&body)),
+        ),
+        ("GET", "/api/fdd-wires/graphs") => raw_json(
+            &mut stream,
+            &fdd::wires::api::list_graphs(query_param(&path, "site_id").as_deref()),
+        ),
+        ("POST", "/api/fdd-wires/graphs") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator"],
+            fdd::wires::api::create_graph(&parse_json_body(&body), &principal.sub),
+        ),
+        ("POST", "/api/fdd-wires/propose-assignments") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            fdd::wires::api::propose_assignments(&parse_json_body(&body), &principal.role),
+        ),
         ("GET", "/api/arrow/demo") => {
             raw_json(&mut stream, historian::arrow_table::demo_rows_json())
         }
@@ -380,11 +419,157 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             json!({"ok": true, "report_id": "rcx-demo-001", "path": "workspace/reports/rcx/rcx-demo-001.md", "sections": ["faults", "overrides", "plotly_trends", "recommendations"]}),
         ),
-        _ => status_json(
-            &mut stream,
-            "404 Not Found",
-            json!({"ok": false, "error": "unknown endpoint", "path": clean_path}),
-        ),
+        _ => {
+            if let Some(resp) = handle_fdd_wires_dynamic(
+                &mut stream,
+                &principal,
+                method.as_str(),
+                &clean_path,
+                &body,
+            ) {
+                resp
+            } else {
+                status_json(
+                    &mut stream,
+                    "404 Not Found",
+                    json!({"ok": false, "error": "unknown endpoint", "path": clean_path}),
+                )
+            }
+        }
+    }
+}
+
+fn parse_json_body(body: &str) -> Value {
+    serde_json::from_str(body).unwrap_or(json!({}))
+}
+
+fn query_param(path: &str, key: &str) -> Option<String> {
+    path.split('?').nth(1).and_then(|qs| {
+        qs.split('&').find_map(|pair| {
+            let mut parts = pair.splitn(2, '=');
+            if parts.next()? == key {
+                Some(parts.next()?.to_string())
+            } else {
+                None
+            }
+        })
+    })
+}
+
+fn path_parts(path: &str) -> Vec<&str> {
+    path.trim_matches('/').split('/').collect()
+}
+
+fn handle_fdd_wires_dynamic(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Option<std::io::Result<()>> {
+    let parts = path_parts(path);
+    if parts.len() < 3 || parts[0] != "api" {
+        return None;
+    }
+
+    match (method, parts.as_slice()) {
+        ("GET", ["api", "fdd-rules", rule_id]) => {
+            Some(raw_json(stream, &fdd::wires::api::get_rule_json(rule_id)))
+        }
+        ("PUT", ["api", "fdd-rules", rule_id]) => {
+            let mut payload = parse_json_body(body);
+            payload["rule_id"] = json!(rule_id);
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator"],
+                fdd::wires::api::save_rule(&payload, &principal.sub),
+            ))
+        }
+        ("POST", ["api", "fdd-rules", rule_id, "validate-sql"]) => {
+            let mut payload = parse_json_body(body);
+            payload["rule_id"] = json!(rule_id);
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent"],
+                fdd::wires::api::validate_rule_sql(&payload),
+            ))
+        }
+        ("POST", ["api", "fdd-rules", rule_id, "test-sql"]) => {
+            let mut payload = parse_json_body(body);
+            payload["rule_id"] = json!(rule_id);
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent"],
+                fdd::wires::api::test_rule_sql(&payload),
+            ))
+        }
+        ("POST", ["api", "fdd-rules", rule_id, "activate"]) => Some(require_role(
+            stream,
+            principal,
+            &["integrator"],
+            fdd::wires::api::activate_rule(rule_id, &principal.sub, &principal.role),
+        )),
+        ("GET", ["api", "fdd-wires", "graphs", graph_id]) => {
+            let site = query_param(path, "site_id").unwrap_or_else(|| "site:demo".to_string());
+            Some(raw_json(
+                stream,
+                &fdd::wires::api::get_graph(&site, graph_id),
+            ))
+        }
+        ("PUT", ["api", "fdd-wires", "graphs", graph_id]) => {
+            let site = query_param(path, "site_id").unwrap_or_else(|| "site:demo".to_string());
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator"],
+                fdd::wires::api::update_graph(
+                    &site,
+                    graph_id,
+                    &parse_json_body(body),
+                    &principal.sub,
+                ),
+            ))
+        }
+        ("POST", ["api", "fdd-wires", "graphs", graph_id, "validate"]) => {
+            let site = query_param(path, "site_id").unwrap_or_else(|| "site:demo".to_string());
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent"],
+                fdd::wires::api::validate_graph(&site, graph_id),
+            ))
+        }
+        ("POST", ["api", "fdd-wires", "graphs", graph_id, "test"]) => {
+            let site = query_param(path, "site_id").unwrap_or_else(|| "site:demo".to_string());
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent"],
+                fdd::wires::api::test_graph(&site, graph_id),
+            ))
+        }
+        ("POST", ["api", "fdd-wires", "graphs", graph_id, "approve"]) => {
+            let site = query_param(path, "site_id").unwrap_or_else(|| "site:demo".to_string());
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator"],
+                fdd::wires::api::approve_graph(&site, graph_id, &principal.sub, &principal.role),
+            ))
+        }
+        ("POST", ["api", "fdd-wires", "graphs", graph_id, "activate"]) => {
+            let site = query_param(path, "site_id").unwrap_or_else(|| "site:demo".to_string());
+            Some(require_role(
+                stream,
+                principal,
+                &["integrator"],
+                fdd::wires::api::activate_graph(&site, graph_id, &principal.sub, &principal.role),
+            ))
+        }
+        _ => None,
     }
 }
 
@@ -520,6 +705,10 @@ fn agent_tools() -> Value {
             {"name":"control.cdl_bindings_save","method":"POST","path":"/api/control/cdl/bindings/save","requires":"integrator|agent"},
             {"name":"algorithms.run","method":"POST","path":"/api/algorithms/run","requires":"integrator|agent"},
             {"name":"fdd.run","method":"POST","path":"/api/fdd/run","requires":"integrator|agent"},
+            {"name":"fdd.wires.graphs","method":"GET","path":"/api/fdd-wires/graphs","requires":"JWT"},
+            {"name":"fdd.wires.propose","method":"POST","path":"/api/fdd-wires/propose-assignments","requires":"integrator|agent"},
+            {"name":"fdd.rules.list","method":"GET","path":"/api/fdd-rules","requires":"JWT"},
+            {"name":"fdd.rules.activate","method":"POST","path":"/api/fdd-rules/{id}/activate","requires":"integrator"},
             {"name":"rules.batch","method":"POST","path":"/api/rules/batch","requires":"integrator|agent"},
             {"name":"historian.query","method":"POST","path":"/api/historian/query","requires":"JWT"},
             {"name":"reports.rcx_plan","method":"POST","path":"/api/reports/rcx/plan","requires":"JWT"},
@@ -624,7 +813,7 @@ fn status_json(stream: &mut TcpStream, status: &str, value: Value) -> std::io::R
 fn options(stream: &mut TcpStream) -> std::io::Result<()> {
     let origin = cors_origin();
     let headers = format!(
-        "HTTP/1.1 204 No Content\r\n{origin}Access-Control-Allow-Methods: GET,POST,OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization\r\nContent-Length: 0\r\n\r\n"
+        "HTTP/1.1 204 No Content\r\n{origin}Access-Control-Allow-Methods: GET,POST,PUT,OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization\r\nContent-Length: 0\r\n\r\n"
     );
     stream.write_all(headers.as_bytes())
 }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -81,11 +81,18 @@ const api = {
     }
     if (!r.ok) throw new Error(`${path} ${r.status}`);
     return r.json();
+  },
+  async put(path, body = {}) {
+    const r = await fetch(path, { method: "PUT", headers: this.headers(), body: JSON.stringify(body) });
+    if (!r.ok) throw new Error(`${path} ${r.status}`);
+    return r.json();
   }
 };
 
 const TABS = [
   ["dashboard", "Dashboard"],
+  ["fdd-wires", "FDD Wires"],
+  ["rules", "SQL Rules"],
   ["fdd", "SQL FDD"],
   ["plots", "Plots"],
   ["haystack", "Haystack"],
@@ -431,6 +438,8 @@ function App() {
 
   let body = null;
   if (tab === "dashboard") body = React.createElement(Dashboard, { health: state.health, overrides: state.overrides, tree: state.tree });
+  if (tab === "fdd-wires" && window.OpenFddFddWires) body = React.createElement(window.OpenFddFddWires.FddWiresWorkspace, { apiClient: api, driverTree: state.tree, onRefresh: load });
+  if (tab === "rules" && window.OpenFddFddWires) body = React.createElement(window.OpenFddFddWires.SqlRuleBuilder, { apiClient: api });
   if (tab === "fdd") body = React.createElement(SqlFdd, { fdd: state.fdd });
   if (tab === "plots") body = React.createElement(Plots, { rows: state.rows, fdd: state.fdd });
   if (tab === "haystack") body = React.createElement(Haystack, { model: state.model });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,6 +1,6 @@
 
 // Open-FDD Rust Edge UI - REAL DEAL BACNET CSV BUILD
-// Niagara-style driver tree + focused tabs.
+// Open-FDD driver tree + focused tabs.
 // Legacy tabs are removed. FDD is DataFusion SQL. Data model is Haystack + assignment graph.
 
 const { useEffect, useMemo, useState } = React;

--- a/frontend/fdd-wires.js
+++ b/frontend/fdd-wires.js
@@ -1,0 +1,319 @@
+// Open-FDD FDD Wires — Rule Assignment Workspace + SQL Rule Builder
+// Open-FDD-native naming only (no third-party product branding in UI).
+
+(function (global) {
+  const { useEffect, useMemo, useRef, useState } = React;
+
+  const NODE_PALETTE = [
+    { group: "Model", items: ["model_site", "model_equipment", "model_point"] },
+    { group: "Drivers", items: ["driver_point"] },
+    { group: "FDD", items: ["fdd_input", "unit_conversion", "quality_check", "sql_rule", "confirmation_timer", "fault_output"] },
+    { group: "Reporting", items: ["recommendation", "report_section"] },
+    { group: "Utility", items: ["comment", "group"] }
+  ];
+
+  const BADGE_CLASS = {
+    simulated: "badge-sim",
+    fixture: "badge-fix",
+    real: "badge-real",
+    ai_suggested: "badge-ai",
+    approved: "badge-ok",
+    active: "badge-ok",
+    failing: "badge-bad"
+  };
+
+  function badge(label, kind) {
+    return React.createElement("span", { className: cx("badge", BADGE_CLASS[kind] || "") }, label);
+  }
+
+  function cx(...parts) { return parts.filter(Boolean).join(" "); }
+
+  function ContextMenu({ x, y, items, onClose }) {
+    useEffect(() => {
+      function close() { onClose(); }
+      window.addEventListener("click", close);
+      return () => window.removeEventListener("click", close);
+    }, [onClose]);
+    return React.createElement("div", { className: "ctx-menu", style: { top: y, left: x }, onClick: e => e.stopPropagation() },
+      items.map((item, i) => React.createElement("button", {
+        key: i,
+        className: "ctx-item",
+        onClick: () => { item.action(); onClose(); }
+      }, item.label))
+    );
+  }
+
+  function SqlRuleBuilder({ apiClient }) {
+    const [mode, setMode] = useState("builder");
+    const [builder, setBuilder] = useState({ name: "OA Temperature Out Of Range", input: "oa_t", operator: ">", value: 110, equipment_id: "AHU-1", confirmation_seconds: 300, severity: "medium", fault_code: "OA_TEMP_OUT_OF_RANGE" });
+    const [sql, setSql] = useState("");
+    const [rawCustom, setRawCustom] = useState(false);
+    const [result, setResult] = useState(null);
+    const [validation, setValidation] = useState(null);
+    const [schema, setSchema] = useState({ tables: [], fdd_inputs: [] });
+
+    useEffect(() => {
+      Promise.all([
+        apiClient.get("/api/fdd-schema/tables"),
+        apiClient.get("/api/fdd-schema/fdd-inputs")
+      ]).then(([t, f]) => setSchema({ tables: t.tables || [], fdd_inputs: f.fdd_inputs || [] })).catch(() => {});
+    }, []);
+
+    async function previewBuilder() {
+      const out = await apiClient.post("/api/fdd-rules/builder-sql", builder);
+      setSql(out.sql || "");
+      setValidation(out.validation || null);
+      setRawCustom(false);
+    }
+
+    async function runSql() {
+      const out = await apiClient.post("/api/fdd-rules/oa_temp_out_of_range/test-sql", {
+        sql,
+        confirmation_seconds: builder.confirmation_seconds,
+        params: { equipment_id: builder.equipment_id }
+      });
+      setResult(out);
+    }
+
+    async function validateSql() {
+      const out = await apiClient.post("/api/fdd-rules/oa_temp_out_of_range/validate-sql", { sql });
+      setValidation(out);
+    }
+
+    function onRawChange(v) {
+      setSql(v);
+      setRawCustom(true);
+    }
+
+    useEffect(() => { if (mode === "builder") previewBuilder(); }, [mode, builder.input, builder.operator, builder.value, builder.equipment_id]);
+
+    useEffect(() => {
+      function onKey(e) {
+        if ((e.ctrlKey || e.metaKey) && e.key === "Enter") runSql();
+      }
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }, [sql, builder.confirmation_seconds]);
+
+    return React.createElement("div", { className: "fdd-rules-panel panel" },
+      React.createElement("div", { className: "toolbar" },
+        React.createElement("h2", null, "SQL Rule Builder"),
+        React.createElement("button", { className: cx(mode === "builder" && "active"), onClick: () => setMode("builder") }, "Builder mode"),
+        React.createElement("button", { className: cx(mode === "raw" && "active"), onClick: () => setMode("raw") }, "Raw DataFusion SQL"),
+        React.createElement("button", { onClick: validateSql }, "Validate safe SQL"),
+        React.createElement("button", { className: "primary", onClick: runSql }, "Run (Ctrl/Cmd+Enter)")
+      ),
+      mode === "builder" && React.createElement("div", { className: "builder-grid" },
+        React.createElement("label", null, "Rule name", React.createElement("input", { value: builder.name, onChange: e => setBuilder({ ...builder, name: e.target.value }) })),
+        React.createElement("label", null, "FDD input", React.createElement("select", { value: builder.input, onChange: e => setBuilder({ ...builder, input: e.target.value }) },
+          (schema.fdd_inputs || []).map(i => React.createElement("option", { key: i.id, value: i.id }, i.label)))),
+        React.createElement("label", null, "Operator", React.createElement("select", { value: builder.operator, onChange: e => setBuilder({ ...builder, operator: e.target.value }) },
+          [">", "<", ">=", "<="].map(op => React.createElement("option", { key: op, value: op }, op)))),
+        React.createElement("label", null, "Threshold", React.createElement("input", { type: "number", value: builder.value, onChange: e => setBuilder({ ...builder, value: Number(e.target.value) }) })),
+        React.createElement("label", null, "Confirmation (sec)", React.createElement("input", { type: "number", value: builder.confirmation_seconds, onChange: e => setBuilder({ ...builder, confirmation_seconds: Number(e.target.value) }) })),
+        React.createElement("label", null, "Fault code", React.createElement("input", { value: builder.fault_code, onChange: e => setBuilder({ ...builder, fault_code: e.target.value }) }))
+      ),
+      rawCustom && React.createElement("div", { className: "warn-banner" }, "Raw SQL is custom — Builder mode may not round-trip these edits."),
+      React.createElement("label", null, "Generated / Raw SQL preview"),
+      React.createElement("textarea", {
+        className: "sql-editor",
+        value: sql,
+        onChange: e => onRawChange(e.target.value),
+        spellCheck: false
+      }),
+      validation && React.createElement("pre", { className: "validation-box" }, JSON.stringify(validation, null, 2)),
+      result && React.createElement("div", { className: "results-box" },
+        React.createElement("strong", null, "Query results"),
+        React.createElement("div", null, `Rows: ${result.row_count || 0} | Raw faults: ${result.confirmation?.raw_fault_count ?? "?"}`),
+        React.createElement("pre", null, JSON.stringify((result.rows || []).slice(0, 8), null, 2))
+      )
+    );
+  }
+
+  function FddWiresWorkspace({ apiClient, driverTree, onRefresh }) {
+    const [graphs, setGraphs] = useState([]);
+    const [graph, setGraph] = useState(null);
+    const [selectedId, setSelectedId] = useState(null);
+    const [proposals, setProposals] = useState(null);
+    const [validation, setValidation] = useState(null);
+    const [testResult, setTestResult] = useState(null);
+    const [search, setSearch] = useState("");
+    const [ctx, setCtx] = useState(null);
+    const [message, setMessage] = useState("");
+    const canvasRef = useRef(null);
+
+    const graphId = "graph:bench-5007-fdd";
+    const siteId = "site:demo";
+
+    async function loadGraphs() {
+      const list = await apiClient.get("/api/fdd-wires/graphs?site_id=" + encodeURIComponent(siteId));
+      setGraphs(list.graphs || []);
+      const detail = await apiClient.get(`/api/fdd-wires/graphs/${encodeURIComponent(graphId)}?site_id=${encodeURIComponent(siteId)}`);
+      setGraph(detail.graph || null);
+    }
+
+    useEffect(() => { loadGraphs().catch(e => setMessage(String(e))); }, []);
+
+    const nodes = (graph && graph.nodes) || [];
+    const edges = (graph && graph.edges) || [];
+    const selected = nodes.find(n => n.id === selectedId) || null;
+
+    const filteredNodes = useMemo(() => {
+      if (!search) return nodes;
+      const q = search.toLowerCase();
+      return nodes.filter(n => JSON.stringify(n).toLowerCase().includes(q));
+    }, [nodes, search]);
+
+    async function propose() {
+      const out = await apiClient.post("/api/fdd-wires/propose-assignments", {
+        site_id: siteId,
+        equipment_type: "ahu",
+        drivers: (driverTree && driverTree.drivers) || []
+      });
+      setProposals(out);
+      setMessage("AI assignment proposals loaded — review required before activation.");
+    }
+
+    async function validateGraph() {
+      const out = await apiClient.post(`/api/fdd-wires/graphs/${encodeURIComponent(graphId)}/validate?site_id=${encodeURIComponent(siteId)}`, {});
+      setValidation(out.validation || out);
+    }
+
+    async function testGraph() {
+      const out = await apiClient.post(`/api/fdd-wires/graphs/${encodeURIComponent(graphId)}/test?site_id=${encodeURIComponent(siteId)}`, {});
+      setTestResult(out);
+    }
+
+    async function approveGraph() {
+      const out = await apiClient.post(`/api/fdd-wires/graphs/${encodeURIComponent(graphId)}/approve?site_id=${encodeURIComponent(siteId)}`, {});
+      setMessage(out.ok ? "Graph approved" : (out.error || "approve failed"));
+      await loadGraphs();
+    }
+
+    async function activateGraph() {
+      const out = await apiClient.post(`/api/fdd-wires/graphs/${encodeURIComponent(graphId)}/activate?site_id=${encodeURIComponent(siteId)}`, {});
+      setMessage(out.ok ? "Graph activated" : (out.error || "activation failed"));
+      await loadGraphs();
+    }
+
+    function exportJson() {
+      const blob = new Blob([JSON.stringify(graph, null, 2)], { type: "application/json" });
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = `${graphId}.json`;
+      a.click();
+    }
+
+    function importJson(file) {
+      const reader = new FileReader();
+      reader.onload = async () => {
+        try {
+          const payload = JSON.parse(reader.result);
+          await apiClient.put(`/api/fdd-wires/graphs/${encodeURIComponent(graphId)}?site_id=${encodeURIComponent(siteId)}`, payload);
+          await loadGraphs();
+          setMessage("Graph imported");
+        } catch (e) { setMessage(String(e)); }
+      };
+      reader.readAsText(file);
+    }
+
+    function onCanvasContextMenu(e) {
+      e.preventDefault();
+      setCtx({
+        x: e.clientX, y: e.clientY,
+        items: [
+          { label: "Validate graph", action: validateGraph },
+          { label: "Test graph", action: testGraph },
+          { label: "Export graph JSON", action: exportJson },
+          { label: "Propose assignments (AI draft)", action: propose }
+        ]
+      });
+    }
+
+    function onNodeContextMenu(e, node) {
+      e.preventDefault();
+      e.stopPropagation();
+      setSelectedId(node.id);
+      setCtx({
+        x: e.clientX, y: e.clientY,
+        items: [
+          { label: "Open settings", action: () => setSelectedId(node.id) },
+          { label: "Copy ID", action: () => navigator.clipboard.writeText(node.id) },
+          { label: "Copy JSON", action: () => navigator.clipboard.writeText(JSON.stringify(node, null, 2)) },
+          { label: "Validate", action: validateGraph },
+          { label: "Run test from here", action: testGraph }
+        ]
+      });
+    }
+
+    return React.createElement("div", { className: "fdd-wires-shell" },
+      ctx && React.createElement(ContextMenu, { ...ctx, onClose: () => setCtx(null) }),
+      React.createElement("aside", { className: "fdd-left panel" },
+        React.createElement("h3", null, "Rule Assignment Workspace"),
+        React.createElement("input", { placeholder: "Search nodes…", value: search, onChange: e => setSearch(e.target.value) }),
+        React.createElement("button", { className: "primary full", onClick: propose }, "Propose assignments"),
+        React.createElement("div", { className: "palette" },
+          NODE_PALETTE.map(g => React.createElement("div", { key: g.group, className: "palette-group" },
+            React.createElement("strong", null, g.group),
+            g.items.map(t => React.createElement("button", { key: t, className: "chip", draggable: true }, t.replace(/_/g, " ")))
+          ))
+        ),
+        React.createElement("div", { className: "graph-list" },
+          graphs.map(g => React.createElement("div", { key: g.graph_id, className: "list-row" },
+            g.graph_id, " ", badge(g.review_status || "draft", g.review_status === "active" ? "active" : "ai_suggested")
+          ))
+        )
+      ),
+      React.createElement("section", { className: "fdd-center" },
+        React.createElement("div", { className: "toolbar" },
+          React.createElement("strong", null, "FDD Wires — Rule Graph"),
+          badge(graph && graph.review_status, graph && graph.review_status === "active" ? "active" : "ai_suggested"),
+          graph && graph.source === "ai_generated" && badge("AI suggested", "ai_suggested"),
+          React.createElement("button", { onClick: validateGraph }, "Validate"),
+          React.createElement("button", { onClick: testGraph }, "Test"),
+          React.createElement("button", { onClick: approveGraph }, "Approve"),
+          React.createElement("button", { className: "primary", onClick: activateGraph }, "Activate"),
+          React.createElement("label", { className: "file-btn" }, "Import JSON",
+            React.createElement("input", { type: "file", accept: "application/json", hidden: true, onChange: e => e.target.files[0] && importJson(e.target.files[0]) }))
+        ),
+        message && React.createElement("div", { className: "info-banner" }, message),
+        React.createElement("div", { className: "wire-canvas", ref: canvasRef, onContextMenu: onCanvasContextMenu },
+          filteredNodes.map((node, idx) => React.createElement("div", {
+            key: node.id,
+            className: cx("wire-node-card", selectedId === node.id && "selected", node.type),
+            style: { left: (node.position && node.position.x) || (40 + idx * 140), top: (node.position && node.position.y) || 80 },
+            onClick: () => setSelectedId(node.id),
+            onContextMenu: e => onNodeContextMenu(e, node)
+          },
+            React.createElement("div", { className: "wire-node-title" }, node.label || node.id),
+            React.createElement("div", { className: "wire-node-meta" }, node.type),
+            node.config && node.config.source_label && badge(node.config.source_label, node.config.source_label === "simulated" ? "simulated" : "real"),
+            node.source === "ai_generated" && badge("AI", "ai_suggested")
+          )),
+          edges.map(e => React.createElement("div", { key: e.id, className: "wire-edge-label" }, `${e.from} → ${e.to} (${e.type})`))
+        )
+      ),
+      React.createElement("aside", { className: "fdd-right panel" },
+        React.createElement("h3", null, "Details / Settings"),
+        selected ? React.createElement("div", null,
+          React.createElement("div", { className: "tabs-mini" },
+            ["config", "validation", "json"].map(t => React.createElement("button", { key: t }, t))
+          ),
+          React.createElement("pre", null, JSON.stringify(selected, null, 2))
+        ) : React.createElement("p", { className: "muted" }, "Select a node to inspect configuration."),
+        proposals && React.createElement("div", { className: "proposal-box" },
+          React.createElement("h4", null, "Assignment Review"),
+          React.createElement("pre", null, JSON.stringify(proposals.proposals || [], null, 2))
+        ),
+        validation && React.createElement("pre", { className: "validation-box" }, JSON.stringify(validation, null, 2)),
+        testResult && React.createElement("pre", { className: "validation-box" }, JSON.stringify(testResult.execution || testResult, null, 2))
+      ),
+      React.createElement("footer", { className: "fdd-bottom panel" },
+        React.createElement("strong", null, "SQL preview / test output"),
+        React.createElement("span", { className: "muted" }, "DataFusion SQL executes in Rust against Apache Arrow telemetry.")
+      )
+    );
+  }
+
+  global.OpenFddFddWires = { FddWiresWorkspace, SqlRuleBuilder };
+})(window);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="app.js?v=default-driver-tree"></script>
+    <script src="fdd-wires.js?v=fdd-wires-1"></script>
+    <script src="app.js?v=fdd-wires-1"></script>
   </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -344,6 +344,103 @@ h3 { margin: 0 0 10px; color: var(--muted); font-size: 14px; text-transform: upp
 }
 .wire-node.rule { border-color: rgba(245,158,11,.45); }
 .wire-node.alg { border-color: rgba(34,197,94,.45); }
+
+/* FDD Wires — Rule Assignment Workspace */
+.fdd-wires-shell {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 300px;
+  grid-template-rows: minmax(320px, 1fr) auto;
+  gap: 12px;
+  min-height: 620px;
+}
+.fdd-left, .fdd-right, .fdd-bottom { overflow: auto; }
+.fdd-center { display: flex; flex-direction: column; gap: 10px; min-width: 0; }
+.wire-canvas {
+  position: relative;
+  min-height: 420px;
+  border: 1px dashed var(--line);
+  border-radius: 16px;
+  background:
+    linear-gradient(var(--line) 1px, transparent 1px) 0 0 / 24px 24px,
+    linear-gradient(90deg, var(--line) 1px, transparent 1px) 0 0 / 24px 24px,
+    var(--panel2);
+}
+.wire-node-card {
+  position: absolute;
+  width: 150px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 10px;
+  background: var(--panel);
+  box-shadow: 0 8px 24px var(--shadow);
+  cursor: pointer;
+}
+.wire-node-card.selected { border-color: var(--blue); }
+.wire-node-card.sql_rule { border-color: rgba(245,158,11,.55); }
+.wire-node-card.fault_output { border-color: rgba(239,68,68,.55); }
+.wire-node-title { font-weight: 700; font-size: 13px; }
+.wire-node-meta { color: var(--muted); font-size: 11px; margin: 4px 0; }
+.wire-edge-label { font-size: 11px; color: var(--muted); padding: 4px 8px; }
+.badge {
+  display: inline-block;
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  margin: 2px 2px 0 0;
+  border: 1px solid var(--line);
+}
+.badge-sim { background: rgba(245,158,11,.15); color: var(--amber); }
+.badge-fix { background: rgba(148,163,184,.15); }
+.badge-real { background: rgba(34,197,94,.15); color: var(--green); }
+.badge-ai { background: rgba(56,189,248,.15); color: var(--blue); }
+.badge-ok { background: rgba(34,197,94,.15); color: var(--green); }
+.badge-bad { background: rgba(239,68,68,.15); color: var(--red); }
+.palette-group { margin: 10px 0; }
+.palette-group .chip { margin: 4px 4px 0 0; font-size: 11px; }
+.ctx-menu {
+  position: fixed;
+  z-index: 1000;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 6px;
+  box-shadow: 0 12px 40px var(--shadow);
+}
+.ctx-item { display: block; width: 100%; text-align: left; margin: 2px 0; }
+.sql-editor {
+  width: 100%;
+  min-height: 140px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  background: var(--panel2);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 12px;
+}
+.builder-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-bottom: 12px; }
+.builder-grid label { display: flex; flex-direction: column; gap: 6px; font-size: 12px; color: var(--muted); }
+.validation-box, .results-box, .proposal-box {
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel2);
+  font-size: 12px;
+  overflow: auto;
+  max-height: 220px;
+}
+.warn-banner, .info-banner {
+  padding: 10px 12px;
+  border-radius: 12px;
+  margin-bottom: 10px;
+  border: 1px solid var(--line);
+}
+.warn-banner { background: rgba(245,158,11,.12); }
+.info-banner { background: rgba(56,189,248,.12); }
+.file-btn { display: inline-block; }
+.muted { color: var(--muted); }
+.fdd-bottom { grid-column: 1 / -1; padding: 10px 14px; }
+
 .error {
   border: 1px solid rgba(239,68,68,.45);
   background: rgba(239,68,68,.12);


### PR DESCRIPTION
## Summary
- Add versioned **FDD Wires** graph schema persisted under `workspace/data/fdd_wires/` with nodes (driver/model/FDD/SQL/confirmation/fault) and typed edges.
- Add deterministic assignment proposal API (AI draft-only) and RBAC-protected graph/rule lifecycle (validate, test, approve, activate).
- Execute DataFusion SQL rules in Rust against Apache Arrow telemetry tables with SQL safety validator, confirmation duration, and fault_raw/confirmed outputs.
- Add React **FDD Wires** + **SQL Rules** tabs with Builder/Raw SQL modes, context menus, badges, and import/export JSON.
- Add VERIFY docs and CI smoke for graph/SQL/RBAC endpoints; UI branding guards (no third-party product names).

## Test plan
- [x] `cargo test` — graph validation, SQL safety, assignment proposals, RBAC activation
- [x] `node --check` on `app.js` and `fdd-wires.js`
- [x] `docker build` smoke
- [ ] GitHub Actions green on PR
- [ ] Manual: FDD Wires tab, propose assignments, validate/test graph, SQL Rule Builder run

## Notes
- Inspiration links documented only in internal VERIFY/dev context; product UI uses Open-FDD-native names.
- Agent role can propose/validate; integrator required for approve/activate.
- Rebase onto merged auth/bootstrap/driver branches before final merge if needed.


Made with [Cursor](https://cursor.com)