### PR TITLE
3.2.3 release prep: dashboard, wiresheet, MCP docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Open-FDD **3.2.x** is a **deterministic Rust edge runtime** (`ghcr.io/bbartling/
 | **Rust edge** | `openfdd-bridge`, `openfdd-commission`, `openfdd-haystack-gateway` — poll, historian, FDD, reports |
 | **External agent** | Docs/code PRs, validation scripts, read-only API inspection |
 | **Optional Ollama** | Local-only doc helper for operators — not a bridge dependency |
-| **Future MCP** | Read-first `openfdd-mcp` sidecar — see [docs/agent/openfdd-mcp-tool-contract.md](docs/agent/openfdd-mcp-tool-contract.md) |
+| **Optional MCP** | Read-first `openfdd-mcp` GHCR sidecar (3.2.3+) — [mcp/README.md](mcp/README.md); not started by site update |
 
 **Agent docs:** [docs/agent/openfdd-agent-current-standing.md](docs/agent/openfdd-agent-current-standing.md) · [architecture](docs/agent/openfdd-agent-architecture.md) · [bench WSL agent prompt](docs/agent/bench-driver-setup-wsl-agent.md) · [safety boundaries](docs/security/agent-safety-boundaries.md)
 
@@ -41,6 +41,16 @@ Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:808
 ```
 
 After a release merge to `master`, run `openfdd_rust_site_update.sh` to pull the new `ghcr.io/bbartling/openfdd-edge-rust` image. Verify with `/api/health` (`version` + `image_tag`).
+
+**Optional MCP (3.2.3+):** site update does not pull/start MCP. After validate:
+
+```bash
+export OPENFDD_COMPOSE_ROOT=~/open-fdd OPENFDD_IMAGE_TAG=3.2.3
+docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
+export OPENFDD_MCP_TOKEN="$TOKEN"
+```
+
+Cursor stdio config: [mcp/README.md](mcp/README.md).
 
 ## Model routing (external agents)
 

--- a/README.md
+++ b/README.md
@@ -168,17 +168,11 @@ Example routes:
 
 ### Future service mode
 
-MCP / agent tooling is expected to become a **separate read-first sidecar** after the core Rust edge, drivers, historian, FDD, and reports are stable. **Built-in Ollama is not required** — dashboard Agent/Ollama panels are placeholders for optional local-only helpers.
+Since **3.2.3**, MCP ships as an **optional GHCR sidecar** (`ghcr.io/bbartling/openfdd-mcp`) — not inside the bridge image. See [Optional MCP sidecar](#optional-mcp-sidecar-after-edge-update) above and [mcp/README.md](mcp/README.md). **Built-in Ollama is not required** — dashboard Agent/Ollama panels are placeholders for optional local-only helpers.
 
 See [docs/agent/openfdd-agent-architecture.md](docs/agent/openfdd-agent-architecture.md) and [docs/agent/openfdd-mcp-tool-contract.md](docs/agent/openfdd-mcp-tool-contract.md).
 
-Possible future shape:
-
-```text
-openfdd-mcp
-```
-
-or:
+Legacy note — an in-process mode was considered but not used:
 
 ```text
 SERVICE_MODE=mcp
@@ -245,6 +239,70 @@ cd ~/open-fdd
 ./scripts/openfdd_rust_site_update.sh
 ./scripts/openfdd_rust_edge_validate.sh
 ```
+
+The update script pulls and recreates the **core edge stack only** (`openfdd-bridge`, commission, Haystack gateway). It does **not** start MCP.
+
+### Optional MCP sidecar (after edge update)
+
+From **3.2.3** onward, GHCR also publishes [`ghcr.io/bbartling/openfdd-mcp`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mcp) — a **separate** read-first stdio server for Cursor/agents. Use the **same image tag** as the edge update (`OPENFDD_IMAGE_TAG` / `NEW_TAG`).
+
+**1. Edge must be healthy** (`curl -fsS http://127.0.0.1:8080/api/health`).
+
+**2. Pull the MCP image** (optional; Cursor can pull on first run):
+
+```bash
+cd ~/open-fdd
+export OPENFDD_COMPOSE_ROOT="$PWD"
+export OPENFDD_IMAGE_TAG=3.2.3   # match your site update tag
+
+docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
+```
+
+**3. Obtain an integrator JWT** (do not log or commit the token):
+
+```bash
+source scripts/openfdd_auth_lib.sh
+INTEGRATOR_PW="$(openfdd_auth_plaintext_password workspace/auth.env.local integrator)"
+export OPENFDD_MCP_TOKEN="$(
+  curl -s -X POST http://127.0.0.1:8080/api/auth/login \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg u integrator --arg p "$INTEGRATOR_PW" '{username:$u,password:$p}')" \
+  | jq -r '.token // .access_token'
+)"
+```
+
+**4. Connect Cursor (recommended)** — add to Cursor MCP settings (WSL path to `docker`):
+
+```json
+{
+  "mcpServers": {
+    "openfdd": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", "--network", "host",
+        "-e", "OPENFDD_API_BASE=http://127.0.0.1:8080",
+        "-e", "OPENFDD_COMMISSION_BASE=http://127.0.0.1:9091",
+        "-e", "OPENFDD_MCP_TOKEN",
+        "ghcr.io/bbartling/openfdd-mcp:3.2.3"
+      ],
+      "env": {
+        "OPENFDD_MCP_TOKEN": "<paste JWT from step 3>"
+      }
+    }
+  }
+}
+```
+
+**Smoke test** (stdio; Ctrl+D to exit):
+
+```bash
+docker run -i --rm --network host \
+  -e OPENFDD_API_BASE=http://127.0.0.1:8080 \
+  -e OPENFDD_MCP_TOKEN="$OPENFDD_MCP_TOKEN" \
+  ghcr.io/bbartling/openfdd-mcp:${OPENFDD_IMAGE_TAG:-3.2.3}
+```
+
+MCP uses **stdio JSON-RPC** — it is not an HTTP service on a port. Full tool list and bench topology: [mcp/README.md](mcp/README.md).
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,8 @@ services:
       - ./workspace:/app/workspace
     restart: unless-stopped
 
-  # MCP will be added later. Agent JSON APIs are already exposed by openfdd-bridge.
+  # Optional MCP sidecar: see mcp/README.md and README "Optional MCP sidecar".
+  # docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
 
   open-fdd-rust-backend:
     profiles: ["rust-prod"]

--- a/docs/operations/rust-update-restore.md
+++ b/docs/operations/rust-update-restore.md
@@ -37,3 +37,17 @@ Verify platform before update:
 ```bash
 ./scripts/openfdd_rust_check_ghcr_platform.sh
 ```
+
+## Optional MCP sidecar (3.2.3+)
+
+Edge update does **not** start MCP. After a successful update, pull the MCP image at the **same tag** and connect Cursor (stdio):
+
+```bash
+cd ~/open-fdd
+export OPENFDD_COMPOSE_ROOT="$PWD"
+export OPENFDD_IMAGE_TAG=3.2.3   # match NEW_TAG / site tag
+
+docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
+```
+
+Then configure Cursor or run interactively — see [mcp/README.md](../mcp/README.md) and README **Optional MCP sidecar**.

--- a/docs/quick-start/rust-site-lifecycle.md
+++ b/docs/quick-start/rust-site-lifecycle.md
@@ -33,6 +33,18 @@ Environment:
 ./scripts/openfdd_rust_edge_validate.sh
 ```
 
+## Optional MCP sidecar (3.2.3+)
+
+Not started by `openfdd_rust_site_update.sh`. After edge validate passes:
+
+```bash
+export OPENFDD_COMPOSE_ROOT=~/open-fdd
+export OPENFDD_IMAGE_TAG=3.2.3   # same as NEW_TAG above
+docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
+```
+
+Wire Cursor with `ghcr.io/bbartling/openfdd-mcp:$OPENFDD_IMAGE_TAG` and an integrator JWT — [mcp/README.md](../../mcp/README.md).
+
 ## Restore workspace
 
 ```bash

--- a/docs/release/3.2.3.md
+++ b/docs/release/3.2.3.md
@@ -1,0 +1,43 @@
+# Open-FDD 3.2.3 Release Notes
+
+**Target branch:** `release/3.2.3-prep` → `master`  
+**GHCR images:** `ghcr.io/bbartling/openfdd-edge-rust:3.2.3`, `ghcr.io/bbartling/openfdd-mcp:3.2.3`
+
+## Highlights
+
+- **CSV UT3 ingest** — Rust parse/plan/execute pipeline, Arrow IPC datasets, React UT3 panel at `/csv` ([#404](https://github.com/bbartling/open-fdd/pull/404))
+- **External multi-agent retrofit** — bench WSL agent doc, `openfdd-mcp` scaffold + GHCR workflow ([#403](https://github.com/bbartling/open-fdd/pull/403))
+- **Dashboard hardening** — public `/api/building/status` HVAC summary, fault detail analytics, read-only context for anonymous viewers
+- **Wiresheet studio** — `/wiresheet` loads empty scaffold graph when none saved; site scope fallback fixes
+- **Open-FDD OS concept** — future HA OS–inspired appliance docs in `os/` (design only)
+- **MCP sidecar docs** — optional pull after `openfdd_rust_site_update.sh` ([mcp/README.md](../mcp/README.md))
+
+## Upgrade
+
+```bash
+cd ~/open-fdd
+./scripts/openfdd_rust_site_backup.sh
+NEW_TAG=3.2.3 ./scripts/openfdd_rust_site_update.sh
+./scripts/openfdd_rust_edge_validate.sh
+curl -s http://127.0.0.1:8080/api/health | jq '{version, image_tag}'
+```
+
+Optional MCP (Cursor stdio):
+
+```bash
+export OPENFDD_COMPOSE_ROOT=~/open-fdd OPENFDD_IMAGE_TAG=3.2.3
+docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
+```
+
+Never run `docker compose down -v`.
+
+## Known follow-ups
+
+- [#405](https://github.com/bbartling/open-fdd/issues/405) CSV linear fill + kW hourly resample
+- [#406](https://github.com/bbartling/open-fdd/issues/406) SPARQL/RDF port to Rust edge
+- [#407](https://github.com/bbartling/open-fdd/issues/407) Building-insight Ollama agent
+
+## References
+
+- [Wiresheet architecture](../wiresheet/ARCHITECTURE.md)
+- [Rust site lifecycle](../quick-start/rust-site-lifecycle.md)

--- a/edge/src/dashboard/mod.rs
+++ b/edge/src/dashboard/mod.rs
@@ -150,6 +150,22 @@ pub fn building_status() -> Value {
     let coverage = query::model_coverage();
     let fault_summary = faults::summary_json();
     let rule_health = faults::rule_health();
+    let model_summary = query::equipment_model_summary();
+    let fdd_rules = crate::fdd::rules::list_rules();
+    let rules_preview: Vec<Value> = fdd_rules
+        .get("rules")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|rule| {
+            json!({
+                "id": rule.get("id").cloned().unwrap_or(Value::Null),
+                "name": rule.get("name").cloned().unwrap_or(Value::Null),
+                "enabled": rule.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true)
+            })
+        })
+        .collect();
     json!({
         "ok": true,
         "model_score": coverage.get("model_score").cloned().unwrap_or(json!(null)),
@@ -159,6 +175,8 @@ pub fn building_status() -> Value {
             "mapped_points": coverage.get("mapped_points").cloned().unwrap_or(json!(0)),
             "unmapped_points": coverage.get("unmapped_points").cloned().unwrap_or(json!(0))
         },
+        "model_summary": model_summary,
+        "fdd_rules": rules_preview,
         "rule_count": rule_health.get("rule_count").cloned().unwrap_or(json!(0)),
         "datafusion_ok": rule_health.get("datafusion_ok").cloned().unwrap_or(json!(false)),
         "alert_count": fault_summary.get("active_count").cloned().unwrap_or(json!(0))

--- a/edge/src/faults/mod.rs
+++ b/edge/src/faults/mod.rs
@@ -290,9 +290,21 @@ pub fn list_json(filter: Option<&str>) -> Value {
 }
 
 pub fn get_fault(fault_id: &str) -> Value {
+    let all_rows = eval_rows();
     for rec in list_records() {
         if rec.get("fault_id").and_then(|v| v.as_str()) == Some(fault_id) {
-            return json!({"ok": true, "fault": rec});
+            let source = rec
+                .get("source")
+                .and_then(|v| v.as_str())
+                .unwrap_or("fdd_rule");
+            let analytics = if source == "bacnet_override" {
+                rec.get("analytics").cloned().unwrap_or(json!({}))
+            } else {
+                fault_analytics_for_record(&rec, &all_rows)
+            };
+            let mut fault = rec.clone();
+            fault["analytics"] = analytics;
+            return json!({"ok": true, "fault": fault});
         }
     }
     json!({"ok": false, "error": "fault not found", "fault_id": fault_id})

--- a/edge/src/fdd/wires/api.rs
+++ b/edge/src/fdd/wires/api.rs
@@ -16,10 +16,10 @@ pub fn list_graphs(site_id: Option<&str>) -> String {
 }
 
 pub fn get_graph(site_id: &str, graph_id: &str) -> String {
-    match persistence::read_graph(site_id, graph_id) {
-        Some(graph) => serde_json::to_string(&json!({"ok": true, "graph": graph})).unwrap(),
-        None => serde_json::to_string(&json!({"ok": false, "error": "graph not found"})).unwrap(),
-    }
+    let graph = persistence::read_graph(site_id, graph_id).unwrap_or_else(|| {
+        super::schema::empty_graph(site_id, graph_id, "system")
+    });
+    serde_json::to_string(&json!({"ok": true, "graph": graph})).unwrap()
 }
 
 pub fn create_graph(payload: &Value, actor: &str) -> Value {

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -99,6 +99,18 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         };
         return json_response(&mut stream, body);
     }
+    if method == "GET" && clean_path.starts_with("/api/faults/") {
+        let tail = clean_path.trim_start_matches("/api/faults/").trim_matches('/');
+        if !tail.is_empty()
+            && !tail.contains('/')
+            && !matches!(
+                tail,
+                "status" | "summary" | "export.csv" | "catalog" | "tree" | "applicable"
+            )
+        {
+            return json_response(&mut stream, faults::get_fault(tail));
+        }
+    }
     if method == "GET"
         && !clean_path.starts_with("/api/")
         && !clean_path.starts_with("/openfdd-agent/")
@@ -507,6 +519,10 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &model::assignments::algorithm_bindings_json_string(),
         ),
         ("GET", "/api/model/tree") => json_response(&mut stream, model::commissioning::tree_json()),
+        ("GET", "/api/model/graph") => json_response(
+            &mut stream,
+            model::query::network_graph(query_param(&path, "site_id").as_deref()),
+        ),
         ("GET", "/api/model/commissioning-export") => json_response(
             &mut stream,
             model::commissioning::commissioning_export_json(),
@@ -1062,7 +1078,8 @@ fn parse_json_body_or_empty(body: &str) -> Value {
 }
 
 fn site_scope_param(path: &str) -> String {
-    model::scope::resolve_site_id(query_param(path, "site_id").as_deref()).unwrap_or_default()
+    model::scope::resolve_site_id(query_param(path, "site_id").as_deref())
+        .unwrap_or_else(|| fdd::wires::persistence::default_site_id())
 }
 
 fn query_param(path: &str, key: &str) -> Option<String> {

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -228,6 +228,167 @@ pub fn group_points_by_equip() -> Value {
     json!({"ok": true, "groups": grouped})
 }
 
+/// HVAC equipment counts and feeds chains for public dashboard context (Haystack grid, not SPARQL).
+pub fn equipment_model_summary() -> Value {
+    let rows = haystack_rows();
+    let mut by_type: HashMap<String, usize> = HashMap::new();
+    let mut labels: HashMap<String, String> = HashMap::new();
+    let mut feed_edges: Vec<(String, String)> = Vec::new();
+
+    for row in &rows {
+        if row.get("equip").and_then(|v| v.as_str()) != Some("M") {
+            continue;
+        }
+        let id = row
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if id.is_empty() {
+            continue;
+        }
+        let dis = row
+            .get("dis")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&id)
+            .to_string();
+        let etype = infer_equip_type(row).to_string();
+        *by_type.entry(etype).or_insert(0) += 1;
+        labels.insert(id.clone(), dis);
+        if let Some(upstream) = row.get("feedRef").and_then(|v| v.as_str()) {
+            feed_edges.push((upstream.to_string(), id));
+        }
+    }
+
+    let feeds_chains: Vec<String> = feed_edges
+        .iter()
+        .map(|(from, to)| {
+            let from_label = labels.get(from).map(String::as_str).unwrap_or(from.as_str());
+            let to_label = labels.get(to).map(String::as_str).unwrap_or(to.as_str());
+            format!("{from_label} feeds {to_label}")
+        })
+        .collect();
+
+    json!({
+        "ok": true,
+        "equipment_by_type": by_type,
+        "feeds_chains": feeds_chains,
+        "equipment_count": labels.len(),
+        "query_engine": "haystack"
+    })
+}
+
+/// Network graph for Model explorer and dashboard feeds visualization.
+pub fn network_graph(site_id: Option<&str>) -> Value {
+    let sid = super::scope::resolve_site_id(site_id);
+    let rows = haystack_rows();
+    let mut equipment: Vec<Value> = Vec::new();
+    let mut feeds: Vec<Value> = Vec::new();
+    let mut points_by_equipment: HashMap<String, Vec<Value>> = HashMap::new();
+    let mut labels: HashMap<String, String> = HashMap::new();
+
+    for row in &rows {
+        if row.get("equip").and_then(|v| v.as_str()) == Some("M") {
+            let row_site = row.get("siteRef").and_then(|v| v.as_str());
+            if let Some(filter) = sid.as_deref() {
+                if row_site != Some(filter) {
+                    continue;
+                }
+            }
+            let equipment_id = row
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if equipment_id.is_empty() {
+                continue;
+            }
+            let name = row
+                .get("dis")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&equipment_id)
+                .to_string();
+            labels.insert(equipment_id.clone(), name.clone());
+            equipment.push(json!({
+                "equipment_id": equipment_id,
+                "name": name,
+                "label": name,
+                "equipment_type": infer_equip_type(row)
+            }));
+            if let Some(upstream) = row.get("feedRef").and_then(|v| v.as_str()) {
+                feeds.push(json!({
+                    "from_equipment_id": upstream,
+                    "to_equipment_id": equipment_id
+                }));
+            }
+        }
+    }
+
+    let equip_site = super::scope::equip_site_map();
+    for row in &rows {
+        if row.get("point").and_then(|v| v.as_str()) != Some("M") {
+            continue;
+        }
+        let equip_ref = row
+            .get("equipRef")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if equip_ref.is_empty() || !labels.contains_key(&equip_ref) {
+            continue;
+        }
+        let point_site = row
+            .get("equipRef")
+            .and_then(|v| v.as_str())
+            .and_then(|e| equip_site.get(e).cloned());
+        if let Some(filter) = sid.as_deref() {
+            if point_site.as_deref() != Some(filter) {
+                continue;
+            }
+        }
+        let point_id = row
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let name = row
+            .get("dis")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&point_id)
+            .to_string();
+        points_by_equipment.entry(equip_ref).or_default().push(json!({
+            "point_id": point_id,
+            "name": name,
+            "label": name,
+            "equipment_id": row.get("equipRef").cloned().unwrap_or(json!(null)),
+            "unit": row.get("unit").cloned().unwrap_or(json!(null))
+        }));
+    }
+
+    for feed in &mut feeds {
+        if let Some(from) = feed.get("from_equipment_id").and_then(|v| v.as_str()) {
+            feed["from_label"] = json!(labels.get(from).cloned().unwrap_or_else(|| from.to_string()));
+        }
+        if let Some(to) = feed.get("to_equipment_id").and_then(|v| v.as_str()) {
+            feed["to_label"] = json!(labels.get(to).cloned().unwrap_or_else(|| to.to_string()));
+        }
+    }
+
+    let points_map: Value = points_by_equipment
+        .into_iter()
+        .map(|(k, v)| (k, json!(v)))
+        .collect();
+
+    json!({
+        "ok": true,
+        "site_id": sid,
+        "query_engine": "haystack",
+        "equipment": equipment,
+        "feeds": feeds,
+        "points_by_equipment": points_map
+    })
+}
+
 fn is_point_mapped(row: &Value) -> bool {
     row.get("fddInput").is_some()
         || row.get("bacnetRef").is_some()
@@ -241,6 +402,12 @@ fn infer_equip_type(row: &Value) -> &'static str {
         "vav"
     } else if row.get("chiller").is_some() {
         "chiller"
+    } else if row.get("boiler").is_some() {
+        "boiler"
+    } else if row.get("coolingTower").is_some() {
+        "cooling_tower"
+    } else if row.get("doas").is_some() {
+        "doas"
     } else {
         "generic"
     }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,6 +4,62 @@ Read-first [Model Context Protocol](https://modelcontextprotocol.io/) server for
 
 **Image:** `ghcr.io/bbartling/openfdd-mcp`
 
+## After a Docker / GHCR site update
+
+`openfdd_rust_site_update.sh` updates the **edge stack only**. MCP is opt-in — pull and wire it **after** the edge is healthy, using the **same tag** as the edge (`OPENFDD_IMAGE_TAG`, e.g. `3.2.3`).
+
+```bash
+cd ~/open-fdd
+export OPENFDD_COMPOSE_ROOT="$PWD"
+export OPENFDD_IMAGE_TAG=3.2.3
+
+# Pull MCP image (optional — docker run will pull if missing)
+docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
+
+# JWT for bridge REST (integrator or agent role)
+source scripts/openfdd_auth_lib.sh
+INTEGRATOR_PW="$(openfdd_auth_plaintext_password workspace/auth.env.local integrator)"
+export OPENFDD_MCP_TOKEN="$(
+  curl -s -X POST http://127.0.0.1:8080/api/auth/login \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg u integrator --arg p "$INTEGRATOR_PW" '{username:$u,password:$p}')" \
+  | jq -r '.token // .access_token'
+)"
+```
+
+**Cursor (stdio via Docker)** — MCP speaks JSON-RPC on stdin/stdout, not HTTP:
+
+```json
+{
+  "mcpServers": {
+    "openfdd": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", "--network", "host",
+        "-e", "OPENFDD_API_BASE=http://127.0.0.1:8080",
+        "-e", "OPENFDD_COMMISSION_BASE=http://127.0.0.1:9091",
+        "-e", "OPENFDD_MCP_TOKEN",
+        "ghcr.io/bbartling/openfdd-mcp:3.2.3"
+      ],
+      "env": {
+        "OPENFDD_MCP_TOKEN": "<JWT from login above>"
+      }
+    }
+  }
+}
+```
+
+**Manual smoke test:**
+
+```bash
+docker run -i --rm --network host \
+  -e OPENFDD_API_BASE=http://127.0.0.1:8080 \
+  -e OPENFDD_MCP_TOKEN="$OPENFDD_MCP_TOKEN" \
+  ghcr.io/bbartling/openfdd-mcp:${OPENFDD_IMAGE_TAG}
+```
+
+The compose service `openfdd-mcp` (`profiles: ["mcp-sidecar"]`) exists to **pull** the image with the same env/volume wiring as production; interactive MCP clients should use `docker run -i` (or the release binary below), not a detached `up -d`.
+
 ## Transport
 
 Stdio JSON-RPC (MCP 2024-11-05). Suitable for Cursor **WSL agent** local config:

--- a/workspace/dashboard/src/components/FddWiresheetSummary.tsx
+++ b/workspace/dashboard/src/components/FddWiresheetSummary.tsx
@@ -4,7 +4,7 @@ import { apiFetch } from "../lib/api";
 import { formatApiError } from "../lib/formatApiError";
 import { useActiveSiteId } from "../lib/useActiveSiteId";
 import { graphToFlow } from "../wiresheet/graphAdapter";
-import type { WiresheetGraph } from "../wiresheet/types";
+import { fetchWiresheetGraph } from "../wiresheet/wiresheetApi";
 
 const GRAPH_ID = "graph:live-fdd-validation";
 
@@ -23,10 +23,7 @@ export default function FddWiresheetSummary({ onStatus }: Props) {
   const loadGraph = useCallback(async () => {
     if (!siteId) return;
     try {
-      const qs = `?site_id=${encodeURIComponent(siteId)}`;
-      const graph = await apiFetch<WiresheetGraph>(
-        `/api/fdd-wires/graphs/${encodeURIComponent(GRAPH_ID)}${qs}`,
-      );
+      const graph = await fetchWiresheetGraph(GRAPH_ID, siteId);
       const flow = graphToFlow(graph);
       setNodeCount(flow.nodes.length);
       setReviewStatus(graph.review_status ?? "draft");

--- a/workspace/dashboard/src/components/buildingInsight/FaultDetailModal.tsx
+++ b/workspace/dashboard/src/components/buildingInsight/FaultDetailModal.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { apiFetch, hasToken } from "../../lib/api";
 import { formatApiError } from "../../lib/formatApiError";
 import type { DisplayFault } from "../../lib/displayFaults";
+import type { FaultAnalytics } from "../../lib/dashboardStream";
+
+type FaultRecord = {
+  fault_id?: string;
+  equipment_id?: string;
+  rule_id?: string;
+  rule_name?: string;
+  input_points?: string[];
+  analytics?: FaultAnalytics;
+};
 
 type Props = {
   fault: DisplayFault | null;
@@ -10,9 +20,21 @@ type Props = {
   onCleared?: () => void;
 };
 
+function analyticsFromFault(fault: DisplayFault): FaultAnalytics | undefined {
+  const fromUnderlying = fault.underlying[0]?.analytics;
+  if (fromUnderlying) return fromUnderlying;
+  const hours = fault.meta.find((m) => m.label === "Time in fault");
+  if (!hours) return undefined;
+  return { estimated_fault_duration_label: hours.value };
+}
+
+
 export default function FaultDetailModal({ fault, onClose, onCleared }: Props) {
   const [clearBusy, setClearBusy] = useState(false);
   const [clearError, setClearError] = useState("");
+  const [detailBusy, setDetailBusy] = useState(false);
+  const [detailError, setDetailError] = useState("");
+  const [record, setRecord] = useState<FaultRecord | null>(null);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -21,6 +43,54 @@ export default function FaultDetailModal({ fault, onClose, onCleared }: Props) {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
+
+  useEffect(() => {
+    if (!fault || fault.id.startsWith("group-")) {
+      setRecord(null);
+      setDetailError("");
+      return;
+    }
+    let cancelled = false;
+    setDetailBusy(true);
+    setDetailError("");
+    apiFetch<{ ok?: boolean; fault?: FaultRecord }>(`/api/faults/${encodeURIComponent(fault.id)}`)
+      .then((res) => {
+        if (cancelled) return;
+        setRecord(res.fault ?? null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setRecord(null);
+        setDetailError(formatApiError(e));
+      })
+      .finally(() => {
+        if (!cancelled) setDetailBusy(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fault]);
+
+  const analytics = useMemo(() => {
+    if (!fault) return undefined;
+    return record?.analytics ?? analyticsFromFault(fault);
+  }, [fault, record]);
+
+  const deviceId = useMemo(() => {
+    if (!fault) return "";
+    return (
+      record?.equipment_id ||
+      fault.underlying[0]?.equipment_id ||
+      fault.underlying[0]?.equipment_name ||
+      fault.equipmentLabel
+    );
+  }, [fault, record]);
+
+  const sensorColumns = analytics?.value_columns?.length
+    ? analytics.value_columns
+    : record?.input_points?.length
+      ? record.input_points
+      : [];
 
   if (!fault) return null;
 
@@ -48,6 +118,20 @@ export default function FaultDetailModal({ fault, onClose, onCleared }: Props) {
     fault.source !== "bacnet_override" &&
     !fault.id.startsWith("group-");
 
+  const metaWithoutAnalytics = fault.meta.filter(
+    (m) =>
+      ![
+        "First seen",
+        "Last seen",
+        "Fault window",
+        "Time in fault",
+        "Avg in fault",
+        "Avg normal",
+        "In-fault range",
+        "Samples",
+      ].includes(m.label),
+  );
+
   return (
     <div
       className="bis-modal-backdrop"
@@ -72,6 +156,84 @@ export default function FaultDetailModal({ fault, onClose, onCleared }: Props) {
             <h4>What this means</h4>
             <p>{fault.plainEnglish}</p>
           </section>
+
+          {deviceId ? (
+            <section className="bis-modal-section">
+              <h4>Device in alarm</h4>
+              <p className="bis-device-id">{deviceId}</p>
+              {record?.rule_name || record?.rule_id ? (
+                <p className="muted">
+                  Rule: {record.rule_name || record.rule_id}
+                  {sensorColumns.length ? ` · sensor ${sensorColumns.join(", ")}` : ""}
+                </p>
+              ) : null}
+            </section>
+          ) : null}
+
+          {detailBusy ? <p className="muted">Loading Rust fault analytics…</p> : null}
+          {detailError ? <p className="error">{detailError}</p> : null}
+
+          {analytics ? (
+            <section className="bis-modal-section">
+              <h4>Sensor statistics (historian)</h4>
+              <p className="muted bis-analytics-note">
+                Computed in Rust from historian samples — in-alarm vs normal operating periods.
+              </p>
+              <dl className="bis-meta-grid bis-analytics-grid">
+                {analytics.estimated_fault_duration_label || analytics.hours_in_fault != null ? (
+                  <div>
+                    <dt>Elapsed in alarm</dt>
+                    <dd>
+                      {analytics.estimated_fault_duration_label ??
+                        `${Number(analytics.hours_in_fault).toFixed(1)} h`}
+                    </dd>
+                  </div>
+                ) : null}
+                {analytics.fault_span_label ? (
+                  <div>
+                    <dt>Alarm window</dt>
+                    <dd>{analytics.fault_span_label}</dd>
+                  </div>
+                ) : null}
+                {analytics.avg_value_fault != null ? (
+                  <div>
+                    <dt>Avg while in alarm</dt>
+                    <dd>
+                      {analytics.avg_value_fault}
+                      {analytics.value_unit ? ` ${analytics.value_unit}` : ""}
+                    </dd>
+                  </div>
+                ) : null}
+                {analytics.avg_value_normal != null ? (
+                  <div>
+                    <dt>Avg while normal</dt>
+                    <dd>
+                      {analytics.avg_value_normal}
+                      {analytics.value_unit ? ` ${analytics.value_unit}` : ""}
+                    </dd>
+                  </div>
+                ) : null}
+                {analytics.min_value_fault != null && analytics.max_value_fault != null ? (
+                  <div>
+                    <dt>In-alarm range</dt>
+                    <dd>
+                      {analytics.min_value_fault} – {analytics.max_value_fault}
+                      {analytics.value_unit ? ` ${analytics.value_unit}` : ""}
+                    </dd>
+                  </div>
+                ) : null}
+                {analytics.fault_samples != null && analytics.total_samples != null ? (
+                  <div>
+                    <dt>Samples in alarm</dt>
+                    <dd>
+                      {analytics.fault_samples} / {analytics.total_samples}
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+            </section>
+          ) : null}
+
           {fault.detail && fault.detail !== fault.plainEnglish ? (
             <section className="bis-modal-section">
               <h4>Detail</h4>
@@ -91,17 +253,11 @@ export default function FaultDetailModal({ fault, onClose, onCleared }: Props) {
               </ul>
             </section>
           ) : null}
-          {fault.technical ? (
-            <section className="bis-modal-section">
-              <h4>Technical</h4>
-              <pre className="bis-technical">{fault.technical}</pre>
-            </section>
-          ) : null}
-          {fault.meta.length ? (
+          {metaWithoutAnalytics.length ? (
             <section className="bis-modal-section">
               <h4>At a glance</h4>
               <dl className="bis-meta-grid">
-                {fault.meta.map((m) => (
+                {metaWithoutAnalytics.map((m) => (
                   <div key={m.label}>
                     <dt>{m.label}</dt>
                     <dd>{m.value}</dd>

--- a/workspace/dashboard/src/components/buildingInsight/OperationalContextPanel.tsx
+++ b/workspace/dashboard/src/components/buildingInsight/OperationalContextPanel.tsx
@@ -17,6 +17,13 @@ type BuildingMeta = {
     mapped_points?: number;
     unmapped_points?: number;
   };
+  model_summary?: {
+    equipment_by_type?: Record<string, number>;
+    feeds_chains?: string[];
+    equipment_count?: number;
+    query_engine?: string;
+  };
+  fdd_rules?: Array<{ id?: string; name?: string; enabled?: boolean }>;
   alert_count?: number;
   rule_count?: number;
   datafusion_ok?: boolean;
@@ -40,17 +47,38 @@ function formatProtocolLabel(protocol: string): string {
   }
 }
 
+function formatEquipTypeLabel(raw: string): string {
+  return raw.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 export default function OperationalContextPanel({
   refreshKey,
   insight,
   insightError,
   buildingMeta,
 }: Props) {
+  const [publicMeta, setPublicMeta] = useState<BuildingMeta | null>(null);
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const [analytics, setAnalytics] = useState<DashboardAnalytics | null>(null);
   const [rules, setRules] = useState<FddRulesResponse | null>(null);
   const [loadError, setLoadError] = useState("");
   const signedIn = hasToken();
+
+  const meta = publicMeta ?? buildingMeta;
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<BuildingMeta>("/api/building/status")
+      .then((data) => {
+        if (!cancelled) setPublicMeta(data);
+      })
+      .catch(() => {
+        if (!cancelled) setPublicMeta(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
 
   useEffect(() => {
     if (!signedIn) {
@@ -86,13 +114,28 @@ export default function OperationalContextPanel({
   }, [refreshKey, signedIn]);
 
   const model = summary?.model_coverage;
+  const modelSummary = meta?.model_summary;
   const ruleHealth = analytics?.rule_health;
-  const ruleList = rules?.rules ?? [];
+  const ruleList = rules?.rules ?? meta?.fdd_rules ?? [];
   const enabledRules = ruleList.filter((r) => r.enabled !== false);
   const ruleCount =
-    ruleHealth?.rule_count ?? ruleList.length ?? buildingMeta?.rule_count ?? 0;
-  const activeFaults = summary?.faults?.active_count ?? buildingMeta?.alert_count ?? 0;
+    ruleHealth?.rule_count ?? ruleList.length ?? meta?.rule_count ?? buildingMeta?.rule_count ?? 0;
+  const activeFaults =
+    summary?.faults?.active_count ?? meta?.alert_count ?? buildingMeta?.alert_count ?? 0;
   const historian = summary?.historian_health;
+
+  const hvacLine = useMemo(() => {
+    const byType = modelSummary?.equipment_by_type;
+    if (!byType || !Object.keys(byType).length) return null;
+    return Object.entries(byType)
+      .sort((a, b) => b[1] - a[1])
+      .map(([type, count]) => `${count} ${formatEquipTypeLabel(type)}`)
+      .join(" · ");
+  }, [modelSummary]);
+
+  const feedsChains = modelSummary?.feeds_chains?.length
+    ? modelSummary.feeds_chains
+    : insight?.brick_model?.feeds_chains ?? [];
 
   const mappedSources = useMemo(() => {
     const fromHealth =
@@ -118,26 +161,23 @@ export default function OperationalContextPanel({
       ? `${model.equipment_count ?? 0} equipment · ${model.point_count ?? 0} points · ${model.mapped_points ?? 0} mapped${
           (model.unmapped_points ?? 0) > 0 ? ` · ${model.unmapped_points} unmapped` : ""
         }${model.model_score != null ? ` · ${model.model_score}% coverage` : ""}`
-      : buildingMeta?.model_counts &&
-          ((buildingMeta.model_counts.equipment ?? 0) > 0 ||
-            (buildingMeta.model_counts.points ?? 0) > 0)
-        ? `${buildingMeta.model_counts.equipment ?? 0} equipment · ${buildingMeta.model_counts.points ?? 0} points · ${buildingMeta.model_counts.mapped_points ?? 0} mapped${
-            (buildingMeta.model_counts.unmapped_points ?? 0) > 0
-              ? ` · ${buildingMeta.model_counts.unmapped_points} unmapped`
+      : meta?.model_counts &&
+          ((meta.model_counts.equipment ?? 0) > 0 || (meta.model_counts.points ?? 0) > 0)
+        ? `${meta.model_counts.equipment ?? 0} equipment · ${meta.model_counts.points ?? 0} points · ${meta.model_counts.mapped_points ?? 0} mapped${
+            (meta.model_counts.unmapped_points ?? 0) > 0
+              ? ` · ${meta.model_counts.unmapped_points} unmapped`
               : ""
-          }${buildingMeta.model_score != null ? ` · ${buildingMeta.model_score}% coverage` : ""}`
-        : "No Haystack model loaded — sign in and import under Model & assignments.";
+          }${meta.model_score != null ? ` · ${meta.model_score}% coverage` : ""}`
+        : "No Haystack model loaded — import under Model & assignments.";
 
   const rulesLine =
     ruleCount > 0
       ? `${enabledRules.length || ruleCount} FDD rule${ruleCount === 1 ? "" : "s"} configured${
-          (ruleHealth?.datafusion_ok ?? buildingMeta?.datafusion_ok) === false
+          (ruleHealth?.datafusion_ok ?? meta?.datafusion_ok ?? buildingMeta?.datafusion_ok) === false
             ? " · DataFusion check failed"
             : ""
         }`
-      : signedIn
-        ? "No FDD rules configured — add rules under SQL FDD."
-        : "Sign in to view FDD rule configuration.";
+      : "No FDD rules configured — add rules under SQL FDD.";
 
   const faultLine =
     activeFaults === 0
@@ -153,7 +193,6 @@ export default function OperationalContextPanel({
       : "Sign in for historian row counts and validation profile details.";
 
   const validationProfile = summary?.validation?.profile_id;
-  const feeds = insight?.brick_model?.feeds_chains ?? [];
 
   return (
     <div className="bis-card">
@@ -164,7 +203,21 @@ export default function OperationalContextPanel({
         <Link to="/model" className="bis-inline-link">
           Model
         </Link>
+        {modelSummary?.query_engine ? (
+          <span className="muted"> · {modelSummary.query_engine} query</span>
+        ) : null}
       </p>
+      {hvacLine ? (
+        <p className="bis-muted-line">
+          <strong>HVAC equipment:</strong> {hvacLine}
+        </p>
+      ) : null}
+      {feedsChains.length ? (
+        <p className="bis-muted-line">
+          <strong>Haystack feeds:</strong> {feedsChains.slice(0, 5).join("; ")}
+          {feedsChains.length > 5 ? " …" : ""}
+        </p>
+      ) : null}
       {mappedSources.length ? (
         <p className="bis-muted-line">
           <strong>Mapped sources:</strong>{" "}
@@ -191,6 +244,9 @@ export default function OperationalContextPanel({
       ) : null}
       <p className="bis-muted-line">
         <strong>Faults:</strong> {faultLine}
+        {!signedIn ? (
+          <span className="muted"> · sign in to clear acknowledged faults</span>
+        ) : null}
       </p>
       <p className="bis-muted-line">
         <strong>Historian:</strong> {historianLine}
@@ -205,15 +261,6 @@ export default function OperationalContextPanel({
         </p>
       ) : null}
 
-      {feeds.length ? (
-        <>
-          <h3 className="bis-subhead">Feeds &amp; research</h3>
-          <p className="bis-muted-line">
-            <strong>Haystack feeds:</strong> {feeds.slice(0, 5).join("; ")}
-            {feeds.length > 5 ? " …" : ""}
-          </p>
-        </>
-      ) : null}
       {insight?.zone_temps?.struggling_zones?.length ? (
         <p className="bis-muted-line">
           <strong>Slow recovery:</strong>{" "}
@@ -235,7 +282,7 @@ export default function OperationalContextPanel({
       ) : null}
 
       <p className="bis-foot-meta">
-        Rule-based summary from bridge APIs
+        Live Haystack model + Rust FDD from bridge APIs
         {insight?.source === "ollama" ? " · insight agent available" : ""}
         {insight?.generated_at != null
           ? ` · insight ${new Date(insight.generated_at * 1000).toLocaleString()}`

--- a/workspace/dashboard/src/lib/useActiveSiteId.ts
+++ b/workspace/dashboard/src/lib/useActiveSiteId.ts
@@ -2,19 +2,24 @@ import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
 /** Active Haystack site from bridge (`/api/model/sites`), not hard-coded demo. */
-export function useActiveSiteId(fallback = ""): string {
+export function useActiveSiteId(fallback = "site:unknown"): string {
   const [siteId, setSiteId] = useState(fallback);
 
   useEffect(() => {
     let cancelled = false;
-    apiFetch<{ active_site_id?: string; sites?: { id: string }[] }>("/api/model/sites")
+    apiFetch<{ active_site_id?: string; sites?: { id: string; site_id?: string }[] }>(
+      "/api/model/sites",
+    )
       .then((res) => {
         if (cancelled) return;
-        const first = res.sites?.[0] as { id?: string; site_id?: string } | undefined;
-        const sid = res.active_site_id || first?.id || first?.site_id || fallback;
+        const first = res.sites?.[0];
+        const sid =
+          res.active_site_id || first?.site_id || first?.id || fallback;
         if (sid) setSiteId(sid);
       })
-      .catch(() => undefined);
+      .catch(() => {
+        if (!cancelled && fallback) setSiteId(fallback);
+      });
     return () => {
       cancelled = true;
     };

--- a/workspace/dashboard/src/pages/WiresheetStudioPage.tsx
+++ b/workspace/dashboard/src/pages/WiresheetStudioPage.tsx
@@ -16,6 +16,7 @@ import WiresheetPalette from "../wiresheet/WiresheetPalette";
 import WiresheetPropertyPanel from "../wiresheet/WiresheetPropertyPanel";
 import { flowToGraph, graphToFlow, newNodeId } from "../wiresheet/graphAdapter";
 import type { NodeCatalogEntry, WiresheetGraph } from "../wiresheet/types";
+import { fetchWiresheetGraph } from "../wiresheet/wiresheetApi";
 
 const DEFAULT_GRAPH_ID = "graph:live-fdd-validation";
 
@@ -37,10 +38,7 @@ export default function WiresheetStudioPage() {
     setBusy(true);
     setError("");
     try {
-      const qs = siteId ? `?site_id=${encodeURIComponent(siteId)}` : "";
-      const graph = await apiFetch<WiresheetGraph>(
-        `/api/fdd-wires/graphs/${encodeURIComponent(DEFAULT_GRAPH_ID)}${qs}`,
-      );
+      const graph = await fetchWiresheetGraph(DEFAULT_GRAPH_ID, siteId);
       const flow = graphToFlow(graph);
       setNodes(flow.nodes);
       setEdges(flow.edges);

--- a/workspace/dashboard/src/wiresheet/FddRuleWiresheet.tsx
+++ b/workspace/dashboard/src/wiresheet/FddRuleWiresheet.tsx
@@ -29,10 +29,8 @@ export default function FddRuleWiresheet({ compact }: Props) {
     if (!siteId) return;
     setBusy(true);
     try {
-      const qs = `?site_id=${encodeURIComponent(siteId)}`;
-      const graph = await apiFetch<WiresheetGraph>(
-        `/api/fdd-wires/graphs/${encodeURIComponent(GRAPH_ID)}${qs}`,
-      );
+      const qs = siteId ? `?site_id=${encodeURIComponent(siteId)}` : "";
+      const graph = await fetchWiresheetGraph(GRAPH_ID, siteId);
       const flow = graphToFlow(graph);
       setNodes(flow.nodes);
       setEdges(flow.edges);

--- a/workspace/dashboard/src/wiresheet/wiresheetApi.ts
+++ b/workspace/dashboard/src/wiresheet/wiresheetApi.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { WiresheetGraph } from "./types";
+
+type GraphResponse = WiresheetGraph & {
+  ok?: boolean;
+  graph?: WiresheetGraph;
+  error?: string;
+};
+
+/** GET /api/fdd-wires/graphs/{id} — unwraps `{ graph }` or legacy flat body. */
+export function parseWiresheetGraphResponse(body: GraphResponse): WiresheetGraph {
+  if (body.graph && typeof body.graph === "object") {
+    return body.graph;
+  }
+  if (body.ok === false && body.error) {
+    throw new Error(body.error);
+  }
+  return body;
+}
+
+export async function fetchWiresheetGraph(
+  graphId: string,
+  siteId: string,
+): Promise<WiresheetGraph> {
+  const qs = siteId ? `?site_id=${encodeURIComponent(siteId)}` : "";
+  const body = await apiFetch<GraphResponse>(
+    `/api/fdd-wires/graphs/${encodeURIComponent(graphId)}${qs}`,
+  );
+  return parseWiresheetGraphResponse(body);
+}


### PR DESCRIPTION
## Summary

- Dashboard fault modal fetches Rust analytics; public building context for anonymous viewers
- Wiresheet `/wiresheet`: GET returns empty scaffold when no graph saved; fixes `{ graph }` response unwrap and site fallback
- MCP optional sidecar docs after site update
- Release notes `docs/release/3.2.3.md`

## Test plan

- [x] `cargo test -p open_fdd_edge_prototype --lib fdd::wires`
- [x] `npm run build` (dashboard)
- [ ] `/wiresheet` loads empty canvas without error; Save persists graph
- [ ] Home dashboard fault click shows sensor stats


Made with [Cursor](https://cursor.com)