### PR TITLE
Fix auth login UX and agent/integrator RBAC parity

### DIFF
--- a/docs/security/secrets-auth.md
+++ b/docs/security/secrets-auth.md
@@ -57,7 +57,18 @@ openfdd-edge auth rotate --all --show-secrets
 
 Rotation backs up the previous file to `auth.env.local.bak.<timestamp>`, preserves usernames unless you edit them manually, and rotates `OFDD_AUTH_SECRET` when using `--all` (invalidates existing JWTs).
 
-## IT-managed passwords
+**Always restart the bridge** after changing `auth.env.local` — the edge loads credentials once at startup.
+
+## Roles
+
+| Role | Access |
+|------|--------|
+| **operator** | Read-only: browse all tabs, exports, trends, faults |
+| **integrator** | Full commissioning mutations (BACnet/Modbus/JSON API, model, FDD) |
+| **agent** | Same mutation tier as integrator (automation / Codex hooks) |
+| **admin** | Same mutation tier as integrator |
+
+The home **Building status** dashboard is public without sign-in.
 
 Set hashes manually in `workspace/auth.env.local`:
 

--- a/edge/src/auth/rbac.rs
+++ b/edge/src/auth/rbac.rs
@@ -10,12 +10,17 @@ pub fn is_read_only_role(role: &str) -> bool {
     role == "operator"
 }
 
+/// Integrator-tier roles may run commissioning mutations; operator is read-only browse/export.
+pub fn is_integrator_tier(role: &str) -> bool {
+    matches!(role, "integrator" | "agent" | "admin")
+}
+
 pub fn is_mutation_role(role: &str) -> bool {
-    matches!(role, "integrator" | "agent")
+    is_integrator_tier(role)
 }
 
 pub fn can_write_field_bus(role: &str, approved: bool) -> bool {
-    role == "integrator" && approved
+    is_integrator_tier(role) && approved
 }
 
 #[cfg(test)]
@@ -25,7 +30,7 @@ mod tests {
     #[test]
     fn operator_cannot_write_field_bus() {
         assert!(!can_write_field_bus("operator", true));
-        assert!(!can_write_field_bus("agent", true));
+        assert!(can_write_field_bus("agent", true));
         assert!(can_write_field_bus("integrator", true));
         assert!(!can_write_field_bus("integrator", false));
     }

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -98,8 +98,8 @@ pub fn test_rule_sql(payload: &Value) -> Value {
 }
 
 pub fn activate_rule(rule_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate rules", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate rules", "role": role});
     }
     let rule = get_rule(rule_id);
     if rule.get("ok").and_then(|v| v.as_bool()) != Some(true) {

--- a/edge/src/fdd/wires/api.rs
+++ b/edge/src/fdd/wires/api.rs
@@ -131,8 +131,8 @@ pub fn test_graph(site_id: &str, graph_id: &str) -> Value {
 }
 
 pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to approve graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to approve graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,
@@ -150,8 +150,8 @@ pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> 
 }
 
 pub fn activate_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -113,7 +113,7 @@ export default function AppLayout() {
             </span>
           ) : null}
         </div>
-        <p className="sidebar-hint">Haystack-first operator console</p>
+        <p className="sidebar-hint">Building summary is public; sign in to browse all tabs (operator read-only).</p>
         <StackStatusStrip />
         <nav className="sidebar-nav">
           {NAV_SECTIONS.map((section) => (
@@ -140,11 +140,6 @@ export default function AppLayout() {
                   >
                     <span className="nav-icon">{item.icon}</span>
                     {item.label}
-                    {item.protected && authRequired && !signedIn ? (
-                      <span className="nav-lock" title="Sign in required">
-                        🔒
-                      </span>
-                    ) : null}
                   </NavLink>
                 ),
               )}

--- a/workspace/dashboard/src/components/RequireAuth.tsx
+++ b/workspace/dashboard/src/components/RequireAuth.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, Outlet } from "react-router-dom";
 import { fetchAuthStatus, hasToken, setToken } from "../lib/api";
 
-/** Gate integrator/agent pages. Check-engine home + fault catalog stay public. */
+/** Gate commissioning tabs. Home building summary stays public; operator is read-only after sign-in. */
 export default function RequireAuth() {
   const [authRequired, setAuthRequired] = useState<boolean | null>(null);
 

--- a/workspace/dashboard/src/lib/api.ts
+++ b/workspace/dashboard/src/lib/api.ts
@@ -56,6 +56,42 @@ function authHeaders(): HeadersInit {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+function parseErrorBody(text: string, status: number): Error {
+  try {
+    const body = JSON.parse(text) as {
+      error?: string;
+      message?: string;
+      detail?: string | { error?: string; detail?: string; message?: string };
+    };
+    if (typeof body.error === "string") {
+      if (body.error === "invalid credentials") {
+        return new Error("Invalid username or password.");
+      }
+      return new Error(body.error);
+    }
+    if (typeof body.message === "string") {
+      return new Error(body.message);
+    }
+    if (typeof body.detail === "string") {
+      return new Error(body.detail);
+    }
+    if (body.detail && typeof body.detail === "object") {
+      const nested = body.detail;
+      if (typeof nested.error === "string") return new Error(nested.error);
+      if (typeof nested.detail === "string") return new Error(nested.detail);
+      if (typeof nested.message === "string") return new Error(nested.message);
+      return new Error(JSON.stringify(nested));
+    }
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      // not JSON — fall through
+    } else if (e instanceof Error) {
+      return e;
+    }
+  }
+  return new Error(text || `HTTP ${status}`);
+}
+
 export async function apiFetch<T>(
   path: string,
   init?: RequestInit,
@@ -80,26 +116,7 @@ export async function apiFetch<T>(
   }
   if (!res.ok) {
     const text = await res.text();
-    try {
-      const body = JSON.parse(text) as { detail?: string | { error?: string; detail?: string; message?: string } };
-      if (typeof body.detail === "string") {
-        throw new Error(body.detail);
-      }
-      if (body.detail && typeof body.detail === "object") {
-        const nested = body.detail;
-        if (typeof nested.error === "string") throw new Error(nested.error);
-        if (typeof nested.detail === "string") throw new Error(nested.detail);
-        if (typeof nested.message === "string") throw new Error(nested.message);
-        throw new Error(JSON.stringify(nested));
-      }
-    } catch (e) {
-      if (e instanceof SyntaxError) {
-        // not JSON — fall through to plain-text error
-      } else if (e instanceof Error) {
-        throw e;
-      }
-    }
-    throw new Error(text || `HTTP ${res.status}`);
+    throw parseErrorBody(text, res.status);
   }
   return res.json() as Promise<T>;
 }

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -70,6 +70,11 @@ export default function LoginPage() {
           />
         </div>
         {error ? <p className="error">{error}</p> : null}
+        <p className="muted login-hint">
+          Passwords live in <code>workspace/auth.env.local</code> (bcrypt only). If sign-in fails after a rotate,
+          restart the bridge and use the password printed by{" "}
+          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets</code>.
+        </p>
         <button type="submit">Sign in</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- Parse `/api/auth/login` error JSON so the UI shows **Invalid username or password** instead of raw `{"error":"invalid credentials"}`.
- Document role tiers (operator read-only browse, integrator/agent/admin mutation tier) and **bridge restart after auth rotate**.
- Align **agent** with **integrator** for FDD rule activation, wire graph approve/activate, and BACnet field-bus writes.
- Remove sidebar 🔒 icons that implied tabs were unavailable; home building summary stays public.

## Test plan
- [x] `npm test` (44 passed)
- [x] `cargo fmt --check` (Docker)
- [ ] Sign in as integrator with password from `openfdd_auth_init.sh --rotate --all --show-secrets`
- [ ] Sign in as operator — browse tabs read-only; mutations return 403
- [ ] Agent can activate SQL FDD rules (same as integrator)

## Notes
Auth file `workspace/auth.env.local` is gitignored. If sign-in fails, rotate credentials and recreate the bridge container.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified dashboard access so the building status home view is public, while other tabs still require sign-in.
  * Added clearer login hints for where authentication credentials are stored and how to refresh rotated secrets.

* **Bug Fixes**
  * Improved API error messages to show more specific details from failed requests.
  * Expanded access for approved actions so integrator, agent, and admin roles are handled consistently across approval and activation flows.

* **Documentation**
  * Updated security guidance with current role access levels and credential-loading instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->