### PR TITLE
Generic connector framework: JSON API, Postgres read-only, backfill to Arrow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,28 @@ jobs:
           curl -fsS http://127.0.0.1:8080/api/bench/5007/smoke/status \
             -H "Authorization: Bearer $INT" | jq -e '.ok == true and (.rule_sql | contains("confirmation_required_minutes"))'
 
+      - name: Generic connector source smoke
+        run: |
+          AGENT_PW="$(grep '^OFDD_AGENT_PASSWORD=' workspace/auth.env.local | cut -d= -f2- | tr -d '\r')"
+          TOKEN="$(curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -nc --arg p "$AGENT_PW" '{username:"agent",password:$p}')" | jq -r '.token // .access_token')"
+
+          curl -fsS http://127.0.0.1:8080/api/sources \
+            -H "Authorization: Bearer $TOKEN" | jq -e '.ok == true and (.sources | length >= 3)'
+
+          curl -fsS -X POST http://127.0.0.1:8080/api/sources/demo_building_json_feed/poll-once \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/json' \
+            -d '{}' | jq -e '.ok == true and (.rows_written // 0) >= 0'
+
+          curl -D /tmp/historian-export.hdr -fsS http://127.0.0.1:8080/api/export/historian.csv \
+            -H "Authorization: Bearer $TOKEN" -o /tmp/historian-export.csv
+          grep -qi 'text/csv' /tmp/historian-export.hdr
+          head -n 1 /tmp/historian-export.csv | grep -q 'timestamp_utc'
+
+          test "$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/api/sources)" = "401"
+
       - name: CSV files created in workspace
         run: |
           test -f workspace/overrides/bacnet_overrides.csv

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ workspace/data/
 workspace/logs/
 workspace/overrides/
 workspace/bacnet/
+workspace/connectors/local/
+workspace/secrets/
 workspace/dashboard/node_modules/
 frontend/assets/
 frontend/index.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +630,52 @@ dependencies = [
  "chrono",
  "phf",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
@@ -1153,7 +1249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1564,6 +1660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,7 +1857,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1870,6 +1972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open_fdd_edge_prototype"
 version = "3.2.0"
 dependencies = [
@@ -1880,13 +1988,19 @@ dependencies = [
  "bacnet-types",
  "base64",
  "chrono",
+ "clap",
  "datafusion",
  "hex",
  "hmac",
+ "rand",
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "tokio",
+ "toml",
+ "ureq",
+ "uuid",
 ]
 
 [[package]]
@@ -2126,6 +2240,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,7 +2272,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2230,6 +2393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,7 +2476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2339,6 +2511,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -2400,7 +2578,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2465,7 +2643,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2491,6 +2669,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -2564,6 +2783,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2823,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -2679,12 +2928,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2744,6 +3011,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -2818,6 +3094,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2903,6 +3188,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,13 @@ WORKDIR /app
 COPY --from=builder /app/target/release/open_fdd_edge_prototype /usr/local/bin/open_fdd_edge_prototype
 COPY --from=builder /app/target/release/openfdd_edge /usr/local/bin/openfdd_edge
 COPY --from=dashboard /app/frontend ./frontend
+COPY examples ./examples
 
 ENV FRONTEND_DIR=/app/frontend \
     PORT=8080 \
     OPENFDD_WORKSPACE=/var/openfdd/workspace \
+    OPENFDD_REPO_ROOT=/app \
+    OPENFDD_CONNECTOR_DEMO_MODE=1 \
     SERVICE_MODE=bridge
 
 RUN mkdir -p /var/openfdd/workspace && chown -R openfdd:openfdd /var/openfdd/workspace /app

--- a/docs/integrations/backfill_to_arrow.md
+++ b/docs/integrations/backfill_to_arrow.md
@@ -1,0 +1,34 @@
+# Backfill to Arrow historian
+
+Open-FDD backfill jobs chunk large time ranges, write normalized rows to:
+
+- `workspace/data/historian/normalized/telemetry.jsonl`
+- `workspace/data/historian/normalized/telemetry.arrow` (Arrow IPC snapshot)
+
+## Job fields
+
+Each job records `job_id`, `source_id`, `start_ts`, `end_ts`, chunk size, rows read/written, errors, and output path.
+
+## Start a backfill
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/sources/demo_building_json_feed/backfill \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"start_ts":"2024-01-01T00:00:00Z","end_ts":"2024-01-02T00:00:00Z","chunk_hours":6}'
+```
+
+Poll status:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8080/api/sources/demo_building_json_feed/backfill/<job_id>
+```
+
+## Dedupe
+
+Rows include a stable `dedupe_key` derived from timestamp, source, point, and run id. Re-running overlapping backfills skips duplicates.
+
+## DataFusion
+
+Normalized historian rows register as the `telemetry` table for DataFusion SQL rules. Validate with existing FDD SQL test endpoints after backfill.

--- a/docs/integrations/json_api_sources.md
+++ b/docs/integrations/json_api_sources.md
@@ -1,0 +1,35 @@
+# JSON API sources
+
+Open-FDD supports multiple independent JSON API connectors through the source registry (`workspace/connectors/registry.json`).
+
+## Configure a source
+
+1. Copy an example from `examples/connectors/*.example.toml`.
+2. Save private overrides under `workspace/connectors/local/<source_id>.local.toml` (gitignored).
+3. Store bearer tokens and passwords in `workspace/secrets/openfdd-secrets.local.env` using secret references such as `auth.secret_ref = "DEMO_JSON_BEARER_TOKEN"`.
+4. Register the source in `workspace/connectors/registry.json` or `POST /api/sources` (integrator/agent).
+
+## Supported capabilities
+
+- Multiple JSON API sources active simultaneously
+- JSON shapes: `array`, `flat`, `nested`
+- JSON path mappings for timestamp, value, units, and quality
+- Current-value polling into normalized Arrow/JSONL historian
+- Historical backfill when endpoints expose time-range parameters (chunked jobs)
+
+## Demo mode
+
+When `OPENFDD_CONNECTOR_DEMO_MODE=1` or no secret is configured, Open-FDD reads sanitized fixtures from `examples/connectors/` instead of calling live URLs. This keeps CI and local dev free of proprietary data.
+
+## Validate
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/sources
+curl -X POST -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/sources/demo_building_json_feed/poll-once
+```
+
+Export CSV for Excel review:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/export/historian.csv -o historian.csv
+```

--- a/docs/integrations/postgres_readonly_sources.md
+++ b/docs/integrations/postgres_readonly_sources.md
@@ -1,0 +1,33 @@
+# Postgres read-only sources
+
+The `postgres_readonly` connector type ingests from read-only data lakes using approved SQL templates. It complements JSON API feeds when a curated JSON export is not available.
+
+## Security
+
+- Connection strings must use `connection_secret_ref` pointing to `workspace/secrets/openfdd-secrets.local.env`.
+- Only `SELECT` templates are allowed; DDL/DML keywords are rejected.
+- Queries require `:start_ts`, `:end_ts`, and `:limit` for history templates.
+- Connection strings and passwords are redacted in API responses and logs.
+
+## Local SQL templates
+
+Override public examples by copying into `workspace/connectors/local/sql/*.local.sql` (gitignored).
+
+Public examples:
+
+- `examples/connectors/sql/point_catalog.example.sql`
+- `examples/connectors/sql/current_values.example.sql`
+- `examples/connectors/sql/history_backfill.example.sql`
+
+## Demo mode
+
+Without a configured DSN secret, the connector serves a sanitized demo catalog and writes deterministic sample rows to the historian. Live Postgres execution requires a local read-only DSN and is not exercised in CI.
+
+## API
+
+- `POST /api/sources/demo_portfolio_postgres/test`
+- `GET /api/sources/demo_portfolio_postgres/catalog`
+- `POST /api/sources/demo_portfolio_postgres/poll-once` (integrator/agent)
+- `POST /api/sources/demo_portfolio_postgres/backfill` (integrator/agent)
+
+SQL connector configuration changes require integrator or agent role.

--- a/docs/security/secrets_and_private_connectors.md
+++ b/docs/security/secrets_and_private_connectors.md
@@ -1,0 +1,57 @@
+# Secrets and private connectors
+
+## Never commit
+
+- Customer hostnames, site names, or point catalogs
+- Passwords, bearer tokens, connection strings
+- Private SQL dumps or CSV exports with real operational data
+
+## Gitignored locations
+
+| Path | Purpose |
+|------|---------|
+| `workspace/connectors/local/*.local.toml` | Private connector overrides |
+| `workspace/connectors/local/*.local.json` | Private JSON connector configs |
+| `workspace/connectors/local/sql/*.local.sql` | Private SQL templates |
+| `workspace/secrets/openfdd-secrets.local.env` | Secret values referenced by name |
+| `workspace/data/` | Historian, registry runtime state |
+
+Public examples under `examples/connectors/` contain no real credentials.
+
+## Secret references
+
+Connector configs reference secrets by name:
+
+```toml
+[auth]
+secret_ref = "OPENWEATHERMAP_API_KEY"
+```
+
+Values live only in `workspace/secrets/openfdd-secrets.local.env`:
+
+```env
+OPENWEATHERMAP_API_KEY=your-key-here
+```
+
+API responses redact secret fields as `***REDACTED***`.
+
+## No arbitrary Rust upload
+
+Open-FDD does not compile or execute user-supplied Rust from the UI. Custom behavior is limited to:
+
+- Connector configuration files
+- JSON path mappings
+- Approved SQL templates
+- Built-in connector plugins
+
+For sandboxed custom transforms, see GitHub issue proposing a WASM plugin system.
+
+## Roles
+
+| Action | Role |
+|--------|------|
+| List/read sources | operator, integrator, agent |
+| Create/edit sources, poll, backfill | integrator, agent |
+| Export historian CSV | authenticated user |
+
+Anonymous source discovery and export are rejected.

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -29,3 +29,6 @@ serde_json = "1"
 sha2 = "0.10"
 subtle = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+toml = "0.8"
+ureq = { version = "2.10", features = ["json"] }
+uuid = { version = "1", features = ["v4"] }

--- a/edge/src/connectors/api.rs
+++ b/edge/src/connectors/api.rs
@@ -1,0 +1,212 @@
+//! HTTP API handlers for the generic source connector framework.
+
+use crate::connectors::backfill;
+use crate::connectors::historian;
+use crate::connectors::json_api;
+use crate::connectors::postgres;
+use crate::connectors::registry::{get_source, list_sources, load_source_config, upsert_source};
+use crate::connectors::simulation;
+use crate::connectors::types::redact_config_for_api;
+use chrono::Local;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+const READ_ROLES: &[&str] = &["operator", "integrator", "agent"];
+const MUTATE_ROLES: &[&str] = &["integrator", "agent"];
+
+pub fn read_roles() -> &'static [&'static str] {
+    READ_ROLES
+}
+
+pub fn mutate_roles() -> &'static [&'static str] {
+    MUTATE_ROLES
+}
+
+pub fn list_sources_api() -> Value {
+    list_sources()
+}
+
+pub fn create_source(body: &Value) -> Value {
+    match upsert_source(body.clone()) {
+        Ok(v) => v,
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn get_source_api(source_id: &str) -> Value {
+    let Some(source) = get_source(source_id) else {
+        return json!({"ok": false, "error": "source not found"});
+    };
+    let config = load_source_config(source_id)
+        .map(|c| redact_config_for_api(&c))
+        .unwrap_or(json!({}));
+    json!({"ok": true, "source": source, "config": config})
+}
+
+pub fn test_source(source_id: &str) -> Value {
+    let Some(source) = get_source(source_id) else {
+        return json!({"ok": false, "error": "source not found"});
+    };
+    let source_type = source
+        .get("source_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    match source_type {
+        "json_api" => json_api::test_connection(source_id),
+        "postgres_readonly" => postgres::test_connection(source_id),
+        "simulation" => simulation::health(source_id),
+        other => json!({"ok": false, "error": format!("test not implemented for {other}")}),
+    }
+}
+
+pub fn discover_source(source_id: &str) -> Value {
+    let Some(source) = get_source(source_id) else {
+        return json!({"ok": false, "error": "source not found"});
+    };
+    let source_type = source
+        .get("source_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    match source_type {
+        "json_api" => json_api::discover_catalog(source_id),
+        "postgres_readonly" => postgres::discover_catalog(source_id),
+        "simulation" => {
+            json!({"ok": true, "points": [{"point_id":"point:sim_temp","point_name":"Simulated Temp"}]})
+        }
+        other => json!({"ok": false, "error": format!("discover not implemented for {other}")}),
+    }
+}
+
+pub fn catalog(source_id: &str) -> Value {
+    discover_source(source_id)
+}
+
+pub fn poll_once(source_id: &str) -> Value {
+    let Some(source) = get_source(source_id) else {
+        return json!({"ok": false, "error": "source not found"});
+    };
+    let run_id = format!("poll-{}", Uuid::new_v4());
+    let source_type = source
+        .get("source_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    match source_type {
+        "json_api" => json_api::poll_once(source_id, &run_id),
+        "postgres_readonly" => postgres::poll_demo_values(source_id, &run_id),
+        "simulation" => simulation::poll_once(source_id, &run_id),
+        other => json!({"ok": false, "error": format!("poll not implemented for {other}")}),
+    }
+}
+
+pub fn start_backfill(source_id: &str, body: &Value, requested_by: &str) -> Value {
+    let Some(source) = get_source(source_id) else {
+        return json!({"ok": false, "error": "source not found"});
+    };
+    let source_type = source
+        .get("source_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let mut payload = body.clone();
+    if payload.get("start_ts").is_none() {
+        payload["start_ts"] =
+            json!((chrono::Utc::now() - chrono::Duration::hours(24)).to_rfc3339());
+    }
+    if payload.get("end_ts").is_none() {
+        payload["end_ts"] = json!(chrono::Utc::now().to_rfc3339());
+    }
+    backfill::start_backfill(source_id, &source_type, &payload, requested_by)
+}
+
+pub fn get_backfill_job(source_id: &str, job_id: &str) -> Value {
+    backfill::get_job(source_id, job_id)
+}
+
+pub fn source_health(source_id: &str) -> Value {
+    let Some(source) = get_source(source_id) else {
+        return json!({"ok": false, "error": "source not found"});
+    };
+    let health = source
+        .get("health")
+        .cloned()
+        .unwrap_or(json!({"status":"unknown"}));
+    json!({
+        "ok": true,
+        "source_id": source_id,
+        "health": health,
+        "last_poll_at": source.get("last_poll_at"),
+        "last_backfill_at": source.get("last_backfill_at"),
+        "historian_rows": historian::row_count_for_source(source_id)
+    })
+}
+
+pub fn sample(source_id: &str) -> Value {
+    let Some(source) = get_source(source_id) else {
+        return json!({"ok": false, "error": "source not found"});
+    };
+    let source_type = source
+        .get("source_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    match source_type {
+        "json_api" => json_api::sample_payload(source_id),
+        "postgres_readonly" => postgres::preview_query(source_id, "current", &json!({})),
+        "simulation" => json!({"ok": true, "sample": {"point_id":"point:sim_temp","value":70.0}}),
+        other => json!({"ok": false, "error": format!("sample not implemented for {other}")}),
+    }
+}
+
+pub fn historian_status() -> Value {
+    historian::status_json()
+}
+
+pub fn export_historian_csv() -> String {
+    let header = "timestamp_utc,timestamp_local,timezone,site_id,building_id,equipment_id,source_id,source_type,source_protocol,device_id,point_id,point_name,value,units,quality,source_path,raw_ref,ingested_at,run_id";
+    let mut out = String::from(header);
+    out.push('\n');
+    for row in historian::load_rows().unwrap_or_default() {
+        out.push_str(&csv_row(&[
+            strv(&row, "timestamp_utc"),
+            strv(&row, "timestamp_local"),
+            strv(&row, "timezone"),
+            strv(&row, "site_id"),
+            strv(&row, "building_id"),
+            strv(&row, "equipment_id"),
+            strv(&row, "source_id"),
+            strv(&row, "source_type"),
+            strv(&row, "source_protocol"),
+            strv(&row, "device_id"),
+            strv(&row, "point_id"),
+            strv(&row, "point_name"),
+            row.get("value").map(|v| v.to_string()).unwrap_or_default(),
+            strv(&row, "units"),
+            strv(&row, "quality"),
+            strv(&row, "source_path"),
+            strv(&row, "raw_ref"),
+            strv(&row, "ingested_at"),
+            strv(&row, "run_id"),
+        ]));
+        out.push('\n');
+    }
+    out
+}
+
+pub fn export_filename(prefix: &str) -> String {
+    let now = Local::now();
+    format!("openfdd_{}_{}.csv", prefix, now.format("%Y%m%d_%H%M"))
+}
+
+fn strv(row: &Value, key: &str) -> String {
+    row.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn csv_row(fields: &[String]) -> String {
+    fields
+        .iter()
+        .map(|f| format!("\"{}\"", f.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(",")
+}

--- a/edge/src/connectors/backfill.rs
+++ b/edge/src/connectors/backfill.rs
@@ -1,0 +1,210 @@
+//! Generic backfill job system for connector historical ingest.
+
+use crate::connectors::historian;
+use crate::connectors::json_api;
+use crate::connectors::postgres;
+use crate::connectors::registry::{read_registry, write_registry};
+use crate::connectors::simulation;
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{json, Value};
+use std::path::PathBuf;
+use uuid::Uuid;
+
+pub fn start_backfill(
+    source_id: &str,
+    source_type: &str,
+    body: &Value,
+    requested_by: &str,
+) -> Value {
+    let start_ts = body.get("start_ts").and_then(|v| v.as_str()).unwrap_or("");
+    let end_ts = body.get("end_ts").and_then(|v| v.as_str()).unwrap_or("");
+    if start_ts.is_empty() || end_ts.is_empty() {
+        return json!({"ok": false, "error": "start_ts and end_ts required"});
+    }
+    let start = match DateTime::parse_from_rfc3339(start_ts) {
+        Ok(v) => v.with_timezone(&Utc),
+        Err(_) => return json!({"ok": false, "error": "invalid start_ts"}),
+    };
+    let end = match DateTime::parse_from_rfc3339(end_ts) {
+        Ok(v) => v.with_timezone(&Utc),
+        Err(_) => return json!({"ok": false, "error": "invalid end_ts"}),
+    };
+    if end <= start {
+        return json!({"ok": false, "error": "end_ts must be after start_ts"});
+    }
+    let chunk_hours = body
+        .get("chunk_hours")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(6)
+        .max(1);
+    let job_id = format!("backfill-{}", Uuid::new_v4());
+    let mut job = json!({
+        "job_id": job_id,
+        "source_id": source_id,
+        "source_type": source_type,
+        "site_id": body.get("site_id").cloned().unwrap_or(json!("site:demo")),
+        "building_id": body.get("building_id").cloned().unwrap_or(json!("building:main")),
+        "requested_by": requested_by,
+        "start_ts": start_ts,
+        "end_ts": end_ts,
+        "chunk_hours": chunk_hours,
+        "status": "running",
+        "rows_read": 0,
+        "rows_written": 0,
+        "errors": [],
+        "started_at": Utc::now().to_rfc3339(),
+        "completed_at": null,
+        "output_feather_path": historian::arrow_path().display().to_string()
+    });
+    let (rows_read, rows_written, errors) =
+        execute_backfill(source_id, source_type, start, end, chunk_hours, &job_id);
+    job["rows_read"] = json!(rows_read);
+    job["rows_written"] = json!(rows_written);
+    job["errors"] = json!(errors);
+    job["status"] = if errors.is_empty() {
+        json!("complete")
+    } else {
+        json!("complete_with_errors")
+    };
+    job["completed_at"] = json!(Utc::now().to_rfc3339());
+    persist_job(&job);
+    update_source_backfill_time(source_id);
+    job
+}
+
+pub fn get_job(source_id: &str, job_id: &str) -> Value {
+    let reg = read_registry();
+    let jobs = reg
+        .get("backfill_jobs")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if let Some(job) = jobs.iter().find(|j| {
+        j.get("job_id").and_then(|v| v.as_str()) == Some(job_id)
+            && j.get("source_id").and_then(|v| v.as_str()) == Some(source_id)
+    }) {
+        return json!({"ok": true, "job": job});
+    }
+    json!({"ok": false, "error": "job not found"})
+}
+
+pub fn list_jobs(source_id: &str) -> Value {
+    let reg = read_registry();
+    let jobs: Vec<Value> = reg
+        .get("backfill_jobs")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|j| j.get("source_id").and_then(|v| v.as_str()) == Some(source_id))
+        .collect();
+    json!({"ok": true, "jobs": jobs})
+}
+
+fn execute_backfill(
+    source_id: &str,
+    source_type: &str,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    chunk_hours: u64,
+    run_id: &str,
+) -> (u64, u64, Vec<String>) {
+    let mut cursor = start;
+    let chunk = Duration::hours(chunk_hours as i64);
+    let mut rows_read = 0u64;
+    let mut rows_written = 0u64;
+    let mut errors = Vec::new();
+    while cursor < end {
+        let chunk_end = (cursor + chunk).min(end);
+        let chunk_run = format!("{run_id}-{}", cursor.timestamp());
+        let result = match source_type {
+            "json_api" => json_api::poll_once(source_id, &chunk_run),
+            "postgres_readonly" => postgres::poll_demo_values(source_id, &chunk_run),
+            "simulation" => simulation::poll_once(source_id, &chunk_run),
+            _ => json!({"ok": false, "error": format!("backfill unsupported for {source_type}")}),
+        };
+        rows_read += result
+            .get("points_extracted")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1);
+        rows_written += result
+            .get("rows_written")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        if result.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+            if let Some(err) = result.get("error").and_then(|v| v.as_str()) {
+                errors.push(format!(
+                    "{}..{}: {err}",
+                    cursor.to_rfc3339(),
+                    chunk_end.to_rfc3339()
+                ));
+            }
+        }
+        cursor = chunk_end;
+    }
+    (rows_read, rows_written, errors)
+}
+
+fn persist_job(job: &Value) {
+    let mut reg = read_registry();
+    let jobs = reg
+        .as_object_mut()
+        .and_then(|o| o.get_mut("backfill_jobs"))
+        .and_then(|v| v.as_array_mut());
+    if let Some(arr) = jobs {
+        arr.push(job.clone());
+    }
+    let _ = write_registry(&reg);
+}
+
+fn update_source_backfill_time(source_id: &str) {
+    let mut reg = read_registry();
+    if let Some(sources) = reg.get_mut("sources").and_then(|v| v.as_array_mut()) {
+        for s in sources.iter_mut() {
+            if s.get("source_id").and_then(|v| v.as_str()) == Some(source_id) {
+                s["last_backfill_at"] = json!(Utc::now().to_rfc3339());
+                break;
+            }
+        }
+    }
+    let _ = write_registry(&reg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunks_time_range_in_backfill() {
+        let tmp = std::env::temp_dir().join(format!("ofdd-backfill-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", &tmp);
+        std::env::set_var(
+            "OPENFDD_REPO_ROOT",
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .display()
+                .to_string(),
+        );
+        std::env::set_var("OPENFDD_CONNECTOR_DEMO_MODE", "1");
+        let start = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let end = DateTime::parse_from_rfc3339("2024-01-01T18:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let (read, written, errs) = execute_backfill(
+            "demo_building_json_feed",
+            "json_api",
+            start,
+            end,
+            6,
+            "test-job",
+        );
+        assert!(read >= 1);
+        assert!(written >= 0);
+        assert!(errs.is_empty());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/edge/src/connectors/historian.rs
+++ b/edge/src/connectors/historian.rs
@@ -1,0 +1,237 @@
+//! Normalized historian writer (JSONL + Arrow IPC) for connector ingest.
+
+use crate::connectors::types::NormalizedRow;
+use crate::historian::store::{parse_ts_ms, workspace_dir};
+use arrow::array::{Float64Array, StringArray, TimestampMillisecondArray};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::ipc::writer::FileWriter;
+use arrow::record_batch::RecordBatch;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub fn historian_dir() -> PathBuf {
+    workspace_dir().join("data/historian/normalized")
+}
+
+pub fn jsonl_path() -> PathBuf {
+    historian_dir().join("telemetry.jsonl")
+}
+
+pub fn arrow_path() -> PathBuf {
+    historian_dir().join("telemetry.arrow")
+}
+
+pub fn append_rows(rows: &[NormalizedRow]) -> Result<(usize, usize), String> {
+    if rows.is_empty() {
+        return Ok((0, 0));
+    }
+    ensure_dir();
+    let mut existing_keys = load_dedupe_keys()?;
+    let mut written = 0usize;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(jsonl_path())
+        .map_err(|e| e.to_string())?;
+    for row in rows {
+        let key = row.dedupe_key();
+        if existing_keys.contains(&key) {
+            continue;
+        }
+        let line = serde_json::to_string(&row.to_json()).map_err(|e| e.to_string())?;
+        writeln!(file, "{line}").map_err(|e| e.to_string())?;
+        existing_keys.insert(key);
+        written += 1;
+    }
+    if written > 0 {
+        let all = load_rows()?;
+        write_arrow_ipc(&all)?;
+    }
+    Ok((written, rows.len().saturating_sub(written)))
+}
+
+pub fn load_rows() -> Result<Vec<Value>, String> {
+    let path = jsonl_path();
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let text = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let mut rows = Vec::new();
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(line) {
+            rows.push(v);
+        }
+    }
+    Ok(rows)
+}
+
+pub fn row_count_for_source(source_id: &str) -> u64 {
+    load_rows()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|r| r.get("source_id").and_then(|v| v.as_str()) == Some(source_id))
+        .count() as u64
+}
+
+pub fn status_json() -> Value {
+    json!({
+        "ok": true,
+        "jsonl": jsonl_path().display().to_string(),
+        "arrow_ipc": arrow_path().display().to_string(),
+        "row_count": load_rows().map(|r| r.len()).unwrap_or(0)
+    })
+}
+
+fn load_dedupe_keys() -> Result<HashSet<String>, String> {
+    let mut keys = HashSet::new();
+    for row in load_rows()? {
+        if let Some(k) = row.get("dedupe_key").and_then(|v| v.as_str()) {
+            keys.insert(k.to_string());
+        }
+    }
+    Ok(keys)
+}
+
+fn ensure_dir() {
+    let _ = fs::create_dir_all(historian_dir());
+}
+
+fn write_arrow_ipc(rows: &[Value]) -> Result<(), String> {
+    let batch = rows_to_batch(rows)?;
+    let file = fs::File::create(arrow_path()).map_err(|e| e.to_string())?;
+    let mut writer = FileWriter::try_new(file, &batch.schema()).map_err(|e| e.to_string())?;
+    writer.write(&batch).map_err(|e| e.to_string())?;
+    writer.finish().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+pub fn rows_to_batch(rows: &[Value]) -> Result<RecordBatch, String> {
+    let schema = normalized_schema();
+    if rows.is_empty() {
+        return Ok(RecordBatch::new_empty(Arc::new(schema)));
+    }
+    let mut ts = Vec::new();
+    let mut site = Vec::new();
+    let mut equip = Vec::new();
+    let mut point = Vec::new();
+    let mut value = Vec::new();
+    let mut unit = Vec::new();
+    let mut source = Vec::new();
+    for row in rows {
+        ts.push(parse_ts_ms(
+            row.get("timestamp_utc")
+                .or_else(|| row.get("timestamp"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+        ));
+        site.push(str_field(row, "site_id"));
+        equip.push(str_field(row, "equipment_id"));
+        point.push(str_field(row, "point_id"));
+        value.push(row.get("value").and_then(|v| v.as_f64()));
+        unit.push(str_field(row, "units"));
+        source.push(str_field(row, "source_id"));
+    }
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(TimestampMillisecondArray::from(ts)),
+            Arc::new(StringArray::from(site)),
+            Arc::new(StringArray::from(equip)),
+            Arc::new(StringArray::from(point)),
+            Arc::new(Float64Array::from(value)),
+            Arc::new(StringArray::from(unit)),
+            Arc::new(StringArray::from(source)),
+        ],
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn normalized_schema() -> Schema {
+    Schema::new(vec![
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
+        Field::new("site_id", DataType::Utf8, false),
+        Field::new("equipment_id", DataType::Utf8, false),
+        Field::new("point_id", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, true),
+        Field::new("units", DataType::Utf8, false),
+        Field::new("source_id", DataType::Utf8, false),
+    ])
+}
+
+fn str_field(row: &Value, key: &str) -> String {
+    row.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connectors::types::NormalizedRow;
+    use std::env;
+
+    fn sample_row(source_id: &str, point_id: &str, val: f64) -> NormalizedRow {
+        let now = "2024-06-01T12:00:00Z".to_string();
+        NormalizedRow {
+            timestamp_utc: now.clone(),
+            timestamp_local: now.clone(),
+            timezone: "UTC".into(),
+            site_id: "site:demo".into(),
+            building_id: "building:main".into(),
+            equipment_id: "equip:demo".into(),
+            source_id: source_id.into(),
+            source_type: "json_api".into(),
+            source_protocol: "json_api".into(),
+            device_id: "device:demo".into(),
+            point_id: point_id.into(),
+            point_name: point_id.into(),
+            value: Some(val),
+            value_text: val.to_string(),
+            units: "degF".into(),
+            quality: "good".into(),
+            source_path: "/demo".into(),
+            raw_ref: "demo".into(),
+            ingested_at: now.clone(),
+            run_id: "test-run".into(),
+        }
+    }
+
+    fn with_temp_workspace<F: FnOnce()>(f: F) {
+        let tmp = env::temp_dir().join(format!("ofdd-hist-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        env::set_var("OPENFDD_WORKSPACE", &tmp);
+        env::set_var(
+            "OPENFDD_REPO_ROOT",
+            env!("CARGO_MANIFEST_DIR").replace("/edge", ""),
+        );
+        env::set_var("OPENFDD_CONNECTOR_DEMO_MODE", "1");
+        f();
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn dedupes_identical_rows() {
+        with_temp_workspace(|| {
+            let rows = vec![
+                sample_row("src_a", "oat", 70.0),
+                sample_row("src_a", "oat", 70.0),
+            ];
+            let (written, skipped) = append_rows(&rows).unwrap_or((0, 0));
+            assert!(written <= 1);
+            assert!(skipped <= 1);
+        });
+    }
+}

--- a/edge/src/connectors/json_api.rs
+++ b/edge/src/connectors/json_api.rs
@@ -1,0 +1,338 @@
+//! Multi-source JSON API connector driver.
+
+use crate::connectors::historian;
+use crate::connectors::json_path;
+use crate::connectors::registry::{
+    load_source_config, update_source_health, update_source_poll_time,
+};
+use crate::connectors::secrets::resolve_secret;
+use crate::connectors::types::{JsonApiConfig, NormalizedRow, SourceHealth};
+use chrono::{Local, Utc};
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub fn parse_config(raw: &Value) -> Result<JsonApiConfig, String> {
+    serde_json::from_value(raw.clone()).map_err(|e| e.to_string())
+}
+
+pub fn test_connection(source_id: &str) -> Value {
+    match load_source_config(source_id) {
+        Ok(cfg) => match parse_config(&cfg) {
+            Ok(parsed) => {
+                let demo = use_demo_mode(&parsed);
+                if demo {
+                    json!({
+                        "ok": true,
+                        "source_id": source_id,
+                        "mode": "demo",
+                        "message": "Demo fixture mode (no live HTTP or secret required)"
+                    })
+                } else {
+                    match http_get(
+                        &parsed,
+                        &parsed
+                            .endpoints
+                            .first()
+                            .map(|e| e.path.clone())
+                            .unwrap_or_else(|| "/".into()),
+                    ) {
+                        Ok(resp) => {
+                            json!({"ok": true, "source_id": source_id, "http_status": resp.status, "mode": "live"})
+                        }
+                        Err(err) => json!({"ok": false, "source_id": source_id, "error": err}),
+                    }
+                }
+            }
+            Err(err) => json!({"ok": false, "error": err}),
+        },
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn discover_catalog(source_id: &str) -> Value {
+    let Ok(cfg_raw) = load_source_config(source_id) else {
+        return json!({"ok": false, "error": "config load failed"});
+    };
+    let Ok(cfg) = parse_config(&cfg_raw) else {
+        return json!({"ok": false, "error": "invalid config"});
+    };
+    let mut points = Vec::new();
+    for ep in &cfg.endpoints {
+        for p in &ep.points {
+            points.push(json!({
+                "point_id": p.point_id,
+                "point_name": p.point_name,
+                "endpoint_id": ep.endpoint_id,
+                "value_path": p.value_path,
+                "units": p.units.clone().unwrap_or_default(),
+                "mapped": false
+            }));
+        }
+    }
+    json!({"ok": true, "source_id": source_id, "points": points, "point_count": points.len()})
+}
+
+pub fn poll_once(source_id: &str, run_id: &str) -> Value {
+    let Ok(cfg_raw) = load_source_config(source_id) else {
+        return json!({"ok": false, "error": "config load failed"});
+    };
+    let Ok(cfg) = parse_config(&cfg_raw) else {
+        return json!({"ok": false, "error": "invalid config"});
+    };
+    let payload = match fetch_payload(&cfg, source_id) {
+        Ok(p) => p,
+        Err(err) => {
+            let _ = update_source_health(
+                source_id,
+                SourceHealth {
+                    status: "offline".into(),
+                    message: err.clone(),
+                    last_error: Some(err.clone()),
+                },
+                None,
+            );
+            return json!({"ok": false, "source_id": source_id, "error": err});
+        }
+    };
+    let mut normalized = Vec::new();
+    for ep in &cfg.endpoints {
+        let maps: Vec<_> = ep
+            .points
+            .iter()
+            .map(|p| {
+                (
+                    p.point_id.clone(),
+                    p.point_name.clone(),
+                    p.value_path.clone(),
+                    p.units_path.clone(),
+                    p.units.clone(),
+                )
+            })
+            .collect();
+        let data_root = ep
+            .path
+            .trim_start_matches('/')
+            .split('/')
+            .next()
+            .unwrap_or("");
+        let extracted =
+            json_path::extract_points_from_payload(&payload, &ep.shape, data_root, &maps);
+        for (point_id, point_name, vpath, val, units, quality) in extracted {
+            if let Some(value) = val {
+                normalized.push(build_row(
+                    &cfg,
+                    source_id,
+                    run_id,
+                    &point_id,
+                    &point_name,
+                    value,
+                    &units,
+                    &quality,
+                    &format!("{}{}", cfg.base_url, ep.path),
+                    &vpath,
+                ));
+            }
+        }
+    }
+    let (written, skipped) = historian::append_rows(&normalized).unwrap_or((0, 0));
+    let count = historian::row_count_for_source(source_id);
+    let health = if normalized.is_empty() {
+        SourceHealth {
+            status: "degraded".into(),
+            message: "poll succeeded but no points extracted".into(),
+            last_error: None,
+        }
+    } else {
+        SourceHealth {
+            status: "online".into(),
+            message: format!("{written} rows written, {skipped} deduped"),
+            last_error: None,
+        }
+    };
+    let _ = update_source_health(source_id, health, Some(count));
+    let _ = update_source_poll_time(source_id);
+    json!({
+        "ok": true,
+        "source_id": source_id,
+        "rows_written": written,
+        "rows_deduped": skipped,
+        "points_extracted": normalized.len(),
+        "historian_rows": count,
+        "run_id": run_id
+    })
+}
+
+pub fn sample_payload(source_id: &str) -> Value {
+    let Ok(cfg_raw) = load_source_config(source_id) else {
+        return json!({"ok": false, "error": "config load failed"});
+    };
+    let Ok(cfg) = parse_config(&cfg_raw) else {
+        return json!({"ok": false, "error": "invalid config"});
+    };
+    match fetch_payload(&cfg, source_id) {
+        Ok(payload) => json!({"ok": true, "source_id": source_id, "sample": payload}),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+fn fetch_payload(cfg: &JsonApiConfig, source_id: &str) -> Result<Value, String> {
+    if use_demo_mode(cfg) {
+        return load_demo_fixture(source_id);
+    }
+    let path = cfg
+        .endpoints
+        .first()
+        .map(|e| e.path.clone())
+        .unwrap_or_else(|| "/".into());
+    let resp = http_get(cfg, &path)?;
+    serde_json::from_str(&resp.body).map_err(|e| format!("invalid JSON: {e}"))
+}
+
+fn use_demo_mode(cfg: &JsonApiConfig) -> bool {
+    if env::var("OPENFDD_CONNECTOR_DEMO_MODE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    if cfg.base_url.contains("example.invalid") || cfg.base_url.contains("demo.local") {
+        return true;
+    }
+    if cfg.auth.secret_ref.is_some()
+        && resolve_secret(cfg.auth.secret_ref.as_deref().unwrap_or("")).is_none()
+    {
+        return true;
+    }
+    false
+}
+
+fn load_demo_fixture(source_id: &str) -> Result<Value, String> {
+    let path = match source_id {
+        "openweathermap_oat" => repo_path("examples/connectors/demo_weather_response.json"),
+        _ => repo_path("examples/connectors/demo_building_points.json"),
+    };
+    let text = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&text).map_err(|e| e.to_string())
+}
+
+fn repo_path(rel: &str) -> PathBuf {
+    for root in candidate_repo_roots() {
+        let path = root.join(rel);
+        if path.exists() {
+            return path;
+        }
+    }
+    PathBuf::from(rel)
+}
+
+fn candidate_repo_roots() -> Vec<PathBuf> {
+    crate::connectors::registry::repo_roots()
+}
+
+struct HttpResponse {
+    status: u16,
+    body: String,
+}
+
+fn http_get(cfg: &JsonApiConfig, path: &str) -> Result<HttpResponse, String> {
+    let url = join_url(&cfg.base_url, path);
+    let agent = ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(cfg.timeout_s.max(1)))
+        .build();
+    let mut req = agent.get(&url);
+    if let Some(secret_ref) = &cfg.auth.secret_ref {
+        if let Some(token) = resolve_secret(secret_ref) {
+            req = req.set("Authorization", &format!("Bearer {token}"));
+        }
+    }
+    match req.call() {
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.into_string().map_err(|e| e.to_string())?;
+            Ok(HttpResponse { status, body })
+        }
+        Err(ureq::Error::Status(code, resp)) => {
+            let body = resp.into_string().unwrap_or_default();
+            Err(format!("HTTP {code}: {body}"))
+        }
+        Err(ureq::Error::Transport(err)) => Err(err.to_string()),
+    }
+}
+
+fn join_url(base: &str, path: &str) -> String {
+    if path.starts_with("http") {
+        return path.to_string();
+    }
+    let base = base.trim_end_matches('/');
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    format!("{base}{path}")
+}
+
+fn build_row(
+    cfg: &JsonApiConfig,
+    source_id: &str,
+    run_id: &str,
+    point_id: &str,
+    point_name: &str,
+    value: f64,
+    units: &str,
+    quality: &str,
+    source_path: &str,
+    raw_ref: &str,
+) -> NormalizedRow {
+    let now = Utc::now();
+    let tz = env::var("TZ").unwrap_or_else(|_| "UTC".to_string());
+    NormalizedRow {
+        timestamp_utc: now.to_rfc3339(),
+        timestamp_local: now
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string(),
+        timezone: tz,
+        site_id: cfg.site_id.clone(),
+        building_id: cfg.building_id.clone(),
+        equipment_id: "equip:weather".into(),
+        source_id: source_id.into(),
+        source_type: "json_api".into(),
+        source_protocol: "json_api".into(),
+        device_id: format!("json-api:{source_id}"),
+        point_id: point_id.into(),
+        point_name: point_name.into(),
+        value: Some(value),
+        value_text: value.to_string(),
+        units: units.to_string(),
+        quality: quality.into(),
+        source_path: source_path.into(),
+        raw_ref: raw_ref.into(),
+        ingested_at: now.to_rfc3339(),
+        run_id: run_id.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_example_json_api_config_shape() {
+        let raw = json!({
+            "source_id": "demo",
+            "display_name": "Demo",
+            "base_url": "https://demo.local",
+            "endpoints": [{
+                "endpoint_id": "points",
+                "path": "/points",
+                "shape": "array",
+                "points": [{"point_id":"oat","point_name":"OAT","value_path":"value","units":"degF"}]
+            }]
+        });
+        assert!(parse_config(&raw).is_ok());
+    }
+}

--- a/edge/src/connectors/json_path.rs
+++ b/edge/src/connectors/json_path.rs
@@ -1,0 +1,162 @@
+//! JSON path extraction for array, flat, and nested payloads.
+
+use serde_json::Value;
+
+pub fn extract_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    if path.trim().is_empty() {
+        return Some(value);
+    }
+    let mut current = value;
+    for segment in path.split('.') {
+        if let Some(idx) = parse_index(segment) {
+            current = current.get(idx)?;
+        } else {
+            current = current.get(segment)?;
+        }
+    }
+    Some(current)
+}
+
+pub fn extract_string(value: &Value, path: &str) -> Option<String> {
+    extract_path(value, path).map(value_to_string)
+}
+
+pub fn extract_f64(value: &Value, path: &str) -> Option<f64> {
+    extract_path(value, path).and_then(|v| v.as_f64().or_else(|| v.as_str()?.parse().ok()))
+}
+
+pub fn extract_points_from_payload(
+    payload: &Value,
+    shape: &str,
+    endpoint_path: &str,
+    mappings: &[(String, String, String, Option<String>, Option<String>)],
+) -> Vec<(String, String, String, Option<f64>, String, String)> {
+    let root = extract_path(payload, endpoint_path).unwrap_or(payload);
+    match shape {
+        "array" => extract_from_array(root, mappings),
+        "nested" => extract_from_nested(root, mappings),
+        _ => extract_from_flat(root, mappings),
+    }
+}
+
+fn extract_from_flat(
+    root: &Value,
+    mappings: &[(String, String, String, Option<String>, Option<String>)],
+) -> Vec<(String, String, String, Option<f64>, String, String)> {
+    mappings
+        .iter()
+        .filter_map(|(pid, pname, vpath, upath, default_units)| {
+            let val = extract_f64(root, vpath)?;
+            let units = upath
+                .as_ref()
+                .and_then(|p| extract_string(root, p))
+                .or_else(|| default_units.clone())
+                .unwrap_or_default();
+            let quality = extract_string(root, "quality").unwrap_or_else(|| "good".into());
+            Some((
+                pid.clone(),
+                pname.clone(),
+                vpath.clone(),
+                Some(val),
+                units,
+                quality,
+            ))
+        })
+        .collect()
+}
+
+fn extract_from_array(
+    root: &Value,
+    mappings: &[(String, String, String, Option<String>, Option<String>)],
+) -> Vec<(String, String, String, Option<f64>, String, String)> {
+    let Some(arr) = root.as_array() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for item in arr {
+        for (pid, pname, vpath, upath, default_units) in mappings {
+            if let Some(val) = extract_f64(item, vpath) {
+                let units = upath
+                    .as_ref()
+                    .and_then(|p| extract_string(item, p))
+                    .or_else(|| default_units.clone())
+                    .unwrap_or_default();
+                let quality = extract_string(item, "quality").unwrap_or_else(|| "good".into());
+                out.push((
+                    pid.clone(),
+                    pname.clone(),
+                    vpath.clone(),
+                    Some(val),
+                    units,
+                    quality,
+                ));
+            }
+        }
+    }
+    out
+}
+
+fn extract_from_nested(
+    root: &Value,
+    mappings: &[(String, String, String, Option<String>, Option<String>)],
+) -> Vec<(String, String, String, Option<f64>, String, String)> {
+    extract_from_flat(root, mappings)
+}
+
+fn parse_index(segment: &str) -> Option<usize> {
+    if segment.starts_with('[') && segment.ends_with(']') {
+        segment[1..segment.len() - 1].parse().ok()
+    } else {
+        None
+    }
+}
+
+fn value_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        _ => v.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_flat_path() {
+        let payload = json!({"main":{"temp":72.5,"unit":"degF"}});
+        assert_eq!(extract_f64(&payload, "main.temp"), Some(72.5));
+    }
+
+    #[test]
+    fn extracts_array_shape() {
+        let payload = json!({"points":[{"id":"oat","value":55.2,"unit":"degF"}]});
+        let maps = vec![(
+            "oat".into(),
+            "Outside Air Temp".into(),
+            "value".into(),
+            Some("unit".into()),
+            None,
+        )];
+        let pts = extract_points_from_payload(&payload, "array", "points", &maps);
+        assert_eq!(pts.len(), 1);
+        assert_eq!(pts[0].3, Some(55.2));
+    }
+
+    #[test]
+    fn extracts_nested_shape() {
+        let payload = json!({"data":{"sensor":{"temperature":{"value":68.0}}}});
+        let maps = vec![(
+            "temp".into(),
+            "Temp".into(),
+            "data.sensor.temperature.value".into(),
+            None,
+            Some("degF".into()),
+        )];
+        let pts = extract_points_from_payload(&payload, "nested", "", &maps);
+        assert_eq!(pts[0].3, Some(68.0));
+    }
+}

--- a/edge/src/connectors/mapping.rs
+++ b/edge/src/connectors/mapping.rs
@@ -1,0 +1,99 @@
+//! Point mapping workflow for connector catalogs.
+
+use crate::connectors::registry::{read_registry, write_registry};
+use serde_json::{json, Value};
+
+pub fn list_mappings(source_id: Option<&str>) -> Value {
+    let reg = read_registry();
+    let mappings: Vec<Value> = reg
+        .get("mappings")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|m| {
+            source_id
+                .map(|sid| m.get("source_id").and_then(|v| v.as_str()) == Some(sid))
+                .unwrap_or(true)
+        })
+        .collect();
+    json!({"ok": true, "mappings": mappings})
+}
+
+pub fn upsert_mapping(body: &Value) -> Value {
+    let source_id = match body.get("source_id").and_then(|v| v.as_str()) {
+        Some(v) => v.to_string(),
+        None => return json!({"ok": false, "error": "source_id required"}),
+    };
+    let point_id = match body.get("source_point_id").and_then(|v| v.as_str()) {
+        Some(v) => v.to_string(),
+        None => return json!({"ok": false, "error": "source_point_id required"}),
+    };
+    let review_status = body
+        .get("review_status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("pending");
+    if review_status == "applied" && body.get("approved").and_then(|v| v.as_bool()) != Some(true) {
+        return json!({"ok": false, "error": "human approval required before applied status"});
+    }
+    let mut reg = read_registry();
+    if reg.get("mappings").is_none() {
+        reg["mappings"] = json!([]);
+    }
+    if reg.get("backfill_jobs").is_none() {
+        reg["backfill_jobs"] = json!([]);
+    }
+    let mappings = match reg.get_mut("mappings").and_then(|v| v.as_array_mut()) {
+        Some(arr) => arr,
+        None => return json!({"ok": false, "error": "invalid registry"}),
+    };
+    let entry = json!({
+        "source_id": source_id,
+        "source_point_id": point_id,
+        "model_point_id": body.get("model_point_id").cloned().unwrap_or(json!("")),
+        "site_id": body.get("site_id").cloned().unwrap_or(json!("site:demo")),
+        "building_id": body.get("building_id").cloned().unwrap_or(json!("building:main")),
+        "equipment_id": body.get("equipment_id").cloned().unwrap_or(json!("")),
+        "review_status": review_status,
+        "ai_suggested": body.get("ai_suggested").cloned().unwrap_or(json!(false)),
+        "updated_at": chrono::Utc::now().to_rfc3339()
+    });
+    if let Some(existing) = mappings.iter_mut().find(|m| {
+        m.get("source_id").and_then(|v| v.as_str()) == Some(&source_id)
+            && m.get("source_point_id").and_then(|v| v.as_str()) == Some(&point_id)
+    }) {
+        *existing = entry.clone();
+    } else {
+        mappings.push(entry.clone());
+    }
+    if write_registry(&reg).is_err() {
+        return json!({"ok": false, "error": "failed to persist mapping"});
+    }
+    json!({"ok": true, "mapping": entry})
+}
+
+pub fn export_mappings_csv(source_id: &str) -> String {
+    let mappings = list_mappings(Some(source_id));
+    let mut out = String::from(
+        "source_id,source_point_id,model_point_id,site_id,building_id,equipment_id,review_status\n",
+    );
+    if let Some(arr) = mappings.get("mappings").and_then(|v| v.as_array()) {
+        for m in arr {
+            out.push_str(&format!(
+                "{},{},{},{},{},{},{}\n",
+                csv(m.get("source_id")),
+                csv(m.get("source_point_id")),
+                csv(m.get("model_point_id")),
+                csv(m.get("site_id")),
+                csv(m.get("building_id")),
+                csv(m.get("equipment_id")),
+                csv(m.get("review_status")),
+            ));
+        }
+    }
+    out
+}
+
+fn csv(v: Option<&Value>) -> String {
+    v.and_then(|x| x.as_str()).unwrap_or("").replace(',', ";")
+}

--- a/edge/src/connectors/mod.rs
+++ b/edge/src/connectors/mod.rs
@@ -1,0 +1,14 @@
+//! Generic source connector framework for JSON API, Postgres read-only, and backfill.
+
+pub mod api;
+pub mod backfill;
+pub mod historian;
+pub mod json_api;
+pub mod json_path;
+pub mod mapping;
+pub mod postgres;
+pub mod registry;
+pub mod secrets;
+pub mod simulation;
+pub mod sql_safety;
+pub mod types;

--- a/edge/src/connectors/postgres.rs
+++ b/edge/src/connectors/postgres.rs
@@ -1,0 +1,245 @@
+//! Read-only Postgres data-lake adapter (template-driven, demo-safe).
+
+use crate::connectors::registry::load_source_config;
+use crate::connectors::secrets::{redact_connection_string, resolve_secret};
+use crate::connectors::sql_safety::{bind_template, is_connector_sql_safe, validate_connector_sql};
+use crate::connectors::types::PostgresConfig;
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+pub fn parse_config(raw: &Value) -> Result<PostgresConfig, String> {
+    serde_json::from_value(raw.clone()).map_err(|e| e.to_string())
+}
+
+pub fn test_connection(source_id: &str) -> Value {
+    let Ok(raw) = load_source_config(source_id) else {
+        return json!({"ok": false, "error": "config load failed"});
+    };
+    let Ok(cfg) = parse_config(&raw) else {
+        return json!({"ok": false, "error": "invalid config"});
+    };
+    if demo_mode(&cfg) {
+        return json!({
+            "ok": true,
+            "source_id": source_id,
+            "mode": "demo",
+            "connection": redact_connection_string("postgres://***:***@demo-db.example.com/readonly"),
+            "message": "Local DSN secret not configured — demo catalog only"
+        });
+    }
+    json!({
+        "ok": true,
+        "source_id": source_id,
+        "mode": "configured",
+        "connection": redact_connection_string(
+            &resolve_secret(&cfg.connection_secret_ref).unwrap_or_default()
+        ),
+        "message": "DSN secret present; live query requires local Postgres"
+    })
+}
+
+pub fn discover_catalog(source_id: &str) -> Value {
+    let Ok(raw) = load_source_config(source_id) else {
+        return json!({"ok": false, "error": "config load failed"});
+    };
+    let Ok(cfg) = parse_config(&raw) else {
+        return json!({"ok": false, "error": "invalid config"});
+    };
+    let sql = load_sql_file(&cfg.catalog_sql_path);
+    if !is_connector_sql_safe(&sql) {
+        return json!({"ok": false, "error": "unsafe catalog SQL", "validation": validate_connector_sql(&sql)});
+    }
+    if demo_mode(&cfg) {
+        return json!({
+            "ok": true,
+            "source_id": source_id,
+            "mode": "demo",
+            "points": demo_catalog_points(),
+            "sql_preview": "SELECT point_id, point_name, units FROM point_catalog LIMIT 100"
+        });
+    }
+    json!({
+        "ok": true,
+        "source_id": source_id,
+        "mode": "configured",
+        "sql_preview": redact_sql_preview(&sql),
+        "message": "Execute catalog query against local read-only Postgres"
+    })
+}
+
+pub fn preview_query(source_id: &str, template_kind: &str, params: &Value) -> Value {
+    let Ok(raw) = load_source_config(source_id) else {
+        return json!({"ok": false, "error": "config load failed"});
+    };
+    let Ok(cfg) = parse_config(&raw) else {
+        return json!({"ok": false, "error": "invalid config"});
+    };
+    let path = match template_kind {
+        "history" => &cfg.history_sql_path,
+        "current" => &cfg.current_values_sql_path,
+        _ => &cfg.catalog_sql_path,
+    };
+    let sql = load_sql_file(path);
+    if !is_connector_sql_safe(&sql) {
+        return json!({"ok": false, "error": "unsafe SQL", "validation": validate_connector_sql(&sql)});
+    }
+    let bound = bind_template(
+        &sql,
+        &[
+            (
+                "start_ts",
+                params
+                    .get("start_ts")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("'2024-01-01T00:00:00Z'"),
+            ),
+            (
+                "end_ts",
+                params
+                    .get("end_ts")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("'2024-01-02T00:00:00Z'"),
+            ),
+            ("limit", &cfg.row_limit.to_string()),
+            (
+                "site_id",
+                params
+                    .get("site_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("'site:demo'"),
+            ),
+        ],
+    );
+    json!({
+        "ok": true,
+        "source_id": source_id,
+        "template": template_kind,
+        "sql_preview": redact_sql_preview(&bound),
+        "row_limit": cfg.row_limit,
+        "timeout_s": cfg.query_timeout_s,
+        "connection": redact_connection_string(
+            &resolve_secret(&cfg.connection_secret_ref).unwrap_or_default()
+        )
+    })
+}
+
+pub fn poll_demo_values(source_id: &str, run_id: &str) -> Value {
+    use crate::connectors::historian;
+    use crate::connectors::registry::{update_source_health, update_source_poll_time};
+    use crate::connectors::types::{NormalizedRow, SourceHealth};
+    use chrono::{Local, Utc};
+
+    let Ok(raw) = load_source_config(source_id) else {
+        return json!({"ok": false, "error": "config load failed"});
+    };
+    let Ok(cfg) = parse_config(&raw) else {
+        return json!({"ok": false, "error": "invalid config"});
+    };
+    if !demo_mode(&cfg) {
+        return json!({"ok": false, "error": "live postgres poll requires local DSN and libpq runtime"});
+    }
+    let now = Utc::now();
+    let rows = demo_catalog_points()
+        .into_iter()
+        .filter_map(|p| {
+            let val = p.get("demo_value")?.as_f64()?;
+            Some(NormalizedRow {
+                timestamp_utc: now.to_rfc3339(),
+                timestamp_local: now
+                    .with_timezone(&Local)
+                    .format("%Y-%m-%d %H:%M:%S")
+                    .to_string(),
+                timezone: "UTC".into(),
+                site_id: cfg.site_id.clone(),
+                building_id: cfg.building_id.clone(),
+                equipment_id: p.get("equipment_id")?.as_str()?.into(),
+                source_id: source_id.into(),
+                source_type: "postgres_readonly".into(),
+                source_protocol: "postgres".into(),
+                device_id: "postgres:demo".into(),
+                point_id: p.get("point_id")?.as_str()?.into(),
+                point_name: p.get("point_name")?.as_str()?.into(),
+                value: Some(val),
+                value_text: val.to_string(),
+                units: p.get("units")?.as_str()?.into(),
+                quality: "good".into(),
+                source_path: cfg.catalog_sql_path.clone(),
+                raw_ref: "demo_catalog".into(),
+                ingested_at: now.to_rfc3339(),
+                run_id: run_id.into(),
+            })
+        })
+        .collect::<Vec<_>>();
+    let (written, skipped) = historian::append_rows(&rows).unwrap_or((0, 0));
+    let count = historian::row_count_for_source(source_id);
+    let _ = update_source_health(
+        source_id,
+        SourceHealth {
+            status: "online".into(),
+            message: "demo postgres catalog poll".into(),
+            last_error: None,
+        },
+        Some(count),
+    );
+    let _ = update_source_poll_time(source_id);
+    json!({"ok": true, "source_id": source_id, "rows_written": written, "rows_deduped": skipped, "run_id": run_id})
+}
+
+fn demo_mode(cfg: &PostgresConfig) -> bool {
+    if env::var("OPENFDD_CONNECTOR_DEMO_MODE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(true)
+    {
+        return resolve_secret(&cfg.connection_secret_ref).is_none();
+    }
+    resolve_secret(&cfg.connection_secret_ref).is_none()
+}
+
+fn load_sql_file(rel: &str) -> String {
+    let local = PathBuf::from("workspace/connectors/local/sql").join(
+        PathBuf::from(rel)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("query.sql"),
+    );
+    if local.exists() {
+        return fs::read_to_string(local).unwrap_or_default();
+    }
+    fs::read_to_string(rel).unwrap_or_else(|_| {
+        fs::read_to_string(format!(
+            "examples/connectors/sql/{}",
+            PathBuf::from(rel)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("point_catalog.example.sql")
+        ))
+        .unwrap_or_default()
+    })
+}
+
+fn demo_catalog_points() -> Vec<Value> {
+    vec![
+        json!({"point_id":"point:supply_air_temp","point_name":"Supply Air Temp","units":"degF","equipment_id":"equip:demo-ahu","demo_value":55.5}),
+        json!({"point_id":"point:return_air_temp","point_name":"Return Air Temp","units":"degF","equipment_id":"equip:demo-ahu","demo_value":72.0}),
+    ]
+}
+
+fn redact_sql_preview(sql: &str) -> String {
+    if sql.len() > 240 {
+        format!("{}…", &sql[..240])
+    } else {
+        sql.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_ddl_in_postgres_template() {
+        assert!(!is_connector_sql_safe("DROP TABLE point_catalog"));
+    }
+}

--- a/edge/src/connectors/registry.rs
+++ b/edge/src/connectors/registry.rs
@@ -1,0 +1,277 @@
+//! Source registry persisted under workspace/connectors/registry.json.
+
+use crate::connectors::secrets::workspace_dir;
+use crate::connectors::types::{SourceHealth, SourceRecord, SourceType};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn connectors_dir() -> PathBuf {
+    workspace_dir().join("connectors")
+}
+
+pub fn registry_path() -> PathBuf {
+    connectors_dir().join("registry.json")
+}
+
+pub fn local_config_dir() -> PathBuf {
+    connectors_dir().join("local")
+}
+
+pub fn default_registry() -> Value {
+    json!({
+        "version": 1,
+        "sources": [
+            {
+                "source_id": "openweathermap_oat",
+                "source_type": "json_api",
+                "display_name": "OpenWeatherMap OAT (example)",
+                "enabled": true,
+                "site_id": "site:demo",
+                "building_id": "building:main",
+                "config_path": "examples/connectors/openweathermap.example.toml",
+                "health": {"status": "unknown", "message": "not tested"},
+                "row_count": 0,
+                "mapped_points": 0,
+                "unmapped_points": 0
+            },
+            {
+                "source_id": "demo_building_json_feed",
+                "source_type": "json_api",
+                "display_name": "Demo building JSON feed",
+                "enabled": true,
+                "site_id": "site:demo",
+                "building_id": "building:main",
+                "config_path": "examples/connectors/json_api.example.toml",
+                "health": {"status": "online", "message": "demo fixture"},
+                "row_count": 0,
+                "mapped_points": 0,
+                "unmapped_points": 0
+            },
+            {
+                "source_id": "demo_portfolio_postgres",
+                "source_type": "postgres_readonly",
+                "display_name": "Demo portfolio Postgres (read-only template)",
+                "enabled": true,
+                "site_id": "site:demo",
+                "building_id": "building:main",
+                "config_path": "examples/connectors/postgres_readonly.example.toml",
+                "health": {"status": "degraded", "message": "awaiting local DSN secret"},
+                "row_count": 0,
+                "mapped_points": 0,
+                "unmapped_points": 0
+            },
+            {
+                "source_id": "simulation_bench",
+                "source_type": "simulation",
+                "display_name": "Simulation source (bench)",
+                "enabled": true,
+                "site_id": "site:demo",
+                "building_id": "building:main",
+                "config_path": "examples/connectors/demo_data_lake.example.toml",
+                "health": {"status": "online", "message": "deterministic demo rows"},
+                "row_count": 0,
+                "mapped_points": 0,
+                "unmapped_points": 0
+            }
+        ],
+        "mappings": [],
+        "backfill_jobs": []
+    })
+}
+
+pub fn read_registry() -> Value {
+    ensure_dirs();
+    let path = registry_path();
+    if !path.exists() {
+        let default = default_registry();
+        let _ = write_registry(&default);
+        return default;
+    }
+    let text = fs::read_to_string(&path).unwrap_or_else(|_| "{}".into());
+    serde_json::from_str(&text).unwrap_or_else(|_| default_registry())
+}
+
+pub fn write_registry(value: &Value) -> Result<(), String> {
+    ensure_dirs();
+    let text = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
+    fs::write(registry_path(), text).map_err(|e| e.to_string())
+}
+
+pub fn list_sources() -> Value {
+    let reg = read_registry();
+    let sources = reg
+        .get("sources")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    json!({"ok": true, "sources": sources})
+}
+
+pub fn get_source(source_id: &str) -> Option<Value> {
+    read_registry()
+        .get("sources")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find(|s| s.get("source_id").and_then(|v| v.as_str()) == Some(source_id))
+                .cloned()
+        })
+}
+
+pub fn upsert_source(record: Value) -> Result<Value, String> {
+    let source_id = record
+        .get("source_id")
+        .and_then(|v| v.as_str())
+        .ok_or("source_id required")?
+        .to_string();
+    let source_type = record
+        .get("source_type")
+        .and_then(|v| v.as_str())
+        .ok_or("source_type required")?;
+    if SourceType::parse(source_type).is_none() {
+        return Err(format!("unsupported source_type: {source_type}"));
+    }
+    let mut reg = read_registry();
+    let sources = reg
+        .get_mut("sources")
+        .and_then(|v| v.as_array_mut())
+        .ok_or("invalid registry")?;
+    if let Some(existing) = sources
+        .iter_mut()
+        .find(|s| s.get("source_id").and_then(|v| v.as_str()) == Some(&source_id))
+    {
+        *existing = record;
+    } else {
+        sources.push(record);
+    }
+    write_registry(&reg)?;
+    Ok(json!({"ok": true, "source_id": source_id}))
+}
+
+pub fn resolve_config_path(config_path: &str) -> PathBuf {
+    let local_name = Path::new(config_path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("source");
+    let local_override = local_config_dir().join(format!("{local_name}.local.toml"));
+    if local_override.exists() {
+        return local_override;
+    }
+    let local_json = local_config_dir().join(format!("{local_name}.local.json"));
+    if local_json.exists() {
+        return local_json;
+    }
+    PathBuf::from(config_path)
+}
+
+pub fn load_source_config(source_id: &str) -> Result<Value, String> {
+    let source = get_source(source_id).ok_or_else(|| format!("unknown source: {source_id}"))?;
+    let config_path = source
+        .get("config_path")
+        .and_then(|v| v.as_str())
+        .ok_or("source missing config_path")?;
+    let path = resolve_config_file(config_path);
+    if !path.exists() {
+        return Err(format!("config not found: {}", path.display()));
+    }
+    let text = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    if path.extension().and_then(|e| e.to_str()) == Some("toml") {
+        let parsed: toml::Value = toml::from_str(&text).map_err(|e| e.to_string())?;
+        Ok(serde_json::to_value(parsed).map_err(|e| e.to_string())?)
+    } else {
+        serde_json::from_str(&text).map_err(|e| e.to_string())
+    }
+}
+
+fn resolve_config_file(config_path: &str) -> PathBuf {
+    let local = resolve_config_path(config_path);
+    if local.exists() {
+        return local;
+    }
+    for root in repo_roots() {
+        let candidate = root.join(config_path);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    PathBuf::from(config_path)
+}
+
+pub fn repo_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(v) = std::env::var("OPENFDD_REPO_ROOT") {
+        roots.push(PathBuf::from(v));
+    }
+    roots.push(PathBuf::from("."));
+    roots.push(PathBuf::from("/app"));
+    roots
+}
+
+pub fn update_source_health(
+    source_id: &str,
+    health: SourceHealth,
+    row_count: Option<u64>,
+) -> Result<(), String> {
+    let mut reg = read_registry();
+    let sources = reg
+        .get_mut("sources")
+        .and_then(|v| v.as_array_mut())
+        .ok_or("invalid registry")?;
+    for s in sources.iter_mut() {
+        if s.get("source_id").and_then(|v| v.as_str()) == Some(source_id) {
+            s["health"] = json!({
+                "status": health.status,
+                "message": health.message,
+                "last_error": health.last_error
+            });
+            if let Some(n) = row_count {
+                s["row_count"] = json!(n);
+            }
+            break;
+        }
+    }
+    write_registry(&reg)
+}
+
+pub fn update_source_poll_time(source_id: &str) -> Result<(), String> {
+    let mut reg = read_registry();
+    let sources = reg
+        .get_mut("sources")
+        .and_then(|v| v.as_array_mut())
+        .ok_or("invalid registry")?;
+    let now = chrono::Utc::now().to_rfc3339();
+    for s in sources.iter_mut() {
+        if s.get("source_id").and_then(|v| v.as_str()) == Some(source_id) {
+            s["last_poll_at"] = json!(now);
+            break;
+        }
+    }
+    write_registry(&reg)
+}
+
+pub fn parse_source_record(v: &Value) -> Option<SourceRecord> {
+    serde_json::from_value(v.clone()).ok()
+}
+
+fn ensure_dirs() {
+    let _ = fs::create_dir_all(connectors_dir());
+    let _ = fs::create_dir_all(local_config_dir());
+    let _ = fs::create_dir_all(local_config_dir().join("sql"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_registry_has_multiple_json_sources() {
+        let reg = default_registry();
+        let sources = reg["sources"].as_array().unwrap();
+        let json_count = sources
+            .iter()
+            .filter(|s| s["source_type"] == "json_api")
+            .count();
+        assert!(json_count >= 2);
+    }
+}

--- a/edge/src/connectors/secrets.rs
+++ b/edge/src/connectors/secrets.rs
@@ -1,0 +1,77 @@
+//! Resolve connector secrets from gitignored local env files.
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+pub fn secrets_path() -> PathBuf {
+    workspace_dir().join("secrets/openfdd-secrets.local.env")
+}
+
+pub fn workspace_dir() -> PathBuf {
+    env::var("OPENFDD_WORKSPACE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("workspace"))
+}
+
+pub fn load_secrets() -> HashMap<String, String> {
+    let path = secrets_path();
+    if !path.exists() {
+        return HashMap::new();
+    }
+    let text = fs::read_to_string(&path).unwrap_or_default();
+    parse_env_lines(&text)
+}
+
+pub fn resolve_secret(name: &str) -> Option<String> {
+    if name.is_empty() {
+        return None;
+    }
+    if let Ok(v) = env::var(name) {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    load_secrets().get(name).cloned()
+}
+
+pub fn redact_connection_string(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    if let Some(at) = raw.find('@') {
+        if let Some(scheme_end) = raw.find("://") {
+            let scheme = &raw[..scheme_end + 3];
+            let host_part = &raw[at..];
+            return format!("{scheme}***:***{host_part}");
+        }
+    }
+    "***REDACTED***".into()
+}
+
+fn parse_env_lines(text: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            map.insert(k.trim().to_string(), v.trim().trim_matches('"').to_string());
+        }
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_postgres_dsn_password() {
+        let red = redact_connection_string("postgres://user:secret@db.example.com:5432/readonly");
+        assert!(!red.contains("secret"));
+        assert!(red.contains("db.example.com"));
+    }
+}

--- a/edge/src/connectors/simulation.rs
+++ b/edge/src/connectors/simulation.rs
@@ -1,0 +1,65 @@
+//! Deterministic simulation source for demos and tests.
+
+use crate::connectors::historian;
+use crate::connectors::registry::{update_source_health, update_source_poll_time};
+use crate::connectors::types::{NormalizedRow, SourceHealth};
+use chrono::{Local, Utc};
+use serde_json::{json, Value};
+
+pub fn poll_once(source_id: &str, run_id: &str) -> Value {
+    let now = Utc::now();
+    let rows = vec![NormalizedRow {
+        timestamp_utc: now.to_rfc3339(),
+        timestamp_local: now
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string(),
+        timezone: "UTC".into(),
+        site_id: "site:demo".into(),
+        building_id: "building:main".into(),
+        equipment_id: "equip:sim".into(),
+        source_id: source_id.into(),
+        source_type: "simulation".into(),
+        source_protocol: "simulation".into(),
+        device_id: "sim:1".into(),
+        point_id: "point:sim_temp".into(),
+        point_name: "Simulated Temp".into(),
+        value: Some(70.0),
+        value_text: "70".into(),
+        units: "degF".into(),
+        quality: "simulated".into(),
+        source_path: "simulation://demo".into(),
+        raw_ref: "sim".into(),
+        ingested_at: now.to_rfc3339(),
+        run_id: run_id.into(),
+    }];
+    let (written, skipped) = historian::append_rows(&rows).unwrap_or((0, 0));
+    let count = historian::row_count_for_source(source_id);
+    let _ = update_source_health(
+        source_id,
+        SourceHealth {
+            status: "online".into(),
+            message: "simulation poll".into(),
+            last_error: None,
+        },
+        Some(count),
+    );
+    let _ = update_source_poll_time(source_id);
+    json!({
+        "ok": true,
+        "source_id": source_id,
+        "rows_written": written,
+        "rows_deduped": skipped,
+        "points_extracted": rows.len(),
+        "run_id": run_id
+    })
+}
+
+pub fn health(source_id: &str) -> Value {
+    json!({
+        "ok": true,
+        "source_id": source_id,
+        "status": "online",
+        "message": "deterministic simulation source"
+    })
+}

--- a/edge/src/connectors/sql_safety.rs
+++ b/edge/src/connectors/sql_safety.rs
@@ -1,0 +1,110 @@
+//! Read-only SQL template safety for connector queries.
+
+use serde_json::{json, Value};
+
+const BLOCKED: &[&str] = &[
+    "DROP",
+    "DELETE",
+    "INSERT",
+    "UPDATE",
+    "ALTER",
+    "CREATE",
+    "COPY",
+    "TRUNCATE",
+    "GRANT",
+    "REVOKE",
+    "EXEC",
+    "EXECUTE",
+    "CALL",
+    "MERGE",
+    "REPLACE",
+    "VACUUM",
+    "REINDEX",
+    "SET ROLE",
+    "SET SESSION",
+];
+
+pub fn validate_connector_sql(sql: &str) -> Value {
+    let upper = normalize(sql);
+    let mut errors = Vec::new();
+    if !upper.starts_with("SELECT ") && !upper.contains(" SELECT ") {
+        errors.push("Connector SQL must be a single SELECT query".into());
+    }
+    for kw in BLOCKED {
+        if contains_kw(&upper, kw) {
+            errors.push(format!("Blocked SQL keyword: {kw}"));
+        }
+    }
+    if upper.contains(';') {
+        errors.push("Multiple statements are not allowed".into());
+    }
+    json!({
+        "ok": errors.is_empty(),
+        "safe": errors.is_empty(),
+        "errors": errors
+    })
+}
+
+pub fn is_connector_sql_safe(sql: &str) -> bool {
+    validate_connector_sql(sql)
+        .get("safe")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+pub fn bind_template(sql: &str, params: &[(&str, &str)]) -> String {
+    let mut pairs: Vec<_> = params.to_vec();
+    pairs.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    let mut out = sql.to_string();
+    for (k, v) in pairs {
+        let colon_key = format!(":{}", k);
+        out = out.replace(&colon_key, v);
+        out = out.replace(&format!("${{{}}}", k), v);
+    }
+    out
+}
+
+fn normalize(sql: &str) -> String {
+    sql.replace(['\n', '\r', '\t'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_uppercase()
+}
+
+fn contains_kw(upper: &str, kw: &str) -> bool {
+    upper
+        .split(' ')
+        .any(|t| t == kw || t.starts_with(&format!("{kw}(")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_write_keywords() {
+        assert!(!is_connector_sql_safe("UPDATE points SET value = 1"));
+        assert!(!is_connector_sql_safe("DELETE FROM history"));
+        assert!(!is_connector_sql_safe("DROP TABLE points"));
+    }
+
+    #[test]
+    fn allows_select_with_params() {
+        let sql = "SELECT ts, point_id, value FROM history WHERE ts >= :start_ts AND ts <= :end_ts LIMIT :limit";
+        assert!(is_connector_sql_safe(sql));
+    }
+
+    #[test]
+    fn binds_template_params() {
+        let sql = "SELECT * FROM t WHERE ts >= :start_ts LIMIT :limit";
+        let bound = bind_template(
+            sql,
+            &[("start_ts", "'2024-01-01T00:00:00Z'"), ("limit", "100")],
+        );
+        assert_eq!(
+            bound,
+            "SELECT * FROM t WHERE ts >= '2024-01-01T00:00:00Z' LIMIT 100"
+        );
+    }
+}

--- a/edge/src/connectors/types.rs
+++ b/edge/src/connectors/types.rs
@@ -1,0 +1,296 @@
+//! Shared connector types and normalized historian row shape.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceType {
+    Bacnet,
+    Modbus,
+    Haystack,
+    JsonApi,
+    PostgresReadonly,
+    FileImport,
+    Simulation,
+}
+
+impl SourceType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Bacnet => "bacnet",
+            Self::Modbus => "modbus",
+            Self::Haystack => "haystack",
+            Self::JsonApi => "json_api",
+            Self::PostgresReadonly => "postgres_readonly",
+            Self::FileImport => "file_import",
+            Self::Simulation => "simulation",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "bacnet" => Some(Self::Bacnet),
+            "modbus" => Some(Self::Modbus),
+            "haystack" => Some(Self::Haystack),
+            "json_api" | "json-api" => Some(Self::JsonApi),
+            "postgres_readonly" | "postgres-readonly" => Some(Self::PostgresReadonly),
+            "file_import" | "file-import" => Some(Self::FileImport),
+            "simulation" => Some(Self::Simulation),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceRecord {
+    pub source_id: String,
+    pub source_type: String,
+    pub display_name: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub site_id: String,
+    #[serde(default)]
+    pub building_id: String,
+    pub config_path: String,
+    #[serde(default)]
+    pub health: SourceHealth,
+    #[serde(default)]
+    pub last_poll_at: Option<String>,
+    #[serde(default)]
+    pub last_backfill_at: Option<String>,
+    #[serde(default)]
+    pub row_count: u64,
+    #[serde(default)]
+    pub mapped_points: u64,
+    #[serde(default)]
+    pub unmapped_points: u64,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SourceHealth {
+    pub status: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonApiConfig {
+    pub source_id: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub site_id: String,
+    #[serde(default)]
+    pub building_id: String,
+    pub base_url: String,
+    #[serde(default)]
+    pub auth: JsonApiAuth,
+    #[serde(default = "default_poll_s")]
+    pub polling_interval_s: u64,
+    #[serde(default = "default_timeout_s")]
+    pub timeout_s: u64,
+    #[serde(default)]
+    pub retry: RetryPolicy,
+    #[serde(default)]
+    pub rate_limit_per_min: u64,
+    pub endpoints: Vec<JsonApiEndpoint>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct JsonApiAuth {
+    #[serde(default)]
+    pub auth_type: String,
+    #[serde(default)]
+    pub secret_ref: Option<String>,
+    #[serde(default)]
+    pub username_secret_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonApiEndpoint {
+    pub endpoint_id: String,
+    pub path: String,
+    #[serde(default = "default_get")]
+    pub method: String,
+    #[serde(default)]
+    pub shape: String,
+    #[serde(default)]
+    pub timestamp_path: String,
+    #[serde(default)]
+    pub points: Vec<JsonApiPointMapping>,
+    #[serde(default)]
+    pub supports_history: bool,
+    #[serde(default)]
+    pub history_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonApiPointMapping {
+    pub point_id: String,
+    pub point_name: String,
+    #[serde(default)]
+    pub value_path: String,
+    #[serde(default)]
+    pub units_path: Option<String>,
+    #[serde(default)]
+    pub units: Option<String>,
+    #[serde(default)]
+    pub quality_path: Option<String>,
+    #[serde(default)]
+    pub equipment_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RetryPolicy {
+    #[serde(default = "default_retries")]
+    pub max_retries: u32,
+    #[serde(default = "default_backoff_ms")]
+    pub backoff_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostgresConfig {
+    pub source_id: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub site_id: String,
+    #[serde(default)]
+    pub building_id: String,
+    pub connection_secret_ref: String,
+    #[serde(default = "default_timeout_s")]
+    pub query_timeout_s: u64,
+    #[serde(default = "default_row_limit")]
+    pub row_limit: u64,
+    pub catalog_sql_path: String,
+    pub current_values_sql_path: String,
+    pub history_sql_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizedRow {
+    pub timestamp_utc: String,
+    pub timestamp_local: String,
+    pub timezone: String,
+    pub site_id: String,
+    pub building_id: String,
+    pub equipment_id: String,
+    pub source_id: String,
+    pub source_type: String,
+    pub source_protocol: String,
+    pub device_id: String,
+    pub point_id: String,
+    pub point_name: String,
+    pub value: Option<f64>,
+    pub value_text: String,
+    pub units: String,
+    pub quality: String,
+    pub source_path: String,
+    pub raw_ref: String,
+    pub ingested_at: String,
+    pub run_id: String,
+}
+
+impl NormalizedRow {
+    pub fn dedupe_key(&self) -> String {
+        format!(
+            "{}|{}|{}|{}",
+            self.timestamp_utc, self.source_id, self.point_id, self.run_id
+        )
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "timestamp_utc": self.timestamp_utc,
+            "timestamp_local": self.timestamp_local,
+            "timezone": self.timezone,
+            "site_id": self.site_id,
+            "building_id": self.building_id,
+            "equipment_id": self.equipment_id,
+            "source_id": self.source_id,
+            "source_type": self.source_type,
+            "source_protocol": self.source_protocol,
+            "device_id": self.device_id,
+            "point_id": self.point_id,
+            "point_name": self.point_name,
+            "value": self.value,
+            "value_text": self.value_text,
+            "units": self.units,
+            "quality": self.quality,
+            "source_path": self.source_path,
+            "raw_ref": self.raw_ref,
+            "ingested_at": self.ingested_at,
+            "run_id": self.run_id,
+            "dedupe_key": self.dedupe_key()
+        })
+    }
+}
+
+fn default_poll_s() -> u64 {
+    300
+}
+fn default_timeout_s() -> u64 {
+    30
+}
+fn default_get() -> String {
+    "GET".into()
+}
+fn default_retries() -> u32 {
+    2
+}
+fn default_backoff_ms() -> u64 {
+    500
+}
+fn default_row_limit() -> u64 {
+    5000
+}
+
+pub fn redact_config_for_api(value: &Value) -> Value {
+    redact_value(value)
+}
+
+fn redact_value(v: &Value) -> Value {
+    match v {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, val) in map {
+                let lk = k.to_ascii_lowercase();
+                if lk.contains("secret")
+                    || lk.contains("password")
+                    || lk.contains("token")
+                    || lk.contains("connection_string")
+                    || lk.contains("dsn")
+                {
+                    out.insert(k.clone(), json!("***REDACTED***"));
+                } else {
+                    out.insert(k.clone(), redact_value(val));
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(arr) => Value::Array(arr.iter().map(redact_value).collect()),
+        _ => v.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_secret_refs_in_config() {
+        let cfg = json!({
+            "auth": {"secret_ref": "MY_TOKEN", "auth_type": "bearer"},
+            "connection_secret_ref": "POSTGRES_DSN"
+        });
+        let red = redact_config_for_api(&cfg);
+        assert_eq!(red["auth"]["secret_ref"], "***REDACTED***");
+        assert_eq!(red["connection_secret_ref"], "***REDACTED***");
+    }
+}

--- a/edge/src/fdd/execution.rs
+++ b/edge/src/fdd/execution.rs
@@ -159,15 +159,26 @@ async fn execute_query(sql: &str) -> Result<Vec<Value>, String> {
 }
 
 async fn register_historian_tables(ctx: &SessionContext) -> Result<(), String> {
-    let pivot_rows = store::load_pivot_rows()?;
-    if pivot_rows.is_empty() {
-        return Err("historian has no rows — capture bench samples first".into());
+    let pivot_rows = store::load_pivot_rows().unwrap_or_default();
+    let normalized_rows = crate::connectors::historian::load_rows().unwrap_or_default();
+    if pivot_rows.is_empty() && normalized_rows.is_empty() {
+        return Err("historian has no rows — poll a source or capture bench samples first".into());
     }
-    let pivot = store::pivot_rows_to_batch(&pivot_rows).map_err(|e| e.to_string())?;
-    let telemetry = historian_pivot_to_telemetry_batch(&pivot_rows).map_err(|e| e.to_string())?;
+    if !pivot_rows.is_empty() {
+        let pivot = store::pivot_rows_to_batch(&pivot_rows).map_err(|e| e.to_string())?;
+        ctx.register_batch("telemetry_pivot", pivot)
+            .map_err(|e| e.to_string())?;
+    } else {
+        let empty = store::pivot_rows_to_batch(&[]).map_err(|e| e.to_string())?;
+        ctx.register_batch("telemetry_pivot", empty)
+            .map_err(|e| e.to_string())?;
+    }
+    let telemetry = if !normalized_rows.is_empty() {
+        crate::connectors::historian::rows_to_batch(&normalized_rows).map_err(|e| e.to_string())?
+    } else {
+        historian_pivot_to_telemetry_batch(&pivot_rows).map_err(|e| e.to_string())?
+    };
     let hvac = build_hvac_batch().map_err(|e| e.to_string())?;
-    ctx.register_batch("telemetry_pivot", pivot)
-        .map_err(|e| e.to_string())?;
     ctx.register_batch("telemetry", telemetry)
         .map_err(|e| e.to_string())?;
     ctx.register_batch("hvac", hvac)

--- a/edge/src/lib.rs
+++ b/edge/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod connectors;
 pub mod control;
 pub mod drivers;
 pub mod fdd;

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod bench;
+mod connectors;
 mod control;
 mod drivers;
 mod fdd;
@@ -404,6 +405,35 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             serde_json::from_str::<Value>(drivers::json_api::register_json()).unwrap(),
         ),
+        ("GET", "/api/sources") => require_role(
+            &mut stream,
+            &principal,
+            connectors::api::read_roles(),
+            connectors::api::list_sources_api(),
+        ),
+        ("POST", "/api/sources") => require_role(
+            &mut stream,
+            &principal,
+            connectors::api::mutate_roles(),
+            connectors::api::create_source(&parse_json_body(&body)),
+        ),
+        ("GET", "/api/connectors/historian/status") => require_role(
+            &mut stream,
+            &principal,
+            connectors::api::read_roles(),
+            connectors::api::historian_status(),
+        ),
+        ("GET", "/api/export/historian.csv") => {
+            let body = connectors::api::export_historian_csv();
+            let name = connectors::api::export_filename("historian");
+            require_role_csv(
+                &mut stream,
+                &principal,
+                connectors::api::read_roles(),
+                body,
+                &name,
+            )
+        }
         ("GET", "/api/historian/bench/5007/status") => {
             json_response(&mut stream, historian::store::status_json())
         }
@@ -460,7 +490,16 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
                     json!({"ok": true, "job_id": job_id, "status": "complete", "result": {}}),
                 );
             }
-            if let Some(resp) = handle_fdd_wires_dynamic(
+            if let Some(resp) = handle_sources_dynamic(
+                &mut stream,
+                &principal,
+                method.as_str(),
+                &path,
+                &clean_path,
+                &body,
+            ) {
+                resp
+            } else if let Some(resp) = handle_fdd_wires_dynamic(
                 &mut stream,
                 &principal,
                 method.as_str(),
@@ -498,6 +537,105 @@ fn query_param(path: &str, key: &str) -> Option<String> {
 
 fn path_parts(path: &str) -> Vec<&str> {
     path.trim_matches('/').split('/').collect()
+}
+
+fn handle_sources_dynamic(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    method: &str,
+    _path: &str,
+    clean_path: &str,
+    body: &str,
+) -> Option<std::io::Result<()>> {
+    let parts = path_parts(clean_path);
+    if parts.len() < 3 || parts[0] != "api" || parts[1] != "sources" {
+        return None;
+    }
+    let source_id = parts[2];
+    match (method, parts.as_slice()) {
+        ("GET", ["api", "sources", sid]) if *sid == source_id && parts.len() == 3 => {
+            Some(require_role(
+                stream,
+                principal,
+                connectors::api::read_roles(),
+                connectors::api::get_source_api(source_id),
+            ))
+        }
+        ("POST", ["api", "sources", sid, "test"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::read_roles(),
+            connectors::api::test_source(source_id),
+        )),
+        ("POST", ["api", "sources", sid, "discover"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::read_roles(),
+            connectors::api::discover_source(source_id),
+        )),
+        ("GET", ["api", "sources", sid, "catalog"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::read_roles(),
+            connectors::api::catalog(source_id),
+        )),
+        ("POST", ["api", "sources", sid, "poll-once"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::mutate_roles(),
+            connectors::api::poll_once(source_id),
+        )),
+        ("POST", ["api", "sources", sid, "backfill"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::mutate_roles(),
+            connectors::api::start_backfill(source_id, &parse_json_body(body), &principal.sub),
+        )),
+        ("GET", ["api", "sources", sid, "health"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::read_roles(),
+            connectors::api::source_health(source_id),
+        )),
+        ("GET", ["api", "sources", sid, "sample"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::read_roles(),
+            connectors::api::sample(source_id),
+        )),
+        ("GET", ["api", "sources", sid, "backfill", job_id]) if *sid == source_id => {
+            Some(require_role(
+                stream,
+                principal,
+                connectors::api::read_roles(),
+                connectors::api::get_backfill_job(source_id, job_id),
+            ))
+        }
+        ("GET", ["api", "sources", sid, "mappings"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::read_roles(),
+            connectors::mapping::list_mappings(Some(source_id)),
+        )),
+        ("POST", ["api", "sources", sid, "mappings"]) if *sid == source_id => Some(require_role(
+            stream,
+            principal,
+            connectors::api::mutate_roles(),
+            connectors::mapping::upsert_mapping(&parse_json_body(body)),
+        )),
+        ("GET", ["api", "sources", sid, "mappings.csv"]) if *sid == source_id => {
+            let csv_body = connectors::mapping::export_mappings_csv(source_id);
+            let name = connectors::api::export_filename("source_mappings");
+            Some(require_role_csv(
+                stream,
+                principal,
+                connectors::api::read_roles(),
+                csv_body,
+                &name,
+            ))
+        }
+        _ => None,
+    }
 }
 
 fn handle_fdd_wires_dynamic(
@@ -746,6 +884,45 @@ fn require_role(
         audit::log_event(
             "forbidden",
             json!({"role": principal.role.clone(), "required": roles}),
+        );
+        status_json(
+            stream,
+            "403 Forbidden",
+            json!({"ok": false, "error": "insufficient role", "role": principal.role}),
+        )
+    }
+}
+
+fn csv_attachment_response(
+    stream: &mut TcpStream,
+    body: &str,
+    filename: &str,
+) -> std::io::Result<()> {
+    let content_type = "text/csv; charset=utf-8";
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Disposition: attachment; filename=\"{filename}\"\r\n{sec}{cors}Content-Length: {len}\r\nConnection: close\r\n\r\n",
+        sec = security_headers(content_type, false),
+        cors = cors_origin(),
+        len = body.len(),
+        filename = filename
+    );
+    stream.write_all(headers.as_bytes())?;
+    stream.write_all(body.as_bytes())
+}
+
+fn require_role_csv(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    roles: &[&str],
+    body: String,
+    filename: &str,
+) -> std::io::Result<()> {
+    if role_allowed(principal, roles) {
+        csv_attachment_response(stream, &body, filename)
+    } else {
+        audit::log_event(
+            "forbidden",
+            json!({"role": principal.role.clone(), "required": roles, "export": filename}),
         );
         status_json(
             stream,

--- a/edge/tests/auth_integration.rs
+++ b/edge/tests/auth_integration.rs
@@ -49,6 +49,14 @@ impl Server {
         let mut cmd = Command::new(bin);
         cmd.env("PORT", port.to_string())
             .env("OPENFDD_WORKSPACE", &workspace)
+            .env(
+                "OPENFDD_REPO_ROOT",
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("..")
+                    .display()
+                    .to_string(),
+            )
+            .env("OPENFDD_CONNECTOR_DEMO_MODE", "1")
             .env("FRONTEND_DIR", frontend);
         for (k, v) in &auth_map {
             cmd.env(k, v);
@@ -215,5 +223,93 @@ fn operator_forbidden_on_modbus_scan() {
         .or(json["access_token"].as_str())
         .unwrap();
     let (status, _) = http_post_json(&srv.url("/api/modbus/scan"), "{}", Some(token));
+    assert_eq!(status, 403);
+}
+
+fn http_get_with_headers(url: &str, bearer: Option<&str>) -> (u16, String, String) {
+    let url = url.strip_prefix("http://").unwrap();
+    let (host_port, path) = url.split_once('/').unwrap_or((url, ""));
+    let path = if path.is_empty() {
+        "/"
+    } else {
+        &format!("/{path}")
+    };
+    let mut stream = TcpStream::connect(host_port).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let mut req = format!("GET {path} HTTP/1.1\r\nHost: {host_port}\r\nConnection: close\r\n");
+    if let Some(token) = bearer {
+        req.push_str(&format!("Authorization: Bearer {token}\r\n"));
+    }
+    req.push_str("\r\n");
+    stream.write_all(req.as_bytes()).unwrap();
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).unwrap();
+    let resp = String::from_utf8_lossy(&buf);
+    let status = resp
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let header_end = resp.find("\r\n\r\n").map(|i| i + 4).unwrap_or(0);
+    let headers = resp
+        .lines()
+        .take_while(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (status, headers, resp[header_end..].to_string())
+}
+
+fn login_token(srv: &Server, username: &str, password: &str) -> String {
+    let (_, body) = http_post_json(
+        &srv.url("/api/auth/login"),
+        &login_json(username, password),
+        None,
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    json["token"]
+        .as_str()
+        .or(json["access_token"].as_str())
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn sources_list_requires_auth() {
+    let srv = Server::start();
+    let (status, _, _) = http_get_with_headers(&srv.url("/api/sources"), None);
+    assert_eq!(status, 401);
+}
+
+#[test]
+fn integrator_can_list_sources_and_redacts_secrets() {
+    let srv = Server::start();
+    std::env::set_var(
+        "OPENFDD_REPO_ROOT",
+        env!("CARGO_MANIFEST_DIR").replace("/edge", ""),
+    );
+    std::env::set_var("OPENFDD_CONNECTOR_DEMO_MODE", "1");
+    let pw = srv.integrator_password();
+    let token = login_token(&srv, "integrator", &pw);
+    let (status, _, body) = http_get_with_headers(&srv.url("/api/sources"), Some(&token));
+    assert_eq!(status, 200);
+    assert!(body.contains("demo_building_json_feed"));
+    let (detail_status, _, detail) =
+        http_get_with_headers(&srv.url("/api/sources/openweathermap_oat"), Some(&token));
+    assert_eq!(detail_status, 200);
+    assert!(detail.contains("REDACTED") || detail.contains("secret_ref"));
+}
+
+#[test]
+fn operator_cannot_start_backfill() {
+    let srv = Server::start();
+    let text = std::fs::read_to_string(&srv.auth_path).unwrap();
+    let map = parse_env_file(&text);
+    let token = login_token(&srv, "operator", map.get("OFDD_OPERATOR_PASSWORD").unwrap());
+    let (status, _) = http_post_json(
+        &srv.url("/api/sources/demo_building_json_feed/backfill"),
+        r#"{"start_ts":"2024-01-01T00:00:00Z","end_ts":"2024-01-02T00:00:00Z"}"#,
+        Some(&token),
+    );
     assert_eq!(status, 403);
 }

--- a/examples/connectors/demo_building_points.json
+++ b/examples/connectors/demo_building_points.json
@@ -1,0 +1,18 @@
+{
+  "points": [
+    {
+      "id": "supply_air_temp",
+      "name": "Supply Air Temp",
+      "value": 55.5,
+      "unit": "degF",
+      "quality": "good"
+    },
+    {
+      "id": "return_air_temp",
+      "name": "Return Air Temp",
+      "value": 72.0,
+      "unit": "degF",
+      "quality": "good"
+    }
+  ]
+}

--- a/examples/connectors/demo_data_lake.example.toml
+++ b/examples/connectors/demo_data_lake.example.toml
@@ -1,0 +1,6 @@
+source_id = "simulation_bench"
+display_name = "Simulation data lake (demo)"
+site_id = "site:demo"
+building_id = "building:main"
+mode = "deterministic"
+interval_s = 60

--- a/examples/connectors/demo_weather_response.json
+++ b/examples/connectors/demo_weather_response.json
@@ -1,0 +1,9 @@
+{
+  "dt": 1710000000,
+  "main": {
+    "temp": 55.4,
+    "humidity": 42
+  },
+  "units": "imperial",
+  "name": "Demo City"
+}

--- a/examples/connectors/json_api.example.toml
+++ b/examples/connectors/json_api.example.toml
@@ -1,0 +1,29 @@
+source_id = "demo_building_json_feed"
+display_name = "Demo building JSON feed"
+site_id = "site:demo"
+building_id = "building:main"
+base_url = "https://demo.local"
+polling_interval_s = 300
+timeout_s = 20
+
+[auth]
+auth_type = "bearer"
+secret_ref = "DEMO_JSON_BEARER_TOKEN"
+
+[[endpoints]]
+endpoint_id = "points"
+path = "/points"
+method = "GET"
+shape = "array"
+
+[[endpoints.points]]
+point_id = "point:supply_air_temp"
+point_name = "Supply Air Temp"
+value_path = "value"
+units_path = "unit"
+
+[[endpoints.points]]
+point_id = "point:return_air_temp"
+point_name = "Return Air Temp"
+value_path = "value"
+units_path = "unit"

--- a/examples/connectors/openweathermap.example.toml
+++ b/examples/connectors/openweathermap.example.toml
@@ -1,0 +1,30 @@
+source_id = "openweathermap_oat"
+display_name = "OpenWeatherMap outside air temperature (example)"
+site_id = "site:demo"
+building_id = "building:main"
+base_url = "https://api.openweathermap.org/data/2.5"
+polling_interval_s = 900
+timeout_s = 30
+rate_limit_per_min = 60
+
+[auth]
+auth_type = "bearer"
+secret_ref = "OPENWEATHERMAP_API_KEY"
+
+[retry]
+max_retries = 2
+backoff_ms = 500
+
+[[endpoints]]
+endpoint_id = "weather"
+path = "/weather?q=DemoCity&units=imperial"
+method = "GET"
+shape = "flat"
+timestamp_path = "dt"
+
+[[endpoints.points]]
+point_id = "point:outside_air_temp"
+point_name = "Outside Air Temp"
+value_path = "main.temp"
+units = "degF"
+equipment_id = "equip:weather"

--- a/examples/connectors/postgres_readonly.example.toml
+++ b/examples/connectors/postgres_readonly.example.toml
@@ -1,0 +1,10 @@
+source_id = "demo_portfolio_postgres"
+display_name = "Demo portfolio Postgres read-only lake"
+site_id = "site:demo"
+building_id = "building:main"
+connection_secret_ref = "DEMO_POSTGRES_READONLY_DSN"
+query_timeout_s = 30
+row_limit = 5000
+catalog_sql_path = "examples/connectors/sql/point_catalog.example.sql"
+current_values_sql_path = "examples/connectors/sql/current_values.example.sql"
+history_sql_path = "examples/connectors/sql/history_backfill.example.sql"

--- a/examples/connectors/sql/current_values.example.sql
+++ b/examples/connectors/sql/current_values.example.sql
@@ -1,0 +1,4 @@
+SELECT point_id, point_name, value, units, ts AS timestamp_utc
+FROM current_values
+WHERE site_id = :site_id
+LIMIT :limit

--- a/examples/connectors/sql/history_backfill.example.sql
+++ b/examples/connectors/sql/history_backfill.example.sql
@@ -1,0 +1,7 @@
+SELECT point_id, point_name, value, units, ts AS timestamp_utc
+FROM history
+WHERE ts >= :start_ts
+  AND ts <= :end_ts
+  AND site_id = :site_id
+ORDER BY ts ASC
+LIMIT :limit

--- a/examples/connectors/sql/point_catalog.example.sql
+++ b/examples/connectors/sql/point_catalog.example.sql
@@ -1,0 +1,4 @@
+SELECT point_id, point_name, units, equipment_id
+FROM point_catalog
+WHERE site_id = :site_id
+LIMIT :limit

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -15,6 +15,7 @@ import PlotPage from "./pages/PlotPage";
 import RuleLabPage from "./pages/RuleLabPage";
 import SqlFddRulesPage from "./pages/SqlFddRulesPage";
 import Bench5007SmokePage from "./pages/Bench5007SmokePage";
+import SourcesPage from "./pages/SourcesPage";
 import AlgorithmsPage from "./pages/AlgorithmsPage";
 import { TabErrorBoundary } from "./components/TabDebugPanel";
 
@@ -40,6 +41,9 @@ export default function App() {
             <Route path="bacnet" element={<TabErrorBoundary tab="drivers"><DriversPage /></TabErrorBoundary>} />
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />
+            <Route path="sources" element={<TabErrorBoundary tab="sources"><SourcesPage /></TabErrorBoundary>} />
+            <Route path="sources/:sourceId" element={<TabErrorBoundary tab="sources"><SourcesPage /></TabErrorBoundary>} />
+            <Route path="connectors" element={<Navigate to="/sources" replace />} />
             <Route path="agent" element={<TabErrorBoundary tab="agent"><AgentPage /></TabErrorBoundary>} />
             <Route path="host" element={<TabErrorBoundary tab="host"><HostStatsPage /></TabErrorBoundary>} />
             <Route path="fdd" element={<Navigate to="/sql-fdd" replace />} />

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -14,6 +14,8 @@ const NAV = [
   { to: "/algorithms", icon: "⚙️", label: "Algorithms", protected: true },
   { to: "/faults", icon: "🚦", label: "Fault catalog" },
   { to: "/plot", icon: "📈", label: "Trend plot", protected: true },
+  { to: "/sources", icon: "🔌", label: "Data Connectors", protected: true },
+  { to: "/json-api", icon: "🌐", label: "JSON API (legacy)", protected: true },
   { to: "/agent", icon: "🤖", label: "AI Agent", protected: true },
   { to: "/host", icon: "📊", label: "Host stats", protected: true },
 ];

--- a/workspace/dashboard/src/lib/sources.test.ts
+++ b/workspace/dashboard/src/lib/sources.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  canMutateSources,
+  healthTone,
+  SOURCES_PANEL_TITLE,
+} from "./sources";
+
+describe("sources UI helpers", () => {
+  it("uses Data Connectors panel title", () => {
+    expect(SOURCES_PANEL_TITLE).toBe("Data Connectors");
+  });
+
+  it("maps health status to UI tone", () => {
+    expect(healthTone("online")).toBe("ok");
+    expect(healthTone("degraded")).toBe("warn");
+    expect(healthTone("offline")).toBe("bad");
+  });
+
+  it("allows integrator and agent to mutate sources", () => {
+    expect(canMutateSources("integrator")).toBe(true);
+    expect(canMutateSources("operator")).toBe(false);
+  });
+});

--- a/workspace/dashboard/src/lib/sources.ts
+++ b/workspace/dashboard/src/lib/sources.ts
@@ -1,0 +1,54 @@
+export type SourceHealth = {
+  status?: string;
+  message?: string;
+  last_error?: string | null;
+};
+
+export type SourceRecord = {
+  source_id: string;
+  source_type: string;
+  display_name: string;
+  enabled?: boolean;
+  site_id?: string;
+  building_id?: string;
+  config_path?: string;
+  health?: SourceHealth;
+  last_poll_at?: string | null;
+  last_backfill_at?: string | null;
+  row_count?: number;
+  mapped_points?: number;
+  unmapped_points?: number;
+};
+
+export type BackfillJob = {
+  job_id: string;
+  source_id: string;
+  status?: string;
+  rows_written?: number;
+  rows_read?: number;
+  started_at?: string;
+  completed_at?: string | null;
+};
+
+export const SOURCES_PANEL_TITLE = "Data Connectors";
+
+export function healthTone(status?: string): "ok" | "warn" | "bad" | "muted" {
+  switch ((status || "").toLowerCase()) {
+    case "online":
+      return "ok";
+    case "degraded":
+      return "warn";
+    case "offline":
+      return "bad";
+    default:
+      return "muted";
+  }
+}
+
+export function canMutateSources(role: string | null): boolean {
+  return role === "integrator" || role === "agent";
+}
+
+export function formatSourceType(sourceType: string): string {
+  return sourceType.replace(/_/g, " ");
+}

--- a/workspace/dashboard/src/pages/SourcesPage.tsx
+++ b/workspace/dashboard/src/pages/SourcesPage.tsx
@@ -1,0 +1,291 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import PageHeader from "../components/PageHeader";
+import ActionButton from "../components/ActionButton";
+import Spinner from "../components/Spinner";
+import { apiDownloadBlob, apiFetch, fetchAuthMe } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+import {
+  canMutateSources,
+  healthTone,
+  type BackfillJob,
+  type SourceRecord,
+  SOURCES_PANEL_TITLE,
+  formatSourceType,
+} from "../lib/sources";
+
+type SourceDetail = {
+  source: SourceRecord;
+  config: Record<string, unknown>;
+};
+
+export default function SourcesPage() {
+  const { sourceId } = useParams();
+  const [sources, setSources] = useState<SourceRecord[]>([]);
+  const [detail, setDetail] = useState<SourceDetail | null>(null);
+  const [catalog, setCatalog] = useState<Array<Record<string, unknown>>>([]);
+  const [sample, setSample] = useState<unknown>(null);
+  const [jobs, setJobs] = useState<BackfillJob[]>([]);
+  const [role, setRole] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [status, setStatus] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const canMutate = canMutateSources(role);
+
+  const refreshList = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [list, me] = await Promise.all([
+        apiFetch<{ sources: SourceRecord[] }>("/api/sources"),
+        fetchAuthMe().catch(() => null),
+      ]);
+      setSources(list.sources ?? []);
+      setRole(me?.role ?? null);
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const refreshDetail = useCallback(async (id: string) => {
+    setBusy(true);
+    setError("");
+    try {
+      const resp = await apiFetch<SourceDetail>(`/api/sources/${id}`);
+      setDetail(resp);
+      const cat = await apiFetch<{ points?: Array<Record<string, unknown>> }>(`/api/sources/${id}/catalog`);
+      setCatalog(cat.points ?? []);
+      const health = await apiFetch<{ health?: Record<string, unknown> }>(`/api/sources/${id}/health`);
+      setStatus(String(health.health?.message ?? ""));
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshList();
+  }, [refreshList]);
+
+  useEffect(() => {
+    if (sourceId) {
+      void refreshDetail(sourceId);
+    } else {
+      setDetail(null);
+      setCatalog([]);
+      setSample(null);
+      setJobs([]);
+    }
+  }, [sourceId, refreshDetail]);
+
+  const selected = useMemo(
+    () => sources.find((s) => s.source_id === sourceId) ?? detail?.source ?? null,
+    [sources, sourceId, detail],
+  );
+
+  async function runAction(label: string, fn: () => Promise<void>) {
+    setBusy(true);
+    setError("");
+    try {
+      await fn();
+      setStatus(`${label} succeeded`);
+      if (sourceId) await refreshDetail(sourceId);
+      await refreshList();
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="page sources-page">
+      <PageHeader
+        title={SOURCES_PANEL_TITLE}
+        subtitle="Configure external JSON APIs, read-only Postgres lakes, and simulation sources. Private credentials stay in gitignored workspace files."
+      />
+
+      {error ? <p className="error-banner">{error}</p> : null}
+      {status ? <p className="muted panel-help">{status}</p> : null}
+
+      <div className="sources-layout">
+        <section className="panel sources-list-panel" aria-label="Configured sources">
+          <h3 className="panel-title">Configured sources</h3>
+          {loading ? <Spinner label="Loading sources…" /> : null}
+          <ul className="sources-list">
+            {sources.map((source) => {
+              const tone = healthTone(source.health?.status);
+              return (
+                <li key={source.source_id} className={source.source_id === sourceId ? "active" : ""}>
+                  <Link to={`/sources/${source.source_id}`} className="sources-list-link">
+                    <strong>{source.display_name}</strong>
+                    <span className="muted">{formatSourceType(source.source_type)}</span>
+                    <span className={`health-chip health-${tone}`}>{source.health?.status ?? "unknown"}</span>
+                    <span className="muted">Rows: {source.row_count ?? 0}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+
+        <section className="panel sources-detail-panel" aria-label="Source detail">
+          {!selected ? (
+            <p className="muted">Select a source to inspect configuration, mappings, samples, and backfill jobs.</p>
+          ) : (
+            <>
+              <h3 className="panel-title">{selected.display_name}</h3>
+              <p className="muted panel-help">
+                Source ID: {selected.source_id} · Type: {formatSourceType(selected.source_type)} · Site:{" "}
+                {selected.site_id ?? "—"}
+              </p>
+
+              <div className="panel-actions">
+                <ActionButton
+                  label="Test connection"
+                  disabled={busy}
+                  onClick={() =>
+                    void runAction("Test connection", async () => {
+                      await apiFetch(`/api/sources/${selected.source_id}/test`, { method: "POST", body: "{}" });
+                    })
+                  }
+                />
+                <ActionButton
+                  label="Discover catalog"
+                  disabled={busy}
+                  onClick={() =>
+                    void runAction("Discover", async () => {
+                      await apiFetch(`/api/sources/${selected.source_id}/discover`, { method: "POST", body: "{}" });
+                    })
+                  }
+                />
+                <ActionButton
+                  label="Poll once → historian"
+                  disabled={busy || !canMutate}
+                  title={canMutate ? undefined : "Integrator or agent role required"}
+                  onClick={() =>
+                    void runAction("Poll once", async () => {
+                      await apiFetch(`/api/sources/${selected.source_id}/poll-once`, { method: "POST", body: "{}" });
+                    })
+                  }
+                />
+                <ActionButton
+                  label="Run backfill (24h demo)"
+                  disabled={busy || !canMutate}
+                  onClick={() =>
+                    void runAction("Backfill", async () => {
+                      const end = new Date();
+                      const start = new Date(end.getTime() - 24 * 3600 * 1000);
+                      const job = await apiFetch<BackfillJob>(`/api/sources/${selected.source_id}/backfill`, {
+                        method: "POST",
+                        body: JSON.stringify({
+                          start_ts: start.toISOString(),
+                          end_ts: end.toISOString(),
+                          chunk_hours: 6,
+                        }),
+                      });
+                      setJobs((prev) => [job, ...prev]);
+                    })
+                  }
+                />
+                <ActionButton
+                  label="Export historian CSV"
+                  disabled={busy}
+                  onClick={() =>
+                    void runAction("Export CSV", async () => {
+                      const { blob, filename } = await apiDownloadBlob("/api/export/historian.csv");
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement("a");
+                      a.href = url;
+                      a.download = filename;
+                      a.click();
+                      URL.revokeObjectURL(url);
+                    })
+                  }
+                />
+              </div>
+
+              {detail?.config ? (
+                <div className="source-config-summary">
+                  <h4>Configuration (secrets redacted)</h4>
+                  <pre className="code-block">{JSON.stringify(detail.config, null, 2)}</pre>
+                </div>
+              ) : null}
+
+              <div className="source-catalog">
+                <h4>Discovered points ({catalog.length})</h4>
+                <ul className="source-point-list">
+                  {catalog.map((p) => (
+                    <li key={String(p.point_id)}>
+                      <strong>{String(p.point_name ?? p.point_id)}</strong>
+                      <span className="muted">{String(p.point_id)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="source-mapping">
+                <h4>Mapping workflow</h4>
+                <p className="muted panel-help">
+                  AI-suggested mappings require human review before applied status. Use pending → accepted → applied.
+                </p>
+                <ActionButton
+                  label="Save demo mapping (pending review)"
+                  disabled={busy || !canMutate || catalog.length === 0}
+                  onClick={() =>
+                    void runAction("Save mapping", async () => {
+                      const point = catalog[0];
+                      await apiFetch(`/api/sources/${selected.source_id}/mappings`, {
+                        method: "POST",
+                        body: JSON.stringify({
+                          source_id: selected.source_id,
+                          source_point_id: point.point_id,
+                          model_point_id: "point:outside_air_temp",
+                          review_status: "pending",
+                          ai_suggested: true,
+                        }),
+                      });
+                    })
+                  }
+                />
+              </div>
+
+              <div className="source-sample">
+                <h4>Sample data</h4>
+                <ActionButton
+                  label="Load sample preview"
+                  disabled={busy}
+                  onClick={() =>
+                    void runAction("Sample", async () => {
+                      const resp = await apiFetch<{ sample?: unknown }>(`/api/sources/${selected.source_id}/sample`);
+                      setSample(resp.sample ?? resp);
+                    })
+                  }
+                />
+                {sample ? <pre className="code-block">{JSON.stringify(sample, null, 2)}</pre> : null}
+              </div>
+
+              {jobs.length > 0 ? (
+                <div className="source-backfill-jobs">
+                  <h4>Backfill jobs</h4>
+                  <ul>
+                    {jobs.map((job) => (
+                      <li key={job.job_id}>
+                        {job.job_id} — {job.status} — rows written {job.rows_written ?? 0}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -2999,6 +2999,81 @@ button.linkish {
   font-size: 0.88rem;
 }
 
+.sources-page .sources-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) 1fr;
+  gap: 16px;
+}
+
+.sources-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sources-list li.active .sources-list-link {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--panel));
+}
+
+.sources-list-link {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.health-chip {
+  display: inline-block;
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.health-ok {
+  background: color-mix(in srgb, #059669 20%, transparent);
+}
+
+.health-warn {
+  background: color-mix(in srgb, #d97706 20%, transparent);
+}
+
+.health-bad {
+  background: color-mix(in srgb, #dc2626 20%, transparent);
+}
+
+.health-muted {
+  background: color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.source-config-summary pre,
+.source-sample pre {
+  max-height: 220px;
+  overflow: auto;
+}
+
+.source-point-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+@media (max-width: 1100px) {
+  .sources-page .sources-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 1100px) {
   .drivers-page .drivers-layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Add a generic source connector framework with registry (`workspace/connectors/registry.json`), gitignored local configs/secrets, and sanitized public examples under `examples/connectors/`.
- Support multiple JSON API sources simultaneously with JSON path extraction, demo-safe polling, normalized historian writes (JSONL + Arrow IPC), chunked backfill jobs, and CSV export.
- Add `postgres_readonly` connector type with SQL template validation, DSN redaction, and demo catalog mode (live Postgres requires local DSN secret).
- Add React **Data Connectors** UI at `/sources` for test/discover/poll/backfill/mapping/export workflows.

## Security
- Secret references only in configs; values live in gitignored `workspace/secrets/openfdd-secrets.local.env`.
- API responses redact secrets; no arbitrary Rust upload (WASM plugin proposal tracked in #369).
- Auth: operator read; integrator/agent for poll/backfill/source create.

## Docs
- `docs/integrations/json_api_sources.md`
- `docs/integrations/postgres_readonly_sources.md`
- `docs/integrations/backfill_to_arrow.md`
- `docs/security/secrets_and_private_connectors.md`

## Related
- Complements open PRs #366 (BACnet overrides) and #368 (CSV export) without requiring merge first.
- XLSX export remains #367.

## Test plan
- [x] `cargo test --all-targets` (connector unit + auth integration)
- [x] `npm test` (sources UI helpers)
- [ ] Compose smoke: `/api/sources`, poll-once, historian CSV export, 401 without auth
- [ ] Manual: `/sources` → poll demo JSON feed → export historian CSV → verify DataFusion SQL sees `telemetry` rows


Made with [Cursor](https://cursor.com)