### PR TITLE
Bulk CSV data export for Excel users (historian, faults, BACnet, model)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,31 @@ jobs:
           curl -fsS http://127.0.0.1:8080/api/bench/5007/smoke/status \
             -H "Authorization: Bearer $INT" | jq -e '.ok == true and (.rule_sql | contains("confirmation_required_minutes"))'
 
+      - name: Data export CSV smoke
+        run: |
+          AGENT_PW="$(grep '^OFDD_AGENT_PASSWORD=' workspace/auth.env.local | cut -d= -f2- | tr -d '\r')"
+          TOKEN="$(curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -nc --arg p "$AGENT_PW" '{username:"agent",password:$p}')" | jq -r '.token // .access_token')"
+
+          curl -fsS http://127.0.0.1:8080/api/export/meta \
+            -H "Authorization: Bearer $TOKEN" | jq -e '.ok == true and (.exports | length >= 5)'
+
+          curl -D /tmp/export-headers.txt -fsS http://127.0.0.1:8080/api/export/historian.csv \
+            -H "Authorization: Bearer $TOKEN" -o /tmp/historian.csv
+          grep -qi 'text/csv' /tmp/export-headers.txt
+          grep -q 'Content-Disposition' /tmp/export-headers.txt
+          grep -q 'openfdd_historian_' /tmp/export-headers.txt
+          head -n 1 /tmp/historian.csv | grep -q 'timestamp_utc,timestamp_local,timezone'
+
+          curl -fsS http://127.0.0.1:8080/api/export/model-points.csv \
+            -H "Authorization: Bearer $TOKEN" | head -n 1 | grep -q 'point_id,point_name'
+
+          curl -fsS http://127.0.0.1:8080/api/export/bench-5007.csv \
+            -H "Authorization: Bearer $TOKEN" | head -n 1 | grep -q 'smoke_run_id'
+
+          test "$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/api/export/historian.csv)" = "401"
+
       - name: CSV files created in workspace
         run: |
           test -f workspace/overrides/bacnet_overrides.csv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +630,52 @@ dependencies = [
  "chrono",
  "phf",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
@@ -1564,6 +1660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open_fdd_edge_prototype"
 version = "3.2.0"
 dependencies = [
@@ -1880,12 +1988,15 @@ dependencies = [
  "bacnet-types",
  "base64",
  "chrono",
+ "clap",
  "datafusion",
  "hex",
  "hmac",
+ "rand",
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "tokio",
 ]
 
@@ -2341,6 +2452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2697,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/edge/src/export/mod.rs
+++ b/edge/src/export/mod.rs
@@ -156,7 +156,7 @@ pub fn meta_json() -> Value {
             "equipment": list_equipment(&historian_rows)
         },
         "xlsx_supported": false,
-        "xlsx_note": "CSV exports are available now; track XLSX in GitHub issue."
+        "xlsx_note": "CSV exports are available now; XLSX tracked in GitHub issue #367."
     })
 }
 

--- a/edge/src/export/mod.rs
+++ b/edge/src/export/mod.rs
@@ -1,0 +1,746 @@
+//! Spreadsheet-friendly CSV exports for historian, faults, model, rules, and bench smoke.
+
+use crate::bench;
+use crate::fdd::rules;
+use crate::historian::store;
+use chrono::{DateTime, Local, Utc};
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::env;
+
+pub const HISTORIAN_CSV_HEADER: &str = "timestamp_utc,timestamp_local,timezone,site_id,building_id,equipment_id,source_protocol,device_id,point_id,point_name,value,units,quality,source_path,data_source_label";
+
+pub const FAULTS_CSV_HEADER: &str = "timestamp_utc,timestamp_local,site_id,building_id,equipment_id,rule_id,rule_name,raw_fault,confirmed_fault,minutes_in_fault,confirmation_required_minutes,clear_state,source_protocol,point_inputs,data_source_label";
+
+pub const MODEL_POINTS_CSV_HEADER: &str = "site_id,building_id,equipment_id,equipment_name,point_id,point_name,source_protocol,source_device,source_object,units,haystack_tags,role,mapped,rule_inputs,data_source_label";
+
+pub const RULES_CSV_HEADER: &str = "rule_id,rule_name,severity,review_status,confirmation_seconds,clear_behavior,required_inputs,optional_inputs,sql,data_source_label";
+
+pub const BENCH_5007_CSV_HEADER: &str = "timestamp_utc,timestamp_local,device_instance,source_protocol,point_name,point_id,value,units,raw_fault,confirmed_fault,minutes_in_fault,smoke_run_id,data_source_label";
+
+#[derive(Default, Clone)]
+pub struct ExportQuery {
+    pub start: Option<String>,
+    pub end: Option<String>,
+    pub site_id: Option<String>,
+    pub building_id: Option<String>,
+    pub equipment_id: Option<String>,
+    pub source_protocol: Option<String>,
+    pub hours: Option<i64>,
+}
+
+pub fn parse_query(query: &str) -> ExportQuery {
+    let mut q = ExportQuery::default();
+    for pair in query.split('&') {
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
+        };
+        let v = url_decode(v);
+        match k {
+            "start" => q.start = Some(v),
+            "end" => q.end = Some(v),
+            "site_id" => q.site_id = Some(v),
+            "building_id" => q.building_id = Some(v),
+            "equipment_id" => q.equipment_id = Some(v),
+            "source_protocol" | "protocol" => q.source_protocol = Some(v),
+            "hours" => q.hours = v.parse().ok(),
+            _ => {}
+        }
+    }
+    q
+}
+
+fn url_decode(raw: &str) -> String {
+    let mut out = String::new();
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'+' {
+            out.push(' ');
+            i += 1;
+        } else if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(v) =
+                u8::from_str_radix(std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""), 16)
+            {
+                out.push(v as char);
+            }
+            i += 3;
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+pub fn export_filename(prefix: &str) -> String {
+    let now = Local::now();
+    format!("openfdd_{}_{}.csv", prefix, now.format("%Y%m%d_%H%M"))
+}
+
+pub fn meta_json() -> Value {
+    let historian_rows = store::load_pivot_rows().unwrap_or_default();
+    let historian_count = historian_rows.len();
+    let data_label = historian_data_label(&historian_rows);
+    let bench_available = historian_count > 0;
+    let smoke_dir = store::workspace_dir().join("logs/bench_5007_smoke");
+    let smoke_artifacts = smoke_dir.exists();
+    json!({
+        "ok": true,
+        "exports": [
+            {
+                "id": "historian",
+                "label": "Historian time series",
+                "format": "csv",
+                "path": "/api/export/historian.csv",
+                "row_count": historian_count.saturating_mul(4),
+                "available": historian_count > 0,
+                "data_source_label": data_label
+            },
+            {
+                "id": "faults",
+                "label": "Fault results",
+                "format": "csv",
+                "path": "/api/export/faults.csv",
+                "row_count": fault_row_estimate(&historian_rows),
+                "available": historian_count > 0,
+                "data_source_label": data_label
+            },
+            {
+                "id": "fault-summary",
+                "label": "Fault summary",
+                "format": "csv",
+                "path": "/api/export/faults.csv?summary=1",
+                "row_count": if historian_count > 0 { 1 } else { 0 },
+                "available": historian_count > 0,
+                "data_source_label": data_label
+            },
+            {
+                "id": "bacnet-overrides",
+                "label": "BACnet override report",
+                "format": "csv",
+                "path": "/api/bacnet/overrides/export",
+                "available": true
+            },
+            {
+                "id": "model-points",
+                "label": "Data model point list",
+                "format": "csv",
+                "path": "/api/export/model-points.csv",
+                "available": true,
+                "data_source_label": "model/assignments"
+            },
+            {
+                "id": "rules",
+                "label": "Rule definitions",
+                "format": "csv",
+                "path": "/api/export/rules.csv",
+                "requires_role": "integrator|agent",
+                "available": true,
+                "data_source_label": "fdd_wires/rules"
+            },
+            {
+                "id": "bench-5007",
+                "label": "5007 bench smoke data",
+                "format": "csv",
+                "path": "/api/export/bench-5007.csv",
+                "row_count": historian_count.saturating_mul(4),
+                "available": bench_available || smoke_artifacts,
+                "data_source_label": data_label
+            }
+        ],
+        "filters": {
+            "sites": ["site:demo"],
+            "buildings": ["building:main"],
+            "protocols": list_protocols(&historian_rows),
+            "equipment": list_equipment(&historian_rows)
+        },
+        "xlsx_supported": false,
+        "xlsx_note": "CSV exports are available now; track XLSX in GitHub issue."
+    })
+}
+
+fn historian_data_label(rows: &[Value]) -> String {
+    if rows.is_empty() {
+        return "empty".to_string();
+    }
+    let mut sim = 0;
+    let mut live = 0;
+    let mut demo = 0;
+    for row in rows {
+        match row.get("source").and_then(|v| v.as_str()).unwrap_or("") {
+            s if s.starts_with("simulation:") => sim += 1,
+            s if s.contains("demo") => demo += 1,
+            s if s.starts_with("bacnet:live") => live += 1,
+            _ if row.get("is_simulated").and_then(|v| v.as_bool()) == Some(true) => sim += 1,
+            _ => live += 1,
+        }
+    }
+    if demo > 0 {
+        "DEMO ONLY — not live historian".to_string()
+    } else if sim > 0 && live == 0 {
+        "simulation:bench_5007_short_fdd".to_string()
+    } else if live > 0 {
+        "historian/live".to_string()
+    } else {
+        "historian/mixed".to_string()
+    }
+}
+
+fn list_protocols(rows: &[Value]) -> Vec<String> {
+    let mut set = BTreeSet::new();
+    for row in rows {
+        if let Some(p) = row.get("source_driver").and_then(|v| v.as_str()) {
+            set.insert(p.to_string());
+        }
+    }
+    set.insert("bacnet".into());
+    set.into_iter().collect()
+}
+
+fn list_equipment(rows: &[Value]) -> Vec<String> {
+    let mut set = BTreeSet::new();
+    for row in rows {
+        if let Some(e) = row.get("equipment_id").and_then(|v| v.as_str()) {
+            set.insert(e.to_string());
+        }
+    }
+    set.insert(bench::smoke::BENCH_EQUIPMENT_ID.into());
+    set.into_iter().collect()
+}
+
+fn fault_row_estimate(rows: &[Value]) -> u64 {
+    if rows.is_empty() {
+        0
+    } else {
+        rows.len() as u64
+    }
+}
+
+pub fn historian_csv(query: &ExportQuery) -> String {
+    let rows = filtered_historian_rows(query);
+    let label = historian_data_label(&rows);
+    let path = store::pivot_jsonl_path().display().to_string();
+    let mut out = String::from(HISTORIAN_CSV_HEADER);
+    out.push('\n');
+    let site = query.site_id.as_deref().unwrap_or("site:demo");
+    let building = query.building_id.as_deref().unwrap_or("building:main");
+    for row in rows {
+        let ts = row.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        let (utc, local, tz) = format_timestamps(ts);
+        let equip = row
+            .get("equipment_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("5007");
+        let protocol = row
+            .get("source_driver")
+            .and_then(|v| v.as_str())
+            .unwrap_or("bacnet");
+        let device = bench::smoke::BENCH_DEVICE.to_string();
+        let quality = if row.get("is_simulated").and_then(|v| v.as_bool()) == Some(true) {
+            "simulated"
+        } else if label.contains("DEMO") {
+            "demo"
+        } else {
+            "good"
+        };
+        for (point_id, point_name, value, unit) in pivot_point_values(&row) {
+            out.push_str(&csv_row(&[
+                utc.clone(),
+                local.clone(),
+                tz.clone(),
+                site.to_string(),
+                building.to_string(),
+                equip.to_string(),
+                protocol.to_string(),
+                device.clone(),
+                point_id,
+                point_name,
+                value,
+                unit,
+                quality.to_string(),
+                path.clone(),
+                label.clone(),
+            ]));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn pivot_point_values(row: &Value) -> Vec<(String, String, String, String)> {
+    vec![
+        (
+            "oa_t".into(),
+            "Outside Air Temp".into(),
+            fmt_f64(row.get("oa_t")),
+            "degF".into(),
+        ),
+        (
+            "oa_h".into(),
+            "Outside Air Humidity".into(),
+            fmt_f64(row.get("oa_h")),
+            "%RH".into(),
+        ),
+        (
+            "duct_t".into(),
+            "Discharge Air Temp".into(),
+            fmt_f64(row.get("duct_t")),
+            "degF".into(),
+        ),
+        (
+            "zn_t".into(),
+            "Zone Temp".into(),
+            fmt_f64(row.get("zn_t")),
+            "degF".into(),
+        ),
+    ]
+}
+
+pub fn faults_csv(query: &ExportQuery, summary: bool) -> String {
+    let rows = filtered_historian_rows(query);
+    let label = historian_data_label(&rows);
+    if rows.is_empty() {
+        return format!("{FAULTS_CSV_HEADER}\n");
+    }
+    let eval = bench::smoke::evaluate_historian_fdd();
+    let eval_rows = eval
+        .get("rows")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if summary {
+        let mut raw = 0;
+        let mut confirmed = 0;
+        for r in &eval_rows {
+            if r.get("raw_fault").and_then(|v| v.as_bool()) == Some(true) {
+                raw += 1;
+            }
+            if r.get("confirmed_fault").and_then(|v| v.as_bool()) == Some(true) {
+                confirmed += 1;
+            }
+        }
+        return format!(
+            "{FAULTS_CSV_HEADER}\n{}",
+            csv_row(&[
+                Utc::now().to_rfc3339(),
+                Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+                "site:demo".into(),
+                "building:main".into(),
+                bench::smoke::BENCH_EQUIPMENT_ID.into(),
+                "oa_temp_out_of_range".into(),
+                "OA Temperature Out Of Range".into(),
+                if raw > 0 { "true" } else { "false" }.into(),
+                if confirmed > 0 { "true" } else { "false" }.into(),
+                "0".into(),
+                bench::smoke::CONFIRMATION_MINUTES.to_string(),
+                if confirmed > 0 { "latched" } else { "normal" }.into(),
+                "bacnet".into(),
+                "oa_t".into(),
+                label.clone(),
+            ])
+        );
+    }
+    let mut out = String::from(FAULTS_CSV_HEADER);
+    out.push('\n');
+    for row in eval_rows {
+        let ts = row.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        let (utc, local, _) = format_timestamps(ts);
+        let raw = row
+            .get("raw_fault")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let confirmed = row
+            .get("confirmed_fault")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let minutes = row
+            .get("minutes_in_fault")
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "0".into());
+        let confirm_min = row
+            .get("confirmation_required_minutes")
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| bench::smoke::CONFIRMATION_MINUTES.to_string());
+        out.push_str(&csv_row(&[
+            utc,
+            local,
+            "site:demo".into(),
+            "building:main".into(),
+            row.get("equipment_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or(bench::smoke::BENCH_EQUIPMENT_ID)
+                .into(),
+            "oa_temp_out_of_range".into(),
+            "OA Temperature Out Of Range".into(),
+            raw.to_string(),
+            confirmed.to_string(),
+            minutes,
+            confirm_min,
+            if raw && !confirmed {
+                "raw_only".into()
+            } else if confirmed {
+                "confirmed".into()
+            } else {
+                "normal".into()
+            },
+            "bacnet".into(),
+            "oa_t".into(),
+            label.clone(),
+        ]));
+        out.push('\n');
+    }
+    out
+}
+
+pub fn model_points_csv() -> String {
+    let assignments: Value =
+        serde_json::from_str(crate::model::assignments::assignments_json()).unwrap_or(json!({}));
+    let label = "model/assignments".to_string();
+    let mut out = String::from(MODEL_POINTS_CSV_HEADER);
+    out.push('\n');
+    if let Some(points) = assignments.get("points").and_then(|v| v.as_array()) {
+        for point in points {
+            let haystack_id = point
+                .get("haystack_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let equip = point
+                .get("equip_ref")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let (protocol, device, object) = first_driver_binding(point);
+            let rule_inputs = rule_inputs_for_point(haystack_id, &assignments);
+            out.push_str(&csv_row(&[
+                "site:demo".into(),
+                "building:main".into(),
+                equip.replace("equip:", ""),
+                point
+                    .get("dis")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                haystack_id.into(),
+                point
+                    .get("dis")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                protocol,
+                device,
+                object,
+                point
+                    .get("unit")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                haystack_id.into(),
+                point
+                    .get("kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                "true".into(),
+                rule_inputs,
+                label.clone(),
+            ]));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+pub fn rules_csv() -> String {
+    let listed = rules::list_rules();
+    let label = "fdd_wires/rules".to_string();
+    let mut out = String::from(RULES_CSV_HEADER);
+    out.push('\n');
+    if let Some(items) = listed.get("rules").and_then(|v| v.as_array()) {
+        for rule in items {
+            let req = rule
+                .get("required_inputs")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str())
+                        .collect::<Vec<_>>()
+                        .join(";")
+                })
+                .unwrap_or_default();
+            let opt = rule
+                .get("optional_inputs")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str())
+                        .collect::<Vec<_>>()
+                        .join(";")
+                })
+                .unwrap_or_default();
+            let sql = rule
+                .get("sql")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .replace('\n', " ");
+            out.push_str(&csv_row(&[
+                rule.get("rule_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                rule.get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                rule.get("severity")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                rule.get("review_status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                rule.get("confirmation_seconds")
+                    .map(|v| v.to_string())
+                    .unwrap_or_default(),
+                rule.get("clear_behavior")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                req,
+                opt,
+                sql,
+                label.clone(),
+            ]));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+pub fn bench_5007_csv(query: &ExportQuery) -> String {
+    let rows = filtered_historian_rows(query);
+    let label = historian_data_label(&rows);
+    let eval = bench::smoke::evaluate_historian_fdd();
+    let eval_by_ts: std::collections::HashMap<String, Value> = eval
+        .get("rows")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|r| {
+            let ts = r.get("timestamp").and_then(|v| v.as_str())?.to_string();
+            Some((ts, r))
+        })
+        .collect();
+    let smoke_run = env::var("BENCH_SMOKE_RUN_ID").unwrap_or_else(|_| "local".into());
+    let mut out = String::from(BENCH_5007_CSV_HEADER);
+    out.push('\n');
+    for row in rows {
+        let ts = row.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        let (utc, local, _) = format_timestamps(ts);
+        let eval_row = eval_by_ts.get(ts);
+        let raw = eval_row
+            .and_then(|r| r.get("raw_fault"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let confirmed = eval_row
+            .and_then(|r| r.get("confirmed_fault"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let minutes = eval_row
+            .and_then(|r| r.get("minutes_in_fault"))
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "0".into());
+        let protocol = row
+            .get("source_driver")
+            .and_then(|v| v.as_str())
+            .unwrap_or("bacnet");
+        for (point_id, point_name, value, unit) in pivot_point_values(&row) {
+            out.push_str(&csv_row(&[
+                utc.clone(),
+                local.clone(),
+                bench::smoke::BENCH_DEVICE.to_string(),
+                protocol.into(),
+                point_name,
+                point_id,
+                value,
+                unit,
+                raw.to_string(),
+                confirmed.to_string(),
+                minutes.clone(),
+                smoke_run.clone(),
+                label.clone(),
+            ]));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn filtered_historian_rows(query: &ExportQuery) -> Vec<Value> {
+    let mut rows = store::load_pivot_rows().unwrap_or_default();
+    rows.sort_by(|a, b| {
+        a.get("timestamp")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .cmp(b.get("timestamp").and_then(|v| v.as_str()).unwrap_or(""))
+    });
+    if let Some(hours) = query.hours {
+        let cutoff = Utc::now() - chrono::Duration::hours(hours);
+        rows.retain(|r| {
+            r.get("timestamp")
+                .and_then(|v| v.as_str())
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc) >= cutoff)
+                .unwrap_or(true)
+        });
+    }
+    if let Some(ref equip) = query.equipment_id {
+        rows.retain(|r| {
+            r.get("equipment_id")
+                .and_then(|v| v.as_str())
+                .map(|e| e == equip)
+                .unwrap_or(false)
+        });
+    }
+    if let Some(ref protocol) = query.source_protocol {
+        rows.retain(|r| {
+            r.get("source_driver")
+                .and_then(|v| v.as_str())
+                .map(|p| p == protocol)
+                .unwrap_or(false)
+        });
+    }
+    if let Some(ref start) = query.start {
+        rows.retain(|r| ts_gte(r, start));
+    }
+    if let Some(ref end) = query.end {
+        rows.retain(|r| ts_lte(r, end));
+    }
+    rows
+}
+
+fn ts_gte(row: &Value, start: &str) -> bool {
+    match (
+        row.get("timestamp").and_then(|v| v.as_str()),
+        DateTime::parse_from_rfc3339(start).ok(),
+    ) {
+        (Some(ts), Some(start_dt)) => DateTime::parse_from_rfc3339(ts)
+            .map(|dt| dt >= start_dt)
+            .unwrap_or(true),
+        _ => true,
+    }
+}
+
+fn ts_lte(row: &Value, end: &str) -> bool {
+    match (
+        row.get("timestamp").and_then(|v| v.as_str()),
+        DateTime::parse_from_rfc3339(end).ok(),
+    ) {
+        (Some(ts), Some(end_dt)) => DateTime::parse_from_rfc3339(ts)
+            .map(|dt| dt <= end_dt)
+            .unwrap_or(true),
+        _ => true,
+    }
+}
+
+fn first_driver_binding(point: &Value) -> (String, String, String) {
+    point
+        .get("driver_bindings")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .map(|b| {
+            (
+                b.get("driver")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .into(),
+                b.get("ref").and_then(|v| v.as_str()).unwrap_or("").into(),
+                b.get("object_id")
+                    .map(|v| v.to_string())
+                    .unwrap_or_default(),
+            )
+        })
+        .unwrap_or_default()
+}
+
+fn rule_inputs_for_point(haystack_id: &str, assignments: &Value) -> String {
+    let mut inputs = Vec::new();
+    if let Some(bindings) = assignments
+        .get("fault_equation_bindings")
+        .and_then(|v| v.as_array())
+    {
+        for binding in bindings {
+            if let Some(map) = binding.get("inputs").and_then(|v| v.as_object()) {
+                for (input, point) in map {
+                    if point.as_str() == Some(haystack_id) {
+                        inputs.push(format!("{input}={haystack_id}"));
+                    }
+                }
+            }
+        }
+    }
+    inputs.join(";")
+}
+
+fn format_timestamps(iso: &str) -> (String, String, String) {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(iso) {
+        let utc = dt.with_timezone(&Utc).to_rfc3339();
+        let local = dt
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        let tz = env::var("TZ").unwrap_or_else(|_| "UTC".to_string());
+        (utc, local, tz)
+    } else {
+        (iso.to_string(), iso.to_string(), "UTC".to_string())
+    }
+}
+
+fn fmt_f64(value: Option<&Value>) -> String {
+    value
+        .and_then(|v| v.as_f64())
+        .map(|n| n.to_string())
+        .unwrap_or_default()
+}
+
+pub fn csv_row(fields: &[String]) -> String {
+    fields
+        .iter()
+        .map(|f| {
+            let escaped = f.replace('"', "\"\"");
+            format!("\"{escaped}\"")
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn historian_header_is_stable() {
+        assert!(HISTORIAN_CSV_HEADER.starts_with("timestamp_utc,timestamp_local,timezone"));
+        assert!(HISTORIAN_CSV_HEADER.contains("source_path"));
+    }
+
+    #[test]
+    fn export_filename_has_prefix_and_timestamp() {
+        let name = export_filename("historian");
+        assert!(name.starts_with("openfdd_historian_"));
+        assert!(name.ends_with(".csv"));
+    }
+
+    #[test]
+    fn timestamps_present_in_historian_export() {
+        let csv = historian_csv(&ExportQuery::default());
+        assert!(csv.starts_with(HISTORIAN_CSV_HEADER));
+    }
+
+    #[test]
+    fn classifies_demo_only_label() {
+        let rows = vec![json!({"source":"demo:static","source_driver":"demo"})];
+        assert!(historian_data_label(&rows).contains("DEMO ONLY"));
+    }
+}

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -2,6 +2,7 @@ mod auth;
 mod bench;
 mod control;
 mod drivers;
+mod export;
 mod fdd;
 mod historian;
 mod model;
@@ -124,6 +125,49 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         }
         ("POST", "/api/historian/query") => {
             raw_json(&mut stream, historian::arrow_table::query_json())
+        }
+        ("GET", "/api/export/meta") => json_response(&mut stream, export::meta_json()),
+        ("GET", "/api/export/historian.csv") => {
+            let q = export::parse_query(query_string(&path));
+            let body = export::historian_csv(&q);
+            let name = export::export_filename("historian");
+            require_role_csv(&mut stream, &principal, READ_EXPORT_ROLES, body, &name)
+        }
+        ("GET", "/api/export/faults.csv") => {
+            let qs = query_string(&path);
+            let q = export::parse_query(qs);
+            let summary = qs
+                .split('&')
+                .any(|p| p == "summary=1" || p.starts_with("summary=1&"));
+            let body = export::faults_csv(&q, summary);
+            let name = export::export_filename(if summary {
+                "fault_summary"
+            } else {
+                "fault_results"
+            });
+            require_role_csv(&mut stream, &principal, READ_EXPORT_ROLES, body, &name)
+        }
+        ("GET", "/api/export/model-points.csv") => {
+            let body = export::model_points_csv();
+            let name = export::export_filename("model_points");
+            require_role_csv(&mut stream, &principal, READ_EXPORT_ROLES, body, &name)
+        }
+        ("GET", "/api/export/rules.csv") => {
+            let body = export::rules_csv();
+            let name = export::export_filename("rules");
+            require_role_csv(
+                &mut stream,
+                &principal,
+                &["integrator", "agent"],
+                body,
+                &name,
+            )
+        }
+        ("GET", "/api/export/bench-5007.csv") => {
+            let q = export::parse_query(query_string(&path));
+            let body = export::bench_5007_csv(&q);
+            let name = export::export_filename("5007_smoke");
+            require_role_csv(&mut stream, &principal, READ_EXPORT_ROLES, body, &name)
         }
         ("POST", "/api/ops/docker/update") => require_role(
             &mut stream,
@@ -315,30 +359,18 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         ),
         ("GET", "/api/bacnet/overrides/export") => {
             let body = drivers::bacnet::overrides_csv();
-            response(
-                &mut stream,
-                "200 OK",
-                "text/csv; charset=utf-8",
-                body.as_bytes(),
-            )
+            let name = export::export_filename("bacnet_overrides");
+            require_role_csv(&mut stream, &principal, READ_EXPORT_ROLES, body, &name)
         }
         ("GET", "/api/bacnet/overrides/export/p8") => {
             let body = drivers::bacnet::priority8_csv();
-            response(
-                &mut stream,
-                "200 OK",
-                "text/csv; charset=utf-8",
-                body.as_bytes(),
-            )
+            let name = export::export_filename("bacnet_overrides_p8");
+            require_role_csv(&mut stream, &principal, READ_EXPORT_ROLES, body, &name)
         }
         ("GET", "/api/bacnet/overrides/export/non-p8") => {
             let body = drivers::bacnet::non_priority8_csv();
-            response(
-                &mut stream,
-                "200 OK",
-                "text/csv; charset=utf-8",
-                body.as_bytes(),
-            )
+            let name = export::export_filename("bacnet_overrides_non_p8");
+            require_role_csv(&mut stream, &principal, READ_EXPORT_ROLES, body, &name)
         }
 
         ("POST", "/api/bacnet/write-dry-run") => require_role(
@@ -755,6 +787,51 @@ fn require_role(
     }
 }
 
+const READ_EXPORT_ROLES: &[&str] = &["operator", "integrator", "agent"];
+
+fn query_string(path: &str) -> &str {
+    path.split('?').nth(1).unwrap_or("")
+}
+
+fn csv_attachment_response(
+    stream: &mut TcpStream,
+    body: &str,
+    filename: &str,
+) -> std::io::Result<()> {
+    let content_type = "text/csv; charset=utf-8";
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Disposition: attachment; filename=\"{filename}\"\r\n{sec}{cors}Content-Length: {len}\r\nConnection: close\r\n\r\n",
+        sec = security_headers(content_type, false),
+        cors = cors_origin(),
+        len = body.len(),
+        filename = filename
+    );
+    stream.write_all(headers.as_bytes())?;
+    stream.write_all(body.as_bytes())
+}
+
+fn require_role_csv(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    roles: &[&str],
+    body: String,
+    filename: &str,
+) -> std::io::Result<()> {
+    if role_allowed(principal, roles) {
+        csv_attachment_response(stream, &body, filename)
+    } else {
+        audit::log_event(
+            "forbidden",
+            json!({"role": principal.role.clone(), "required": roles, "export": filename}),
+        );
+        status_json(
+            stream,
+            "403 Forbidden",
+            json!({"ok": false, "error": "insufficient role", "role": principal.role}),
+        )
+    }
+}
+
 fn agent_manifest() -> Value {
     json!({
         "name": "open-fdd-rust-edge",
@@ -805,6 +882,12 @@ fn agent_tools() -> Value {
             {"name":"fdd.rules.activate","method":"POST","path":"/api/fdd-rules/{id}/activate","requires":"integrator"},
             {"name":"rules.batch","method":"POST","path":"/api/rules/batch","requires":"integrator|agent"},
             {"name":"historian.query","method":"POST","path":"/api/historian/query","requires":"JWT"},
+            {"name":"export.meta","method":"GET","path":"/api/export/meta","requires":"JWT"},
+            {"name":"export.historian_csv","method":"GET","path":"/api/export/historian.csv","requires":"operator|integrator|agent"},
+            {"name":"export.faults_csv","method":"GET","path":"/api/export/faults.csv","requires":"operator|integrator|agent"},
+            {"name":"export.model_points_csv","method":"GET","path":"/api/export/model-points.csv","requires":"operator|integrator|agent"},
+            {"name":"export.rules_csv","method":"GET","path":"/api/export/rules.csv","requires":"integrator|agent"},
+            {"name":"export.bench_5007_csv","method":"GET","path":"/api/export/bench-5007.csv","requires":"operator|integrator|agent"},
             {"name":"reports.rcx_plan","method":"POST","path":"/api/reports/rcx/plan","requires":"JWT"},
             {"name":"reports.rcx_generate","method":"POST","path":"/api/reports/rcx/generate","requires":"integrator|agent"},
             {"name":"ops.update","method":"POST","path":"/api/ops/docker/update","requires":"integrator|agent"}

--- a/edge/tests/auth_integration.rs
+++ b/edge/tests/auth_integration.rs
@@ -217,3 +217,94 @@ fn operator_forbidden_on_modbus_scan() {
     let (status, _) = http_post_json(&srv.url("/api/modbus/scan"), "{}", Some(token));
     assert_eq!(status, 403);
 }
+
+fn http_get_with_headers(url: &str, bearer: Option<&str>) -> (u16, String, String) {
+    let url = url.strip_prefix("http://").unwrap();
+    let (host_port, path) = url.split_once('/').unwrap_or((url, ""));
+    let path = if path.is_empty() {
+        "/"
+    } else {
+        &format!("/{path}")
+    };
+    let mut stream = TcpStream::connect(host_port).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let mut req = format!("GET {path} HTTP/1.1\r\nHost: {host_port}\r\nConnection: close\r\n");
+    if let Some(token) = bearer {
+        req.push_str(&format!("Authorization: Bearer {token}\r\n"));
+    }
+    req.push_str("\r\n");
+    stream.write_all(req.as_bytes()).unwrap();
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).unwrap();
+    let resp = String::from_utf8_lossy(&buf);
+    let status = resp
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let header_end = resp.find("\r\n\r\n").map(|i| i + 4).unwrap_or(0);
+    let headers = resp
+        .lines()
+        .take_while(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (status, headers, resp[header_end..].to_string())
+}
+
+fn login_token(srv: &Server, username: &str, password: &str) -> String {
+    let login_body = login_json(username, password);
+    let (_, body) = http_post_json(&srv.url("/api/auth/login"), &login_body, None);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    json["token"]
+        .as_str()
+        .or(json["access_token"].as_str())
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn export_requires_authentication() {
+    let srv = Server::start();
+    let (status, _, _) = http_get_with_headers(&srv.url("/api/export/historian.csv"), None);
+    assert_eq!(status, 401);
+}
+
+#[test]
+fn historian_export_returns_csv_attachment() {
+    let srv = Server::start();
+    let pw = srv.integrator_password();
+    let token = login_token(&srv, "integrator", &pw);
+    let (status, headers, body) =
+        http_get_with_headers(&srv.url("/api/export/historian.csv"), Some(&token));
+    assert_eq!(status, 200);
+    assert!(headers.to_ascii_lowercase().contains("text/csv"));
+    assert!(headers.contains("Content-Disposition"));
+    assert!(headers.contains("openfdd_historian_"));
+    assert!(body.starts_with("timestamp_utc,timestamp_local,timezone"));
+}
+
+#[test]
+fn model_points_export_has_expected_columns() {
+    let srv = Server::start();
+    let pw = srv.integrator_password();
+    let token = login_token(&srv, "integrator", &pw);
+    let (status, _, body) =
+        http_get_with_headers(&srv.url("/api/export/model-points.csv"), Some(&token));
+    assert_eq!(status, 200);
+    let header = body.lines().next().unwrap_or("");
+    assert!(header.contains("point_id"));
+    assert!(header.contains("haystack_tags"));
+    assert!(header.contains("rule_inputs"));
+}
+
+#[test]
+fn operator_cannot_export_rules() {
+    let srv = Server::start();
+    let text = std::fs::read_to_string(&srv.auth_path).unwrap();
+    let map = parse_env_file(&text);
+    let op_pw = map.get("OFDD_OPERATOR_PASSWORD").unwrap();
+    let token = login_token(&srv, "operator", op_pw);
+    let (status, _, _) = http_get_with_headers(&srv.url("/api/export/rules.csv"), Some(&token));
+    assert_eq!(status, 403);
+}

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -15,6 +15,7 @@ import PlotPage from "./pages/PlotPage";
 import RuleLabPage from "./pages/RuleLabPage";
 import SqlFddRulesPage from "./pages/SqlFddRulesPage";
 import Bench5007SmokePage from "./pages/Bench5007SmokePage";
+import DataExportPage from "./pages/DataExportPage";
 import AlgorithmsPage from "./pages/AlgorithmsPage";
 import { TabErrorBoundary } from "./components/TabDebugPanel";
 
@@ -36,6 +37,8 @@ export default function App() {
             <Route path="data-model" element={<Navigate to="/model" replace />} />
             <Route path="fdd-assignments" element={<Navigate to="/model" replace />} />
             <Route path="plot" element={<TabErrorBoundary tab="plot"><PlotPage /></TabErrorBoundary>} />
+            <Route path="exports" element={<TabErrorBoundary tab="exports"><DataExportPage /></TabErrorBoundary>} />
+            <Route path="downloads" element={<Navigate to="/exports" replace />} />
             <Route path="drivers" element={<TabErrorBoundary tab="drivers"><DriversPage /></TabErrorBoundary>} />
             <Route path="bacnet" element={<TabErrorBoundary tab="drivers"><DriversPage /></TabErrorBoundary>} />
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -13,6 +13,7 @@ const NAV = [
   { to: "/model", icon: "🧱", label: "Model & assignments", protected: true },
   { to: "/algorithms", icon: "⚙️", label: "Algorithms", protected: true },
   { to: "/faults", icon: "🚦", label: "Fault catalog" },
+  { to: "/exports", icon: "⬇️", label: "Data Export", protected: true },
   { to: "/plot", icon: "📈", label: "Trend plot", protected: true },
   { to: "/agent", icon: "🤖", label: "AI Agent", protected: true },
   { to: "/host", icon: "📊", label: "Host stats", protected: true },

--- a/workspace/dashboard/src/lib/dataExport.test.ts
+++ b/workspace/dashboard/src/lib/dataExport.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendExportQuery,
+  canDownloadExport,
+  DATA_EXPORT_PANEL_TITLE,
+  exportButtonLabel,
+  type ExportMeta,
+  type ExportMetaItem,
+  visibleExports,
+} from "./dataExport";
+
+describe("dataExport helpers", () => {
+  const baseMeta: ExportMeta = {
+    ok: true,
+    xlsx_supported: false,
+    filters: {
+      sites: ["site:demo"],
+      buildings: ["building:main"],
+      protocols: ["bacnet"],
+      equipment: ["5007"],
+    },
+    exports: [
+      {
+        id: "historian",
+        label: "Historian time series",
+        format: "csv",
+        path: "/api/export/historian.csv",
+        available: true,
+      },
+      {
+        id: "bacnet-overrides",
+        label: "BACnet override report",
+        format: "csv",
+        path: "/api/bacnet/overrides/export",
+        available: true,
+      },
+      {
+        id: "rules",
+        label: "Rule definitions",
+        format: "csv",
+        path: "/api/export/rules.csv",
+        requires_role: "integrator|agent",
+        available: true,
+      },
+      {
+        id: "bench-5007",
+        label: "5007 bench smoke data",
+        format: "csv",
+        path: "/api/export/bench-5007.csv",
+        available: false,
+      },
+    ],
+  };
+
+  it("uses Data Export panel title", () => {
+    expect(DATA_EXPORT_PANEL_TITLE).toBe("Data Export");
+  });
+
+  it("appends filter query params for historian download", () => {
+    const path = appendExportQuery("/api/export/historian.csv", {
+      hours: 24,
+      equipment_id: "5007",
+      source_protocol: "bacnet",
+    });
+    expect(path).toContain("hours=24");
+    expect(path).toContain("equipment_id=5007");
+    expect(path).toContain("source_protocol=bacnet");
+  });
+
+  it("shows historian and BACnet override buttons for operators", () => {
+    const items = visibleExports(baseMeta, "operator");
+    const ids = items.map((i) => i.id);
+    expect(ids).toContain("historian");
+    expect(ids).toContain("bacnet-overrides");
+    expect(ids).not.toContain("rules");
+  });
+
+  it("hides unavailable bench export when smoke artifacts absent", () => {
+    const items = visibleExports(baseMeta, "integrator");
+    expect(items.some((i) => i.id === "bench-5007")).toBe(false);
+  });
+
+  it("shows bench export when available", () => {
+    const meta: ExportMeta = {
+      ...baseMeta,
+      exports: baseMeta.exports.map((e) =>
+        e.id === "bench-5007" ? { ...e, available: true, row_count: 48 } : e,
+      ),
+    };
+    const items = visibleExports(meta, "integrator");
+    expect(items.some((i) => i.id === "bench-5007")).toBe(true);
+  });
+
+  it("labels download buttons for Excel users", () => {
+    const item: ExportMetaItem = {
+      id: "historian",
+      label: "Historian time series",
+      format: "csv",
+      path: "/api/export/historian.csv",
+      row_count: 120,
+    };
+    expect(exportButtonLabel(item)).toContain("Historian time series");
+    expect(exportButtonLabel(item)).toContain("CSV");
+  });
+
+  it("blocks integrator-only exports for operators", () => {
+    const rules: ExportMetaItem = {
+      id: "rules",
+      label: "Rule definitions",
+      format: "csv",
+      path: "/api/export/rules.csv",
+      requires_role: "integrator|agent",
+      available: true,
+    };
+    expect(canDownloadExport(rules, "operator")).toBe(false);
+    expect(canDownloadExport(rules, "integrator")).toBe(true);
+  });
+});

--- a/workspace/dashboard/src/lib/dataExport.ts
+++ b/workspace/dashboard/src/lib/dataExport.ts
@@ -1,0 +1,74 @@
+export type ExportMetaItem = {
+  id: string;
+  label: string;
+  format: string;
+  path: string;
+  row_count?: number;
+  available?: boolean;
+  requires_role?: string;
+  data_source_label?: string;
+};
+
+export type ExportMeta = {
+  ok: boolean;
+  exports: ExportMetaItem[];
+  filters: {
+    sites: string[];
+    buildings: string[];
+    protocols: string[];
+    equipment: string[];
+  };
+  xlsx_supported: boolean;
+  xlsx_note?: string;
+};
+
+export type ExportFilters = {
+  hours?: number;
+  start?: string;
+  end?: string;
+  site_id?: string;
+  building_id?: string;
+  equipment_id?: string;
+  source_protocol?: string;
+};
+
+export const DATA_EXPORT_PANEL_TITLE = "Data Export";
+
+export function buildExportQuery(filters: ExportFilters): string {
+  const params = new URLSearchParams();
+  if (filters.hours != null && filters.hours > 0) {
+    params.set("hours", String(filters.hours));
+  }
+  if (filters.start?.trim()) params.set("start", filters.start.trim());
+  if (filters.end?.trim()) params.set("end", filters.end.trim());
+  if (filters.site_id?.trim()) params.set("site_id", filters.site_id.trim());
+  if (filters.building_id?.trim()) params.set("building_id", filters.building_id.trim());
+  if (filters.equipment_id?.trim()) params.set("equipment_id", filters.equipment_id.trim());
+  if (filters.source_protocol?.trim()) params.set("source_protocol", filters.source_protocol.trim());
+  return params.toString();
+}
+
+export function appendExportQuery(path: string, filters: ExportFilters): string {
+  const q = buildExportQuery(filters);
+  if (!q) return path;
+  const sep = path.includes("?") ? "&" : "?";
+  return `${path}${sep}${q}`;
+}
+
+export function canDownloadExport(item: ExportMetaItem, role: string | null): boolean {
+  const req = item.requires_role || "";
+  if (req.includes("integrator") && role !== "integrator" && role !== "agent") {
+    return false;
+  }
+  return item.available !== false;
+}
+
+export function visibleExports(meta: ExportMeta, role: string | null): ExportMetaItem[] {
+  return meta.exports.filter((item) => canDownloadExport(item, role));
+}
+
+export function exportButtonLabel(item: ExportMetaItem): string {
+  const rows =
+    item.row_count != null && item.row_count > 0 ? ` (~${item.row_count.toLocaleString()} rows)` : "";
+  return `Download ${item.label} CSV${rows}`;
+}

--- a/workspace/dashboard/src/pages/DataExportPage.tsx
+++ b/workspace/dashboard/src/pages/DataExportPage.tsx
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import PageHeader from "../components/PageHeader";
+import ActionButton from "../components/ActionButton";
+import { apiDownloadBlob, apiFetch, fetchAuthMe } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+import {
+  appendExportQuery,
+  DATA_EXPORT_PANEL_TITLE,
+  exportButtonLabel,
+  type ExportFilters,
+  type ExportMeta,
+  visibleExports,
+} from "../lib/dataExport";
+
+type LastExport = {
+  label: string;
+  ok: boolean;
+  detail: string;
+  at: string;
+};
+
+const HOUR_OPTIONS = [
+  { value: 0, label: "All available data" },
+  { value: 6, label: "Last 6 hours" },
+  { value: 24, label: "Last 24 hours" },
+  { value: 168, label: "Last 7 days" },
+];
+
+export default function DataExportPage() {
+  const [meta, setMeta] = useState<ExportMeta | null>(null);
+  const [role, setRole] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [lastExport, setLastExport] = useState<LastExport | null>(null);
+  const [filters, setFilters] = useState<ExportFilters>({
+    hours: 24,
+    site_id: "site:demo",
+    building_id: "building:main",
+  });
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [m, me] = await Promise.all([
+        apiFetch<ExportMeta>("/api/export/meta"),
+        fetchAuthMe().catch(() => null),
+      ]);
+      setMeta(m);
+      setRole(me?.role ?? null);
+      setFilters((prev) => ({
+        ...prev,
+        site_id: prev.site_id || m.filters.sites[0] || "site:demo",
+        building_id: prev.building_id || m.filters.buildings[0] || "building:main",
+      }));
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const exports = useMemo(
+    () => (meta ? visibleExports(meta, role) : []),
+    [meta, role],
+  );
+
+  async function downloadExport(exportId: string, path: string, label: string) {
+    setDownloadingId(exportId);
+    setError("");
+    try {
+      const url = appendExportQuery(path, filters);
+      const { blob, filename } = await apiDownloadBlob(url);
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = filename;
+      anchor.click();
+      URL.revokeObjectURL(objectUrl);
+      setLastExport({
+        label,
+        ok: true,
+        detail: `Saved ${filename}`,
+        at: new Date().toLocaleString(),
+      });
+    } catch (err) {
+      const detail = formatApiError(err);
+      setLastExport({
+        label,
+        ok: false,
+        detail,
+        at: new Date().toLocaleString(),
+      });
+      setError(detail);
+    } finally {
+      setDownloadingId(null);
+    }
+  }
+
+  return (
+    <div className="page data-export-page">
+      <PageHeader
+        title={DATA_EXPORT_PANEL_TITLE}
+        subtitle="Download spreadsheet-ready CSV files for historian trends, faults, BACnet overrides, and model metadata."
+      />
+
+      {error ? <p className="error-banner">{error}</p> : null}
+
+      <section className="panel" aria-label={DATA_EXPORT_PANEL_TITLE}>
+        <h3 className="panel-title">{DATA_EXPORT_PANEL_TITLE}</h3>
+        <p className="muted panel-help">
+          Exports use ISO 8601 UTC timestamps plus Excel-friendly local time columns, stable headers, units, and
+          point metadata. CSV is the default format for operators and energy engineers.
+        </p>
+
+        {meta && !meta.xlsx_supported ? (
+          <p className="muted panel-help">{meta.xlsx_note}</p>
+        ) : null}
+
+        <div className="export-filters">
+          <label className="field">
+            <span>Time range</span>
+            <select
+              value={filters.hours ?? 0}
+              onChange={(e) =>
+                setFilters((f) => ({ ...f, hours: Number(e.target.value) || undefined }))
+              }
+            >
+              {HOUR_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Site</span>
+            <select
+              value={filters.site_id || ""}
+              onChange={(e) => setFilters((f) => ({ ...f, site_id: e.target.value }))}
+            >
+              {(meta?.filters.sites ?? ["site:demo"]).map((site) => (
+                <option key={site} value={site}>
+                  {site}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Building</span>
+            <select
+              value={filters.building_id || ""}
+              onChange={(e) => setFilters((f) => ({ ...f, building_id: e.target.value }))}
+            >
+              {(meta?.filters.buildings ?? ["building:main"]).map((b) => (
+                <option key={b} value={b}>
+                  {b}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Protocol / source</span>
+            <select
+              value={filters.source_protocol || ""}
+              onChange={(e) =>
+                setFilters((f) => ({
+                  ...f,
+                  source_protocol: e.target.value || undefined,
+                }))
+              }
+            >
+              <option value="">All protocols</option>
+              {(meta?.filters.protocols ?? []).map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Equipment</span>
+            <select
+              value={filters.equipment_id || ""}
+              onChange={(e) =>
+                setFilters((f) => ({
+                  ...f,
+                  equipment_id: e.target.value || undefined,
+                }))
+              }
+            >
+              <option value="">All equipment</option>
+              {(meta?.filters.equipment ?? []).map((e) => (
+                <option key={e} value={e}>
+                  {e}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {loading ? <p className="muted">Loading export catalog…</p> : null}
+
+        <div className="export-download-list">
+          {exports.map((item) => (
+            <div key={item.id} className="export-download-row">
+              <div className="export-download-meta">
+                <strong>{item.label}</strong>
+                {item.data_source_label ? (
+                  <span className="muted">Source: {item.data_source_label}</span>
+                ) : null}
+                {item.row_count != null ? (
+                  <span className="muted">Estimated rows: {item.row_count.toLocaleString()}</span>
+                ) : null}
+              </div>
+              <ActionButton
+                label={
+                  downloadingId === item.id
+                    ? "Downloading…"
+                    : exportButtonLabel(item)
+                }
+                disabled={loading || downloadingId != null || item.available === false}
+                onClick={() => void downloadExport(item.id, item.path, item.label)}
+              />
+            </div>
+          ))}
+        </div>
+
+        {lastExport ? (
+          <p className={`export-last-status ${lastExport.ok ? "ok" : "error"}`}>
+            Last export ({lastExport.at}): {lastExport.label} — {lastExport.detail}
+          </p>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -2999,6 +2999,51 @@ button.linkish {
   font-size: 0.88rem;
 }
 
+.data-export-page .export-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 14px 16px;
+  margin: 16px 0 20px;
+}
+
+.export-download-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.export-download-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 92%, var(--accent) 8%);
+}
+
+.export-download-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 220px;
+}
+
+.export-last-status {
+  margin-top: 16px;
+  font-size: 0.9rem;
+}
+
+.export-last-status.ok {
+  color: #059669;
+}
+
+.export-last-status.error {
+  color: var(--danger, #dc2626);
+}
+
 @media (max-width: 1100px) {
   .drivers-page .drivers-layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Add authenticated `/api/export/*` CSV routes for historian time series, fault results/summary, model points, rule definitions (integrator/agent), and bench-5007 smoke data.
- Wire BACnet override downloads into the same export experience with `Content-Disposition` filenames (`openfdd_*_YYYYMMDD_HHMM.csv`).
- Add React **Data Export** panel at `/exports` with time range, site/building, protocol, and equipment filters plus row-count estimates and last-export status.

## Related
- XLSX deferred to #367 (CSV only in this PR).
- Complements open BACnet override parity work in #366 without blocking on merge.

## Test plan
- [x] `cargo test --all-targets` (export unit + auth integration tests)
- [x] `npm test` in dashboard (Data Export panel helpers)
- [ ] GitHub Actions compose smoke for `/api/export/meta`, historian CSV headers, bench-5007 CSV, and unauthenticated 401
- [ ] Manual: sign in as operator → download historian + BACnet override CSV from `/exports`
- [ ] Manual: operator blocked from rules CSV; integrator can download rules


Made with [Cursor](https://cursor.com)