### PR TITLE
3.2.3 patch: SPARQL facade, CSV fill/resample, MCP Docker fix

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -2,6 +2,7 @@
 FROM rust:1.95-bookworm AS builder
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
+COPY edge ./edge
 COPY mcp ./mcp
 RUN cargo build --release -p openfdd-mcp
 

--- a/docs/release/3.2.3-test-results.md
+++ b/docs/release/3.2.3-test-results.md
@@ -1,0 +1,45 @@
+# 3.2.3 test results
+
+Validation checklist for release **3.2.3** (see [#411](https://github.com/bbartling/open-fdd/issues/411)).
+
+## CI / GHCR
+
+| Check | Status |
+| --- | --- |
+| Rust Edge CI (`master`) | Run after merge |
+| `ghcr.io/bbartling/openfdd-edge-rust:3.2.3` | Publish on green CI |
+| `ghcr.io/bbartling/openfdd-mcp:3.2.3` | Publish on green CI (Dockerfile.mcp workspace fix) |
+
+## Automated (repo)
+
+| Suite | Result |
+| --- | --- |
+| `cargo test -p open_fdd_edge_prototype --test csv_ingest_tests` | 10 pass (incl. resample kW hourly) |
+| `cargo test -p open_fdd_edge_prototype --lib sparql` | predefined + execute |
+| `cargo test -p open_fdd_edge_prototype --lib fdd::wires` | pass |
+| `npm run build` (dashboard) | pass |
+
+## Manual smoke (operator)
+
+| Area | Route / command | Expected |
+| --- | --- | --- |
+| Health | `GET /api/health` | `version: 3.2.3` |
+| Home dashboard | `/` | Fault cards, public context |
+| Wiresheet | `/wiresheet` | Empty scaffold loads; Save persists |
+| CSV UT3 | `/csv` | Preview → plan → execute |
+| SPARQL panel | `/model` → SPARQL tab | Predefined queries return bindings |
+| Site update | `NEW_TAG=3.2.3 ./scripts/openfdd_rust_site_update.sh` | Pull + recreate |
+
+## Issues closed in 3.2.3 patch
+
+| Issue | Resolution |
+| --- | --- |
+| [#405](https://github.com/bbartling/open-fdd/issues/405) | Linear fill + kW hourly resample (dataset→historian sync remains follow-up) |
+| [#406](https://github.com/bbartling/open-fdd/issues/406) | Haystack-backed SPARQL predefined + execute (full RDF engine deferred) |
+
+## Deferred
+
+| Issue | Reason |
+| --- | --- |
+| [#407](https://github.com/bbartling/open-fdd/issues/407) | Ollama building-insight agent — optional, large port |
+| [#369](https://github.com/bbartling/open-fdd/issues/369) | WASM connector sandbox — design proposal only |

--- a/docs/release/3.2.3.md
+++ b/docs/release/3.2.3.md
@@ -39,5 +39,6 @@ Never run `docker compose down -v`.
 
 ## References
 
+- [3.2.3 test results](3.2.3-test-results.md)
 - [Wiresheet architecture](../wiresheet/ARCHITECTURE.md)
 - [Rust site lifecycle](../quick-start/rust-site-lifecycle.md)

--- a/edge/src/csv_ingest/plan.rs
+++ b/edge/src/csv_ingest/plan.rs
@@ -201,7 +201,8 @@ pub fn join_rows(
         }
         JoinAlignment::ResampleWeather15m => join_weather_to_15m(left, right, fill),
         JoinAlignment::ResampleKwHourly => {
-            Err("resample kW hourly not yet implemented in preview".into())
+            let left_hourly = resample_kw_hourly(left);
+            join_asof(left_hourly, right, true, fill)
         }
     }
 }
@@ -259,15 +260,138 @@ fn join_asof(
             for (k, v) in &r.values {
                 l.values.insert(k.clone(), v.clone());
             }
-        } else if matches!(fill, FillPolicy::Forward | FillPolicy::Backward) {
-            // no prior weather — leave gaps
         }
         out.push(l);
     }
-    if matches!(fill, FillPolicy::Forward) {
-        forward_fill_numeric(&mut out);
-    }
+    apply_fill_policy(&mut out, fill);
     Ok(out)
+}
+
+fn resample_kw_hourly(rows: Vec<OutputRow>) -> Vec<OutputRow> {
+    let mut buckets: BTreeMap<DateTime<Utc>, (OutputRow, Vec<BTreeMap<String, f64>>)> =
+        BTreeMap::new();
+    for row in rows {
+        let Some(ts) = row.ts_utc else { continue };
+        let hour = floor_hour(ts);
+        let entry = buckets.entry(hour).or_insert_with(|| {
+            let mut base = row.clone();
+            base.ts_utc = Some(hour);
+            base.ts_local = hour.format("%Y-%m-%d %H:%M:%S").to_string();
+            base.source_timestamp_fold = Some("resample_kw_hourly".into());
+            base.values.clear();
+            base.fill_created = false;
+            (base, Vec::new())
+        });
+        let mut nums = BTreeMap::new();
+        for (k, v) in &row.values {
+            if let Ok(n) = v.trim().parse::<f64>() {
+                nums.insert(k.clone(), n);
+            }
+        }
+        if !nums.is_empty() {
+            entry.1.push(nums);
+        }
+    }
+    buckets
+        .into_iter()
+        .map(|(_, (mut base, samples))| {
+            if !samples.is_empty() {
+                let mut sums: BTreeMap<String, f64> = BTreeMap::new();
+                for sample in &samples {
+                    for (k, v) in sample {
+                        *sums.entry(k.clone()).or_insert(0.0) += v;
+                    }
+                }
+                for (k, sum) in sums {
+                    let avg = sum / samples.len() as f64;
+                    base.values.insert(k, format!("{avg:.4}"));
+                }
+            }
+            base
+        })
+        .collect()
+}
+
+fn apply_fill_policy(rows: &mut [OutputRow], fill: FillPolicy) {
+    match fill {
+        FillPolicy::Forward => forward_fill_numeric(rows),
+        FillPolicy::Backward => backward_fill_numeric(rows),
+        FillPolicy::Linear => linear_fill_numeric(rows),
+        _ => {}
+    }
+}
+
+fn backward_fill_numeric(rows: &mut [OutputRow]) {
+    let mut next: BTreeMap<String, String> = BTreeMap::new();
+    for row in rows.iter_mut().rev() {
+        for (k, v) in row.values.clone() {
+            if v.trim().is_empty() {
+                if let Some(nxt) = next.get(&k) {
+                    row.values.insert(k, nxt.clone());
+                    row.fill_created = true;
+                }
+            } else {
+                next.insert(k, v);
+            }
+        }
+    }
+}
+
+fn linear_fill_numeric(rows: &mut [OutputRow]) {
+    if rows.is_empty() {
+        return;
+    }
+    let col_keys: Vec<String> = rows
+        .iter()
+        .flat_map(|r| r.values.keys().cloned())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    for col in col_keys {
+        let mut i = 0usize;
+        while i < rows.len() {
+            if rows[i]
+                .values
+                .get(&col)
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false)
+            {
+                i += 1;
+                continue;
+            }
+            let gap_start = i;
+            while i < rows.len()
+                && rows[i]
+                    .values
+                    .get(&col)
+                    .map(|s| s.trim().is_empty())
+                    .unwrap_or(true)
+            {
+                i += 1;
+            }
+            let gap_end = i;
+            let prev_idx = gap_start.checked_sub(1);
+            let next_idx = if gap_end < rows.len() {
+                Some(gap_end)
+            } else {
+                None
+            };
+            let (Some(p), Some(n)) = (prev_idx, next_idx) else {
+                continue;
+            };
+            let v0 = rows[p].values.get(&col).and_then(|s| s.parse::<f64>().ok());
+            let v1 = rows[n].values.get(&col).and_then(|s| s.parse::<f64>().ok());
+            if let (Some(a), Some(b)) = (v0, v1) {
+                let steps = (gap_end - gap_start + 1) as f64;
+                for (j, idx) in (gap_start..gap_end).enumerate() {
+                    let t = (j as f64 + 1.0) / steps;
+                    let v = a + (b - a) * t;
+                    rows[idx].values.insert(col.clone(), format!("{v:.4}"));
+                    rows[idx].fill_created = true;
+                }
+            }
+        }
+    }
 }
 
 fn join_weather_to_15m(
@@ -388,6 +512,58 @@ pub fn preview_rows(rows: &[OutputRow], limit: usize) -> PlanPreview {
         timestamp_analysis,
         warnings,
         time_range,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn linear_fill_between_known_points() {
+        let mut rows = vec![
+            OutputRow {
+                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 0, 0, 0).unwrap()),
+                ts_local: String::new(),
+                timezone: "UTC".into(),
+                source_timestamp_raw: String::new(),
+                source_timestamp_parse_status: "ok".into(),
+                source_timestamp_fold: None,
+                source_file: "t.csv".into(),
+                source_row_number: 1,
+                values: BTreeMap::from([("kw".into(), "10".into())]),
+                fill_created: false,
+            },
+            OutputRow {
+                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 1, 0, 0).unwrap()),
+                ts_local: String::new(),
+                timezone: "UTC".into(),
+                source_timestamp_raw: String::new(),
+                source_timestamp_parse_status: "ok".into(),
+                source_timestamp_fold: None,
+                source_file: "t.csv".into(),
+                source_row_number: 2,
+                values: BTreeMap::from([("kw".into(), String::new())]),
+                fill_created: false,
+            },
+            OutputRow {
+                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 2, 0, 0).unwrap()),
+                ts_local: String::new(),
+                timezone: "UTC".into(),
+                source_timestamp_raw: String::new(),
+                source_timestamp_parse_status: "ok".into(),
+                source_timestamp_fold: None,
+                source_file: "t.csv".into(),
+                source_row_number: 3,
+                values: BTreeMap::from([("kw".into(), "20".into())]),
+                fill_created: false,
+            },
+        ];
+        apply_fill_policy(&mut rows, FillPolicy::Linear);
+        let mid = rows[1].values.get("kw").unwrap();
+        let v: f64 = mid.parse().unwrap();
+        assert!(v > 10.0 && v < 20.0);
     }
 }
 

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -620,6 +620,13 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &mut stream,
             json!({"ok": true, "rows": model::query::haystack_rows()}),
         ),
+        ("GET", "/api/model/sparql/predefined") => {
+            json_response(&mut stream, model::sparql::predefined())
+        }
+        ("POST", "/api/model/sparql") => json_response(
+            &mut stream,
+            model::sparql::execute(&parse_json_body_or_empty(&body)),
+        ),
         ("POST", "/api/fdd/run") => match parse_json_body(&body) {
             Ok(payload) => require_role(
                 &mut stream,

--- a/edge/src/model/mod.rs
+++ b/edge/src/model/mod.rs
@@ -10,3 +10,4 @@ pub mod csv_workbench;
 pub mod persist;
 pub mod query;
 pub mod scope;
+pub mod sparql;

--- a/edge/src/model/sparql.rs
+++ b/edge/src/model/sparql.rs
@@ -1,0 +1,440 @@
+//! Haystack-grid SPARQL facade (predefined SELECT queries; read-only).
+//!
+//! Full RDF/SPARQL engine deferred — executes equivalent Haystack row filters and
+//! returns SPARQL-style bindings for the dashboard panel.
+
+use crate::model::query;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+const MAX_ROWS: usize = 500;
+
+pub fn predefined() -> Value {
+    let queries = catalog();
+    let default = queries
+        .first()
+        .map(|q| q["query"].as_str().unwrap_or(""))
+        .unwrap_or("");
+    json!({
+        "ok": true,
+        "default_query": default,
+        "queries": queries,
+        "query_engine": "haystack",
+        "note": "Predefined queries run against the Haystack grid; custom SPARQL subset limited to exact predefined text."
+    })
+}
+
+pub fn execute(body: &Value) -> Value {
+    let query_text = body
+        .get("query")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
+    if query_text.is_empty() {
+        return json!({"ok": false, "error": "query required", "bindings": []});
+    }
+
+    let handler = resolve_handler(query_text);
+    let bindings = match handler {
+        Some(h) => h(),
+        None => {
+            return json!({
+                "ok": false,
+                "error": "Unsupported SPARQL — pick a predefined query or use POST /api/model/query for raw Haystack rows",
+                "bindings": [],
+                "query_engine": "haystack"
+            });
+        }
+    };
+
+    let truncated = bindings.len() > MAX_ROWS;
+    let rows: Vec<Value> = bindings
+        .into_iter()
+        .take(MAX_ROWS)
+        .map(|m| {
+            let obj: serde_json::Map<String, Value> = m
+                .into_iter()
+                .map(|(k, v)| (k, Value::String(v)))
+                .collect();
+            Value::Object(obj)
+        })
+        .collect();
+    let count = rows.len();
+    json!({
+        "ok": true,
+        "bindings": rows,
+        "row_count": count,
+        "truncated": truncated,
+        "query_engine": "haystack"
+    })
+}
+
+fn resolve_handler(query: &str) -> Option<fn() -> Vec<HashMap<String, String>>> {
+    for item in catalog() {
+        for key in ["query", "query_with_bacnet"] {
+            if item.get(key).and_then(|v| v.as_str()) == Some(query) {
+                let id = item.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                return handler_for_id(id);
+            }
+        }
+    }
+    handler_for_id(query)
+}
+
+fn handler_for_id(id: &str) -> Option<fn() -> Vec<HashMap<String, String>>> {
+    match id {
+        "hvac_equipment" => Some(bind_equipment),
+        "hvac_equipment_types" => Some(bind_equipment_types),
+        "hvac_points" => Some(bind_points),
+        "hvac_points_bacnet" => Some(bind_points_bacnet),
+        "hvac_unmapped_points" => Some(bind_unmapped_points),
+        "hvac_feeds" => Some(bind_feeds),
+        "eng_sites" => Some(bind_sites),
+        _ => None,
+    }
+}
+
+fn catalog() -> Vec<Value> {
+    vec![
+        json!({
+            "id": "hvac_equipment",
+            "label": "All equipment",
+            "short_label": "Equipment",
+            "category": "hvac",
+            "query": "SELECT ?equip ?dis ?equipType WHERE { ?equip a haystack:Equip . OPTIONAL { ?equip haystack:dis ?dis } }",
+            "query_with_bacnet": "SELECT ?equip ?dis ?equipType ?bacnetRef WHERE { ?equip a haystack:Equip . OPTIONAL { ?equip haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equip . ?point haystack:bacnetRef ?bacnetRef } }"
+        }),
+        json!({
+            "id": "hvac_equipment_types",
+            "label": "Equipment by HVAC type",
+            "short_label": "Equip types",
+            "category": "hvac",
+            "query": "SELECT ?equipType (COUNT(?equip) AS ?count) WHERE { ?equip a haystack:Equip . BIND(haystack:inferType(?equip) AS ?equipType) } GROUP BY ?equipType"
+        }),
+        json!({
+            "id": "hvac_points",
+            "label": "All points",
+            "short_label": "Points",
+            "category": "hvac",
+            "query": "SELECT ?point ?dis ?equipRef ?fddInput WHERE { ?point a haystack:Point . OPTIONAL { ?point haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equipRef } . OPTIONAL { ?point haystack:fddInput ?fddInput } }"
+        }),
+        json!({
+            "id": "hvac_points_bacnet",
+            "label": "BACnet-mapped points",
+            "short_label": "BACnet pts",
+            "category": "hvac",
+            "query": "SELECT ?point ?dis ?equipRef ?bacnetRef WHERE { ?point a haystack:Point . ?point haystack:bacnetRef ?bacnetRef . OPTIONAL { ?point haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equipRef } }",
+            "query_with_bacnet": "SELECT ?point ?dis ?equipRef ?bacnetRef ?objectIdentifier WHERE { ?point a haystack:Point . ?point haystack:bacnetRef ?bacnetRef . OPTIONAL { ?point haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equipRef } }"
+        }),
+        json!({
+            "id": "hvac_unmapped_points",
+            "label": "Unmapped points (no fddInput / driver ref)",
+            "short_label": "Unmapped",
+            "category": "engineering",
+            "query": "SELECT ?point ?dis ?equipRef WHERE { ?point a haystack:Point . FILTER NOT EXISTS { ?point haystack:fddInput ?x } FILTER NOT EXISTS { ?point haystack:bacnetRef ?y } }"
+        }),
+        json!({
+            "id": "hvac_feeds",
+            "label": "Equipment feeds relationships",
+            "short_label": "Feeds",
+            "category": "hvac",
+            "query": "SELECT ?from ?to ?fromLabel ?toLabel WHERE { ?to haystack:feedRef ?from . OPTIONAL { ?from haystack:dis ?fromLabel } . OPTIONAL { ?to haystack:dis ?toLabel } }"
+        }),
+        json!({
+            "id": "eng_sites",
+            "label": "Sites",
+            "short_label": "Sites",
+            "category": "engineering",
+            "query": "SELECT ?site ?dis WHERE { ?site a haystack:Site . OPTIONAL { ?site haystack:dis ?dis } }"
+        }),
+    ]
+}
+
+fn bind_equipment() -> Vec<HashMap<String, String>> {
+    let summary = query::equipment_model_summary();
+    let mut labels: HashMap<String, String> = HashMap::new();
+    let mut types: HashMap<String, String> = HashMap::new();
+    for row in query::haystack_rows() {
+        if row.get("equip").and_then(|v| v.as_str()) != Some("M") {
+            continue;
+        }
+        let id = row
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if id.is_empty() {
+            continue;
+        }
+        labels.insert(
+            id.clone(),
+            row.get("dis")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&id)
+                .to_string(),
+        );
+        types.insert(id, infer_equip_type_label(&row));
+    }
+    let _ = summary;
+    labels
+        .into_iter()
+        .map(|(equip, dis)| {
+            let mut m = HashMap::new();
+            m.insert("equip".into(), equip.clone());
+            m.insert("dis".into(), dis);
+            m.insert(
+                "equipType".into(),
+                types
+                    .get(&equip)
+                    .cloned()
+                    .unwrap_or_else(|| "generic".into()),
+            );
+            m
+        })
+        .collect()
+}
+
+fn bind_equipment_types() -> Vec<HashMap<String, String>> {
+    let summary = query::equipment_model_summary();
+    summary
+        .get("equipment_by_type")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .map(|(etype, count)| {
+                    let mut m = HashMap::new();
+                    m.insert("equipType".into(), etype.clone());
+                    m.insert("count".into(), count.to_string());
+                    m
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn bind_points() -> Vec<HashMap<String, String>> {
+    query::haystack_rows()
+        .into_iter()
+        .filter(|r| r.get("point").and_then(|v| v.as_str()) == Some("M"))
+        .map(|row| {
+            let mut m = HashMap::new();
+            m.insert(
+                "point".into(),
+                row.get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "dis".into(),
+                row.get("dis")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "equipRef".into(),
+                row.get("equipRef")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "fddInput".into(),
+                row.get("fddInput")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m
+        })
+        .collect()
+}
+
+fn bind_points_bacnet() -> Vec<HashMap<String, String>> {
+    query::haystack_rows()
+        .into_iter()
+        .filter(|r| {
+            r.get("point").and_then(|v| v.as_str()) == Some("M") && r.get("bacnetRef").is_some()
+        })
+        .map(|row| {
+            let mut m = HashMap::new();
+            m.insert(
+                "point".into(),
+                row.get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "dis".into(),
+                row.get("dis")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "equipRef".into(),
+                row.get("equipRef")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "bacnetRef".into(),
+                row.get("bacnetRef")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m
+        })
+        .collect()
+}
+
+fn bind_unmapped_points() -> Vec<HashMap<String, String>> {
+    let unmapped = query::unmapped_points();
+    unmapped
+        .get("points")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|p| {
+            let mut m = HashMap::new();
+            m.insert(
+                "point".into(),
+                p.get("point_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "dis".into(),
+                p.get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "equipRef".into(),
+                p.get("equip_ref")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m
+        })
+        .collect()
+}
+
+fn bind_feeds() -> Vec<HashMap<String, String>> {
+    let summary = query::equipment_model_summary();
+    let mut labels: HashMap<String, String> = HashMap::new();
+    for row in query::haystack_rows() {
+        if row.get("equip").and_then(|v| v.as_str()) == Some("M") {
+            let id = row.get("id").and_then(|v| v.as_str()).unwrap_or("");
+            labels.insert(
+                id.to_string(),
+                row.get("dis")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(id)
+                    .to_string(),
+            );
+        }
+    }
+    let mut out = Vec::new();
+    for row in query::haystack_rows() {
+        if let Some(from) = row.get("feedRef").and_then(|v| v.as_str()) {
+            let to = row.get("id").and_then(|v| v.as_str()).unwrap_or("");
+            let mut m = HashMap::new();
+            m.insert("from".into(), from.to_string());
+            m.insert("to".into(), to.to_string());
+            m.insert(
+                "fromLabel".into(),
+                labels
+                    .get(from)
+                    .cloned()
+                    .unwrap_or_else(|| from.to_string()),
+            );
+            m.insert(
+                "toLabel".into(),
+                labels.get(to).cloned().unwrap_or_else(|| to.to_string()),
+            );
+            out.push(m);
+        }
+    }
+    if out.is_empty() {
+        if let Some(chains) = summary.get("feeds_chains").and_then(|v| v.as_array()) {
+            for chain in chains {
+                if let Some(s) = chain.as_str() {
+                    let mut m = HashMap::new();
+                    m.insert("feeds_chain".into(), s.to_string());
+                    out.push(m);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn bind_sites() -> Vec<HashMap<String, String>> {
+    query::list_sites()
+        .get("sites")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| {
+            let mut m = HashMap::new();
+            m.insert(
+                "site".into(),
+                s.get("site_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m.insert(
+                "dis".into(),
+                s.get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            m
+        })
+        .collect()
+}
+
+fn infer_equip_type_label(row: &Value) -> String {
+    if row.get("ahu").is_some() {
+        "ahu".into()
+    } else if row.get("vav").is_some() {
+        "vav".into()
+    } else if row.get("chiller").is_some() {
+        "chiller".into()
+    } else if row.get("boiler").is_some() {
+        "boiler".into()
+    } else {
+        "generic".into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn predefined_catalog_non_empty() {
+        let p = predefined();
+        assert!(p.get("queries").and_then(|v| v.as_array()).unwrap().len() >= 5);
+    }
+
+    #[test]
+    fn execute_known_query() {
+        let cat = catalog();
+        let q = cat[0]["query"].as_str().unwrap();
+        let out = execute(&json!({"query": q}));
+        assert_eq!(out.get("ok").and_then(|v| v.as_bool()), Some(true));
+    }
+}

--- a/edge/tests/csv_ingest_tests.rs
+++ b/edge/tests/csv_ingest_tests.rs
@@ -119,6 +119,32 @@ fn timestamp_column_detection() {
 }
 
 #[test]
+fn resample_kw_hourly_averages() {
+    let kw_csv = include_str!("fixtures/csv_ingest/school_kw_sample.csv");
+    let kw_map = FileMapping {
+        filename: "kw.csv".into(),
+        timestamp_column: "Date".into(),
+        timezone: "America/Chicago".into(),
+        value_columns: vec!["kW".into()],
+    };
+    let left = parse_file_to_rows(kw_csv, &kw_map, ',', "first").unwrap();
+    assert_eq!(left.len(), 3);
+    let hourly = join_rows(
+        left,
+        vec![],
+        JoinAlignment::ResampleKwHourly,
+        FillPolicy::None,
+    )
+    .unwrap();
+    assert_eq!(hourly.len(), 1);
+    let kw = hourly[0]
+        .values
+        .get("kw")
+        .or_else(|| hourly[0].values.get("kW"));
+    assert!(kw.is_some());
+}
+
+#[test]
 fn plan_api_append_mode() {
     with_temp_workspace(|_| {
         use base64::Engine;
@@ -137,7 +163,7 @@ fn plan_api_append_mode() {
                 "mode": "append",
                 "output_dataset_name": "school_kw_test",
                 "ambiguous_policy": "first",
-                "fill_policy": "none",
+                "fill_policy": "linear",
                 "files": [{
                     "filename": "school.csv",
                     "timestamp_column": "Date",


### PR DESCRIPTION
## Summary

Closes patch-cycle items from open issues where feasible:

- **#406** — `GET /api/model/sparql/predefined` + `POST /api/model/sparql` (Haystack grid bindings; predefined HVAC/engineering catalog)
- **#405** — linear interpolation fill, backward fill, kW hourly resample join
- **MCP GHCR** — `Dockerfile.mcp` copies `edge/` workspace member (fixes cargo build failure)
- **#411** — `docs/release/3.2.3-test-results.md` validation checklist

## Not in scope

- #407 Ollama building-insight (large optional port)
- #369 WASM sandbox (design only)
- CSV dataset→historian sync (#405 remainder)

## Test plan

- [x] `cargo test --test csv_ingest_tests` (10 pass)
- [x] `cargo test --lib sparql`
- [x] `cargo test --lib linear_fill`
- [ ] `/model` SPARQL tab — predefined queries return rows
- [ ] `/csv` join with `resample_kw_hourly` + `linear` fill


Made with [Cursor](https://cursor.com)