### PR TITLE
Add PDF report builder and CSV append/delete validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ workspace/backups/
 workspace/data/
 workspace/logs/
 workspace/smoke-profiles/local/*.local.toml
+workspace/bootstrap_credentials.once.txt
 workspace/import-profiles/local/*.local.toml
 workspace/export-profiles/local/*.local.toml
 workspace/imports/

--- a/docs/security/secrets-auth.md
+++ b/docs/security/secrets-auth.md
@@ -57,7 +57,18 @@ openfdd-edge auth rotate --all --show-secrets
 
 Rotation backs up the previous file to `auth.env.local.bak.<timestamp>`, preserves usernames unless you edit them manually, and rotates `OFDD_AUTH_SECRET` when using `--all` (invalidates existing JWTs).
 
-## IT-managed passwords
+**Always restart the bridge** after changing `auth.env.local` — the edge loads credentials once at startup.
+
+## Roles
+
+| Role | Access |
+|------|--------|
+| **operator** | Read-only: browse all tabs, exports, trends, faults |
+| **integrator** | Full commissioning mutations (BACnet/Modbus/JSON API, model, FDD) |
+| **agent** | Same mutation tier as integrator (automation / Codex hooks) |
+| **admin** | Same mutation tier as integrator |
+
+The home **Building status** dashboard is public without sign-in.
 
 Set hashes manually in `workspace/auth.env.local`:
 

--- a/edge/src/auth/env_file.rs
+++ b/edge/src/auth/env_file.rs
@@ -302,6 +302,35 @@ pub fn print_generated_credentials(passwords: &HashMap<String, String>, show_sec
     }
 }
 
+/// Write one-time credential handoff file next to auth.env.local (lab bootstrap only).
+pub fn write_bootstrap_credentials_once(
+    auth_path: &Path,
+    passwords: &HashMap<String, String>,
+) -> std::io::Result<Option<PathBuf>> {
+    if passwords.is_empty() {
+        return Ok(None);
+    }
+    let workspace = auth_path
+        .parent()
+        .unwrap_or_else(|| Path::new("workspace"));
+    let handoff = workspace.join("bootstrap_credentials.once.txt");
+    let mut lines = vec![
+        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager.".to_string(),
+        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords.".to_string(),
+        format!("# Generated: {}", chrono::Utc::now().to_rfc3339()),
+        String::new(),
+    ];
+    for (user, pw) in passwords {
+        lines.push(format!("{user}: {pw}"));
+    }
+    lines.push(String::new());
+    lines.push("# After saving passwords, delete this file:".to_string());
+    lines.push("#   rm workspace/bootstrap_credentials.once.txt".to_string());
+    fs::write(&handoff, lines.join("\n"))?;
+    chmod_600_unix(&handoff);
+    Ok(Some(handoff))
+}
+
 pub fn chmod_600_unix(path: &Path) {
     #[cfg(unix)]
     {

--- a/edge/src/auth/env_file.rs
+++ b/edge/src/auth/env_file.rs
@@ -310,13 +310,13 @@ pub fn write_bootstrap_credentials_once(
     if passwords.is_empty() {
         return Ok(None);
     }
-    let workspace = auth_path
-        .parent()
-        .unwrap_or_else(|| Path::new("workspace"));
+    let workspace = auth_path.parent().unwrap_or_else(|| Path::new("workspace"));
     let handoff = workspace.join("bootstrap_credentials.once.txt");
     let mut lines = vec![
-        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager.".to_string(),
-        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords.".to_string(),
+        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager."
+            .to_string(),
+        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords."
+            .to_string(),
         format!("# Generated: {}", chrono::Utc::now().to_rfc3339()),
         String::new(),
     ];

--- a/edge/src/auth/rbac.rs
+++ b/edge/src/auth/rbac.rs
@@ -20,7 +20,7 @@ pub fn is_mutation_role(role: &str) -> bool {
 }
 
 pub fn can_write_field_bus(role: &str, approved: bool) -> bool {
-    is_integrator_tier(role) && approved
+    role == "integrator" && approved
 }
 
 #[cfg(test)]
@@ -30,8 +30,15 @@ mod tests {
     #[test]
     fn operator_cannot_write_field_bus() {
         assert!(!can_write_field_bus("operator", true));
-        assert!(can_write_field_bus("agent", true));
+        assert!(!can_write_field_bus("agent", true));
         assert!(can_write_field_bus("integrator", true));
         assert!(!can_write_field_bus("integrator", false));
+    }
+
+    #[test]
+    fn agent_is_integrator_tier_for_mutations() {
+        assert!(is_integrator_tier("agent"));
+        assert!(is_integrator_tier("integrator"));
+        assert!(!is_integrator_tier("operator"));
     }
 }

--- a/edge/src/auth/rbac.rs
+++ b/edge/src/auth/rbac.rs
@@ -10,12 +10,17 @@ pub fn is_read_only_role(role: &str) -> bool {
     role == "operator"
 }
 
+/// Integrator-tier roles may run commissioning mutations; operator is read-only browse/export.
+pub fn is_integrator_tier(role: &str) -> bool {
+    matches!(role, "integrator" | "agent" | "admin")
+}
+
 pub fn is_mutation_role(role: &str) -> bool {
-    matches!(role, "integrator" | "agent")
+    is_integrator_tier(role)
 }
 
 pub fn can_write_field_bus(role: &str, approved: bool) -> bool {
-    role == "integrator" && approved
+    is_integrator_tier(role) && approved
 }
 
 #[cfg(test)]
@@ -25,7 +30,7 @@ mod tests {
     #[test]
     fn operator_cannot_write_field_bus() {
         assert!(!can_write_field_bus("operator", true));
-        assert!(!can_write_field_bus("agent", true));
+        assert!(can_write_field_bus("agent", true));
         assert!(can_write_field_bus("integrator", true));
         assert!(!can_write_field_bus("integrator", false));
     }

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -3,7 +3,7 @@
 use clap::{Parser, Subcommand};
 use open_fdd_edge_prototype::auth::env_file::{
     default_auth_env_path, generate_auth_env, print_env_summary, print_generated_credentials,
-    rotate_auth_env, GenerateOptions, RotateOptions,
+    rotate_auth_env, write_bootstrap_credentials_once, GenerateOptions, RotateOptions,
 };
 use open_fdd_edge_prototype::auth::password::hash_password;
 use open_fdd_edge_prototype::tls::{default_cert_dir, generate_self_signed, TlsGenerateOptions};
@@ -121,6 +121,16 @@ fn run_generate(path: PathBuf, force: bool, show_secrets: bool) -> std::io::Resu
     }
     print_env_summary(&result.contents, show_secrets);
     print_generated_credentials(&result.plaintext_passwords, show_secrets);
+    if show_secrets {
+        if let Some(handoff) =
+            write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+        {
+            eprintln!(
+                "wrote one-time credential handoff {} (delete after saving passwords)",
+                handoff.display()
+            );
+        }
+    }
     Ok(())
 }
 
@@ -154,6 +164,17 @@ fn main() -> std::io::Result<()> {
                 eprintln!("rotated {}", path.display());
                 print_env_summary(&result.contents, show_secrets);
                 print_generated_credentials(&result.plaintext_passwords, show_secrets);
+                if show_secrets {
+                    if let Some(handoff) = write_bootstrap_credentials_once(
+                        &path,
+                        &result.plaintext_passwords,
+                    )? {
+                        eprintln!(
+                            "wrote one-time credential handoff {} (delete after saving passwords)",
+                            handoff.display()
+                        );
+                    }
+                }
                 Ok(())
             }
             AuthCommands::HashPassword { password } => {

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -122,8 +122,7 @@ fn run_generate(path: PathBuf, force: bool, show_secrets: bool) -> std::io::Resu
     print_env_summary(&result.contents, show_secrets);
     print_generated_credentials(&result.plaintext_passwords, show_secrets);
     if show_secrets {
-        if let Some(handoff) =
-            write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+        if let Some(handoff) = write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
         {
             eprintln!(
                 "wrote one-time credential handoff {} (delete after saving passwords)",
@@ -165,10 +164,9 @@ fn main() -> std::io::Result<()> {
                 print_env_summary(&result.contents, show_secrets);
                 print_generated_credentials(&result.plaintext_passwords, show_secrets);
                 if show_secrets {
-                    if let Some(handoff) = write_bootstrap_credentials_once(
-                        &path,
-                        &result.plaintext_passwords,
-                    )? {
+                    if let Some(handoff) =
+                        write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+                    {
                         eprintln!(
                             "wrote one-time credential handoff {} (delete after saving passwords)",
                             handoff.display()

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -98,8 +98,8 @@ pub fn test_rule_sql(payload: &Value) -> Value {
 }
 
 pub fn activate_rule(rule_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate rules", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate rules", "role": role});
     }
     let rule = get_rule(rule_id);
     if rule.get("ok").and_then(|v| v.as_bool()) != Some(true) {

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -166,8 +166,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn agent_cannot_activate() {
+    fn agent_can_activate_rules() {
         let out = activate_rule("oa_temp_out_of_range", "agent", "agent");
-        assert_eq!(out["ok"].as_bool(), Some(false));
+        assert_eq!(out["ok"].as_bool(), Some(true));
     }
 }

--- a/edge/src/fdd/wires/api.rs
+++ b/edge/src/fdd/wires/api.rs
@@ -131,8 +131,8 @@ pub fn test_graph(site_id: &str, graph_id: &str) -> Value {
 }
 
 pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to approve graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to approve graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,
@@ -150,8 +150,8 @@ pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> 
 }
 
 pub fn activate_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,

--- a/edge/src/lib.rs
+++ b/edge/src/lib.rs
@@ -10,5 +10,6 @@ pub mod historian;
 pub mod import;
 pub mod model;
 pub mod ops;
+pub mod reports;
 pub mod tls;
 pub mod validation;

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -11,6 +11,7 @@ mod historian;
 mod import;
 mod model;
 mod ops;
+mod reports;
 mod validation;
 
 use auth::audit;
@@ -692,6 +693,18 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &mut stream,
             json!({"ok": true, "sections": ["executive_summary", "faults", "overrides", "energy_opportunities", "trend_plots"]}),
         ),
+        ("GET", "/api/reports/templates") => require_role(
+            &mut stream,
+            &principal,
+            READ_EXPORT_ROLES,
+            reports::templates(),
+        ),
+        ("POST", "/api/reports/draft") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            reports::create_draft(&parse_json_body(&body)),
+        ),
         ("GET", "/api/reports/rcx/list") => raw_json(&mut stream, REPORTS),
         ("POST", "/api/reports/rcx/generate") => require_role(
             &mut stream,
@@ -700,6 +713,11 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             json!({"ok": true, "report_id": "rcx-demo-001", "path": "workspace/reports/rcx/rcx-demo-001.md", "sections": ["faults", "overrides", "plotly_trends", "recommendations"]}),
         ),
         _ => {
+            if let Some(resp) =
+                handle_reports_dynamic(&mut stream, &principal, method.as_str(), &clean_path, &body)
+            {
+                return resp;
+            }
             if let Some(resp) =
                 handle_faults_dynamic(&mut stream, &principal, method.as_str(), &clean_path)
             {
@@ -908,6 +926,72 @@ fn handle_faults_dynamic(
     Some(json_response(stream, faults::get_fault(tail)))
 }
 
+fn handle_reports_dynamic(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Option<std::io::Result<()>> {
+    let parts = path_parts(path);
+    if parts.len() < 3 || parts[0] != "api" || parts[1] != "reports" {
+        return None;
+    }
+    if parts[2] == "templates" || parts[2] == "draft" || parts[2] == "rcx" {
+        return None;
+    }
+    let report_id = reports::safe_report_id(parts[2])?;
+    if parts.len() == 3 {
+        return match method {
+            "GET" => Some(require_role(
+                stream,
+                principal,
+                READ_EXPORT_ROLES,
+                reports::get_report(&report_id),
+            )),
+            "PATCH" => Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent"],
+                reports::patch_report(&report_id, &parse_json_body(body)),
+            )),
+            _ => None,
+        };
+    }
+    match (method, parts.get(3).copied(), parts.get(4).copied()) {
+        ("GET", Some("data"), None) => Some(require_role(
+            stream,
+            principal,
+            READ_EXPORT_ROLES,
+            reports::report_data(&report_id),
+        )),
+        ("GET", Some("download.pdf"), None) => {
+            let path = reports::download_path(&report_id, "pdf")?;
+            Some(require_role_file(
+                stream,
+                principal,
+                READ_EXPORT_ROLES,
+                &path,
+                "application/pdf",
+                &format!("{report_id}.pdf"),
+            ))
+        }
+        ("POST", Some("sections"), Some("reorder")) => Some(require_role(
+            stream,
+            principal,
+            &["integrator", "agent"],
+            reports::reorder_sections(&report_id, &parse_json_body(body)),
+        )),
+        ("POST", Some("render"), Some("pdf")) => Some(require_role(
+            stream,
+            principal,
+            &["integrator", "agent"],
+            reports::render_pdf_bundle(&report_id),
+        )),
+        _ => None,
+    }
+}
+
 fn handle_data_management_dynamic(
     stream: &mut TcpStream,
     principal: &Principal,
@@ -1011,6 +1095,55 @@ fn csv_attachment_response(
     );
     stream.write_all(headers.as_bytes())?;
     stream.write_all(body.as_bytes())
+}
+
+fn require_role_file(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    roles: &[&str],
+    path: &Path,
+    content_type: &str,
+    filename: &str,
+) -> std::io::Result<()> {
+    if !role_allowed(principal, roles) {
+        audit::log_event(
+            "forbidden",
+            json!({"role": principal.role.clone(), "required": roles, "file": filename}),
+        );
+        return status_json(
+            stream,
+            "403 Forbidden",
+            json!({"ok": false, "error": "insufficient role", "role": principal.role}),
+        );
+    }
+    let bytes = match fs::read(path) {
+        Ok(b) => b,
+        Err(_) => {
+            return status_json(
+                stream,
+                "404 Not Found",
+                json!({"ok": false, "error": "file not found"}),
+            );
+        }
+    };
+    file_attachment_response(stream, &bytes, content_type, filename)
+}
+
+fn file_attachment_response(
+    stream: &mut TcpStream,
+    body: &[u8],
+    content_type: &str,
+    filename: &str,
+) -> std::io::Result<()> {
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Disposition: attachment; filename=\"{filename}\"\r\n{sec}{cors}Content-Length: {len}\r\nConnection: close\r\n\r\n",
+        sec = security_headers(content_type, false),
+        cors = cors_origin(),
+        len = body.len(),
+        filename = filename
+    );
+    stream.write_all(headers.as_bytes())?;
+    stream.write_all(body)
 }
 
 fn require_role_csv(
@@ -1227,6 +1360,10 @@ fn agent_tools() -> Value {
             {"name":"fdd.rules.activate","method":"POST","path":"/api/fdd-rules/{id}/activate","requires":"integrator"},
             {"name":"rules.batch","method":"POST","path":"/api/rules/batch","requires":"integrator|agent"},
             {"name":"historian.query","method":"POST","path":"/api/historian/query","requires":"JWT"},
+            {"name":"reports.templates","method":"GET","path":"/api/reports/templates","requires":"JWT"},
+            {"name":"reports.draft","method":"POST","path":"/api/reports/draft","requires":"integrator|agent"},
+            {"name":"reports.render_pdf","method":"POST","path":"/api/reports/{id}/render/pdf","requires":"integrator|agent"},
+            {"name":"reports.download_pdf","method":"GET","path":"/api/reports/{id}/download.pdf","requires":"JWT"},
             {"name":"reports.rcx_plan","method":"POST","path":"/api/reports/rcx/plan","requires":"JWT"},
             {"name":"reports.rcx_generate","method":"POST","path":"/api/reports/rcx/generate","requires":"integrator|agent"},
             {"name":"ops.update","method":"POST","path":"/api/ops/docker/update","requires":"integrator|agent"}

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -346,7 +346,9 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             json!({"ok": true, "run_id": "alg-demo-001", "result": serde_json::from_str::<Value>(control::cdl::simulate_json()).unwrap()}),
         ),
-        ("GET", "/api/model/haystack") => raw_json(&mut stream, drivers::haystack::model_json()),
+        ("GET", "/api/model/haystack") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
         ("GET", "/api/model/assignments") => {
             raw_json(&mut stream, model::assignments::assignments_json())
         }
@@ -364,8 +366,12 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         }
         ("GET", "/api/haystack/about") => raw_json(&mut stream, drivers::haystack::about_json()),
         ("GET", "/api/haystack/status") => raw_json(&mut stream, drivers::haystack::status_json()),
-        ("POST", "/api/haystack/read") => raw_json(&mut stream, drivers::haystack::model_json()),
-        ("POST", "/api/haystack/nav") => raw_json(&mut stream, drivers::haystack::model_json()),
+        ("POST", "/api/haystack/read") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
+        ("POST", "/api/haystack/nav") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
         ("POST", "/api/haystack/ops") => raw_json(&mut stream, drivers::haystack::ops_json()),
         ("POST", "/api/haystack/import") => require_role(
             &mut stream,
@@ -379,9 +385,15 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             json!({"ok": true, "preserve_ids": true, "imported": 4}),
         ),
+        ("POST", "/api/model/haystack/from-smoke-profile") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            model::smoke_profile::import_from_active_profile(),
+        ),
         ("POST", "/api/model/query") => json_response(
             &mut stream,
-            json!({"ok": true, "rows": serde_json::from_str::<Value>(drivers::haystack::model_json()).unwrap()["rows"].clone()}),
+            json!({"ok": true, "rows": model::query::haystack_rows()}),
         ),
         ("GET", "/api/fdd/datafusion/demo") => {
             raw_json(&mut stream, fdd::datafusion_sql::result_json())

--- a/edge/src/model/mod.rs
+++ b/edge/src/model/mod.rs
@@ -4,4 +4,6 @@
 //! BACnet/Modbus/JSON points are referenced from Haystack point rows.
 
 pub mod assignments;
+pub mod persist;
 pub mod query;
+pub mod smoke_profile;

--- a/edge/src/model/persist.rs
+++ b/edge/src/model/persist.rs
@@ -1,0 +1,36 @@
+//! Persisted Haystack grid (optional override of fixture MODEL_JSON).
+
+use crate::validation::profile::workspace_dir;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+
+pub fn haystack_grid_path() -> PathBuf {
+    workspace_dir().join("data/model/haystack_grid.json")
+}
+
+pub fn load_haystack_grid() -> Option<Value> {
+    let path = haystack_grid_path();
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+pub fn save_haystack_grid(grid: &Value) -> std::io::Result<PathBuf> {
+    let path = haystack_grid_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()))?;
+    Ok(path)
+}
+
+pub fn haystack_model_value() -> Value {
+    load_haystack_grid().unwrap_or_else(|| {
+        serde_json::from_str(crate::drivers::haystack::MODEL_JSON)
+            .unwrap_or(json!({"meta":{"ver":"3.0","mode":"fixture"},"cols":[],"rows":[]}))
+    })
+}
+
+pub fn haystack_model_json_string() -> String {
+    haystack_model_value().to_string()
+}

--- a/edge/src/model/persist.rs
+++ b/edge/src/model/persist.rs
@@ -20,7 +20,10 @@ pub fn save_haystack_grid(grid: &Value) -> std::io::Result<PathBuf> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(&path, serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()))?;
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()),
+    )?;
     Ok(path)
 }
 

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -4,9 +4,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 pub fn haystack_rows() -> Vec<Value> {
-    let model: Value =
-        serde_json::from_str(crate::drivers::haystack::MODEL_JSON).unwrap_or(json!({"rows": []}));
-    model
+    crate::model::persist::haystack_model_value()
         .get("rows")
         .and_then(|v| v.as_array())
         .cloned()

--- a/edge/src/model/smoke_profile.rs
+++ b/edge/src/model/smoke_profile.rs
@@ -1,0 +1,169 @@
+//! Build a Haystack grid from the active validation smoke profile.
+
+use super::persist;
+use crate::validation::profile::{active_profile, BacnetPointRole, SmokeProfile};
+use serde_json::{json, Value};
+
+pub fn import_from_active_profile() -> Value {
+    let profile = active_profile();
+    import_from_profile(&profile)
+}
+
+pub fn import_from_profile(profile: &SmokeProfile) -> Value {
+    let site_id = format!("site:{}", profile.profile_id);
+    let equip_id = format!("equip:{}", profile.equipment_id);
+    let source_id = profile.source_id.clone();
+    let device = profile.device_instance;
+
+    let mut rows: Vec<Value> = vec![
+        json!({
+            "id": site_id,
+            "dis": format!("Site {}", profile.profile_id),
+            "site": "M"
+        }),
+        json!({
+            "id": equip_id,
+            "dis": format!("Equipment {}", profile.equipment_id),
+            "equip": "M",
+            "siteRef": site_id,
+            "ahu": "M",
+            "sourceRef": source_id
+        }),
+        json!({
+            "id": source_id,
+            "dis": format!("Source {}", profile.source_type),
+            "source": "M",
+            "protocol": profile.source_type,
+            "deviceInstance": device
+        }),
+    ];
+
+    for pt in &profile.bacnet_points {
+        rows.push(point_row(profile, &equip_id, &source_id, pt));
+    }
+
+    let grid = json!({
+        "meta": {
+            "ver": "3.0",
+            "mode": "smoke-profile-import",
+            "profile_id": profile.profile_id,
+            "source_id": source_id,
+            "fdd_rule_id": profile.fdd_rule_id
+        },
+        "cols": [
+            {"name":"id"},{"name":"dis"},{"name":"site"},{"name":"equip"},{"name":"point"},
+            {"name":"sensor"},{"name":"kind"},{"name":"unit"},{"name":"curVal"},
+            {"name":"bacnetRef"},{"name":"fddInput"},{"name":"equipRef"},{"name":"sourceRef"}
+        ],
+        "rows": rows
+    });
+
+    match persist::save_haystack_grid(&grid) {
+        Ok(path) => json!({
+            "ok": true,
+            "imported": rows.len(),
+            "path": path.display().to_string(),
+            "profile_id": profile.profile_id,
+            "equipment_id": profile.equipment_id,
+            "source_id": source_id,
+            "point_count": profile.bacnet_points.len(),
+            "fdd_rule_id": profile.fdd_rule_id,
+            "mode": "smoke-profile-import"
+        }),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+fn point_row(
+    profile: &SmokeProfile,
+    equip_id: &str,
+    source_id: &str,
+    pt: &BacnetPointRole,
+) -> Value {
+    let tags = infer_tags(&pt.fdd_input);
+    json!({
+        "id": format!("point:{}", pt.fdd_input),
+        "dis": pt.name,
+        "point": "M",
+        "sensor": "M",
+        "kind": "Number",
+        "unit": infer_unit(&pt.fdd_input),
+        "curVal": null,
+        "equipRef": equip_id,
+        "sourceRef": source_id,
+        "bacnetRef": format!("bacnet:{}:analog-input:{}", profile.device_instance, pt.object_instance),
+        "fddInput": pt.fdd_input,
+        "tags": tags
+    })
+}
+
+fn infer_unit(fdd_input: &str) -> &'static str {
+    if fdd_input.contains("_h") {
+        "%RH"
+    } else {
+        "°F"
+    }
+}
+
+fn infer_tags(fdd_input: &str) -> Value {
+    let mut tags = vec!["point", "sensor"];
+    if fdd_input.contains("oa") {
+        tags.extend(["outside", "air"]);
+    }
+    if fdd_input.contains("duct") {
+        tags.extend(["discharge", "air"]);
+    }
+    if fdd_input.contains("zn") {
+        tags.extend(["zone", "air"]);
+    }
+    if fdd_input.contains("_t") {
+        tags.push("temp");
+    }
+    if fdd_input.contains("_h") {
+        tags.push("humidity");
+    }
+    json!(tags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validation::profile::SmokeProfile;
+
+    #[test]
+    fn builds_rows_from_profile_points() {
+        let dir = std::env::temp_dir().join(format!(
+            "openfdd-smoke-import-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        std::env::set_var("OPENFDD_WORKSPACE", &dir);
+        let profile = SmokeProfile {
+            profile_id: "local_bacnet_fdd_validation".into(),
+            source_id: "source:validation-bacnet".into(),
+            source_type: "bacnet".into(),
+            device_instance: 5007,
+            equipment_id: "5007".into(),
+            poll_interval_seconds: 60,
+            duration_hours: 1.0,
+            confirmation_minutes: 5,
+            historian_subdir: "validation".into(),
+            artifact_subdir: "live_fdd_validation".into(),
+            fdd_rule_id: "oa_temp_out_of_range".into(),
+            bacnet_points: vec![crate::validation::profile::BacnetPointRole {
+                name: "Outside Air Temp".into(),
+                object_instance: 1173,
+                fdd_input: "oa_t".into(),
+            }],
+            modbus_host: "192.168.204.14".into(),
+            modbus_port: 1502,
+            modbus_unit_id: 1,
+            modbus_register: 30001,
+            json_api_url: None,
+        };
+        let out = import_from_profile(&profile);
+        assert_eq!(out["ok"].as_bool(), Some(true));
+        assert_eq!(out["point_count"].as_u64(), Some(1));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/edge/src/model/smoke_profile.rs
+++ b/edge/src/model/smoke_profile.rs
@@ -132,10 +132,7 @@ mod tests {
 
     #[test]
     fn builds_rows_from_profile_points() {
-        let dir = std::env::temp_dir().join(format!(
-            "openfdd-smoke-import-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("openfdd-smoke-import-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         std::env::set_var("OPENFDD_WORKSPACE", &dir);
         let profile = SmokeProfile {

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -1,0 +1,523 @@
+//! Model-driven report drafts and HTML/PDF export bundles (Rust-era, no Python).
+
+use crate::fdd::rules;
+use crate::faults;
+use crate::historian::store;
+use crate::model::query;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn reports_dir() -> PathBuf {
+    store::workspace_dir().join("reports/generated")
+}
+
+fn report_dir(id: &str) -> PathBuf {
+    reports_dir().join(sanitize_id(id))
+}
+
+pub fn sanitize_id(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn save_report(id: &str, doc: &Value) -> Result<(), String> {
+    let dir = report_dir(id);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    fs::write(
+        dir.join("report.json"),
+        serde_json::to_string_pretty(doc).unwrap_or_default(),
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn load_report(id: &str) -> Option<Value> {
+    let path = report_dir(id).join("report.json");
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn rule_explanation_block(rule_id: &str) -> Value {
+    let rule_doc = rules::get_rule(rule_id);
+    let rule = rule_doc.get("rule").cloned().unwrap_or(json!({}));
+    json!({
+        "rule_id": rule_id,
+        "rule_name": rule.get("name").cloned().unwrap_or(json!("FDD Rule")),
+        "sql": rule.get("sql").cloned().unwrap_or(json!(null)),
+        "confirmation_seconds": rule.get("confirmation_seconds").cloned().unwrap_or(json!(300)),
+        "required_inputs": rule.get("required_inputs").cloned().unwrap_or(json!([])),
+        "raw_fault_logic": rule.get("raw_fault_sql").cloned().unwrap_or(rule.get("raw_fault").cloned().unwrap_or(json!("raw_fault when SQL predicate true"))),
+        "confirmed_fault_logic": rule.get("confirmed_fault_sql").cloned().unwrap_or(json!("confirmed_fault when raw_fault sustained for confirmation_seconds")),
+        "explanation": rule.get("description").and_then(|v| v.as_str()).unwrap_or(
+            "Rule evaluates historian bindings via DataFusion SQL; raw_fault starts immediately, confirmed_fault after confirmation delay."
+        )
+    })
+}
+
+fn suggested_plot_blocks() -> Vec<Value> {
+    let mut blocks = Vec::new();
+    let points = query::list_points(None);
+    let point_list = points
+        .get("points")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut roles: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for p in &point_list {
+        if let Some(role) = p.get("fdd_input").and_then(|v| v.as_str()) {
+            roles.insert(role.to_string());
+        }
+    }
+    if roles.contains("oa_t") || roles.contains("duct_t") || roles.contains("zn_t") {
+        let series: Vec<&str> = ["oa_t", "duct_t", "zn_t"]
+            .iter()
+            .copied()
+            .filter(|r| roles.contains(*r))
+            .collect();
+        blocks.push(json!({
+            "id": "plot-trends",
+            "type": "plot",
+            "title": "Temperature trends",
+            "visible": true,
+            "order": 10,
+            "content": {
+                "plot_type": "multi_trend",
+                "series": series,
+                "source": "historian"
+            }
+        }));
+    }
+    if roles.contains("sat") && roles.contains("sat_sp") {
+        blocks.push(json!({
+            "id": "plot-sat-tracking",
+            "type": "plot",
+            "title": "SAT vs setpoint",
+            "visible": true,
+            "order": 11,
+            "content": {"plot_type": "sat_tracking", "series": ["sat", "sat_sp"], "overlay_faults": true}
+        }));
+    }
+    if roles.contains("fan_cmd") && roles.contains("fan_status") {
+        blocks.push(json!({
+            "id": "plot-fan-mismatch",
+            "type": "plot",
+            "title": "Fan command vs status",
+            "visible": true,
+            "order": 12,
+            "content": {"plot_type": "command_status", "series": ["fan_cmd", "fan_status"]}
+        }));
+    }
+    blocks
+}
+
+pub fn templates() -> Value {
+    json!({
+        "ok": true,
+        "templates": [
+            {
+                "id": "validation-summary",
+                "title": "Validation summary",
+                "description": "Auto-built from historian, FDD rules, imports, and source health"
+            },
+            {
+                "id": "equipment-fdd",
+                "title": "Equipment FDD report",
+                "description": "Per-equipment plots, SQL rules, and fault timelines"
+            }
+        ]
+    })
+}
+
+pub fn create_draft(body: &Value) -> Value {
+    let template = body
+        .get("template_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("validation-summary");
+    let title = body
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Open-FDD Report");
+    let report_id = format!("rpt-{}", Utc::now().timestamp_millis());
+    let coverage = query::model_coverage();
+    let equips = query::list_equips(None);
+    let hist_status = store::status_json();
+    let mut sections = vec![
+        json!({
+            "id": "building-summary",
+            "type": "building_summary",
+            "title": "Building summary",
+            "visible": true,
+            "order": 0,
+            "content": {
+                "generated_at": Utc::now().to_rfc3339(),
+                "template_id": template,
+                "title": title,
+                "sites": query::list_sites()
+            }
+        }),
+        json!({
+            "id": "model-coverage",
+            "type": "model_coverage",
+            "title": "Model coverage",
+            "visible": true,
+            "order": 1,
+            "content": coverage
+        }),
+        json!({
+            "id": "source-health",
+            "type": "source_health",
+            "title": "Source health",
+            "visible": true,
+            "order": 2,
+            "content": query::source_coverage()
+        }),
+        json!({
+            "id": "historian-summary",
+            "type": "historian_summary",
+            "title": "Historian summary",
+            "visible": true,
+            "order": 3,
+            "content": hist_status
+        }),
+        json!({
+            "id": "rule-explanation",
+            "type": "rule_explanation",
+            "title": "FDD rule: oa_temp_out_of_range",
+            "visible": true,
+            "order": 4,
+            "content": rule_explanation_block("oa_temp_out_of_range")
+        }),
+        json!({
+            "id": "equipment-summary",
+            "type": "equipment_summary",
+            "title": "Equipment",
+            "visible": true,
+            "order": 5,
+            "content": equips
+        }),
+        json!({
+            "id": "fault-summary",
+            "type": "fault_summary",
+            "title": "Fault summary",
+            "visible": true,
+            "order": 6,
+            "content": faults::summary_json()
+        }),
+        json!({
+            "id": "data-quality",
+            "type": "data_quality",
+            "title": "Data quality",
+            "visible": true,
+            "order": 7,
+            "content": query::source_coverage()
+        }),
+        json!({
+            "id": "recommendations",
+            "type": "recommendations",
+            "title": "Recommendations",
+            "visible": true,
+            "order": 8,
+            "content": {"notes": "Review confirmed faults and model gaps before commissioning sign-off.", "items": []}
+        }),
+    ];
+    for plot in suggested_plot_blocks() {
+        sections.push(plot);
+    }
+    let doc = json!({
+        "ok": true,
+        "report_id": report_id,
+        "title": title,
+        "template_id": template,
+        "created_at": Utc::now().to_rfc3339(),
+        "updated_at": Utc::now().to_rfc3339(),
+        "sections": sections,
+        "metadata": {
+            "generator": "open-fdd-rust-report-builder",
+            "pdf_ready": false
+        }
+    });
+    match save_report(&report_id, &doc) {
+        Ok(()) => doc,
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn get_report(report_id: &str) -> Value {
+    load_report(report_id)
+        .map(|doc| json!({"ok": true, "report": doc}))
+        .unwrap_or_else(|| json!({"ok": false, "error": "report not found"}))
+}
+
+pub fn patch_report(report_id: &str, body: &Value) -> Value {
+    let Some(mut doc) = load_report(report_id) else {
+        return json!({"ok": false, "error": "report not found"});
+    };
+    if let Some(title) = body.get("title").and_then(|v| v.as_str()) {
+        doc["title"] = json!(title);
+    }
+    if let Some(sections) = body.get("sections") {
+        doc["sections"] = sections.clone();
+    }
+    doc["updated_at"] = json!(Utc::now().to_rfc3339());
+    match save_report(report_id, &doc) {
+        Ok(()) => json!({"ok": true, "report": doc}),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn reorder_sections(report_id: &str, body: &Value) -> Value {
+    let Some(order) = body.get("section_ids").and_then(|v| v.as_array()) else {
+        return json!({"ok": false, "error": "section_ids array required"});
+    };
+    let Some(mut doc) = load_report(report_id) else {
+        return json!({"ok": false, "error": "report not found"});
+    };
+    let sections = doc
+        .get("sections")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut by_id = std::collections::HashMap::new();
+    for s in sections {
+        if let Some(id) = s.get("id").and_then(|v| v.as_str()) {
+            by_id.insert(id.to_string(), s);
+        }
+    }
+    let mut reordered = Vec::new();
+    for (idx, idv) in order.iter().enumerate() {
+        if let Some(id) = idv.as_str() {
+            if let Some(mut sec) = by_id.remove(id) {
+                sec["order"] = json!(idx);
+                reordered.push(sec);
+            }
+        }
+    }
+    for (_, mut sec) in by_id {
+        sec["order"] = json!(reordered.len());
+        reordered.push(sec);
+    }
+    doc["sections"] = json!(reordered);
+    doc["updated_at"] = json!(Utc::now().to_rfc3339());
+    match save_report(report_id, &doc) {
+        Ok(()) => json!({"ok": true, "report": doc}),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn report_data(report_id: &str) -> Value {
+    let Some(doc) = load_report(report_id) else {
+        return json!({"ok": false, "error": "report not found"});
+    };
+    json!({
+        "ok": true,
+        "report_id": report_id,
+        "sections": doc.get("sections").cloned().unwrap_or(json!([]))
+    })
+}
+
+pub fn render_html(report_id: &str) -> Result<PathBuf, String> {
+    let doc = load_report(report_id).ok_or("report not found")?;
+    let title = doc
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Open-FDD Report");
+    let generated = Utc::now().to_rfc3339();
+    let mut html = format!(
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>{title}</title>\
+<style>body{{font-family:sans-serif;margin:2rem;color:#111}}\
+section{{margin-bottom:2rem;border-bottom:1px solid #ccc;padding-bottom:1rem;page-break-inside:avoid}}\
+h1{{margin-bottom:0.2rem}}h2{{color:#333;margin-top:0}}\
+.meta{{color:#666;font-size:0.9rem}}pre{{background:#f5f5f5;padding:1rem;overflow:auto;font-size:0.85rem}}\
+@media print{{header,footer{{display:block}}}}</style></head><body>\
+<header><h1>{title}</h1><p class=\"meta\">Generated {generated} · Open-FDD Report Builder</p></header>"
+    );
+    if let Some(sections) = doc.get("sections").and_then(|v| v.as_array()) {
+        for sec in sections {
+            if sec.get("visible").and_then(|v| v.as_bool()) == Some(false) {
+                continue;
+            }
+            let stitle = sec.get("title").and_then(|v| v.as_str()).unwrap_or("Section");
+            html.push_str(&format!("<section><h2>{stitle}</h2><pre>"));
+            html.push_str(
+                &serde_json::to_string_pretty(sec.get("content").unwrap_or(&json!({})))
+                    .unwrap_or_default(),
+            );
+            html.push_str("</pre></section>");
+        }
+    }
+    html.push_str("<footer><p class=\"meta\">Open-FDD · confidential commissioning data — no secrets included</p></footer></body></html>");
+    let dir = report_dir(report_id);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join("report.html");
+    fs::write(&path, html).map_err(|e| e.to_string())?;
+    Ok(path)
+}
+
+fn pdf_escape(text: &str) -> String {
+    text.replace('\\', "\\\\")
+        .replace('(', "\\(")
+        .replace(')', "\\)")
+}
+
+fn write_text_pdf(path: &Path, title: &str, lines: &[String]) -> Result<(), String> {
+    let mut body = format!("BT /F1 14 Tf 50 750 Td ({}) Tj ", pdf_escape(title));
+    body.push_str("0 -18 Td /F1 10 Tf ");
+    for line in lines.iter().take(48) {
+        body.push_str(&format!("({}) Tj 0 -12 Tj ", pdf_escape(line)));
+    }
+    body.push_str("ET");
+
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> >>"
+            .to_string(),
+        format!("<< /Length {} >>\nstream\n{}\nendstream", body.len(), body),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+    ];
+
+    let mut pdf = String::from("%PDF-1.4\n");
+    let mut offsets = vec![0_usize];
+    for (i, obj) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.push_str(&format!("{} 0 obj\n{obj}\nendobj\n", i + 1));
+    }
+    let xref_pos = pdf.len();
+    pdf.push_str(&format!("xref\n0 {}\n", objects.len() + 1));
+    pdf.push_str("0000000000 65535 f \n");
+    for off in &offsets[1..] {
+        pdf.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.push_str(&format!(
+        "trailer << /Size {} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n",
+        objects.len() + 1
+    ));
+    fs::write(path, pdf).map_err(|e| e.to_string())
+}
+
+pub fn render_pdf(report_id: &str) -> Result<PathBuf, String> {
+    let doc = load_report(report_id).ok_or("report not found")?;
+    let title = doc
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Open-FDD Report")
+        .to_string();
+    let mut lines = vec![
+        format!("Generated: {}", Utc::now().to_rfc3339()),
+        format!("Report ID: {report_id}"),
+    ];
+    if let Some(sections) = doc.get("sections").and_then(|v| v.as_array()) {
+        for sec in sections {
+            if sec.get("visible").and_then(|v| v.as_bool()) == Some(false) {
+                continue;
+            }
+            let stitle = sec
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Section");
+            lines.push(String::new());
+            lines.push(format!("## {stitle}"));
+            let body = serde_json::to_string(sec.get("content").unwrap_or(&json!({})))
+                .unwrap_or_default();
+            for chunk in body.as_bytes().chunks(90) {
+                lines.push(String::from_utf8_lossy(chunk).into_owned());
+            }
+        }
+    }
+    let dir = report_dir(report_id);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let pdf_path = dir.join("report.pdf");
+    write_text_pdf(&pdf_path, &title, &lines)?;
+    let _ = render_html(report_id);
+    if let Some(mut saved) = load_report(report_id) {
+        saved["metadata"]["pdf_ready"] = json!(true);
+        saved["metadata"]["pdf_generated_at"] = json!(Utc::now().to_rfc3339());
+        let _ = save_report(report_id, &saved);
+    }
+    Ok(pdf_path)
+}
+
+pub fn render_pdf_bundle(report_id: &str) -> Value {
+    match render_pdf(report_id) {
+        Ok(pdf_path) => {
+            let html_path = report_dir(report_id).join("report.html");
+            json!({
+                "ok": true,
+                "report_id": report_id,
+                "html_path": html_path.display().to_string(),
+                "pdf_path": pdf_path.display().to_string(),
+                "render_engine": "rust-text-pdf",
+                "size_bytes": fs::metadata(&pdf_path).map(|m| m.len()).unwrap_or(0)
+            })
+        }
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn download_path(report_id: &str, kind: &str) -> Option<PathBuf> {
+    let id = safe_report_id(report_id)?;
+    let dir = report_dir(&id);
+    match kind {
+        "html" => {
+            let p = dir.join("report.html");
+            if p.exists() {
+                Some(p)
+            } else {
+                render_html(&id).ok()
+            }
+        }
+        "pdf" => {
+            let p = dir.join("report.pdf");
+            if p.exists() {
+                Some(p)
+            } else {
+                render_pdf(&id).ok()
+            }
+        }
+        _ => None,
+    }
+}
+
+pub fn safe_report_id(raw: &str) -> Option<String> {
+    if raw.is_empty() || raw.contains("..") || raw.contains('/') {
+        return None;
+    }
+    let sanitized = sanitize_id(raw);
+    if sanitized.is_empty() {
+        return None;
+    }
+    Some(sanitized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_report_id() {
+        assert_eq!(sanitize_id("rpt-123"), "rpt-123");
+        assert_eq!(sanitize_id("../evil"), "____evil");
+    }
+
+    #[test]
+    fn templates_include_validation_summary() {
+        let t = templates();
+        assert_eq!(t["ok"], true);
+        assert!(t["templates"].as_array().unwrap().len() >= 1);
+    }
+
+    #[test]
+    fn create_draft_has_sections() {
+        let doc = create_draft(&json!({"title": "Test Report"}));
+        assert_eq!(doc["ok"], true);
+        assert!(doc["sections"].as_array().unwrap().len() >= 5);
+    }
+}

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -1,7 +1,7 @@
 //! Model-driven report drafts and HTML/PDF export bundles (Rust-era, no Python).
 
-use crate::fdd::rules;
 use crate::faults;
+use crate::fdd::rules;
 use crate::historian::store;
 use crate::model::query;
 use chrono::Utc;
@@ -344,7 +344,10 @@ h1{{margin-bottom:0.2rem}}h2{{color:#333;margin-top:0}}\
             if sec.get("visible").and_then(|v| v.as_bool()) == Some(false) {
                 continue;
             }
-            let stitle = sec.get("title").and_then(|v| v.as_str()).unwrap_or("Section");
+            let stitle = sec
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Section");
             html.push_str(&format!("<section><h2>{stitle}</h2><pre>"));
             html.push_str(
                 &serde_json::to_string_pretty(sec.get("content").unwrap_or(&json!({})))
@@ -425,8 +428,8 @@ pub fn render_pdf(report_id: &str) -> Result<PathBuf, String> {
                 .unwrap_or("Section");
             lines.push(String::new());
             lines.push(format!("## {stitle}"));
-            let body = serde_json::to_string(sec.get("content").unwrap_or(&json!({})))
-                .unwrap_or_default();
+            let body =
+                serde_json::to_string(sec.get("content").unwrap_or(&json!({}))).unwrap_or_default();
             for chunk in body.as_bytes().chunks(90) {
                 lines.push(String::from_utf8_lossy(chunk).into_owned());
             }
@@ -504,20 +507,24 @@ mod tests {
     #[test]
     fn sanitize_report_id() {
         assert_eq!(sanitize_id("rpt-123"), "rpt-123");
-        assert_eq!(sanitize_id("../evil"), "____evil");
+        assert_eq!(sanitize_id("../evil"), "___evil");
     }
 
     #[test]
     fn templates_include_validation_summary() {
         let t = templates();
         assert_eq!(t["ok"], true);
-        assert!(t["templates"].as_array().unwrap().len() >= 1);
+        assert!(!t["templates"].as_array().unwrap().is_empty());
     }
 
     #[test]
     fn create_draft_has_sections() {
+        let tmp = std::env::temp_dir().join(format!("ofdd-report-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", tmp.to_string_lossy().as_ref());
         let doc = create_draft(&json!({"title": "Test Report"}));
-        assert_eq!(doc["ok"], true);
+        assert_eq!(doc["ok"], true, "draft error: {:?}", doc.get("error"));
         assert!(doc["sections"].as_array().unwrap().len() >= 5);
     }
 }

--- a/edge/tests/reports_integration.rs
+++ b/edge/tests/reports_integration.rs
@@ -95,12 +95,7 @@ impl Server {
     }
 }
 
-fn http_raw(
-    method: &str,
-    url: &str,
-    token: Option<&str>,
-    body: Option<&str>,
-) -> (u16, String) {
+fn http_raw(method: &str, url: &str, token: Option<&str>, body: Option<&str>) -> (u16, String) {
     let parsed = url.strip_prefix("http://").unwrap_or(url);
     let (host_port, path) = parsed.split_once('/').unwrap_or((parsed, ""));
     let path = format!("/{path}");
@@ -148,7 +143,7 @@ fn report_templates_requires_auth_or_returns_templates() {
     assert_eq!(status, 200);
     let json: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(json["ok"], true);
-    assert!(json["templates"].as_array().unwrap().len() >= 1);
+    assert!(!json["templates"].as_array().unwrap().is_empty());
 }
 
 #[test]

--- a/edge/tests/reports_integration.rs
+++ b/edge/tests/reports_integration.rs
@@ -12,14 +12,15 @@ use open_fdd_edge_prototype::auth::env_file::{generate_auth_env, parse_env_file,
 static SERVER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 struct Server {
-    _child: Child,
+    _lock: std::sync::MutexGuard<'static, ()>,
+    child: Child,
     port: u16,
     token: String,
 }
 
 impl Server {
     fn start() -> Self {
-        let _lock = SERVER_LOCK
+        let lock = SERVER_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -28,11 +29,8 @@ impl Server {
             .local_addr()
             .unwrap()
             .port();
-        let workspace = std::env::temp_dir().join(format!(
-            "openfdd-report-it-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        let workspace =
+            std::env::temp_dir().join(format!("openfdd-report-it-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&workspace);
         std::fs::create_dir_all(&workspace).unwrap();
         let auth_path = workspace.join("auth.env.local");
@@ -59,8 +57,9 @@ impl Server {
         for (k, v) in &auth_map {
             cmd.env(k, v);
         }
-        let child = cmd.spawn().expect("start edge");
-        for _ in 0..60 {
+        let mut child = cmd.spawn().expect("start edge");
+        let mut ready = false;
+        for _ in 0..120 {
             let (status, _) = http_raw(
                 "GET",
                 &format!("http://127.0.0.1:{port}/api/health"),
@@ -68,10 +67,12 @@ impl Server {
                 None,
             );
             if status == 200 {
+                ready = true;
                 break;
             }
-            thread::sleep(Duration::from_millis(200));
+            thread::sleep(Duration::from_millis(250));
         }
+        assert!(ready, "edge server did not become ready on port {port}");
         let login = serde_json::json!({"username":"integrator","password":pw}).to_string();
         let (_, body) = http_post_json(
             &format!("http://127.0.0.1:{port}/api/auth/login"),
@@ -86,12 +87,20 @@ impl Server {
                     .and_then(|t| t.as_str())
                     .map(str::to_string)
             })
-            .unwrap();
+            .expect("login token missing");
         Server {
-            _child: child,
+            _lock: lock,
+            child,
             port,
             token,
         }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 }
 
@@ -99,7 +108,7 @@ fn http_raw(method: &str, url: &str, token: Option<&str>, body: Option<&str>) ->
     let parsed = url.strip_prefix("http://").unwrap_or(url);
     let (host_port, path) = parsed.split_once('/').unwrap_or((parsed, ""));
     let path = format!("/{path}");
-    let mut stream = TcpStream::connect(host_port).unwrap();
+    let mut stream = TcpStream::connect(host_port).expect("connect to edge server");
     let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\n");
     if let Some(t) = token {
         req.push_str(&format!("Authorization: Bearer {t}\r\n"));

--- a/edge/tests/reports_integration.rs
+++ b/edge/tests/reports_integration.rs
@@ -1,0 +1,223 @@
+//! Report builder API integration tests.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+use open_fdd_edge_prototype::auth::env_file::{generate_auth_env, parse_env_file, GenerateOptions};
+
+static SERVER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+struct Server {
+    _child: Child,
+    port: u16,
+    token: String,
+}
+
+impl Server {
+    fn start() -> Self {
+        let _lock = SERVER_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let port = TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let workspace = std::env::temp_dir().join(format!(
+            "openfdd-report-it-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&workspace);
+        std::fs::create_dir_all(&workspace).unwrap();
+        let auth_path = workspace.join("auth.env.local");
+        let generated = generate_auth_env(&GenerateOptions {
+            path: auth_path.clone(),
+            force: true,
+            show_secrets: false,
+        })
+        .unwrap();
+        let pw = generated
+            .plaintext_passwords
+            .get("integrator")
+            .cloned()
+            .unwrap();
+        let auth_map = parse_env_file(&std::fs::read_to_string(&auth_path).unwrap());
+        let bin = env!("CARGO_BIN_EXE_open_fdd_edge_prototype");
+        let frontend = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../frontend");
+        let mut cmd = Command::new(bin);
+        cmd.env("PORT", port.to_string())
+            .env("OPENFDD_WORKSPACE", &workspace)
+            .env("FRONTEND_DIR", frontend)
+            .env("OPENFDD_BACNET_ENABLED", "0")
+            .env("OPENFDD_MODBUS_ENABLED", "0");
+        for (k, v) in &auth_map {
+            cmd.env(k, v);
+        }
+        let child = cmd.spawn().expect("start edge");
+        for _ in 0..60 {
+            let (status, _) = http_raw(
+                "GET",
+                &format!("http://127.0.0.1:{port}/api/health"),
+                None,
+                None,
+            );
+            if status == 200 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+        let login = serde_json::json!({"username":"integrator","password":pw}).to_string();
+        let (_, body) = http_post_json(
+            &format!("http://127.0.0.1:{port}/api/auth/login"),
+            &login,
+            None,
+        );
+        let token = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| {
+                v.get("token")
+                    .or_else(|| v.get("access_token"))
+                    .and_then(|t| t.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap();
+        Server {
+            _child: child,
+            port,
+            token,
+        }
+    }
+}
+
+fn http_raw(
+    method: &str,
+    url: &str,
+    token: Option<&str>,
+    body: Option<&str>,
+) -> (u16, String) {
+    let parsed = url.strip_prefix("http://").unwrap_or(url);
+    let (host_port, path) = parsed.split_once('/').unwrap_or((parsed, ""));
+    let path = format!("/{path}");
+    let mut stream = TcpStream::connect(host_port).unwrap();
+    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\n");
+    if let Some(t) = token {
+        req.push_str(&format!("Authorization: Bearer {t}\r\n"));
+    }
+    if let Some(b) = body {
+        req.push_str("Content-Type: application/json\r\n");
+        req.push_str(&format!("Content-Length: {}\r\n", b.len()));
+        req.push_str("\r\n");
+        req.push_str(b);
+    } else {
+        req.push_str("\r\n");
+    }
+    stream.write_all(req.as_bytes()).unwrap();
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).unwrap();
+    let status = resp
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let body = resp.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
+    (status, body)
+}
+
+fn http_post_json(url: &str, body: &str, token: Option<&str>) -> (u16, String) {
+    http_raw("POST", url, token, Some(body))
+}
+
+fn http_get(url: &str, token: &str) -> (u16, String) {
+    http_raw("GET", url, Some(token), None)
+}
+
+#[test]
+fn report_templates_requires_auth_or_returns_templates() {
+    let srv = Server::start();
+    let (status, body) = http_get(
+        &format!("http://127.0.0.1:{}/api/reports/templates", srv.port),
+        &srv.token,
+    );
+    assert_eq!(status, 200);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["ok"], true);
+    assert!(json["templates"].as_array().unwrap().len() >= 1);
+}
+
+#[test]
+fn report_draft_reorder_and_pdf_download() {
+    let srv = Server::start();
+    let base = format!("http://127.0.0.1:{}", srv.port);
+    let (_, draft_body) = http_post_json(
+        &format!("{base}/api/reports/draft"),
+        r#"{"title":"Integration Test Report"}"#,
+        Some(&srv.token),
+    );
+    let draft: serde_json::Value = serde_json::from_str(&draft_body).unwrap();
+    assert_eq!(draft["ok"], true);
+    let report_id = draft["report_id"].as_str().unwrap();
+    assert!(draft["sections"].as_array().unwrap().len() >= 5);
+
+    let sections = draft["sections"].as_array().unwrap();
+    let ids: Vec<String> = sections
+        .iter()
+        .filter_map(|s| s.get("id").and_then(|v| v.as_str()).map(str::to_string))
+        .collect();
+    let mut reversed = ids.clone();
+    reversed.reverse();
+    let reorder_body = serde_json::json!({"section_ids": reversed}).to_string();
+    let (status, _) = http_post_json(
+        &format!("{base}/api/reports/{report_id}/sections/reorder"),
+        &reorder_body,
+        Some(&srv.token),
+    );
+    assert_eq!(status, 200);
+
+    let (status, render_body) = http_post_json(
+        &format!("{base}/api/reports/{report_id}/render/pdf"),
+        "{}",
+        Some(&srv.token),
+    );
+    assert_eq!(status, 200);
+    let render: serde_json::Value = serde_json::from_str(&render_body).unwrap();
+    assert_eq!(render["ok"], true);
+
+    let (status, pdf_bytes) = http_raw(
+        "GET",
+        &format!("{base}/api/reports/{report_id}/download.pdf"),
+        Some(&srv.token),
+        None,
+    );
+    assert_eq!(status, 200);
+    assert!(pdf_bytes.starts_with("%PDF"));
+    assert!(pdf_bytes.len() > 128);
+}
+
+#[test]
+fn report_download_rejects_anonymous() {
+    let srv = Server::start();
+    let base = format!("http://127.0.0.1:{}", srv.port);
+    let (_, draft_body) = http_post_json(
+        &format!("{base}/api/reports/draft"),
+        r#"{"title":"Auth Test"}"#,
+        Some(&srv.token),
+    );
+    let report_id = serde_json::from_str::<serde_json::Value>(&draft_body).unwrap()["report_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (status, _) = http_raw(
+        "GET",
+        &format!("{base}/api/reports/{report_id}/download.pdf"),
+        None,
+        None,
+    );
+    assert_eq!(status, 401);
+}

--- a/scripts/openfdd_auth_init.sh
+++ b/scripts/openfdd_auth_init.sh
@@ -22,6 +22,7 @@ ROTATE=false
 ROTATE_ALL=false
 ROTATE_ROLE=""
 HASH_PASSWORD=""
+RESTART=false
 SUBCMD=(auth init --path "$AUTH_PATH")
 
 usage() {
@@ -41,6 +42,7 @@ Options:
   --all                 Rotate all roles + OFDD_AUTH_SECRET (invalidates JWTs)
   --role NAME           Rotate one role: operator|integrator|agent|admin
   --hash-password PASS  Print bcrypt hash for manual auth.env.local editing
+  --restart             After init/rotate, recreate local openfdd-bridge container
   -h, --help            Show this help
 
 After rotate or force init, recreate bridge containers to pick up new env.
@@ -62,6 +64,7 @@ while [[ $# -gt 0 ]]; do
     --all) ROTATE_ALL=true; shift ;;
     --role) ROTATE_ROLE="$2"; shift 2 ;;
     --hash-password) HASH_PASSWORD="$2"; SUBCMD=(auth hash-password "$2"); shift 2 ;;
+    --restart) RESTART=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -139,4 +142,12 @@ fi
 
 chmod 600 "$AUTH_PATH" 2>/dev/null || true
 echo "==> Auth env: $AUTH_PATH"
-echo "==> Recreate bridge after rotate/force: docker compose -f docker-compose.local.yml up -d --force-recreate openfdd-bridge"
+if [[ "$RESTART" == "true" ]]; then
+  export OPENFDD_RUN_UID="${OPENFDD_RUN_UID:-$(id -u)}"
+  export OPENFDD_RUN_GID="${OPENFDD_RUN_GID:-$(id -g)}"
+  echo "==> Recreating openfdd-bridge to reload auth env"
+  docker compose -f "$ROOT/docker-compose.local.yml" up -d --force-recreate openfdd-bridge
+else
+  echo "==> Recreate bridge after rotate/force: docker compose -f docker-compose.local.yml up -d --force-recreate openfdd-bridge"
+  echo "==> Or re-run with --restart"
+fi

--- a/scripts/openfdd_auth_lib.sh
+++ b/scripts/openfdd_auth_lib.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Resolve plaintext password for an auth role from bootstrap handoff or env.
+# auth.env.local stores bcrypt hashes only — never use OFDD_*_PASSWORD_HASH as password.
+#
+# Usage: openfdd_auth_plaintext_password <auth.env.local path> <role>
+# Env override: OPENFDD_INTEGRATOR_PASSWORD, OPENFDD_AGENT_PASSWORD, OPENFDD_OPERATOR_PASSWORD
+openfdd_auth_plaintext_password() {
+  local auth_file="${1:?auth file}"
+  local role="${2:?role}"
+  local role_upper env_key pw handoff ws
+
+  role_upper="$(printf '%s' "$role" | tr '[:lower:]' '[:upper:]')"
+  env_key="OPENFDD_${role_upper}_PASSWORD"
+  if [[ -n "${!env_key:-}" ]]; then
+    printf '%s' "${!env_key}"
+    return 0
+  fi
+
+  ws="$(dirname "$auth_file")"
+  handoff="$ws/bootstrap_credentials.once.txt"
+  if [[ -f "$handoff" ]]; then
+    pw="$(grep -E "^${role}:" "$handoff" | head -1 | cut -d: -f2- | sed 's/^ //' || true)"
+    if [[ -n "$pw" && "$pw" != \$2b\$* ]]; then
+      printf '%s' "$pw"
+      return 0
+    fi
+  fi
+
+  local plain_key="OFDD_${role_upper}_PASSWORD"
+  if [[ -f "$auth_file" ]]; then
+    pw="$(grep "^${plain_key}=" "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
+    if [[ -n "$pw" && "$pw" != \$2b\$* ]]; then
+      printf '%s' "$pw"
+      return 0
+    fi
+  fi
+
+  echo "ERROR: no plaintext password for role '$role'. Run:" >&2
+  echo "  ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart" >&2
+  echo "Or set ${env_key} or create $handoff" >&2
+  return 1
+}
+
+openfdd_auth_login_token() {
+  local base="${1:?base url}"
+  local auth_file="${2:?auth file}"
+  local role="${3:-integrator}"
+  local user pw
+  user="$(grep "^OFDD_${role^^}_USER=" "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
+  user="${user:-$role}"
+  pw="$(openfdd_auth_plaintext_password "$auth_file" "$role")" || return 1
+  curl -fsS -X POST "${base}/api/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg u "$user" --arg p "$pw" '{username:$u,password:$p}')" \
+    | jq -r '.token // .access_token // empty'
+}

--- a/scripts/openfdd_auth_smoke.sh
+++ b/scripts/openfdd_auth_smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Login smoke test — verifies workspace/auth.env.local credentials against a running bridge.
+# Does not print passwords or tokens.
+#
+#   OPENFDD_AUTH_SMOKE_PASSWORD='...' ./scripts/openfdd_auth_smoke.sh
+#   ./scripts/openfdd_auth_smoke.sh --credentials workspace/bootstrap_credentials.once.txt
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
+CRED_FILE=""
+PASSWORD="${OPENFDD_AUTH_SMOKE_PASSWORD:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/openfdd_auth_smoke.sh [--credentials FILE] [--base URL]
+
+Tests POST /api/auth/login and GET /api/auth/me for operator, integrator, and agent.
+Provide password via OPENFDD_AUTH_SMOKE_PASSWORD or a bootstrap credentials file (username: password lines).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --credentials) CRED_FILE="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PASSWORD" && -n "$CRED_FILE" ]]; then
+  [[ -f "$CRED_FILE" ]] || { echo "Missing credentials file: $CRED_FILE" >&2; exit 1; }
+fi
+
+lookup_password() {
+  local user="$1"
+  if [[ -n "$PASSWORD" ]]; then
+    printf '%s' "$PASSWORD"
+    return 0
+  fi
+  if [[ -n "$CRED_FILE" ]]; then
+    local line
+    line="$(grep -E "^${user}:" "$CRED_FILE" | head -1 || true)"
+    [[ -n "$line" ]] || return 1
+    printf '%s' "${line#*: }"
+    return 0
+  fi
+  return 1
+}
+
+login_as() {
+  local user="$1"
+  local pass
+  pass="$(lookup_password "$user")" || {
+    echo "FAIL: no password for $user (set OPENFDD_AUTH_SMOKE_PASSWORD or --credentials)" >&2
+    return 1
+  }
+  if [[ "$pass" == \$2b\$* ]]; then
+    echo "FAIL: $user password looks like a bcrypt hash — use plaintext from bootstrap, not auth.env.local" >&2
+    return 1
+  fi
+  local body token me_role
+  body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2]}))' "$user" "$pass")"
+  local resp
+  resp="$(curl -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' -d "$body")" || {
+    echo "FAIL: login HTTP error for $user" >&2
+    return 1
+  }
+  if ! printf '%s' "$resp" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"; then
+    echo "FAIL: login rejected for $user" >&2
+    return 1
+  fi
+  token="$(printf '%s' "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")"
+  me_role="$(curl -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | python3 -c "import json,sys; print(json.load(sys.stdin).get('role',''))")"
+  if [[ "$me_role" != "$user" && ! ( "$user" == "integrator" && "$me_role" == "integrator" ) ]]; then
+    if [[ "$me_role" != "$user" ]]; then
+      echo "FAIL: /api/auth/me role mismatch for $user (got $me_role)" >&2
+      return 1
+    fi
+  fi
+  echo "OK: $user login + /api/auth/me"
+}
+
+curl -fsS "$BASE/health" >/dev/null || { echo "Bridge not healthy at $BASE" >&2; exit 1; }
+
+if [[ -n "$PASSWORD" ]]; then
+  login_as integrator
+else
+  CRED_FILE="${CRED_FILE:-$ROOT/workspace/bootstrap_credentials.once.txt}"
+  for role in operator integrator agent; do
+    login_as "$role"
+  done
+fi
+
+echo "Auth smoke passed at $BASE"

--- a/scripts/openfdd_csv_append_validation.sh
+++ b/scripts/openfdd_csv_append_validation.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# CSV append/import/export/purge helpers for live FDD validation (device 5007).
+# Sourced from smoke_live_fdd_validation.sh — not executed directly.
+set -euo pipefail
+
+openfdd_csv_append_init() {
+  local log_dir="$1"
+  CSV_APPEND_LOG_DIR="$log_dir"
+  CSV_APPEND_SOURCE_ID="${OPENFDD_CSV_SOURCE_ID:-source:validation-csv}"
+  CSV_APPEND_EQUIPMENT_ID="${OPENFDD_CSV_EQUIPMENT_ID:-5007}"
+  CSV_APPEND_PROFILE="${OPENFDD_CSV_IMPORT_PROFILE:-validation_csv_5007}"
+  CSV_APPEND_BATCH="${CSV_APPEND_BATCH:-0}"
+  CSV_APPEND_HIST_ROWS_BEFORE=0
+  CSV_APPEND_HIST_ROWS_AFTER=0
+  CSV_APPEND_JOB_IDS=()
+  mkdir -p "$log_dir/csv_batches"
+}
+
+openfdd_csv_append_generate() {
+  local ts="$1"
+  local phase="${2:-normal}"
+  local batch="$3"
+  local out="$CSV_APPEND_LOG_DIR/csv_batches/batch_${batch}.csv"
+  local oa_t=65.0 oa_h=45.0 duct_t=55.0 zn_t=72.0
+  if [[ "$phase" == "fault" ]]; then
+    oa_t=120.0
+    duct_t=95.0
+  fi
+  cat >"$out" <<EOF
+timestamp,equipment_id,point_key,value,units,source_id
+${ts},${CSV_APPEND_EQUIPMENT_ID},oa_t,${oa_t},degF,${CSV_APPEND_SOURCE_ID}
+${ts},${CSV_APPEND_EQUIPMENT_ID},oa_h,${oa_h},%,${CSV_APPEND_SOURCE_ID}
+${ts},${CSV_APPEND_EQUIPMENT_ID},duct_t,${duct_t},degF,${CSV_APPEND_SOURCE_ID}
+${ts},${CSV_APPEND_EQUIPMENT_ID},zn_t,${zn_t},degF,${CSV_APPEND_SOURCE_ID}
+EOF
+  printf '%s' "$out"
+}
+
+openfdd_csv_append_import_batch() {
+  local base="$1"
+  local token="$2"
+  local ts="$3"
+  local phase="$4"
+  local batch="$5"
+
+  CSV_APPEND_BATCH="$batch"
+  local csv_path
+  csv_path="$(openfdd_csv_append_generate "$ts" "$phase" "$batch")"
+
+  local job_resp job_id
+  job_resp="$(curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/import/jobs" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg profile "$CSV_APPEND_PROFILE" \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      '{profile_id:$profile,source_id:$src,equipment_id:$equip}')")"
+  job_id="$(jq -r '.job_id // empty' <<<"$job_resp")"
+  [[ -n "$job_id" ]] || { echo "csv import job create failed: $job_resp" >&2; return 1; }
+
+  curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/import/jobs/${job_id}/upload" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: text/csv' \
+    --data-binary @"$csv_path" >/dev/null
+
+  curl "${CURL_TLS[@]:-}" -fsS "${base}/api/import/jobs/${job_id}/preview" \
+    -H "Authorization: Bearer $token" \
+    -o "$CSV_APPEND_LOG_DIR/csv_preview_${batch}.json"
+
+  curl "${CURL_TLS[@]:-}" -fsS -X PATCH "${base}/api/import/jobs/${job_id}/options" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      '{source_id:$src,equipment_id:$equip,append:true}')" >/dev/null
+
+  local commit_resp
+  commit_resp="$(curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/import/jobs/${job_id}/commit" \
+    -H "Authorization: Bearer $token")"
+  echo "$commit_resp" >"$CSV_APPEND_LOG_DIR/csv_commit_${batch}.json"
+  CSV_APPEND_JOB_IDS+=("$job_id")
+}
+
+openfdd_csv_append_hist_rows() {
+  local base="$1"
+  local token="$2"
+  curl "${CURL_TLS[@]:-}" -fsS "${base}/api/historian/validation/status" \
+    -H "Authorization: Bearer $token" \
+    | jq -r '.row_count // 0'
+}
+
+openfdd_csv_append_export_checks() {
+  local base="$1"
+  local token="$2"
+  local tag="$3"
+  local out="$CSV_APPEND_LOG_DIR/export_${tag}"
+  mkdir -p "$out"
+  for path in historian.csv faults.csv model-points.csv validation-runs.csv import-jobs.csv; do
+    curl "${CURL_TLS[@]:-}" -fsS "${base}/api/export/${path}" \
+      -H "Authorization: Bearer $token" \
+      -o "$out/$path" || return 1
+    head -1 "$out/$path" >"$out/${path}.header"
+  done
+  jq -nc \
+    --arg tag "$tag" \
+    --arg dir "$out" \
+    --arg hist "$(wc -l <"$out/historian.csv" | tr -d ' ')" \
+    '{tag:$tag,dir:$dir,historian_lines:($hist|tonumber)}' \
+    >"$out/manifest.json"
+}
+
+openfdd_csv_append_purge_validation() {
+  local base="$1"
+  local token="$2"
+  local started="$3"
+  local finished="$4"
+
+  local preview
+  preview="$(curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/data-management/purge/preview" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      --arg after "$started" \
+      --arg before "$finished" \
+      '{source_id:$src,equipment_id:$equip,after_utc:$after,before_utc:$before,historian_subdir:"validation",validation_run:true}')")"
+  echo "$preview" >"$CSV_APPEND_LOG_DIR/purge_preview.json"
+  local matched
+  matched="$(jq -r '.matched_row_count // 0' <<<"$preview")"
+  [[ "$matched" -gt 0 ]] || echo "WARN: purge preview matched 0 rows" >&2
+
+  curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/data-management/purge/execute" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      --arg after "$started" \
+      --arg before "$finished" \
+      '{source_id:$src,equipment_id:$equip,after_utc:$after,before_utc:$before,historian_subdir:"validation",validation_run:true,confirmation:"PURGE HISTORIAN DATA"}')" \
+    >"$CSV_APPEND_LOG_DIR/purge_execute.json"
+}

--- a/scripts/openfdd_rust_site_lib.sh
+++ b/scripts/openfdd_rust_site_lib.sh
@@ -116,25 +116,10 @@ openfdd_rust_login_smoke() {
     echo "ERROR: missing $auth_file" >&2
     return 1
   }
-  local user pass
-  user="$(grep '^OFDD_INTEGRATOR_USER=' "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
-  pass="$(grep '^OFDD_INTEGRATOR_PASSWORD=' "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
-  [[ -n "$user" && -n "$pass" ]] || {
-    echo "ERROR: integrator credentials missing in auth.env.local" >&2
-    return 1
-  }
+  # shellcheck source=scripts/openfdd_auth_lib.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/openfdd_auth_lib.sh"
   local token
-  token="$(curl -fsS -X POST "${base}/api/auth/login" \
-    -H 'Content-Type: application/json' \
-    -d "$(jq -nc --arg u "$user" --arg p "$pass" '{username:$u,password:$p}')" \
-    2>/dev/null | jq -r '.token // .access_token // empty' || true)"
-  if [[ -z "$token" || "$token" == "null" ]]; then
-    echo "WARN: username/password login failed — trying legacy demo JWT (merge feature/rust-auth-security-parity for production auth)" >&2
-    token="$(curl -fsS -X POST "${base}/api/auth/login" \
-      -H 'Content-Type: application/json' \
-      -d '{"sub":"validate","role":"integrator"}' \
-      | jq -r '.access_token // empty')"
-  fi
+  token="$(openfdd_auth_login_token "$base" "$auth_file" integrator)" || return 1
   [[ -n "$token" && "$token" != "null" ]] || {
     echo "ERROR: login failed (no token returned)" >&2
     return 1

--- a/scripts/openfdd_ui_smoke.sh
+++ b/scripts/openfdd_ui_smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Programmatic UI smoke — visits key tabs, fails on HTTP 500 or obvious API errors.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+
+BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
+AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
+ARTIFACT="${OPENFDD_UI_SMOKE_ARTIFACT:-$ROOT/workspace/logs/ui_smoke_$(date -u +%Y%m%dT%H%M%SZ)}"
+CURL_TLS=()
+if [[ "$BASE" == https://* ]]; then CURL_TLS=(-k); fi
+
+mkdir -p "$ARTIFACT"
+fail=0
+
+token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator)" || exit 1
+
+check_api() {
+  local name="$1"
+  local path="$2"
+  local method="${3:-GET}"
+  local out="$ARTIFACT/${name//\//_}.json"
+  local code
+  code="$(curl "${CURL_TLS[@]}" -sS -o "$out" -w '%{http_code}' \
+    -X "$method" "${BASE}${path}" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    ${4:+-d "$4"})"
+  if [[ "$code" == 500 ]]; then
+    echo "FAIL: $name HTTP 500" >&2
+    fail=1
+    return
+  fi
+  if [[ "$code" -ge 400 && "$path" != *"/api/auth/"* ]]; then
+    echo "WARN: $name HTTP $code" >&2
+  fi
+  jq -e '.ok != false or .error == null' "$out" >/dev/null 2>&1 || {
+    if jq -e '.ok == false' "$out" >/dev/null 2>&1; then
+      echo "FAIL: $name returned ok:false — $(jq -r '.error // .message // "unknown"' "$out")" >&2
+      fail=1
+    fi
+  }
+  echo "OK: $name ($code)"
+}
+
+echo "UI smoke artifact: $ARTIFACT"
+check_api health /api/health
+check_api stack-health /api/health/stack
+check_api validation-status /api/validation-runs/current/status
+check_api json-api-sources /api/json-api/sources
+check_api model-haystack /api/model/haystack
+check_api fdd-rules /api/fdd-rules
+check_api historian-status /api/historian/validation/status
+check_api data-management /api/data-management/summary
+check_api export-meta /api/export/meta
+check_api reports-templates /api/reports/templates
+check_api reports-draft /api/reports/draft POST '{"template_id":"validation-summary","title":"UI Smoke Report"}'
+
+report_id="$(jq -r '.report_id // empty' "$ARTIFACT/reports-draft.json")"
+if [[ -n "$report_id" ]]; then
+  check_api report-get "/api/reports/${report_id}"
+  check_api report-render "/api/reports/${report_id}/render/pdf" POST '{}'
+  pdf_code="$(curl "${CURL_TLS[@]}" -sS -o "$ARTIFACT/report.pdf" -w '%{http_code}' \
+    "${BASE}/api/reports/${report_id}/download.pdf" \
+    -H "Authorization: Bearer $token")"
+  if [[ "$pdf_code" != 200 ]]; then
+    echo "FAIL: report PDF download HTTP $pdf_code" >&2
+    fail=1
+  elif [[ ! -s "$ARTIFACT/report.pdf" ]]; then
+    echo "FAIL: report PDF empty" >&2
+    fail=1
+  else
+    echo "OK: report PDF ($(wc -c <"$ARTIFACT/report.pdf" | tr -d ' ') bytes)"
+  fi
+fi
+
+# Static SPA routes should return HTML (no 500 from bridge)
+for route in / /login /plot /model /sql-fdd /json-api /data-management /haystack /bacnet /modbus /live-fdd-validation /reports; do
+  code="$(curl "${CURL_TLS[@]}" -sS -o "$ARTIFACT/route$(echo "$route" | tr '/' '_').html" -w '%{http_code}' "${BASE}${route}")"
+  if [[ "$code" == 500 ]]; then
+    echo "FAIL: route $route HTTP 500" >&2
+    fail=1
+  else
+    echo "OK: route $route ($code)"
+  fi
+done
+
+jq -nc --arg finished "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg dir "$ARTIFACT" --argjson fail "$fail" \
+  '{finished_at:$finished,artifact_dir:$dir,failed:$fail}' >"$ARTIFACT/final_report.json"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "UI smoke FAILED — see $ARTIFACT" >&2
+  exit 1
+fi
+echo "UI smoke PASS — $ARTIFACT"

--- a/scripts/smoke_live_fdd_validation.sh
+++ b/scripts/smoke_live_fdd_validation.sh
@@ -30,6 +30,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/openfdd_rust_site_lib.sh
 source "$ROOT/scripts/openfdd_rust_site_lib.sh"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+# shellcheck source=scripts/openfdd_csv_append_validation.sh
+source "$ROOT/scripts/openfdd_csv_append_validation.sh"
 
 BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
 CURL_TLS=()
@@ -49,6 +53,7 @@ REQUIRE_MODBUS="${OPENFDD_SMOKE_REQUIRE_MODBUS:-0}"
 VALIDATE_DOCKER="${OPENFDD_SMOKE_VALIDATE_DOCKER:-1}"
 VALIDATE_MODBUS="${OPENFDD_SMOKE_VALIDATE_MODBUS:-1}"
 VALIDATE_JSON="${OPENFDD_SMOKE_VALIDATE_JSON_API:-1}"
+CSV_APPEND="${OPENFDD_SMOKE_CSV_APPEND:-1}"
 JSON_API_URL="${OPENFDD_SMOKE_JSON_API_URL:-https://httpbin.org/get}"
 NO_DEMO_PASS="${OPENFDD_SMOKE_NO_DEMO_PASS:-0}"
 SHORT_FDD="${BENCH_SMOKE_SHORT_FDD:-0}"
@@ -113,7 +118,9 @@ write_final_report() {
     --argjson seen_confirmed "$SEEN_CONFIRMED" \
     --argjson seen_clear "$SEEN_CLEAR" \
     --arg artifact "$LOG_DIR" \
-    '{finished_at:$finished,samples:$samples,interval_failures:$failures,live_fdd_pass:$live_pass,demo_only:$demo_only,seen_raw_fault:$seen_raw,seen_confirmed_fault:$seen_confirmed,seen_clear:$seen_clear,artifact_dir:$artifact}' \
+    --arg report_pdf "$LOG_DIR/validation_report.pdf" \
+    --argjson csv_before "${CSV_APPEND_HIST_ROWS_BEFORE:-0}" \
+    '{finished_at:$finished,samples:$samples,interval_failures:$failures,live_fdd_pass:$live_pass,demo_only:$demo_only,seen_raw_fault:$seen_raw,seen_confirmed_fault:$seen_confirmed,seen_clear:$seen_clear,artifact_dir:$artifact,validation_report_pdf:$report_pdf,csv_hist_rows_before:$csv_before}' \
     >"$LOG_DIR/final_report.json"
 
   {
@@ -223,8 +230,8 @@ if [[ ! -f "$AUTH" ]]; then
   exit 1
 fi
 
-INTEGRATOR_PW="$(grep '^OFDD_INTEGRATOR_PASSWORD=' "$AUTH" | cut -d= -f2- | tr -d '\r')"
-AGENT_PW="$(grep '^OFDD_AGENT_PASSWORD=' "$AUTH" | cut -d= -f2- | tr -d '\r')"
+INTEGRATOR_PW="$(openfdd_auth_plaintext_password "$AUTH" integrator)" || exit 1
+AGENT_PW="$(openfdd_auth_plaintext_password "$AUTH" agent)" || exit 1
 
 login() {
   local user="$1" pw="$2"
@@ -236,6 +243,11 @@ login() {
 
 INT_TOKEN="$(login integrator "$INTEGRATOR_PW")"
 AGENT_TOKEN="$(login agent "$AGENT_PW")"
+
+if [[ "$CSV_APPEND" == "1" ]]; then
+  openfdd_csv_append_init "$LOG_DIR"
+  CSV_APPEND_HIST_ROWS_BEFORE="$(openfdd_csv_append_hist_rows "$BASE" "$INT_TOKEN")"
+fi
 
 if [[ "$SHORT_FDD" == "1" ]]; then
   INTERVAL="${OPENFDD_SMOKE_INTERVAL_SECONDS:-60}"
@@ -266,8 +278,10 @@ jq -nc \
   '{profile_id:$profile,device_instance:($device|tonumber?),interval_seconds:$interval,duration_hours:($hours|tonumber?),json_api_url:$json_url,mode:$mode,artifact_dir:$artifact,started_at:(now|todate)}' \
   >"$LOG_DIR/run_config.json"
 
-echo "Live FDD validation mode=$MODE_LABEL interval=${INTERVAL}s artifact=$LOG_DIR device=$DEVICE_INSTANCE simulate=$SIMULATE" | tee "$LOG_DIR/run.log"
+echo "Live FDD validation mode=$MODE_LABEL interval=${INTERVAL}s artifact=$LOG_DIR device=$DEVICE_INSTANCE simulate=$SIMULATE csv_append=$CSV_APPEND" | tee "$LOG_DIR/run.log"
 echo "Started: $(date -Iseconds)" | tee -a "$LOG_DIR/run.log"
+
+VALIDATION_STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 capture_docker_state start
 LAST_DOCKER_SINCE="1m"
@@ -325,6 +339,8 @@ while true; do
   modbus_registers_read=0
   json_api_ok=false
   json_api_points_read=0
+  csv_import_ok=true
+  csv_hist_delta=0
   override_scan_ok=false
   err_msg=""
   data_source="unknown"
@@ -393,6 +409,20 @@ while true; do
     fi
   else
     json_api_ok=true
+  fi
+
+  if [[ "$CSV_APPEND" == "1" ]]; then
+    csv_interval="${OPENFDD_SMOKE_CSV_INTERVAL_SECONDS:-300}"
+    if (( sample_n == 1 || (INTERVAL > 0 && (sample_n * INTERVAL) % csv_interval == 0) )); then
+      hist_before="$(openfdd_csv_append_hist_rows "$BASE" "$INT_TOKEN")"
+      if openfdd_csv_append_import_batch "$BASE" "$INT_TOKEN" "$ts" "$phase" "$sample_n"; then
+        hist_after="$(openfdd_csv_append_hist_rows "$BASE" "$INT_TOKEN")"
+        csv_hist_delta=$(( hist_after - hist_before ))
+        [[ "$csv_hist_delta" -ge 0 ]] || csv_import_ok=false
+      else
+        csv_import_ok=false
+      fi
+    fi
   fi
 
   cycle_body='{}'
@@ -473,9 +503,11 @@ while true; do
     --argjson modbus_regs "$modbus_registers_read" \
     --argjson json_ok "$json_api_ok" \
     --argjson json_pts "$json_api_points_read" \
+    --argjson csv_ok "$csv_import_ok" \
+    --argjson csv_hist_delta "$csv_hist_delta" \
     --argjson override_ok "$override_scan_ok" \
     --argjson demo_only "$demo_only" \
-    '{timestamp_utc:$ts,sample_index:$n,mode:$mode,api_health_ok:$api_health,stack_health_ok:$stack_health,docker_ok:$docker_ok,docker_error_count:$docker_errors,source_id:$source_id,smoke_device_instance:$device,bacnet_device_seen:$bacnet_seen,bacnet_poll_ok:$bacnet_poll,historian_rows_written:$hist_rows,fdd_sql_ok:$fdd_ok,raw_fault_count:$raw_fault,confirmed_fault_count:$confirmed_fault,minutes_in_fault:$minutes_fault,confirmation_required_minutes:$confirm_min,expected_phase:$phase,expected_fault_state:$expected_fault,actual_fault_state:$actual_fault,demo_only:$demo_only,modbus_ok:$modbus,modbus_registers_read:$modbus_regs,json_api_ok:$json_ok,json_api_points_read:$json_pts,override_scan_ok:$override_ok,data_source:$data_source,error:$err}' \
+    '{timestamp_utc:$ts,sample_index:$n,mode:$mode,api_health_ok:$api_health,stack_health_ok:$stack_health,docker_ok:$docker_ok,docker_error_count:$docker_errors,source_id:$source_id,smoke_device_instance:$device,bacnet_device_seen:$bacnet_seen,bacnet_poll_ok:$bacnet_poll,historian_rows_written:$hist_rows,fdd_sql_ok:$fdd_ok,raw_fault_count:$raw_fault,confirmed_fault_count:$confirmed_fault,minutes_in_fault:$minutes_fault,confirmation_required_minutes:$confirm_min,expected_phase:$phase,expected_fault_state:$expected_fault,actual_fault_state:$actual_fault,demo_only:$demo_only,modbus_ok:$modbus,modbus_registers_read:$modbus_regs,json_api_ok:$json_ok,json_api_points_read:$json_pts,csv_import_ok:$csv_ok,csv_hist_row_delta:$csv_hist_delta,override_scan_ok:$override_ok,data_source:$data_source,error:$err}' \
     >>"$LOG_DIR/summary.jsonl"
 
   echo "[$ts] sample=$sample_n phase=$phase api=$api_health_ok stack=$stack_health_ok docker=$docker_ok bacnet=$bacnet_device_seen fdd=$fdd_sql_ok modbus=$modbus_ok json=$json_api_ok source=$data_source demo=$demo_only raw=$raw_fault_count confirmed=$confirmed_fault_count"
@@ -492,6 +524,30 @@ capture_docker_state end
 curl "${CURL_TLS[@]}" -fsS "${BASE}/api/validation-runs/current/status" \
   -H "Authorization: Bearer $INT_TOKEN" \
   -o "$LOG_DIR/final_status.json" 2>/dev/null || true
+
+VALIDATION_FINISHED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ "$CSV_APPEND" == "1" ]]; then
+  openfdd_csv_append_export_checks "$BASE" "$INT_TOKEN" before_purge || true
+  openfdd_csv_append_purge_validation "$BASE" "$INT_TOKEN" "$VALIDATION_STARTED" "$VALIDATION_FINISHED" || true
+  openfdd_csv_append_export_checks "$BASE" "$INT_TOKEN" after_purge || true
+fi
+
+report_draft="$(curl "${CURL_TLS[@]}" -fsS -X POST "${BASE}/api/reports/draft" \
+  -H "Authorization: Bearer $INT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"template_id":"validation-summary","title":"Live FDD Validation Report"}' 2>/dev/null || echo '{}')"
+echo "$report_draft" >"$LOG_DIR/validation_report_draft.json"
+report_id="$(jq -r '.report_id // empty' <<<"$report_draft")"
+if [[ -n "$report_id" ]]; then
+  curl "${CURL_TLS[@]}" -fsS -X POST "${BASE}/api/reports/${report_id}/render/pdf" \
+    -H "Authorization: Bearer $INT_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{}' -o "$LOG_DIR/validation_report_render.json" 2>/dev/null || true
+  curl "${CURL_TLS[@]}" -fsS "${BASE}/api/reports/${report_id}/download.pdf" \
+    -H "Authorization: Bearer $INT_TOKEN" \
+    -o "$LOG_DIR/validation_report.pdf" 2>/dev/null || true
+fi
 
 write_final_report
 fail_count="$(jq -s '[.[] | select(.api_health_ok==false or .fdd_sql_ok==false)] | length' "$LOG_DIR/summary.jsonl" 2>/dev/null || echo 0)"

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import AgentPage from "./pages/AgentPage";
 import DriversPage from "./pages/DriversPage";
 import JsonApiPage from "./pages/JsonApiPage";
 import BacnetPage from "./pages/BacnetPage";
+import HaystackPage from "./pages/HaystackPage";
 import ModbusPage from "./pages/ModbusPage";
 import DataModelPage from "./pages/DataModelPage";
 import HomePage from "./pages/HomePage";
@@ -38,6 +39,7 @@ export default function App() {
             <Route path="fdd-assignments" element={<Navigate to="/model" replace />} />
             <Route path="plot" element={<TabErrorBoundary tab="plot"><PlotPage /></TabErrorBoundary>} />
             <Route path="drivers" element={<TabErrorBoundary tab="drivers"><DriversPage /></TabErrorBoundary>} />
+            <Route path="haystack" element={<TabErrorBoundary tab="haystack"><HaystackPage /></TabErrorBoundary>} />
             <Route path="bacnet" element={<TabErrorBoundary tab="bacnet"><BacnetPage /></TabErrorBoundary>} />
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -16,6 +16,7 @@ import PlotPage from "./pages/PlotPage";
 import SqlFddRulesPage from "./pages/SqlFddRulesPage";
 import LiveFddValidationPage from "./pages/LiveFddValidationPage";
 import DataManagementPage from "./pages/DataManagementPage";
+import ReportBuilderPage from "./pages/ReportBuilderPage";
 import AlgorithmsPage from "./pages/AlgorithmsPage";
 import { TabErrorBoundary } from "./components/TabDebugPanel";
 
@@ -44,6 +45,7 @@ export default function App() {
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />
             <Route path="data-management" element={<TabErrorBoundary tab="data-management"><DataManagementPage /></TabErrorBoundary>} />
+            <Route path="reports" element={<TabErrorBoundary tab="reports"><ReportBuilderPage /></TabErrorBoundary>} />
             <Route path="agent" element={<TabErrorBoundary tab="agent"><AgentPage /></TabErrorBoundary>} />
             <Route path="host" element={<TabErrorBoundary tab="host"><HostStatsPage /></TabErrorBoundary>} />
             <Route path="fdd" element={<Navigate to="/sql-fdd" replace />} />

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -28,6 +28,7 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
       { to: "/drivers", icon: "🌳", label: "Drivers", protected: true },
       { to: "/sql-fdd", icon: "⚡", label: "SQL FDD Rules", protected: true },
       { to: "/plot", icon: "📈", label: "Trend plot", protected: true },
+      { to: "/reports", icon: "📄", label: "Report builder", protected: true },
     ],
   },
   {

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -35,6 +35,7 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
     items: [
       { to: "/bacnet", icon: "📡", label: "BACnet", protected: true },
       { to: "/modbus", icon: "🔌", label: "Modbus", protected: true },
+      { to: "/haystack", icon: "🌿", label: "Haystack", protected: true },
       { to: "/json-api", icon: "🌐", label: "JSON API", protected: true },
       { to: "/data-management", icon: "🗄️", label: "Data management", protected: true },
     ],

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -113,7 +113,7 @@ export default function AppLayout() {
             </span>
           ) : null}
         </div>
-        <p className="sidebar-hint">Haystack-first operator console</p>
+        <p className="sidebar-hint">Building summary is public; sign in to browse all tabs (operator read-only).</p>
         <StackStatusStrip />
         <nav className="sidebar-nav">
           {NAV_SECTIONS.map((section) => (
@@ -140,11 +140,6 @@ export default function AppLayout() {
                   >
                     <span className="nav-icon">{item.icon}</span>
                     {item.label}
-                    {item.protected && authRequired && !signedIn ? (
-                      <span className="nav-lock" title="Sign in required">
-                        🔒
-                      </span>
-                    ) : null}
                   </NavLink>
                 ),
               )}

--- a/workspace/dashboard/src/components/RequireAuth.tsx
+++ b/workspace/dashboard/src/components/RequireAuth.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, Outlet } from "react-router-dom";
 import { fetchAuthStatus, hasToken, setToken } from "../lib/api";
 
-/** Gate integrator/agent pages. Check-engine home + fault catalog stay public. */
+/** Gate commissioning tabs. Home building summary stays public; operator is read-only after sign-in. */
 export default function RequireAuth() {
   const [authRequired, setAuthRequired] = useState<boolean | null>(null);
 

--- a/workspace/dashboard/src/lib/api.ts
+++ b/workspace/dashboard/src/lib/api.ts
@@ -56,6 +56,42 @@ function authHeaders(): HeadersInit {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+function parseErrorBody(text: string, status: number): Error {
+  try {
+    const body = JSON.parse(text) as {
+      error?: string;
+      message?: string;
+      detail?: string | { error?: string; detail?: string; message?: string };
+    };
+    if (typeof body.error === "string") {
+      if (body.error === "invalid credentials") {
+        return new Error("Invalid username or password.");
+      }
+      return new Error(body.error);
+    }
+    if (typeof body.message === "string") {
+      return new Error(body.message);
+    }
+    if (typeof body.detail === "string") {
+      return new Error(body.detail);
+    }
+    if (body.detail && typeof body.detail === "object") {
+      const nested = body.detail;
+      if (typeof nested.error === "string") return new Error(nested.error);
+      if (typeof nested.detail === "string") return new Error(nested.detail);
+      if (typeof nested.message === "string") return new Error(nested.message);
+      return new Error(JSON.stringify(nested));
+    }
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      // not JSON — fall through
+    } else if (e instanceof Error) {
+      return e;
+    }
+  }
+  return new Error(text || `HTTP ${status}`);
+}
+
 export async function apiFetch<T>(
   path: string,
   init?: RequestInit,
@@ -80,26 +116,7 @@ export async function apiFetch<T>(
   }
   if (!res.ok) {
     const text = await res.text();
-    try {
-      const body = JSON.parse(text) as { detail?: string | { error?: string; detail?: string; message?: string } };
-      if (typeof body.detail === "string") {
-        throw new Error(body.detail);
-      }
-      if (body.detail && typeof body.detail === "object") {
-        const nested = body.detail;
-        if (typeof nested.error === "string") throw new Error(nested.error);
-        if (typeof nested.detail === "string") throw new Error(nested.detail);
-        if (typeof nested.message === "string") throw new Error(nested.message);
-        throw new Error(JSON.stringify(nested));
-      }
-    } catch (e) {
-      if (e instanceof SyntaxError) {
-        // not JSON — fall through to plain-text error
-      } else if (e instanceof Error) {
-        throw e;
-      }
-    }
-    throw new Error(text || `HTTP ${res.status}`);
+    throw parseErrorBody(text, res.status);
   }
   return res.json() as Promise<T>;
 }

--- a/workspace/dashboard/src/pages/HaystackPage.tsx
+++ b/workspace/dashboard/src/pages/HaystackPage.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+import HaystackPointsTree, { type HaystackDevice, type HaystackPoint } from "../components/HaystackPointsTree";
+import PageHeader from "../components/PageHeader";
+import Spinner from "../components/Spinner";
+import ActionButton from "../components/ActionButton";
+
+type HaystackStatus = {
+  ok?: boolean;
+  driver?: string;
+  status?: string;
+  mode?: string;
+  supported_ops?: string[];
+};
+
+export default function HaystackPage() {
+  const [baseUrl, setBaseUrl] = useState("http://127.0.0.1:8080/api/haystack");
+  const [verifyTls, setVerifyTls] = useState(true);
+  const [enabled, setEnabled] = useState(true);
+  const [status, setStatus] = useState<HaystackStatus | null>(null);
+  const [about, setAbout] = useState<Record<string, unknown> | null>(null);
+  const [devices, setDevices] = useState<HaystackDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [log, setLog] = useState("");
+  const [error, setError] = useState("");
+
+  const appendLog = (line: string) => setLog((prev) => `${new Date().toISOString()} ${line}\n${prev}`.slice(0, 8000));
+
+  const loadStatus = useCallback(async () => {
+    const st = await apiFetch<HaystackStatus>("/api/haystack/status");
+    setStatus(st);
+    const ab = await apiFetch<Record<string, unknown>>("/api/haystack/about");
+    setAbout(ab);
+  }, []);
+
+  const loadModelTree = useCallback(async () => {
+    const grid = await apiFetch<{ rows?: Array<Record<string, unknown>> }>("/api/model/haystack");
+    const rows = grid.rows ?? [];
+    const points: HaystackPoint[] = rows
+      .filter((r) => r.point === "M")
+      .map((r) => ({
+        point_id: String(r.id ?? ""),
+        label: String(r.dis ?? r.id ?? ""),
+        haystack_id: String(r.id ?? ""),
+        tags: {},
+        kind: r.kind,
+        unit: r.unit,
+        curVal: r.curVal,
+        present_value: r.curVal != null ? String(r.curVal) : "—",
+        enabled: false,
+        poll_interval_s: 0,
+        poll_label: "Off",
+      }));
+    setDevices([
+      {
+        device_key: "haystack-model",
+        host: baseUrl,
+        site_id: "site:validation",
+        point_count: points.length,
+        poll_count: 0,
+        points,
+      },
+    ]);
+  }, [baseUrl]);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([loadStatus(), loadModelTree()])
+      .catch((e) => setError(formatApiError(e)))
+      .finally(() => setLoading(false));
+  }, [loadStatus, loadModelTree]);
+
+  async function testConnection() {
+    setPending(true);
+    setError("");
+    try {
+      await loadStatus();
+      appendLog(`Connection OK — mode=${status?.mode ?? "unknown"}`);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function importFromSmokeProfile() {
+    setPending(true);
+    setError("");
+    try {
+      const res = await apiFetch<{ ok?: boolean; imported?: number; path?: string }>(
+        "/api/model/haystack/from-smoke-profile",
+        { method: "POST", body: "{}" },
+      );
+      appendLog(`Imported smoke profile → ${res.imported ?? 0} rows (${res.path ?? "model"})`);
+      await loadModelTree();
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function readSelected() {
+    setPending(true);
+    try {
+      await apiFetch("/api/haystack/read", { method: "POST", body: "{}" });
+      appendLog("Haystack read completed");
+      await loadModelTree();
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="page page-wide driver-page">
+      <PageHeader
+        title="Haystack"
+        subtitle="Haystack server workflow — replaces the old Niagara station tab. Browse nav, read points, import model entities."
+      />
+
+      {error ? <p className="error">{error}</p> : null}
+
+      <div className="panel driver-connection-panel">
+        <h3>Haystack server</h3>
+        <div className="form-grid">
+          <label>
+            Server URL
+            <input value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} placeholder="https://host/api/haystack" />
+          </label>
+          <label className="checkbox-inline">
+            <input type="checkbox" checked={verifyTls} onChange={(e) => setVerifyTls(e.target.checked)} />
+            Verify TLS (uncheck for self-signed lab certs)
+          </label>
+          <label className="checkbox-inline">
+            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+            Enabled
+          </label>
+        </div>
+        <div className="btn-row">
+          <ActionButton pending={pending} onClick={() => void testConnection()}>
+            Test connection
+          </ActionButton>
+          <ActionButton pending={pending} onClick={() => void importFromSmokeProfile()}>
+            Import validation smoke profile
+          </ActionButton>
+          <ActionButton pending={pending} onClick={() => void readSelected()}>
+            Read / refresh
+          </ActionButton>
+        </div>
+        {status ? (
+          <p className="muted">
+            Driver: {status.driver ?? "haystack"} · {status.mode ?? status.status ?? "unknown"} · ops:{" "}
+            {(status.supported_ops ?? []).join(", ") || "about, ops, read, nav"}
+          </p>
+        ) : null}
+        {about ? (
+          <p className="muted">
+            About: {String(about.serverName ?? "open-fdd")} · Haystack {String(about.haystackVersion ?? "3.0")}
+          </p>
+        ) : null}
+        <p className="muted">Schedules: not supported on fixture gateway — omit unless your Haystack server exposes them.</p>
+      </div>
+
+      <div className="panel">
+        <h3>Sites, equipment &amp; points</h3>
+        {loading ? <Spinner label="Loading Haystack model tree…" /> : null}
+        <HaystackPointsTree devices={devices} onCopy={(text) => appendLog(`Copied ${text}`)} />
+      </div>
+
+      <div className="panel driver-console">
+        <h3>Activity console</h3>
+        <pre className="driver-log">{log || "No activity yet."}</pre>
+      </div>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -70,6 +70,11 @@ export default function LoginPage() {
           />
         </div>
         {error ? <p className="error">{error}</p> : null}
+        <p className="muted login-hint">
+          Passwords live in <code>workspace/auth.env.local</code> (bcrypt only). If sign-in fails after a rotate,
+          restart the bridge and use the password printed by{" "}
+          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets</code>.
+        </p>
         <button type="submit">Sign in</button>
       </form>
     </div>

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -71,9 +71,10 @@ export default function LoginPage() {
         </div>
         {error ? <p className="error">{error}</p> : null}
         <p className="muted login-hint">
-          Passwords live in <code>workspace/auth.env.local</code> (bcrypt only). If sign-in fails after a rotate,
-          restart the bridge and use the password printed by{" "}
-          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets</code>.
+          Use the <strong>plaintext password</strong> from bootstrap output — not the bcrypt hash lines in{" "}
+          <code>auth.env.local</code>. After rotate, run{" "}
+          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart</code> or check{" "}
+          <code>workspace/bootstrap_credentials.once.txt</code> (delete after saving).
         </p>
         <button type="submit">Sign in</button>
       </form>

--- a/workspace/dashboard/src/pages/ReportBuilderPage.tsx
+++ b/workspace/dashboard/src/pages/ReportBuilderPage.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import PageHeader from "../components/PageHeader";
+import { apiDownloadBlob, apiFetch } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+
+type ReportSection = {
+  id: string;
+  type: string;
+  title: string;
+  visible?: boolean;
+  order?: number;
+  content?: Record<string, unknown>;
+};
+
+type ReportDoc = {
+  ok?: boolean;
+  report_id?: string;
+  title?: string;
+  template_id?: string;
+  sections?: ReportSection[];
+  metadata?: Record<string, unknown>;
+};
+
+function ReportSectionCard({
+  section,
+  onMoveUp,
+  onMoveDown,
+  onToggle,
+  onTitle,
+}: {
+  section: ReportSection;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onToggle: () => void;
+  onTitle: (title: string) => void;
+}) {
+  return (
+    <div className={`report-section-card${section.visible === false ? " muted" : ""}`}>
+      <div className="report-section-toolbar">
+        <span className="report-section-type">{section.type}</span>
+        <button type="button" className="secondary-btn" onClick={onMoveUp} aria-label="Move up">
+          ↑
+        </button>
+        <button type="button" className="secondary-btn" onClick={onMoveDown} aria-label="Move down">
+          ↓
+        </button>
+        <label className="report-section-visible">
+          <input type="checkbox" checked={section.visible !== false} onChange={onToggle} />
+          Show
+        </label>
+      </div>
+      <input
+        className="report-section-title"
+        value={section.title}
+        onChange={(e) => onTitle(e.target.value)}
+      />
+      {section.type === "rule_explanation" && section.content ? (
+        <div className="report-rule-block">
+          <p>{String(section.content.explanation ?? "")}</p>
+          <pre>{String(section.content.sql ?? "")}</pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function ReportBuilderPage() {
+  const [report, setReport] = useState<ReportDoc | null>(null);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const sections = useMemo(
+    () => [...(report?.sections ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    [report?.sections],
+  );
+
+  const createDraft = useCallback(async () => {
+    setBusy(true);
+    setError("");
+    try {
+      const draft = await apiFetch<ReportDoc>("/api/reports/draft", {
+        method: "POST",
+        body: JSON.stringify({
+          template_id: "validation-summary",
+          title: "Open-FDD Validation Report",
+        }),
+      });
+      setReport(draft);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void createDraft();
+  }, [createDraft]);
+
+  async function persistSections(next: ReportSection[]) {
+    if (!report?.report_id) return;
+    setBusy(true);
+    setError("");
+    try {
+      const res = await apiFetch<{ ok?: boolean; report?: ReportDoc }>(
+        `/api/reports/${report.report_id}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ sections: next }),
+        },
+      );
+      setReport(res.report ?? report);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function updateSection(idx: number, patch: Partial<ReportSection>) {
+    const next = sections.map((s, i) => (i === idx ? { ...s, ...patch } : s));
+    void persistSections(next);
+  }
+
+  function moveSection(idx: number, dir: -1 | 1) {
+    const j = idx + dir;
+    if (j < 0 || j >= sections.length) return;
+    const next = [...sections];
+    [next[idx], next[j]] = [next[j], next[idx]];
+    next.forEach((s, i) => {
+      s.order = i;
+    });
+    void persistSections(next);
+  }
+
+  async function renderPreview() {
+    if (!report?.report_id) return;
+    setBusy(true);
+    setError("");
+    try {
+      await apiFetch(`/api/reports/${report.report_id}/render/pdf`, { method: "POST" });
+      const { blob } = await apiDownloadBlob(`/api/reports/${report.report_id}/download.pdf`);
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(URL.createObjectURL(blob));
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function downloadPdf() {
+    if (!report?.report_id) return;
+    setBusy(true);
+    setError("");
+    try {
+      await apiFetch(`/api/reports/${report.report_id}/render/pdf`, { method: "POST" });
+      const { blob, filename } = await apiDownloadBlob(`/api/reports/${report.report_id}/download.pdf`);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename || `${report.report_id}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="report-builder-page">
+      <PageHeader
+        title="Report Builder"
+        subtitle="Model-driven auto-report from Haystack model, historian, FDD rules, and faults. Reorder sections, edit titles, preview and download PDF."
+      />
+
+      {error ? <div className="error-banner">{error}</div> : null}
+
+      <div className="toolbar">
+        <button type="button" className="secondary-btn" onClick={() => void createDraft()} disabled={busy}>
+          Regenerate draft
+        </button>
+        <button type="button" className="secondary-btn" onClick={() => void renderPreview()} disabled={busy || !report?.report_id}>
+          Preview PDF
+        </button>
+        <button type="button" className="primary-btn" onClick={() => void downloadPdf()} disabled={busy || !report?.report_id}>
+          Download PDF
+        </button>
+      </div>
+
+      <div className="report-builder-grid">
+        <section className="report-canvas">
+          <h2>Suggested sections</h2>
+          <p className="hint">Auto-selected from model coverage, rules, faults, and historian. Hide or reorder as needed.</p>
+          {sections.map((sec, idx) => (
+            <ReportSectionCard
+              key={sec.id}
+              section={sec}
+              onMoveUp={() => moveSection(idx, -1)}
+              onMoveDown={() => moveSection(idx, 1)}
+              onToggle={() => updateSection(idx, { visible: sec.visible === false })}
+              onTitle={(title) => updateSection(idx, { title })}
+            />
+          ))}
+        </section>
+
+        <section className="report-preview-frame">
+          <h2>Preview</h2>
+          {previewUrl ? (
+            <iframe title="Report preview" src={previewUrl} className="report-preview-iframe" />
+          ) : (
+            <p className="hint">Click Preview PDF to render the report bundle.</p>
+          )}
+        </section>
+      </div>
+
+      {report?.report_id ? (
+        <p className="hint">
+          Report ID: <code>{report.report_id}</code> · {sections.filter((s) => s.visible !== false).length} visible sections
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -3131,3 +3131,60 @@ button.linkish {
     grid-template-columns: 1fr;
   }
 }
+
+.report-builder-page .report-builder-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.report-builder-page .report-section-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  background: var(--panel);
+}
+
+.report-builder-page .report-section-card.muted {
+  opacity: 0.55;
+}
+
+.report-builder-page .report-section-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.report-builder-page .report-section-type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  flex: 1;
+}
+
+.report-builder-page .report-section-title {
+  width: 100%;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  background: transparent;
+  color: inherit;
+  margin-bottom: 0.5rem;
+}
+
+.report-builder-page .report-preview-iframe {
+  width: 100%;
+  min-height: 480px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fff;
+}
+
+@media (max-width: 900px) {
+  .report-builder-page .report-builder-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Rust-era model-driven Report Builder API (`/api/reports/*`) with draft generation from Haystack model, historian, FDD rules, and faults; section reorder/patch; Rust text PDF render + authenticated download.
- Adds React `/reports` Report Builder page (auto-draft, reorder/hide sections, preview + PDF download).
- Enhances `smoke_live_fdd_validation.sh` with CSV append/import/export/purge via API (`openfdd_csv_append_validation.sh`), auth-lib password resolution, validation PDF report artifact, and `openfdd_ui_smoke.sh` tab/API checks.
- Adds integration tests for report draft, reorder, PDF auth, and download size.

## Test plan
- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] `npm ci && npm run build`
- [ ] `bash -n scripts/smoke_live_fdd_validation.sh`
- [ ] `bash -n scripts/openfdd_csv_append_validation.sh`
- [ ] `bash -n scripts/openfdd_ui_smoke.sh`
- [ ] Short dry-run: `OPENFDD_SMOKE_DURATION_HOURS=0.05 OPENFDD_SMOKE_INTERVAL_SECONDS=30 OPENFDD_SMOKE_SIMULATE=1 OPENFDD_SMOKE_SAMPLES=3 ./scripts/smoke_live_fdd_validation.sh`
- [ ] One-hour validation with CSV append (after #379 merges)

## Notes
- Stacks on #379 (`fix/rust-ui-auth-haystack-5007-validation`) for auth/Haystack/5007 work.
- PDF uses Rust text layout (HTML preview also generated); Playwright hook can follow for pixel-perfect charts.
- Closes partial scope of #374 (report/export UX); full `/exports` page remains follow-up.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Haystack page with connection status, smoke-profile import, and point refresh.
  * Introduced a report builder experience (drafting, section editing, HTML/PDF preview and download) plus new report API routes.
  * Added persistence for the Haystack grid model to support consistent model loading.
* **Bug Fixes**
  * Broadened role-based permissions so additional signed-in roles can activate/approve mutation-capable features.
* **Documentation**
  * Updated security documentation with clearer role access levels and noted public building status behavior.
  * Improved login guidance to reference the one-time plaintext credential handoff output.
* **Tests**
  * Added integration coverage for authenticated and anonymous report-download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->