### PR TITLE
UI inspection build: Docker, auth, dashboard tabs (no long validation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@
 # then recreate containers so docker compose reloads env_file.
 OPENFDD_WORKSPACE=/app/workspace
 
+# Set to 1 only when you intentionally compile Rust on this host (needs 12GB+ free disk).
+OPENFDD_ALLOW_LOCAL_BUILD=0
+OPENFDD_CARGO_BUILD_JOBS=1
+OPENFDD_RUST_GHCR_IMAGE=ghcr.io/bbartling/openfdd-edge-rust:latest
+
 # BACnet mode:
 # - simulated: safe CI/dev mode, no OT network required
 # - live: use host OT NIC and live BACnet adapter path

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ workspace/data/
 workspace/logs/
 workspace/smoke-profiles/local/*.local.toml
 workspace/bootstrap_credentials.once.txt
+workspace/bench.env.local
 workspace/import-profiles/local/*.local.toml
 workspace/export-profiles/local/*.local.toml
 workspace/imports/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ workspace/backups/
 workspace/data/
 workspace/logs/
 workspace/smoke-profiles/local/*.local.toml
+workspace/bootstrap_credentials.once.txt
 workspace/import-profiles/local/*.local.toml
 workspace/export-profiles/local/*.local.toml
 workspace/imports/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -477,6 +477,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bcrypt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1866ecef4f2d06a0bb77880015fdf2b89e25a1c2e5addacb87e459c86dc67e"
+dependencies = [
+ "base64",
+ "blowfish",
+ "getrandom 0.2.17",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +531,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -629,6 +652,16 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1209,6 +1242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,7 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1642,6 +1681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,7 +1905,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1892,6 +1940,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1987,6 +2041,7 @@ dependencies = [
  "bacnet-transport",
  "bacnet-types",
  "base64",
+ "bcrypt",
  "chrono",
  "clap",
  "csv",
@@ -1994,6 +2049,7 @@ dependencies = [
  "hex",
  "hmac",
  "rand",
+ "rcgen",
  "serde",
  "serde_json",
  "sha2",
@@ -2076,6 +2132,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2195,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2200,6 +2272,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2323,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,7 +2355,16 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -2416,7 +2524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2518,7 +2626,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2553,6 +2661,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,7 +2710,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2680,6 +2807,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2808,7 +2941,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2868,6 +3001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -2965,6 +3107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3178,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,16 @@ Full detail: [architecture/overview.md](architecture/overview.md).
 | Backup, update, restore | [quick-start/rust-site-lifecycle.md](quick-start/rust-site-lifecycle.md) |
 | Raspberry Pi / ARM64 | [quick-start/raspberry-pi-rust-edge.md](quick-start/raspberry-pi-rust-edge.md) |
 
+## Local development
+
+| Topic | Document |
+| --- | --- |
+| **Build recipes** (local up, Caddy TLS, auth) | [deployment/local-dev.md](deployment/local-dev.md) |
+| UI inspection (no long validation) | [deployment/local_ui_inspection.md](deployment/local_ui_inspection.md) |
+| GHCR vs local Dockerfile | [deployment/local_ui_build.md](deployment/local_ui_build.md) |
+| Caddy LAN ingress | [deployment/caddy.md](deployment/caddy.md) |
+| Windows Docker Desktop | [deployment/windows_docker_desktop.md](deployment/windows_docker_desktop.md) |
+
 ## Operations
 
 | Topic | Document |

--- a/docs/deployment/caddy.md
+++ b/docs/deployment/caddy.md
@@ -2,7 +2,42 @@
 
 Caddy is the recommended LAN ingress for Open-FDD Rust edge deployments.
 
-## Compose profiles
+## Local dev — `openfdd_local_caddy_up.sh` (recommended on bench)
+
+Uses `docker-compose.local.yml` + `docker-compose.local.caddy.yml` and the **local** image (`open-fdd-openfdd-bridge:local`).
+
+**Prerequisite:** build the local image first:
+
+```bash
+./scripts/openfdd_local_up.sh --build
+```
+
+**Remote TLS dial-in** (production-like; self-signed cert):
+
+```bash
+./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip 192.168.204.55
+```
+
+Regenerate cert if the LAN IP changed:
+
+```bash
+./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip 192.168.204.55 --regen-certs
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--mode tls` | HTTPS on :443, redirect :80 → HTTPS (default) |
+| `--mode http` | HTTP only on :80 |
+| `--lan-ip ADDR` | Include IP in cert SANs (auto-detected if omitted) |
+| `--regen-certs` | Force new `workspace/deploy/caddy/certs/cert.pem` |
+
+Open from another machine: **https://\<LAN-IP\>/** — accept self-signed warning.
+
+Login: use plaintext from `workspace/bootstrap_credentials.once.txt` (not bcrypt hashes in `auth.env.local`).
+
+Full dev recipes: [local-dev.md](./local-dev.md).
+
+## Compose profiles (GHCR / production compose)
 
 From repo root:
 
@@ -47,4 +82,16 @@ Caddyfiles live under `docker/caddy/Caddyfile.http` and `docker/caddy/Caddyfile.
 
 ## Direct dev mode
 
-For local development without Caddy, run the bridge on `127.0.0.1:8080` with `OPENFDD_CADDY_MODE=off`. Auth remains enabled by default.
+For local development without Caddy, run the bridge on `127.0.0.1:8080`:
+
+```bash
+./scripts/openfdd_local_up.sh
+```
+
+With Caddy for remote access:
+
+```bash
+./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip <YOUR_LAN_IP>
+```
+
+Auth remains enabled by default. See [local-dev.md](./local-dev.md).

--- a/docs/deployment/local-dev.md
+++ b/docs/deployment/local-dev.md
@@ -14,11 +14,54 @@ Use the **local overlay** instead (`Dockerfile.local` + `docker-compose.local.ym
 | **Restart after code/UI change** | `cd workspace/dashboard && npm run build` then `./scripts/openfdd_local_up.sh` | http://127.0.0.1:8080 |
 | **UI inspection (auth + tab smoke)** | `./scripts/openfdd_inspection_build.sh --build --smoke` | http://127.0.0.1:8080 |
 | **JSON/CSV-only (no BACnet/Modbus)** | `./scripts/openfdd_inspection_build.sh --desktop --smoke` | http://127.0.0.1:8080 |
-| **Remote LAN dial-in (Caddy TLS)** | `./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip <YOUR_IP>` | https://\<LAN-IP\>/ |
-| **Regenerate TLS cert for new IP** | add `--regen-certs` to the Caddy command above | https://\<LAN-IP\>/ |
+| **Remote LAN dial-in (Caddy TLS)** | `./scripts/openfdd_remote_up.sh` | https://\<LAN-IP\>/ |
+| **Health check (API + auth)** | `./scripts/openfdd_health_check.sh --remote --auth` | — |
+| **Pull GHCR image (no bench compile)** | `./scripts/openfdd_bench_pull_ghcr.sh` | — |
+| **One-time bench hardening** | `./scripts/openfdd_bench_setup.sh` | cron + buildx + bench.env |
+| **Extend root disk (once, sudo)** | `sudo ./scripts/openfdd_bench_extend_disk.sh` | ~233G total |
+| **Regenerate TLS cert for new IP** | add `--regen-certs` to Caddy command | https://\<LAN-IP\>/ |
 | **GHCR compose (when publish is green)** | see [local_ui_build.md](./local_ui_build.md) | http://127.0.0.1:8080 |
 
 Logs for local bridge starts: `workspace/logs/local-up.log`
+
+## Bench long-term (bensbench / 8 GB / small root)
+
+Rust edge **images are built in GitHub Actions** (`.github/workflows/rust-ghcr.yml` → `ghcr.io/bbartling/openfdd-edge-rust`). The bench should **pull**, not compile, unless you explicitly opt in.
+
+One-time setup:
+
+```bash
+./scripts/openfdd_bench_setup.sh              # buildx hint, weekly cron, workspace/bench.env.local
+sudo ./scripts/openfdd_bench_extend_disk.sh   # grow / from ~100G to full ~233G disk (once)
+```
+
+Daily / remote:
+
+```bash
+./scripts/openfdd_remote_up.sh                # cleanup + GHCR pull + Caddy + health (no --build)
+./scripts/openfdd_health_check.sh --remote --auth
+```
+
+**React UI local dev** (hot reload — no Docker Rust compile):
+
+```bash
+./scripts/openfdd_ui_dev.sh                   # Vite http://127.0.0.1:5173 → API on :8080
+./scripts/openfdd_ui_dev.sh --lan             # Vite on all interfaces for remote browser
+./scripts/openfdd_ui_dev.sh --build-only      # sync frontend/ only (Caddy :443 path)
+```
+
+| Policy | Default |
+|--------|---------|
+| Local Docker `--build` | **Off** (`OPENFDD_ALLOW_LOCAL_BUILD=0` in `workspace/bench.env.local`) |
+| `CARGO_BUILD_JOBS` | `1` |
+| Weekly Docker cleanup | Cron Sun 03:00 → `openfdd_docker_maintenance.sh --aggressive` |
+| GHCR publish | GitHub Actions on `master` / tags — **not on the bench** |
+
+Rare local rebuild (12GB+ free disk required):
+
+```bash
+OPENFDD_ALLOW_LOCAL_BUILD=1 ./scripts/openfdd_local_up.sh --build
+```
 
 ## Auth and login
 
@@ -158,8 +201,9 @@ docker compose -f docker-compose.local.yml down   # never use down -v
 
 | Symptom | Fix |
 |---------|-----|
+| Caddy script: missing image | `./scripts/openfdd_bench_pull_ghcr.sh` or `./scripts/openfdd_remote_up.sh` |
+| Disk full / crash during build | `./scripts/openfdd_docker_maintenance.sh --aggressive`; extend disk with `sudo ./scripts/openfdd_bench_extend_disk.sh` |
 | Login “invalid credentials” | Use bootstrap plaintext, not bcrypt hash |
-| Caddy script: missing image | Run `./scripts/openfdd_local_up.sh --build` first |
 | Remote TLS cert warning | Expected (self-signed); use `--regen-certs` if wrong IP |
 | Remote timeout | `sudo ufw allow 443/tcp`; check routing to LAN IP |
 | Build OOM | `OPENFDD_CARGO_BUILD_JOBS=1`, add swap, use buildx memory cap |
@@ -172,7 +216,7 @@ sudo apt install docker-buildx-plugin   # Debian/Ubuntu
 
 ## GHCR compose
 
-Production edge compose pulls `ghcr.io/bbartling/openfdd-edge-rust` — use `./scripts/openfdd_local_up.sh` until a GHCR tag is published, or build and tag locally. See [local_ui_build.md](./local_ui_build.md).
+Production edge compose pulls `ghcr.io/bbartling/openfdd-edge-rust`. **GitHub Actions** builds and pushes multi-arch images (`rust-ghcr.yml`); the bench pulls `:latest` via `./scripts/openfdd_bench_pull_ghcr.sh`. See [local_ui_build.md](./local_ui_build.md).
 
 ## See also
 

--- a/docs/deployment/local-dev.md
+++ b/docs/deployment/local-dev.md
@@ -12,7 +12,7 @@ Use the **local overlay** instead (`Dockerfile.local` + `docker-compose.local.ym
 |------|---------|-----|
 | **First local image + dashboard** | `./scripts/openfdd_local_up.sh --build` | http://127.0.0.1:8080 |
 | **Restart after code/UI change** | `cd workspace/dashboard && npm run build` then `./scripts/openfdd_local_up.sh` | http://127.0.0.1:8080 |
-| **UI inspection (auth + tab smoke)** | `./scripts/openfdd_inspection_build.sh --build --smoke` | http://127.0.0.1:8080 |
+| **UI inspection (auth + tab smoke)** | `OPENFDD_ALLOW_LOCAL_BUILD=1 ./scripts/openfdd_inspection_build.sh --build --smoke` | http://127.0.0.1:8080 |
 | **JSON/CSV-only (no BACnet/Modbus)** | `./scripts/openfdd_inspection_build.sh --desktop --smoke` | http://127.0.0.1:8080 |
 | **Remote LAN dial-in (Caddy TLS)** | `./scripts/openfdd_remote_up.sh` | https://\<LAN-IP\>/ |
 | **Health check (API + auth)** | `./scripts/openfdd_health_check.sh --remote --auth` | — |

--- a/docs/deployment/local-dev.md
+++ b/docs/deployment/local-dev.md
@@ -4,9 +4,50 @@
 
 The root `Dockerfile` runs **npm build + release Rust (DataFusion/Arrow)** inside Docker. On an 8 GB host that can exhaust RAM, trigger the Linux OOM killer, and drop SSH — requiring a hard reboot.
 
-Use the **local overlay** instead.
+Use the **local overlay** instead (`Dockerfile.local` + `docker-compose.local.yml`).
 
-## Quick start (recommended)
+## Build recipes (pick one)
+
+| Goal | Command | URL |
+|------|---------|-----|
+| **First local image + dashboard** | `./scripts/openfdd_local_up.sh --build` | http://127.0.0.1:8080 |
+| **Restart after code/UI change** | `cd workspace/dashboard && npm run build` then `./scripts/openfdd_local_up.sh` | http://127.0.0.1:8080 |
+| **UI inspection (auth + tab smoke)** | `./scripts/openfdd_inspection_build.sh --build --smoke` | http://127.0.0.1:8080 |
+| **JSON/CSV-only (no BACnet/Modbus)** | `./scripts/openfdd_inspection_build.sh --desktop --smoke` | http://127.0.0.1:8080 |
+| **Remote LAN dial-in (Caddy TLS)** | `./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip <YOUR_IP>` | https://\<LAN-IP\>/ |
+| **Regenerate TLS cert for new IP** | add `--regen-certs` to the Caddy command above | https://\<LAN-IP\>/ |
+| **GHCR compose (when publish is green)** | see [local_ui_build.md](./local_ui_build.md) | http://127.0.0.1:8080 |
+
+Logs for local bridge starts: `workspace/logs/local-up.log`
+
+## Auth and login
+
+`workspace/auth.env.local` stores **bcrypt hashes only** — do not paste `OFDD_*_PASSWORD_HASH=` values into the login form.
+
+| File | Purpose |
+|------|---------|
+| `workspace/auth.env.local` | Hashes + JWT secret (gitignored) |
+| `workspace/bootstrap_credentials.once.txt` | **Plaintext passwords** (one-time handoff, gitignored) |
+
+Generate or rotate:
+
+```bash
+./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart
+```
+
+Save printed passwords or `bootstrap_credentials.once.txt`, then delete the handoff file when done.
+
+Verify login (no secrets printed):
+
+```bash
+OPENFDD_BRIDGE_BASE=http://127.0.0.1:8080 ./scripts/openfdd_auth_smoke.sh
+# Caddy TLS:
+OPENFDD_BRIDGE_BASE=https://127.0.0.1 ./scripts/openfdd_auth_smoke.sh   # health via curl -k if needed
+```
+
+Default users: `operator` (read-only), `integrator`, `agent`.
+
+## Quick start (localhost only)
 
 ```bash
 cd ~/open-fdd
@@ -18,22 +59,72 @@ cd ~/open-fdd
 ./scripts/openfdd_local_up.sh
 ```
 
-Open **http://127.0.0.1:8080** and log in with `workspace/auth.env.local` credentials.
+Open **http://127.0.0.1:8080** and sign in with plaintext from bootstrap (see above).
+
+## Remote dial-in (production-like Caddy + TLS)
+
+After the local image exists (`openfdd_local_up.sh --build`):
+
+```bash
+# Example: bench at 192.168.204.55
+./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip 192.168.204.55
+
+# If cert was generated without this IP before:
+./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip 192.168.204.55 --regen-certs
+```
+
+What you get:
+
+- Caddy on **0.0.0.0:80** and **:443** (all interfaces)
+- Bridge internal only (`127.0.0.1:8080` on host; Caddy reverse-proxies to `openfdd-bridge:8080`)
+- Self-signed TLS with LAN IP in cert SANs
+- Same JWT users as local/prod
+
+From another machine: **https://192.168.204.55/** (accept browser cert warning).
+
+Optional client hosts entry: `192.168.204.55 openfdd.local` → **https://openfdd.local/**
+
+HTTP-only lab mode:
+
+```bash
+./scripts/openfdd_local_caddy_up.sh --mode http --lan-ip 192.168.204.55
+```
+
+Firewall on the server:
+
+```bash
+sudo ufw allow 443/tcp
+sudo ufw allow 80/tcp   # optional; redirects to HTTPS in TLS mode
+```
+
+Health check:
+
+```bash
+curl -kfsS https://127.0.0.1/api/health
+curl -kfsS https://192.168.204.55/api/health
+```
+
+More detail: [caddy.md](./caddy.md), [operations/production-caddy.md](../operations/production-caddy.md).
 
 ## What the local path does
 
 | Piece | Behavior |
 |-------|----------|
 | `Dockerfile.local` | Skips npm in Docker; uses repo `frontend/`; `cargo -j 1` |
-| `docker-compose.local.yml` | Bridge only, binds `127.0.0.1:8080`, desktop protocol flags |
+| `docker-compose.local.yml` | Bridge only, binds `127.0.0.1:8080`, auth read from mounted `workspace/` |
+| `docker-compose.local.caddy.yml` | Caddy profile; exposes :80/:443 |
 | `openfdd_local_up.sh` | Memory check, build `--memory=3g`, health wait, logging |
+| `openfdd_local_caddy_up.sh` | Cert generation, Caddy + bridge compose up |
+| `openfdd_inspection_build.sh` | Dashboard build, optional auth/UI smoke, no long validation |
 
 ## Environment
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `OPENFDD_CARGO_BUILD_JOBS` | `1` | Parallel rustc jobs during image build |
-| `OPENFDD_BACNET_ENABLED` | `0` | Desktop mode |
+| `OPENFDD_BACNET_ENABLED` | `1` in local compose | Set `0` for JSON/CSV-only inspection |
+| `OPENFDD_CADDY_MODE` | `tls` | `http` or `tls` for Caddy script |
+| `OPENFDD_CADDY_HOSTNAME` | `openfdd.local` | TLS site name / cert CN |
 
 ## UI changes
 
@@ -50,47 +141,42 @@ After **Rust** changes:
 ./scripts/openfdd_local_up.sh --build
 ```
 
+After **Caddy or cert** changes:
+
+```bash
+./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip <IP> --regen-certs
+```
+
 ## Troubleshooting
 
 ```bash
 tail -f workspace/logs/local-up.log
 docker compose -f docker-compose.local.yml logs -f openfdd-bridge
+docker compose -f docker-compose.local.yml -f docker-compose.local.caddy.yml --profile caddy logs -f openfdd-caddy
 docker compose -f docker-compose.local.yml down   # never use down -v
 ```
 
-If build still OOMs: add swap, set `OPENFDD_CARGO_BUILD_JOBS=1`, close browsers/IDE, or install buildx for memory-capped builds:
+| Symptom | Fix |
+|---------|-----|
+| Login “invalid credentials” | Use bootstrap plaintext, not bcrypt hash |
+| Caddy script: missing image | Run `./scripts/openfdd_local_up.sh --build` first |
+| Remote TLS cert warning | Expected (self-signed); use `--regen-certs` if wrong IP |
+| Remote timeout | `sudo ufw allow 443/tcp`; check routing to LAN IP |
+| Build OOM | `OPENFDD_CARGO_BUILD_JOBS=1`, add swap, use buildx memory cap |
+
+If build still OOMs, install buildx for memory-capped builds:
 
 ```bash
 sudo apt install docker-buildx-plugin   # Debian/Ubuntu
 ```
 
-## GHCR / Caddy
+## GHCR compose
 
-Production edge compose pulls `ghcr.io/bbartling/openfdd-edge-rust` — use `./scripts/openfdd_local_up.sh` until a GHCR tag is published or you build and tag locally.
+Production edge compose pulls `ghcr.io/bbartling/openfdd-edge-rust` — use `./scripts/openfdd_local_up.sh` until a GHCR tag is published, or build and tag locally. See [local_ui_build.md](./local_ui_build.md).
 
-## Remote dial-in (production-like Caddy + TLS)
+## See also
 
-After the local image is built:
-
-```bash
-# Wait for ./scripts/openfdd_local_up.sh --build to finish, then:
-./scripts/openfdd_local_caddy_up.sh --mode tls
-```
-
-- Caddy listens on **0.0.0.0:443** (and redirects :80 → HTTPS)
-- Bridge stays internal; **same `workspace/auth.env.local`** JWT users
-- Open from another machine: `https://<your-LAN-IP>/` (accept self-signed cert warning)
-- Optional hosts entry on client: `<LAN-IP> openfdd.local`
-
-HTTP-only lab mode:
-
-```bash
-./scripts/openfdd_local_caddy_up.sh --mode http
-```
-
-Firewall on the server if needed:
-
-```bash
-sudo ufw allow 443/tcp
-sudo ufw allow 80/tcp
-```
+- [local_ui_inspection.md](./local_ui_inspection.md) — click-through UI smoke, no long validation
+- [local_ui_build.md](./local_ui_build.md) — GHCR vs local Dockerfile
+- [windows_docker_desktop.md](./windows_docker_desktop.md) — Docker Desktop on Windows
+- [security/rust-edge-auth.md](../security/rust-edge-auth.md) — auth file format

--- a/docs/deployment/local_ui_build.md
+++ b/docs/deployment/local_ui_build.md
@@ -1,6 +1,18 @@
 # Local UI build and inspection
 
-Run the Rust edge locally, open the dashboard in a browser, and verify auth, Live FDD Validation, exports, and JSON/CSV-only mode.
+Run the Rust edge locally, open the dashboard in a browser, and verify auth and main tabs.
+
+**Canonical build recipes:** [local-dev.md](./local-dev.md) (localhost, Caddy remote TLS, auth, troubleshooting).
+
+## Build recipes (quick reference)
+
+| Goal | Command |
+|------|---------|
+| Local image (8 GB safe) | `./scripts/openfdd_local_up.sh --build` |
+| Restart bridge | `./scripts/openfdd_local_up.sh` |
+| UI inspection + smoke | `./scripts/openfdd_inspection_build.sh --build --smoke` |
+| Remote HTTPS (Caddy) | `./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip <IP>` |
+| GHCR desktop profile | see below |
 
 ## Prerequisites
 
@@ -8,7 +20,7 @@ Run the Rust edge locally, open the dashboard in a browser, and verify auth, Liv
 - Git
 - Optional: Node 20+ if you change the React dashboard (`workspace/dashboard`)
 
-Auth credentials live in `workspace/auth.env.local` (never commit). Copy from `.env.example` patterns or generate with bootstrap scripts.
+Auth: `workspace/auth.env.local` holds **bcrypt hashes** (never commit). Login passwords are in **`workspace/bootstrap_credentials.once.txt`** after `./scripts/openfdd_auth_init.sh --show-secrets`.
 
 ## Linux — GHCR image (recommended when publish is green)
 
@@ -49,7 +61,7 @@ curl -fsS http://127.0.0.1:8080/api/health
 
 ## Windows Docker Desktop
 
-See [windows_docker_desktop.md](../desktop/windows_docker_desktop.md). Quick path:
+See [windows_docker_desktop.md](./windows_docker_desktop.md). Quick path:
 
 ```powershell
 git clone https://github.com/bbartling/open-fdd.git
@@ -63,21 +75,17 @@ curl.exe -fsS http://localhost:8080/api/health
 Start-Process http://localhost:8080
 ```
 
-With local Caddy/TLS overlay (feature branch or production-like lab):
-
-```powershell
-curl.exe -k -fsS https://localhost/api/health
-Start-Process https://localhost
-```
+Remote Caddy TLS on Linux bench: use `./scripts/openfdd_local_caddy_up.sh` — see [local-dev.md](./local-dev.md).
 
 ## Login
 
-Default users: `integrator`, `operator`, `agent`. Passwords are in `workspace/auth.env.local` (plaintext CI-style values work; bcrypt hashes preferred).
+Default users: `integrator`, `operator`, `agent`.
+
+**Password:** plaintext from `workspace/bootstrap_credentials.once.txt` — **not** the `OFDD_*_PASSWORD_HASH=` lines in `auth.env.local`.
 
 ```bash
-curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
-  -H 'Content-Type: application/json' \
-  -d '{"username":"integrator","password":"<from auth.env.local>"}'
+./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart
+OPENFDD_BRIDGE_BASE=http://127.0.0.1:8080 ./scripts/openfdd_auth_smoke.sh
 ```
 
 ## Pages to inspect

--- a/docs/deployment/local_ui_inspection.md
+++ b/docs/deployment/local_ui_inspection.md
@@ -88,5 +88,17 @@ Those are a **follow-up pass** after UI inspection is satisfactory.
 
 ## See also
 
+- [local-dev.md](./local-dev.md) — all build recipes (localhost, Caddy TLS, auth)
 - [local_ui_build.md](./local_ui_build.md) — GHCR vs local Dockerfile paths
 - [windows_docker_desktop.md](./windows_docker_desktop.md) — Docker Desktop on Windows
+- [caddy.md](./caddy.md) — Caddy ingress details
+
+## Remote HTTPS (production-like bench access)
+
+After local image build:
+
+```bash
+./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip 192.168.204.55
+```
+
+Open **https://192.168.204.55/** from another machine (accept self-signed cert). Full recipe: [local-dev.md](./local-dev.md).

--- a/docs/deployment/local_ui_inspection.md
+++ b/docs/deployment/local_ui_inspection.md
@@ -1,0 +1,92 @@
+# Local UI inspection (no long validation)
+
+Use this path when you want to **click around the dashboard** — login, tabs, JSON/CSV mode — without running 1-hour or 6-hour FDD validation.
+
+## Quick start (Linux)
+
+```bash
+git clone https://github.com/bbartling/open-fdd.git
+cd open-fdd
+git checkout integration/ui-inspection-build   # or merge PR when ready
+
+chmod +x scripts/openfdd_inspection_build.sh
+./scripts/openfdd_inspection_build.sh --build --smoke
+```
+
+Open **http://127.0.0.1:8080**
+
+## Credentials
+
+| File | Purpose |
+| --- | --- |
+| `workspace/auth.env.local` | **Bcrypt hashes only** — do not paste these as login passwords |
+| `workspace/bootstrap_credentials.once.txt` | **Plaintext passwords** (one-time handoff, gitignored) |
+
+If login fails with “invalid credentials”, you are probably using a hash. Run:
+
+```bash
+./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart
+```
+
+Save the printed passwords (or `bootstrap_credentials.once.txt`), then delete the handoff file when done.
+
+Default users: `operator` (read-only), `integrator`, `agent`.
+
+## JSON/CSV-only mode (no BACnet/Modbus hardware)
+
+```bash
+./scripts/openfdd_inspection_build.sh --desktop --smoke
+```
+
+Equivalent env:
+
+```bash
+OPENFDD_BACNET_ENABLED=0
+OPENFDD_MODBUS_ENABLED=0
+OPENFDD_HAYSTACK_ENABLED=0
+OPENFDD_JSON_API_ENABLED=1
+OPENFDD_IMPORT_ENABLED=1
+OPENFDD_EXPORT_ENABLED=1
+```
+
+BACnet and Modbus tabs should show **disabled / not configured**, not red 500 errors.
+
+## Manual smoke (optional)
+
+```bash
+OPENFDD_BRIDGE_BASE=http://127.0.0.1:8080 ./scripts/openfdd_auth_smoke.sh
+OPENFDD_API_BASE=http://127.0.0.1:8080 ./scripts/openfdd_ui_smoke.sh
+```
+
+Artifacts: `workspace/logs/ui_smoke_<timestamp>/`
+
+## Pages to click
+
+| Route | Tab |
+| --- | --- |
+| `/` | Building status (public) |
+| `/login` | Sign in |
+| `/bacnet` | BACnet |
+| `/modbus` | Modbus |
+| `/haystack` | Haystack |
+| `/json-api` | JSON API |
+| `/model` | Data model |
+| `/sql-fdd` | SQL FDD rules |
+| `/plot` | Trend plot |
+| `/reports` | Report builder |
+| `/data-management` | Data management |
+
+## What this pass intentionally skips
+
+- 1-hour live FDD validation
+- 6-hour validation
+- CSV append/delete proof
+- PDF quality validation
+- Live BACnet / Modbus hardware
+
+Those are a **follow-up pass** after UI inspection is satisfactory.
+
+## See also
+
+- [local_ui_build.md](./local_ui_build.md) — GHCR vs local Dockerfile paths
+- [windows_docker_desktop.md](./windows_docker_desktop.md) — Docker Desktop on Windows

--- a/docs/deployment/windows_docker_desktop.md
+++ b/docs/deployment/windows_docker_desktop.md
@@ -67,6 +67,12 @@ Start-Process https://localhost
 | Login invalid | Rotate auth; use plaintext bootstrap file, not bcrypt hash |
 | Port 8080 in use | Change compose port mapping or stop conflicting service |
 | BACnet/Modbus red | Expected off in `desktop-json-csv` profile — use JSON API tab instead |
+| Remote HTTPS from LAN | Linux bench: `./scripts/openfdd_local_caddy_up.sh --mode tls --lan-ip <IP>` — [local-dev.md](./local-dev.md) |
+
+## See also
+
+- [local-dev.md](./local-dev.md) — build recipes including Caddy remote TLS
+- [local_ui_inspection.md](./local_ui_inspection.md)
 
 ## Intentionally not required
 

--- a/docs/deployment/windows_docker_desktop.md
+++ b/docs/deployment/windows_docker_desktop.md
@@ -1,0 +1,77 @@
+# Windows Docker Desktop — UI inspection
+
+Run Open-FDD on Windows without BACnet/Modbus hardware. JSON API, CSV import/export, and dashboard tabs are enough for UI inspection.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (WSL2 backend recommended)
+- Git
+
+## Quick start (PowerShell)
+
+```powershell
+git clone https://github.com/bbartling/open-fdd.git
+cd open-fdd
+git checkout integration/ui-inspection-build
+
+Copy-Item .env.example .env -ErrorAction SilentlyContinue
+$env:OPENFDD_COMPOSE_ROOT = (Get-Location).Path
+
+# Generate auth (first time) — save printed passwords
+docker run --rm -v "${PWD}/workspace:/app/workspace" ghcr.io/bbartling/openfdd-edge-rust:latest `
+  openfdd-edge auth init --path /app/workspace/auth.env.local --show-secrets
+
+docker compose -f docker/compose.edge.rust.yml `
+  -f docker/compose.desktop.json-csv.yml `
+  --profile desktop-json-csv up -d
+
+curl.exe -fsS http://127.0.0.1:8080/health
+Start-Process http://127.0.0.1:8080
+```
+
+## Login
+
+- Open http://127.0.0.1:8080/login
+- User: `integrator` (or `operator` / `agent`)
+- Password: from bootstrap output or `workspace/bootstrap_credentials.once.txt`
+- **Do not** use values from `OFDD_*_PASSWORD_HASH=` in `auth.env.local`
+
+## Build dashboard from source (optional)
+
+If the bundled frontend is stale:
+
+```powershell
+cd workspace/dashboard
+npm ci
+npm run build
+cd ../..
+docker compose -f docker/compose.edge.rust.yml `
+  -f docker/compose.desktop.json-csv.yml `
+  --profile desktop-json-csv up -d --force-recreate
+```
+
+## Caddy / HTTPS (optional)
+
+If using the `caddy-tls` profile from `docker/compose.edge.rust.yml`:
+
+```powershell
+curl.exe -k -fsS https://localhost/health
+Start-Process https://localhost
+```
+
+## Troubleshooting
+
+| Issue | Fix |
+| --- | --- |
+| Pull fails from GHCR | Log in to `ghcr.io` or build locally on Linux and export image |
+| Login invalid | Rotate auth; use plaintext bootstrap file, not bcrypt hash |
+| Port 8080 in use | Change compose port mapping or stop conflicting service |
+| BACnet/Modbus red | Expected off in `desktop-json-csv` profile — use JSON API tab instead |
+
+## Intentionally not required
+
+- 1-hour / 6-hour validation smoke
+- Live field hardware
+- CSV append/delete long tests
+
+See [local_ui_inspection.md](./local_ui_inspection.md).

--- a/docs/release_cleanup/current_pr_issue_ledger.md
+++ b/docs/release_cleanup/current_pr_issue_ledger.md
@@ -1,0 +1,39 @@
+# Open-FDD release cleanup ledger
+
+Generated: 2026-06-18 (cleanup pass on PR #381)
+
+## Open pull requests
+
+| PR | Branch | Base | CI | Mergeable | Decision | Blocking items |
+|----|--------|------|-----|-----------|----------|----------------|
+| [#381](https://github.com/bbartling/open-fdd/pull/381) | `integration/ui-inspection-build` | master | Green + CodeRabbit | MERGEABLE | **Continue / merge target** — this cleanup PR | Final UI smoke + ledger comment |
+| [#380](https://github.com/bbartling/open-fdd/pull/380) | `feature/report-builder-csv-append-delete-validation` | master | Rust CI fail (older) | MERGEABLE | **Close as superseded by #381** | Full CSV append/delete validation deferred |
+| [#379](https://github.com/bbartling/open-fdd/pull/379) | `fix/rust-ui-auth-haystack-5007-validation` | master | Green | MERGEABLE | **Close as superseded by #381** | Useful commits already stacked in #381 |
+
+### PR comments posted
+
+- #379: Superseded by #381 — auth/Haystack/UI parity preserved; long validation tracked separately.
+- #380: Superseded by #381 — report builder UI preserved; CSV append/delete validation is follow-up.
+
+## Open issues
+
+| Issue | Title | Decision | Cleanup PR action |
+|-------|-------|----------|-------------------|
+| [#374](https://github.com/bbartling/open-fdd/issues/374) | Generic Data Export React UI | **Partial close** if `/exports` ships; else update | Add Data Export page wired to `/api/export/meta` |
+| [#367](https://github.com/bbartling/open-fdd/issues/367) | XLSX export support | **Leave open** | Comment: CSV is supported; XLSX is future work |
+| [#369](https://github.com/bbartling/open-fdd/issues/369) | WASM sandbox for connector transforms | **Leave open** | Comment: safe connectors only; no arbitrary upload |
+
+## Fixes in this cleanup pass
+
+- Missing API routes: model equipment, modbus/json-api driver tree + poll status, host stats, favicon
+- Navigation: remove Drivers tab; move Live FDD Validation under Ops; add Data Export
+- SQL FDD: block run without equipment; hide raw JSON validation by default
+- Host stats: structured response instead of unknown endpoint
+- Auth/UI smoke scripts updated for new routes
+
+## Intentionally deferred (linked issues)
+
+- XLSX export (#367)
+- WASM custom transforms (#369)
+- Full CSV append/delete proof (supersedes #380 remainder)
+- 1-hour / 6-hour field validation (not in cleanup pass)

--- a/docs/release_cleanup/current_pr_issue_ledger.md
+++ b/docs/release_cleanup/current_pr_issue_ledger.md
@@ -1,39 +1,47 @@
 # Open-FDD release cleanup ledger
 
-Generated: 2026-06-18 (cleanup pass on PR #381)
+Updated: 2026-06-25 (CLI source of truth)
 
-## Open pull requests
+## Current PRs
 
-| PR | Branch | Base | CI | Mergeable | Decision | Blocking items |
-|----|--------|------|-----|-----------|----------|----------------|
-| [#381](https://github.com/bbartling/open-fdd/pull/381) | `integration/ui-inspection-build` | master | Green + CodeRabbit | MERGEABLE | **Continue / merge target** — this cleanup PR | Final UI smoke + ledger comment |
-| [#380](https://github.com/bbartling/open-fdd/pull/380) | `feature/report-builder-csv-append-delete-validation` | master | Rust CI fail (older) | MERGEABLE | **Close as superseded by #381** | Full CSV append/delete validation deferred |
-| [#379](https://github.com/bbartling/open-fdd/pull/379) | `fix/rust-ui-auth-haystack-5007-validation` | master | Green | MERGEABLE | **Close as superseded by #381** | Useful commits already stacked in #381 |
+| PR | Title | Branch | CI | Status | Local UI inspection? |
+|----|-------|--------|-----|--------|----------------------|
+| [#381](https://github.com/bbartling/open-fdd/pull/381) | UI inspection build: Docker, auth, dashboard tabs | `integration/ui-inspection-build` | Rust/tests green; compose smoke may still run | **Use this branch** for local UI — has inspection scripts, API route fixes, `/exports` page | **Yes — primary branch** |
+| [#382](https://github.com/bbartling/open-fdd/pull/382) | Docs cleanup for Rust-only Open-FDD | `docs/rust-readme-docs-ci-cleanup` | Mostly green | Docs/CI only — no runtime fixes | **No** — docs-only from `master`; use #381 for UI |
 
-### PR comments posted
+### Closed PRs (recent)
 
-- #379: Superseded by #381 — auth/Haystack/UI parity preserved; long validation tracked separately.
-- #380: Superseded by #381 — report builder UI preserved; CSV append/delete validation is follow-up.
+| PR | Title | Final state |
+|----|-------|-------------|
+| #379 | Rust auth / UI parity / Haystack / 5007 | Closed — superseded by #381 |
+| #380 | PDF report builder + CSV validation | Closed — superseded by #381 |
+| #378 | Auth login UX / RBAC | Closed |
+| #377 | Operator dashboard UX | Merged to master |
 
-## Open issues
+## Current issues
 
-| Issue | Title | Decision | Cleanup PR action |
-|-------|-------|----------|-------------------|
-| [#374](https://github.com/bbartling/open-fdd/issues/374) | Generic Data Export React UI | **Partial close** if `/exports` ships; else update | Add Data Export page wired to `/api/export/meta` |
-| [#367](https://github.com/bbartling/open-fdd/issues/367) | XLSX export support | **Leave open** | Comment: CSV is supported; XLSX is future work |
-| [#369](https://github.com/bbartling/open-fdd/issues/369) | WASM sandbox for connector transforms | **Leave open** | Comment: safe connectors only; no arbitrary upload |
+| Issue | Title | Action | Reason |
+|-------|-------|--------|--------|
+| [#374](https://github.com/bbartling/open-fdd/issues/374) | Generic Data Export React UI | **Keep open** | `/exports` route exists on #381 with CSV downloads; missing last-export status and rich filters — partial MVP |
+| [#367](https://github.com/bbartling/open-fdd/issues/367) | XLSX export support | **Keep open** | App is CSV-only; XLSX not implemented |
+| [#369](https://github.com/bbartling/open-fdd/issues/369) | WASM sandbox for connector transforms | **Keep open** | Deferred; safe connectors only, no arbitrary transform execution |
 
-## Fixes in this cleanup pass
+## Ben — local dev launch (use PR #381 branch)
 
-- Missing API routes: model equipment, modbus/json-api driver tree + poll status, host stats, favicon
-- Navigation: remove Drivers tab; move Live FDD Validation under Ops; add Data Export
-- SQL FDD: block run without equipment; hide raw JSON validation by default
-- Host stats: structured response instead of unknown endpoint
-- Auth/UI smoke scripts updated for new routes
+```bash
+git fetch origin
+git checkout integration/ui-inspection-build
+git pull --ff-only
 
-## Intentionally deferred (linked issues)
+OPENFDD_ALLOW_LOCAL_BUILD=1 ./scripts/openfdd_inspection_build.sh --build --smoke
+```
 
-- XLSX export (#367)
-- WASM custom transforms (#369)
-- Full CSV append/delete proof (supersedes #380 remainder)
-- 1-hour / 6-hour field validation (not in cleanup pass)
+Expected:
+
+- UI: http://127.0.0.1:8080
+- Credentials: `workspace/bootstrap_credentials.once.txt` (plaintext — not `auth.env.local` hashes)
+- Stop: `docker compose -f docker-compose.local.yml down`
+
+Hot reload (optional): `./scripts/openfdd_ui_dev.sh --lan` → http://127.0.0.1:5173
+
+Playwright browser smoke: **not implemented** — API/route smoke only via `openfdd_ui_smoke.sh`.

--- a/docs/release_cleanup/current_pr_issue_ledger.md
+++ b/docs/release_cleanup/current_pr_issue_ledger.md
@@ -23,7 +23,7 @@ Updated: 2026-06-25 (CLI source of truth)
 | Issue | Title | Action | Reason |
 |-------|-------|--------|--------|
 | [#374](https://github.com/bbartling/open-fdd/issues/374) | Generic Data Export React UI | **Keep open** | `/exports` route exists on #381 with CSV downloads; missing last-export status and rich filters — partial MVP |
-| [#367](https://github.com/bbartling/open-fdd/issues/367) | XLSX export support | **Keep open** | App is CSV-only; XLSX not implemented |
+| [#367](https://github.com/bbartling/open-fdd/issues/367) | XLSX export support | **Closed** | CSV is supported and Excel-ready via `/exports` + `/api/export/*.csv`; native XLSX not planned |
 | [#369](https://github.com/bbartling/open-fdd/issues/369) | WASM sandbox for connector transforms | **Keep open** | Deferred; safe connectors only, no arbitrary transform execution |
 
 ## Ben — local dev launch (use PR #381 branch)

--- a/docs/security/secrets-auth.md
+++ b/docs/security/secrets-auth.md
@@ -57,7 +57,18 @@ openfdd-edge auth rotate --all --show-secrets
 
 Rotation backs up the previous file to `auth.env.local.bak.<timestamp>`, preserves usernames unless you edit them manually, and rotates `OFDD_AUTH_SECRET` when using `--all` (invalidates existing JWTs).
 
-## IT-managed passwords
+**Always restart the bridge** after changing `auth.env.local` — the edge loads credentials once at startup.
+
+## Roles
+
+| Role | Access |
+|------|--------|
+| **operator** | Read-only: browse all tabs, exports, trends, faults |
+| **integrator** | Full commissioning mutations (BACnet/Modbus/JSON API, model, FDD) |
+| **agent** | Same mutation tier as integrator (automation / Codex hooks) |
+| **admin** | Same mutation tier as integrator |
+
+The home **Building status** dashboard is public without sign-in.
 
 Set hashes manually in `workspace/auth.env.local`:
 

--- a/edge/src/auth/env_file.rs
+++ b/edge/src/auth/env_file.rs
@@ -302,6 +302,35 @@ pub fn print_generated_credentials(passwords: &HashMap<String, String>, show_sec
     }
 }
 
+/// Write one-time credential handoff file next to auth.env.local (lab bootstrap only).
+pub fn write_bootstrap_credentials_once(
+    auth_path: &Path,
+    passwords: &HashMap<String, String>,
+) -> std::io::Result<Option<PathBuf>> {
+    if passwords.is_empty() {
+        return Ok(None);
+    }
+    let workspace = auth_path
+        .parent()
+        .unwrap_or_else(|| Path::new("workspace"));
+    let handoff = workspace.join("bootstrap_credentials.once.txt");
+    let mut lines = vec![
+        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager.".to_string(),
+        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords.".to_string(),
+        format!("# Generated: {}", chrono::Utc::now().to_rfc3339()),
+        String::new(),
+    ];
+    for (user, pw) in passwords {
+        lines.push(format!("{user}: {pw}"));
+    }
+    lines.push(String::new());
+    lines.push("# After saving passwords, delete this file:".to_string());
+    lines.push("#   rm workspace/bootstrap_credentials.once.txt".to_string());
+    fs::write(&handoff, lines.join("\n"))?;
+    chmod_600_unix(&handoff);
+    Ok(Some(handoff))
+}
+
 pub fn chmod_600_unix(path: &Path) {
     #[cfg(unix)]
     {

--- a/edge/src/auth/env_file.rs
+++ b/edge/src/auth/env_file.rs
@@ -310,13 +310,13 @@ pub fn write_bootstrap_credentials_once(
     if passwords.is_empty() {
         return Ok(None);
     }
-    let workspace = auth_path
-        .parent()
-        .unwrap_or_else(|| Path::new("workspace"));
+    let workspace = auth_path.parent().unwrap_or_else(|| Path::new("workspace"));
     let handoff = workspace.join("bootstrap_credentials.once.txt");
     let mut lines = vec![
-        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager.".to_string(),
-        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords.".to_string(),
+        "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager."
+            .to_string(),
+        "# Do NOT commit this file. Do NOT paste bcrypt hashes from auth.env.local as passwords."
+            .to_string(),
         format!("# Generated: {}", chrono::Utc::now().to_rfc3339()),
         String::new(),
     ];

--- a/edge/src/auth/env_file.rs
+++ b/edge/src/auth/env_file.rs
@@ -55,10 +55,12 @@ fn random_secret_hex(bytes: usize) -> String {
     hex::encode(buf)
 }
 
+const PASSWORD_LENGTH: usize = 14;
+
 fn random_password() -> String {
     const CHARSET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#%^*_-";
     let mut rng = rand::thread_rng();
-    (0..28)
+    (0..PASSWORD_LENGTH)
         .map(|_| {
             let idx = (rng.next_u32() as usize) % CHARSET.len();
             CHARSET[idx] as char
@@ -399,6 +401,22 @@ mod tests {
         ));
         let _ = fs::create_dir_all(&dir);
         dir.join("auth.env.local")
+    }
+
+    #[test]
+    fn generated_passwords_are_fourteen_chars() {
+        let path = temp_auth_path();
+        let _ = fs::remove_file(&path);
+        let result = generate_auth_env(&GenerateOptions {
+            path: path.clone(),
+            force: true,
+            show_secrets: false,
+        })
+        .unwrap();
+        for pw in result.plaintext_passwords.values() {
+            assert_eq!(pw.len(), PASSWORD_LENGTH);
+        }
+        let _ = fs::remove_dir_all(path.parent().unwrap());
     }
 
     #[test]

--- a/edge/src/auth/rbac.rs
+++ b/edge/src/auth/rbac.rs
@@ -20,7 +20,7 @@ pub fn is_mutation_role(role: &str) -> bool {
 }
 
 pub fn can_write_field_bus(role: &str, approved: bool) -> bool {
-    is_integrator_tier(role) && approved
+    role == "integrator" && approved
 }
 
 #[cfg(test)]
@@ -30,8 +30,15 @@ mod tests {
     #[test]
     fn operator_cannot_write_field_bus() {
         assert!(!can_write_field_bus("operator", true));
-        assert!(can_write_field_bus("agent", true));
+        assert!(!can_write_field_bus("agent", true));
         assert!(can_write_field_bus("integrator", true));
         assert!(!can_write_field_bus("integrator", false));
+    }
+
+    #[test]
+    fn agent_is_integrator_tier_for_mutations() {
+        assert!(is_integrator_tier("agent"));
+        assert!(is_integrator_tier("integrator"));
+        assert!(!is_integrator_tier("operator"));
     }
 }

--- a/edge/src/auth/rbac.rs
+++ b/edge/src/auth/rbac.rs
@@ -10,12 +10,17 @@ pub fn is_read_only_role(role: &str) -> bool {
     role == "operator"
 }
 
+/// Integrator-tier roles may run commissioning mutations; operator is read-only browse/export.
+pub fn is_integrator_tier(role: &str) -> bool {
+    matches!(role, "integrator" | "agent" | "admin")
+}
+
 pub fn is_mutation_role(role: &str) -> bool {
-    matches!(role, "integrator" | "agent")
+    is_integrator_tier(role)
 }
 
 pub fn can_write_field_bus(role: &str, approved: bool) -> bool {
-    role == "integrator" && approved
+    is_integrator_tier(role) && approved
 }
 
 #[cfg(test)]
@@ -25,7 +30,7 @@ mod tests {
     #[test]
     fn operator_cannot_write_field_bus() {
         assert!(!can_write_field_bus("operator", true));
-        assert!(!can_write_field_bus("agent", true));
+        assert!(can_write_field_bus("agent", true));
         assert!(can_write_field_bus("integrator", true));
         assert!(!can_write_field_bus("integrator", false));
     }

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -3,7 +3,7 @@
 use clap::{Parser, Subcommand};
 use open_fdd_edge_prototype::auth::env_file::{
     default_auth_env_path, generate_auth_env, print_env_summary, print_generated_credentials,
-    rotate_auth_env, GenerateOptions, RotateOptions,
+    rotate_auth_env, write_bootstrap_credentials_once, GenerateOptions, RotateOptions,
 };
 use open_fdd_edge_prototype::auth::password::hash_password;
 use open_fdd_edge_prototype::tls::{default_cert_dir, generate_self_signed, TlsGenerateOptions};
@@ -121,6 +121,16 @@ fn run_generate(path: PathBuf, force: bool, show_secrets: bool) -> std::io::Resu
     }
     print_env_summary(&result.contents, show_secrets);
     print_generated_credentials(&result.plaintext_passwords, show_secrets);
+    if show_secrets {
+        if let Some(handoff) =
+            write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+        {
+            eprintln!(
+                "wrote one-time credential handoff {} (delete after saving passwords)",
+                handoff.display()
+            );
+        }
+    }
     Ok(())
 }
 
@@ -154,6 +164,17 @@ fn main() -> std::io::Result<()> {
                 eprintln!("rotated {}", path.display());
                 print_env_summary(&result.contents, show_secrets);
                 print_generated_credentials(&result.plaintext_passwords, show_secrets);
+                if show_secrets {
+                    if let Some(handoff) = write_bootstrap_credentials_once(
+                        &path,
+                        &result.plaintext_passwords,
+                    )? {
+                        eprintln!(
+                            "wrote one-time credential handoff {} (delete after saving passwords)",
+                            handoff.display()
+                        );
+                    }
+                }
                 Ok(())
             }
             AuthCommands::HashPassword { password } => {

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -122,8 +122,7 @@ fn run_generate(path: PathBuf, force: bool, show_secrets: bool) -> std::io::Resu
     print_env_summary(&result.contents, show_secrets);
     print_generated_credentials(&result.plaintext_passwords, show_secrets);
     if show_secrets {
-        if let Some(handoff) =
-            write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+        if let Some(handoff) = write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
         {
             eprintln!(
                 "wrote one-time credential handoff {} (delete after saving passwords)",
@@ -165,10 +164,9 @@ fn main() -> std::io::Result<()> {
                 print_env_summary(&result.contents, show_secrets);
                 print_generated_credentials(&result.plaintext_passwords, show_secrets);
                 if show_secrets {
-                    if let Some(handoff) = write_bootstrap_credentials_once(
-                        &path,
-                        &result.plaintext_passwords,
-                    )? {
+                    if let Some(handoff) =
+                        write_bootstrap_credentials_once(&path, &result.plaintext_passwords)?
+                    {
                         eprintln!(
                             "wrote one-time credential handoff {} (delete after saving passwords)",
                             handoff.display()

--- a/edge/src/dashboard/mod.rs
+++ b/edge/src/dashboard/mod.rs
@@ -147,13 +147,18 @@ pub fn building_insight_stub() -> Value {
 pub fn building_status() -> Value {
     let coverage = query::model_coverage();
     let fault_summary = faults::summary_json();
+    let rule_health = faults::rule_health();
     json!({
         "ok": true,
         "model_score": coverage.get("model_score").cloned().unwrap_or(json!(null)),
         "model_counts": {
             "equipment": coverage.get("equipment_count").cloned().unwrap_or(json!(0)),
-            "points": coverage.get("point_count").cloned().unwrap_or(json!(0))
+            "points": coverage.get("point_count").cloned().unwrap_or(json!(0)),
+            "mapped_points": coverage.get("mapped_points").cloned().unwrap_or(json!(0)),
+            "unmapped_points": coverage.get("unmapped_points").cloned().unwrap_or(json!(0))
         },
+        "rule_count": rule_health.get("rule_count").cloned().unwrap_or(json!(0)),
+        "datafusion_ok": rule_health.get("datafusion_ok").cloned().unwrap_or(json!(false)),
         "alert_count": fault_summary.get("active_count").cloned().unwrap_or(json!(0))
     })
 }
@@ -366,5 +371,14 @@ mod tests {
         assert_eq!(body.get("ok").and_then(|v| v.as_bool()), Some(true));
         assert!(body.get("overall").is_some());
         assert!(body.get("services").and_then(|v| v.as_array()).is_some());
+    }
+
+    #[test]
+    fn building_status_includes_model_and_rules() {
+        let body = building_status();
+        assert_eq!(body.get("ok").and_then(|v| v.as_bool()), Some(true));
+        assert!(body.get("model_counts").is_some());
+        assert!(body.get("rule_count").is_some());
+        assert!(body.get("alert_count").is_some());
     }
 }

--- a/edge/src/drivers/json_api.rs
+++ b/edge/src/drivers/json_api.rs
@@ -81,3 +81,35 @@ pub fn poll_once_value(body: &Value) -> Value {
     let _ = body;
     poll_test_source()
 }
+
+fn protocol_enabled(env_key: &str) -> bool {
+    env::var(env_key)
+        .map(|v| v != "0" && v.to_lowercase() != "false")
+        .unwrap_or(true)
+}
+
+pub fn poll_status_json() -> String {
+    if !protocol_enabled("OPENFDD_JSON_API_ENABLED") {
+        return json!({
+            "ok": true,
+            "enabled": false,
+            "status": "disabled",
+            "message": "JSON API driver is disabled or not configured"
+        })
+        .to_string();
+    }
+    let sources: Vec<Value> = serde_json::from_str(SOURCES_JSON).unwrap_or_default();
+    json!({
+        "ok": true,
+        "enabled": true,
+        "service": "json-api-poll",
+        "status": "ready",
+        "enabled_points": sources.len(),
+        "samples": 0
+    })
+    .to_string()
+}
+
+pub fn driver_tree_json() -> String {
+    super::tree::json_api_driver_tree_json()
+}

--- a/edge/src/drivers/modbus.rs
+++ b/edge/src/drivers/modbus.rs
@@ -115,3 +115,36 @@ pub fn commission_status_json() -> String {
     })
     .to_string()
 }
+
+fn protocol_enabled(env_key: &str) -> bool {
+    env::var(env_key)
+        .map(|v| v != "0" && v.to_lowercase() != "false")
+        .unwrap_or(true)
+}
+
+pub fn poll_status_json() -> String {
+    if !protocol_enabled("OPENFDD_MODBUS_ENABLED") {
+        return json!({
+            "ok": true,
+            "enabled": false,
+            "status": "disabled",
+            "message": "Modbus is disabled or not configured"
+        })
+        .to_string();
+    }
+    let points: Vec<Value> = serde_json::from_str(&points_json()).unwrap_or_default();
+    json!({
+        "ok": true,
+        "enabled": true,
+        "service": "modbus-poll",
+        "status": commission_status_mode(),
+        "enabled_points": points.len(),
+        "samples": 0,
+        "config": modbus_config_value()
+    })
+    .to_string()
+}
+
+pub fn driver_tree_json() -> String {
+    super::tree::modbus_driver_tree_json()
+}

--- a/edge/src/drivers/tree.rs
+++ b/edge/src/drivers/tree.rs
@@ -7,6 +7,7 @@ use super::json_api;
 use super::modbus;
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap};
+use std::env;
 
 const COMMANDABLE: &[&str] = &[
     "analog-output",
@@ -380,6 +381,124 @@ pub fn json_api_devices_ui() -> Vec<Value> {
             })
         })
         .collect()
+}
+
+pub fn modbus_driver_tree_value() -> Value {
+    if env::var("OPENFDD_MODBUS_ENABLED")
+        .map(|v| v == "0" || v.eq_ignore_ascii_case("false"))
+        .unwrap_or(false)
+    {
+        return json!({
+            "ok": true,
+            "enabled": false,
+            "status": "disabled",
+            "message": "Modbus is disabled or not configured",
+            "devices": []
+        });
+    }
+    let mut devices = modbus_devices_ui();
+    if devices.is_empty() {
+        let points: Vec<Value> = serde_json::from_str(&modbus::points_json()).unwrap_or_default();
+        if !points.is_empty() {
+            let cfg = modbus::modbus_config_value();
+            let host = cfg
+                .get("host")
+                .and_then(|v| v.as_str())
+                .unwrap_or("127.0.0.1");
+            let port = cfg.get("port").and_then(|v| v.as_str()).unwrap_or("502");
+            let unit_id = cfg.get("unit_id").and_then(|v| v.as_str()).unwrap_or("1");
+            let mapped: Vec<Value> = points
+                .iter()
+                .map(|p| {
+                    json!({
+                        "point_id": p.get("id").cloned().unwrap_or(json!(null)),
+                        "label": p.get("name").cloned().unwrap_or(json!("point")),
+                        "register_address": p.get("register").cloned().unwrap_or(json!(null)),
+                        "function": p.get("function").cloned().unwrap_or(json!("holding_register")),
+                        "present_value": p.get("value").cloned().unwrap_or(json!(null)),
+                        "units": p.get("unit").cloned().unwrap_or(json!(null)),
+                        "poll_label": "simulated",
+                        "enabled": false
+                    })
+                })
+                .collect();
+            devices.push(json!({
+                "device_key": format!("{host}:{port}:{unit_id}"),
+                "host": host,
+                "port": port,
+                "unit_id": unit_id,
+                "device_address": format!("{host}:{port}"),
+                "point_count": mapped.len(),
+                "poll_count": 0,
+                "points": mapped
+            }));
+        }
+    }
+    json!({"ok": true, "enabled": true, "devices": devices})
+}
+
+pub fn modbus_driver_tree_json() -> String {
+    serde_json::to_string_pretty(&modbus_driver_tree_value()).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn json_api_driver_tree_value() -> Value {
+    if env::var("OPENFDD_JSON_API_ENABLED")
+        .map(|v| v == "0" || v.eq_ignore_ascii_case("false"))
+        .unwrap_or(false)
+    {
+        return json!({
+            "ok": true,
+            "enabled": false,
+            "status": "disabled",
+            "message": "JSON API driver is disabled or not configured",
+            "devices": []
+        });
+    }
+    let mut devices = json_api_devices_ui();
+    if devices.is_empty() {
+        let sources: Vec<Value> =
+            serde_json::from_str(json_api::sources_json()).unwrap_or_default();
+        let mut by_host: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+        for src in sources {
+            let url = src
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("http://localhost/");
+            let host = url.split('/').nth(2).unwrap_or("localhost").to_string();
+            let point_id = src
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("json-api:point")
+                .to_string();
+            by_host.entry(host.clone()).or_default().push(json!({
+                "point_id": point_id,
+                "label": point_id,
+                "url": url,
+                "method": "GET",
+                "json_path": src.get("maps_to").cloned().unwrap_or(json!("$")),
+                "present_value": json!(null),
+                "poll_label": "off",
+                "enabled": false
+            }));
+        }
+        devices = by_host
+            .into_iter()
+            .map(|(host, points)| {
+                json!({
+                    "device_key": host.clone(),
+                    "host": host,
+                    "point_count": points.len(),
+                    "poll_count": 0,
+                    "points": points
+                })
+            })
+            .collect();
+    }
+    json!({"ok": true, "enabled": true, "devices": devices})
+}
+
+pub fn json_api_driver_tree_json() -> String {
+    serde_json::to_string_pretty(&json_api_driver_tree_value()).unwrap_or_else(|_| "{}".to_string())
 }
 
 pub fn haystack_devices_ui() -> Vec<Value> {

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -98,8 +98,8 @@ pub fn test_rule_sql(payload: &Value) -> Value {
 }
 
 pub fn activate_rule(rule_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate rules", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate rules", "role": role});
     }
     let rule = get_rule(rule_id);
     if rule.get("ok").and_then(|v| v.as_bool()) != Some(true) {

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -166,8 +166,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn agent_cannot_activate() {
+    fn agent_can_activate_rules() {
         let out = activate_rule("oa_temp_out_of_range", "agent", "agent");
-        assert_eq!(out["ok"].as_bool(), Some(false));
+        assert_eq!(out["ok"].as_bool(), Some(true));
     }
 }

--- a/edge/src/fdd/wires/api.rs
+++ b/edge/src/fdd/wires/api.rs
@@ -131,8 +131,8 @@ pub fn test_graph(site_id: &str, graph_id: &str) -> Value {
 }
 
 pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to approve graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to approve graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,
@@ -150,8 +150,8 @@ pub fn approve_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> 
 }
 
 pub fn activate_graph(site_id: &str, graph_id: &str, actor: &str, role: &str) -> Value {
-    if role != "integrator" {
-        return json!({"ok": false, "error": "integrator role required to activate graphs", "role": role});
+    if !crate::auth::rbac::is_integrator_tier(role) {
+        return json!({"ok": false, "error": "integrator or agent role required to activate graphs", "role": role});
     }
     let mut graph = match persistence::read_graph(site_id, graph_id) {
         Some(g) => g,

--- a/edge/src/lib.rs
+++ b/edge/src/lib.rs
@@ -10,5 +10,6 @@ pub mod historian;
 pub mod import;
 pub mod model;
 pub mod ops;
+pub mod reports;
 pub mod tls;
 pub mod validation;

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -11,6 +11,7 @@ mod historian;
 mod import;
 mod model;
 mod ops;
+mod reports;
 mod validation;
 
 use auth::audit;
@@ -692,6 +693,18 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &mut stream,
             json!({"ok": true, "sections": ["executive_summary", "faults", "overrides", "energy_opportunities", "trend_plots"]}),
         ),
+        ("GET", "/api/reports/templates") => require_role(
+            &mut stream,
+            &principal,
+            READ_EXPORT_ROLES,
+            reports::templates(),
+        ),
+        ("POST", "/api/reports/draft") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            reports::create_draft(&parse_json_body(&body)),
+        ),
         ("GET", "/api/reports/rcx/list") => raw_json(&mut stream, REPORTS),
         ("POST", "/api/reports/rcx/generate") => require_role(
             &mut stream,
@@ -700,6 +713,11 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             json!({"ok": true, "report_id": "rcx-demo-001", "path": "workspace/reports/rcx/rcx-demo-001.md", "sections": ["faults", "overrides", "plotly_trends", "recommendations"]}),
         ),
         _ => {
+            if let Some(resp) =
+                handle_reports_dynamic(&mut stream, &principal, method.as_str(), &clean_path, &body)
+            {
+                return resp;
+            }
             if let Some(resp) =
                 handle_faults_dynamic(&mut stream, &principal, method.as_str(), &clean_path)
             {
@@ -908,6 +926,72 @@ fn handle_faults_dynamic(
     Some(json_response(stream, faults::get_fault(tail)))
 }
 
+fn handle_reports_dynamic(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Option<std::io::Result<()>> {
+    let parts = path_parts(path);
+    if parts.len() < 3 || parts[0] != "api" || parts[1] != "reports" {
+        return None;
+    }
+    if parts[2] == "templates" || parts[2] == "draft" || parts[2] == "rcx" {
+        return None;
+    }
+    let report_id = reports::safe_report_id(parts[2])?;
+    if parts.len() == 3 {
+        return match method {
+            "GET" => Some(require_role(
+                stream,
+                principal,
+                READ_EXPORT_ROLES,
+                reports::get_report(&report_id),
+            )),
+            "PATCH" => Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent"],
+                reports::patch_report(&report_id, &parse_json_body(body)),
+            )),
+            _ => None,
+        };
+    }
+    match (method, parts.get(3).copied(), parts.get(4).copied()) {
+        ("GET", Some("data"), None) => Some(require_role(
+            stream,
+            principal,
+            READ_EXPORT_ROLES,
+            reports::report_data(&report_id),
+        )),
+        ("GET", Some("download.pdf"), None) => {
+            let path = reports::download_path(&report_id, "pdf")?;
+            Some(require_role_file(
+                stream,
+                principal,
+                READ_EXPORT_ROLES,
+                &path,
+                "application/pdf",
+                &format!("{report_id}.pdf"),
+            ))
+        }
+        ("POST", Some("sections"), Some("reorder")) => Some(require_role(
+            stream,
+            principal,
+            &["integrator", "agent"],
+            reports::reorder_sections(&report_id, &parse_json_body(body)),
+        )),
+        ("POST", Some("render"), Some("pdf")) => Some(require_role(
+            stream,
+            principal,
+            &["integrator", "agent"],
+            reports::render_pdf_bundle(&report_id),
+        )),
+        _ => None,
+    }
+}
+
 fn handle_data_management_dynamic(
     stream: &mut TcpStream,
     principal: &Principal,
@@ -1011,6 +1095,55 @@ fn csv_attachment_response(
     );
     stream.write_all(headers.as_bytes())?;
     stream.write_all(body.as_bytes())
+}
+
+fn require_role_file(
+    stream: &mut TcpStream,
+    principal: &Principal,
+    roles: &[&str],
+    path: &Path,
+    content_type: &str,
+    filename: &str,
+) -> std::io::Result<()> {
+    if !role_allowed(principal, roles) {
+        audit::log_event(
+            "forbidden",
+            json!({"role": principal.role.clone(), "required": roles, "file": filename}),
+        );
+        return status_json(
+            stream,
+            "403 Forbidden",
+            json!({"ok": false, "error": "insufficient role", "role": principal.role}),
+        );
+    }
+    let bytes = match fs::read(path) {
+        Ok(b) => b,
+        Err(_) => {
+            return status_json(
+                stream,
+                "404 Not Found",
+                json!({"ok": false, "error": "file not found"}),
+            );
+        }
+    };
+    file_attachment_response(stream, &bytes, content_type, filename)
+}
+
+fn file_attachment_response(
+    stream: &mut TcpStream,
+    body: &[u8],
+    content_type: &str,
+    filename: &str,
+) -> std::io::Result<()> {
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Disposition: attachment; filename=\"{filename}\"\r\n{sec}{cors}Content-Length: {len}\r\nConnection: close\r\n\r\n",
+        sec = security_headers(content_type, false),
+        cors = cors_origin(),
+        len = body.len(),
+        filename = filename
+    );
+    stream.write_all(headers.as_bytes())?;
+    stream.write_all(body)
 }
 
 fn require_role_csv(
@@ -1227,6 +1360,10 @@ fn agent_tools() -> Value {
             {"name":"fdd.rules.activate","method":"POST","path":"/api/fdd-rules/{id}/activate","requires":"integrator"},
             {"name":"rules.batch","method":"POST","path":"/api/rules/batch","requires":"integrator|agent"},
             {"name":"historian.query","method":"POST","path":"/api/historian/query","requires":"JWT"},
+            {"name":"reports.templates","method":"GET","path":"/api/reports/templates","requires":"JWT"},
+            {"name":"reports.draft","method":"POST","path":"/api/reports/draft","requires":"integrator|agent"},
+            {"name":"reports.render_pdf","method":"POST","path":"/api/reports/{id}/render/pdf","requires":"integrator|agent"},
+            {"name":"reports.download_pdf","method":"GET","path":"/api/reports/{id}/download.pdf","requires":"JWT"},
             {"name":"reports.rcx_plan","method":"POST","path":"/api/reports/rcx/plan","requires":"JWT"},
             {"name":"reports.rcx_generate","method":"POST","path":"/api/reports/rcx/generate","requires":"integrator|agent"},
             {"name":"ops.update","method":"POST","path":"/api/ops/docker/update","requires":"integrator|agent"}

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -287,6 +287,12 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent", "operator"],
             data_management::storage_summary(),
         ),
+        ("GET", "/api/host/stats") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent", "operator"],
+            ops::host_stats::stats_json(),
+        ),
         ("POST", "/api/data-management/purge/preview") => require_role(
             &mut stream,
             &principal,
@@ -591,6 +597,14 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             let body = drivers::modbus::commission_status_json();
             raw_json(&mut stream, &body)
         }
+        ("GET", "/api/modbus/poll/status") => {
+            let body = drivers::modbus::poll_status_json();
+            raw_json(&mut stream, &body)
+        }
+        ("GET", "/api/modbus/driver/tree") => {
+            let body = drivers::modbus::driver_tree_json();
+            raw_json(&mut stream, &body)
+        }
         ("POST", "/api/modbus/scan") => require_role(
             &mut stream,
             &principal,
@@ -604,6 +618,14 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         }
         ("GET", "/api/json-api/sources") => {
             raw_json(&mut stream, drivers::json_api::sources_json())
+        }
+        ("GET", "/api/json-api/poll/status") => {
+            let body = drivers::json_api::poll_status_json();
+            raw_json(&mut stream, &body)
+        }
+        ("GET", "/api/json-api/driver/tree") => {
+            let body = drivers::json_api::driver_tree_json();
+            raw_json(&mut stream, &body)
         }
         ("POST", "/api/json-api/poll-once") => {
             require_role(&mut stream, &principal, &["integrator", "agent"], {
@@ -740,6 +762,9 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             ) {
                 return resp;
             }
+            if let Some(resp) = handle_model_dynamic(&mut stream, method.as_str(), &clean_path) {
+                return resp;
+            }
             if method == "GET" && clean_path.starts_with("/api/bacnet/jobs/") {
                 let job_id = clean_path.trim_start_matches("/api/bacnet/jobs/");
                 return json_response(
@@ -785,6 +810,33 @@ fn query_param(path: &str, key: &str) -> Option<String> {
 
 fn path_parts(path: &str) -> Vec<&str> {
     path.trim_matches('/').split('/').collect()
+}
+
+fn handle_model_dynamic(
+    stream: &mut TcpStream,
+    method: &str,
+    path: &str,
+) -> Option<std::io::Result<()>> {
+    if method != "GET" {
+        return None;
+    }
+    let prefix = "/api/model/sites/";
+    let suffix = "/equipment";
+    if !path.starts_with(prefix) || !path.ends_with(suffix) {
+        return None;
+    }
+    let site_id = path
+        .trim_start_matches(prefix)
+        .trim_end_matches(suffix)
+        .trim();
+    if site_id.is_empty() {
+        return Some(status_json(
+            stream,
+            "400 Bad Request",
+            json!({"ok": false, "error": "site_id required"}),
+        ));
+    }
+    Some(json_response(stream, model::query::list_equipment(site_id)))
 }
 
 fn handle_fdd_wires_dynamic(
@@ -1496,6 +1548,9 @@ fn static_file(stream: &mut TcpStream, frontend: &Path, path: &str) -> std::io::
                 "html" => "text/html; charset=utf-8",
                 "css" => "text/css; charset=utf-8",
                 "js" => "application/javascript; charset=utf-8",
+                "svg" => "image/svg+xml",
+                "ico" => "image/x-icon",
+                "png" => "image/png",
                 _ => "application/octet-stream",
             };
             response(stream, "200 OK", ctype, &bytes)

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -1555,7 +1555,16 @@ fn static_file(stream: &mut TcpStream, frontend: &Path, path: &str) -> std::io::
             };
             response(stream, "200 OK", ctype, &bytes)
         }
-        Err(_) => response(stream, "404 Not Found", "text/plain", b"not found"),
+        Err(_) => {
+            // React SPA: unknown paths without a file extension serve index.html.
+            if !rel.contains('.') {
+                let index = PathBuf::from(frontend).join("index.html");
+                if let Ok(bytes) = fs::read(&index) {
+                    return response(stream, "200 OK", "text/html; charset=utf-8", &bytes);
+                }
+            }
+            response(stream, "404 Not Found", "text/plain", b"not found")
+        }
     }
 }
 

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -346,7 +346,9 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             json!({"ok": true, "run_id": "alg-demo-001", "result": serde_json::from_str::<Value>(control::cdl::simulate_json()).unwrap()}),
         ),
-        ("GET", "/api/model/haystack") => raw_json(&mut stream, drivers::haystack::model_json()),
+        ("GET", "/api/model/haystack") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
         ("GET", "/api/model/assignments") => {
             raw_json(&mut stream, model::assignments::assignments_json())
         }
@@ -364,8 +366,12 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         }
         ("GET", "/api/haystack/about") => raw_json(&mut stream, drivers::haystack::about_json()),
         ("GET", "/api/haystack/status") => raw_json(&mut stream, drivers::haystack::status_json()),
-        ("POST", "/api/haystack/read") => raw_json(&mut stream, drivers::haystack::model_json()),
-        ("POST", "/api/haystack/nav") => raw_json(&mut stream, drivers::haystack::model_json()),
+        ("POST", "/api/haystack/read") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
+        ("POST", "/api/haystack/nav") => {
+            raw_json(&mut stream, &model::persist::haystack_model_json_string())
+        }
         ("POST", "/api/haystack/ops") => raw_json(&mut stream, drivers::haystack::ops_json()),
         ("POST", "/api/haystack/import") => require_role(
             &mut stream,
@@ -379,9 +385,15 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             json!({"ok": true, "preserve_ids": true, "imported": 4}),
         ),
+        ("POST", "/api/model/haystack/from-smoke-profile") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            model::smoke_profile::import_from_active_profile(),
+        ),
         ("POST", "/api/model/query") => json_response(
             &mut stream,
-            json!({"ok": true, "rows": serde_json::from_str::<Value>(drivers::haystack::model_json()).unwrap()["rows"].clone()}),
+            json!({"ok": true, "rows": model::query::haystack_rows()}),
         ),
         ("GET", "/api/fdd/datafusion/demo") => {
             raw_json(&mut stream, fdd::datafusion_sql::result_json())

--- a/edge/src/model/mod.rs
+++ b/edge/src/model/mod.rs
@@ -4,4 +4,6 @@
 //! BACnet/Modbus/JSON points are referenced from Haystack point rows.
 
 pub mod assignments;
+pub mod persist;
 pub mod query;
+pub mod smoke_profile;

--- a/edge/src/model/persist.rs
+++ b/edge/src/model/persist.rs
@@ -1,0 +1,36 @@
+//! Persisted Haystack grid (optional override of fixture MODEL_JSON).
+
+use crate::validation::profile::workspace_dir;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+
+pub fn haystack_grid_path() -> PathBuf {
+    workspace_dir().join("data/model/haystack_grid.json")
+}
+
+pub fn load_haystack_grid() -> Option<Value> {
+    let path = haystack_grid_path();
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+pub fn save_haystack_grid(grid: &Value) -> std::io::Result<PathBuf> {
+    let path = haystack_grid_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()))?;
+    Ok(path)
+}
+
+pub fn haystack_model_value() -> Value {
+    load_haystack_grid().unwrap_or_else(|| {
+        serde_json::from_str(crate::drivers::haystack::MODEL_JSON)
+            .unwrap_or(json!({"meta":{"ver":"3.0","mode":"fixture"},"cols":[],"rows":[]}))
+    })
+}
+
+pub fn haystack_model_json_string() -> String {
+    haystack_model_value().to_string()
+}

--- a/edge/src/model/persist.rs
+++ b/edge/src/model/persist.rs
@@ -20,7 +20,10 @@ pub fn save_haystack_grid(grid: &Value) -> std::io::Result<PathBuf> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(&path, serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()))?;
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()),
+    )?;
     Ok(path)
 }
 

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -43,6 +43,33 @@ pub fn list_buildings(site_id: Option<&str>) -> Value {
     })
 }
 
+pub fn list_equipment(site_id: &str) -> Value {
+    let equips = list_equips(Some(site_id));
+    let equipment: Vec<Value> = equips
+        .get("equips")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|row| {
+            let equipment_id = row.get("equipment_id").cloned().unwrap_or(json!(null));
+            json!({
+                "id": equipment_id.clone(),
+                "equipment_id": equipment_id,
+                "name": row.get("name").cloned().unwrap_or(json!(null)),
+                "site_id": row.get("site_id").cloned().unwrap_or(json!(site_id)),
+                "equipment_type": row.get("equipment_type").cloned().unwrap_or(json!(null))
+            })
+        })
+        .collect();
+    json!({
+        "ok": true,
+        "site_id": site_id,
+        "equipment": equipment,
+        "count": equipment.len()
+    })
+}
+
 pub fn list_equips(site_id: Option<&str>) -> Value {
     let sid = site_id.unwrap_or("site:demo");
     let mut equips = Vec::new();

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -4,9 +4,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 pub fn haystack_rows() -> Vec<Value> {
-    let model: Value =
-        serde_json::from_str(crate::drivers::haystack::MODEL_JSON).unwrap_or(json!({"rows": []}));
-    model
+    crate::model::persist::haystack_model_value()
         .get("rows")
         .and_then(|v| v.as_array())
         .cloned()

--- a/edge/src/model/smoke_profile.rs
+++ b/edge/src/model/smoke_profile.rs
@@ -1,0 +1,169 @@
+//! Build a Haystack grid from the active validation smoke profile.
+
+use super::persist;
+use crate::validation::profile::{active_profile, BacnetPointRole, SmokeProfile};
+use serde_json::{json, Value};
+
+pub fn import_from_active_profile() -> Value {
+    let profile = active_profile();
+    import_from_profile(&profile)
+}
+
+pub fn import_from_profile(profile: &SmokeProfile) -> Value {
+    let site_id = format!("site:{}", profile.profile_id);
+    let equip_id = format!("equip:{}", profile.equipment_id);
+    let source_id = profile.source_id.clone();
+    let device = profile.device_instance;
+
+    let mut rows: Vec<Value> = vec![
+        json!({
+            "id": site_id,
+            "dis": format!("Site {}", profile.profile_id),
+            "site": "M"
+        }),
+        json!({
+            "id": equip_id,
+            "dis": format!("Equipment {}", profile.equipment_id),
+            "equip": "M",
+            "siteRef": site_id,
+            "ahu": "M",
+            "sourceRef": source_id
+        }),
+        json!({
+            "id": source_id,
+            "dis": format!("Source {}", profile.source_type),
+            "source": "M",
+            "protocol": profile.source_type,
+            "deviceInstance": device
+        }),
+    ];
+
+    for pt in &profile.bacnet_points {
+        rows.push(point_row(profile, &equip_id, &source_id, pt));
+    }
+
+    let grid = json!({
+        "meta": {
+            "ver": "3.0",
+            "mode": "smoke-profile-import",
+            "profile_id": profile.profile_id,
+            "source_id": source_id,
+            "fdd_rule_id": profile.fdd_rule_id
+        },
+        "cols": [
+            {"name":"id"},{"name":"dis"},{"name":"site"},{"name":"equip"},{"name":"point"},
+            {"name":"sensor"},{"name":"kind"},{"name":"unit"},{"name":"curVal"},
+            {"name":"bacnetRef"},{"name":"fddInput"},{"name":"equipRef"},{"name":"sourceRef"}
+        ],
+        "rows": rows
+    });
+
+    match persist::save_haystack_grid(&grid) {
+        Ok(path) => json!({
+            "ok": true,
+            "imported": rows.len(),
+            "path": path.display().to_string(),
+            "profile_id": profile.profile_id,
+            "equipment_id": profile.equipment_id,
+            "source_id": source_id,
+            "point_count": profile.bacnet_points.len(),
+            "fdd_rule_id": profile.fdd_rule_id,
+            "mode": "smoke-profile-import"
+        }),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+fn point_row(
+    profile: &SmokeProfile,
+    equip_id: &str,
+    source_id: &str,
+    pt: &BacnetPointRole,
+) -> Value {
+    let tags = infer_tags(&pt.fdd_input);
+    json!({
+        "id": format!("point:{}", pt.fdd_input),
+        "dis": pt.name,
+        "point": "M",
+        "sensor": "M",
+        "kind": "Number",
+        "unit": infer_unit(&pt.fdd_input),
+        "curVal": null,
+        "equipRef": equip_id,
+        "sourceRef": source_id,
+        "bacnetRef": format!("bacnet:{}:analog-input:{}", profile.device_instance, pt.object_instance),
+        "fddInput": pt.fdd_input,
+        "tags": tags
+    })
+}
+
+fn infer_unit(fdd_input: &str) -> &'static str {
+    if fdd_input.contains("_h") {
+        "%RH"
+    } else {
+        "°F"
+    }
+}
+
+fn infer_tags(fdd_input: &str) -> Value {
+    let mut tags = vec!["point", "sensor"];
+    if fdd_input.contains("oa") {
+        tags.extend(["outside", "air"]);
+    }
+    if fdd_input.contains("duct") {
+        tags.extend(["discharge", "air"]);
+    }
+    if fdd_input.contains("zn") {
+        tags.extend(["zone", "air"]);
+    }
+    if fdd_input.contains("_t") {
+        tags.push("temp");
+    }
+    if fdd_input.contains("_h") {
+        tags.push("humidity");
+    }
+    json!(tags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validation::profile::SmokeProfile;
+
+    #[test]
+    fn builds_rows_from_profile_points() {
+        let dir = std::env::temp_dir().join(format!(
+            "openfdd-smoke-import-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        std::env::set_var("OPENFDD_WORKSPACE", &dir);
+        let profile = SmokeProfile {
+            profile_id: "local_bacnet_fdd_validation".into(),
+            source_id: "source:validation-bacnet".into(),
+            source_type: "bacnet".into(),
+            device_instance: 5007,
+            equipment_id: "5007".into(),
+            poll_interval_seconds: 60,
+            duration_hours: 1.0,
+            confirmation_minutes: 5,
+            historian_subdir: "validation".into(),
+            artifact_subdir: "live_fdd_validation".into(),
+            fdd_rule_id: "oa_temp_out_of_range".into(),
+            bacnet_points: vec![crate::validation::profile::BacnetPointRole {
+                name: "Outside Air Temp".into(),
+                object_instance: 1173,
+                fdd_input: "oa_t".into(),
+            }],
+            modbus_host: "192.168.204.14".into(),
+            modbus_port: 1502,
+            modbus_unit_id: 1,
+            modbus_register: 30001,
+            json_api_url: None,
+        };
+        let out = import_from_profile(&profile);
+        assert_eq!(out["ok"].as_bool(), Some(true));
+        assert_eq!(out["point_count"].as_u64(), Some(1));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/edge/src/model/smoke_profile.rs
+++ b/edge/src/model/smoke_profile.rs
@@ -132,10 +132,7 @@ mod tests {
 
     #[test]
     fn builds_rows_from_profile_points() {
-        let dir = std::env::temp_dir().join(format!(
-            "openfdd-smoke-import-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("openfdd-smoke-import-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         std::env::set_var("OPENFDD_WORKSPACE", &dir);
         let profile = SmokeProfile {

--- a/edge/src/ops/host_stats.rs
+++ b/edge/src/ops/host_stats.rs
@@ -1,0 +1,184 @@
+//! Host resource stats for the Host / Data Management UI.
+
+use crate::data_management;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn read_to_string(path: &str) -> Option<String> {
+    fs::read_to_string(path).ok()
+}
+
+fn logical_cores() -> u64 {
+    read_to_string("/proc/cpuinfo")
+        .map(|s| s.lines().filter(|l| l.starts_with("processor")).count() as u64)
+        .filter(|n| *n > 0)
+        .unwrap_or(1)
+}
+
+fn load_averages() -> (Option<f64>, Option<f64>, Option<f64>) {
+    let Some(line) = read_to_string("/proc/loadavg") else {
+        return (None, None, None);
+    };
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 3 {
+        return (None, None, None);
+    }
+    (
+        parts[0].parse().ok(),
+        parts[1].parse().ok(),
+        parts[2].parse().ok(),
+    )
+}
+
+fn memory_block() -> Value {
+    let meminfo = match read_to_string("/proc/meminfo") {
+        Some(s) => s,
+        None => {
+            return json!({
+                "available": false,
+                "note": "Memory stats unavailable in this container"
+            });
+        }
+    };
+    let mut total_kb = 0_u64;
+    let mut avail_kb = 0_u64;
+    for line in meminfo.lines() {
+        if let Some(v) = line.strip_prefix("MemTotal:") {
+            total_kb = v.trim().trim_end_matches(" kB").parse().unwrap_or(0);
+        } else if let Some(v) = line.strip_prefix("MemAvailable:") {
+            avail_kb = v.trim().trim_end_matches(" kB").parse().unwrap_or(0);
+        }
+    }
+    if total_kb == 0 {
+        return json!({"available": false, "note": "Could not parse /proc/meminfo"});
+    }
+    let total_bytes = total_kb * 1024;
+    let available_bytes = avail_kb * 1024;
+    let used_bytes = total_bytes.saturating_sub(available_bytes);
+    let percent_used = (used_bytes as f64 / total_bytes as f64) * 100.0;
+    json!({
+        "available": true,
+        "total_bytes": total_bytes,
+        "used_bytes": used_bytes,
+        "available_bytes": available_bytes,
+        "free_bytes": available_bytes,
+        "percent_used": (percent_used * 10.0).round() / 10.0
+    })
+}
+
+fn disk_for_path(path: &Path) -> Value {
+    if !path.exists() {
+        return json!({
+            "available": false,
+            "label": "Data directory",
+            "path": path.display().to_string(),
+            "note": "Path not present in container"
+        });
+    }
+    let mut used_bytes = 0_u64;
+    if path.is_dir() {
+        if let Ok(rd) = fs::read_dir(path) {
+            for entry in rd.flatten() {
+                if let Ok(meta) = entry.metadata() {
+                    used_bytes = used_bytes.saturating_add(meta.len());
+                }
+            }
+        }
+    } else if let Ok(meta) = fs::metadata(path) {
+        used_bytes = meta.len();
+    }
+    let storage_summary = data_management::storage_summary();
+    let feather_bytes = storage_summary
+        .get("estimated_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(used_bytes);
+    json!({
+        "available": true,
+        "label": "Open-FDD workspace data",
+        "path": path.display().to_string(),
+        "used_bytes": used_bytes,
+        "feather_bytes": feather_bytes,
+        "percent_used": null,
+        "note": "Container filesystem — host disk totals may differ",
+        "breakdown": storage_summary.get("by_subdir").cloned().unwrap_or(json!({}))
+    })
+}
+
+fn uptime_seconds() -> Option<u64> {
+    read_to_string("/proc/uptime").and_then(|line| {
+        line.split_whitespace()
+            .next()
+            .and_then(|s| s.parse::<f64>().ok())
+            .map(|s| s as u64)
+    })
+}
+
+pub fn stats_json() -> Value {
+    let collected_at = Utc::now().to_rfc3339();
+    let hostname = env::var("HOSTNAME")
+        .or_else(|_| env::var("OPENFDD_HOSTNAME"))
+        .unwrap_or_else(|_| "openfdd-edge".into());
+    let (load_1, load_5, load_15) = load_averages();
+    let cores = logical_cores();
+    let usage_percent = load_1.map(|l| ((l / cores as f64) * 100.0).min(100.0));
+    let workspace = crate::historian::store::workspace_dir();
+    let storage = disk_for_path(&workspace);
+    let dm = data_management::storage_summary();
+
+    json!({
+        "ok": true,
+        "collected_at": collected_at,
+        "host": {
+            "hostname": hostname,
+            "platform": env::consts::OS,
+            "platform_release": env::consts::ARCH,
+            "machine": env::consts::ARCH,
+            "python_version": "n/a (Rust edge)",
+            "uptime_seconds": uptime_seconds()
+        },
+        "cpu": {
+            "logical_cores": cores,
+            "usage_percent": usage_percent,
+            "load_1": load_1,
+            "load_5": load_5,
+            "load_15": load_15,
+            "note": usage_percent.is_none().then_some("CPU percent estimated from load average when available")
+        },
+        "memory": memory_block(),
+        "storage": storage,
+        "network": {"available": false, "note": "Network counters not collected in Rust edge yet"},
+        "ollama": {
+            "api_ok": false,
+            "interactive_chat_enabled": false,
+            "error": "Ollama not wired in Rust edge host stats"
+        },
+        "container_revisions": {
+            "image_tag": env::var("OPENFDD_IMAGE_TAG").unwrap_or_else(|_| "local".into()),
+            "git_sha": env::var("OPENFDD_GIT_SHA").unwrap_or_else(|_| "unknown".into()),
+            "services": [{
+                "id": "openfdd-bridge",
+                "label": "Rust edge bridge",
+                "image": env::var("OPENFDD_IMAGE").unwrap_or_else(|_| "openfdd-edge:local".into()),
+                "api_version": env!("CARGO_PKG_VERSION")
+            }]
+        },
+        "data_management": dm
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_stats_shape_ok() {
+        let body = stats_json();
+        assert_eq!(body.get("ok"), Some(&json!(true)));
+        assert!(body.get("collected_at").and_then(|v| v.as_str()).is_some());
+        assert!(body.get("host").is_some());
+        assert!(body.get("storage").is_some());
+    }
+}

--- a/edge/src/ops/mod.rs
+++ b/edge/src/ops/mod.rs
@@ -1,3 +1,4 @@
 //! Operations and Open-FDD service status facade.
 
 pub mod bridge;
+pub mod host_stats;

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -1,0 +1,523 @@
+//! Model-driven report drafts and HTML/PDF export bundles (Rust-era, no Python).
+
+use crate::fdd::rules;
+use crate::faults;
+use crate::historian::store;
+use crate::model::query;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn reports_dir() -> PathBuf {
+    store::workspace_dir().join("reports/generated")
+}
+
+fn report_dir(id: &str) -> PathBuf {
+    reports_dir().join(sanitize_id(id))
+}
+
+pub fn sanitize_id(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn save_report(id: &str, doc: &Value) -> Result<(), String> {
+    let dir = report_dir(id);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    fs::write(
+        dir.join("report.json"),
+        serde_json::to_string_pretty(doc).unwrap_or_default(),
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn load_report(id: &str) -> Option<Value> {
+    let path = report_dir(id).join("report.json");
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn rule_explanation_block(rule_id: &str) -> Value {
+    let rule_doc = rules::get_rule(rule_id);
+    let rule = rule_doc.get("rule").cloned().unwrap_or(json!({}));
+    json!({
+        "rule_id": rule_id,
+        "rule_name": rule.get("name").cloned().unwrap_or(json!("FDD Rule")),
+        "sql": rule.get("sql").cloned().unwrap_or(json!(null)),
+        "confirmation_seconds": rule.get("confirmation_seconds").cloned().unwrap_or(json!(300)),
+        "required_inputs": rule.get("required_inputs").cloned().unwrap_or(json!([])),
+        "raw_fault_logic": rule.get("raw_fault_sql").cloned().unwrap_or(rule.get("raw_fault").cloned().unwrap_or(json!("raw_fault when SQL predicate true"))),
+        "confirmed_fault_logic": rule.get("confirmed_fault_sql").cloned().unwrap_or(json!("confirmed_fault when raw_fault sustained for confirmation_seconds")),
+        "explanation": rule.get("description").and_then(|v| v.as_str()).unwrap_or(
+            "Rule evaluates historian bindings via DataFusion SQL; raw_fault starts immediately, confirmed_fault after confirmation delay."
+        )
+    })
+}
+
+fn suggested_plot_blocks() -> Vec<Value> {
+    let mut blocks = Vec::new();
+    let points = query::list_points(None);
+    let point_list = points
+        .get("points")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut roles: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for p in &point_list {
+        if let Some(role) = p.get("fdd_input").and_then(|v| v.as_str()) {
+            roles.insert(role.to_string());
+        }
+    }
+    if roles.contains("oa_t") || roles.contains("duct_t") || roles.contains("zn_t") {
+        let series: Vec<&str> = ["oa_t", "duct_t", "zn_t"]
+            .iter()
+            .copied()
+            .filter(|r| roles.contains(*r))
+            .collect();
+        blocks.push(json!({
+            "id": "plot-trends",
+            "type": "plot",
+            "title": "Temperature trends",
+            "visible": true,
+            "order": 10,
+            "content": {
+                "plot_type": "multi_trend",
+                "series": series,
+                "source": "historian"
+            }
+        }));
+    }
+    if roles.contains("sat") && roles.contains("sat_sp") {
+        blocks.push(json!({
+            "id": "plot-sat-tracking",
+            "type": "plot",
+            "title": "SAT vs setpoint",
+            "visible": true,
+            "order": 11,
+            "content": {"plot_type": "sat_tracking", "series": ["sat", "sat_sp"], "overlay_faults": true}
+        }));
+    }
+    if roles.contains("fan_cmd") && roles.contains("fan_status") {
+        blocks.push(json!({
+            "id": "plot-fan-mismatch",
+            "type": "plot",
+            "title": "Fan command vs status",
+            "visible": true,
+            "order": 12,
+            "content": {"plot_type": "command_status", "series": ["fan_cmd", "fan_status"]}
+        }));
+    }
+    blocks
+}
+
+pub fn templates() -> Value {
+    json!({
+        "ok": true,
+        "templates": [
+            {
+                "id": "validation-summary",
+                "title": "Validation summary",
+                "description": "Auto-built from historian, FDD rules, imports, and source health"
+            },
+            {
+                "id": "equipment-fdd",
+                "title": "Equipment FDD report",
+                "description": "Per-equipment plots, SQL rules, and fault timelines"
+            }
+        ]
+    })
+}
+
+pub fn create_draft(body: &Value) -> Value {
+    let template = body
+        .get("template_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("validation-summary");
+    let title = body
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Open-FDD Report");
+    let report_id = format!("rpt-{}", Utc::now().timestamp_millis());
+    let coverage = query::model_coverage();
+    let equips = query::list_equips(None);
+    let hist_status = store::status_json();
+    let mut sections = vec![
+        json!({
+            "id": "building-summary",
+            "type": "building_summary",
+            "title": "Building summary",
+            "visible": true,
+            "order": 0,
+            "content": {
+                "generated_at": Utc::now().to_rfc3339(),
+                "template_id": template,
+                "title": title,
+                "sites": query::list_sites()
+            }
+        }),
+        json!({
+            "id": "model-coverage",
+            "type": "model_coverage",
+            "title": "Model coverage",
+            "visible": true,
+            "order": 1,
+            "content": coverage
+        }),
+        json!({
+            "id": "source-health",
+            "type": "source_health",
+            "title": "Source health",
+            "visible": true,
+            "order": 2,
+            "content": query::source_coverage()
+        }),
+        json!({
+            "id": "historian-summary",
+            "type": "historian_summary",
+            "title": "Historian summary",
+            "visible": true,
+            "order": 3,
+            "content": hist_status
+        }),
+        json!({
+            "id": "rule-explanation",
+            "type": "rule_explanation",
+            "title": "FDD rule: oa_temp_out_of_range",
+            "visible": true,
+            "order": 4,
+            "content": rule_explanation_block("oa_temp_out_of_range")
+        }),
+        json!({
+            "id": "equipment-summary",
+            "type": "equipment_summary",
+            "title": "Equipment",
+            "visible": true,
+            "order": 5,
+            "content": equips
+        }),
+        json!({
+            "id": "fault-summary",
+            "type": "fault_summary",
+            "title": "Fault summary",
+            "visible": true,
+            "order": 6,
+            "content": faults::summary_json()
+        }),
+        json!({
+            "id": "data-quality",
+            "type": "data_quality",
+            "title": "Data quality",
+            "visible": true,
+            "order": 7,
+            "content": query::source_coverage()
+        }),
+        json!({
+            "id": "recommendations",
+            "type": "recommendations",
+            "title": "Recommendations",
+            "visible": true,
+            "order": 8,
+            "content": {"notes": "Review confirmed faults and model gaps before commissioning sign-off.", "items": []}
+        }),
+    ];
+    for plot in suggested_plot_blocks() {
+        sections.push(plot);
+    }
+    let doc = json!({
+        "ok": true,
+        "report_id": report_id,
+        "title": title,
+        "template_id": template,
+        "created_at": Utc::now().to_rfc3339(),
+        "updated_at": Utc::now().to_rfc3339(),
+        "sections": sections,
+        "metadata": {
+            "generator": "open-fdd-rust-report-builder",
+            "pdf_ready": false
+        }
+    });
+    match save_report(&report_id, &doc) {
+        Ok(()) => doc,
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn get_report(report_id: &str) -> Value {
+    load_report(report_id)
+        .map(|doc| json!({"ok": true, "report": doc}))
+        .unwrap_or_else(|| json!({"ok": false, "error": "report not found"}))
+}
+
+pub fn patch_report(report_id: &str, body: &Value) -> Value {
+    let Some(mut doc) = load_report(report_id) else {
+        return json!({"ok": false, "error": "report not found"});
+    };
+    if let Some(title) = body.get("title").and_then(|v| v.as_str()) {
+        doc["title"] = json!(title);
+    }
+    if let Some(sections) = body.get("sections") {
+        doc["sections"] = sections.clone();
+    }
+    doc["updated_at"] = json!(Utc::now().to_rfc3339());
+    match save_report(report_id, &doc) {
+        Ok(()) => json!({"ok": true, "report": doc}),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn reorder_sections(report_id: &str, body: &Value) -> Value {
+    let Some(order) = body.get("section_ids").and_then(|v| v.as_array()) else {
+        return json!({"ok": false, "error": "section_ids array required"});
+    };
+    let Some(mut doc) = load_report(report_id) else {
+        return json!({"ok": false, "error": "report not found"});
+    };
+    let sections = doc
+        .get("sections")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut by_id = std::collections::HashMap::new();
+    for s in sections {
+        if let Some(id) = s.get("id").and_then(|v| v.as_str()) {
+            by_id.insert(id.to_string(), s);
+        }
+    }
+    let mut reordered = Vec::new();
+    for (idx, idv) in order.iter().enumerate() {
+        if let Some(id) = idv.as_str() {
+            if let Some(mut sec) = by_id.remove(id) {
+                sec["order"] = json!(idx);
+                reordered.push(sec);
+            }
+        }
+    }
+    for (_, mut sec) in by_id {
+        sec["order"] = json!(reordered.len());
+        reordered.push(sec);
+    }
+    doc["sections"] = json!(reordered);
+    doc["updated_at"] = json!(Utc::now().to_rfc3339());
+    match save_report(report_id, &doc) {
+        Ok(()) => json!({"ok": true, "report": doc}),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn report_data(report_id: &str) -> Value {
+    let Some(doc) = load_report(report_id) else {
+        return json!({"ok": false, "error": "report not found"});
+    };
+    json!({
+        "ok": true,
+        "report_id": report_id,
+        "sections": doc.get("sections").cloned().unwrap_or(json!([]))
+    })
+}
+
+pub fn render_html(report_id: &str) -> Result<PathBuf, String> {
+    let doc = load_report(report_id).ok_or("report not found")?;
+    let title = doc
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Open-FDD Report");
+    let generated = Utc::now().to_rfc3339();
+    let mut html = format!(
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>{title}</title>\
+<style>body{{font-family:sans-serif;margin:2rem;color:#111}}\
+section{{margin-bottom:2rem;border-bottom:1px solid #ccc;padding-bottom:1rem;page-break-inside:avoid}}\
+h1{{margin-bottom:0.2rem}}h2{{color:#333;margin-top:0}}\
+.meta{{color:#666;font-size:0.9rem}}pre{{background:#f5f5f5;padding:1rem;overflow:auto;font-size:0.85rem}}\
+@media print{{header,footer{{display:block}}}}</style></head><body>\
+<header><h1>{title}</h1><p class=\"meta\">Generated {generated} · Open-FDD Report Builder</p></header>"
+    );
+    if let Some(sections) = doc.get("sections").and_then(|v| v.as_array()) {
+        for sec in sections {
+            if sec.get("visible").and_then(|v| v.as_bool()) == Some(false) {
+                continue;
+            }
+            let stitle = sec.get("title").and_then(|v| v.as_str()).unwrap_or("Section");
+            html.push_str(&format!("<section><h2>{stitle}</h2><pre>"));
+            html.push_str(
+                &serde_json::to_string_pretty(sec.get("content").unwrap_or(&json!({})))
+                    .unwrap_or_default(),
+            );
+            html.push_str("</pre></section>");
+        }
+    }
+    html.push_str("<footer><p class=\"meta\">Open-FDD · confidential commissioning data — no secrets included</p></footer></body></html>");
+    let dir = report_dir(report_id);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join("report.html");
+    fs::write(&path, html).map_err(|e| e.to_string())?;
+    Ok(path)
+}
+
+fn pdf_escape(text: &str) -> String {
+    text.replace('\\', "\\\\")
+        .replace('(', "\\(")
+        .replace(')', "\\)")
+}
+
+fn write_text_pdf(path: &Path, title: &str, lines: &[String]) -> Result<(), String> {
+    let mut body = format!("BT /F1 14 Tf 50 750 Td ({}) Tj ", pdf_escape(title));
+    body.push_str("0 -18 Td /F1 10 Tf ");
+    for line in lines.iter().take(48) {
+        body.push_str(&format!("({}) Tj 0 -12 Tj ", pdf_escape(line)));
+    }
+    body.push_str("ET");
+
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> >>"
+            .to_string(),
+        format!("<< /Length {} >>\nstream\n{}\nendstream", body.len(), body),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+    ];
+
+    let mut pdf = String::from("%PDF-1.4\n");
+    let mut offsets = vec![0_usize];
+    for (i, obj) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.push_str(&format!("{} 0 obj\n{obj}\nendobj\n", i + 1));
+    }
+    let xref_pos = pdf.len();
+    pdf.push_str(&format!("xref\n0 {}\n", objects.len() + 1));
+    pdf.push_str("0000000000 65535 f \n");
+    for off in &offsets[1..] {
+        pdf.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.push_str(&format!(
+        "trailer << /Size {} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n",
+        objects.len() + 1
+    ));
+    fs::write(path, pdf).map_err(|e| e.to_string())
+}
+
+pub fn render_pdf(report_id: &str) -> Result<PathBuf, String> {
+    let doc = load_report(report_id).ok_or("report not found")?;
+    let title = doc
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Open-FDD Report")
+        .to_string();
+    let mut lines = vec![
+        format!("Generated: {}", Utc::now().to_rfc3339()),
+        format!("Report ID: {report_id}"),
+    ];
+    if let Some(sections) = doc.get("sections").and_then(|v| v.as_array()) {
+        for sec in sections {
+            if sec.get("visible").and_then(|v| v.as_bool()) == Some(false) {
+                continue;
+            }
+            let stitle = sec
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Section");
+            lines.push(String::new());
+            lines.push(format!("## {stitle}"));
+            let body = serde_json::to_string(sec.get("content").unwrap_or(&json!({})))
+                .unwrap_or_default();
+            for chunk in body.as_bytes().chunks(90) {
+                lines.push(String::from_utf8_lossy(chunk).into_owned());
+            }
+        }
+    }
+    let dir = report_dir(report_id);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let pdf_path = dir.join("report.pdf");
+    write_text_pdf(&pdf_path, &title, &lines)?;
+    let _ = render_html(report_id);
+    if let Some(mut saved) = load_report(report_id) {
+        saved["metadata"]["pdf_ready"] = json!(true);
+        saved["metadata"]["pdf_generated_at"] = json!(Utc::now().to_rfc3339());
+        let _ = save_report(report_id, &saved);
+    }
+    Ok(pdf_path)
+}
+
+pub fn render_pdf_bundle(report_id: &str) -> Value {
+    match render_pdf(report_id) {
+        Ok(pdf_path) => {
+            let html_path = report_dir(report_id).join("report.html");
+            json!({
+                "ok": true,
+                "report_id": report_id,
+                "html_path": html_path.display().to_string(),
+                "pdf_path": pdf_path.display().to_string(),
+                "render_engine": "rust-text-pdf",
+                "size_bytes": fs::metadata(&pdf_path).map(|m| m.len()).unwrap_or(0)
+            })
+        }
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+pub fn download_path(report_id: &str, kind: &str) -> Option<PathBuf> {
+    let id = safe_report_id(report_id)?;
+    let dir = report_dir(&id);
+    match kind {
+        "html" => {
+            let p = dir.join("report.html");
+            if p.exists() {
+                Some(p)
+            } else {
+                render_html(&id).ok()
+            }
+        }
+        "pdf" => {
+            let p = dir.join("report.pdf");
+            if p.exists() {
+                Some(p)
+            } else {
+                render_pdf(&id).ok()
+            }
+        }
+        _ => None,
+    }
+}
+
+pub fn safe_report_id(raw: &str) -> Option<String> {
+    if raw.is_empty() || raw.contains("..") || raw.contains('/') {
+        return None;
+    }
+    let sanitized = sanitize_id(raw);
+    if sanitized.is_empty() {
+        return None;
+    }
+    Some(sanitized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_report_id() {
+        assert_eq!(sanitize_id("rpt-123"), "rpt-123");
+        assert_eq!(sanitize_id("../evil"), "____evil");
+    }
+
+    #[test]
+    fn templates_include_validation_summary() {
+        let t = templates();
+        assert_eq!(t["ok"], true);
+        assert!(t["templates"].as_array().unwrap().len() >= 1);
+    }
+
+    #[test]
+    fn create_draft_has_sections() {
+        let doc = create_draft(&json!({"title": "Test Report"}));
+        assert_eq!(doc["ok"], true);
+        assert!(doc["sections"].as_array().unwrap().len() >= 5);
+    }
+}

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -1,7 +1,7 @@
 //! Model-driven report drafts and HTML/PDF export bundles (Rust-era, no Python).
 
-use crate::fdd::rules;
 use crate::faults;
+use crate::fdd::rules;
 use crate::historian::store;
 use crate::model::query;
 use chrono::Utc;
@@ -344,7 +344,10 @@ h1{{margin-bottom:0.2rem}}h2{{color:#333;margin-top:0}}\
             if sec.get("visible").and_then(|v| v.as_bool()) == Some(false) {
                 continue;
             }
-            let stitle = sec.get("title").and_then(|v| v.as_str()).unwrap_or("Section");
+            let stitle = sec
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Section");
             html.push_str(&format!("<section><h2>{stitle}</h2><pre>"));
             html.push_str(
                 &serde_json::to_string_pretty(sec.get("content").unwrap_or(&json!({})))
@@ -425,8 +428,8 @@ pub fn render_pdf(report_id: &str) -> Result<PathBuf, String> {
                 .unwrap_or("Section");
             lines.push(String::new());
             lines.push(format!("## {stitle}"));
-            let body = serde_json::to_string(sec.get("content").unwrap_or(&json!({})))
-                .unwrap_or_default();
+            let body =
+                serde_json::to_string(sec.get("content").unwrap_or(&json!({}))).unwrap_or_default();
             for chunk in body.as_bytes().chunks(90) {
                 lines.push(String::from_utf8_lossy(chunk).into_owned());
             }
@@ -504,20 +507,24 @@ mod tests {
     #[test]
     fn sanitize_report_id() {
         assert_eq!(sanitize_id("rpt-123"), "rpt-123");
-        assert_eq!(sanitize_id("../evil"), "____evil");
+        assert_eq!(sanitize_id("../evil"), "___evil");
     }
 
     #[test]
     fn templates_include_validation_summary() {
         let t = templates();
         assert_eq!(t["ok"], true);
-        assert!(t["templates"].as_array().unwrap().len() >= 1);
+        assert!(!t["templates"].as_array().unwrap().is_empty());
     }
 
     #[test]
     fn create_draft_has_sections() {
+        let tmp = std::env::temp_dir().join(format!("ofdd-report-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", tmp.to_string_lossy().as_ref());
         let doc = create_draft(&json!({"title": "Test Report"}));
-        assert_eq!(doc["ok"], true);
+        assert_eq!(doc["ok"], true, "draft error: {:?}", doc.get("error"));
         assert!(doc["sections"].as_array().unwrap().len() >= 5);
     }
 }

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -519,7 +519,10 @@ mod tests {
 
     #[test]
     fn create_draft_has_sections() {
-        let tmp = std::env::temp_dir().join(format!("ofdd-report-test-{}", std::process::id()));
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let n = NEXT.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ofdd-report-test-{}-{n}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
         std::env::set_var("OPENFDD_WORKSPACE", tmp.to_string_lossy().as_ref());

--- a/edge/tests/dashboard_integration.rs
+++ b/edge/tests/dashboard_integration.rs
@@ -160,6 +160,23 @@ fn dashboard_summary_requires_auth() {
 }
 
 #[test]
+fn building_status_and_analytics_shape() {
+    let srv = Server::start();
+    let (status, body) = srv.get("/api/building/status");
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v.get("ok").and_then(|x| x.as_bool()), Some(true));
+    assert!(v.get("model_counts").is_some());
+    assert!(v.get("rule_count").is_some());
+
+    let (a_status, a_body) = srv.get("/api/dashboard/analytics");
+    assert_eq!(a_status, 200);
+    let a: serde_json::Value = serde_json::from_str(&a_body).unwrap();
+    assert!(a.get("rule_health").is_some());
+    assert!(a.get("model").is_some());
+}
+
+#[test]
 fn faults_list_and_csv_export() {
     let srv = Server::start();
     let (status, body) = srv.get("/api/faults");

--- a/edge/tests/reports_integration.rs
+++ b/edge/tests/reports_integration.rs
@@ -2,7 +2,7 @@
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
@@ -10,6 +10,14 @@ use std::time::Duration;
 use open_fdd_edge_prototype::auth::env_file::{generate_auth_env, parse_env_file, GenerateOptions};
 
 static SERVER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn pick_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("port")
+        .port()
+}
 
 struct Server {
     _lock: std::sync::MutexGuard<'static, ()>,
@@ -24,11 +32,7 @@ impl Server {
             .get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        let port = TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port();
+        let port = pick_port();
         let workspace =
             std::env::temp_dir().join(format!("openfdd-report-it-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&workspace);
@@ -53,32 +57,43 @@ impl Server {
             .env("OPENFDD_WORKSPACE", &workspace)
             .env("FRONTEND_DIR", frontend)
             .env("OPENFDD_BACNET_ENABLED", "0")
-            .env("OPENFDD_MODBUS_ENABLED", "0");
+            .env("OPENFDD_MODBUS_ENABLED", "0")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
         for (k, v) in &auth_map {
             cmd.env(k, v);
         }
         let mut child = cmd.spawn().expect("start edge");
         let mut ready = false;
         for _ in 0..120 {
-            let (status, _) = http_raw(
+            let (status, body) = http_raw(
                 "GET",
                 &format!("http://127.0.0.1:{port}/api/health"),
                 None,
                 None,
             );
-            if status == 200 {
+            if status == 200 && body.contains("\"ok\"") {
                 ready = true;
                 break;
             }
             thread::sleep(Duration::from_millis(250));
         }
-        assert!(ready, "edge server did not become ready on port {port}");
+        if !ready {
+            let mut stderr = String::new();
+            if let Some(mut err) = child.stderr.take() {
+                let _ = err.read_to_string(&mut stderr);
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("edge server did not become ready on port {port}; stderr:\n{stderr}");
+        }
         let login = serde_json::json!({"username":"integrator","password":pw}).to_string();
-        let (_, body) = http_post_json(
+        let (status, body) = http_post_json(
             &format!("http://127.0.0.1:{port}/api/auth/login"),
             &login,
             None,
         );
+        assert_eq!(status, 200, "login failed: {body}");
         let token = serde_json::from_str::<serde_json::Value>(&body)
             .ok()
             .and_then(|v| {
@@ -104,14 +119,22 @@ impl Drop for Server {
     }
 }
 
-fn http_raw(method: &str, url: &str, token: Option<&str>, body: Option<&str>) -> (u16, String) {
-    let parsed = url.strip_prefix("http://").unwrap_or(url);
-    let (host_port, path) = parsed.split_once('/').unwrap_or((parsed, ""));
-    let path = format!("/{path}");
-    let mut stream = TcpStream::connect(host_port).expect("connect to edge server");
-    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\n");
-    if let Some(t) = token {
-        req.push_str(&format!("Authorization: Bearer {t}\r\n"));
+fn http_raw(method: &str, url: &str, body: Option<&str>, bearer: Option<&str>) -> (u16, String) {
+    let url = url.strip_prefix("http://").unwrap_or(url);
+    let (host_port, path) = url.split_once('/').unwrap_or((url, ""));
+    let path = if path.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{path}")
+    };
+    let mut stream = match TcpStream::connect(host_port) {
+        Ok(s) => s,
+        Err(_) => return (0, String::new()),
+    };
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\nConnection: close\r\n");
+    if let Some(token) = bearer {
+        req.push_str(&format!("Authorization: Bearer {token}\r\n"));
     }
     if let Some(b) = body {
         req.push_str("Content-Type: application/json\r\n");
@@ -121,9 +144,14 @@ fn http_raw(method: &str, url: &str, token: Option<&str>, body: Option<&str>) ->
     } else {
         req.push_str("\r\n");
     }
-    stream.write_all(req.as_bytes()).unwrap();
-    let mut resp = String::new();
-    stream.read_to_string(&mut resp).unwrap();
+    if stream.write_all(req.as_bytes()).is_err() {
+        return (0, String::new());
+    }
+    let mut buf = Vec::new();
+    if stream.read_to_end(&mut buf).is_err() {
+        return (0, String::new());
+    }
+    let resp = String::from_utf8_lossy(&buf);
     let status = resp
         .lines()
         .next()
@@ -134,12 +162,12 @@ fn http_raw(method: &str, url: &str, token: Option<&str>, body: Option<&str>) ->
     (status, body)
 }
 
-fn http_post_json(url: &str, body: &str, token: Option<&str>) -> (u16, String) {
-    http_raw("POST", url, token, Some(body))
+fn http_post_json(url: &str, body: &str, bearer: Option<&str>) -> (u16, String) {
+    http_raw("POST", url, Some(body), bearer)
 }
 
 fn http_get(url: &str, token: &str) -> (u16, String) {
-    http_raw("GET", url, Some(token), None)
+    http_raw("GET", url, None, Some(token))
 }
 
 #[test]
@@ -159,11 +187,12 @@ fn report_templates_requires_auth_or_returns_templates() {
 fn report_draft_reorder_and_pdf_download() {
     let srv = Server::start();
     let base = format!("http://127.0.0.1:{}", srv.port);
-    let (_, draft_body) = http_post_json(
+    let (status, draft_body) = http_post_json(
         &format!("{base}/api/reports/draft"),
         r#"{"title":"Integration Test Report"}"#,
         Some(&srv.token),
     );
+    assert_eq!(status, 200);
     let draft: serde_json::Value = serde_json::from_str(&draft_body).unwrap();
     assert_eq!(draft["ok"], true);
     let report_id = draft["report_id"].as_str().unwrap();
@@ -196,8 +225,8 @@ fn report_draft_reorder_and_pdf_download() {
     let (status, pdf_bytes) = http_raw(
         "GET",
         &format!("{base}/api/reports/{report_id}/download.pdf"),
-        Some(&srv.token),
         None,
+        Some(&srv.token),
     );
     assert_eq!(status, 200);
     assert!(pdf_bytes.starts_with("%PDF"));
@@ -208,11 +237,12 @@ fn report_draft_reorder_and_pdf_download() {
 fn report_download_rejects_anonymous() {
     let srv = Server::start();
     let base = format!("http://127.0.0.1:{}", srv.port);
-    let (_, draft_body) = http_post_json(
+    let (status, draft_body) = http_post_json(
         &format!("{base}/api/reports/draft"),
         r#"{"title":"Auth Test"}"#,
         Some(&srv.token),
     );
+    assert_eq!(status, 200);
     let report_id = serde_json::from_str::<serde_json::Value>(&draft_body).unwrap()["report_id"]
         .as_str()
         .unwrap()

--- a/edge/tests/reports_integration.rs
+++ b/edge/tests/reports_integration.rs
@@ -95,12 +95,7 @@ impl Server {
     }
 }
 
-fn http_raw(
-    method: &str,
-    url: &str,
-    token: Option<&str>,
-    body: Option<&str>,
-) -> (u16, String) {
+fn http_raw(method: &str, url: &str, token: Option<&str>, body: Option<&str>) -> (u16, String) {
     let parsed = url.strip_prefix("http://").unwrap_or(url);
     let (host_port, path) = parsed.split_once('/').unwrap_or((parsed, ""));
     let path = format!("/{path}");
@@ -148,7 +143,7 @@ fn report_templates_requires_auth_or_returns_templates() {
     assert_eq!(status, 200);
     let json: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(json["ok"], true);
-    assert!(json["templates"].as_array().unwrap().len() >= 1);
+    assert!(!json["templates"].as_array().unwrap().is_empty());
 }
 
 #[test]

--- a/edge/tests/reports_integration.rs
+++ b/edge/tests/reports_integration.rs
@@ -12,14 +12,15 @@ use open_fdd_edge_prototype::auth::env_file::{generate_auth_env, parse_env_file,
 static SERVER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 struct Server {
-    _child: Child,
+    _lock: std::sync::MutexGuard<'static, ()>,
+    child: Child,
     port: u16,
     token: String,
 }
 
 impl Server {
     fn start() -> Self {
-        let _lock = SERVER_LOCK
+        let lock = SERVER_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -28,11 +29,8 @@ impl Server {
             .local_addr()
             .unwrap()
             .port();
-        let workspace = std::env::temp_dir().join(format!(
-            "openfdd-report-it-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        let workspace =
+            std::env::temp_dir().join(format!("openfdd-report-it-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&workspace);
         std::fs::create_dir_all(&workspace).unwrap();
         let auth_path = workspace.join("auth.env.local");
@@ -59,8 +57,9 @@ impl Server {
         for (k, v) in &auth_map {
             cmd.env(k, v);
         }
-        let child = cmd.spawn().expect("start edge");
-        for _ in 0..60 {
+        let mut child = cmd.spawn().expect("start edge");
+        let mut ready = false;
+        for _ in 0..120 {
             let (status, _) = http_raw(
                 "GET",
                 &format!("http://127.0.0.1:{port}/api/health"),
@@ -68,10 +67,12 @@ impl Server {
                 None,
             );
             if status == 200 {
+                ready = true;
                 break;
             }
-            thread::sleep(Duration::from_millis(200));
+            thread::sleep(Duration::from_millis(250));
         }
+        assert!(ready, "edge server did not become ready on port {port}");
         let login = serde_json::json!({"username":"integrator","password":pw}).to_string();
         let (_, body) = http_post_json(
             &format!("http://127.0.0.1:{port}/api/auth/login"),
@@ -86,12 +87,20 @@ impl Server {
                     .and_then(|t| t.as_str())
                     .map(str::to_string)
             })
-            .unwrap();
+            .expect("login token missing");
         Server {
-            _child: child,
+            _lock: lock,
+            child,
             port,
             token,
         }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 }
 
@@ -99,7 +108,7 @@ fn http_raw(method: &str, url: &str, token: Option<&str>, body: Option<&str>) ->
     let parsed = url.strip_prefix("http://").unwrap_or(url);
     let (host_port, path) = parsed.split_once('/').unwrap_or((parsed, ""));
     let path = format!("/{path}");
-    let mut stream = TcpStream::connect(host_port).unwrap();
+    let mut stream = TcpStream::connect(host_port).expect("connect to edge server");
     let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\n");
     if let Some(t) = token {
         req.push_str(&format!("Authorization: Bearer {t}\r\n"));

--- a/edge/tests/reports_integration.rs
+++ b/edge/tests/reports_integration.rs
@@ -1,0 +1,223 @@
+//! Report builder API integration tests.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+use open_fdd_edge_prototype::auth::env_file::{generate_auth_env, parse_env_file, GenerateOptions};
+
+static SERVER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+struct Server {
+    _child: Child,
+    port: u16,
+    token: String,
+}
+
+impl Server {
+    fn start() -> Self {
+        let _lock = SERVER_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let port = TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let workspace = std::env::temp_dir().join(format!(
+            "openfdd-report-it-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&workspace);
+        std::fs::create_dir_all(&workspace).unwrap();
+        let auth_path = workspace.join("auth.env.local");
+        let generated = generate_auth_env(&GenerateOptions {
+            path: auth_path.clone(),
+            force: true,
+            show_secrets: false,
+        })
+        .unwrap();
+        let pw = generated
+            .plaintext_passwords
+            .get("integrator")
+            .cloned()
+            .unwrap();
+        let auth_map = parse_env_file(&std::fs::read_to_string(&auth_path).unwrap());
+        let bin = env!("CARGO_BIN_EXE_open_fdd_edge_prototype");
+        let frontend = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../frontend");
+        let mut cmd = Command::new(bin);
+        cmd.env("PORT", port.to_string())
+            .env("OPENFDD_WORKSPACE", &workspace)
+            .env("FRONTEND_DIR", frontend)
+            .env("OPENFDD_BACNET_ENABLED", "0")
+            .env("OPENFDD_MODBUS_ENABLED", "0");
+        for (k, v) in &auth_map {
+            cmd.env(k, v);
+        }
+        let child = cmd.spawn().expect("start edge");
+        for _ in 0..60 {
+            let (status, _) = http_raw(
+                "GET",
+                &format!("http://127.0.0.1:{port}/api/health"),
+                None,
+                None,
+            );
+            if status == 200 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+        let login = serde_json::json!({"username":"integrator","password":pw}).to_string();
+        let (_, body) = http_post_json(
+            &format!("http://127.0.0.1:{port}/api/auth/login"),
+            &login,
+            None,
+        );
+        let token = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| {
+                v.get("token")
+                    .or_else(|| v.get("access_token"))
+                    .and_then(|t| t.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap();
+        Server {
+            _child: child,
+            port,
+            token,
+        }
+    }
+}
+
+fn http_raw(
+    method: &str,
+    url: &str,
+    token: Option<&str>,
+    body: Option<&str>,
+) -> (u16, String) {
+    let parsed = url.strip_prefix("http://").unwrap_or(url);
+    let (host_port, path) = parsed.split_once('/').unwrap_or((parsed, ""));
+    let path = format!("/{path}");
+    let mut stream = TcpStream::connect(host_port).unwrap();
+    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\n");
+    if let Some(t) = token {
+        req.push_str(&format!("Authorization: Bearer {t}\r\n"));
+    }
+    if let Some(b) = body {
+        req.push_str("Content-Type: application/json\r\n");
+        req.push_str(&format!("Content-Length: {}\r\n", b.len()));
+        req.push_str("\r\n");
+        req.push_str(b);
+    } else {
+        req.push_str("\r\n");
+    }
+    stream.write_all(req.as_bytes()).unwrap();
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).unwrap();
+    let status = resp
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let body = resp.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
+    (status, body)
+}
+
+fn http_post_json(url: &str, body: &str, token: Option<&str>) -> (u16, String) {
+    http_raw("POST", url, token, Some(body))
+}
+
+fn http_get(url: &str, token: &str) -> (u16, String) {
+    http_raw("GET", url, Some(token), None)
+}
+
+#[test]
+fn report_templates_requires_auth_or_returns_templates() {
+    let srv = Server::start();
+    let (status, body) = http_get(
+        &format!("http://127.0.0.1:{}/api/reports/templates", srv.port),
+        &srv.token,
+    );
+    assert_eq!(status, 200);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["ok"], true);
+    assert!(json["templates"].as_array().unwrap().len() >= 1);
+}
+
+#[test]
+fn report_draft_reorder_and_pdf_download() {
+    let srv = Server::start();
+    let base = format!("http://127.0.0.1:{}", srv.port);
+    let (_, draft_body) = http_post_json(
+        &format!("{base}/api/reports/draft"),
+        r#"{"title":"Integration Test Report"}"#,
+        Some(&srv.token),
+    );
+    let draft: serde_json::Value = serde_json::from_str(&draft_body).unwrap();
+    assert_eq!(draft["ok"], true);
+    let report_id = draft["report_id"].as_str().unwrap();
+    assert!(draft["sections"].as_array().unwrap().len() >= 5);
+
+    let sections = draft["sections"].as_array().unwrap();
+    let ids: Vec<String> = sections
+        .iter()
+        .filter_map(|s| s.get("id").and_then(|v| v.as_str()).map(str::to_string))
+        .collect();
+    let mut reversed = ids.clone();
+    reversed.reverse();
+    let reorder_body = serde_json::json!({"section_ids": reversed}).to_string();
+    let (status, _) = http_post_json(
+        &format!("{base}/api/reports/{report_id}/sections/reorder"),
+        &reorder_body,
+        Some(&srv.token),
+    );
+    assert_eq!(status, 200);
+
+    let (status, render_body) = http_post_json(
+        &format!("{base}/api/reports/{report_id}/render/pdf"),
+        "{}",
+        Some(&srv.token),
+    );
+    assert_eq!(status, 200);
+    let render: serde_json::Value = serde_json::from_str(&render_body).unwrap();
+    assert_eq!(render["ok"], true);
+
+    let (status, pdf_bytes) = http_raw(
+        "GET",
+        &format!("{base}/api/reports/{report_id}/download.pdf"),
+        Some(&srv.token),
+        None,
+    );
+    assert_eq!(status, 200);
+    assert!(pdf_bytes.starts_with("%PDF"));
+    assert!(pdf_bytes.len() > 128);
+}
+
+#[test]
+fn report_download_rejects_anonymous() {
+    let srv = Server::start();
+    let base = format!("http://127.0.0.1:{}", srv.port);
+    let (_, draft_body) = http_post_json(
+        &format!("{base}/api/reports/draft"),
+        r#"{"title":"Auth Test"}"#,
+        Some(&srv.token),
+    );
+    let report_id = serde_json::from_str::<serde_json::Value>(&draft_body).unwrap()["report_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (status, _) = http_raw(
+        "GET",
+        &format!("{base}/api/reports/{report_id}/download.pdf"),
+        None,
+        None,
+    );
+    assert_eq!(status, 401);
+}

--- a/scripts/openfdd_auth_init.sh
+++ b/scripts/openfdd_auth_init.sh
@@ -73,6 +73,35 @@ done
 mkdir -p "$(dirname "$AUTH_PATH")"
 CONTAINER_AUTH_PATH="/app/workspace/$(basename "$AUTH_PATH")"
 WORKSPACE_MOUNT="$(cd "$(dirname "$AUTH_PATH")" && pwd)"
+HANDOFF="$WORKSPACE_MOUNT/bootstrap_credentials.once.txt"
+AUTH_LOG="$(mktemp "${TMPDIR:-/tmp}/openfdd-auth-init.XXXXXX")"
+trap 'rm -f "$AUTH_LOG"' EXIT
+
+write_bootstrap_handoff_from_log() {
+  [[ "$SHOW_SECRETS" == "true" ]] || return 0
+  local role line
+  local -a creds=()
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*(operator|integrator|agent|admin):[[:space:]]+(.+)$ ]]; then
+      role="${BASH_REMATCH[1]}"
+      creds+=("${role}: ${BASH_REMATCH[2]}")
+    fi
+  done < <(grep -E '^[[:space:]]*(operator|integrator|agent|admin):' "$AUTH_LOG" 2>/dev/null || true)
+  [[ ${#creds[@]} -eq 0 ]] && return 0
+  {
+    echo "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager."
+    echo "# Do NOT paste bcrypt hashes from auth.env.local as login passwords."
+    echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "# Rotate again: ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart"
+    echo
+    printf '%s\n' "${creds[@]}"
+    echo
+    echo "# After saving passwords, delete this file:"
+    echo "#   rm workspace/bootstrap_credentials.once.txt"
+  } >"$HANDOFF"
+  chmod 600 "$HANDOFF" 2>/dev/null || true
+  echo "==> Wrote one-time handoff: $HANDOFF"
+}
 
 run_host() {
   if [[ -n "$HASH_PASSWORD" ]]; then
@@ -88,6 +117,25 @@ run_host() {
     [[ "$FORCE" == "true" ]] && args+=(--force)
     [[ "$SHOW_SECRETS" == "true" ]] && args+=(--show-secrets)
     openfdd-edge "${args[@]}"
+  fi
+}
+
+run_local_binary() {
+  local bin="$1"
+  shift
+  if [[ -n "$HASH_PASSWORD" ]]; then
+    "$bin" auth hash-password "$HASH_PASSWORD"
+  elif [[ "$ROTATE" == "true" ]]; then
+    local args=(auth rotate --out "$AUTH_PATH")
+    [[ "$ROTATE_ALL" == "true" ]] && args+=(--all)
+    [[ -n "$ROTATE_ROLE" ]] && args+=(--role "$ROTATE_ROLE")
+    [[ "$SHOW_SECRETS" == "true" ]] && args+=(--show-secrets)
+    "$bin" "${args[@]}"
+  else
+    local args=(auth init --path "$AUTH_PATH")
+    [[ "$FORCE" == "true" ]] && args+=(--force)
+    [[ "$SHOW_SECRETS" == "true" ]] && args+=(--show-secrets)
+    "$bin" "${args[@]}"
   fi
 }
 
@@ -133,12 +181,15 @@ else
   [[ "$SHOW_SECRETS" == "true" ]] && DOCKER_ARGS+=(--show-secrets)
 fi
 
-if command -v openfdd-edge >/dev/null 2>&1; then
-  run_host
+if [[ -x "$ROOT/target/debug/openfdd-edge" ]]; then
+  run_local_binary "$ROOT/target/debug/openfdd-edge" 2>&1 | tee "$AUTH_LOG"
+elif command -v openfdd-edge >/dev/null 2>&1; then
+  run_host 2>&1 | tee "$AUTH_LOG"
 else
   img="$(resolve_docker_image)"
-  run_docker "$img"
+  run_docker "$img" 2>&1 | tee "$AUTH_LOG"
 fi
+write_bootstrap_handoff_from_log
 
 chmod 600 "$AUTH_PATH" 2>/dev/null || true
 echo "==> Auth env: $AUTH_PATH"

--- a/scripts/openfdd_auth_init.sh
+++ b/scripts/openfdd_auth_init.sh
@@ -22,6 +22,7 @@ ROTATE=false
 ROTATE_ALL=false
 ROTATE_ROLE=""
 HASH_PASSWORD=""
+RESTART=false
 SUBCMD=(auth init --path "$AUTH_PATH")
 
 usage() {
@@ -41,6 +42,7 @@ Options:
   --all                 Rotate all roles + OFDD_AUTH_SECRET (invalidates JWTs)
   --role NAME           Rotate one role: operator|integrator|agent|admin
   --hash-password PASS  Print bcrypt hash for manual auth.env.local editing
+  --restart             After init/rotate, recreate local openfdd-bridge container
   -h, --help            Show this help
 
 After rotate or force init, recreate bridge containers to pick up new env.
@@ -62,6 +64,7 @@ while [[ $# -gt 0 ]]; do
     --all) ROTATE_ALL=true; shift ;;
     --role) ROTATE_ROLE="$2"; shift 2 ;;
     --hash-password) HASH_PASSWORD="$2"; SUBCMD=(auth hash-password "$2"); shift 2 ;;
+    --restart) RESTART=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -139,4 +142,12 @@ fi
 
 chmod 600 "$AUTH_PATH" 2>/dev/null || true
 echo "==> Auth env: $AUTH_PATH"
-echo "==> Recreate bridge after rotate/force: docker compose -f docker-compose.local.yml up -d --force-recreate openfdd-bridge"
+if [[ "$RESTART" == "true" ]]; then
+  export OPENFDD_RUN_UID="${OPENFDD_RUN_UID:-$(id -u)}"
+  export OPENFDD_RUN_GID="${OPENFDD_RUN_GID:-$(id -g)}"
+  echo "==> Recreating openfdd-bridge to reload auth env"
+  docker compose -f "$ROOT/docker-compose.local.yml" up -d --force-recreate openfdd-bridge
+else
+  echo "==> Recreate bridge after rotate/force: docker compose -f docker-compose.local.yml up -d --force-recreate openfdd-bridge"
+  echo "==> Or re-run with --restart"
+fi

--- a/scripts/openfdd_auth_lib.sh
+++ b/scripts/openfdd_auth_lib.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Resolve plaintext password for an auth role from bootstrap handoff or env.
+# auth.env.local stores bcrypt hashes only — never use OFDD_*_PASSWORD_HASH as password.
+#
+# Usage: openfdd_auth_plaintext_password <auth.env.local path> <role>
+# Env override: OPENFDD_INTEGRATOR_PASSWORD, OPENFDD_AGENT_PASSWORD, OPENFDD_OPERATOR_PASSWORD
+openfdd_auth_plaintext_password() {
+  local auth_file="${1:?auth file}"
+  local role="${2:?role}"
+  local role_upper env_key pw handoff ws
+
+  role_upper="$(printf '%s' "$role" | tr '[:lower:]' '[:upper:]')"
+  env_key="OPENFDD_${role_upper}_PASSWORD"
+  if [[ -n "${!env_key:-}" ]]; then
+    printf '%s' "${!env_key}"
+    return 0
+  fi
+
+  ws="$(dirname "$auth_file")"
+  handoff="$ws/bootstrap_credentials.once.txt"
+  if [[ -f "$handoff" ]]; then
+    pw="$(grep -E "^${role}:" "$handoff" | head -1 | cut -d: -f2- | sed 's/^ //' || true)"
+    if [[ -n "$pw" && "$pw" != \$2b\$* ]]; then
+      printf '%s' "$pw"
+      return 0
+    fi
+  fi
+
+  local plain_key="OFDD_${role_upper}_PASSWORD"
+  if [[ -f "$auth_file" ]]; then
+    pw="$(grep "^${plain_key}=" "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
+    if [[ -n "$pw" && "$pw" != \$2b\$* ]]; then
+      printf '%s' "$pw"
+      return 0
+    fi
+  fi
+
+  echo "ERROR: no plaintext password for role '$role'. Run:" >&2
+  echo "  ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart" >&2
+  echo "Or set ${env_key} or create $handoff" >&2
+  return 1
+}
+
+openfdd_auth_login_token() {
+  local base="${1:?base url}"
+  local auth_file="${2:?auth file}"
+  local role="${3:-integrator}"
+  local user pw
+  user="$(grep "^OFDD_${role^^}_USER=" "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
+  user="${user:-$role}"
+  pw="$(openfdd_auth_plaintext_password "$auth_file" "$role")" || return 1
+  curl -fsS -X POST "${base}/api/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg u "$user" --arg p "$pw" '{username:$u,password:$p}')" \
+    | jq -r '.token // .access_token // empty'
+}

--- a/scripts/openfdd_auth_lib.sh
+++ b/scripts/openfdd_auth_lib.sh
@@ -46,10 +46,12 @@ openfdd_auth_login_token() {
   local auth_file="${2:?auth file}"
   local role="${3:-integrator}"
   local user pw
+  local CURL_TLS=()
+  if [[ "$base" == https://* ]]; then CURL_TLS=(-k); fi
   user="$(grep "^OFDD_${role^^}_USER=" "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
   user="${user:-$role}"
   pw="$(openfdd_auth_plaintext_password "$auth_file" "$role")" || return 1
-  curl -fsS -X POST "${base}/api/auth/login" \
+  curl "${CURL_TLS[@]}" -fsS -X POST "${base}/api/auth/login" \
     -H 'Content-Type: application/json' \
     -d "$(jq -nc --arg u "$user" --arg p "$pw" '{username:$u,password:$p}')" \
     | jq -r '.token // .access_token // empty'

--- a/scripts/openfdd_auth_smoke.sh
+++ b/scripts/openfdd_auth_smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Login smoke test — verifies workspace/auth.env.local credentials against a running bridge.
+# Does not print passwords or tokens.
+#
+#   OPENFDD_AUTH_SMOKE_PASSWORD='...' ./scripts/openfdd_auth_smoke.sh
+#   ./scripts/openfdd_auth_smoke.sh --credentials workspace/bootstrap_credentials.once.txt
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
+CRED_FILE=""
+PASSWORD="${OPENFDD_AUTH_SMOKE_PASSWORD:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/openfdd_auth_smoke.sh [--credentials FILE] [--base URL]
+
+Tests POST /api/auth/login and GET /api/auth/me for operator, integrator, and agent.
+Provide password via OPENFDD_AUTH_SMOKE_PASSWORD or a bootstrap credentials file (username: password lines).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --credentials) CRED_FILE="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PASSWORD" && -n "$CRED_FILE" ]]; then
+  [[ -f "$CRED_FILE" ]] || { echo "Missing credentials file: $CRED_FILE" >&2; exit 1; }
+fi
+
+lookup_password() {
+  local user="$1"
+  if [[ -n "$PASSWORD" ]]; then
+    printf '%s' "$PASSWORD"
+    return 0
+  fi
+  if [[ -n "$CRED_FILE" ]]; then
+    local line
+    line="$(grep -E "^${user}:" "$CRED_FILE" | head -1 || true)"
+    [[ -n "$line" ]] || return 1
+    printf '%s' "${line#*: }"
+    return 0
+  fi
+  return 1
+}
+
+login_as() {
+  local user="$1"
+  local pass
+  pass="$(lookup_password "$user")" || {
+    echo "FAIL: no password for $user (set OPENFDD_AUTH_SMOKE_PASSWORD or --credentials)" >&2
+    return 1
+  }
+  if [[ "$pass" == \$2b\$* ]]; then
+    echo "FAIL: $user password looks like a bcrypt hash — use plaintext from bootstrap, not auth.env.local" >&2
+    return 1
+  fi
+  local body token me_role
+  body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2]}))' "$user" "$pass")"
+  local resp
+  resp="$(curl -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' -d "$body")" || {
+    echo "FAIL: login HTTP error for $user" >&2
+    return 1
+  }
+  if ! printf '%s' "$resp" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"; then
+    echo "FAIL: login rejected for $user" >&2
+    return 1
+  fi
+  token="$(printf '%s' "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")"
+  me_role="$(curl -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | python3 -c "import json,sys; print(json.load(sys.stdin).get('role',''))")"
+  if [[ "$me_role" != "$user" && ! ( "$user" == "integrator" && "$me_role" == "integrator" ) ]]; then
+    if [[ "$me_role" != "$user" ]]; then
+      echo "FAIL: /api/auth/me role mismatch for $user (got $me_role)" >&2
+      return 1
+    fi
+  fi
+  echo "OK: $user login + /api/auth/me"
+}
+
+curl -fsS "$BASE/health" >/dev/null || { echo "Bridge not healthy at $BASE" >&2; exit 1; }
+
+if [[ -n "$PASSWORD" ]]; then
+  login_as integrator
+else
+  CRED_FILE="${CRED_FILE:-$ROOT/workspace/bootstrap_credentials.once.txt}"
+  for role in operator integrator agent; do
+    login_as "$role"
+  done
+fi
+
+echo "Auth smoke passed at $BASE"

--- a/scripts/openfdd_auth_smoke.sh
+++ b/scripts/openfdd_auth_smoke.sh
@@ -4,6 +4,7 @@
 #
 #   ./scripts/openfdd_auth_smoke.sh
 #   OPENFDD_BRIDGE_BASE=http://127.0.0.1:8080 ./scripts/openfdd_auth_smoke.sh
+#   OPENFDD_BRIDGE_BASE=https://192.168.204.55 ./scripts/openfdd_auth_smoke.sh
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -14,6 +15,8 @@ BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
 AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
 CRED_FILE="${OPENFDD_AUTH_CREDENTIALS:-$ROOT/workspace/bootstrap_credentials.once.txt}"
 PASSWORD="${OPENFDD_AUTH_SMOKE_PASSWORD:-}"
+CURL_TLS=()
+if [[ "$BASE" == https://* ]]; then CURL_TLS=(-k); fi
 
 usage() {
   cat <<'EOF'
@@ -28,6 +31,7 @@ Password resolution (in order):
   4. Legacy plaintext keys in auth.env.local
 
 auth.env.local stores bcrypt HASHES — never use OFDD_*_PASSWORD_HASH as the login password.
+If bootstrap handoff is missing: ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart
 EOF
 }
 
@@ -39,6 +43,26 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
+
+if [[ "$BASE" == https://* && ${#CURL_TLS[@]} -eq 0 ]]; then CURL_TLS=(-k); fi
+
+require_bootstrap_or_env() {
+  if [[ -n "$PASSWORD" ]]; then
+    return 0
+  fi
+  for role in operator integrator agent; do
+    if openfdd_auth_plaintext_password "$AUTH" "$role" >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  if [[ -f "$CRED_FILE" ]] && grep -qE '^(operator|integrator|agent):' "$CRED_FILE"; then
+    return 0
+  fi
+  echo "FAIL: no plaintext credentials for auth smoke" >&2
+  echo "  Run: ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart" >&2
+  echo "  Or save roles in $CRED_FILE (see workspace/dashboard/DEV_AUTH.md)" >&2
+  return 1
+}
 
 login_as() {
   local role="$1"
@@ -62,7 +86,7 @@ login_as() {
   fi
   local resp token me_role body
   body="$(jq -nc --arg u "$role" --arg p "$pass" '{username:$u,password:$p}')"
-  if ! resp="$(curl -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' -d "$body")"; then
+  if ! resp="$(curl "${CURL_TLS[@]}" -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' -d "$body")"; then
     echo "FAIL: login HTTP error for $role" >&2
     return 1
   fi
@@ -70,10 +94,11 @@ login_as() {
     local err
     err="$(jq -r '.error // "invalid credentials"' <<<"$resp")"
     echo "FAIL: login rejected for $role — $err" >&2
+    echo "  Hint: auth.env.local holds bcrypt hashes only — not login passwords." >&2
     return 1
   fi
   token="$(jq -r '.token // .access_token // empty' <<<"$resp")"
-  me_role="$(curl -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | jq -r '.role // .principal.role // empty')"
+  me_role="$(curl "${CURL_TLS[@]}" -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | jq -r '.role // .principal.role // empty')"
   if [[ -n "$me_role" && "$me_role" != "$role" ]]; then
     echo "FAIL: /api/auth/me role mismatch for $role (got $me_role)" >&2
     return 1
@@ -81,7 +106,9 @@ login_as() {
   echo "OK: $role login + /api/auth/me"
 }
 
-curl -fsS "$BASE/health" >/dev/null || { echo "Bridge not healthy at $BASE" >&2; exit 1; }
+require_bootstrap_or_env
+
+curl "${CURL_TLS[@]}" -fsS "$BASE/health" >/dev/null || { echo "Bridge not healthy at $BASE" >&2; exit 1; }
 
 if [[ -n "$PASSWORD" ]]; then
   login_as integrator
@@ -91,9 +118,16 @@ else
   done
 fi
 
-# Dashboard summary endpoint (authenticated)
-token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator")"
-curl -fsS "$BASE/api/building/snapshot" -H "Authorization: Bearer $token" >/dev/null
+token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator)"
+curl "${CURL_TLS[@]}" -fsS "$BASE/api/building/snapshot" -H "Authorization: Bearer $token" >/dev/null
 echo "OK: /api/building/snapshot"
+
+summary_out="$(curl "${CURL_TLS[@]}" -fsS "$BASE/api/dashboard/summary" -H "Authorization: Bearer $token")"
+jq -e '.ok == true and .model_coverage != null and .faults != null' <<<"$summary_out" >/dev/null
+echo "OK: /api/dashboard/summary"
+
+analytics_out="$(curl "${CURL_TLS[@]}" -fsS "$BASE/api/dashboard/analytics" -H "Authorization: Bearer $token")"
+jq -e '.ok == true and .rule_health != null' <<<"$analytics_out" >/dev/null
+echo "OK: /api/dashboard/analytics"
 
 echo "Auth smoke passed at $BASE"

--- a/scripts/openfdd_auth_smoke.sh
+++ b/scripts/openfdd_auth_smoke.sh
@@ -1,85 +1,84 @@
 #!/usr/bin/env bash
-# Login smoke test — verifies workspace/auth.env.local credentials against a running bridge.
+# Login smoke test — verifies workspace credentials against a running bridge.
 # Does not print passwords or tokens.
 #
-#   OPENFDD_AUTH_SMOKE_PASSWORD='...' ./scripts/openfdd_auth_smoke.sh
-#   ./scripts/openfdd_auth_smoke.sh --credentials workspace/bootstrap_credentials.once.txt
+#   ./scripts/openfdd_auth_smoke.sh
+#   OPENFDD_BRIDGE_BASE=http://127.0.0.1:8080 ./scripts/openfdd_auth_smoke.sh
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+
 BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
-CRED_FILE=""
+AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
+CRED_FILE="${OPENFDD_AUTH_CREDENTIALS:-$ROOT/workspace/bootstrap_credentials.once.txt}"
 PASSWORD="${OPENFDD_AUTH_SMOKE_PASSWORD:-}"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/openfdd_auth_smoke.sh [--credentials FILE] [--base URL]
+Usage: scripts/openfdd_auth_smoke.sh [--base URL]
 
 Tests POST /api/auth/login and GET /api/auth/me for operator, integrator, and agent.
-Provide password via OPENFDD_AUTH_SMOKE_PASSWORD or a bootstrap credentials file (username: password lines).
+
+Password resolution (in order):
+  1. OPENFDD_AUTH_SMOKE_PASSWORD (single password for integrator-only quick test)
+  2. OPENFDD_{ROLE}_PASSWORD env vars
+  3. workspace/bootstrap_credentials.once.txt (integrator: ..., operator: ..., agent: ...)
+  4. Legacy plaintext keys in auth.env.local
+
+auth.env.local stores bcrypt HASHES — never use OFDD_*_PASSWORD_HASH as the login password.
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --credentials) CRED_FILE="$2"; shift 2 ;;
     --base) BASE="$2"; shift 2 ;;
+    --credentials) CRED_FILE="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
 
-if [[ -z "$PASSWORD" && -n "$CRED_FILE" ]]; then
-  [[ -f "$CRED_FILE" ]] || { echo "Missing credentials file: $CRED_FILE" >&2; exit 1; }
-fi
-
-lookup_password() {
-  local user="$1"
-  if [[ -n "$PASSWORD" ]]; then
-    printf '%s' "$PASSWORD"
-    return 0
-  fi
-  if [[ -n "$CRED_FILE" ]]; then
-    local line
-    line="$(grep -E "^${user}:" "$CRED_FILE" | head -1 || true)"
-    [[ -n "$line" ]] || return 1
-    printf '%s' "${line#*: }"
-    return 0
-  fi
-  return 1
-}
-
 login_as() {
-  local user="$1"
-  local pass
-  pass="$(lookup_password "$user")" || {
-    echo "FAIL: no password for $user (set OPENFDD_AUTH_SMOKE_PASSWORD or --credentials)" >&2
-    return 1
-  }
-  if [[ "$pass" == \$2b\$* ]]; then
-    echo "FAIL: $user password looks like a bcrypt hash — use plaintext from bootstrap, not auth.env.local" >&2
-    return 1
-  fi
-  local body token me_role
-  body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2]}))' "$user" "$pass")"
-  local resp
-  resp="$(curl -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' -d "$body")" || {
-    echo "FAIL: login HTTP error for $user" >&2
-    return 1
-  }
-  if ! printf '%s' "$resp" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"; then
-    echo "FAIL: login rejected for $user" >&2
-    return 1
-  fi
-  token="$(printf '%s' "$resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")"
-  me_role="$(curl -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | python3 -c "import json,sys; print(json.load(sys.stdin).get('role',''))")"
-  if [[ "$me_role" != "$user" && ! ( "$user" == "integrator" && "$me_role" == "integrator" ) ]]; then
-    if [[ "$me_role" != "$user" ]]; then
-      echo "FAIL: /api/auth/me role mismatch for $user (got $me_role)" >&2
-      return 1
+  local role="$1"
+  local pass=""
+  if [[ -n "$PASSWORD" ]]; then
+    pass="$PASSWORD"
+  else
+    pass="$(openfdd_auth_plaintext_password "$AUTH" "$role" 2>/dev/null || true)"
+    if [[ -z "$pass" && -f "$CRED_FILE" ]]; then
+      pass="$(grep -E "^${role}:" "$CRED_FILE" | head -1 | cut -d: -f2- | sed 's/^ //' || true)"
     fi
   fi
-  echo "OK: $user login + /api/auth/me"
+  if [[ -z "$pass" ]]; then
+    echo "FAIL: no plaintext password for $role" >&2
+    echo "  Run: ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart" >&2
+    return 1
+  fi
+  if [[ "$pass" == \$2b\$* ]]; then
+    echo "FAIL: $role password looks like a bcrypt hash — use plaintext from bootstrap handoff" >&2
+    return 1
+  fi
+  local resp token me_role body
+  body="$(jq -nc --arg u "$role" --arg p "$pass" '{username:$u,password:$p}')"
+  if ! resp="$(curl -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' -d "$body")"; then
+    echo "FAIL: login HTTP error for $role" >&2
+    return 1
+  fi
+  if ! jq -e '.ok == true or .token != null or .access_token != null' <<<"$resp" >/dev/null; then
+    local err
+    err="$(jq -r '.error // "invalid credentials"' <<<"$resp")"
+    echo "FAIL: login rejected for $role — $err" >&2
+    return 1
+  fi
+  token="$(jq -r '.token // .access_token // empty' <<<"$resp")"
+  me_role="$(curl -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | jq -r '.role // .principal.role // empty')"
+  if [[ -n "$me_role" && "$me_role" != "$role" ]]; then
+    echo "FAIL: /api/auth/me role mismatch for $role (got $me_role)" >&2
+    return 1
+  fi
+  echo "OK: $role login + /api/auth/me"
 }
 
 curl -fsS "$BASE/health" >/dev/null || { echo "Bridge not healthy at $BASE" >&2; exit 1; }
@@ -87,10 +86,14 @@ curl -fsS "$BASE/health" >/dev/null || { echo "Bridge not healthy at $BASE" >&2;
 if [[ -n "$PASSWORD" ]]; then
   login_as integrator
 else
-  CRED_FILE="${CRED_FILE:-$ROOT/workspace/bootstrap_credentials.once.txt}"
   for role in operator integrator agent; do
     login_as "$role"
   done
 fi
+
+# Dashboard summary endpoint (authenticated)
+token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator")"
+curl -fsS "$BASE/api/building/snapshot" -H "Authorization: Bearer $token" >/dev/null
+echo "OK: /api/building/snapshot"
 
 echo "Auth smoke passed at $BASE"

--- a/scripts/openfdd_bench_extend_disk.sh
+++ b/scripts/openfdd_bench_extend_disk.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Extend root LVM to use all free space on the physical disk (one-time, requires sudo).
+#
+#   sudo ./scripts/openfdd_bench_extend_disk.sh
+#
+# Before: ~100G on / (rest of ~233G disk unused)
+# After:  root uses full ubuntu-vg free extents
+set -euo pipefail
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  echo "ERROR: run with sudo: sudo $0" >&2
+  exit 1
+fi
+
+LV_PATH="/dev/ubuntu-vg/ubuntu-lv"
+[[ -b "$LV_PATH" ]] || LV_PATH="/dev/mapper/ubuntu--vg-ubuntu--lv"
+
+echo "==> Before"
+df -h /
+vgs
+lvs
+
+echo "==> Grow partition (if needed) and PV"
+if command -v growpart >/dev/null 2>&1; then
+  growpart /dev/sda 3 || true
+fi
+pvresize /dev/sda3
+
+echo "==> Extend logical volume to 100% of VG free space"
+lvextend -l +100%FREE "$LV_PATH"
+
+echo "==> Resize filesystem"
+if xfs_info / >/dev/null 2>&1; then
+  xfs_growfs /
+else
+  resize2fs "$LV_PATH"
+fi
+
+echo "==> After"
+df -h /
+vgs
+lvs
+echo "Done. Root should now use the full disk."

--- a/scripts/openfdd_bench_lib.sh
+++ b/scripts/openfdd_bench_lib.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Bench defaults — source from lifecycle scripts (gitignored workspace copy optional).
+# Copy to workspace/bench.env.local to override without editing repo files.
+
+export OPENFDD_CARGO_BUILD_JOBS="${OPENFDD_CARGO_BUILD_JOBS:-1}"
+export OPENFDD_RUST_GHCR_IMAGE="${OPENFDD_RUST_GHCR_IMAGE:-ghcr.io/bbartling/openfdd-edge-rust:latest}"
+# Set to 1 only when you intentionally compile Rust on this host (needs 12GB+ free disk).
+export OPENFDD_ALLOW_LOCAL_BUILD="${OPENFDD_ALLOW_LOCAL_BUILD:-0}"
+
+openfdd_bench_load_env() {
+  local root="${1:?root}"
+  if [[ -f "$root/workspace/bench.env.local" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$root/workspace/bench.env.local"
+    set +a
+  fi
+}
+
+openfdd_bench_free_disk_gb() {
+  local avail_kb
+  avail_kb="$(df --output=avail / | tail -1 | tr -d ' ')"
+  echo $((avail_kb / 1024 / 1024))
+}
+
+openfdd_bench_require_free_disk_gb() {
+  local min_gb="${1:?min gb}"
+  local avail_gb
+  avail_gb="$(openfdd_bench_free_disk_gb)"
+  if [[ "$avail_gb" -lt "$min_gb" ]]; then
+    echo "ERROR: only ${avail_gb}GB free on / — need at least ${min_gb}GB." >&2
+    echo "  Run: ./scripts/openfdd_docker_maintenance.sh --aggressive" >&2
+    echo "  Or:  sudo ./scripts/openfdd_bench_extend_disk.sh" >&2
+    return 1
+  fi
+}
+
+openfdd_bench_require_local_build_allowed() {
+  if [[ "${OPENFDD_ALLOW_LOCAL_BUILD:-0}" != "1" ]]; then
+    echo "ERROR: local Docker Rust --build is disabled on this bench." >&2
+    echo "  Use: ./scripts/openfdd_remote_up.sh  (pulls GHCR + Caddy, no rebuild)" >&2
+    echo "  Or:  ./scripts/openfdd_bench_pull_ghcr.sh" >&2
+    echo "  To allow one rebuild: OPENFDD_ALLOW_LOCAL_BUILD=1 ./scripts/openfdd_local_up.sh --build" >&2
+    return 1
+  fi
+  openfdd_bench_require_free_disk_gb "${1:-12}"
+}

--- a/scripts/openfdd_bench_pull_ghcr.sh
+++ b/scripts/openfdd_bench_pull_ghcr.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Pull published Rust edge from GHCR and tag for local compose (no local compile).
+#
+#   ./scripts/openfdd_bench_pull_ghcr.sh
+#   OPENFDD_RUST_GHCR_IMAGE=ghcr.io/bbartling/openfdd-edge-rust:sha-abc123 ./scripts/openfdd_bench_pull_ghcr.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_bench_lib.sh
+source "$ROOT/scripts/openfdd_bench_lib.sh"
+openfdd_bench_load_env "$ROOT"
+
+GHCR="${OPENFDD_RUST_GHCR_IMAGE:-ghcr.io/bbartling/openfdd-edge-rust:latest}"
+LOCAL="${OPENFDD_LOCAL_BRIDGE_IMAGE:-open-fdd-openfdd-bridge:local}"
+
+echo "==> Pulling $GHCR"
+docker pull "$GHCR"
+echo "==> Tagging as $LOCAL (docker-compose.local.yml)"
+docker tag "$GHCR" "$LOCAL"
+docker tag "$GHCR" "open-fdd-openfdd-bridge:latest"
+echo "OK: bench bridge image ready — no local Rust compile required"
+echo "    Start: ./scripts/openfdd_remote_up.sh"

--- a/scripts/openfdd_bench_setup.sh
+++ b/scripts/openfdd_bench_setup.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# One-time bench hardening: buildx, weekly maintenance cron, bench env template, optional disk extend.
+#
+#   ./scripts/openfdd_bench_setup.sh
+#   sudo ./scripts/openfdd_bench_setup.sh --extend-disk
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXTEND_DISK=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --extend-disk) EXTEND_DISK=1 ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scripts/openfdd_bench_setup.sh [--extend-disk]
+
+  --extend-disk   Run LVM extend (requires sudo — pass on same command line)
+
+Does NOT run local Docker Rust --build. GHCR images are built in GitHub Actions.
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+chmod +x "$ROOT/scripts/openfdd_bench_extend_disk.sh" \
+  "$ROOT/scripts/openfdd_bench_pull_ghcr.sh" \
+  "$ROOT/scripts/openfdd_docker_maintenance.sh" \
+  "$ROOT/scripts/openfdd_remote_up.sh" \
+  "$ROOT/scripts/openfdd_health_check.sh" 2>/dev/null || true
+
+mkdir -p "$ROOT/workspace/logs"
+
+BENCH_ENV="$ROOT/workspace/bench.env.local"
+if [[ ! -f "$BENCH_ENV" ]]; then
+  cat >"$BENCH_ENV" <<'EOF'
+# Bench overrides (gitignored). Defaults keep local Rust --build off.
+OPENFDD_CARGO_BUILD_JOBS=1
+OPENFDD_ALLOW_LOCAL_BUILD=0
+OPENFDD_RUST_GHCR_IMAGE=ghcr.io/bbartling/openfdd-edge-rust:latest
+EOF
+  chmod 600 "$BENCH_ENV"
+  echo "==> Created $BENCH_ENV"
+else
+  echo "==> Keeping existing $BENCH_ENV"
+fi
+
+echo "==> Docker buildx (memory-capped builds when OPENFDD_ALLOW_LOCAL_BUILD=1)"
+if command -v docker >/dev/null 2>&1 && docker buildx version >/dev/null 2>&1; then
+  echo "    buildx already available: $(docker buildx version | head -1)"
+elif [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  apt-get update -qq
+  apt-get install -y -qq docker-buildx-plugin || apt-get install -y -qq docker-buildx || true
+  docker buildx create --name openfdd-bench --use 2>/dev/null || docker buildx use openfdd-bench 2>/dev/null || docker buildx use default
+  echo "    buildx installed"
+else
+  echo "    Install manually (once): sudo apt install docker-buildx-plugin"
+  echo "    Then: docker buildx create --name openfdd-bench --use"
+fi
+
+CRON_LINE="0 3 * * 0 cd $ROOT && ./scripts/openfdd_docker_maintenance.sh --aggressive >> workspace/logs/bench-maintenance.log 2>&1"
+if crontab -l 2>/dev/null | grep -Fq "openfdd_docker_maintenance.sh"; then
+  echo "==> Weekly maintenance cron already installed"
+else
+  existing="$(crontab -l 2>/dev/null || true)"
+  { echo "$existing"; echo "$CRON_LINE"; } | crontab -
+  echo "==> Installed weekly cron (Sun 03:00): openfdd_docker_maintenance.sh --aggressive"
+fi
+
+if [[ "$EXTEND_DISK" == "1" ]]; then
+  "$ROOT/scripts/openfdd_bench_extend_disk.sh"
+else
+  avail="$(df --output=avail / | tail -1 | tr -d ' ')"
+  avail_gb=$((avail / 1024 / 1024))
+  if [[ "$avail_gb" -lt 50 ]]; then
+    echo "==> Tip: root has ${avail_gb}GB free but disk is ~233GB — extend once:"
+    echo "    sudo ./scripts/openfdd_bench_extend_disk.sh"
+  fi
+fi
+
+echo ""
+echo "Bench setup complete."
+echo "  Daily remote dial-in:  ./scripts/openfdd_remote_up.sh"
+echo "  Health check:          ./scripts/openfdd_health_check.sh --remote --auth"
+echo "  Pull GHCR (no build):  ./scripts/openfdd_bench_pull_ghcr.sh"
+echo "  GHCR images built by:  .github/workflows/rust-ghcr.yml (GitHub Actions — not on this host)"

--- a/scripts/openfdd_csv_append_validation.sh
+++ b/scripts/openfdd_csv_append_validation.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# CSV append/import/export/purge helpers for live FDD validation (device 5007).
+# Sourced from smoke_live_fdd_validation.sh — not executed directly.
+set -euo pipefail
+
+openfdd_csv_append_init() {
+  local log_dir="$1"
+  CSV_APPEND_LOG_DIR="$log_dir"
+  CSV_APPEND_SOURCE_ID="${OPENFDD_CSV_SOURCE_ID:-source:validation-csv}"
+  CSV_APPEND_EQUIPMENT_ID="${OPENFDD_CSV_EQUIPMENT_ID:-5007}"
+  CSV_APPEND_PROFILE="${OPENFDD_CSV_IMPORT_PROFILE:-validation_csv_5007}"
+  CSV_APPEND_BATCH="${CSV_APPEND_BATCH:-0}"
+  CSV_APPEND_HIST_ROWS_BEFORE=0
+  CSV_APPEND_HIST_ROWS_AFTER=0
+  CSV_APPEND_JOB_IDS=()
+  mkdir -p "$log_dir/csv_batches"
+}
+
+openfdd_csv_append_generate() {
+  local ts="$1"
+  local phase="${2:-normal}"
+  local batch="$3"
+  local out="$CSV_APPEND_LOG_DIR/csv_batches/batch_${batch}.csv"
+  local oa_t=65.0 oa_h=45.0 duct_t=55.0 zn_t=72.0
+  if [[ "$phase" == "fault" ]]; then
+    oa_t=120.0
+    duct_t=95.0
+  fi
+  cat >"$out" <<EOF
+timestamp,equipment_id,point_key,value,units,source_id
+${ts},${CSV_APPEND_EQUIPMENT_ID},oa_t,${oa_t},degF,${CSV_APPEND_SOURCE_ID}
+${ts},${CSV_APPEND_EQUIPMENT_ID},oa_h,${oa_h},%,${CSV_APPEND_SOURCE_ID}
+${ts},${CSV_APPEND_EQUIPMENT_ID},duct_t,${duct_t},degF,${CSV_APPEND_SOURCE_ID}
+${ts},${CSV_APPEND_EQUIPMENT_ID},zn_t,${zn_t},degF,${CSV_APPEND_SOURCE_ID}
+EOF
+  printf '%s' "$out"
+}
+
+openfdd_csv_append_import_batch() {
+  local base="$1"
+  local token="$2"
+  local ts="$3"
+  local phase="$4"
+  local batch="$5"
+
+  CSV_APPEND_BATCH="$batch"
+  local csv_path
+  csv_path="$(openfdd_csv_append_generate "$ts" "$phase" "$batch")"
+
+  local job_resp job_id
+  job_resp="$(curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/import/jobs" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg profile "$CSV_APPEND_PROFILE" \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      '{profile_id:$profile,source_id:$src,equipment_id:$equip}')")"
+  job_id="$(jq -r '.job_id // empty' <<<"$job_resp")"
+  [[ -n "$job_id" ]] || { echo "csv import job create failed: $job_resp" >&2; return 1; }
+
+  curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/import/jobs/${job_id}/upload" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: text/csv' \
+    --data-binary @"$csv_path" >/dev/null
+
+  curl "${CURL_TLS[@]:-}" -fsS "${base}/api/import/jobs/${job_id}/preview" \
+    -H "Authorization: Bearer $token" \
+    -o "$CSV_APPEND_LOG_DIR/csv_preview_${batch}.json"
+
+  curl "${CURL_TLS[@]:-}" -fsS -X PATCH "${base}/api/import/jobs/${job_id}/options" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      '{source_id:$src,equipment_id:$equip,append:true}')" >/dev/null
+
+  local commit_resp
+  commit_resp="$(curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/import/jobs/${job_id}/commit" \
+    -H "Authorization: Bearer $token")"
+  echo "$commit_resp" >"$CSV_APPEND_LOG_DIR/csv_commit_${batch}.json"
+  CSV_APPEND_JOB_IDS+=("$job_id")
+}
+
+openfdd_csv_append_hist_rows() {
+  local base="$1"
+  local token="$2"
+  curl "${CURL_TLS[@]:-}" -fsS "${base}/api/historian/validation/status" \
+    -H "Authorization: Bearer $token" \
+    | jq -r '.row_count // 0'
+}
+
+openfdd_csv_append_export_checks() {
+  local base="$1"
+  local token="$2"
+  local tag="$3"
+  local out="$CSV_APPEND_LOG_DIR/export_${tag}"
+  mkdir -p "$out"
+  for path in historian.csv faults.csv model-points.csv validation-runs.csv import-jobs.csv; do
+    curl "${CURL_TLS[@]:-}" -fsS "${base}/api/export/${path}" \
+      -H "Authorization: Bearer $token" \
+      -o "$out/$path" || return 1
+    head -1 "$out/$path" >"$out/${path}.header"
+  done
+  jq -nc \
+    --arg tag "$tag" \
+    --arg dir "$out" \
+    --arg hist "$(wc -l <"$out/historian.csv" | tr -d ' ')" \
+    '{tag:$tag,dir:$dir,historian_lines:($hist|tonumber)}' \
+    >"$out/manifest.json"
+}
+
+openfdd_csv_append_purge_validation() {
+  local base="$1"
+  local token="$2"
+  local started="$3"
+  local finished="$4"
+
+  local preview
+  preview="$(curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/data-management/purge/preview" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      --arg after "$started" \
+      --arg before "$finished" \
+      '{source_id:$src,equipment_id:$equip,after_utc:$after,before_utc:$before,historian_subdir:"validation",validation_run:true}')")"
+  echo "$preview" >"$CSV_APPEND_LOG_DIR/purge_preview.json"
+  local matched
+  matched="$(jq -r '.matched_row_count // 0' <<<"$preview")"
+  [[ "$matched" -gt 0 ]] || echo "WARN: purge preview matched 0 rows" >&2
+
+  curl "${CURL_TLS[@]:-}" -fsS -X POST "${base}/api/data-management/purge/execute" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc \
+      --arg src "$CSV_APPEND_SOURCE_ID" \
+      --arg equip "$CSV_APPEND_EQUIPMENT_ID" \
+      --arg after "$started" \
+      --arg before "$finished" \
+      '{source_id:$src,equipment_id:$equip,after_utc:$after,before_utc:$before,historian_subdir:"validation",validation_run:true,confirmation:"PURGE HISTORIAN DATA"}')" \
+    >"$CSV_APPEND_LOG_DIR/purge_execute.json"
+}

--- a/scripts/openfdd_docker_maintenance.sh
+++ b/scripts/openfdd_docker_maintenance.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Safe local Docker + build-artifact maintenance (does not stop running Open-FDD stack).
+#
+#   ./scripts/openfdd_docker_maintenance.sh
+#   ./scripts/openfdd_docker_maintenance.sh --aggressive   # also remove unused images
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AGGRESSIVE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --aggressive) AGGRESSIVE=1 ;;
+    -h|--help)
+      echo "Usage: $0 [--aggressive]"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+echo "==> Before"
+df -h / | tail -1
+docker system df 2>/dev/null || true
+
+echo "==> Remove root-owned Rust target dirs (Docker builds)"
+if [[ -d "$ROOT/edge/target" || -d "$ROOT/target" ]]; then
+  docker run --rm -v "$ROOT:/repo" alpine sh -c 'rm -rf /repo/edge/target /repo/target' 2>/dev/null || true
+fi
+
+echo "==> Prune dangling images, stopped containers, unused volumes"
+docker container prune -f >/dev/null 2>&1 || true
+docker image prune -f >/dev/null 2>&1 || true
+docker volume prune -f >/dev/null 2>&1 || true
+
+echo "==> Prune build cache"
+docker builder prune -af >/dev/null 2>&1 || docker builder prune -af 2>/dev/null || true
+
+if [[ "$AGGRESSIVE" == "1" ]]; then
+  echo "==> Remove unused images (keeps images used by running containers)"
+  docker image prune -a -f >/dev/null 2>&1 || true
+fi
+
+echo "==> After"
+df -h / | tail -1
+docker system df 2>/dev/null || true
+echo "Done. Running containers were not stopped."

--- a/scripts/openfdd_health_check.sh
+++ b/scripts/openfdd_health_check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Quick health check — local bridge, optional LAN/Caddy, optional auth login.
+#
+#   ./scripts/openfdd_health_check.sh
+#   ./scripts/openfdd_health_check.sh --remote
+#   OPENFDD_BRIDGE_BASE=https://192.168.204.55 ./scripts/openfdd_health_check.sh --remote --auth
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+
+BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
+REMOTE=0
+AUTH=0
+CURL_TLS=()
+if [[ "$BASE" == https://* ]]; then CURL_TLS=(-k); fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote) REMOTE=1 ;;
+    --auth) AUTH=1 ;;
+    --base) BASE="$2"; shift 2 ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scripts/openfdd_health_check.sh [--remote] [--auth] [--base URL]
+
+Checks /health, /api/health, optional /api/health/stack, and SPA root.
+With --remote, also probes https://<LAN-IP>/health via Caddy.
+With --auth, verifies integrator login + /api/auth/me.
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+fail=0
+LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+
+check() {
+  local name="$1"
+  local url="$2"
+  local bearer="${3:-}"
+  local code body
+  local curl_args=("${CURL_TLS[@]}" -sS -o /tmp/openfdd_health_body.json -w '%{http_code}' --max-time 8)
+  if [[ -n "$bearer" ]]; then
+    curl_args+=(-H "Authorization: Bearer $bearer")
+  fi
+  code="$(curl "${curl_args[@]}" "$url" 2>/dev/null || echo 000)"
+  if [[ "$code" != "200" ]]; then
+    echo "FAIL: $name HTTP $code ($url)" >&2
+    fail=1
+    return
+  fi
+  body="$(cat /tmp/openfdd_health_body.json 2>/dev/null || true)"
+  if [[ "$body" == *'"ok":true'* || "$body" == *'"ok": true'* || "$url" == *"/health"* ]]; then
+    echo "OK: $name ($code)"
+  else
+    echo "WARN: $name HTTP $code but body may not be ok"
+  fi
+}
+
+df_line="$(df -h / | tail -1)"
+avail_gb="$(df --output=avail / | tail -1 | tr -d ' ')"
+avail_gb=$((avail_gb / 1024 / 1024))
+mem_mb="$(awk '/MemAvailable:/ {print int($2/1024)}' /proc/meminfo)"
+echo "Host: $df_line | MemAvailable: ${mem_mb}MB"
+if [[ "$avail_gb" -lt 5 ]]; then
+  echo "WARN: low disk (${avail_gb}GB free) — run ./scripts/openfdd_docker_maintenance.sh" >&2
+fi
+
+echo "Bridge base: $BASE"
+check public-health "$BASE/health"
+check api-health "$BASE/api/health"
+
+token=""
+if [[ "$AUTH" == "1" ]]; then
+  token="$(openfdd_auth_login_token "$BASE" "$ROOT/workspace/auth.env.local" integrator 2>/dev/null || true)"
+  if [[ -z "$token" ]]; then
+    echo "FAIL: integrator login" >&2
+    fail=1
+  else
+    me="$(curl "${CURL_TLS[@]}" -fsS "$BASE/api/auth/me" -H "Authorization: Bearer $token" | jq -r '.role // empty')"
+    echo "OK: integrator login (role=${me:-integrator})"
+    check stack-health "$BASE/api/health/stack" "$token"
+  fi
+else
+  stack_code="$(curl "${CURL_TLS[@]}" -sS -o /dev/null -w '%{http_code}' --max-time 8 "$BASE/api/health/stack" 2>/dev/null || echo 000)"
+  if [[ "$stack_code" == "401" ]]; then
+    echo "OK: stack-health (401 without auth — expected)"
+  elif [[ "$stack_code" == "200" ]]; then
+    echo "OK: stack-health (200)"
+  else
+    echo "FAIL: stack-health HTTP $stack_code" >&2
+    fail=1
+  fi
+fi
+
+spa_code="$(curl "${CURL_TLS[@]}" -sS -o /dev/null -w '%{http_code}' --max-time 8 "$BASE/" 2>/dev/null || echo 000)"
+if [[ "$spa_code" == "200" ]]; then
+  echo "OK: SPA root ($spa_code)"
+else
+  echo "FAIL: SPA root HTTP $spa_code" >&2
+  fail=1
+fi
+
+if [[ "$REMOTE" == "1" && -n "$LAN_IP" ]]; then
+  if curl -kfsS --max-time 8 "https://${LAN_IP}/health" >/dev/null 2>&1; then
+    echo "OK: Caddy HTTPS https://${LAN_IP}/health"
+  else
+    echo "FAIL: Caddy HTTPS https://${LAN_IP}/health" >&2
+    fail=1
+  fi
+fi
+
+rm -f /tmp/openfdd_health_body.json
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "Health check FAILED" >&2
+  exit 1
+fi
+echo "Health check PASS"

--- a/scripts/openfdd_inspection_build.sh
+++ b/scripts/openfdd_inspection_build.sh
@@ -6,10 +6,15 @@
 #   ./scripts/openfdd_inspection_build.sh --smoke      # also run auth + UI API smoke
 #   ./scripts/openfdd_inspection_build.sh --desktop    # JSON/CSV-only (BACnet/Modbus off)
 #
+# Prefer one command: ./scripts/openfdd_start.sh
+#
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/openfdd_rust_site_lib.sh
 source "$ROOT/scripts/openfdd_rust_site_lib.sh"
+# shellcheck source=scripts/openfdd_bench_lib.sh
+source "$ROOT/scripts/openfdd_bench_lib.sh"
+openfdd_bench_load_env "$ROOT"
 
 BUILD=0
 SMOKE=0
@@ -55,15 +60,20 @@ if [[ ! -f "$AUTH" ]]; then
     "$ROOT/scripts/openfdd_auth_init.sh" --show-secrets
   echo "==> Save passwords from above or from $BOOTSTRAP (gitignored), then delete the handoff file when done."
 elif [[ ! -f "$BOOTSTRAP" ]]; then
-  echo "==> Auth file exists. Login password is NOT the bcrypt hash in auth.env.local."
-  echo "    If you forgot it: ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart"
+  echo "==> No bootstrap handoff — rotating credentials (plaintext shown once)"
+  "$ROOT/scripts/openfdd_auth_init.sh" --rotate --all --show-secrets --restart
 fi
 
 echo "==> Building React dashboard"
-(cd "$ROOT/workspace/dashboard" && npm ci && npm run build)
+if [[ -d "$ROOT/workspace/dashboard/node_modules" ]]; then
+  (cd "$ROOT/workspace/dashboard" && npm run build)
+else
+  (cd "$ROOT/workspace/dashboard" && npm ci && npm run build)
+fi
 
 if [[ "$SKIP_RUST" != "1" ]] && command -v cargo >/dev/null 2>&1; then
   echo "==> Host cargo build (optional sanity check)"
+  openfdd_bench_require_free_disk_gb 6
   (cd "$ROOT/edge" && cargo build --workspace)
 fi
 
@@ -91,6 +101,7 @@ if [[ "$DESKTOP" == "1" ]]; then
 else
   echo "==> Starting local bridge (docker-compose.local.yml)"
   if [[ "$BUILD" == "1" ]]; then
+    openfdd_bench_require_local_build_allowed 12
     "$ROOT/scripts/openfdd_local_up.sh" --build
   else
     "$ROOT/scripts/openfdd_local_up.sh"
@@ -109,9 +120,11 @@ echo
 
 if [[ "$SMOKE" == "1" ]]; then
   echo "==> Auth smoke"
-  OPENFDD_BRIDGE_BASE="$BASE" "$ROOT/scripts/openfdd_auth_smoke.sh" || true
+  OPENFDD_BRIDGE_BASE="$BASE" "$ROOT/scripts/openfdd_auth_smoke.sh"
+  echo "==> Login smoke (all roles)"
+  OPENFDD_BRIDGE_BASE="$BASE" "$ROOT/scripts/openfdd_login_ui_smoke.sh"
   echo "==> UI smoke"
-  OPENFDD_API_BASE="$BASE" "$ROOT/scripts/openfdd_ui_smoke.sh" || true
+  OPENFDD_API_BASE="$BASE" "$ROOT/scripts/openfdd_ui_smoke.sh"
 fi
 
 echo ""

--- a/scripts/openfdd_inspection_build.sh
+++ b/scripts/openfdd_inspection_build.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Local UI inspection build — Rust edge + React dashboard + Docker, no long validation.
+#
+#   ./scripts/openfdd_inspection_build.sh              # start stack (build image if needed)
+#   ./scripts/openfdd_inspection_build.sh --build      # rebuild dashboard + docker image
+#   ./scripts/openfdd_inspection_build.sh --smoke      # also run auth + UI API smoke
+#   ./scripts/openfdd_inspection_build.sh --desktop    # JSON/CSV-only (BACnet/Modbus off)
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_rust_site_lib.sh
+source "$ROOT/scripts/openfdd_rust_site_lib.sh"
+
+BUILD=0
+SMOKE=0
+DESKTOP=0
+SKIP_RUST=0
+COMPOSE_FILE="${COMPOSE_FILE:-$ROOT/docker-compose.local.yml}"
+BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/openfdd_inspection_build.sh [--build] [--smoke] [--desktop] [--skip-rust]
+
+Prepares auth, builds the React dashboard, starts Docker, waits for health, prints UI URL.
+Does NOT run 1-hour or 6-hour validation.
+
+  --build       npm run build + docker image build (local Dockerfile.local)
+  --smoke       Run scripts/openfdd_auth_smoke.sh and scripts/openfdd_ui_smoke.sh
+  --desktop     Use GHCR compose with JSON/CSV-only profile (BACnet/Modbus disabled)
+  --skip-rust   Skip optional host cargo build (Docker image still includes Rust edge)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build) BUILD=1 ;;
+    --smoke) SMOKE=1 ;;
+    --desktop) DESKTOP=1 ;;
+    --skip-rust) SKIP_RUST=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+AUTH="$ROOT/workspace/auth.env.local"
+BOOTSTRAP="$ROOT/workspace/bootstrap_credentials.once.txt"
+
+mkdir -p "$ROOT/workspace/logs"
+
+if [[ ! -f "$AUTH" ]]; then
+  echo "==> Generating $AUTH (plaintext shown once)"
+  "$ROOT/scripts/openfdd_auth_init.sh" --show-secrets --restart || \
+    "$ROOT/scripts/openfdd_auth_init.sh" --show-secrets
+  echo "==> Save passwords from above or from $BOOTSTRAP (gitignored), then delete the handoff file when done."
+elif [[ ! -f "$BOOTSTRAP" ]]; then
+  echo "==> Auth file exists. Login password is NOT the bcrypt hash in auth.env.local."
+  echo "    If you forgot it: ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart"
+fi
+
+echo "==> Building React dashboard"
+(cd "$ROOT/workspace/dashboard" && npm ci && npm run build)
+
+if [[ "$SKIP_RUST" != "1" ]] && command -v cargo >/dev/null 2>&1; then
+  echo "==> Host cargo build (optional sanity check)"
+  (cd "$ROOT/edge" && cargo build --workspace)
+fi
+
+export OPENFDD_COMPOSE_ROOT="$ROOT"
+export OPENFDD_RUN_UID="${OPENFDD_RUN_UID:-$(id -u)}"
+export OPENFDD_RUN_GID="${OPENFDD_RUN_GID:-$(id -g)}"
+
+if [[ "$DESKTOP" == "1" ]]; then
+  echo "==> Starting desktop JSON/CSV inspection profile (GHCR compose)"
+  export OPENFDD_BACNET_ENABLED=0
+  export OPENFDD_MODBUS_ENABLED=0
+  export OPENFDD_HAYSTACK_ENABLED=0
+  export OPENFDD_JSON_API_ENABLED=1
+  export OPENFDD_IMPORT_ENABLED=1
+  export OPENFDD_EXPORT_ENABLED=1
+  if [[ "$BUILD" == "1" ]]; then
+    docker compose -f "$ROOT/docker/compose.edge.rust.yml" \
+      -f "$ROOT/docker/compose.desktop.json-csv.yml" \
+      --profile desktop-json-csv up -d --build
+  else
+    docker compose -f "$ROOT/docker/compose.edge.rust.yml" \
+      -f "$ROOT/docker/compose.desktop.json-csv.yml" \
+      --profile desktop-json-csv up -d
+  fi
+else
+  echo "==> Starting local bridge (docker-compose.local.yml)"
+  if [[ "$BUILD" == "1" ]]; then
+    "$ROOT/scripts/openfdd_local_up.sh" --build
+  else
+    "$ROOT/scripts/openfdd_local_up.sh"
+  fi
+fi
+
+echo "==> Waiting for health at $BASE"
+for i in $(seq 1 45); do
+  if curl -fsS "$BASE/health" >/dev/null 2>&1 && curl -fsS "$BASE/api/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+curl -fsS "$BASE/api/health" | head -c 400
+echo
+
+if [[ "$SMOKE" == "1" ]]; then
+  echo "==> Auth smoke"
+  OPENFDD_BRIDGE_BASE="$BASE" "$ROOT/scripts/openfdd_auth_smoke.sh" || true
+  echo "==> UI smoke"
+  OPENFDD_API_BASE="$BASE" "$ROOT/scripts/openfdd_ui_smoke.sh" || true
+fi
+
+echo ""
+echo "Open-FDD UI:"
+echo "  $BASE"
+echo ""
+echo "Credentials (plaintext — NOT the bcrypt hash in auth.env.local):"
+if [[ -f "$BOOTSTRAP" ]]; then
+  echo "  $BOOTSTRAP"
+else
+  echo "  (missing — rotate with ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets)"
+fi
+echo ""
+echo "Login users: operator, integrator, agent"
+echo "Tabs to click: / /login /bacnet /modbus /haystack /json-api /model /sql-fdd /plot /reports /data-management"
+echo ""
+if [[ -f "$ROOT/docker/caddy/Caddyfile" ]] && docker ps --format '{{.Names}}' 2>/dev/null | grep -q openfdd-caddy; then
+  echo "Caddy:"
+  echo "  http://localhost"
+  echo "  https://localhost  (curl -k https://localhost/health)"
+fi

--- a/scripts/openfdd_inspection_build.sh
+++ b/scripts/openfdd_inspection_build.sh
@@ -49,6 +49,11 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+# Explicit --build overrides bench.env.local (inspection/dev intent).
+if [[ "$BUILD" == "1" ]]; then
+  export OPENFDD_ALLOW_LOCAL_BUILD=1
+fi
+
 AUTH="$ROOT/workspace/auth.env.local"
 BOOTSTRAP="$ROOT/workspace/bootstrap_credentials.once.txt"
 
@@ -139,7 +144,15 @@ else
 fi
 echo ""
 echo "Login users: operator, integrator, agent"
-echo "Tabs to click: / /login /bacnet /modbus /haystack /json-api /model /sql-fdd /plot /reports /data-management"
+echo "Tabs to click: / /login /bacnet /modbus /haystack /json-api /model /sql-fdd /plot /reports /exports /host /data-management"
+echo ""
+if [[ "$DESKTOP" == "1" ]]; then
+  echo "Stop stack:"
+  echo "  docker compose -f docker/compose.edge.rust.yml -f docker/compose.desktop.json-csv.yml --profile desktop-json-csv down"
+else
+  echo "Stop stack:"
+  echo "  docker compose -f docker-compose.local.yml down"
+fi
 echo ""
 if [[ -f "$ROOT/docker/caddy/Caddyfile" ]] && docker ps --format '{{.Names}}' 2>/dev/null | grep -q openfdd-caddy; then
   echo "Caddy:"

--- a/scripts/openfdd_local_caddy_up.sh
+++ b/scripts/openfdd_local_caddy_up.sh
@@ -23,7 +23,8 @@ Uses workspace/auth.env.local (same JWT users as production).
 
 After start:
   https://<LAN-IP>/     (accept browser cert warning)
-  Login: integrator + password from workspace/auth.env.local
+  Login: integrator + password from workspace/bootstrap_credentials.once.txt
+         (auth.env.local stores bcrypt hashes only — not login passwords)
 
 Requires: open-fdd-openfdd-bridge:local image (run ./scripts/openfdd_local_up.sh --build first)
 EOF
@@ -123,7 +124,9 @@ if [[ -n "$LAN_IP" ]]; then
 else
   echo "    Could not detect LAN IP — use: ip -4 addr show"
 fi
-echo "    Login users: operator, integrator, agent (see workspace/auth.env.local)"
+echo "    Login users: operator, integrator, agent"
+echo "    Passwords: workspace/bootstrap_credentials.once.txt (plaintext)"
+echo "               auth.env.local stores bcrypt hashes only — do not use as login password"
 if [[ "$MODE" == "tls" ]]; then
   echo "    Browser: accept self-signed certificate warning (expected for lab TLS)"
 fi

--- a/scripts/openfdd_local_up.sh
+++ b/scripts/openfdd_local_up.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+# shellcheck source=scripts/openfdd_bench_lib.sh
+source "$ROOT/scripts/openfdd_bench_lib.sh"
+openfdd_bench_load_env "$ROOT"
 
 LOG_DIR="$ROOT/workspace/logs"
 LOG_FILE="$LOG_DIR/local-up.log"
@@ -24,9 +27,9 @@ Usage: scripts/openfdd_local_up.sh [--build]
 
 Starts openfdd-bridge only using docker-compose.local.yml (no GHCR, no npm-in-docker).
 
-  --build   Rebuild image with Dockerfile.local (memory-limited; can take 15–40 min on 8 GB)
+  --build   Rebuild image with Dockerfile.local (requires OPENFDD_ALLOW_LOCAL_BUILD=1 and 12GB+ free disk)
 
-Without --build, reuses image open-fdd-openfdd-bridge:local if present.
+Without --build, reuses open-fdd-openfdd-bridge:local or pulls ghcr.io/bbartling/openfdd-edge-rust:latest.
 
 UI: http://127.0.0.1:8080
 Log: workspace/logs/local-up.log
@@ -108,6 +111,7 @@ build_local_image() {
 }
 
 if [[ "$BUILD" -eq 1 ]]; then
+  openfdd_bench_require_local_build_allowed 12
   echo "==> Building open-fdd-openfdd-bridge:local (jobs=${OPENFDD_CARGO_BUILD_JOBS}, log appended here)"
   build_local_image
   echo "==> Docker build finished"
@@ -115,8 +119,12 @@ elif docker image inspect open-fdd-openfdd-bridge:latest >/dev/null 2>&1; then
   echo "==> Tagging existing open-fdd-openfdd-bridge:latest as :local (no rebuild)"
   docker tag open-fdd-openfdd-bridge:latest open-fdd-openfdd-bridge:local
 elif ! docker image inspect open-fdd-openfdd-bridge:local >/dev/null 2>&1; then
-  echo "==> No local image — run with --build once: ./scripts/openfdd_local_up.sh --build"
-  exit 1
+  echo "==> No local image — pulling from GHCR (no bench compile)"
+  "$ROOT/scripts/openfdd_bench_pull_ghcr.sh" || {
+    echo "ERROR: GHCR pull failed. If offline, run once with:"
+    echo "  OPENFDD_ALLOW_LOCAL_BUILD=1 ./scripts/openfdd_local_up.sh --build"
+    exit 1
+  }
 fi
 
 if [[ "$BUILD" -eq 0 ]] && curl -fsS http://127.0.0.1:8080/api/health >/dev/null 2>&1; then

--- a/scripts/openfdd_local_up.sh
+++ b/scripts/openfdd_local_up.sh
@@ -47,6 +47,11 @@ EOF
   shift
 done
 
+# --build explicitly opts into local Docker compile (overrides workspace/bench.env.local).
+if [[ "$BUILD" -eq 1 ]]; then
+  export OPENFDD_ALLOW_LOCAL_BUILD=1
+fi
+
 if [[ ! -f "$ROOT/workspace/auth.env.local" ]]; then
   echo "ERROR: missing workspace/auth.env.local"
   echo "Create one or copy from workspace/auth.env.example"

--- a/scripts/openfdd_login_ui_smoke.sh
+++ b/scripts/openfdd_login_ui_smoke.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Login smoke — every role via the same API the UI uses, plus SPA health.
+#
+#   ./scripts/openfdd_login_ui_smoke.sh
+#   OPENFDD_BRIDGE_BASE=https://192.168.204.55 ./scripts/openfdd_login_ui_smoke.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+
+BASE="${OPENFDD_BRIDGE_BASE:-http://127.0.0.1:8080}"
+AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
+CRED_FILE="${OPENFDD_AUTH_CREDENTIALS:-$ROOT/workspace/bootstrap_credentials.once.txt}"
+CURL_TLS=()
+if [[ "$BASE" == https://* ]]; then CURL_TLS=(-k); fi
+
+fail=0
+
+login_role() {
+  local role="$1"
+  local pass
+  pass="$(openfdd_auth_plaintext_password "$AUTH" "$role")" || {
+    echo "FAIL: no plaintext for $role — run ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart" >&2
+    return 1
+  }
+  if [[ ${#pass} -gt 20 ]]; then
+    echo "WARN: $role password length ${#pass} — expected ~14 chars after rotate" >&2
+  fi
+  if [[ "$pass" == \$2b\$* ]]; then
+    echo "FAIL: $role password looks like bcrypt hash" >&2
+    return 1
+  fi
+  local body resp token me_role code
+  body="$(jq -nc --arg u "$role" --arg p "$pass" '{username:$u,password:$p}')"
+  resp="$(curl "${CURL_TLS[@]}" -sS -X POST "$BASE/api/auth/login" \
+    -H 'Content-Type: application/json' -d "$body")" || {
+    echo "FAIL: $role login HTTP error" >&2
+    return 1
+  }
+  if ! jq -e '.ok == true' <<<"$resp" >/dev/null; then
+    echo "FAIL: $role login rejected — $(jq -r '.error // "invalid credentials"' <<<"$resp")" >&2
+    return 1
+  fi
+  token="$(jq -r '.token // .access_token // empty' <<<"$resp")"
+  if [[ -z "$token" ]]; then
+    echo "FAIL: $role login missing token/access_token" >&2
+    return 1
+  fi
+  me_role="$(curl "${CURL_TLS[@]}" -fsS "$BASE/api/auth/me" \
+    -H "Authorization: Bearer $token" | jq -r '.role // .principal.role // empty')"
+  if [[ -n "$me_role" && "$me_role" != "$role" ]]; then
+    echo "FAIL: $role /api/auth/me role mismatch (got $me_role)" >&2
+    return 1
+  fi
+  code="$(curl "${CURL_TLS[@]}" -sS -o /dev/null -w '%{http_code}' \
+    "$BASE/api/dashboard/summary" -H "Authorization: Bearer $token")"
+  if [[ "$code" != "200" ]]; then
+    echo "FAIL: $role dashboard summary HTTP $code" >&2
+    return 1
+  fi
+  echo "OK: $role login + me + dashboard (${#pass} char password)"
+}
+
+echo "Login UI smoke at $BASE"
+curl "${CURL_TLS[@]}" -fsS "$BASE/health" >/dev/null
+
+for role in operator integrator agent admin; do
+  login_role "$role" || fail=1
+done
+
+html_code="$(curl "${CURL_TLS[@]}" -sS -o /dev/null -w '%{http_code}' "$BASE/")"
+if [[ "$html_code" != "200" ]]; then
+  echo "FAIL: SPA root HTTP $html_code" >&2
+  fail=1
+else
+  echo "OK: SPA root ($html_code)"
+fi
+
+if [[ -f "$CRED_FILE" ]]; then
+  echo "Credentials: $CRED_FILE"
+else
+  echo "WARN: missing $CRED_FILE" >&2
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "Login UI smoke FAILED" >&2
+  exit 1
+fi
+echo "Login UI smoke PASS"

--- a/scripts/openfdd_remote_up.sh
+++ b/scripts/openfdd_remote_up.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Remote dial-in: safe startup (no Docker rebuild) + Caddy + health check.
+#
+#   ./scripts/openfdd_remote_up.sh
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_bench_lib.sh
+source "$ROOT/scripts/openfdd_bench_lib.sh"
+openfdd_bench_load_env "$ROOT"
+LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+
+echo "==> Preflight: disk + Docker cleanup (no container stop)"
+"$ROOT/scripts/openfdd_docker_maintenance.sh"
+
+if ! docker image inspect open-fdd-openfdd-bridge:local >/dev/null 2>&1; then
+  echo "==> No local bridge image — pull from GHCR (GitHub Actions build, not bench compile)"
+  "$ROOT/scripts/openfdd_bench_pull_ghcr.sh"
+fi
+
+echo "==> Dashboard build (fast — no Docker image rebuild)"
+if [[ -d "$ROOT/workspace/dashboard/node_modules" ]]; then
+  (cd "$ROOT/workspace/dashboard" && npm run build)
+else
+  (cd "$ROOT/workspace/dashboard" && npm ci && npm run build)
+fi
+
+echo "==> Bridge (reuse existing image — no --build)"
+"$ROOT/scripts/openfdd_local_up.sh"
+
+echo "==> Caddy remote ingress"
+"$ROOT/scripts/openfdd_local_caddy_up.sh" --mode tls ${LAN_IP:+--lan-ip "$LAN_IP"}
+
+echo "==> Health check"
+"$ROOT/scripts/openfdd_health_check.sh" --remote --auth
+
+echo ""
+echo "Remote UI:"
+if [[ -n "$LAN_IP" ]]; then
+  echo "  https://${LAN_IP}/"
+fi
+echo "  http://127.0.0.1:8080/  (local only)"
+echo ""
+echo "Login: integrator + password from workspace/bootstrap_credentials.once.txt"
+echo "Quick check: ./scripts/openfdd_health_check.sh --remote --auth"

--- a/scripts/openfdd_rust_site_lib.sh
+++ b/scripts/openfdd_rust_site_lib.sh
@@ -116,25 +116,10 @@ openfdd_rust_login_smoke() {
     echo "ERROR: missing $auth_file" >&2
     return 1
   }
-  local user pass
-  user="$(grep '^OFDD_INTEGRATOR_USER=' "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
-  pass="$(grep '^OFDD_INTEGRATOR_PASSWORD=' "$auth_file" | cut -d= -f2- | tr -d '\r' || true)"
-  [[ -n "$user" && -n "$pass" ]] || {
-    echo "ERROR: integrator credentials missing in auth.env.local" >&2
-    return 1
-  }
+  # shellcheck source=scripts/openfdd_auth_lib.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/openfdd_auth_lib.sh"
   local token
-  token="$(curl -fsS -X POST "${base}/api/auth/login" \
-    -H 'Content-Type: application/json' \
-    -d "$(jq -nc --arg u "$user" --arg p "$pass" '{username:$u,password:$p}')" \
-    2>/dev/null | jq -r '.token // .access_token // empty' || true)"
-  if [[ -z "$token" || "$token" == "null" ]]; then
-    echo "WARN: username/password login failed — trying legacy demo JWT (merge feature/rust-auth-security-parity for production auth)" >&2
-    token="$(curl -fsS -X POST "${base}/api/auth/login" \
-      -H 'Content-Type: application/json' \
-      -d '{"sub":"validate","role":"integrator"}' \
-      | jq -r '.access_token // empty')"
-  fi
+  token="$(openfdd_auth_login_token "$base" "$auth_file" integrator)" || return 1
   [[ -n "$token" && "$token" != "null" ]] || {
     echo "ERROR: login failed (no token returned)" >&2
     return 1

--- a/scripts/openfdd_start.sh
+++ b/scripts/openfdd_start.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# One command: auth (auto-rotate if needed) + dashboard + Docker + smoke.
+# Does NOT run local Docker Rust --build (use openfdd_remote_up.sh for remote dial-in).
+#
+#   ./scripts/openfdd_start.sh
+#   OPENFDD_ALLOW_LOCAL_BUILD=1 ./scripts/openfdd_start.sh --build   # rare; needs 12GB+ free
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ " $* " == *" --build "* ]]; then
+  echo "WARN: --build compiles Rust on this bench — prefer ./scripts/openfdd_remote_up.sh or ./scripts/openfdd_bench_pull_ghcr.sh" >&2
+fi
+exec "$ROOT/scripts/openfdd_inspection_build.sh" --smoke --skip-rust "$@"

--- a/scripts/openfdd_ui_dev.sh
+++ b/scripts/openfdd_ui_dev.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Local React UI dev — Vite hot reload, API proxied to bridge. No Docker Rust --build.
+#
+#   ./scripts/openfdd_ui_dev.sh              # localhost:5173
+#   ./scripts/openfdd_ui_dev.sh --lan        # 0.0.0.0:5173 for remote browser on LAN
+#   ./scripts/openfdd_ui_dev.sh --build-only # sync frontend/ for Caddy :443 without starting Vite
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_bench_lib.sh
+source "$ROOT/scripts/openfdd_bench_lib.sh"
+openfdd_bench_load_env "$ROOT"
+
+LAN=0
+BUILD_ONLY=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lan) LAN=1 ;;
+    --build-only) BUILD_ONLY=1 ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scripts/openfdd_ui_dev.sh [--lan] [--build-only]
+
+Starts (or prepares) local React development:
+  - Bridge from GHCR (no bench Rust compile)
+  - Vite on :5173 with /api + /openfdd-agent proxied to :8080
+
+  --lan         Bind Vite to 0.0.0.0 (remote browser on http://<LAN-IP>:5173)
+  --build-only  npm run build → frontend/ for Caddy/production; skip Vite server
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+
+echo "==> Ensure API bridge is up (GHCR image, no --build)"
+if ! curl -fsS --max-time 3 http://127.0.0.1:8080/health >/dev/null 2>&1; then
+  "$ROOT/scripts/openfdd_local_up.sh"
+fi
+
+echo "==> Dashboard dependencies"
+if [[ -d "$ROOT/workspace/dashboard/node_modules" ]]; then
+  echo "    node_modules present"
+else
+  (cd "$ROOT/workspace/dashboard" && npm ci)
+fi
+
+echo "==> Production bundle → frontend/ (for https:// LAN / Caddy)"
+(cd "$ROOT/workspace/dashboard" && npm run build)
+
+if [[ "$BUILD_ONLY" == "1" ]]; then
+  echo "OK: frontend/ synced — use Caddy https://${LAN_IP:-127.0.0.1}/ or restart bridge mount"
+  exit 0
+fi
+
+export VITE_DEV_HOST="127.0.0.1"
+if [[ "$LAN" == "1" ]]; then
+  export VITE_DEV_HOST="0.0.0.0"
+fi
+
+echo ""
+echo "React UI dev server:"
+echo "  API bridge:  http://127.0.0.1:8080"
+if [[ "$LAN" == "1" && -n "$LAN_IP" ]]; then
+  echo "  Vite (LAN):  http://${LAN_IP}:5173/"
+  echo "  Vite (local): http://127.0.0.1:5173/"
+  echo "  Firewall:    sudo ufw allow 5173/tcp  (if remote browser cannot connect)"
+else
+  echo "  Vite:        http://127.0.0.1:5173/"
+fi
+echo "  Login:       integrator + workspace/bootstrap_credentials.once.txt"
+echo "  Edit files in workspace/dashboard/src/ — saves hot-reload in the browser"
+echo ""
+
+cd "$ROOT/workspace/dashboard"
+exec npm run dev -- --host "$VITE_DEV_HOST"

--- a/scripts/openfdd_ui_smoke.sh
+++ b/scripts/openfdd_ui_smoke.sh
@@ -63,7 +63,7 @@ check_api() {
 }
 
 assert_dashboard_summary() {
-  local out="$ARTIFACT/_api_dashboard_summary.json"
+  local out="$ARTIFACT/dashboard-summary.json"
   if [[ ! -f "$out" ]]; then
     echo "FAIL: dashboard summary artifact missing" >&2
     fail=1
@@ -83,7 +83,7 @@ assert_dashboard_summary() {
 }
 
 assert_dashboard_analytics() {
-  local out="$ARTIFACT/_api_dashboard_analytics.json"
+  local out="$ARTIFACT/dashboard-analytics.json"
   if [[ ! -f "$out" ]]; then
     echo "FAIL: dashboard analytics artifact missing" >&2
     fail=1

--- a/scripts/openfdd_ui_smoke.sh
+++ b/scripts/openfdd_ui_smoke.sh
@@ -62,6 +62,41 @@ check_api() {
   echo "OK: $name ($code)"
 }
 
+assert_dashboard_summary() {
+  local out="$ARTIFACT/_api_dashboard_summary.json"
+  if [[ ! -f "$out" ]]; then
+    echo "FAIL: dashboard summary artifact missing" >&2
+    fail=1
+    return
+  fi
+  if ! jq -e '.model_coverage.equipment_count != null and .model_coverage.point_count != null' "$out" >/dev/null; then
+    echo "FAIL: dashboard summary missing model_coverage counts" >&2
+    fail=1
+    return
+  fi
+  if ! jq -e '.faults != null and .historian_health != null' "$out" >/dev/null; then
+    echo "FAIL: dashboard summary missing faults or historian sections" >&2
+    fail=1
+    return
+  fi
+  echo "OK: dashboard summary shape"
+}
+
+assert_dashboard_analytics() {
+  local out="$ARTIFACT/_api_dashboard_analytics.json"
+  if [[ ! -f "$out" ]]; then
+    echo "FAIL: dashboard analytics artifact missing" >&2
+    fail=1
+    return
+  fi
+  if ! jq -e '.rule_health.rule_count != null' "$out" >/dev/null; then
+    echo "FAIL: dashboard analytics missing rule_health.rule_count" >&2
+    fail=1
+    return
+  fi
+  echo "OK: dashboard analytics shape"
+}
+
 check_route() {
   local route="$1"
   local out="$ARTIFACT/route$(echo "$route" | tr '/' '_').html"
@@ -81,6 +116,9 @@ echo "UI inspection smoke → $ARTIFACT"
 check_api public-health /api/health
 check_api auth-me /api/auth/me
 check_api building-snapshot /api/building/snapshot
+check_api building-status /api/building/status
+check_api dashboard-summary /api/dashboard/summary
+check_api dashboard-analytics /api/dashboard/analytics
 check_api stack-health /api/health/stack
 check_api json-api-sources /api/json-api/sources
 check_api model-haystack /api/model/haystack
@@ -88,6 +126,12 @@ check_api fdd-rules /api/fdd-rules
 check_api historian-status /api/historian/validation/status
 check_api data-management /api/data-management/summary
 check_api export-meta /api/export/meta
+check_api host-stats /api/host/stats
+check_api modbus-poll /api/modbus/poll/status
+check_api modbus-tree /api/modbus/driver/tree
+check_api json-api-poll /api/json-api/poll/status
+check_api json-api-tree /api/json-api/driver/tree
+check_api model-equipment "/api/model/sites/site%3Ademo/equipment"
 
 if [[ "$CHECK_REPORTS" == "1" ]]; then
   check_api reports-templates /api/reports/templates
@@ -104,10 +148,15 @@ for route in \
   /sql-fdd \
   /plot \
   /reports \
+  /exports \
+  /host \
   /data-management \
   /live-fdd-validation; do
   check_route "$route"
 done
+
+assert_dashboard_summary
+assert_dashboard_analytics
 
 jq -nc \
   --arg finished "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/scripts/openfdd_ui_smoke.sh
+++ b/scripts/openfdd_ui_smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Programmatic UI smoke — visits key tabs, fails on HTTP 500 or obvious API errors.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+
+BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
+AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
+ARTIFACT="${OPENFDD_UI_SMOKE_ARTIFACT:-$ROOT/workspace/logs/ui_smoke_$(date -u +%Y%m%dT%H%M%SZ)}"
+CURL_TLS=()
+if [[ "$BASE" == https://* ]]; then CURL_TLS=(-k); fi
+
+mkdir -p "$ARTIFACT"
+fail=0
+
+token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator)" || exit 1
+
+check_api() {
+  local name="$1"
+  local path="$2"
+  local method="${3:-GET}"
+  local out="$ARTIFACT/${name//\//_}.json"
+  local code
+  code="$(curl "${CURL_TLS[@]}" -sS -o "$out" -w '%{http_code}' \
+    -X "$method" "${BASE}${path}" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    ${4:+-d "$4"})"
+  if [[ "$code" == 500 ]]; then
+    echo "FAIL: $name HTTP 500" >&2
+    fail=1
+    return
+  fi
+  if [[ "$code" -ge 400 && "$path" != *"/api/auth/"* ]]; then
+    echo "WARN: $name HTTP $code" >&2
+  fi
+  jq -e '.ok != false or .error == null' "$out" >/dev/null 2>&1 || {
+    if jq -e '.ok == false' "$out" >/dev/null 2>&1; then
+      echo "FAIL: $name returned ok:false — $(jq -r '.error // .message // "unknown"' "$out")" >&2
+      fail=1
+    fi
+  }
+  echo "OK: $name ($code)"
+}
+
+echo "UI smoke artifact: $ARTIFACT"
+check_api health /api/health
+check_api stack-health /api/health/stack
+check_api validation-status /api/validation-runs/current/status
+check_api json-api-sources /api/json-api/sources
+check_api model-haystack /api/model/haystack
+check_api fdd-rules /api/fdd-rules
+check_api historian-status /api/historian/validation/status
+check_api data-management /api/data-management/summary
+check_api export-meta /api/export/meta
+check_api reports-templates /api/reports/templates
+check_api reports-draft /api/reports/draft POST '{"template_id":"validation-summary","title":"UI Smoke Report"}'
+
+report_id="$(jq -r '.report_id // empty' "$ARTIFACT/reports-draft.json")"
+if [[ -n "$report_id" ]]; then
+  check_api report-get "/api/reports/${report_id}"
+  check_api report-render "/api/reports/${report_id}/render/pdf" POST '{}'
+  pdf_code="$(curl "${CURL_TLS[@]}" -sS -o "$ARTIFACT/report.pdf" -w '%{http_code}' \
+    "${BASE}/api/reports/${report_id}/download.pdf" \
+    -H "Authorization: Bearer $token")"
+  if [[ "$pdf_code" != 200 ]]; then
+    echo "FAIL: report PDF download HTTP $pdf_code" >&2
+    fail=1
+  elif [[ ! -s "$ARTIFACT/report.pdf" ]]; then
+    echo "FAIL: report PDF empty" >&2
+    fail=1
+  else
+    echo "OK: report PDF ($(wc -c <"$ARTIFACT/report.pdf" | tr -d ' ') bytes)"
+  fi
+fi
+
+# Static SPA routes should return HTML (no 500 from bridge)
+for route in / /login /plot /model /sql-fdd /json-api /data-management /haystack /bacnet /modbus /live-fdd-validation /reports; do
+  code="$(curl "${CURL_TLS[@]}" -sS -o "$ARTIFACT/route$(echo "$route" | tr '/' '_').html" -w '%{http_code}' "${BASE}${route}")"
+  if [[ "$code" == 500 ]]; then
+    echo "FAIL: route $route HTTP 500" >&2
+    fail=1
+  else
+    echo "OK: route $route ($code)"
+  fi
+done
+
+jq -nc --arg finished "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg dir "$ARTIFACT" --argjson fail "$fail" \
+  '{finished_at:$finished,artifact_dir:$dir,failed:$fail}' >"$ARTIFACT/final_report.json"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "UI smoke FAILED — see $ARTIFACT" >&2
+  exit 1
+fi
+echo "UI smoke PASS — $ARTIFACT"

--- a/scripts/openfdd_ui_smoke.sh
+++ b/scripts/openfdd_ui_smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Programmatic UI smoke — visits key tabs, fails on HTTP 500 or obvious API errors.
+# Lightweight UI inspection smoke — API + SPA routes, no long validation or field hardware.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/openfdd_auth_lib.sh
@@ -8,89 +8,117 @@ source "$ROOT/scripts/openfdd_auth_lib.sh"
 BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
 AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
 ARTIFACT="${OPENFDD_UI_SMOKE_ARTIFACT:-$ROOT/workspace/logs/ui_smoke_$(date -u +%Y%m%dT%H%M%SZ)}"
+CHECK_REPORTS="${OPENFDD_UI_SMOKE_REPORTS:-1}"
 CURL_TLS=()
 if [[ "$BASE" == https://* ]]; then CURL_TLS=(-k); fi
 
 mkdir -p "$ARTIFACT"
 fail=0
 
-token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator)" || exit 1
+if [[ ! -f "$AUTH" ]]; then
+  echo "ERROR: missing $AUTH — run ./scripts/openfdd_inspection_build.sh first" >&2
+  exit 1
+fi
+
+token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator)" || {
+  echo "ERROR: integrator login failed — use plaintext from workspace/bootstrap_credentials.once.txt" >&2
+  echo "       auth.env.local stores bcrypt hashes only; do not paste OFDD_*_PASSWORD_HASH as password." >&2
+  exit 1
+}
 
 check_api() {
   local name="$1"
   local path="$2"
   local method="${3:-GET}"
+  local data="${4:-}"
   local out="$ARTIFACT/${name//\//_}.json"
   local code
-  code="$(curl "${CURL_TLS[@]}" -sS -o "$out" -w '%{http_code}' \
-    -X "$method" "${BASE}${path}" \
-    -H "Authorization: Bearer $token" \
-    -H 'Content-Type: application/json' \
-    ${4:+-d "$4"})"
+  if [[ -n "$data" ]]; then
+    code="$(curl "${CURL_TLS[@]}" -sS -o "$out" -w '%{http_code}' \
+      -X "$method" "${BASE}${path}" \
+      -H "Authorization: Bearer $token" \
+      -H 'Content-Type: application/json' \
+      -d "$data")"
+  else
+    code="$(curl "${CURL_TLS[@]}" -sS -o "$out" -w '%{http_code}' \
+      -X "$method" "${BASE}${path}" \
+      -H "Authorization: Bearer $token")"
+  fi
   if [[ "$code" == 500 ]]; then
     echo "FAIL: $name HTTP 500" >&2
     fail=1
     return
   fi
-  if [[ "$code" -ge 400 && "$path" != *"/api/auth/"* ]]; then
-    echo "WARN: $name HTTP $code" >&2
+  if [[ "$code" -ge 400 ]]; then
+    echo "FAIL: $name HTTP $code" >&2
+    fail=1
+    return
   fi
-  jq -e '.ok != false or .error == null' "$out" >/dev/null 2>&1 || {
-    if jq -e '.ok == false' "$out" >/dev/null 2>&1; then
-      echo "FAIL: $name returned ok:false — $(jq -r '.error // .message // "unknown"' "$out")" >&2
-      fail=1
-    fi
-  }
+  if jq -e '.ok == false' "$out" >/dev/null 2>&1; then
+    echo "FAIL: $name ok:false — $(jq -r '.error // "unknown"' "$out")" >&2
+    fail=1
+    return
+  fi
   echo "OK: $name ($code)"
 }
 
-echo "UI smoke artifact: $ARTIFACT"
-check_api health /api/health
+check_route() {
+  local route="$1"
+  local out="$ARTIFACT/route$(echo "$route" | tr '/' '_').html"
+  local code
+  code="$(curl "${CURL_TLS[@]}" -sS -o "$out" -w '%{http_code}' "${BASE}${route}")"
+  if [[ "$code" == 500 ]]; then
+    echo "FAIL: route $route HTTP 500" >&2
+    fail=1
+  elif [[ "$code" -ge 400 && "$route" != "/login" ]]; then
+    echo "WARN: route $route HTTP $code" >&2
+  else
+    echo "OK: route $route ($code)"
+  fi
+}
+
+echo "UI inspection smoke → $ARTIFACT"
+check_api public-health /api/health
+check_api auth-me /api/auth/me
+check_api building-snapshot /api/building/snapshot
 check_api stack-health /api/health/stack
-check_api validation-status /api/validation-runs/current/status
 check_api json-api-sources /api/json-api/sources
 check_api model-haystack /api/model/haystack
 check_api fdd-rules /api/fdd-rules
 check_api historian-status /api/historian/validation/status
 check_api data-management /api/data-management/summary
 check_api export-meta /api/export/meta
-check_api reports-templates /api/reports/templates
-check_api reports-draft /api/reports/draft POST '{"template_id":"validation-summary","title":"UI Smoke Report"}'
 
-report_id="$(jq -r '.report_id // empty' "$ARTIFACT/reports-draft.json")"
-if [[ -n "$report_id" ]]; then
-  check_api report-get "/api/reports/${report_id}"
-  check_api report-render "/api/reports/${report_id}/render/pdf" POST '{}'
-  pdf_code="$(curl "${CURL_TLS[@]}" -sS -o "$ARTIFACT/report.pdf" -w '%{http_code}' \
-    "${BASE}/api/reports/${report_id}/download.pdf" \
-    -H "Authorization: Bearer $token")"
-  if [[ "$pdf_code" != 200 ]]; then
-    echo "FAIL: report PDF download HTTP $pdf_code" >&2
-    fail=1
-  elif [[ ! -s "$ARTIFACT/report.pdf" ]]; then
-    echo "FAIL: report PDF empty" >&2
-    fail=1
-  else
-    echo "OK: report PDF ($(wc -c <"$ARTIFACT/report.pdf" | tr -d ' ') bytes)"
-  fi
+if [[ "$CHECK_REPORTS" == "1" ]]; then
+  check_api reports-templates /api/reports/templates
 fi
 
-# Static SPA routes should return HTML (no 500 from bridge)
-for route in / /login /plot /model /sql-fdd /json-api /data-management /haystack /bacnet /modbus /live-fdd-validation /reports; do
-  code="$(curl "${CURL_TLS[@]}" -sS -o "$ARTIFACT/route$(echo "$route" | tr '/' '_').html" -w '%{http_code}' "${BASE}${route}")"
-  if [[ "$code" == 500 ]]; then
-    echo "FAIL: route $route HTTP 500" >&2
-    fail=1
-  else
-    echo "OK: route $route ($code)"
-  fi
+for route in \
+  / \
+  /login \
+  /bacnet \
+  /modbus \
+  /haystack \
+  /json-api \
+  /model \
+  /sql-fdd \
+  /plot \
+  /reports \
+  /data-management \
+  /live-fdd-validation; do
+  check_route "$route"
 done
 
-jq -nc --arg finished "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg dir "$ARTIFACT" --argjson fail "$fail" \
-  '{finished_at:$finished,artifact_dir:$dir,failed:$fail}' >"$ARTIFACT/final_report.json"
+jq -nc \
+  --arg finished "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg dir "$ARTIFACT" \
+  --arg base "$BASE" \
+  --argjson fail "$fail" \
+  '{finished_at:$finished,artifact_dir:$dir,base:$base,failed:$fail,mode:"ui_inspection_smoke"}' \
+  >"$ARTIFACT/final_report.json"
 
 if [[ "$fail" -ne 0 ]]; then
-  echo "UI smoke FAILED — see $ARTIFACT" >&2
+  echo "UI inspection smoke FAILED — see $ARTIFACT" >&2
   exit 1
 fi
-echo "UI smoke PASS — $ARTIFACT"
+echo "UI inspection smoke PASS — $ARTIFACT"

--- a/scripts/smoke_live_fdd_validation.sh
+++ b/scripts/smoke_live_fdd_validation.sh
@@ -30,6 +30,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/openfdd_rust_site_lib.sh
 source "$ROOT/scripts/openfdd_rust_site_lib.sh"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+# shellcheck source=scripts/openfdd_csv_append_validation.sh
+source "$ROOT/scripts/openfdd_csv_append_validation.sh"
 
 BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
 CURL_TLS=()
@@ -49,6 +53,7 @@ REQUIRE_MODBUS="${OPENFDD_SMOKE_REQUIRE_MODBUS:-0}"
 VALIDATE_DOCKER="${OPENFDD_SMOKE_VALIDATE_DOCKER:-1}"
 VALIDATE_MODBUS="${OPENFDD_SMOKE_VALIDATE_MODBUS:-1}"
 VALIDATE_JSON="${OPENFDD_SMOKE_VALIDATE_JSON_API:-1}"
+CSV_APPEND="${OPENFDD_SMOKE_CSV_APPEND:-1}"
 JSON_API_URL="${OPENFDD_SMOKE_JSON_API_URL:-https://httpbin.org/get}"
 NO_DEMO_PASS="${OPENFDD_SMOKE_NO_DEMO_PASS:-0}"
 SHORT_FDD="${BENCH_SMOKE_SHORT_FDD:-0}"
@@ -113,7 +118,9 @@ write_final_report() {
     --argjson seen_confirmed "$SEEN_CONFIRMED" \
     --argjson seen_clear "$SEEN_CLEAR" \
     --arg artifact "$LOG_DIR" \
-    '{finished_at:$finished,samples:$samples,interval_failures:$failures,live_fdd_pass:$live_pass,demo_only:$demo_only,seen_raw_fault:$seen_raw,seen_confirmed_fault:$seen_confirmed,seen_clear:$seen_clear,artifact_dir:$artifact}' \
+    --arg report_pdf "$LOG_DIR/validation_report.pdf" \
+    --argjson csv_before "${CSV_APPEND_HIST_ROWS_BEFORE:-0}" \
+    '{finished_at:$finished,samples:$samples,interval_failures:$failures,live_fdd_pass:$live_pass,demo_only:$demo_only,seen_raw_fault:$seen_raw,seen_confirmed_fault:$seen_confirmed,seen_clear:$seen_clear,artifact_dir:$artifact,validation_report_pdf:$report_pdf,csv_hist_rows_before:$csv_before}' \
     >"$LOG_DIR/final_report.json"
 
   {
@@ -223,8 +230,8 @@ if [[ ! -f "$AUTH" ]]; then
   exit 1
 fi
 
-INTEGRATOR_PW="$(grep '^OFDD_INTEGRATOR_PASSWORD=' "$AUTH" | cut -d= -f2- | tr -d '\r')"
-AGENT_PW="$(grep '^OFDD_AGENT_PASSWORD=' "$AUTH" | cut -d= -f2- | tr -d '\r')"
+INTEGRATOR_PW="$(openfdd_auth_plaintext_password "$AUTH" integrator)" || exit 1
+AGENT_PW="$(openfdd_auth_plaintext_password "$AUTH" agent)" || exit 1
 
 login() {
   local user="$1" pw="$2"
@@ -236,6 +243,11 @@ login() {
 
 INT_TOKEN="$(login integrator "$INTEGRATOR_PW")"
 AGENT_TOKEN="$(login agent "$AGENT_PW")"
+
+if [[ "$CSV_APPEND" == "1" ]]; then
+  openfdd_csv_append_init "$LOG_DIR"
+  CSV_APPEND_HIST_ROWS_BEFORE="$(openfdd_csv_append_hist_rows "$BASE" "$INT_TOKEN")"
+fi
 
 if [[ "$SHORT_FDD" == "1" ]]; then
   INTERVAL="${OPENFDD_SMOKE_INTERVAL_SECONDS:-60}"
@@ -266,8 +278,10 @@ jq -nc \
   '{profile_id:$profile,device_instance:($device|tonumber?),interval_seconds:$interval,duration_hours:($hours|tonumber?),json_api_url:$json_url,mode:$mode,artifact_dir:$artifact,started_at:(now|todate)}' \
   >"$LOG_DIR/run_config.json"
 
-echo "Live FDD validation mode=$MODE_LABEL interval=${INTERVAL}s artifact=$LOG_DIR device=$DEVICE_INSTANCE simulate=$SIMULATE" | tee "$LOG_DIR/run.log"
+echo "Live FDD validation mode=$MODE_LABEL interval=${INTERVAL}s artifact=$LOG_DIR device=$DEVICE_INSTANCE simulate=$SIMULATE csv_append=$CSV_APPEND" | tee "$LOG_DIR/run.log"
 echo "Started: $(date -Iseconds)" | tee -a "$LOG_DIR/run.log"
+
+VALIDATION_STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 capture_docker_state start
 LAST_DOCKER_SINCE="1m"
@@ -325,6 +339,8 @@ while true; do
   modbus_registers_read=0
   json_api_ok=false
   json_api_points_read=0
+  csv_import_ok=true
+  csv_hist_delta=0
   override_scan_ok=false
   err_msg=""
   data_source="unknown"
@@ -393,6 +409,20 @@ while true; do
     fi
   else
     json_api_ok=true
+  fi
+
+  if [[ "$CSV_APPEND" == "1" ]]; then
+    csv_interval="${OPENFDD_SMOKE_CSV_INTERVAL_SECONDS:-300}"
+    if (( sample_n == 1 || (INTERVAL > 0 && (sample_n * INTERVAL) % csv_interval == 0) )); then
+      hist_before="$(openfdd_csv_append_hist_rows "$BASE" "$INT_TOKEN")"
+      if openfdd_csv_append_import_batch "$BASE" "$INT_TOKEN" "$ts" "$phase" "$sample_n"; then
+        hist_after="$(openfdd_csv_append_hist_rows "$BASE" "$INT_TOKEN")"
+        csv_hist_delta=$(( hist_after - hist_before ))
+        [[ "$csv_hist_delta" -ge 0 ]] || csv_import_ok=false
+      else
+        csv_import_ok=false
+      fi
+    fi
   fi
 
   cycle_body='{}'
@@ -473,9 +503,11 @@ while true; do
     --argjson modbus_regs "$modbus_registers_read" \
     --argjson json_ok "$json_api_ok" \
     --argjson json_pts "$json_api_points_read" \
+    --argjson csv_ok "$csv_import_ok" \
+    --argjson csv_hist_delta "$csv_hist_delta" \
     --argjson override_ok "$override_scan_ok" \
     --argjson demo_only "$demo_only" \
-    '{timestamp_utc:$ts,sample_index:$n,mode:$mode,api_health_ok:$api_health,stack_health_ok:$stack_health,docker_ok:$docker_ok,docker_error_count:$docker_errors,source_id:$source_id,smoke_device_instance:$device,bacnet_device_seen:$bacnet_seen,bacnet_poll_ok:$bacnet_poll,historian_rows_written:$hist_rows,fdd_sql_ok:$fdd_ok,raw_fault_count:$raw_fault,confirmed_fault_count:$confirmed_fault,minutes_in_fault:$minutes_fault,confirmation_required_minutes:$confirm_min,expected_phase:$phase,expected_fault_state:$expected_fault,actual_fault_state:$actual_fault,demo_only:$demo_only,modbus_ok:$modbus,modbus_registers_read:$modbus_regs,json_api_ok:$json_ok,json_api_points_read:$json_pts,override_scan_ok:$override_ok,data_source:$data_source,error:$err}' \
+    '{timestamp_utc:$ts,sample_index:$n,mode:$mode,api_health_ok:$api_health,stack_health_ok:$stack_health,docker_ok:$docker_ok,docker_error_count:$docker_errors,source_id:$source_id,smoke_device_instance:$device,bacnet_device_seen:$bacnet_seen,bacnet_poll_ok:$bacnet_poll,historian_rows_written:$hist_rows,fdd_sql_ok:$fdd_ok,raw_fault_count:$raw_fault,confirmed_fault_count:$confirmed_fault,minutes_in_fault:$minutes_fault,confirmation_required_minutes:$confirm_min,expected_phase:$phase,expected_fault_state:$expected_fault,actual_fault_state:$actual_fault,demo_only:$demo_only,modbus_ok:$modbus,modbus_registers_read:$modbus_regs,json_api_ok:$json_ok,json_api_points_read:$json_pts,csv_import_ok:$csv_ok,csv_hist_row_delta:$csv_hist_delta,override_scan_ok:$override_ok,data_source:$data_source,error:$err}' \
     >>"$LOG_DIR/summary.jsonl"
 
   echo "[$ts] sample=$sample_n phase=$phase api=$api_health_ok stack=$stack_health_ok docker=$docker_ok bacnet=$bacnet_device_seen fdd=$fdd_sql_ok modbus=$modbus_ok json=$json_api_ok source=$data_source demo=$demo_only raw=$raw_fault_count confirmed=$confirmed_fault_count"
@@ -492,6 +524,30 @@ capture_docker_state end
 curl "${CURL_TLS[@]}" -fsS "${BASE}/api/validation-runs/current/status" \
   -H "Authorization: Bearer $INT_TOKEN" \
   -o "$LOG_DIR/final_status.json" 2>/dev/null || true
+
+VALIDATION_FINISHED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ "$CSV_APPEND" == "1" ]]; then
+  openfdd_csv_append_export_checks "$BASE" "$INT_TOKEN" before_purge || true
+  openfdd_csv_append_purge_validation "$BASE" "$INT_TOKEN" "$VALIDATION_STARTED" "$VALIDATION_FINISHED" || true
+  openfdd_csv_append_export_checks "$BASE" "$INT_TOKEN" after_purge || true
+fi
+
+report_draft="$(curl "${CURL_TLS[@]}" -fsS -X POST "${BASE}/api/reports/draft" \
+  -H "Authorization: Bearer $INT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"template_id":"validation-summary","title":"Live FDD Validation Report"}' 2>/dev/null || echo '{}')"
+echo "$report_draft" >"$LOG_DIR/validation_report_draft.json"
+report_id="$(jq -r '.report_id // empty' <<<"$report_draft")"
+if [[ -n "$report_id" ]]; then
+  curl "${CURL_TLS[@]}" -fsS -X POST "${BASE}/api/reports/${report_id}/render/pdf" \
+    -H "Authorization: Bearer $INT_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{}' -o "$LOG_DIR/validation_report_render.json" 2>/dev/null || true
+  curl "${CURL_TLS[@]}" -fsS "${BASE}/api/reports/${report_id}/download.pdf" \
+    -H "Authorization: Bearer $INT_TOKEN" \
+    -o "$LOG_DIR/validation_report.pdf" 2>/dev/null || true
+fi
 
 write_final_report
 fail_count="$(jq -s '[.[] | select(.api_health_ok==false or .fdd_sql_ok==false)] | length' "$LOG_DIR/summary.jsonl" 2>/dev/null || echo 0)"

--- a/workspace/dashboard/DEV_AUTH.md
+++ b/workspace/dashboard/DEV_AUTH.md
@@ -1,0 +1,38 @@
+# Local auth (developers only)
+
+The login form accepts **plaintext passwords only**. Do not paste values from `OFDD_*_PASSWORD_HASH=` lines in `workspace/auth.env.local` — those are bcrypt hashes for the bridge, not login passwords.
+
+## First bootstrap
+
+```bash
+./scripts/openfdd_auth_init.sh --show-secrets --restart
+```
+
+Save the printed passwords (or `workspace/bootstrap_credentials.once.txt`), then delete the handoff file when done.
+
+Passwords are **14 characters** (plaintext only). The lines in `auth.env.local` starting with `$2b$` are bcrypt hashes — never paste those into the login form.
+
+## Forgot password / login fails after rotate
+
+```bash
+./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart
+```
+
+The `--restart` flag recreates the bridge so it loads the new hashes.
+
+## Verify login
+
+```bash
+./scripts/openfdd_auth_smoke.sh
+./scripts/openfdd_inspection_build.sh --smoke
+```
+
+## Roles
+
+| Role | Typical use |
+|------|-------------|
+| `integrator` | Full writes, validation, reports |
+| `operator` | Day-to-day operations |
+| `agent` | Read-only proposals |
+
+Usernames default to the role name unless overridden in `auth.env.local`.

--- a/workspace/dashboard/index.html
+++ b/workspace/dashboard/index.html
@@ -3,9 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Open-FDD Operator</title>
   </head>
   <body>
+    <!-- Dev auth: plaintext passwords from bootstrap handoff only — see workspace/dashboard/DEV_AUTH.md -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/workspace/dashboard/public/favicon.svg
+++ b/workspace/dashboard/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Open-FDD">
+  <rect width="32" height="32" rx="6" fill="#1a2332"/>
+  <path d="M8 22V10h4l3 7 3-7h4v12h-3.5V15l-3.2 7h-2.6L9.5 15v7H8z" fill="#7fd992"/>
+</svg>

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import AgentPage from "./pages/AgentPage";
 import DriversPage from "./pages/DriversPage";
 import JsonApiPage from "./pages/JsonApiPage";
 import BacnetPage from "./pages/BacnetPage";
+import HaystackPage from "./pages/HaystackPage";
 import ModbusPage from "./pages/ModbusPage";
 import DataModelPage from "./pages/DataModelPage";
 import HomePage from "./pages/HomePage";
@@ -38,6 +39,7 @@ export default function App() {
             <Route path="fdd-assignments" element={<Navigate to="/model" replace />} />
             <Route path="plot" element={<TabErrorBoundary tab="plot"><PlotPage /></TabErrorBoundary>} />
             <Route path="drivers" element={<TabErrorBoundary tab="drivers"><DriversPage /></TabErrorBoundary>} />
+            <Route path="haystack" element={<TabErrorBoundary tab="haystack"><HaystackPage /></TabErrorBoundary>} />
             <Route path="bacnet" element={<TabErrorBoundary tab="bacnet"><BacnetPage /></TabErrorBoundary>} />
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -16,6 +16,7 @@ import PlotPage from "./pages/PlotPage";
 import SqlFddRulesPage from "./pages/SqlFddRulesPage";
 import LiveFddValidationPage from "./pages/LiveFddValidationPage";
 import DataManagementPage from "./pages/DataManagementPage";
+import ReportBuilderPage from "./pages/ReportBuilderPage";
 import AlgorithmsPage from "./pages/AlgorithmsPage";
 import { TabErrorBoundary } from "./components/TabDebugPanel";
 
@@ -44,6 +45,7 @@ export default function App() {
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />
             <Route path="data-management" element={<TabErrorBoundary tab="data-management"><DataManagementPage /></TabErrorBoundary>} />
+            <Route path="reports" element={<TabErrorBoundary tab="reports"><ReportBuilderPage /></TabErrorBoundary>} />
             <Route path="agent" element={<TabErrorBoundary tab="agent"><AgentPage /></TabErrorBoundary>} />
             <Route path="host" element={<TabErrorBoundary tab="host"><HostStatsPage /></TabErrorBoundary>} />
             <Route path="fdd" element={<Navigate to="/sql-fdd" replace />} />

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -3,7 +3,6 @@ import AppLayout from "./components/AppLayout";
 import RequireAuth from "./components/RequireAuth";
 import { DashboardStreamProvider } from "./lib/dashboardStream";
 import AgentPage from "./pages/AgentPage";
-import DriversPage from "./pages/DriversPage";
 import JsonApiPage from "./pages/JsonApiPage";
 import BacnetPage from "./pages/BacnetPage";
 import HaystackPage from "./pages/HaystackPage";
@@ -18,6 +17,7 @@ import LiveFddValidationPage from "./pages/LiveFddValidationPage";
 import DataManagementPage from "./pages/DataManagementPage";
 import ReportBuilderPage from "./pages/ReportBuilderPage";
 import AlgorithmsPage from "./pages/AlgorithmsPage";
+import DataExportPage from "./pages/DataExportPage";
 import { TabErrorBoundary } from "./components/TabDebugPanel";
 
 export default function App() {
@@ -39,7 +39,8 @@ export default function App() {
             <Route path="data-model" element={<Navigate to="/model" replace />} />
             <Route path="fdd-assignments" element={<Navigate to="/model" replace />} />
             <Route path="plot" element={<TabErrorBoundary tab="plot"><PlotPage /></TabErrorBoundary>} />
-            <Route path="drivers" element={<TabErrorBoundary tab="drivers"><DriversPage /></TabErrorBoundary>} />
+            <Route path="drivers" element={<Navigate to="/bacnet" replace />} />
+            <Route path="exports" element={<TabErrorBoundary tab="exports"><DataExportPage /></TabErrorBoundary>} />
             <Route path="haystack" element={<TabErrorBoundary tab="haystack"><HaystackPage /></TabErrorBoundary>} />
             <Route path="bacnet" element={<TabErrorBoundary tab="bacnet"><BacnetPage /></TabErrorBoundary>} />
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -28,6 +28,7 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
       { to: "/drivers", icon: "🌳", label: "Drivers", protected: true },
       { to: "/sql-fdd", icon: "⚡", label: "SQL FDD Rules", protected: true },
       { to: "/plot", icon: "📈", label: "Trend plot", protected: true },
+      { to: "/reports", icon: "📄", label: "Report builder", protected: true },
     ],
   },
   {

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -35,6 +35,7 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
     items: [
       { to: "/bacnet", icon: "📡", label: "BACnet", protected: true },
       { to: "/modbus", icon: "🔌", label: "Modbus", protected: true },
+      { to: "/haystack", icon: "🌿", label: "Haystack", protected: true },
       { to: "/json-api", icon: "🌐", label: "JSON API", protected: true },
       { to: "/data-management", icon: "🗄️", label: "Data management", protected: true },
     ],

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -113,7 +113,7 @@ export default function AppLayout() {
             </span>
           ) : null}
         </div>
-        <p className="sidebar-hint">Haystack-first operator console</p>
+        <p className="sidebar-hint">Building summary is public; sign in to browse all tabs (operator read-only).</p>
         <StackStatusStrip />
         <nav className="sidebar-nav">
           {NAV_SECTIONS.map((section) => (
@@ -140,11 +140,6 @@ export default function AppLayout() {
                   >
                     <span className="nav-icon">{item.icon}</span>
                     {item.label}
-                    {item.protected && authRequired && !signedIn ? (
-                      <span className="nav-lock" title="Sign in required">
-                        🔒
-                      </span>
-                    ) : null}
                   </NavLink>
                 ),
               )}

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -17,42 +17,40 @@ type NavItem = {
 const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   {
     title: "Overview",
-    items: [
-      { to: "/", end: true, icon: "🏠", label: "Building status" },
-      { to: "/live-fdd-validation", icon: "🧪", label: "Live FDD Validation", protected: true },
-    ],
-  },
-  {
-    title: "Data & rules",
-    items: [
-      { to: "/drivers", icon: "🌳", label: "Drivers", protected: true },
-      { to: "/sql-fdd", icon: "⚡", label: "SQL FDD Rules", protected: true },
-      { to: "/plot", icon: "📈", label: "Trend plot", protected: true },
-      { to: "/reports", icon: "📄", label: "Report builder", protected: true },
-    ],
+    items: [{ to: "/", end: true, icon: "🏠", label: "Dashboard" }],
   },
   {
     title: "Integrations",
     items: [
       { to: "/bacnet", icon: "📡", label: "BACnet", protected: true },
-      { to: "/modbus", icon: "🔌", label: "Modbus", protected: true },
       { to: "/haystack", icon: "🌿", label: "Haystack", protected: true },
+      { to: "/modbus", icon: "🔌", label: "Modbus", protected: true },
       { to: "/json-api", icon: "🌐", label: "JSON API", protected: true },
-      { to: "/data-management", icon: "🗄️", label: "Data management", protected: true },
     ],
   },
   {
-    title: "Haystack model",
+    title: "Model & rules",
     items: [
       { to: "/model", icon: "📐", label: "Model & assignments", protected: true },
+      { to: "/sql-fdd", icon: "⚡", label: "SQL FDD Rules", protected: true },
+      { to: "/plot", icon: "📈", label: "Plots", protected: true },
+      { to: "/reports", icon: "📄", label: "Reports", protected: true },
+    ],
+  },
+  {
+    title: "Data & ops",
+    items: [
+      { to: "/exports", icon: "⬇️", label: "Data export", protected: true },
+      { to: "/data-management", icon: "🗄️", label: "Host / data management", protected: true },
+      { to: "/host", icon: "📊", label: "Host stats", protected: true },
+      { to: "/live-fdd-validation", icon: "🧪", label: "Validation runs", protected: true },
       { to: "/algorithms", icon: "⚙️", label: "Algorithms", protected: true },
     ],
   },
   {
-    title: "Ops",
+    title: "Settings",
     items: [
       { to: "/agent", icon: "🤖", label: "AI Agent", protected: true, disabled: true, disabledHint: "Coming soon — Ollama & Codex" },
-      { to: "/host", icon: "📊", label: "Host stats", protected: true },
     ],
   },
 ];

--- a/workspace/dashboard/src/components/BuildingInsightDashboard.tsx
+++ b/workspace/dashboard/src/components/BuildingInsightDashboard.tsx
@@ -11,6 +11,7 @@ import FaultCard from "./buildingInsight/FaultCard";
 import FaultDetailModal from "./buildingInsight/FaultDetailModal";
 import HealthGauge from "./buildingInsight/HealthGauge";
 import type { InsightResponse } from "../lib/insightTypes";
+import OperationalContextPanel from "./buildingInsight/OperationalContextPanel";
 
 type BuildingStatusResponse = {
   ok?: boolean;
@@ -113,10 +114,6 @@ export default function BuildingInsightDashboard() {
           .join(" · ");
 
   const days = insight?.lookback_days ?? 14;
-  const updatedLabel =
-    insight?.generated_at != null
-      ? new Date(insight.generated_at * 1000).toLocaleString()
-      : null;
 
   if (streamError && !snapshot) {
     return (
@@ -246,48 +243,11 @@ export default function BuildingInsightDashboard() {
           )}
         </div>
 
-        <div className="bis-card">
-          <h3>Context</h3>
-          <h2>Feeds &amp; research</h2>
-          {insight?.brick_model?.feeds_chains?.length ? (
-            <p className="bis-muted-line">
-              <strong>Haystack feeds:</strong> {insight.brick_model.feeds_chains.slice(0, 5).join("; ")}
-              {(insight.brick_model.feeds_chains.length ?? 0) > 5 ? " …" : ""}
-            </p>
-          ) : (
-            <p className="muted">No feed relationships in model summary.</p>
-          )}
-          {insight?.zone_temps?.struggling_zones?.length ? (
-            <p className="bis-muted-line">
-              <strong>Slow recovery:</strong>{" "}
-              {insight.zone_temps.struggling_zones
-                .slice(0, 4)
-                .map((z) => `${z.label || "?"} (${z.ahu_name || "AHU"})`)
-                .join(", ")}
-            </p>
-          ) : null}
-          {insight?.faults_linked?.length ? (
-            <ul className="bis-linked-faults">
-              {insight.faults_linked.slice(0, 6).map((f) => (
-                <li key={`${f.code}-${f.equipment_name}`}>
-                  <span className="bis-code">{f.code}</span> {f.title}
-                  {f.equipment_name ? ` · ${f.equipment_name}` : ""}
-                </li>
-              ))}
-            </ul>
-          ) : null}
-          <p className="bis-foot-meta">
-            {insight?.source === "ollama" ? "AI summary" : "Rule-based summary"}
-            {updatedLabel ? ` · updated ${updatedLabel}` : ""}
-            {insight?.refresh_interval_s
-              ? ` · every ${Math.round(insight.refresh_interval_s / 60)} min`
-              : ""}
-          </p>
-          {insight?.error && !insight.ollama_ok ? (
-            <p className="muted">Ollama offline — deterministic summary only.</p>
-          ) : null}
-          {insightError ? <p className="error">{insightError}</p> : null}
-        </div>
+        <OperationalContextPanel
+          refreshKey={snapshot?.faults.alert_count}
+          insight={insight}
+          insightError={insightError}
+        />
       </div>
 
       <FaultDetailModal fault={selectedFault} onClose={() => setSelectedFault(null)} />

--- a/workspace/dashboard/src/components/RequireAuth.tsx
+++ b/workspace/dashboard/src/components/RequireAuth.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, Outlet } from "react-router-dom";
 import { fetchAuthStatus, hasToken, setToken } from "../lib/api";
 
-/** Gate integrator/agent pages. Check-engine home + fault catalog stay public. */
+/** Gate commissioning tabs. Home building summary stays public; operator is read-only after sign-in. */
 export default function RequireAuth() {
   const [authRequired, setAuthRequired] = useState<boolean | null>(null);
 

--- a/workspace/dashboard/src/components/buildingInsight/OperationalContextPanel.tsx
+++ b/workspace/dashboard/src/components/buildingInsight/OperationalContextPanel.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { apiFetch } from "../../lib/api";
+import type {
+  DashboardAnalytics,
+  DashboardSummary,
+  FddRulesResponse,
+} from "../../lib/dashboardSummaryTypes";
+import type { InsightResponse } from "../../lib/insightTypes";
+
+type Props = {
+  refreshKey?: number;
+  insight?: InsightResponse | null;
+  insightError?: string;
+};
+
+function formatProtocolLabel(protocol: string): string {
+  switch (protocol) {
+    case "json_api":
+      return "JSON API";
+    case "csv_import":
+      return "CSV import";
+    default:
+      return protocol.replace(/_/g, " ");
+  }
+}
+
+export default function OperationalContextPanel({ refreshKey, insight, insightError }: Props) {
+  const [summary, setSummary] = useState<DashboardSummary | null>(null);
+  const [analytics, setAnalytics] = useState<DashboardAnalytics | null>(null);
+  const [rules, setRules] = useState<FddRulesResponse | null>(null);
+  const [loadError, setLoadError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadError("");
+    Promise.all([
+      apiFetch<DashboardSummary>("/api/dashboard/summary"),
+      apiFetch<DashboardAnalytics>("/api/dashboard/analytics"),
+      apiFetch<FddRulesResponse>("/api/fdd-rules"),
+    ])
+      .then(([s, a, r]) => {
+        if (cancelled) return;
+        setSummary(s);
+        setAnalytics(a);
+        setRules(r);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setSummary(null);
+        setAnalytics(null);
+        setRules(null);
+        setLoadError(e instanceof Error ? e.message : "Could not load operational context");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  const model = summary?.model_coverage;
+  const ruleHealth = analytics?.rule_health;
+  const ruleList = rules?.rules ?? [];
+  const enabledRules = ruleList.filter((r) => r.enabled !== false);
+  const ruleCount = ruleHealth?.rule_count ?? ruleList.length;
+  const activeFaults = summary?.faults?.active_count ?? 0;
+  const historian = summary?.historian_health;
+
+  const mappedSources = useMemo(() => {
+    const fromHealth =
+      summary?.source_health?.sources?.filter((s) => (s.point_count ?? 0) > 0) ?? [];
+    if (fromHealth.length) {
+      return fromHealth.map((s) => ({
+        label: formatProtocolLabel(s.protocol ?? "unknown"),
+        count: s.point_count ?? 0,
+        status: s.status ?? (s.enabled ? "ready" : "disabled"),
+      }));
+    }
+    return (analytics?.source_coverage?.protocols ?? [])
+      .filter((p) => (p.point_count ?? 0) > 0 && p.protocol !== "unmapped")
+      .map((p) => ({
+        label: formatProtocolLabel(p.protocol ?? "unknown"),
+        count: p.point_count ?? 0,
+        status: "mapped",
+      }));
+  }, [summary, analytics]);
+
+  const modelLine =
+    model && (model.equipment_count ?? 0) + (model.point_count ?? 0) > 0
+      ? `${model.equipment_count ?? 0} equipment · ${model.point_count ?? 0} points · ${model.mapped_points ?? 0} mapped${
+          (model.unmapped_points ?? 0) > 0 ? ` · ${model.unmapped_points} unmapped` : ""
+        }${model.model_score != null ? ` · ${model.model_score}% coverage` : ""}`
+      : "No Haystack model loaded — import under Model & assignments.";
+
+  const rulesLine =
+    ruleCount > 0
+      ? `${enabledRules.length || ruleCount} FDD rule${ruleCount === 1 ? "" : "s"} configured${
+          ruleHealth?.datafusion_ok === false ? " · DataFusion check failed" : ""
+        }`
+      : "No FDD rules configured — add rules under SQL FDD.";
+
+  const faultLine =
+    activeFaults === 0
+      ? "No active faults."
+      : `${activeFaults} active fault${activeFaults === 1 ? "" : "s"} in historian evaluation.`;
+
+  const historianLine = historian
+    ? `${historian.row_count ?? 0} historian rows${
+        historian.latest_sample_at ? ` · latest ${historian.latest_sample_at}` : ""
+      }${historian.subdir_count ? ` · ${historian.subdir_count} partition(s)` : ""}`
+    : "Historian status unavailable.";
+
+  const validationProfile = summary?.validation?.profile_id;
+  const feeds = insight?.brick_model?.feeds_chains ?? [];
+
+  return (
+    <div className="bis-card">
+      <h3>Context</h3>
+      <h2>Data model &amp; FDD</h2>
+      <p className="bis-muted-line">
+        <strong>Model:</strong> {modelLine}{" "}
+        <Link to="/model" className="bis-inline-link">
+          Model
+        </Link>
+      </p>
+      {mappedSources.length ? (
+        <p className="bis-muted-line">
+          <strong>Mapped sources:</strong>{" "}
+          {mappedSources.map((s) => `${s.label} (${s.count})`).join(" · ")}
+        </p>
+      ) : (
+        <p className="muted">No protocol-mapped points yet.</p>
+      )}
+      <p className="bis-muted-line">
+        <strong>Rules:</strong> {rulesLine}{" "}
+        <Link to="/sql-fdd" className="bis-inline-link">
+          SQL FDD
+        </Link>
+      </p>
+      {enabledRules.length ? (
+        <p className="bis-muted-line">
+          <strong>Active rules:</strong>{" "}
+          {enabledRules
+            .slice(0, 6)
+            .map((r) => r.name || r.id || "rule")
+            .join(", ")}
+          {enabledRules.length > 6 ? " …" : ""}
+        </p>
+      ) : null}
+      <p className="bis-muted-line">
+        <strong>Faults:</strong> {faultLine}
+      </p>
+      <p className="bis-muted-line">
+        <strong>Historian:</strong> {historianLine}
+      </p>
+      {validationProfile ? (
+        <p className="bis-muted-line">
+          <strong>Validation profile:</strong> {validationProfile}
+          {summary?.validation?.live_fdd_pass &&
+          summary.validation.live_fdd_pass !== "unknown"
+            ? ` · last pass ${summary.validation.live_fdd_pass}`
+            : ""}
+        </p>
+      ) : null}
+
+      {feeds.length ? (
+        <>
+          <h3 className="bis-subhead">Feeds &amp; research</h3>
+          <p className="bis-muted-line">
+            <strong>Haystack feeds:</strong> {feeds.slice(0, 5).join("; ")}
+            {feeds.length > 5 ? " …" : ""}
+          </p>
+        </>
+      ) : null}
+      {insight?.zone_temps?.struggling_zones?.length ? (
+        <p className="bis-muted-line">
+          <strong>Slow recovery:</strong>{" "}
+          {insight.zone_temps.struggling_zones
+            .slice(0, 4)
+            .map((z) => `${z.label || "?"} (${z.ahu_name || "AHU"})`)
+            .join(", ")}
+        </p>
+      ) : null}
+      {insight?.faults_linked?.length ? (
+        <ul className="bis-linked-faults">
+          {insight.faults_linked.slice(0, 6).map((f) => (
+            <li key={`${f.code}-${f.equipment_name}`}>
+              <span className="bis-code">{f.code}</span> {f.title}
+              {f.equipment_name ? ` · ${f.equipment_name}` : ""}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <p className="bis-foot-meta">
+        Rule-based summary from bridge APIs
+        {insight?.source === "ollama" ? " · insight agent available" : ""}
+        {insight?.generated_at != null
+          ? ` · insight ${new Date(insight.generated_at * 1000).toLocaleString()}`
+          : ""}
+      </p>
+      {insight?.error && !insight.ollama_ok ? (
+        <p className="muted">Ollama offline — operational context above is from live APIs.</p>
+      ) : null}
+      {loadError ? <p className="error">{loadError}</p> : null}
+      {insightError ? <p className="error">{insightError}</p> : null}
+    </div>
+  );
+}

--- a/workspace/dashboard/src/lib/api.ts
+++ b/workspace/dashboard/src/lib/api.ts
@@ -56,6 +56,42 @@ function authHeaders(): HeadersInit {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+function parseErrorBody(text: string, status: number): Error {
+  try {
+    const body = JSON.parse(text) as {
+      error?: string;
+      message?: string;
+      detail?: string | { error?: string; detail?: string; message?: string };
+    };
+    if (typeof body.error === "string") {
+      if (body.error === "invalid credentials") {
+        return new Error("Invalid username or password.");
+      }
+      return new Error(body.error);
+    }
+    if (typeof body.message === "string") {
+      return new Error(body.message);
+    }
+    if (typeof body.detail === "string") {
+      return new Error(body.detail);
+    }
+    if (body.detail && typeof body.detail === "object") {
+      const nested = body.detail;
+      if (typeof nested.error === "string") return new Error(nested.error);
+      if (typeof nested.detail === "string") return new Error(nested.detail);
+      if (typeof nested.message === "string") return new Error(nested.message);
+      return new Error(JSON.stringify(nested));
+    }
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      // not JSON — fall through
+    } else if (e instanceof Error) {
+      return e;
+    }
+  }
+  return new Error(text || `HTTP ${status}`);
+}
+
 export async function apiFetch<T>(
   path: string,
   init?: RequestInit,
@@ -80,26 +116,7 @@ export async function apiFetch<T>(
   }
   if (!res.ok) {
     const text = await res.text();
-    try {
-      const body = JSON.parse(text) as { detail?: string | { error?: string; detail?: string; message?: string } };
-      if (typeof body.detail === "string") {
-        throw new Error(body.detail);
-      }
-      if (body.detail && typeof body.detail === "object") {
-        const nested = body.detail;
-        if (typeof nested.error === "string") throw new Error(nested.error);
-        if (typeof nested.detail === "string") throw new Error(nested.detail);
-        if (typeof nested.message === "string") throw new Error(nested.message);
-        throw new Error(JSON.stringify(nested));
-      }
-    } catch (e) {
-      if (e instanceof SyntaxError) {
-        // not JSON — fall through to plain-text error
-      } else if (e instanceof Error) {
-        throw e;
-      }
-    }
-    throw new Error(text || `HTTP ${res.status}`);
+    throw parseErrorBody(text, res.status);
   }
   return res.json() as Promise<T>;
 }

--- a/workspace/dashboard/src/lib/api.ts
+++ b/workspace/dashboard/src/lib/api.ts
@@ -211,7 +211,13 @@ export async function fetchAuthMe(): Promise<AuthMe> {
 }
 
 export async function login(username: string, password: string) {
-  return apiFetch<{ token: string; username: string; role: string }>("/api/auth/login", {
+  return apiFetch<{
+    token?: string;
+    access_token?: string;
+    username?: string;
+    subject?: string;
+    role: string;
+  }>("/api/auth/login", {
     method: "POST",
     body: JSON.stringify({ username, password }),
   });

--- a/workspace/dashboard/src/lib/dashboardSummaryTypes.ts
+++ b/workspace/dashboard/src/lib/dashboardSummaryTypes.ts
@@ -1,0 +1,53 @@
+/** Shapes from GET /api/dashboard/summary and /api/dashboard/analytics */
+
+export type DashboardSummary = {
+  ok?: boolean;
+  model_coverage?: {
+    equipment_count?: number;
+    point_count?: number;
+    mapped_points?: number;
+    unmapped_points?: number;
+    model_score?: number | null;
+    query_engine?: string;
+  };
+  source_health?: {
+    sources?: Array<{
+      protocol?: string;
+      enabled?: boolean;
+      status?: string;
+      point_count?: number;
+    }>;
+  };
+  historian_health?: {
+    row_count?: number;
+    latest_sample_at?: string;
+    subdir_count?: number;
+    storage_label?: string;
+  };
+  faults?: {
+    active_count?: number;
+    total_count?: number;
+    confirmed_count?: number;
+  };
+  validation?: {
+    profile_id?: string;
+    live_fdd_pass?: string;
+  };
+};
+
+export type DashboardAnalytics = {
+  ok?: boolean;
+  rule_health?: {
+    rule_count?: number;
+    datafusion_ok?: boolean;
+    last_error?: string | null;
+  };
+  source_coverage?: {
+    protocols?: Array<{ protocol?: string; point_count?: number }>;
+  };
+};
+
+export type FddRulesResponse = {
+  ok?: boolean;
+  rules?: Array<{ id?: string; name?: string; enabled?: boolean }>;
+};

--- a/workspace/dashboard/src/pages/DataExportPage.tsx
+++ b/workspace/dashboard/src/pages/DataExportPage.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import PageHeader from "../components/PageHeader";
+import { apiFetch, apiDownloadBlob } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+
+type ExportMeta = {
+  ok?: boolean;
+  exports?: {
+    id: string;
+    label: string;
+    format: string;
+    path: string;
+    row_count?: number;
+    available?: boolean;
+    data_source_label?: string;
+  }[];
+};
+
+export default function DataExportPage() {
+  const [meta, setMeta] = useState<ExportMeta | null>(null);
+  const [error, setError] = useState("");
+  const [status, setStatus] = useState("");
+  const [hours, setHours] = useState(24);
+
+  useEffect(() => {
+    apiFetch<ExportMeta>("/api/export/meta")
+      .then(setMeta)
+      .catch((e) => setError(formatApiError(e)));
+  }, []);
+
+  async function download(path: string, label: string) {
+    setStatus("");
+    setError("");
+    try {
+      const qs = path.includes("?") ? "&" : "?";
+      const url = `${path}${qs}hours=${hours}`;
+      const { blob, filename } = await apiDownloadBlob(url);
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = blobUrl;
+      a.download = filename.endsWith(".csv") ? filename : `${label.replace(/\s+/g, "_").toLowerCase()}.csv`;
+      a.click();
+      URL.revokeObjectURL(blobUrl);
+      setStatus(`Downloaded ${label}`);
+    } catch (e) {
+      setError(formatApiError(e));
+    }
+  }
+
+  const exports = meta?.exports ?? [];
+
+  return (
+    <div className="page page-wide">
+      <PageHeader
+        title="Data export"
+        subtitle="Download CSV extracts for historian, faults, model points, rules, and validation runs."
+      />
+
+      {error ? <div className="error-banner">{error}</div> : null}
+      {status ? <div className="status-banner">{status}</div> : null}
+
+      <section className="panel">
+        <div className="toolbar">
+          <label>
+            Default range (hours)
+            <input type="number" min={1} max={720} value={hours} onChange={(e) => setHours(Number(e.target.value))} />
+          </label>
+        </div>
+
+        <div className="table-like export-list">
+          {exports.length === 0 ? (
+            <p className="muted-copy">No export endpoints reported — check bridge export sidecar configuration.</p>
+          ) : (
+            exports.map((item) => (
+              <div key={item.id} className="table-row export-row">
+                <div>
+                  <strong>{item.label}</strong>
+                  <p className="muted-copy">
+                    {item.format.toUpperCase()} · {item.row_count ?? 0} rows
+                    {item.data_source_label ? ` · ${item.data_source_label}` : ""}
+                    {!item.available ? " · empty until historian has data" : ""}
+                  </p>
+                </div>
+                <button type="button" className="primary-btn" onClick={() => void download(item.path, item.label)}>
+                  Download
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/pages/HaystackPage.tsx
+++ b/workspace/dashboard/src/pages/HaystackPage.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+import HaystackPointsTree, { type HaystackDevice, type HaystackPoint } from "../components/HaystackPointsTree";
+import PageHeader from "../components/PageHeader";
+import Spinner from "../components/Spinner";
+import ActionButton from "../components/ActionButton";
+
+type HaystackStatus = {
+  ok?: boolean;
+  driver?: string;
+  status?: string;
+  mode?: string;
+  supported_ops?: string[];
+};
+
+export default function HaystackPage() {
+  const [baseUrl, setBaseUrl] = useState("http://127.0.0.1:8080/api/haystack");
+  const [verifyTls, setVerifyTls] = useState(true);
+  const [enabled, setEnabled] = useState(true);
+  const [status, setStatus] = useState<HaystackStatus | null>(null);
+  const [about, setAbout] = useState<Record<string, unknown> | null>(null);
+  const [devices, setDevices] = useState<HaystackDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [log, setLog] = useState("");
+  const [error, setError] = useState("");
+
+  const appendLog = (line: string) => setLog((prev) => `${new Date().toISOString()} ${line}\n${prev}`.slice(0, 8000));
+
+  const loadStatus = useCallback(async () => {
+    const st = await apiFetch<HaystackStatus>("/api/haystack/status");
+    setStatus(st);
+    const ab = await apiFetch<Record<string, unknown>>("/api/haystack/about");
+    setAbout(ab);
+  }, []);
+
+  const loadModelTree = useCallback(async () => {
+    const grid = await apiFetch<{ rows?: Array<Record<string, unknown>> }>("/api/model/haystack");
+    const rows = grid.rows ?? [];
+    const points: HaystackPoint[] = rows
+      .filter((r) => r.point === "M")
+      .map((r) => ({
+        point_id: String(r.id ?? ""),
+        label: String(r.dis ?? r.id ?? ""),
+        haystack_id: String(r.id ?? ""),
+        tags: {},
+        kind: r.kind,
+        unit: r.unit,
+        curVal: r.curVal,
+        present_value: r.curVal != null ? String(r.curVal) : "—",
+        enabled: false,
+        poll_interval_s: 0,
+        poll_label: "Off",
+      }));
+    setDevices([
+      {
+        device_key: "haystack-model",
+        host: baseUrl,
+        site_id: "site:validation",
+        point_count: points.length,
+        poll_count: 0,
+        points,
+      },
+    ]);
+  }, [baseUrl]);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([loadStatus(), loadModelTree()])
+      .catch((e) => setError(formatApiError(e)))
+      .finally(() => setLoading(false));
+  }, [loadStatus, loadModelTree]);
+
+  async function testConnection() {
+    setPending(true);
+    setError("");
+    try {
+      await loadStatus();
+      appendLog(`Connection OK — mode=${status?.mode ?? "unknown"}`);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function importFromSmokeProfile() {
+    setPending(true);
+    setError("");
+    try {
+      const res = await apiFetch<{ ok?: boolean; imported?: number; path?: string }>(
+        "/api/model/haystack/from-smoke-profile",
+        { method: "POST", body: "{}" },
+      );
+      appendLog(`Imported smoke profile → ${res.imported ?? 0} rows (${res.path ?? "model"})`);
+      await loadModelTree();
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function readSelected() {
+    setPending(true);
+    try {
+      await apiFetch("/api/haystack/read", { method: "POST", body: "{}" });
+      appendLog("Haystack read completed");
+      await loadModelTree();
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="page page-wide driver-page">
+      <PageHeader
+        title="Haystack"
+        subtitle="Haystack server workflow — replaces the old Niagara station tab. Browse nav, read points, import model entities."
+      />
+
+      {error ? <p className="error">{error}</p> : null}
+
+      <div className="panel driver-connection-panel">
+        <h3>Haystack server</h3>
+        <div className="form-grid">
+          <label>
+            Server URL
+            <input value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} placeholder="https://host/api/haystack" />
+          </label>
+          <label className="checkbox-inline">
+            <input type="checkbox" checked={verifyTls} onChange={(e) => setVerifyTls(e.target.checked)} />
+            Verify TLS (uncheck for self-signed lab certs)
+          </label>
+          <label className="checkbox-inline">
+            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+            Enabled
+          </label>
+        </div>
+        <div className="btn-row">
+          <ActionButton pending={pending} onClick={() => void testConnection()}>
+            Test connection
+          </ActionButton>
+          <ActionButton pending={pending} onClick={() => void importFromSmokeProfile()}>
+            Import validation smoke profile
+          </ActionButton>
+          <ActionButton pending={pending} onClick={() => void readSelected()}>
+            Read / refresh
+          </ActionButton>
+        </div>
+        {status ? (
+          <p className="muted">
+            Driver: {status.driver ?? "haystack"} · {status.mode ?? status.status ?? "unknown"} · ops:{" "}
+            {(status.supported_ops ?? []).join(", ") || "about, ops, read, nav"}
+          </p>
+        ) : null}
+        {about ? (
+          <p className="muted">
+            About: {String(about.serverName ?? "open-fdd")} · Haystack {String(about.haystackVersion ?? "3.0")}
+          </p>
+        ) : null}
+        <p className="muted">Schedules: not supported on fixture gateway — omit unless your Haystack server exposes them.</p>
+      </div>
+
+      <div className="panel">
+        <h3>Sites, equipment &amp; points</h3>
+        {loading ? <Spinner label="Loading Haystack model tree…" /> : null}
+        <HaystackPointsTree devices={devices} onCopy={(text) => appendLog(`Copied ${text}`)} />
+      </div>
+
+      <div className="panel driver-console">
+        <h3>Activity console</h3>
+        <pre className="driver-log">{log || "No activity yet."}</pre>
+      </div>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -31,9 +31,21 @@ export default function LoginPage() {
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
     setError("");
+    const user = username.trim();
+    const pass = password.trimEnd();
+    if (pass.startsWith("$2b$") || (pass.includes("OFDD_") && pass.includes("PASSWORD_HASH"))) {
+      setError(
+        "That value is a bcrypt hash, not a login password. Use workspace/bootstrap_credentials.once.txt.",
+      );
+      return;
+    }
     try {
-      const res = await login(username, password);
-      setToken(res.token);
+      const res = await login(user, pass);
+      const token = res.token ?? res.access_token;
+      if (!token) {
+        throw new Error("Login succeeded but no session token was returned.");
+      }
+      setToken(token);
       navigate("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "login failed");
@@ -70,12 +82,6 @@ export default function LoginPage() {
           />
         </div>
         {error ? <p className="error">{error}</p> : null}
-        <p className="muted login-hint">
-          Use the <strong>plaintext password</strong> from bootstrap output — not the bcrypt hash lines in{" "}
-          <code>auth.env.local</code>. After rotate, run{" "}
-          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart</code> or check{" "}
-          <code>workspace/bootstrap_credentials.once.txt</code> (delete after saving).
-        </p>
         <button type="submit">Sign in</button>
       </form>
     </div>

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -70,6 +70,11 @@ export default function LoginPage() {
           />
         </div>
         {error ? <p className="error">{error}</p> : null}
+        <p className="muted login-hint">
+          Passwords live in <code>workspace/auth.env.local</code> (bcrypt only). If sign-in fails after a rotate,
+          restart the bridge and use the password printed by{" "}
+          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets</code>.
+        </p>
         <button type="submit">Sign in</button>
       </form>
     </div>

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -71,9 +71,10 @@ export default function LoginPage() {
         </div>
         {error ? <p className="error">{error}</p> : null}
         <p className="muted login-hint">
-          Passwords live in <code>workspace/auth.env.local</code> (bcrypt only). If sign-in fails after a rotate,
-          restart the bridge and use the password printed by{" "}
-          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets</code>.
+          Use the <strong>plaintext password</strong> from bootstrap output — not the bcrypt hash lines in{" "}
+          <code>auth.env.local</code>. After rotate, run{" "}
+          <code>./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart</code> or check{" "}
+          <code>workspace/bootstrap_credentials.once.txt</code> (delete after saving).
         </p>
         <button type="submit">Sign in</button>
       </form>

--- a/workspace/dashboard/src/pages/ReportBuilderPage.tsx
+++ b/workspace/dashboard/src/pages/ReportBuilderPage.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import PageHeader from "../components/PageHeader";
+import { apiDownloadBlob, apiFetch } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+
+type ReportSection = {
+  id: string;
+  type: string;
+  title: string;
+  visible?: boolean;
+  order?: number;
+  content?: Record<string, unknown>;
+};
+
+type ReportDoc = {
+  ok?: boolean;
+  report_id?: string;
+  title?: string;
+  template_id?: string;
+  sections?: ReportSection[];
+  metadata?: Record<string, unknown>;
+};
+
+function ReportSectionCard({
+  section,
+  onMoveUp,
+  onMoveDown,
+  onToggle,
+  onTitle,
+}: {
+  section: ReportSection;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onToggle: () => void;
+  onTitle: (title: string) => void;
+}) {
+  return (
+    <div className={`report-section-card${section.visible === false ? " muted" : ""}`}>
+      <div className="report-section-toolbar">
+        <span className="report-section-type">{section.type}</span>
+        <button type="button" className="secondary-btn" onClick={onMoveUp} aria-label="Move up">
+          ↑
+        </button>
+        <button type="button" className="secondary-btn" onClick={onMoveDown} aria-label="Move down">
+          ↓
+        </button>
+        <label className="report-section-visible">
+          <input type="checkbox" checked={section.visible !== false} onChange={onToggle} />
+          Show
+        </label>
+      </div>
+      <input
+        className="report-section-title"
+        value={section.title}
+        onChange={(e) => onTitle(e.target.value)}
+      />
+      {section.type === "rule_explanation" && section.content ? (
+        <div className="report-rule-block">
+          <p>{String(section.content.explanation ?? "")}</p>
+          <pre>{String(section.content.sql ?? "")}</pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function ReportBuilderPage() {
+  const [report, setReport] = useState<ReportDoc | null>(null);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const sections = useMemo(
+    () => [...(report?.sections ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    [report?.sections],
+  );
+
+  const createDraft = useCallback(async () => {
+    setBusy(true);
+    setError("");
+    try {
+      const draft = await apiFetch<ReportDoc>("/api/reports/draft", {
+        method: "POST",
+        body: JSON.stringify({
+          template_id: "validation-summary",
+          title: "Open-FDD Validation Report",
+        }),
+      });
+      setReport(draft);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void createDraft();
+  }, [createDraft]);
+
+  async function persistSections(next: ReportSection[]) {
+    if (!report?.report_id) return;
+    setBusy(true);
+    setError("");
+    try {
+      const res = await apiFetch<{ ok?: boolean; report?: ReportDoc }>(
+        `/api/reports/${report.report_id}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ sections: next }),
+        },
+      );
+      setReport(res.report ?? report);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function updateSection(idx: number, patch: Partial<ReportSection>) {
+    const next = sections.map((s, i) => (i === idx ? { ...s, ...patch } : s));
+    void persistSections(next);
+  }
+
+  function moveSection(idx: number, dir: -1 | 1) {
+    const j = idx + dir;
+    if (j < 0 || j >= sections.length) return;
+    const next = [...sections];
+    [next[idx], next[j]] = [next[j], next[idx]];
+    next.forEach((s, i) => {
+      s.order = i;
+    });
+    void persistSections(next);
+  }
+
+  async function renderPreview() {
+    if (!report?.report_id) return;
+    setBusy(true);
+    setError("");
+    try {
+      await apiFetch(`/api/reports/${report.report_id}/render/pdf`, { method: "POST" });
+      const { blob } = await apiDownloadBlob(`/api/reports/${report.report_id}/download.pdf`);
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(URL.createObjectURL(blob));
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function downloadPdf() {
+    if (!report?.report_id) return;
+    setBusy(true);
+    setError("");
+    try {
+      await apiFetch(`/api/reports/${report.report_id}/render/pdf`, { method: "POST" });
+      const { blob, filename } = await apiDownloadBlob(`/api/reports/${report.report_id}/download.pdf`);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename || `${report.report_id}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="report-builder-page">
+      <PageHeader
+        title="Report Builder"
+        subtitle="Model-driven auto-report from Haystack model, historian, FDD rules, and faults. Reorder sections, edit titles, preview and download PDF."
+      />
+
+      {error ? <div className="error-banner">{error}</div> : null}
+
+      <div className="toolbar">
+        <button type="button" className="secondary-btn" onClick={() => void createDraft()} disabled={busy}>
+          Regenerate draft
+        </button>
+        <button type="button" className="secondary-btn" onClick={() => void renderPreview()} disabled={busy || !report?.report_id}>
+          Preview PDF
+        </button>
+        <button type="button" className="primary-btn" onClick={() => void downloadPdf()} disabled={busy || !report?.report_id}>
+          Download PDF
+        </button>
+      </div>
+
+      <div className="report-builder-grid">
+        <section className="report-canvas">
+          <h2>Suggested sections</h2>
+          <p className="hint">Auto-selected from model coverage, rules, faults, and historian. Hide or reorder as needed.</p>
+          {sections.map((sec, idx) => (
+            <ReportSectionCard
+              key={sec.id}
+              section={sec}
+              onMoveUp={() => moveSection(idx, -1)}
+              onMoveDown={() => moveSection(idx, 1)}
+              onToggle={() => updateSection(idx, { visible: sec.visible === false })}
+              onTitle={(title) => updateSection(idx, { title })}
+            />
+          ))}
+        </section>
+
+        <section className="report-preview-frame">
+          <h2>Preview</h2>
+          {previewUrl ? (
+            <iframe title="Report preview" src={previewUrl} className="report-preview-iframe" />
+          ) : (
+            <p className="hint">Click Preview PDF to render the report bundle.</p>
+          )}
+        </section>
+      </div>
+
+      {report?.report_id ? (
+        <p className="hint">
+          Report ID: <code>{report.report_id}</code> · {sections.filter((s) => s.visible !== false).length} visible sections
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
+++ b/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
@@ -32,6 +32,33 @@ type DemoResult = {
 
 const GRAPH_ID = "graph:live-fdd-validation";
 
+function validationSummary(payload: Record<string, unknown> | null): string {
+  if (!payload) return "";
+  if (typeof payload.error === "string") return payload.error;
+  if (typeof payload.message === "string") return payload.message;
+  if (payload.ok === true) return "SQL validation passed.";
+  const issues = payload.issues;
+  if (Array.isArray(issues) && issues.length > 0) {
+    return issues.map((item) => String(item)).join("; ");
+  }
+  if (payload.valid === true) return "SQL validation passed.";
+  if (payload.valid === false) return "SQL validation failed — check table/column names.";
+  return "Validation finished.";
+}
+
+function runResultSummary(payload: Record<string, unknown> | null): string {
+  if (!payload) return "";
+  if (typeof payload.error === "string") return payload.error;
+  const rows = payload.rows;
+  if (Array.isArray(rows)) {
+    return `Preview returned ${rows.length} row(s).`;
+  }
+  const count = payload.row_count ?? payload.count;
+  if (typeof count === "number") return `Preview returned ${count} row(s).`;
+  if (payload.ok === true) return "SQL preview completed.";
+  return "Preview finished.";
+}
+
 const DEFAULT_BUILDER: BuilderState = {
   name: "OA Temperature Out Of Range",
   input: "oa_t",
@@ -55,7 +82,9 @@ export default function SqlFddRulesPage() {
   const [demo, setDemo] = useState<DemoResult | null>(null);
   const [graphStatus, setGraphStatus] = useState("");
   const [busy, setBusy] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [error, setError] = useState("");
+  const equipmentMissing = mode === "builder" && !builder.equipment_id.trim();
 
   useEffect(() => {
     Promise.all([
@@ -88,6 +117,10 @@ export default function SqlFddRulesPage() {
   }, [mode, builder.input, builder.operator, builder.value, builder.equipment_id, previewBuilder]);
 
   async function runSql() {
+    if (equipmentMissing) {
+      setError("Select equipment first.");
+      return;
+    }
     setBusy(true);
     setError("");
     try {
@@ -109,14 +142,16 @@ export default function SqlFddRulesPage() {
 
   useEffect(() => {
     if (!siteId) return;
-    apiFetch<{ equipment?: { id?: string }[] }>(`/api/model/sites/${encodeURIComponent(siteId)}/equipment`)
+    apiFetch<{ equipment?: { id?: string; equipment_id?: string }[] }>(
+      `/api/model/sites/${encodeURIComponent(siteId)}/equipment`,
+    )
       .then((res) => {
-        const first = res.equipment?.[0]?.id;
+        const first = res.equipment?.[0]?.id ?? res.equipment?.[0]?.equipment_id;
         if (first) {
           setBuilder((b) => (b.equipment_id ? b : { ...b, equipment_id: first }));
         }
       })
-      .catch(() => undefined);
+      .catch(() => setError("Could not load equipment for this site — enter an equip id manually."));
   }, [siteId]);
 
   useEffect(() => {
@@ -201,10 +236,12 @@ export default function SqlFddRulesPage() {
           <button type="button" className="secondary-btn" onClick={() => void validateSql()} disabled={busy}>
             Validate SQL
           </button>
-          <button type="button" className="primary-btn" onClick={() => void runSql()} disabled={busy || !sql.trim()}>
+          <button type="button" className="primary-btn" onClick={() => void runSql()} disabled={busy || !sql.trim() || equipmentMissing}>
             Run (Ctrl/Cmd+Enter)
           </button>
         </div>
+
+        {equipmentMissing ? <div className="warn-banner">Select equipment first.</div> : null}
 
         {mode === "builder" ? (
           <div className="builder-grid">
@@ -277,11 +314,19 @@ export default function SqlFddRulesPage() {
           />
         </label>
 
-        {validation ? (
-          <pre className="code-block">{JSON.stringify(validation, null, 2)}</pre>
+        {validation ? <div className="status-banner">{validationSummary(validation)}</div> : null}
+        {runResult ? <div className="status-banner">{runResultSummary(runResult)}</div> : null}
+        {(validation || runResult) && showAdvanced ? (
+          <details className="advanced-json">
+            <summary>Advanced / raw JSON</summary>
+            {validation ? <pre className="code-block">{JSON.stringify(validation, null, 2)}</pre> : null}
+            {runResult ? <pre className="code-block">{JSON.stringify(runResult, null, 2)}</pre> : null}
+          </details>
         ) : null}
-        {runResult ? (
-          <pre className="code-block">{JSON.stringify(runResult, null, 2)}</pre>
+        {(validation || runResult) && !showAdvanced ? (
+          <button type="button" className="secondary-btn" onClick={() => setShowAdvanced(true)}>
+            Show advanced JSON
+          </button>
         ) : null}
       </section>
 
@@ -308,8 +353,9 @@ export default function SqlFddRulesPage() {
         {graphStatus ? <div className="status-banner">{graphStatus}</div> : null}
       </section>
 
-      <section className="panel">
-        <h2 className="panel-title">DataFusion batch demo</h2>
+      <section className="panel demo-panel">
+        <h2 className="panel-title">DataFusion batch demo (sample data)</h2>
+        <p className="muted-copy">Demonstration only — not live historian results.</p>
         {demo?.sql ? <pre className="sql-block">{demo.sql}</pre> : null}
         <div className="table-like">
           {(demo?.faults ?? []).map((f) => (

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -3131,3 +3131,60 @@ button.linkish {
     grid-template-columns: 1fr;
   }
 }
+
+.report-builder-page .report-builder-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.report-builder-page .report-section-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  background: var(--panel);
+}
+
+.report-builder-page .report-section-card.muted {
+  opacity: 0.55;
+}
+
+.report-builder-page .report-section-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.report-builder-page .report-section-type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  flex: 1;
+}
+
+.report-builder-page .report-section-title {
+  width: 100%;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  background: transparent;
+  color: inherit;
+  margin-bottom: 0.5rem;
+}
+
+.report-builder-page .report-preview-iframe {
+  width: 100%;
+  min-height: 480px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fff;
+}
+
+@media (max-width: 900px) {
+  .report-builder-page .report-builder-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/workspace/dashboard/src/styles/bis-dashboard.css
+++ b/workspace/dashboard/src/styles/bis-dashboard.css
@@ -462,6 +462,19 @@
   color: var(--muted);
 }
 
+.bis-inline-link {
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.bis-subhead {
+  margin: 1.1rem 0 0.35rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
 /* Buttons */
 .bis-btn {
   display: inline-flex;

--- a/workspace/dashboard/vite.config.ts
+++ b/workspace/dashboard/vite.config.ts
@@ -12,11 +12,12 @@ export default defineConfig({
     emptyOutDir: false,
   },
   server: {
-    port: 5173,
-    host: "127.0.0.1",
+    port: Number(process.env.VITE_DEV_PORT || 5173),
+    host: process.env.VITE_DEV_HOST || "127.0.0.1",
     proxy: {
       "/api": { target: "http://127.0.0.1:8080", changeOrigin: true },
       "/health": { target: "http://127.0.0.1:8080", changeOrigin: true },
+      "/openfdd-agent": { target: "http://127.0.0.1:8080", changeOrigin: true },
     },
   },
 });


### PR DESCRIPTION
## Summary
Inspection-focused branch combining #379 (auth/UI/Haystack) + #380 (report builder) with fixes to get a **clickable local UI** without 1-hour/6-hour validation.

- **Fixed** `reports_integration` CI race — non-panicking TCP connect + retry until health OK (matches `auth_integration` pattern)
- **Added** `scripts/openfdd_inspection_build.sh` — dashboard build, auth bootstrap, Docker up, health wait, URL/credentials print
- **Updated** `scripts/openfdd_auth_smoke.sh` — operator/integrator/agent login via bootstrap handoff (not bcrypt hashes)
- **Updated** `scripts/openfdd_ui_smoke.sh` — lightweight tab/API inspection smoke (no field hardware)
- **Docs** `docs/deployment/local_ui_inspection.md`, `docs/deployment/windows_docker_desktop.md`

## Local inspection

```bash
./scripts/openfdd_inspection_build.sh --build --smoke
# Open http://127.0.0.1:8080
# Passwords: workspace/bootstrap_credentials.once.txt (NOT auth.env.local hashes)
```

JSON/CSV-only mode: `./scripts/openfdd_inspection_build.sh --desktop --smoke`

## Intentionally skipped in this PR
- 1-hour / 6-hour validation
- CSV append/delete proof
- PDF quality validation
- Live BACnet / Modbus hardware

Next pass after UI inspection is satisfactory.

## Test plan
- [ ] `cargo fmt --all --check`
- [ ] `cargo test --workspace`
- [ ] `npm run build`
- [ ] `./scripts/openfdd_inspection_build.sh --smoke`
- [ ] Manual browser click-through of main tabs

## Related
- Stacks on #379 + #380 work
- Supersedes blocking CI on #380 for inspection purposes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Report Builder UI (draft/edit/reorder) with HTML/PDF preview and downloads; introduced reports endpoints.
  * Added Haystack UI and equipment/model persistence; added exports/Data Export page, host stats, and new driver status/tree endpoints.
* **Bug Fixes**
  * Expanded integrator-tier permissions (agent/admin) for mutation/rule actions; updated authorization messaging.
  * Enhanced building status details and improved API error parsing/login token handling.
* **Documentation**
  * New/updated local UI inspection and Windows deployment guides; refreshed secrets-auth and local-dev docs (including developer auth notes).
* **Chores**
  * Shortened one-time bootstrap plaintext passwords to 14 chars and improved credential handoff workflow/scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->