### PR TITLE
Fix Rust auth, restore old UI parity, add Haystack model validation, and harden 5007 smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ workspace/backups/
 workspace/data/
 workspace/logs/
 workspace/smoke-profiles/local/*.local.toml
+workspace/bootstrap_credentials.once.txt
 workspace/import-profiles/local/*.local.toml
 workspace/export-profiles/local/*.local.toml
 workspace/imports/

--- a/docs/security/secrets-auth.md
+++ b/docs/security/secrets-auth.md
@@ -57,7 +57,18 @@ openfdd-edge auth rotate --all --show-secrets
 
 Rotation backs up the previous file to `auth.env.local.bak.<timestamp>`, preserves usernames unless you edit them manually, and rotates `OFDD_AUTH_SECRET` when using `--all` (invalidates existing JWTs).
 
-## IT-managed passwords
+**Always restart the bridge** after changing `auth.env.local` — the edge loads credentials once at startup.
+
+## Roles
+
+| Role | Access |
+|------|--------|
+| **operator** | Read-only: browse all tabs, exports, trends, faults |
+| **integrator** | Full commissioning mutations (BACnet/Modbus/JSON API, model, FDD) |
+| **agent** | Same mutation tier as integrator (automation / Codex hooks) |
+| **admin** | Same mutation tier as integrator |
+
+The home **Building status** dashboard is public without sign-in.
 
 Set hashes manually in `workspace/auth.env.local`:
 

--- a/edge/src/auth/env_file.rs
+++ b/edge/src/auth/env_file.rs
@@ -302,6 +302,35 @@ pub fn print_generated_credentials(passwords: &HashMap<String, String>, show_sec
     }
 }
 
+/// Write one-time credential handoff file next to auth.env.local (lab bootstrap only).
+pub fn write_bootstrap_credentials_once(
+    auth_path: &Path,
+    passwords: &HashMap<String, String>,
+) -> std::io::Result<Option<PathBuf>> {
+    if passwords.is_empty() {
+        return Ok(None);
+    }
+    let workspace = auth_path
+        .parent()
+        .unwrap_or_else(|| Path::new("workspace"));
+    let handoff = workspace.join("bootstrap_credentials.once.txt");
+    let mut lines = vec![
+        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager.".to_string(),
+        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords.".to_string(),
+        format!("# Generated: {}", chrono::Utc::now().to_rfc3339()),
+        String::new(),
+    ];
+    for (user, pw) in passwords {
+        lines.push(format!("{user}: {pw}"));
+    }
+    lines.push(String::new());
+    lines.push("# After saving passwords, delete this file:".to_string());
+    lines.push("#   rm workspace/bootstrap_credentials.once.txt".to_string());
+    fs::write(&handoff, lines.join("\n"))?;
+    chmod_600_unix(&handoff);
+    Ok(Some(handoff))
+}
+
 pub fn chmod_600_unix(path: &Path) {
     #[cfg(unix)]
     {

--- a/edge/src/auth/env_file.rs
+++ b/edge/src/auth/env_file.rs
@@ -310,13 +310,13 @@ pub fn write_bootstrap_credentials_once(
     if passwords.is_empty() {
         return Ok(None);
     }
-    let workspace = auth_path
-        .parent()
-        .unwrap_or_else(|| Path::new("workspace"));
+    let workspace = auth_path.parent().unwrap_or_else(|| Path::new("workspace"));
     let handoff = workspace.join("bootstrap_credentials.once.txt");
     let mut lines = vec![
-        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager.".to_string(),
-        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords.".to_string(),
+        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager."
+            .to_string(),
+        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords."
+            .to_string(),
         format!("# Generated: {}", chrono::Utc::now().to_rfc3339()),
         String::new(),
     ];

--- a/edge/src/auth/rbac.rs
+++ b/edge/src/auth/rbac.rs
@@ -20,7 +20,7 @@ pub fn is_mutation_role(role: &str) -> bool {
 }
 
 pub fn can_write_field_bus(role: &str, approved: bool) -> bool {
-    is_integrator_tier(role) && approved
+    role == "integrator" && approved
 }
 
 #[cfg(test)]
@@ -30,8 +30,15 @@ mod tests {
     #[test]
     fn operator_cannot_write_field_bus() {
         assert!(!can_write_field_bus("operator", true));
-        assert!(can_write_field_bus("agent", true));
+        assert!(!can_write_field_bus("agent", true));
         assert!(can_write_field_bus("integrator", true));
         assert!(!can_write_field_bus("integrator", false));
+    }
+
+    #[test]
+    fn agent_is_integrator_tier_for_mutations() {
+        assert!(is_integrator_tier("agent"));
+        assert!(is_integrator_tier("integrator"));
+        assert!(!is_integrator_tier("operator"));
     }
 }

--- a/edge/src/auth/rbac.rs
+++ b/edge/src/auth/rbac.rs
@@ -10,12 +10,17 @@ pub fn is_read_only_role(role: &str) -> bool {
     role == "operator"
 }
 
+/// Integrator-tier roles may run commissioning mutations; operator is read-only browse/export.
+pub fn is_integrator_tier(role: &str) -> bool {
+    matches!(role, "integrator" | "agent" | "admin")
+}
+
 pub fn is_mutation_role(role: &str) -> bool {
-    matches!(role, "integrator" | "agent")
+    is_integrator_tier(role)
 }
 
 pub fn can_write_field_bus(role: &str, approved: bool) -> bool {
-    role == "integrator" && approved
+    is_integrator_tier(role) && approved
 }
 
 #[cfg(test)]
@@ -25,7 +30,7 @@ mod tests {
     #[test]
     fn operator_cannot_write_field_bus() {
         assert!(!can_write_field_bus("operator", true));
-        assert!(!can_write_field_bus("agent", true));
+        assert!(can_write_field_bus("agent", true));
         assert!(can_write_field_bus("integrator", true));
         assert!(!can_write_field_bus("integrator", false));
     }

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -3,7 +3,7 @@
 use clap::{Parser, Subcommand};
 use open_fdd_edge_prototype::auth::env_file::{
     default_auth_env_path, generate_auth_env, print_env_summary, print_generated_credentials,
-    rotate_auth_env, GenerateOptions, RotateOptions,
+    rotate_auth_env, write_bootstrap_credentials_once, GenerateOptions, RotateOptions,
 };
 use open_fdd_edge_prototype::auth::password::hash_password;
 use open_fdd_edge_prototype::tls::{default_cert_dir, generate_self_signed, TlsGenerateOptions};
@@ -121,6 +121,16 @@ fn run_generate(path: PathBuf, force: bool, show_secrets: bool) -> std::io::Resu
     }
     print_env_summary(&result.contents, show_secrets);
     print_generated_credentials(&result.plaintext_passwords, show_secrets);
+    if show_secrets {
+        if let Some(handoff) =
+            write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+        {
+            eprintln!(
+                "wrote one-time credential handoff {} (delete after saving passwords)",
+                handoff.display()
+            );
+        }
+    }
     Ok(())
 }
 
@@ -154,6 +164,17 @@ fn main() -> std::io::Result<()> {
                 eprintln!("rotated {}", path.display());
                 print_env_summary(&result.contents, show_secrets);
                 print_generated_credentials(&result.plaintext_passwords, show_secrets);
+                if show_secrets {
+                    if let Some(handoff) = write_bootstrap_credentials_once(
+                        &path,
+                        &result.plaintext_passwords,
+                    )? {
+                        eprintln!(
+                            "wrote one-time credential handoff {} (delete after saving passwords)",
+                            handoff.display()
+                        );
+                    }
+                }
                 Ok(())
             }
             AuthCommands::HashPassword { password } => {

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -122,8 +122,7 @@ fn run_generate(path: PathBuf, force: bool, show_secrets: bool) -> std::io::Resu
     print_env_summary(&result.contents, show_secrets);
     print_generated_credentials(&result.plaintext_passwords, show_secrets);
     if show_secrets {
-        if let Some(handoff) =
-            write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+        if let Some(handoff) = write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
         {
             eprintln!(
                 "wrote one-time credential handoff {} (delete after saving passwords)",
@@ -165,10 +164,9 @@ fn main() -> std::io::Result<()> {
                 print_env_summary(&result.contents, show_secrets);
                 print_generated_credentials(&result.plaintext_passwords, show_secrets);
                 if show_secrets {
-                    if let Some(handoff) = write_bootstrap_credentials_once(
-                        &path,
-                        &result.plaintext_passwords,
-                    )? {
+                    if let Some(handoff) =
+                        write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+                    {
                         eprintln!(
                             "wrote one-time credential handoff {} (delete after saving passwords)",
                             handoff.display()

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -98,8 +98,8 @@ pub fn test_rule_sql(payload: &Value) -> Value {
 }
 
 pub fn activate_rule(rule_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate rules", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate rules", "role": role});
     }
     let rule = get_rule(rule_id);
     if rule.get("ok").and_then(|v| v.as_bool()) != Some(true) {

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -166,8 +166,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn agent_cannot_activate() {
+    fn agent_can_activate_rules() {
         let out = activate_rule("oa_temp_out_of_range", "agent", "agent");
-        assert_eq!(out["ok"].as_bool(), Some(false));
+        assert_eq!(out["ok"].as_bool(), Some(true));
     }
 }

--- a/edge/src/fdd/wires/api.rs
+++ b/edge/src/fdd/wires/api.rs
@@ -131,8 +131,8 @@ pub fn test_graph(site_id: &str, graph_id: &str) -> Value {
 }
 
 pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to approve graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to approve graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,
@@ -150,8 +150,8 @@ pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> 
 }
 
 pub fn activate_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -346,7 +346,9 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             json!({"ok": true, "run_id": "alg-demo-001", "result": serde_json::from_str::<Value>(control::cdl::simulate_json()).unwrap()}),
         ),
-        ("GET", "/api/model/haystack") => raw_json(&mut stream, drivers::haystack::model_json()),
+        ("GET", "/api/model/haystack") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
         ("GET", "/api/model/assignments") => {
             raw_json(&mut stream, model::assignments::assignments_json())
         }
@@ -364,8 +366,12 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         }
         ("GET", "/api/haystack/about") => raw_json(&mut stream, drivers::haystack::about_json()),
         ("GET", "/api/haystack/status") => raw_json(&mut stream, drivers::haystack::status_json()),
-        ("POST", "/api/haystack/read") => raw_json(&mut stream, drivers::haystack::model_json()),
-        ("POST", "/api/haystack/nav") => raw_json(&mut stream, drivers::haystack::model_json()),
+        ("POST", "/api/haystack/read") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
+        ("POST", "/api/haystack/nav") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
         ("POST", "/api/haystack/ops") => raw_json(&mut stream, drivers::haystack::ops_json()),
         ("POST", "/api/haystack/import") => require_role(
             &mut stream,
@@ -379,9 +385,15 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             json!({"ok": true, "preserve_ids": true, "imported": 4}),
         ),
+        ("POST", "/api/model/haystack/from-smoke-profile") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            model::smoke_profile::import_from_active_profile(),
+        ),
         ("POST", "/api/model/query") => json_response(
             &mut stream,
-            json!({"ok": true, "rows": serde_json::from_str::<Value>(drivers::haystack::model_json()).unwrap()["rows"].clone()}),
+            json!({"ok": true, "rows": model::query::haystack_rows()}),
         ),
         ("GET", "/api/fdd/datafusion/demo") => {
             raw_json(&mut stream, fdd::datafusion_sql::result_json())

--- a/edge/src/model/mod.rs
+++ b/edge/src/model/mod.rs
@@ -4,4 +4,6 @@
 //! BACnet/Modbus/JSON points are referenced from Haystack point rows.
 
 pub mod assignments;
+pub mod persist;
 pub mod query;
+pub mod smoke_profile;

--- a/edge/src/model/persist.rs
+++ b/edge/src/model/persist.rs
@@ -1,0 +1,36 @@
+//! Persisted Haystack grid (optional override of fixture MODEL_JSON).
+
+use crate::validation::profile::workspace_dir;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+
+pub fn haystack_grid_path() -> PathBuf {
+    workspace_dir().join("data/model/haystack_grid.json")
+}
+
+pub fn load_haystack_grid() -> Option<Value> {
+    let path = haystack_grid_path();
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+pub fn save_haystack_grid(grid: &Value) -> std::io::Result<PathBuf> {
+    let path = haystack_grid_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()))?;
+    Ok(path)
+}
+
+pub fn haystack_model_value() -> Value {
+    load_haystack_grid().unwrap_or_else(|| {
+        serde_json::from_str(crate::drivers::haystack::MODEL_JSON)
+            .unwrap_or(json!({"meta":{"ver":"3.0","mode":"fixture"},"cols":[],"rows":[]}))
+    })
+}
+
+pub fn haystack_model_json_string() -> String {
+    haystack_model_value().to_string()
+}

--- a/edge/src/model/persist.rs
+++ b/edge/src/model/persist.rs
@@ -20,7 +20,10 @@ pub fn save_haystack_grid(grid: &Value) -> std::io::Result<PathBuf> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(&path, serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()))?;
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()),
+    )?;
     Ok(path)
 }
 

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -4,9 +4,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 pub fn haystack_rows() -> Vec<Value> {
-    let model: Value =
-        serde_json::from_str(crate::drivers::haystack::MODEL_JSON).unwrap_or(json!({"rows": []}));
-    model
+    crate::model::persist::haystack_model_value()
         .get("rows")
         .and_then(|v| v.as_array())
         .cloned()

--- a/edge/src/model/smoke_profile.rs
+++ b/edge/src/model/smoke_profile.rs
@@ -1,0 +1,169 @@
+//! Build a Haystack grid from the active validation smoke profile.
+
+use super::persist;
+use crate::validation::profile::{active_profile, BacnetPointRole, SmokeProfile};
+use serde_json::{json, Value};
+
+pub fn import_from_active_profile() -> Value {
+    let profile = active_profile();
+    import_from_profile(&profile)
+}
+
+pub fn import_from_profile(profile: &SmokeProfile) -> Value {
+    let site_id = format!("site:{}", profile.profile_id);
+    let equip_id = format!("equip:{}", profile.equipment_id);
+    let source_id = profile.source_id.clone();
+    let device = profile.device_instance;
+
+    let mut rows: Vec<Value> = vec![
+        json!({
+            "id": site_id,
+            "dis": format!("Site {}", profile.profile_id),
+            "site": "M"
+        }),
+        json!({
+            "id": equip_id,
+            "dis": format!("Equipment {}", profile.equipment_id),
+            "equip": "M",
+            "siteRef": site_id,
+            "ahu": "M",
+            "sourceRef": source_id
+        }),
+        json!({
+            "id": source_id,
+            "dis": format!("Source {}", profile.source_type),
+            "source": "M",
+            "protocol": profile.source_type,
+            "deviceInstance": device
+        }),
+    ];
+
+    for pt in &profile.bacnet_points {
+        rows.push(point_row(profile, &equip_id, &source_id, pt));
+    }
+
+    let grid = json!({
+        "meta": {
+            "ver": "3.0",
+            "mode": "smoke-profile-import",
+            "profile_id": profile.profile_id,
+            "source_id": source_id,
+            "fdd_rule_id": profile.fdd_rule_id
+        },
+        "cols": [
+            {"name":"id"},{"name":"dis"},{"name":"site"},{"name":"equip"},{"name":"point"},
+            {"name":"sensor"},{"name":"kind"},{"name":"unit"},{"name":"curVal"},
+            {"name":"bacnetRef"},{"name":"fddInput"},{"name":"equipRef"},{"name":"sourceRef"}
+        ],
+        "rows": rows
+    });
+
+    match persist::save_haystack_grid(&grid) {
+        Ok(path) => json!({
+            "ok": true,
+            "imported": rows.len(),
+            "path": path.display().to_string(),
+            "profile_id": profile.profile_id,
+            "equipment_id": profile.equipment_id,
+            "source_id": source_id,
+            "point_count": profile.bacnet_points.len(),
+            "fdd_rule_id": profile.fdd_rule_id,
+            "mode": "smoke-profile-import"
+        }),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+fn point_row(
+    profile: &SmokeProfile,
+    equip_id: &str,
+    source_id: &str,
+    pt: &BacnetPointRole,
+) -> Value {
+    let tags = infer_tags(&pt.fdd_input);
+    json!({
+        "id": format!("point:{}", pt.fdd_input),
+        "dis": pt.name,
+        "point": "M",
+        "sensor": "M",
+        "kind": "Number",
+        "unit": infer_unit(&pt.fdd_input),
+        "curVal": null,
+        "equipRef": equip_id,
+        "sourceRef": source_id,
+        "bacnetRef": format!("bacnet:{}:analog-input:{}", profile.device_instance, pt.object_instance),
+        "fddInput": pt.fdd_input,
+        "tags": tags
+    })
+}
+
+fn infer_unit(fdd_input: &str) -> &'static str {
+    if fdd_input.contains("_h") {
+        "%RH"
+    } else {
+        "°F"
+    }
+}
+
+fn infer_tags(fdd_input: &str) -> Value {
+    let mut tags = vec!["point", "sensor"];
+    if fdd_input.contains("oa") {
+        tags.extend(["outside", "air"]);
+    }
+    if fdd_input.contains("duct") {
+        tags.extend(["discharge", "air"]);
+    }
+    if fdd_input.contains("zn") {
+        tags.extend(["zone", "air"]);
+    }
+    if fdd_input.contains("_t") {
+        tags.push("temp");
+    }
+    if fdd_input.contains("_h") {
+        tags.push("humidity");
+    }
+    json!(tags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validation::profile::SmokeProfile;
+
+    #[test]
+    fn builds_rows_from_profile_points() {
+        let dir = std::env::temp_dir().join(format!(
+            "openfdd-smoke-import-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        std::env::set_var("OPENFDD_WORKSPACE", &dir);
+        let profile = SmokeProfile {
+            profile_id: "local_bacnet_fdd_validation".into(),
+            source_id: "source:validation-bacnet".into(),
+            source_type: "bacnet".into(),
+            device_instance: 5007,
+            equipment_id: "5007".into(),
+            poll_interval_seconds: 60,
+            duration_hours: 1.0,
+            confirmation_minutes: 5,
+            historian_subdir: "validation".into(),
+            artifact_subdir: "live_fdd_validation".into(),
+            fdd_rule_id: "oa_temp_out_of_range".into(),
+            bacnet_points: vec![crate::validation::profile::BacnetPointRole {
+                name: "Outside Air Temp".into(),
+                object_instance: 1173,
+                fdd_input: "oa_t".into(),
+            }],
+            modbus_host: "192.168.204.14".into(),
+            modbus_port: 1502,
+            modbus_unit_id: 1,
+            modbus_register: 30001,
+            json_api_url: None,
+        };
+        let out = import_from_profile(&profile);
+        assert_eq!(out["ok"].as_bool(), Some(true));
+        assert_eq!(out["point_count"].as_u64(), Some(1));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/edge/src/model/smoke_profile.rs
+++ b/edge/src/model/smoke_profile.rs
@@ -132,10 +132,7 @@ mod tests {
 
     #[test]
     fn builds_rows_from_profile_points() {
-        let dir = std::env::temp_dir().join(format!(
-            "openfdd-smoke-import-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("openfdd-smoke-import-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         std::env::set_var("OPENFDD_WORKSPACE", &dir);
         let profile = SmokeProfile {

--- a/scripts/openfdd_auth_init.sh
+++ b/scripts/openfdd_auth_init.sh
@@ -22,6 +22,7 @@ ROTATE=false
 ROTATE_ALL=false
 ROTATE_ROLE=""
 HASH_PASSWORD=""
+RESTART=false
 SUBCMD=(auth init --path "$AUTH_PATH")
 
 usage() {
@@ -41,6 +42,7 @@ Options:
   --all                 Rotate all roles + OFDD_AUTH_SECRET (invalidates JWTs)
   --role NAME           Rotate one role: operator|integrator|agent|admin
   --hash-password PASS  Print bcrypt hash for manual auth.env.local editing
+  --restart             After init/rotate, recreate local openfdd-bridge container
   -h, --help            Show this help
 
 After rotate or force init, recreate bridge containers to pick up new env.
@@ -62,6 +64,7 @@ while [[ $# -gt 0 ]]; do
     --all) ROTATE_ALL=true; shift ;;
     --role) ROTATE_ROLE="$2"; shift 2 ;;
     --hash-password) HASH_PASSWORD="$2"; SUBCMD=(auth hash-password "$2"); shift 2 ;;
+    --restart) RESTART=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -139,4 +142,12 @@ fi
 
 chmod 600 "$AUTH_PATH" 2>/dev/null || true
 echo "==> Auth env: $AUTH_PATH"
-echo "==> Recreate bridge after rotate/force: docker compose -f docker-compose.local.yml up -d --force-recreate openfdd-bridge"
+if [[ "$RESTART" == "true" ]]; then
+  export OPENFDD_RUN_UID="${OPENFDD_RUN_UID:-$(id -u)}"
+  export OPENFDD_RUN_GID="${OPENFDD_RUN_GID:-$(id -g)}"
+  echo "==> Recreating openfdd-bridge to reload auth env"
+  docker compose -f "$ROOT/docker-compose.local.yml" up -d --force-recreate openfdd-bridge
+else
+  echo "==> Recreate bridge after rotate/force: docker compose -f docker-compose.local.yml up -d --force-recreate openfdd-bridge"
+  echo "==> Or re-run with --restart"
+fi

--- a/scripts/openfdd_auth_smoke.sh
+++ b/scripts/openfdd_auth_smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Login smoke test — verifies workspace/auth.env.local credentials against a running bridge.
+# Does not print passwords or tokens.
+#
+#   OPENFDD_AUTH_SMOKE_PASSWORD='...' ./scripts/openfdd_auth_smoke.sh
+#   ./scripts/openfdd_auth_smoke.sh --credentials workspace/bootstrap_credentials.once.txt
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
+CRED_FILE=""
+PASSWORD="${OPENFDD_AUTH_SMOKE_PASSWORD:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/openfdd_auth_smoke.sh [--credentials FILE] [--base URL]
+
+Tests POST /api/auth/login and GET /api/auth/me for operator, integrator, and agent.
+Provide password via OPENFDD_AUTH_SMOKE_PASSWORD or a bootstrap credentials file (username: password lines).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --credentials) CRED_FILE="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PASSWORD" && -n "$CRED_FILE" ]]; then
+  [[ -f "$CRED_FILE" ]] || { echo "Missing credentials file: $CRED_FILE" >&2; exit 1; }
+fi
+
+lookup_password() {
+  local user="$1"
+  if [[ -n "$PASSWORD" ]]; then
+    printf '%s' "$PASSWORD"
+    return 0
+  fi
+  if [[ -n "$CRED_FILE" ]]; then
+    local line
+    line="$(grep -E "^${user}:" "$CRED_FILE" | head -1 || true)"
+    [[ -n "$line" ]] || return 1
+    printf '%s' "${line#*: }"
+    return 0
+  fi
+  return 1
+}
+
+login_as() {
+  local user="$1"
+  local pass
+  pass="$(lookup_password "$user")" || {
+    echo "FAIL: no password for $user (set OPENFDD_AUTH_SMOKE_PASSWORD or --credentials)" >&2
+    return 1
+  }
+  if [[ "$pass" == \$2b\$* ]]; then
+    echo "FAIL: $user password looks like a bcrypt hash — use plaintext from bootstrap, not auth.env.local" >&2
+    return 1
+  fi
+  local body token me_role
+  body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2]}))' "$user" "$pass")"
+  local resp
+  resp="$(curl -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' -d "$body")" || {
+    echo "FAIL: login HTTP error for $user" >&2
+    return 1
+  }
+  if ! printf '%s' "$resp" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"; then
+    echo "FAIL: login rejected for $user" >&2
+    return 1
+  fi
+  token="$(printf '%s' "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")"
+  me_role="$(curl -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | python3 -c "import json,sys; print(json.load(sys.stdin).get('role',''))")"
+  if [[ "$me_role" != "$user" && ! ( "$user" == "integrator" && "$me_role" == "integrator" ) ]]; then
+    if [[ "$me_role" != "$user" ]]; then
+      echo "FAIL: /api/auth/me role mismatch for $user (got $me_role)" >&2
+      return 1
+    fi
+  fi
+  echo "OK: $user login + /api/auth/me"
+}
+
+curl -fsS "$BASE/health" >/dev/null || { echo "Bridge not healthy at $BASE" >&2; exit 1; }
+
+if [[ -n "$PASSWORD" ]]; then
+  login_as integrator
+else
+  CRED_FILE="${CRED_FILE:-$ROOT/workspace/bootstrap_credentials.once.txt}"
+  for role in operator integrator agent; do
+    login_as "$role"
+  done
+fi
+
+echo "Auth smoke passed at $BASE"

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import AgentPage from "./pages/AgentPage";
 import DriversPage from "./pages/DriversPage";
 import JsonApiPage from "./pages/JsonApiPage";
 import BacnetPage from "./pages/BacnetPage";
+import HaystackPage from "./pages/HaystackPage";
 import ModbusPage from "./pages/ModbusPage";
 import DataModelPage from "./pages/DataModelPage";
 import HomePage from "./pages/HomePage";
@@ -38,6 +39,7 @@ export default function App() {
             <Route path="fdd-assignments" element={<Navigate to="/model" replace />} />
             <Route path="plot" element={<TabErrorBoundary tab="plot"><PlotPage /></TabErrorBoundary>} />
             <Route path="drivers" element={<TabErrorBoundary tab="drivers"><DriversPage /></TabErrorBoundary>} />
+            <Route path="haystack" element={<TabErrorBoundary tab="haystack"><HaystackPage /></TabErrorBoundary>} />
             <Route path="bacnet" element={<TabErrorBoundary tab="bacnet"><BacnetPage /></TabErrorBoundary>} />
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -35,6 +35,7 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
     items: [
       { to: "/bacnet", icon: "📡", label: "BACnet", protected: true },
       { to: "/modbus", icon: "🔌", label: "Modbus", protected: true },
+      { to: "/haystack", icon: "🌿", label: "Haystack", protected: true },
       { to: "/json-api", icon: "🌐", label: "JSON API", protected: true },
       { to: "/data-management", icon: "🗄️", label: "Data management", protected: true },
     ],

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -113,7 +113,7 @@ export default function AppLayout() {
             </span>
           ) : null}
         </div>
-        <p className="sidebar-hint">Haystack-first operator console</p>
+        <p className="sidebar-hint">Building summary is public; sign in to browse all tabs (operator read-only).</p>
         <StackStatusStrip />
         <nav className="sidebar-nav">
           {NAV_SECTIONS.map((section) => (
@@ -140,11 +140,6 @@ export default function AppLayout() {
                   >
                     <span className="nav-icon">{item.icon}</span>
                     {item.label}
-                    {item.protected && authRequired && !signedIn ? (
-                      <span className="nav-lock" title="Sign in required">
-                        🔒
-                      </span>
-                    ) : null}
                   </NavLink>
                 ),
               )}

--- a/workspace/dashboard/src/components/RequireAuth.tsx
+++ b/workspace/dashboard/src/components/RequireAuth.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, Outlet } from "react-router-dom";
 import { fetchAuthStatus, hasToken, setToken } from "../lib/api";
 
-/** Gate integrator/agent pages. Check-engine home + fault catalog stay public. */
+/** Gate commissioning tabs. Home building summary stays public; operator is read-only after sign-in. */
 export default function RequireAuth() {
   const [authRequired, setAuthRequired] = useState<boolean | null>(null);
 

--- a/workspace/dashboard/src/lib/api.ts
+++ b/workspace/dashboard/src/lib/api.ts
@@ -56,6 +56,42 @@ function authHeaders(): HeadersInit {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+function parseErrorBody(text: string, status: number): Error {
+  try {
+    const body = JSON.parse(text) as {
+      error?: string;
+      message?: string;
+      detail?: string | { error?: string; detail?: string; message?: string };
+    };
+    if (typeof body.error === "string") {
+      if (body.error === "invalid credentials") {
+        return new Error("Invalid username or password.");
+      }
+      return new Error(body.error);
+    }
+    if (typeof body.message === "string") {
+      return new Error(body.message);
+    }
+    if (typeof body.detail === "string") {
+      return new Error(body.detail);
+    }
+    if (body.detail && typeof body.detail === "object") {
+      const nested = body.detail;
+      if (typeof nested.error === "string") return new Error(nested.error);
+      if (typeof nested.detail === "string") return new Error(nested.detail);
+      if (typeof nested.message === "string") return new Error(nested.message);
+      return new Error(JSON.stringify(nested));
+    }
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      // not JSON — fall through
+    } else if (e instanceof Error) {
+      return e;
+    }
+  }
+  return new Error(text || `HTTP ${status}`);
+}
+
 export async function apiFetch<T>(
   path: string,
   init?: RequestInit,
@@ -80,26 +116,7 @@ export async function apiFetch<T>(
   }
   if (!res.ok) {
     const text = await res.text();
-    try {
-      const body = JSON.parse(text) as { detail?: string | { error?: string; detail?: string; message?: string } };
-      if (typeof body.detail === "string") {
-        throw new Error(body.detail);
-      }
-      if (body.detail && typeof body.detail === "object") {
-        const nested = body.detail;
-        if (typeof nested.error === "string") throw new Error(nested.error);
-        if (typeof nested.detail === "string") throw new Error(nested.detail);
-        if (typeof nested.message === "string") throw new Error(nested.message);
-        throw new Error(JSON.stringify(nested));
-      }
-    } catch (e) {
-      if (e instanceof SyntaxError) {
-        // not JSON — fall through to plain-text error
-      } else if (e instanceof Error) {
-        throw e;
-      }
-    }
-    throw new Error(text || `HTTP ${res.status}`);
+    throw parseErrorBody(text, res.status);
   }
   return res.json() as Promise<T>;
 }

--- a/workspace/dashboard/src/pages/HaystackPage.tsx
+++ b/workspace/dashboard/src/pages/HaystackPage.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+import HaystackPointsTree, { type HaystackDevice, type HaystackPoint } from "../components/HaystackPointsTree";
+import PageHeader from "../components/PageHeader";
+import Spinner from "../components/Spinner";
+import ActionButton from "../components/ActionButton";
+
+type HaystackStatus = {
+  ok?: boolean;
+  driver?: string;
+  status?: string;
+  mode?: string;
+  supported_ops?: string[];
+};
+
+export default function HaystackPage() {
+  const [baseUrl, setBaseUrl] = useState("http://127.0.0.1:8080/api/haystack");
+  const [verifyTls, setVerifyTls] = useState(true);
+  const [enabled, setEnabled] = useState(true);
+  const [status, setStatus] = useState<HaystackStatus | null>(null);
+  const [about, setAbout] = useState<Record<string, unknown> | null>(null);
+  const [devices, setDevices] = useState<HaystackDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [log, setLog] = useState("");
+  const [error, setError] = useState("");
+
+  const appendLog = (line: string) => setLog((prev) => `${new Date().toISOString()} ${line}\n${prev}`.slice(0, 8000));
+
+  const loadStatus = useCallback(async () => {
+    const st = await apiFetch<HaystackStatus>("/api/haystack/status");
+    setStatus(st);
+    const ab = await apiFetch<Record<string, unknown>>("/api/haystack/about");
+    setAbout(ab);
+  }, []);
+
+  const loadModelTree = useCallback(async () => {
+    const grid = await apiFetch<{ rows?: Array<Record<string, unknown>> }>("/api/model/haystack");
+    const rows = grid.rows ?? [];
+    const points: HaystackPoint[] = rows
+      .filter((r) => r.point === "M")
+      .map((r) => ({
+        point_id: String(r.id ?? ""),
+        label: String(r.dis ?? r.id ?? ""),
+        haystack_id: String(r.id ?? ""),
+        tags: {},
+        kind: r.kind,
+        unit: r.unit,
+        curVal: r.curVal,
+        present_value: r.curVal != null ? String(r.curVal) : "—",
+        enabled: false,
+        poll_interval_s: 0,
+        poll_label: "Off",
+      }));
+    setDevices([
+      {
+        device_key: "haystack-model",
+        host: baseUrl,
+        site_id: "site:validation",
+        point_count: points.length,
+        poll_count: 0,
+        points,
+      },
+    ]);
+  }, [baseUrl]);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([loadStatus(), loadModelTree()])
+      .catch((e) => setError(formatApiError(e)))
+      .finally(() => setLoading(false));
+  }, [loadStatus, loadModelTree]);
+
+  async function testConnection() {
+    setPending(true);
+    setError("");
+    try {
+      await loadStatus();
+      appendLog(`Connection OK — mode=${status?.mode ?? "unknown"}`);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function importFromSmokeProfile() {
+    setPending(true);
+    setError("");
+    try {
+      const res = await apiFetch<{ ok?: boolean; imported?: number; path?: string }>(
+        "/api/model/haystack/from-smoke-profile",
+        { method: "POST", body: "{}" },
+      );
+      appendLog(`Imported smoke profile → ${res.imported ?? 0} rows (${res.path ?? "model"})`);
+      await loadModelTree();
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function readSelected() {
+    setPending(true);
+    try {
+      await apiFetch("/api/haystack/read", { method: "POST", body: "{}" });
+      appendLog("Haystack read completed");
+      await loadModelTree();
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="page page-wide driver-page">
+      <PageHeader
+        title="Haystack"
+        subtitle="Haystack server workflow — replaces the old Niagara station tab. Browse nav, read points, import model entities."
+      />
+
+      {error ? <p className="error">{error}</p> : null}
+
+      <div className="panel driver-connection-panel">
+        <h3>Haystack server</h3>
+        <div className="form-grid">
+          <label>
+            Server URL
+            <input value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} placeholder="https://host/api/haystack" />
+          </label>
+          <label className="checkbox-inline">
+            <input type="checkbox" checked={verifyTls} onChange={(e) => setVerifyTls(e.target.checked)} />
+            Verify TLS (uncheck for self-signed lab certs)
+          </label>
+          <label className="checkbox-inline">
+            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+            Enabled
+          </label>
+        </div>
+        <div className="btn-row">
+          <ActionButton pending={pending} onClick={() => void testConnection()}>
+            Test connection
+          </ActionButton>
+          <ActionButton pending={pending} onClick={() => void importFromSmokeProfile()}>
+            Import validation smoke profile
+          </ActionButton>
+          <ActionButton pending={pending} onClick={() => void readSelected()}>
+            Read / refresh
+          </ActionButton>
+        </div>
+        {status ? (
+          <p className="muted">
+            Driver: {status.driver ?? "haystack"} · {status.mode ?? status.status ?? "unknown"} · ops:{" "}
+            {(status.supported_ops ?? []).join(", ") || "about, ops, read, nav"}
+          </p>
+        ) : null}
+        {about ? (
+          <p className="muted">
+            About: {String(about.serverName ?? "open-fdd")} · Haystack {String(about.haystackVersion ?? "3.0")}
+          </p>
+        ) : null}
+        <p className="muted">Schedules: not supported on fixture gateway — omit unless your Haystack server exposes them.</p>
+      </div>
+
+      <div className="panel">
+        <h3>Sites, equipment &amp; points</h3>
+        {loading ? <Spinner label="Loading Haystack model tree…" /> : null}
+        <HaystackPointsTree devices={devices} onCopy={(text) => appendLog(`Copied ${text}`)} />
+      </div>
+
+      <div className="panel driver-console">
+        <h3>Activity console</h3>
+        <pre className="driver-log">{log || "No activity yet."}</pre>
+      </div>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -70,6 +70,11 @@ export default function LoginPage() {
           />
         </div>
         {error ? <p className="error">{error}</p> : null}
+        <p className="muted login-hint">
+          Passwords live in <code>workspace/auth.env.local</code> (bcrypt only). If sign-in fails after a rotate,
+          restart the bridge and use the password printed by{" "}
+          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets</code>.
+        </p>
         <button type="submit">Sign in</button>
       </form>
     </div>

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -71,9 +71,10 @@ export default function LoginPage() {
         </div>
         {error ? <p className="error">{error}</p> : null}
         <p className="muted login-hint">
-          Passwords live in <code>workspace/auth.env.local</code> (bcrypt only). If sign-in fails after a rotate,
-          restart the bridge and use the password printed by{" "}
-          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets</code>.
+          Use the <strong>plaintext password</strong> from bootstrap output — not the bcrypt hash lines in{" "}
+          <code>auth.env.local</code>. After rotate, run{" "}
+          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart</code> or check{" "}
+          <code>workspace/bootstrap_credentials.once.txt</code> (delete after saving).
         </p>
         <button type="submit">Sign in</button>
       </form>


### PR DESCRIPTION
Patch branch for Rust auth/login repair, old UI parity retrofit, Haystack replacement for Niagara, and validation profile hardening.

## Part 1 — Auth (this commit)
- Friendly login errors (no raw JSON); login page clarifies **plaintext vs bcrypt hash**
- `workspace/bootstrap_credentials.once.txt` handoff on `--show-secrets` (gitignored, chmod 600)
- `./scripts/openfdd_auth_init.sh --restart` recreates bridge after rotate
- `./scripts/openfdd_auth_smoke.sh` — operator/integrator/agent login smoke
- Agent = integrator for FDD mutations; **field-bus writes remain integrator-only**

## Part 2–4 — UI (in progress on this branch)
- **Haystack** tab (`/haystack`) replaces Niagara workflow
- Integrations nav: BACnet · Modbus · Haystack · JSON API · Data management
- `POST /api/model/haystack/from-smoke-profile` builds Haystack grid from local validation TOML

## Still open on this PR
- [ ] Full BACnet/Modbus/JSON API parity checklist vs old UI
- [ ] TLS-by-default bootstrap (`openfdd-edge bootstrap security` + Caddy)
- [ ] `scripts/openfdd_ui_smoke.sh` (Playwright)
- [ ] 1-hour validation run + artifacts
- [ ] 6-hour validation run + `final_report.json` / `final_report.md`
- [ ] BACnet override scan regression fixture (5007 / P8)

Supersedes #378 (auth UX subset merged here).

## Test plan
- [x] `npm test`
- [ ] `cargo test --workspace`
- [ ] `./scripts/openfdd_auth_smoke.sh --credentials workspace/bootstrap_credentials.once.txt`
- [ ] Sign in at http://127.0.0.1:8080/login


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Haystack page with connection controls, model browsing, point refresh, and a smoke-profile import action.
  * Added a Haystack tab to the dashboard navigation.

* **Bug Fixes**
  * Improved auth and error handling so login and API failures show clearer, more user-friendly messages.
  * Expanded role permissions so more users can approve and activate supported workflows.

* **Documentation**
  * Updated security guidance, role access details, and login instructions.
  * Added notes about restarting the bridge after auth changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->