### PR TITLE
Open-FDD OS future concept (Home Assistant OS–inspired)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Full detail: [architecture/overview.md](architecture/overview.md).
 | Topic | Document |
 | --- | --- |
 | Platform overview | [architecture/overview.md](architecture/overview.md) |
+| **Open-FDD OS (future concept)** | [../os/README.md](../os/README.md) — HA OS–inspired appliance image; Rust GHCR under the hood |
 | Local BACnet server (diagnostics) | [architecture/bacnet-local-server.md](architecture/bacnet-local-server.md) |
 | Drivers, historian, and FDD | [architecture/drivers-and-fdd.md](architecture/drivers-and-fdd.md) |
 | Haystack assignment model | [ASSIGNMENT_MODEL.md](ASSIGNMENT_MODEL.md) |

--- a/os/Documentation/concept.md
+++ b/os/Documentation/concept.md
@@ -1,0 +1,65 @@
+# Open-FDD OS — concept (Home Assistant OS–inspired)
+
+**Future concept only.** Open-FDD **3.2.x** ships as Docker on a generic Linux host. This document captures design intent for a dedicated appliance OS — analogous to how [Home Assistant OS](https://developers.home-assistant.io/docs/operating-system/) wraps Home Assistant Core.
+
+## Why an appliance OS?
+
+Building FDD edges run headless for years on LANs with:
+
+- BACnet / Modbus on local NICs (host networking, multicast)
+- Large historian partitions on durable storage
+- Infrequent, trusted operator updates (integrator/agent JWT)
+- Need for rollback when an OTA bundle misbehaves
+
+A **single-purpose OS image** reduces drift (no desktop packages, no accidental `apt upgrade` breaking Docker), simplifies field support, and enables signed OTA — the same reasons Home Assistant moved from “Docker on Raspbian” to **HA OS**.
+
+## Design principles (aligned with HA OS, adapted for FDD)
+
+| Principle | Open-FDD interpretation |
+| --- | --- |
+| **Appliance, not desktop** | No GUI desktop; SSH optional; dashboard via browser to bridge `:8080` or Caddy |
+| **Read-only root** | OS rootfs immutable; all site state in `/var/openfdd/workspace` |
+| **Containers only** | Rust edge runs in GHCR containers — never `cargo install` on host for production |
+| **Supervisor layer** | Future daemon or script bundle: compose up, health, pinned versions, addon profiles (`mcp-sidecar`, `caddy-tls`) |
+| **OTA with rollback** | RAUC A/B slots for OS; separate channel for “supervisor + app” bundle (compose + manifest) |
+| **Board support packages** | x86_64 UEFI (Acme VM, NUC-class), Raspberry Pi 4/5 ARM64 |
+| **LAN-first security** | Bind API to loopback or site VLAN; JWT auth; no public internet exposure by default |
+
+## Mapping: Home Assistant → Open-FDD
+
+| Home Assistant | Open-FDD (planned) |
+| --- | --- |
+| HA OS | Open-FDD OS (`os/`) |
+| Supervisor | Future supervisor (compose + manifest; today: `scripts/openfdd_rust_*`) |
+| Home Assistant Core | `openfdd-bridge` container (`open_fdd_edge_prototype`) |
+| Add-ons | GHCR sidecars: commission, haystack-gateway, `openfdd-mcp`, Caddy |
+| `/config` | `workspace/` (historian, Haystack grid, rules, auth) |
+| Home Assistant Container | **Not the goal** — we target appliance OS, not “Docker on random Linux” long term |
+
+## Rust cargo project (not Python)
+
+Legacy Open-FDD docs referenced Python sidecars and `mcp-rag`. The **3.2 Rust edge** baseline is:
+
+```text
+Cargo workspace
+├── edge/     → open_fdd_edge_prototype (bridge, commission modes)
+└── mcp/      → openfdd-mcp (optional MCP stdio sidecar)
+```
+
+The OS image would ship **Docker + RAUC + kernel** only. Application bytes come from GHCR builds of those crates — same as today, but with a controlled host and OTA path.
+
+## Non-goals (for Open-FDD OS)
+
+- Running application code via `pip`, `npm`, or host `cargo run` in production
+- Multi-tenant unrelated stacks on one edge (single `openfdd-edge` compose project)
+- Cloud-dependent runtime (must operate offline on building LAN)
+- Embedding Ollama or MCP **inside** the bridge container (optional sidecars only)
+- Replacing integrator workflow before Phase A (Ubuntu + GHCR) is stable on field Pi
+
+## Relationship to current deploys
+
+**Phase A (now):** Ubuntu 24.04 or Raspberry Pi OS + Docker CE + [`docker/compose.edge.rust.yml`](../../docker/compose.edge.rust.yml) + [`scripts/openfdd_rust_site_update.sh`](../../scripts/openfdd_rust_site_update.sh).
+
+**Phase D (future):** Flash Open-FDD OS image → supervisor pulls pinned GHCR tags → OTA updates OS and app bundle.
+
+No code in `os/` is required to install, update, or validate a site in 3.2.x.

--- a/os/Documentation/roadmap.md
+++ b/os/Documentation/roadmap.md
@@ -1,0 +1,57 @@
+# Open-FDD OS roadmap
+
+**Future concept** — track progress here; do not block 3.2.x patch releases on these items.
+
+Design principles:
+
+- **Lightweight** — Buildroot or similar; no desktop distribution
+- **Docker-first** — container engine is the only app runtime on the host
+- **Rust apps in GHCR** — `open_fdd_edge_prototype` + `openfdd-mcp`; no host Python
+- **OTA** — RAUC A/B slots (future); offline `docker load` / GHCR pull until then
+- **Read-only root** — SquashFS rootfs; mutable state under `/var/openfdd/workspace`
+- **Board support** — x86_64 UEFI (bench VM), Raspberry Pi 4/5 ARM64 (field)
+
+## Phases
+
+| Phase | Deliverable | Status (3.2.3-prep) | Notes |
+| --- | --- | --- | --- |
+| **A** | Ubuntu/Pi OS + Docker + `docker/compose.edge.rust.yml` + lifecycle scripts | **Shipping** | [`openfdd_rust_edge_bootstrap.sh`](../../scripts/openfdd_rust_edge_bootstrap.sh), [`openfdd_rust_site_update.sh`](../../scripts/openfdd_rust_site_update.sh) |
+| **B** | GHCR multi-arch Rust edge + MCP images, version pins | **Shipping** | `ghcr.io/bbartling/openfdd-edge-rust`, `ghcr.io/bbartling/openfdd-mcp`; tag via `VERSION` + CI |
+| **C** | `os/buildroot-external` board defconfig (x86_64, then Pi) | **Not started** | Docker pre-installed, no apt on target; placeholder dir only |
+| **D** | RAUC OTA for OS + supervisor bundle (compose + manifest) | **Not started** | Replace manual pull/recreate; rollback slot |
+
+## Phase C sketch (when started)
+
+```text
+os/
+  buildroot-external/
+    board/openfdd/x86_64/     # UEFI, Docker CE, RAUC stub
+    board/openfdd/rpi4/       # ARM64, same stack
+  rauc/
+    manifest.raucm            # A/B update descriptor (future)
+```
+
+Supervisor manifest (future) might pin:
+
+```yaml
+# conceptual — not implemented
+edge_image: ghcr.io/bbartling/openfdd-edge-rust:3.2.3
+mcp_image: ghcr.io/bbartling/openfdd-mcp:3.2.3
+profiles: [full-edge]
+workspace_mount: /var/openfdd/workspace
+```
+
+Today those pins are operator env (`OPENFDD_IMAGE_TAG`) and Compose profiles.
+
+## Non-goals (OS program)
+
+- Host `pip install` / legacy Python bridge
+- Bundling MCP or Ollama inside the bridge image
+- Multiple unrelated compose projects on one appliance
+- Public-internet exposure of bridge or MCP
+
+## See also
+
+- [concept.md](concept.md) — Home Assistant OS inspiration
+- [../README.md](../README.md) — folder index
+- [../../docs/quick-start/rust-site-lifecycle.md](../../docs/quick-start/rust-site-lifecycle.md) — current update path

--- a/os/README.md
+++ b/os/README.md
@@ -1,0 +1,94 @@
+# Open-FDD OS (future concept)
+
+> **Status:** Design placeholder only — **not** used for production deploys in Open-FDD **3.2.x**.  
+> Inspired by [Home Assistant OS](https://www.home-assistant.io/operating-system/) (dedicated appliance image, read-only root, container runtime, OTA updates). Open-FDD OS would apply the same *shape* to **HVAC edge FDD** on BACnet/Modbus/Haystack building networks.
+
+## What this is
+
+A **future** thin Linux host image for field edge devices:
+
+- Read-only root filesystem (SquashFS or equivalent)
+- Container engine as the **only** application runtime
+- Writable state on a dedicated partition (`/var/openfdd` → bind-mount `workspace/`)
+- A/B OTA updates (RAUC or similar) for OS + supervisor bundle
+- Board support: x86_64 UEFI (VM/bench), Raspberry Pi 4/5 (ARM64 field Pi)
+
+**Application logic stays in published GHCR images**, compiled from the Rust workspace (`edge/`, `mcp/`) — not baked into the OS rootfs.
+
+## What this is not (today)
+
+| Do not use `os/` for | Use instead |
+| --- | --- |
+| Fresh site install | [`scripts/openfdd_rust_edge_bootstrap.sh`](../scripts/openfdd_rust_edge_bootstrap.sh) |
+| Image updates | [`scripts/openfdd_rust_site_update.sh`](../scripts/openfdd_rust_site_update.sh) + GHCR |
+| Compose stack | [`docker/compose.edge.rust.yml`](../docker/compose.edge.rust.yml) |
+| Optional MCP sidecar | [`mcp/README.md`](../mcp/README.md) (`--profile mcp-sidecar`) |
+
+Current production path: **Ubuntu (or Pi OS) + Docker CE + GHCR Rust edge** — same operational model Home Assistant used before HA OS matured, but with Open-FDD’s Rust cargo crates under the hood.
+
+## Layered model (HA OS–like)
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  Open-FDD OS (future) — Buildroot / board image              │
+│  Kernel · read-only root · Docker · RAUC A/B (planned)       │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│  Supervisor (future) — compose project + version manifest    │
+│  Pins GHCR tags · health · rollback · addon profiles           │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+        ┌───────────────────┼───────────────────┐
+        ▼                   ▼                   ▼
+  openfdd-bridge      openfdd-commission   openfdd-haystack-gw
+  (Rust edge crate)   (same image)         (same image)
+        │                   │                   │
+        └───────────────────┴───────────────────┘
+                            │
+                    workspace/ (persistent)
+                    historian · Haystack model · rules · auth
+```
+
+Optional addon (separate GHCR image, stdio MCP):
+
+```text
+  openfdd-mcp  ←  cargo crate `openfdd-mcp`, profile `mcp-sidecar`
+```
+
+## Repo layout (concept vs implemented)
+
+| Path | Role | 3.2.x today |
+| --- | --- | --- |
+| `os/` | Board defs, Buildroot external, OTA bundles | **This folder — docs only** |
+| `edge/` | Rust bridge, historian, FDD, drivers (`open_fdd_edge_prototype`) | **Implemented** |
+| `mcp/` | Read-first MCP stdio sidecar (`openfdd-mcp`) | **Scaffold + GHCR** |
+| `docker/` | `Dockerfile`, `compose.edge.rust.yml` | **Implemented** |
+| `workspace/` | Site state (bind-mounted) | **Implemented** |
+| `scripts/` | Bootstrap, backup, update, validate | **Implemented** |
+
+There is **no** `supervisor/` crate yet; today Compose + lifecycle scripts play that role.
+
+## Rust under the hood
+
+Open-FDD OS would **not** ship Python or `pip install` on the host. Containers are built from:
+
+| Crate / package | GHCR image | `SERVICE_MODE` |
+| --- | --- | --- |
+| `open_fdd_edge_prototype` | `ghcr.io/bbartling/openfdd-edge-rust` | `bridge`, `commission`, `haystack-gateway` |
+| `openfdd-mcp` | `ghcr.io/bbartling/openfdd-mcp` | stdio MCP (sidecar) |
+
+CI: [`.github/workflows/rust-ghcr.yml`](../.github/workflows/rust-ghcr.yml), [`.github/workflows/rust-ghcr-mcp.yml`](../.github/workflows/rust-ghcr-mcp.yml).
+
+## Documentation
+
+| Doc | Purpose |
+| --- | --- |
+| [Documentation/concept.md](Documentation/concept.md) | Home Assistant OS inspiration, principles, non-goals |
+| [Documentation/roadmap.md](Documentation/roadmap.md) | Phased delivery (A → D) |
+
+## Development today
+
+Use a normal Linux edge host (WSL bench, VM, Raspberry Pi) with Docker and the Rust GHCR stack. Do **not** block releases on `os/` image work.
+
+Quick start: [docs/quick-start/rust-edge-bootstrap.md](../docs/quick-start/rust-edge-bootstrap.md).

--- a/os/buildroot-external/README.md
+++ b/os/buildroot-external/README.md
@@ -1,0 +1,12 @@
+# Buildroot external (placeholder)
+
+**Not implemented.** Reserved for Phase C of [Open-FDD OS](../README.md): board support packages and defconfigs for x86_64 UEFI and Raspberry Pi ARM64.
+
+When work starts, this tree will follow a Home Assistant OS–style layout:
+
+- Minimal kernel + read-only rootfs
+- Docker CE (or containerd + nerdctl) preinstalled
+- RAUC hooks for A/B updates
+- First-boot mount of `/var/openfdd` for `workspace/`
+
+Until then, use standard Linux + [docker/compose.edge.rust.yml](../../docker/compose.edge.rust.yml).


### PR DESCRIPTION
## Summary

- Adds `os/` design placeholder copied from the Downloads concept and updated for the **3.2.x Rust edge** (cargo workspace `edge/` + `mcp/`, GHCR images, no Python host runtime).
- Documents future appliance OS inspired by [Home Assistant OS](https://www.home-assistant.io/operating-system/): read-only root, Docker-only apps, RAUC OTA, board support — **not used for production deploys today**.
- Phased roadmap (A–D): Phase A/B = current Ubuntu/Pi + GHCR; Phase C/D = Buildroot + RAUC (placeholders only).
- Links from `docs/README.md`.

## Files

| Path | Purpose |
| --- | --- |
| `os/README.md` | Index, layer diagram, “use scripts instead today” |
| `os/Documentation/concept.md` | HA OS mapping, Rust-under-the-hood principles |
| `os/Documentation/roadmap.md` | Phases A–D vs 3.2.3-prep status |
| `os/buildroot-external/README.md` | Phase C placeholder |

## Test plan

- [ ] Read `os/README.md` — confirms future concept, points to bootstrap/update scripts
- [ ] No runtime or CI changes; docs-only PR


Made with [Cursor](https://cursor.com)