### PR TITLE
3.2.3 patch: CSV fusion, FDD results, SPARQL RDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,7 +709,16 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -748,6 +777,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2050,6 +2090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-event-parser"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574b0cd5e90ee2ba03a66d0611fc9a09c9a0c28b2ecc2dc8a181dd31a53ca5d7"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2163,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -2194,6 +2250,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2274,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2361,6 +2433,7 @@ dependencies = [
  "hex",
  "hmac",
  "once_cell",
+ "oxigraph",
  "rand 0.8.6",
  "rcgen",
  "reqwest 0.13.4",
@@ -2398,6 +2471,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "oxigraph"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d945cbe78640ab719a73697b9bd250054ea82c60470754efea79c21d5fc1cd1"
+dependencies = [
+ "dashmap",
+ "getrandom 0.3.4",
+ "libc",
+ "oxiri",
+ "oxrdf",
+ "oxrdfio",
+ "oxrocksdb-sys",
+ "oxsdatatypes",
+ "rand 0.9.4",
+ "rustc-hash",
+ "siphasher",
+ "sparesults",
+ "spareval",
+ "spargebra",
+ "thiserror",
+]
+
+[[package]]
+name = "oxilangtag"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3b4eb570abd4a1dcb062c31fd37b832264d9dc7292c3e69acfe926c87b063f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "oxiri"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4ed3a7192fa19f5f48f99871f2755047fabefd7f222f12a1df1773796a102"
+
+[[package]]
+name = "oxjsonld"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e1380a504a8571763f13b8bcad629ff90d0300d47d8a519f3c6c599625840e"
+dependencies = [
+ "json-event-parser",
+ "oxiri",
+ "oxrdf",
+ "ryu-js",
+ "thiserror",
+]
+
+[[package]]
+name = "oxrdf"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0afd5c28e4a399c57ee2bc3accd40c7b671fdc7b6537499f14e95b265af7d7e0"
+dependencies = [
+ "hex",
+ "oxilangtag",
+ "oxiri",
+ "oxsdatatypes",
+ "rand 0.9.4",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "oxrdfio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696223589ecbcab06b1a5df9b527dc25b0c656160cca38752fdb3878a5d3dd03"
+dependencies = [
+ "oxjsonld",
+ "oxrdf",
+ "oxrdfxml",
+ "oxttl",
+ "thiserror",
+]
+
+[[package]]
+name = "oxrdfxml"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5516ae083d09bc57ec65ed5ee97701481725de6ffaa83d968ab42a96157ba1"
+dependencies = [
+ "oxilangtag",
+ "oxiri",
+ "oxrdf",
+ "quick-xml",
+ "thiserror",
+]
+
+[[package]]
+name = "oxrocksdb-sys"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6977c1d1827fcbf14480e768e4dede0b39c2961f6028497d012f9c04bcda91c6"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
+name = "oxsdatatypes"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "oxttl"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fd471bd54c23d76631c0a2677aa4bb308d905f6e491ee35dcb0732b7c5c6c"
+dependencies = [
+ "memchr",
+ "oxilangtag",
+ "oxiri",
+ "oxrdf",
+ "thiserror",
 ]
 
 [[package]]
@@ -2489,6 +2686,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aad070be5b63aa72103f2fcdd70a83adbd5e90112ce5b574171ff1c65501773"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd8ef6825cae95355031ae26a99b616a2a21f22ba2de0197c43dfb05acbe7ee"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7011d97b484a5ebdc4b1fdb3b12d5e4bbbea56e9d22b688f2e79e04b65a7d8a6"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,12 +2793,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3113,6 +3356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,6 +3508,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -3350,6 +3605,67 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sparesults"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e13362decdcbeb3fefadff1631238c835c112027221e83d217cc5779f5a81c2"
+dependencies = [
+ "json-event-parser",
+ "memchr",
+ "oxrdf",
+ "quick-xml",
+ "thiserror",
+]
+
+[[package]]
+name = "spareval"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8eab80b96dc836e4cf8fda72daa67ccc0244dc5303be5d4566e8fd04adbdde5"
+dependencies = [
+ "hex",
+ "json-event-parser",
+ "md-5",
+ "oxiri",
+ "oxrdf",
+ "oxsdatatypes",
+ "rand 0.9.4",
+ "regex",
+ "rustc-hash",
+ "sha1",
+ "sha2",
+ "sparesults",
+ "spargebra",
+ "sparopt",
+ "thiserror",
+]
+
+[[package]]
+name = "spargebra"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46715eb957d1fe960cbbc0b713da8f78e2cb19df315b48fb09c9467a1c84f656"
+dependencies = [
+ "oxilangtag",
+ "oxiri",
+ "oxrdf",
+ "peg",
+ "rand 0.9.4",
+ "thiserror",
+]
+
+[[package]]
+name = "sparopt"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
+dependencies = [
+ "oxrdf",
+ "rand 0.9.4",
+ "spargebra",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ COPY frontend/style.css /app/frontend/
 FROM rust:1.95-bookworm AS builder
 ARG CARGO_BUILD_JOBS=2
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends clang libclang-dev build-essential pkg-config \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY edge ./edge

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -9,6 +9,9 @@
 FROM rust:1.95-bookworm AS builder
 ARG CARGO_BUILD_JOBS=1
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends clang libclang-dev build-essential pkg-config \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY edge ./edge

--- a/docs/AI_AGENT_API.md
+++ b/docs/AI_AGENT_API.md
@@ -1,175 +1,90 @@
-# Open-FDD Rust Edge
+# REST API reference (Rust edge)
 
-> **Note:** Prefer `openfdd_rust_edge_bootstrap.sh` and [AGENTS.md](../AGENTS.md) for current install. This file lists REST routes; external agents use Cursor/Codex — built-in Ollama/MCP are optional/future ([agent architecture](../agent/openfdd-agent-architecture.md)).
+Authoritative route list: `GET /api/agent/tools` on a running site. Prefer [AGENTS.md](../AGENTS.md) and [quick-start/rust-edge-bootstrap.md](quick-start/rust-edge-bootstrap.md) for install.
 
-Turn-key Rust + React prototype that mirrors the Open-FDD edge split:
+**Base URL:** `http://127.0.0.1:8080` (LAN only). **Auth:** Bearer JWT except where noted.
 
-```text
-openfdd-bridge             API + dashboard + historian
-openfdd-commission         BACnet / Modbus / JSON API discover-read-poll
-openfdd-haystack-gateway   Haystack read/nav/ops integration
-MCP                         intentionally deferred
-```
+## Authentication
 
-## Start on Docker Desktop
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| GET | `/api/health` | none | Liveness |
+| POST | `/api/auth/login` | none | Body: `{"username","password"}` → `token` / `access_token` |
+| GET | `/api/auth/me` | JWT | Current principal |
 
-```bash
-cp .env.example .env
-./scripts/edge_bootstrap.sh
-```
+Roles: `operator`, `integrator`, `agent`. Mutations on drivers, model import, rule activation, and field-bus writes require `integrator` or `agent` unless noted.
 
-Open:
+## Haystack model (RDF / SPARQL)
 
-```text
-http://localhost:8080
-```
+The Haystack grid is projected to Turtle and queried with **Oxigraph** (read-only SELECT).
 
-## Direct Docker command
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| GET | `/api/model/haystack` | JWT | Raw Haystack grid JSON |
+| GET | `/api/model/ttl` | JWT | Turtle export (`Accept: text/turtle`) |
+| POST | `/api/model/sync-ttl` | integrator+ | Persist `workspace/data/model/data_model.ttl` |
+| GET | `/api/model/sparql/predefined` | JWT | Catalog + default query |
+| POST | `/api/model/sparql` | JWT | Body: `{"query":"<SPARQL SELECT>"}` → `bindings` |
+| GET | `/api/model/sites` | JWT | Sites + active site |
+| GET | `/api/model/sites/{id}/equipment` | JWT | Equipment for site |
+| GET | `/api/model/tree` | JWT | Site-scoped equipment + points (SPARQL-backed) |
+| GET | `/api/model/graph` | JWT | Network graph (equipment, feeds, points) |
+| GET | `/api/model/assignments` | JWT | Driver → Haystack → FDD bindings |
+| POST | `/api/model/assignments/save` | integrator+ | Save bindings |
+| POST | `/api/model/haystack/import` | integrator+ | Import from Haystack driver |
+| GET | `/api/dashboard/model-coverage` | JWT | Mapped / unmapped summary |
 
-```bash
-docker compose up --build
-```
-
-## Auth
-
-Public endpoints:
-
-```text
-GET  /api/health
-POST /api/auth/login
-```
-
-JWT login:
+Example SPARQL:
 
 ```bash
-TOKEN="$(curl -s -X POST http://127.0.0.1:8080/api/auth/login \
-  -H 'Content-Type: application/json' \
-  -d '{"sub":"agent","role":"agent"}' | jq -r .access_token)"
+curl -s -X POST http://127.0.0.1:8080/api/model/sparql \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"query":"PREFIX hs: <https://project-haystack.org/def/> PREFIX ofdd: <https://open-fdd.dev/model#> SELECT ?site ?dis WHERE { ?s a hs:Site . ?s ofdd:haystackId ?site . OPTIONAL { ?s hs:dis ?dis . } }"}'
 ```
 
-Use:
+Vocabulary: `hs:` = Project Haystack def; `ofdd:haystackId` = canonical Haystack ref string.
 
-```bash
--H "Authorization: Bearer $TOKEN"
-```
+## Drivers
 
-Roles:
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/bacnet/driver/tree` | BACnet registry |
+| POST | `/api/bacnet/read` | Read property |
+| POST | `/api/bacnet/write` | integrator+; dry-run in prototype |
+| GET | `/api/modbus/points` | Register map |
+| POST | `/api/modbus/read` | Read registers |
+| GET | `/api/haystack/status` | Gateway status (200 when disabled) |
+| POST | `/api/haystack/read` | Read by ids or filter |
+| POST | `/api/haystack/import` | Import into model grid |
+| GET | `/api/json-api/sources` | JSON API sources |
 
-```text
-operator
-integrator
-agent
-```
+Commission OT reads (host network): `http://127.0.0.1:9091` — see [architecture/drivers-and-fdd.md](architecture/drivers-and-fdd.md).
 
-## Required Open-FDD-style endpoints now included
+## FDD and historian
 
-```text
-POST /api/auth/login
-GET  /api/health/stack
-POST /api/rules/save
-POST /api/rules/batch
-POST /api/model/haystack/import
-GET  /api/bacnet/driver/tree
-POST /api/bacnet/overrides/scan-once
-POST /api/reports/rcx/generate
-GET  /api/agent/tools
-```
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/rules` | Rule catalog |
+| POST | `/api/fdd-rules/builder-sql` | Draft SQL from inputs |
+| POST | `/api/fdd-rules/{id}/test-sql` | Dry-run against historian |
+| POST | `/api/fdd/run` | Run evaluation |
+| GET | `/api/historian/query` | Arrow / DataFusion query |
+| GET | `/api/faults` | Active faults |
+| GET | `/api/building/status` | Public building summary (no JWT) |
 
-## Driver/data APIs
+## Agent and MCP
 
-```text
-POST /api/bacnet/whois
-POST /api/bacnet/point-discovery
-GET  /api/bacnet/points
-GET  /api/bacnet/driver/tree
-POST /api/bacnet/driver/sync-discovery
-POST /api/bacnet/read
-POST /api/bacnet/write
-GET  /api/bacnet/overrides/status
-POST /api/bacnet/overrides/scan-once
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/agent/tools` | Machine-readable tool manifest |
+| GET | `/api/agent/manifest` | Agent metadata |
+| GET | `/api/health/stack` | Bridge + sidecar health |
 
-GET  /api/modbus/points
-POST /api/modbus/scan
-POST /api/modbus/read
+MCP sidecar: [mcp/README.md](../mcp/README.md) · [agent/openfdd-mcp-tool-contract.md](agent/openfdd-mcp-tool-contract.md)
 
-GET  /api/json-api/sources
-POST /api/json-api/register
-POST /api/json-api/poll-once
+## Safety
 
-GET  /api/haystack/about
-POST /api/haystack/read
-POST /api/haystack/nav
-POST /api/haystack/ops
-GET  /api/model/haystack
-POST /api/model/haystack/import
-POST /api/model/query
-```
-
-## Algorithms / FDD / historian
-
-```text
-GET  /api/algorithms
-POST /api/algorithms/run
-GET  /api/arrow/demo
-GET  /api/fdd/datafusion/demo
-POST /api/fdd/run
-GET  /api/rules
-POST /api/rules/save
-POST /api/rules/batch
-GET  /api/historian/query
-POST /api/historian/query
-```
-
-## Agent and lifecycle APIs
-
-```text
-GET  /api/agent/manifest
-GET  /api/agent/tools
-POST /api/agent/bootstrap
-POST /api/agent/update
-GET  /api/building/checkin
-GET  /api/ops/stack
-POST /api/ops/docker/update
-POST /api/reports/rcx/plan
-POST /api/reports/rcx/generate
-GET  /api/reports/rcx/list
-```
-
-## Security posture
-
-- `OPENFDD_JWT_SECRET` signs HS256 JWTs.
-- Token TTL is 8 hours.
-- Static UI and `/api/health` are public.
-- All operational `/api/*` calls require Bearer JWT.
-- BACnet write requires `integrator` role and `approved=true`.
-- Prototype BACnet writes are dry-run only.
-- Keep this edge stack on LAN/Tailscale.
-- Never run `docker compose down -v`.
-- Never delete `workspace/`.
-- Never print secrets or auth files.
-
-## Niagara integration direction
-
-Custom Niagara WebSockets are intentionally replaced by the Haystack gateway path:
-
-```text
-Niagara / BAS server -> Project Haystack read/nav/ops -> Rust Haystack gateway -> Open-FDD model + Arrow tables
-```
-
-MCP/RAG sidecar comes later; this release is focused on full JSON/JWT agent drivability.
-
-## Production Rust backend skeleton
-
-`backend/` is the production integration direction with:
-
-```text
-rusty-bacnet
-rusty-modbus
-rusty-haystack
-open-control-engine
-Apache Arrow
-DataFusion SQL
-JWT auth module
-```
-
-The fast default container uses `edge_prototype_rust/` so Docker Desktop can start quickly.
+- Do not delete `workspace/` or run `docker compose down -v`.
+- Do not log JWTs or `auth.env.local`.
+- Field-bus writes require explicit human approval.
+- Keep the edge on LAN / Tailscale, not the public internet.

--- a/docs/ASSIGNMENT_MODEL.md
+++ b/docs/ASSIGNMENT_MODEL.md
@@ -36,6 +36,7 @@ GET  /api/model/assignments
 POST /api/model/assignments/save
 POST /api/model/assignments/resolve
 GET  /api/model/algorithm-bindings
+POST /api/model/sparql          # explore model (SELECT)
 GET  /api/control/cdl/bindings
 POST /api/control/cdl/bindings/save
 ```

--- a/docs/FRONTEND_TAB_PARITY.md
+++ b/docs/FRONTEND_TAB_PARITY.md
@@ -9,7 +9,7 @@ This document maps the old Open-FDD UI areas to the Rust-only UI.
 | BACnet commission | BACnet Commission | `/api/bacnet/commission/status` |
 | BACnet poll | BACnet Poll | `/api/bacnet/poll/status` |
 | Niagara | Haystack Model | `/api/haystack/read` |
-| Data model | Haystack Model | `/api/model/haystack` |
+| Data model | Haystack Model | `/api/model/haystack`, `/api/model/sparql` |
 | Rule Lab | Rule Lab | `/api/rules/save` |
 | FDD | DataFusion FDD | `/api/fdd/run` |
 | Modbus | Modbus | `/api/modbus/points` |
@@ -21,7 +21,7 @@ This document maps the old Open-FDD UI areas to the Rust-only UI.
 ## Converted or removed
 
 - Niagara WebSocket tab is converted to Project Haystack read/nav/ops.
-- Data model is Haystack-only.
+- Data model is Haystack + SPARQL over RDF.
 - FDD is DataFusion SQL only.
 - CDL algorithms get a dedicated tab.
 - MCP/RAG and Ollama are deferred.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,77 +1,49 @@
-# Open-FDD Rust Edge Documentation
+# Open-FDD documentation
 
-Open-FDD is a local-first, on-prem HVAC supervisory fault-detection edge application built around **Rust**, **Apache Arrow**, **DataFusion SQL**, **React**, and **Docker/GHCR**.
+Local-first HVAC fault detection on a **Rust edge** (Arrow historian, DataFusion SQL, React dashboard, Docker/GHCR).
 
-## Architecture
+## Start here
 
-Open-FDD uses **Apache Arrow** and **Feather** as the native historian and data storage layer, while **DataFusion SQL** serves as the fault detection and analytics engine that operates directly on those Arrow datasets. Telemetry from BACnet, Haystack, Modbus, and JSON APIs is normalized into Arrow-native structures (persisted as Feather files at the edge) instead of a traditional relational database. DataFusion executes SQL-based fault detection rules, reporting logic, and data quality checks directly against that historian.
+| Audience | Document |
+|----------|----------|
+| Operators | [quick-start/rust-edge-bootstrap.md](quick-start/rust-edge-bootstrap.md) |
+| Developers | [deployment/local-dev.md](deployment/local-dev.md) |
+| AI / MCP agents | [ai-agent/README.md](ai-agent/README.md) · [AI_AGENT_API.md](AI_AGENT_API.md) |
+| API (OpenAPI stub) | [openapi.yaml](openapi.yaml) |
 
-The stack is migrating to an all-Rust edge runtime: BACnet and Modbus drivers, Haystack gateway, Arrow historian, DataFusion FDD, JWT auth, and the React dashboard. Docker containers (`openfdd-bridge`, `openfdd-commission`, `openfdd-haystack-gateway`) share one workspace volume and form a self-hosted platform without cloud dependency.
-
-Full detail: [architecture/overview.md](architecture/overview.md).
-
-## Quick start
-
-| Topic | Document |
-| --- | --- |
-| Fresh GHCR install | [quick-start/rust-edge-bootstrap.md](quick-start/rust-edge-bootstrap.md) |
-| Backup, update, restore | [quick-start/rust-site-lifecycle.md](quick-start/rust-site-lifecycle.md) |
-| Raspberry Pi / ARM64 | [quick-start/raspberry-pi-rust-edge.md](quick-start/raspberry-pi-rust-edge.md) |
-
-## Local development
+## Platform
 
 | Topic | Document |
-| --- | --- |
-| **Build recipes** (local up, Caddy TLS, auth) | [deployment/local-dev.md](deployment/local-dev.md) |
-| UI inspection (no long validation) | [deployment/local_ui_inspection.md](deployment/local_ui_inspection.md) |
-| GHCR vs local Dockerfile | [deployment/local_ui_build.md](deployment/local_ui_build.md) |
-| Caddy LAN ingress | [deployment/caddy.md](deployment/caddy.md) |
-| Windows Docker Desktop | [deployment/windows_docker_desktop.md](deployment/windows_docker_desktop.md) |
+|-------|----------|
+| Architecture | [architecture/overview.md](architecture/overview.md) |
+| Drivers and FDD | [architecture/drivers-and-fdd.md](architecture/drivers-and-fdd.md) |
+| Haystack integration | [integrations/haystack.md](integrations/haystack.md) |
+| Model + SPARQL | [modeling/haystack_dashboard_model.md](modeling/haystack_dashboard_model.md) |
+| Assignments | [ASSIGNMENT_MODEL.md](ASSIGNMENT_MODEL.md) |
+| Future appliance (OS) | [../os/README.md](../os/README.md) |
 
 ## Operations
 
 | Topic | Document |
-| --- | --- |
-| Site update and restore | [operations/rust-update-restore.md](operations/rust-update-restore.md) |
-| Production Caddy TLS | [operations/production-caddy.md](operations/production-caddy.md) |
-| Auth and credentials | [security/rust-edge-auth.md](security/rust-edge-auth.md) |
-| CI and GitHub Actions | [verification/ci-github-actions.md](verification/ci-github-actions.md) |
+|-------|----------|
+| Backup / update / restore | [quick-start/rust-site-lifecycle.md](quick-start/rust-site-lifecycle.md) |
+| Production TLS | [operations/production-caddy.md](operations/production-caddy.md) |
+| Auth | [security/rust-edge-auth.md](security/rust-edge-auth.md) |
 
-## Architecture
-
-| Topic | Document |
-| --- | --- |
-| Platform overview | [architecture/overview.md](architecture/overview.md) |
-| **Open-FDD OS (future concept)** | [../os/README.md](../os/README.md) — HA OS–inspired appliance image; Rust GHCR under the hood |
-| Local BACnet server (diagnostics) | [architecture/bacnet-local-server.md](architecture/bacnet-local-server.md) |
-| Drivers, historian, and FDD | [architecture/drivers-and-fdd.md](architecture/drivers-and-fdd.md) |
-| Haystack assignment model | [ASSIGNMENT_MODEL.md](ASSIGNMENT_MODEL.md) |
-| Agent API surface | [AI_AGENT_API.md](AI_AGENT_API.md) |
-| OpenAPI spec | [openapi.yaml](openapi.yaml) |
-
-## Verification checklists
-
-Manual QA procedures live under [verification/](verification/). Use these after bootstrap, driver changes, or releases — they are **not** bench-specific runbooks.
-
-| Check | Document |
-| --- | --- |
-| BACnet NIC and bind config | [verification/bacnet-nic-setup.md](verification/bacnet-nic-setup.md) |
-| BACnet override scan and CSV | [verification/bacnet-overrides.md](verification/bacnet-overrides.md) |
-| Modbus live path | [verification/modbus-live.md](verification/modbus-live.md) |
-| Default React UI | [verification/ui-smoke.md](verification/ui-smoke.md) |
-| Auth, login, and RBAC | [verification/auth-and-login.md](verification/auth-and-login.md) |
-| FDD Wires and SQL rules | [verification/fdd-wires.md](verification/fdd-wires.md) |
-| Live FDD validation (development) | [testing/live-fdd-validation.md](testing/live-fdd-validation.md) |
-| Legacy bench 5007 runbook | [verification/bench-5007-long-smoke.md](verification/bench-5007-long-smoke.md) |
-
-## AI agent and FDD cookbooks
+## Agents and MCP
 
 | Topic | Document |
-| --- | --- |
-| AI agent index | [ai-agent/README.md](ai-agent/README.md) |
-| Haystack + assignments | [ai-agent/haystack-and-assignments.md](ai-agent/haystack-and-assignments.md) |
-| SQL HVAC FDD rules | [rule-cookbook/sql-hvac-fdd.md](rule-cookbook/sql-hvac-fdd.md) |
+|-------|----------|
+| Agent index | [ai-agent/README.md](ai-agent/README.md) |
+| Session context | [ai-agent-context.md](ai-agent-context.md) |
+| MCP tool contract | [agent/openfdd-mcp-tool-contract.md](agent/openfdd-mcp-tool-contract.md) |
+| MCP setup | [../mcp/README.md](../mcp/README.md) |
+| Safety boundaries | [security/agent-safety-boundaries.md](security/agent-safety-boundaries.md) |
 
-## AI agents
+## Verification
 
-See [ai-agent-context.md](ai-agent-context.md) and root [AGENTS.md](../AGENTS.md) for safe operator guidance (no workspace deletion, no `docker compose down -v`, no secret printing).
+Checklists under [verification/](verification/) — run after bootstrap, driver changes, or releases.
+
+## Agent safety (all docs)
+
+See root [AGENTS.md](../AGENTS.md): never delete `workspace/`, never `docker compose down -v`, never print secrets.

--- a/docs/agent/openfdd-agent-architecture.md
+++ b/docs/agent/openfdd-agent-architecture.md
@@ -79,11 +79,11 @@ Use for:
 - Dashboard Agent tab and Ollama host-stats blocks are **placeholders** — not production dependencies
 - Do not block releases on Ollama availability
 
-### Future MCP (`openfdd-mcp`)
+### MCP (`openfdd-mcp`)
 
-- Separate process / `SERVICE_MODE=mcp` (design only in 3.2.x)
-- **Read-first** tool surface — see [openfdd-mcp-tool-contract.md](openfdd-mcp-tool-contract.md)
-- Rule activation, restore, and field-bus writes require **explicit human approval** tokens in tool policy
+- Stdio sidecar — [mcp/README.md](../../mcp/README.md)
+- Read-first tools including model SPARQL — [openfdd-mcp-tool-contract.md](openfdd-mcp-tool-contract.md)
+- Writes and rule activation require explicit human approval
 
 ## Session pattern (external agent)
 

--- a/docs/agent/openfdd-agent-current-standing.md
+++ b/docs/agent/openfdd-agent-current-standing.md
@@ -1,61 +1,47 @@
-# Open-FDD agent current standing (2026-06)
+# Agent runtime status (3.2.x)
 
-This document summarizes **what is true in the repo today** versus **legacy Python / built-in Ollama / MCP-RAG** assumptions still visible in UI stubs, comments, or old workflows.
+What is shipped today vs legacy UI stubs (Ollama, Python MCP-RAG).
 
-## Current runtime (authoritative)
+## Authoritative
 
-| Item | Current state |
-| --- | --- |
-| **Stack** | Rust edge — `open_fdd_edge_prototype` / `openfdd-edge` binary, React dashboard |
-| **GHCR image** | `ghcr.io/bbartling/openfdd-edge-rust` (tags e.g. `3.2.2`, `3.2.3`, `latest`) |
-| **Compose profiles** | `desktop-json-csv`, `full-edge`, optional `caddy-http` / `caddy-tls` |
-| **Service containers** | `openfdd-bridge`, `openfdd-commission` (host network BACnet), `openfdd-haystack-gateway` |
-| **Service modes** | `SERVICE_MODE=bridge \| commission \| haystack-gateway` (same image) |
-| **Auth** | JWT + RBAC from `workspace/auth.env.local` (bcrypt; not in compose `env_file`) |
-| **Historian / FDD** | Apache Arrow/Feather + DataFusion SQL in bridge |
-| **Agent HTTP surface** | JSON REST + JWT (`GET /api/agent/tools`, `/openfdd-agent/building-insight` stub) |
-| **MCP service mode** | **Phase 1 scaffold** — `openfdd-mcp` crate + `ghcr.io/bbartling/openfdd-mcp` (stdio sidecar); not in edge binary |
-| **Built-in Ollama** | **Not required** — UI panels and host-stats placeholders only |
+| Item | State |
+|------|-------|
+| Runtime | Rust `openfdd-edge` + React dashboard |
+| Image | `ghcr.io/bbartling/openfdd-edge-rust` (`3.2.3`, `latest`) |
+| Services | `openfdd-bridge`, `openfdd-commission`, `openfdd-haystack-gateway` |
+| Auth | JWT + RBAC from `workspace/auth.env.local` |
+| Historian / FDD | Arrow/Feather + DataFusion SQL |
+| Model queries | SPARQL over Haystack RDF projection |
+| Agent HTTP | `GET /api/agent/tools`, REST catalog |
+| MCP | `openfdd-mcp` stdio sidecar (read-first) |
+| Built-in Ollama | Not required — UI placeholders only |
 
-## External orchestration (target policy)
+## External orchestration
 
-| Role | Tooling | Scope |
-| --- | --- | --- |
-| **Deterministic runtime** | Open-FDD Rust edge | Poll, historian, FDD, reports, driver trees |
-| **Orchestrator** | Cursor / Codex (this repo's agents) | Plans, PRs, docs, safe script invocation |
-| **Simple triage** | Worker / mini model | Pass/fail tests, HTTP status, missing selectors, syntax |
-| **Complex evaluation** | Thinking model | Auth, multi-service failures, deploy scripts, field-bus writes |
-| **Optional local LLM** | Ollama (operator LAN only) | Doc Q&A / RAG helper — **not** a runtime dependency |
-| **Future MCP** | `openfdd-mcp` (scaffold) | Read-first tools; writes gated by human approval |
+| Role | Tooling |
+|------|---------|
+| Runtime | Open-FDD Rust edge |
+| Planning / PRs | Cursor, Codex, OpenClaw (LAN) |
+| MCP | `openfdd-mcp` with JWT |
+| Optional LLM | Local Ollama for doc Q&A only |
 
-## Legacy artifacts (do not treat as current without verification)
+## Legacy (verify before use)
 
-| Location | Legacy signal | Current interpretation |
-| --- | --- | --- |
-| `workspace/dashboard` — Agent tab, Faults "Validate with Ollama", Host stats Ollama panel | Built-in Ollama chat/RAG | **Deferred UI**; edge returns stub/offline for Ollama stats |
-| `GET /openfdd-agent/building-insight` | Python-era building agent | **Rust stub** (`building_insight_stub`) |
-| `docs/AI_AGENT_API.md` header | Mentions `edge_bootstrap.sh`, demo JWT body | Partially stale — prefer `openfdd_rust_edge_bootstrap.sh` + real login |
-| `.github/workflows/ghcr-multiarch-publish.yml` | Python `openfdd-mcp-rag` image | **Legacy** — marked in workflow; Rust uses `rust-ghcr.yml` |
-| `.github/actions/publish-multiarch` | `mcp-rag:openfdd-mcp-rag` | Legacy Python stack only |
-| `edge/src/ops/bridge.rs` parity manifest | `"Rule Lab"`, deferred `mcp-rag` / `ollama` | Accurate deferral list for porting audit |
-| README OpenClaw copy-paste blocks | External agent on Pi | **Still valid** as external orchestrator prompts (not in-container Ollama) |
-| `docker-compose.yml` comment | "MCP will be added later" | Still accurate |
-| Rule Lab naming in dashboard copy | Old tab name | Functionality lives under **SQL FDD rules** / FDD Wires — no Rule Lab route in CI guards |
+| Signal | Interpretation |
+|--------|----------------|
+| Agent tab / “Validate with Ollama” | Deferred UI |
+| `GET /openfdd-agent/building-insight` | Rust stub |
+| Python `openfdd-mcp-rag` GHCR workflow | Legacy; use `rust-ghcr.yml` |
+| `edge_bootstrap.sh` in old docs | Use `openfdd_rust_edge_bootstrap.sh` |
 
-## Model routing (for agents working this repo)
+## Model routing for repo agents
 
-**SIMPLE** (worker/mini): single-file lint, one HTTP 4xx/5xx, one failing test name, env missing, `cargo fmt` diff.
+**Simple:** single test failure, one HTTP status, fmt/lint.
 
-**COMPLEX** (orchestrator/thinking): auth/RBAC, race/flaky CI, bridge + commission + haystack + frontend together, deploy/restore scripts, any BACnet/Modbus/Haystack **write**, behavior that passes tests but violates safety rules.
+**Complex:** auth/RBAC, multi-container issues, deploy scripts, any field-bus write.
 
-## Related docs
+## Related
 
-- [openfdd-agent-architecture.md](openfdd-agent-architecture.md) — target multi-agent design
-- [bench-driver-setup-wsl-agent.md](bench-driver-setup-wsl-agent.md) — on-bench WSL Cursor agent prompt (Haystack + drivers)
-- [openfdd-mcp-tool-contract.md](openfdd-mcp-tool-contract.md) — MCP tools + bench extensions
-- [../security/agent-safety-boundaries.md](../security/agent-safety-boundaries.md) — hard limits
-- [../ai-agent/README.md](../ai-agent/README.md) — session start + API index (updated to link here)
-
-## Downloads research pack
-
-The operator research folder `research_review_agent_skills_v1_2_openfdd_agent_retrofit` was not present on the dev WSL mount at implementation time. Content below was derived from repo inspection and issue #402 / external-agent retrofit requirements. Merge any missing research files into `docs/agent/` in a follow-up commit if the pack is copied to the repo.
+- [openfdd-agent-architecture.md](openfdd-agent-architecture.md)
+- [openfdd-mcp-tool-contract.md](openfdd-mcp-tool-contract.md)
+- [../ai-agent/README.md](../ai-agent/README.md)

--- a/docs/agent/openfdd-mcp-tool-contract.md
+++ b/docs/agent/openfdd-mcp-tool-contract.md
@@ -1,90 +1,81 @@
-# Open-FDD MCP tool contract (draft)
+# MCP tool contract
 
-**Status:** Phase 1 scaffold ships as **`openfdd-mcp`** crate + `ghcr.io/bbartling/openfdd-mcp` (stdio sidecar). Not required for core edge runtime.
+**Server:** `openfdd-mcp` · **Image:** `ghcr.io/bbartling/openfdd-mcp` · **Setup:** [mcp/README.md](../../mcp/README.md)
 
-**Principles:**
+Read-first sidecar. JWT via `OPENFDD_MCP_TOKEN`. Bind `127.0.0.1` or site VLAN only.
 
-1. **Read-first** — default tool set is observability and export only.
-2. **JWT inherit** — MCP server uses operator-supplied bearer token; no embedded secrets.
-3. **LAN/local bind** — listen on `127.0.0.1` or site VLAN; never public internet.
-4. **Human approval** — field-bus writes, rule activation, restore, and override clearing require an explicit approval record (out of band from MCP auto-invoke).
+## Principles
 
-## Tool catalog (phase 1 — read-only)
+1. **Read-first** — observability and export by default.
+2. **JWT inherit** — operator supplies bearer token; no embedded secrets.
+3. **Human approval** — writes, rule activation, restore, and field-bus tools require explicit operator ACK (phase 2).
 
-| Tool ID | REST mapping | Roles | Notes |
-| --- | --- | --- | --- |
-| `health.get` | `GET /api/health` | public | Liveness |
-| `stack.status` | `GET /api/health/stack` | JWT | Bridge + sidecar summary |
-| `drivers.bacnet.tree` | `GET /api/bacnet/driver/tree` | JWT | Device/point registry |
-| `drivers.bacnet.override_scan_export` | `GET /api/bacnet/overrides/export` | operator+ | CSV attachment |
-| `drivers.bacnet.overrides_summary` | `GET /api/bacnet/overrides/summary` | operator+ | Scan metadata |
-| `drivers.modbus.points` | `GET /api/modbus/points` | JWT | Register map |
-| `drivers.haystack.status` | `GET /api/haystack/status` | JWT | Gateway config redacted |
-| `drivers.haystack.tree` | `GET /api/haystack/driver/tree` | JWT | Normalized points |
-| `drivers.haystack.nav` | `POST /api/haystack/nav` | JWT | Body: `{ "navId": "..." }` |
-| `drivers.haystack.read` | `POST /api/haystack/read` | JWT | Body: `{ "ids": [...] }` or filter |
-| `rules.sql.validate` | `POST /api/fdd-rules/{id}/test-sql` | integrator+ | Dry-run SQL against historian |
-| `rules.list` | `GET /api/rules` | JWT | Catalog |
-| `model.export` | `GET /api/model/haystack` + assignments | JWT | Haystack grid snapshot |
-| `model.import_dry_run` | `POST /api/model/haystack/import` with `dry_run: true` | integrator+ | **Proposed:** no persist until approved |
-| `reports.rcx.generate` | `POST /api/reports/from-validation-run` | integrator+ | Rust PDF pipeline |
-| `reports.list` | `GET /api/reports` | JWT | Draft metadata |
-| `agent.tools` | `GET /api/agent/tools` | JWT | Discovery |
+## Implemented tools (stdio)
 
-Role shorthand: `operator+` = operator, integrator, or agent per existing RBAC.
+| Tool | REST | Auth |
+|------|------|------|
+| `openfdd_health` | `GET /api/health` | none |
+| `openfdd_driver_status` | Bundle: health, haystack/modbus/bacnet/json status | JWT |
+| `openfdd_bench_topology` | Env `OPENFDD_BENCH_TOPOLOGY_FILE` or doc pointer | — |
+| `openfdd_haystack_status` | `GET /api/haystack/status` | JWT |
+| `openfdd_haystack_test` | `POST /api/haystack/test` | JWT |
+| `openfdd_haystack_read` | `POST /api/haystack/read` | JWT |
+| `openfdd_bacnet_read` | Commission `POST /api/bacnet/read` | JWT |
+| `openfdd_model_sparql_catalog` | `GET /api/model/sparql/predefined` | JWT |
+| `openfdd_model_sparql` | `POST /api/model/sparql` | JWT |
+| `openfdd_model_sites` | `GET /api/model/sites` | JWT |
+| `openfdd_model_coverage` | `GET /api/dashboard/model-coverage` | JWT |
 
-## Phase 2 — gated mutations (approval required)
+### `openfdd_model_sparql`
 
-These tools MUST NOT be callable without a documented approval artifact (ticket ID, operator ACK, or signed one-time token):
-
-| Tool ID | REST mapping | Risk |
-| --- | --- | --- |
-| `rules.activate` | `POST /api/fdd-rules/{id}/activate` | Live fault detection |
-| `model.assignments.save` | `POST /api/model/assignments` | Binds OT to FDD |
-| `site.restore` | restore scripts / backup import | Data loss risk |
-| `bacnet.write_property` | `POST /api/bacnet/write` | **Field bus write** |
-| `bacnet.clear_overrides` | override clear routes | **BAS intervention** |
-| `modbus.write` | Modbus write APIs | **Field bus write** |
-| `haystack.point_write` | `POST /api/haystack/write` | **Station write** |
-| `control.execute` | CDL execute (if added) | **Control** |
-
-Default MCP policy: **deny all phase 2** unless `OPENFDD_MCP_ALLOW_WRITES=1` **and** per-call `approval_id` matches server-side allowlist.
-
-## Forbidden (never expose via MCP)
-
-- Raw `workspace/auth.env.local` or password hashes
-- Unauthenticated bridge on `0.0.0.0` without Caddy/TLS site policy
-- `docker compose down -v`, `docker volume prune`
-- Bulk delete of `workspace/` historian/feather data without backup verification
-
-## Error shape
-
-Tools return JSON aligned with bridge responses:
+Arguments:
 
 ```json
-{ "ok": false, "error": "insufficient role", "tool": "drivers.bacnet.tree" }
+{ "query": "PREFIX hs: <...> SELECT ?site ?dis WHERE { ... }" }
 ```
 
-## Implementation notes
+Returns bridge JSON: `{ "ok", "bindings", "row_count", "query_engine": "sparql" }`. Only SELECT allowed; INSERT/DELETE rejected.
 
-- Model after read-only patterns in [rusty-bacnet-mcp](https://github.com/jscott3201/rusty-bacnet-mcp) (community) — separate binary, stdio or SSE transport.
-- Reuse `GET /api/agent/tools` manifest until MCP server ships.
-- Issue #402 proposed `open-fdd-mcp` as a **separate future task** — do not block edge releases on MCP.
+## REST mappings (agents without MCP)
 
-## Bench tools (WSL agent)
+Use the same JWT against the bridge directly — see [AI_AGENT_API.md](../AI_AGENT_API.md).
 
-Additional tools implemented in `mcp/` for live bench work — see [bench-driver-setup-wsl-agent.md](bench-driver-setup-wsl-agent.md):
+| Intent | Method | Path |
+|--------|--------|------|
+| Tool manifest | GET | `/api/agent/tools` |
+| Haystack grid | GET | `/api/model/haystack` |
+| SPARQL | POST | `/api/model/sparql` |
+| Assignments | GET | `/api/model/assignments` |
+| BACnet tree | GET | `/api/bacnet/driver/tree` |
+| Test SQL rule | POST | `/api/fdd-rules/{id}/test-sql` |
+| Stack health | GET | `/api/health/stack` |
 
-| Tool ID | Purpose |
-| --- | --- |
-| `openfdd_bench_topology` | NIC, bridge/commission bases, optional topology JSON file |
-| `openfdd_driver_status` | Bundle of poll/status endpoints |
-| `openfdd_bacnet_read` | Commission BACnet read by `point_id` |
-| `openfdd_haystack_read` | Filter/ids read via bridge |
+## Phase 2 — gated (not in MCP by default)
+
+Requires `OPENFDD_MCP_ALLOW_WRITES=1` and per-call approval record:
+
+| Tool | REST | Risk |
+|------|------|------|
+| Rule activation | `POST /api/fdd-rules/{id}/activate` | Live FDD |
+| Save assignments | `POST /api/model/assignments/save` | OT binding |
+| BACnet write | `POST /api/bacnet/write` | Field bus |
+| Haystack write | `POST /api/haystack/write` | Station write |
+| Site restore | backup/restore scripts | Data loss |
+
+## Forbidden
+
+- Exposing `auth.env.local`, password hashes, or JWTs in tool output
+- `docker compose down -v`, bulk `workspace/` delete without verified backup
+- Public `0.0.0.0` bridge without TLS policy
+
+## Errors
+
+```json
+{ "ok": false, "error": "insufficient role", "tool": "openfdd_model_sparql" }
+```
 
 ## Related
 
-- [openfdd-agent-architecture.md](openfdd-agent-architecture.md)
 - [bench-driver-setup-wsl-agent.md](bench-driver-setup-wsl-agent.md)
-- [../../mcp/README.md](../../mcp/README.md)
+- [openfdd-agent-architecture.md](openfdd-agent-architecture.md)
 - [../security/agent-safety-boundaries.md](../security/agent-safety-boundaries.md)

--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -1,54 +1,52 @@
-# AI agent context (Rust edge)
+# AI agent context
 
-## Runtime
+Rust-only edge runtime. Use JWT REST and safe lifecycle scripts — no Python stack required.
 
-100% Rust edge — no Python/FastAPI required for install, auth, drivers, or FDD.
+## Guides
 
-## AI assistance map
+| Task | Document |
+|------|----------|
+| Haystack + assignments | [ai-agent/haystack-and-assignments.md](ai-agent/haystack-and-assignments.md) |
+| SQL FDD rules | [rule-cookbook/sql-hvac-fdd.md](rule-cookbook/sql-hvac-fdd.md) |
+| MCP tools | [agent/openfdd-mcp-tool-contract.md](agent/openfdd-mcp-tool-contract.md) |
+| Full index | [ai-agent/README.md](ai-agent/README.md) |
 
-| Task | Guide |
-| --- | --- |
-| Haystack modeling + assignments | [ai-agent/haystack-and-assignments.md](ai-agent/haystack-and-assignments.md) |
-| SQL HVAC fault rules | [rule-cookbook/sql-hvac-fdd.md](rule-cookbook/sql-hvac-fdd.md) |
-| FDD Wires graph | [verification/fdd-wires.md](verification/fdd-wires.md) |
-| Bench 5007 long validation | [verification/bench-5007-long-smoke.md](verification/bench-5007-long-smoke.md) |
-| Full agent index | [ai-agent/README.md](ai-agent/README.md) |
+## Session login
+
+```bash
+INTEGRATOR_PW="$(grep '^OFDD_INTEGRATOR_PASSWORD=' ~/open-fdd/workspace/auth.env.local | cut -d= -f2-)"
+TOKEN="$(curl -s -X POST http://127.0.0.1:8080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg u integrator --arg p "$INTEGRATOR_PW" '{username:$u,password:$p}')" \
+  | jq -r '.token // .access_token')"
+```
+
+## Key endpoints
+
+```text
+GET  /api/health/stack
+GET  /api/agent/tools
+GET  /api/model/haystack
+GET  /api/model/sparql/predefined
+POST /api/model/sparql
+GET  /api/model/assignments
+GET  /api/bacnet/driver/tree
+POST /api/fdd-wires/propose-assignments
+POST /api/fdd-rules/{id}/test-sql
+```
 
 ## Safe scripts
 
 ```bash
-scripts/openfdd_rust_edge_bootstrap.sh
-scripts/openfdd_rust_site_backup.sh
-scripts/openfdd_rust_site_update.sh
-scripts/openfdd_rust_edge_validate.sh
-scripts/openfdd_rust_check_ghcr_platform.sh
-scripts/bench_5007_long_smoke.sh      # 6h device 5007 + FDD capture
-scripts/openfdd_prod_validate.sh      # Caddy TLS + auth
+./scripts/openfdd_rust_edge_bootstrap.sh --start
+./scripts/openfdd_rust_site_backup.sh
+./scripts/openfdd_rust_site_update.sh
+./scripts/openfdd_rust_edge_validate.sh
 ```
 
 ## Never
 
-- delete `workspace/`
-- `docker compose down -v`
-- `docker volume prune`
-- print `auth.env.local` or JWT tokens
-- BACnet/Modbus write without explicit human approval + audit
-
-## API entry points
-
-```text
-GET  /api/health
-POST /api/auth/login
-GET  /api/health/stack
-GET  /api/bacnet/driver/tree
-GET  /api/model/haystack
-GET  /api/model/assignments
-POST /api/fdd-wires/propose-assignments
-POST /api/fdd-rules/builder-sql
-POST /api/fdd-rules/{id}/test-sql
-GET  /api/agent/tools
-```
-
-## GHCR publish prompt
-
-Run `cargo fmt`, `cargo test`, `docker build`, push via `.github/workflows/rust-ghcr.yml`, verify multi-arch digest, update README install URL, open PR against `master`.
+- Delete `workspace/`
+- Run `docker compose down -v` or `docker volume prune`
+- Print tokens or `auth.env.local`
+- BACnet/Modbus/Haystack **writes** without explicit human approval

--- a/docs/ai-agent/README.md
+++ b/docs/ai-agent/README.md
@@ -1,24 +1,20 @@
-# AI agent guide (Rust edge + external orchestrators)
+# AI agents (Rust edge)
 
-How **external** AI agents (Cursor, Codex, OpenClaw, future MCP clients) assist with Open-FDD on the **3.2 Rust edge** — without requiring built-in Ollama or MCP-RAG in the bridge container.
+External orchestrators (Cursor, Codex, MCP clients) operate Open-FDD through **JWT REST**, optional **MCP stdio**, and repo scripts. The bridge container does not embed Ollama or Python agents.
 
-**Architecture:** [agent/openfdd-agent-current-standing.md](../agent/openfdd-agent-current-standing.md) · [agent/openfdd-agent-architecture.md](../agent/openfdd-agent-architecture.md) · [security/agent-safety-boundaries.md](../security/agent-safety-boundaries.md)
+**Architecture:** [agent/openfdd-agent-architecture.md](../agent/openfdd-agent-architecture.md) · **MCP:** [agent/openfdd-mcp-tool-contract.md](../agent/openfdd-mcp-tool-contract.md) · **Safety:** [security/agent-safety-boundaries.md](../security/agent-safety-boundaries.md)
 
-**Legacy Python/Ollama docs:** [legacy/README.md](../legacy/README.md)
+## Capabilities
 
-## What AI can do on this stack
+| Area | Actions | API |
+|------|---------|-----|
+| Health | Stack status, driver poll state | `/api/health/stack`, `/api/agent/tools` |
+| Model | Grid, SPARQL, assignments | `/api/model/haystack`, `/api/model/sparql`, `/api/model/assignments` |
+| Drivers | BACnet/Modbus/Haystack trees and reads | `/api/bacnet/driver/tree`, `/api/haystack/read` |
+| FDD | Draft SQL, test rules, propose bindings | `/api/fdd-rules/*`, `/api/fdd-wires/propose-assignments` |
+| MCP | Read-first tools via sidecar | [mcp/README.md](../../mcp/README.md) |
 
-| Area | Agent actions | API / UI |
-| --- | --- | --- |
-| **Deploy** | Bootstrap GHCR stack, validate health, safe updates | `openfdd_rust_edge_bootstrap.sh`, `/api/health` |
-| **Drivers** | Inspect driver tree, poll BACnet/Modbus, scan overrides | `/api/bacnet/driver/tree`, `/api/modbus/points` |
-| **Haystack model** | Read model, propose point assignments, save bindings | `/api/model/haystack`, `/api/model/assignments` |
-| **FDD Wires** | Propose AI assignments (draft), validate graph, approve | `/api/fdd-wires/propose-assignments`, FDD Wires tab |
-| **SQL rules** | Build/test/validate DataFusion SQL fault rules | `/api/fdd-rules/builder-sql`, `/api/fdd-rules/{id}/test-sql` |
-| **Operations** | Stack check-in, override exports, historian queries | `/api/health/stack`, `/api/bacnet/overrides/export` |
-| **Safety** | Read-only by default; integrator required for activation | RBAC on `/api/fdd-rules/{id}/activate` |
-
-## Session start (copy-paste)
+## Session start
 
 ```bash
 INTEGRATOR_PW="$(grep '^OFDD_INTEGRATOR_PASSWORD=' ~/open-fdd/workspace/auth.env.local | cut -d= -f2- | tr -d '\r')"
@@ -29,26 +25,15 @@ TOKEN="$(curl -s -X POST http://127.0.0.1:8080/api/auth/login \
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/agent/tools | jq '.tools | length'
 ```
 
-## Deep guides
+## Further reading
 
-- [Haystack modeling and assignments](haystack-and-assignments.md)
-- [SQL HVAC FDD rule cookbook](../rule-cookbook/sql-hvac-fdd.md)
+- [Haystack and assignments](haystack-and-assignments.md)
+- [REST API reference](../AI_AGENT_API.md)
 - [Assignment model](../ASSIGNMENT_MODEL.md)
-- [Agent API reference](../AI_AGENT_API.md)
-- [Verification checklists](../verification/README.md)
+- [Verification](../verification/README.md)
 
 ## Never
 
-- delete `workspace/`
-- `docker compose down -v` or `docker volume prune`
-- print passwords, tokens, or full `auth.env.local`
-- BACnet/Modbus **writes** without explicit human approval
-- expose bridge/MCP to the public internet
-
-## GHCR publish (maintainers)
-
-```bash
-cargo fmt --all --check && cargo test --workspace
-docker build -t openfdd-edge-rust:local .
-# Push via .github/workflows/rust-ghcr.yml on master or tag v3.2.0
-```
+- Delete `workspace/` · `docker compose down -v` · print secrets
+- Field-bus writes or rule activation without human approval
+- Expose bridge or MCP on the public internet

--- a/docs/ai-agent/haystack-and-assignments.md
+++ b/docs/ai-agent/haystack-and-assignments.md
@@ -1,95 +1,61 @@
-# AI-assisted Haystack modeling and assignments
+# AI-assisted Haystack modeling
 
-Open-FDD binds **drivers → Haystack IDs → FDD inputs → DataFusion SQL rules**. AI agents help draft assignments; humans approve before activation.
+Binding chain: **driver ref → Haystack point ID → FDD input → DataFusion SQL**. Agents draft; integrators approve.
 
-## Data flow
+See [ASSIGNMENT_MODEL.md](../ASSIGNMENT_MODEL.md).
 
-```text
-BACnet / Modbus / JSON point
-    → Haystack point ID (point:sat, point:oa-t)
-    → FDD input (sat, oa_t)
-    → SQL rule (fault_raw column)
-    → confirmation timer → fault output
-```
-
-See [ASSIGNMENT_MODEL.md](../ASSIGNMENT_MODEL.md) for the binding contract.
-
-## Read the site model
+## Read model state
 
 ```bash
-curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/model/haystack | jq .
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/model/haystack | jq '.rows | length'
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/model/assignments | jq .
-curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/driver/tree | jq '.drivers[0].devices[0].points'
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/driver/tree | jq .
 ```
 
-## AI propose assignments (draft only)
+## SPARQL (preferred for analytics)
 
-Agents call **propose** — output stays `needs_review` until an integrator approves in the UI or via API.
+Model queries run against the RDF projection — use SPARQL instead of scanning the raw grid.
+
+```bash
+# Predefined catalog
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8080/api/model/sparql/predefined | jq '.queries[].id'
+
+# Sites
+curl -s -X POST http://127.0.0.1:8080/api/model/sparql \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"query":"PREFIX hs: <https://project-haystack.org/def/> PREFIX ofdd: <https://open-fdd.dev/model#> SELECT ?point ?dis ?equipRef ?fddInput WHERE { ?p a hs:Point . ?p ofdd:haystackId ?point . OPTIONAL { ?p hs:dis ?dis . } OPTIONAL { ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . } OPTIONAL { ?p hs:fddInput ?fddInput . } }"}'
+```
+
+Turtle export: `GET /api/model/ttl` · Coverage: `GET /api/dashboard/model-coverage`
+
+Details: [modeling/haystack_dashboard_model.md](../modeling/haystack_dashboard_model.md)
+
+## Propose assignments (draft)
 
 ```bash
 curl -s -X POST http://127.0.0.1:8080/api/fdd-wires/propose-assignments \
-  -H "Authorization: Bearer $TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d '{"site_id":"site:demo","equipment_type":"ahu"}' | jq '.review_status, .proposals[0]'
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"site_id":"site:demo","equipment_type":"ahu"}' | jq '.review_status'
 ```
 
-Expected:
+Expect `needs_review` — do not activate without human approval.
 
-- `review_status`: `needs_review`
-- Each proposal: `ai_suggested`, confidence in `provenance`
-- No external LLM required in CI — heuristic proposals seed the workflow
-
-## Save human-reviewed assignments
+## Save reviewed bindings
 
 ```bash
 curl -s -X POST http://127.0.0.1:8080/api/model/assignments/save \
-  -H "Authorization: Bearer $TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "points": [{
-      "haystack_id": "point:oa-t",
-      "driver_bindings": [{"driver":"bacnet","ref":"bacnet:5007:analog-input:1173"}],
-      "fdd_input": "oa_t"
-    }]
-  }' | jq .
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"points":[{"haystack_id":"point:oa-t","driver_bindings":[{"driver":"bacnet","ref":"bacnet:5007:analog-input:1173"}],"fdd_input":"oa_t"}]}'
 ```
 
-## FDD Wires graph (visual)
+## Agent checklist
 
-1. Open dashboard → **FDD Wires** tab
-2. Right-click canvas → **Propose assignments**
-3. Validate graph → approve → activate (integrator only)
+1. Authenticate (never log password or token).
+2. `GET /api/bacnet/driver/tree` — commissioned points.
+3. `POST /api/model/sparql` or predefined queries — model structure.
+4. `GET /api/model/assignments` — current bindings.
+5. `POST /api/fdd-wires/propose-assignments` — draft only.
+6. Present proposals to operator before save or rule activation.
 
-```bash
-curl -s -H "Authorization: Bearer $TOKEN" \
-  'http://127.0.0.1:8080/api/fdd-wires/graphs?site_id=site:demo' | jq .
-```
-
-## Agent prompt snippet
-
-```text
-You are modeling a site on Open-FDD Rust edge.
-
-1. Login as integrator (never print password).
-2. GET /api/bacnet/driver/tree — list commissioned points.
-3. GET /api/model/haystack and /api/model/assignments — current bindings.
-4. POST /api/fdd-wires/propose-assignments for equipment_type ahu — draft only.
-5. Present proposals to the human; do not activate without approval.
-6. Map each driver ref to a Haystack ID before saving SQL rules.
-7. Use /api/fdd-rules/builder-sql to preview SQL from FDD inputs.
-```
-
-## Local test bench example (profile-driven)
-
-Do **not** hardcode device instances or BACnet object IDs in production code. Map your lab bench in a gitignored local profile, for example:
-
-`workspace/smoke-profiles/local/local_validation_profile.local.toml`
-
-| BACnet ref (example) | Haystack ID | FDD input |
-| --- | --- | --- |
-| `bacnet:<device>:analog-input:<instance>` | `point:oa-t` | `oa_t` |
-| `bacnet:<device>:analog-input:<instance>` | `point:oa-h` | `oa_h` |
-| `bacnet:<device>:analog-input:<instance>` | `point:duct-t` | `duct_t` |
-| `bacnet:<device>:analog-input:<instance>` | `point:zone-t` | `zone_t` |
-
-See `workspace/smoke-profiles/local/local_haystack_5007_parity.local.toml.example` for a copy-paste template (placeholders only).
+Lab benches: use gitignored profiles under `workspace/smoke-profiles/local/` — do not hardcode device IDs in production code.

--- a/docs/dashboard/analytics.md
+++ b/docs/dashboard/analytics.md
@@ -1,30 +1,18 @@
-# Dashboard analytics (Haystack + DataFusion)
+# Dashboard analytics
 
-The Rust dashboard replaces SPARQL-only analytics with a Haystack model query layer, historian summaries, and DataFusion fault outputs.
+Home and portfolio views combine **SPARQL-backed model coverage**, historian health, and DataFusion fault output.
 
-## API routes (auth required)
+## Routes
 
-| Route | Purpose |
-|-------|---------|
-| `GET /api/dashboard/summary` | Portfolio, model, sources, faults, historian, security |
-| `GET /api/dashboard/analytics` | Trends, top faulted equipment, rule health |
-| `GET /api/dashboard/model-coverage` | Equipment/point counts, mapped vs unmapped |
-| `GET /api/dashboard/source-health` | Protocol enablement and coverage |
-| `GET /api/dashboard/historian-health` | Row counts, latest sample |
-| `GET /api/dashboard/security` | Auth + Caddy/TLS status |
-| `GET /api/health/stack` | Stack health for React dashboard stream |
-| `GET /api/faults/status` | Fault families for home dashboard |
+| Route | Auth | Purpose |
+|-------|------|---------|
+| `GET /api/dashboard/summary` | JWT | Portfolio rollup |
+| `GET /api/dashboard/analytics` | JWT | Trends and rule health |
+| `GET /api/dashboard/model-coverage` | JWT | Equipment/point counts, mapped vs unmapped |
+| `GET /api/dashboard/source-health` | JWT | Protocol coverage |
+| `GET /api/dashboard/historian-health` | JWT | Sample freshness |
+| `GET /api/dashboard/security` | JWT | Auth and TLS status |
+| `GET /api/building/status` | none | Public HVAC summary (feeds, rules, faults) |
+| `GET /api/faults/status` | JWT | Fault families |
 
-Public: `GET /api/building/snapshot` (unauthenticated snapshot for login page).
-
-## UI concepts
-
-- **Equipment model** — Haystack equips from `GET /api/model/haystack`
-- **Mapped / unmapped points** — from model query layer
-- **Source coverage** — BACnet, Modbus, JSON API, CSV by protocol flags
-- **Fault coverage** — active/confirmed/raw faults from DataFusion rules
-- **BACnet overrides** — priority 8 and other counts when BACnet enabled
-
-Legacy RDF import remains optional; Haystack JSON is the primary model path for dashboard analytics.
-
-See [modeling/haystack_dashboard_model.md](../modeling/haystack_dashboard_model.md).
+Model counts are computed via SPARQL over the Haystack RDF projection — not client-side grid filtering. See [modeling/haystack_dashboard_model.md](../modeling/haystack_dashboard_model.md).

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -1,56 +1,46 @@
-# Haystack integration (Open-FDD edge)
+# Haystack integration
 
-Open-FDD connects to a **Project Haystack REST server** — typically **Niagara nHaystack** on a local station — using the Rust driver built on [`rusty-haystack-client`](https://github.com/jscott3201/rusty-haystack) (pinned git rev in `edge/Cargo.toml`).
+Rust driver on [`rusty-haystack-client`](https://github.com/jscott3201/rusty-haystack) (git pin in `edge/Cargo.toml`). Typical target: **Niagara nHaystack** REST.
 
-## What you need
+## Configuration
 
 | Setting | Description |
 |---------|-------------|
-| `base_url` | Haystack API root, e.g. `http://<host>:<port>/haystack` |
-| Credentials | HTTP Basic (typical for nHaystack) or SCRAM (`auth_mode = "scram"`) |
-| TLS | Set `tls_verify = false` only for lab self-signed certs |
+| `base_url` | e.g. `http://<host>:<port>/haystack` |
+| Credentials | HTTP Basic (typical) or SCRAM (`auth_mode = "scram"`) |
+| TLS | `tls_verify = false` for lab self-signed certs only |
 
-**Do not commit passwords or private IPs.** Use environment variables or a gitignored local TOML file.
-
-## Enable locally
-
-1. Copy `workspace/haystack/local.nhaystack.example.toml` → `workspace/haystack/local.nhaystack.toml` (gitignored).
-2. Set `OPENFDD_HAYSTACK_USER` and `OPENFDD_HAYSTACK_PASS`, or use `username_env` / `password_env` keys in the TOML.
-3. Optionally override with `OPENFDD_HAYSTACK_BASE`.
-4. Restart the edge / Docker stack.
-
-For CI and unit tests without a live station, set `OPENFDD_HAYSTACK_FIXTURE=1`.
+Use `workspace/haystack/local.nhaystack.toml` (gitignored) or `OPENFDD_HAYSTACK_*` env vars. Set `OPENFDD_HAYSTACK_FIXTURE=1` for CI without a live station.
 
 ## Dashboard
 
-**Integrations → Haystack** (`/haystack`):
+**Integrations → Haystack** (`/haystack`): connect, browse, read, poll, import into the Open-FDD model grid.
 
-- Test connection, About, Ops, Browse/Nav, Read, Poll once, Import model
-- Tree view for sites/equipment/points with mapping status
-- Activity console (raw JSON under Advanced)
-
-## API routes
+## Bridge API
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/api/haystack/status` | Driver status (200 even when disabled) |
-| POST | `/api/haystack/test` | Connect + about |
-| GET | `/api/haystack/about` | Server metadata |
-| GET | `/api/haystack/ops` | Supported ops |
-| POST | `/api/haystack/nav` | Browse navigation tree |
+| GET | `/api/haystack/status` | Status (200 when disabled) |
+| POST | `/api/haystack/test` | Connection test |
 | POST | `/api/haystack/read` | Read by ids or filter |
-| POST | `/api/haystack/poll-once` | One-shot poll → normalized samples |
-| POST | `/api/haystack/import` | Import Haystack records into model |
-| GET | `/api/haystack/driver/tree` | UI driver tree |
-| GET | `/api/model/haystack` | Imported model grid |
-| POST | `/api/model/haystack/import` | Same as import |
-| GET | `/api/model/sources` | Normalized sources |
-| GET | `/api/model/equipment` | Normalized equipment |
-| GET | `/api/model/points` | Normalized points |
+| POST | `/api/haystack/nav` | Navigation tree |
+| POST | `/api/haystack/import` | Import records → model grid |
+| GET | `/api/haystack/driver/tree` | Normalized driver tree |
 
-When disabled, responses include `"enabled": false` and `"status": "disabled"` — never HTTP 404.
+## Model API (after import)
 
-## Manual smoke script
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/model/haystack` | Haystack grid JSON |
+| GET | `/api/model/ttl` | RDF Turtle export |
+| GET | `/api/model/sparql/predefined` | SPARQL query catalog |
+| POST | `/api/model/sparql` | Execute SELECT |
+| GET | `/api/model/tree` | Site equipment + points |
+| POST | `/api/model/haystack/import` | Same as haystack import |
+
+SPARQL details: [modeling/haystack_dashboard_model.md](../modeling/haystack_dashboard_model.md)
+
+## Smoke test
 
 ```bash
 export OPENFDD_HAYSTACK_BASE="http://127.0.0.1:8080/haystack"
@@ -59,12 +49,7 @@ export OPENFDD_HAYSTACK_PASS="..."
 ./scripts/openfdd_haystack_smoke.sh
 ```
 
-## Future BACnet parity
+## References
 
-See [haystack_bacnet_parity.md](../validation/haystack_bacnet_parity.md) and the example profile `workspace/smoke-profiles/local/local_haystack_5007_parity.local.toml.example`.
-
-## Niagara setup (high level)
-
-Enable the **nHaystack** module on your Niagara station and expose the Haystack REST servlet. For a walkthrough example (external), see the [nHaystack Niagara Pi tutorial](https://github.com/bbartling/py-bacnet-stacks-playground/tree/develop/vibe_code_apps_17/nhaystack-niagara-pi-tutorial).
-
-Live Niagara tests are **local/manual only** for now — CI uses mocked/fixture responses.
+- [development/local_haystack_niagara.md](../development/local_haystack_niagara.md)
+- [validation/haystack_bacnet_parity.md](../validation/haystack_bacnet_parity.md)

--- a/docs/modeling/haystack_dashboard_model.md
+++ b/docs/modeling/haystack_dashboard_model.md
@@ -1,26 +1,54 @@
-# Haystack dashboard model layer
+# Haystack model and SPARQL
 
-The generic model query layer (`edge/src/model/query.rs`) powers dashboard analytics without hardcoded sites or SPARQL.
+Open-FDD stores the site model as a **Project Haystack grid** (`workspace/data/model/haystack_grid.json`). The edge projects that grid to **RDF (Turtle)** and serves **read-only SPARQL SELECT** queries via Oxigraph.
 
-## Capabilities
+## Data flow
 
-- List sites, buildings, equips, points
-- Group points by equip; group equips by type
-- Count mapped vs unmapped points
-- Source coverage by protocol (BACnet, Modbus, JSON API tags)
-- Future RDF/SPARQL adapter hook (optional)
+```text
+Haystack grid JSON
+  → RDF projection (hs: + ofdd: prefixes)
+  → in-memory Oxigraph store (reloaded on grid save)
+  → SPARQL SELECT → JSON bindings
+```
 
-## Data sources
+Assignments (`/api/model/assignments`) layer driver refs and FDD inputs on top of Haystack point IDs. See [ASSIGNMENT_MODEL.md](../ASSIGNMENT_MODEL.md).
 
-1. Haystack fixture/model JSON (`/api/model/haystack`)
-2. Open-FDD assignment layer (`/api/model/assignments`)
-3. Historian pivot rows for live fault evaluation
-4. Imported point mappings and source registry metadata
+## HTTP API
+
+| Route | Purpose |
+|-------|---------|
+| `GET /api/model/haystack` | Raw grid (edit/import) |
+| `GET /api/model/ttl` | Turtle export |
+| `POST /api/model/sync-ttl` | Write `data_model.ttl` to disk |
+| `GET /api/model/sparql/predefined` | Named queries for dashboard |
+| `POST /api/model/sparql` | Custom SELECT (updates rejected) |
+| `GET /api/model/tree` | Site equipment + points |
+| `GET /api/model/graph` | Feeds graph for explorer |
+| `GET /api/dashboard/model-coverage` | Mapped vs unmapped counts |
+
+Dashboard list/coverage/graph endpoints use the same SPARQL layer internally (`query_engine: "sparql"` in responses).
+
+## SPARQL vocabulary
+
+```sparql
+PREFIX hs: <https://project-haystack.org/def/>
+PREFIX ofdd: <https://open-fdd.dev/model#>
+```
+
+- `?s a hs:Site` / `hs:Equip` / `hs:Point` — entity types
+- `?s ofdd:haystackId ?id` — Haystack ref (`site:demo`, `point:oa-t`)
+- `?s hs:dis ?label` — display name
+- `?s hs:equipRef ?eq` — point → equipment (object IRI; join `ofdd:haystackId` for string id)
+- `?s ofdd:equipType ?type` — inferred HVAC type (`ahu`, `vav`, …)
 
 ## Example
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/dashboard/model-coverage
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8080/api/model/sparql/predefined | jq '.queries[0].id'
+
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8080/api/dashboard/model-coverage | jq .
 ```
 
-Returns `equipment_count`, `point_count`, `mapped_points`, `unmapped_points`, and `model_score`.
+UI: **Data model** tab → SPARQL panel runs predefined and custom queries against this graph.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,40 +1,101 @@
 openapi: 3.1.0
 info:
   title: Open-FDD Rust Edge API
-  version: 0.1.0
+  version: 3.2.3
+  description: |
+    Partial spec — full route list from `GET /api/agent/tools` on a running site.
+    See docs/AI_AGENT_API.md for narrative reference.
 security:
   - bearerAuth: []
 paths:
   /api/health:
     get:
       security: []
+      summary: Liveness
       responses:
-        "200": { description: OK }
+        "200":
+          description: OK
   /api/auth/login:
     post:
       security: []
+      summary: Obtain JWT
       responses:
-        "200": { description: JWT token }
+        "200":
+          description: Token payload
   /api/health/stack:
     get:
+      summary: Stack health
       responses:
-        "200": { description: Stack health }
+        "200":
+          description: Bridge and sidecar status
   /api/agent/tools:
     get:
+      summary: Agent tool manifest
       responses:
-        "200": { description: Agent tool list }
+        "200":
+          description: Tool list for external agents
+  /api/model/haystack:
+    get:
+      summary: Haystack model grid
+      responses:
+        "200":
+          description: Grid JSON with rows
+  /api/model/ttl:
+    get:
+      summary: RDF Turtle export
+      responses:
+        "200":
+          description: text/turtle
+          content:
+            text/turtle:
+              schema:
+                type: string
+  /api/model/sparql/predefined:
+    get:
+      summary: SPARQL query catalog
+      responses:
+        "200":
+          description: Predefined SELECT queries
+  /api/model/sparql:
+    post:
+      summary: Execute SPARQL SELECT
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [query]
+              properties:
+                query:
+                  type: string
+      responses:
+        "200":
+          description: Bindings and row count
+  /api/model/assignments:
+    get:
+      summary: Driver and FDD bindings
+      responses:
+        "200":
+          description: Assignment layer
+  /api/model/sites:
+    get:
+      summary: Sites and active site
+      responses:
+        "200":
+          description: Site list
   /api/bacnet/driver/tree:
     get:
+      summary: BACnet driver tree
       responses:
-        "200": { description: BACnet driver tree }
-  /api/rules/save:
-    post:
+        "200":
+          description: Devices and points
+  /api/dashboard/model-coverage:
+    get:
+      summary: Model coverage metrics
       responses:
-        "200": { description: Save rule }
-  /api/rules/batch:
-    post:
-      responses:
-        "200": { description: Run batch FDD rules }
+        "200":
+          description: Equipment and point counts
 components:
   securitySchemes:
     bearerAuth:

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -46,3 +46,4 @@ once_cell = "1.21.4"
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls"] }
 rusty-modbus-client = { git = "https://github.com/jscott3201/rusty-modbus", version = "0.1.0" }
 rusty-modbus-types = { git = "https://github.com/jscott3201/rusty-modbus", version = "0.1.0" }
+oxigraph = "0.5"

--- a/edge/src/csv_ingest/dataset.rs
+++ b/edge/src/csv_ingest/dataset.rs
@@ -189,11 +189,84 @@ pub fn save_dataset(
     // Register Haystack model columns from value keys
     register_haystack_from_dataset(&id, &value_keys);
 
+    let historian_sync = sync_output_rows_to_historian(&id, rows);
+
     Ok(json!({
         "ok": true,
         "dataset": metadata,
         "validation_report": validation_report,
+        "historian_sync": historian_sync,
+        "plot_url": historian_sync.get("plot_url").cloned().unwrap_or(json!(null)),
+        "model_url": historian_sync.get("model_url").cloned().unwrap_or(json!(null)),
     }))
+}
+
+/// Push merged CSV rows into historian pivot + refresh Haystack so Plot tab works.
+pub fn sync_output_rows_to_historian(dataset_id: &str, rows: &[OutputRow]) -> Value {
+    use crate::historian::store;
+    use crate::model::csv_import::{apply_pivot_aliases, column_slug, ids_from_filename};
+
+    let filename = format!("{dataset_id}.csv");
+    let (site_id, equip_id, source_id, _) = ids_from_filename(&filename);
+    let mut new_rows: Vec<Value> = Vec::new();
+    for r in rows {
+        let ts = r
+            .ts_utc
+            .map(|u| u.to_rfc3339())
+            .unwrap_or_else(|| r.ts_local.clone());
+        if ts.trim().is_empty() {
+            continue;
+        }
+        let mut row = json!({
+            "timestamp": ts,
+            "equipment_id": equip_id,
+            "site_id": site_id,
+            "source": source_id,
+            "source_driver": "csv",
+            "is_simulated": false
+        });
+        for (k, v) in &r.values {
+            if v.trim().is_empty() {
+                continue;
+            }
+            if let Ok(n) = v.parse::<f64>() {
+                let slug = column_slug(k);
+                row[slug.clone()] = json!(n);
+                apply_pivot_aliases(&mut row, &slug, n);
+            }
+        }
+        if row.as_object().map(|o| o.len()).unwrap_or(0) > 5 {
+            new_rows.push(row);
+        }
+    }
+    if new_rows.is_empty() {
+        return json!({
+            "ok": false,
+            "error": "no numeric rows synced to historian",
+            "site_id": site_id,
+            "equipment_id": equip_id
+        });
+    }
+    let mut all = store::load_pivot_rows().unwrap_or_default();
+    all.retain(|r| {
+        r.get("source")
+            .and_then(|v| v.as_str())
+            .is_none_or(|s| s != source_id.as_str())
+    });
+    all.extend(new_rows.clone());
+    match store::rewrite_all(&all) {
+        Ok(()) => json!({
+            "ok": true,
+            "rows_synced": new_rows.len(),
+            "historian_total": all.len(),
+            "site_id": site_id,
+            "equipment_id": equip_id,
+            "source_id": source_id,
+            "plot_url": format!("/plot?site={site_id}&device={equip_id}&hours=8760"),
+            "model_url": format!("/model?site={site_id}")
+        }),
+        Err(e) => json!({"ok": false, "error": e, "site_id": site_id}),
+    }
 }
 
 fn register_haystack_from_dataset(dataset_id: &str, columns: &[String]) {

--- a/edge/src/csv_ingest/mod.rs
+++ b/edge/src/csv_ingest/mod.rs
@@ -312,23 +312,23 @@ pub fn fusion_preview_handler(session_id: &str, limit: usize) -> Value {
         });
     }
     let mut plan_val = session.get("plan").cloned().unwrap_or(json!({}));
-    let mut plan: plan::ImportPlan =
-        match serde_json::from_value::<plan::ImportPlan>(plan_val.clone()) {
-            Ok(p) if !p.files.is_empty() => p,
-            _ => {
-                let inferred = infer_ut3_plan_from_session(&session);
-                if inferred.files.is_empty() {
-                    return json!({"ok": false, "error": "session has no staged files"});
-                }
-                plan_val = serde_json::to_value(&inferred).unwrap_or(json!({}));
-                session["plan"] = plan_val.clone();
-                if status == "previewed" {
-                    session["status"] = json!("planned");
-                }
-                let _ = save_session(session_id, &session);
-                inferred
+    let plan: plan::ImportPlan = match serde_json::from_value::<plan::ImportPlan>(plan_val.clone())
+    {
+        Ok(p) if !p.files.is_empty() => p,
+        _ => {
+            let inferred = infer_ut3_plan_from_session(&session);
+            if inferred.files.is_empty() {
+                return json!({"ok": false, "error": "session has no staged files"});
             }
-        };
+            plan_val = serde_json::to_value(&inferred).unwrap_or(json!({}));
+            session["plan"] = plan_val.clone();
+            if status == "previewed" {
+                session["status"] = json!("planned");
+            }
+            let _ = save_session(session_id, &session);
+            inferred
+        }
+    };
     if plan.files.is_empty() {
         return json!({"ok": false, "error": "session plan has no file mappings — run Preview plan"});
     }

--- a/edge/src/csv_ingest/mod.rs
+++ b/edge/src/csv_ingest/mod.rs
@@ -11,7 +11,10 @@ pub use dataset::{
     delete_dataset, list_datasets, preview_dataset, query_dataset_sql, save_dataset,
 };
 pub use parse::{sanitize_filename, ParseProfile};
-pub use plan::{auto_detect_mapping, plan_from_json, ImportPlan, OperationMode, OutputRow};
+pub use plan::{
+    auto_detect_mapping, infer_ut3_plan_from_session, is_weather_filename, plan_from_json,
+    ImportPlan, OperationMode, OutputRow,
+};
 pub use session::{create_session, load_session, save_session, stage_file};
 
 use plan::{append_rows, join_rows, parse_file_to_rows, preview_rows, JoinAlignment};
@@ -142,6 +145,7 @@ pub fn plan_handler(body: &Value) -> Value {
         "plan": plan,
         "preview": preview,
         "validation_report": validation_report,
+        "fusion_url": format!("/csv?session={session_id}"),
     })
 }
 
@@ -168,22 +172,67 @@ fn execute_plan_preview(
             if plan.files.len() < 2 {
                 return Err("join requires at least two file mappings".into());
             }
-            let (profile_l, text_l) = read_staged_file(session_id, &plan.files[0].filename)?;
-            let (profile_r, text_r) = read_staged_file(session_id, &plan.files[1].filename)?;
-            let left = parse_file_to_rows(
-                &text_l,
-                &plan.files[0],
-                profile_l.delimiter,
-                &plan.ambiguous_policy,
-            )?;
-            let right = parse_file_to_rows(
-                &text_r,
-                &plan.files[1],
-                profile_r.delimiter,
-                &plan.ambiguous_policy,
-            )?;
-            let alignment = plan.join_alignment.unwrap_or(JoinAlignment::FloorHour);
-            join_rows(left, right, alignment, plan.fill_policy)
+            let weather_idx = plan
+                .files
+                .iter()
+                .position(|f| is_weather_filename(&f.filename));
+            if let Some(widx) = weather_idx {
+                let school_maps: Vec<_> = plan
+                    .files
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != widx)
+                    .map(|(_, f)| f.clone())
+                    .collect();
+                let weather_map = plan.files[widx].clone();
+                let left = if school_maps.len() > 1 {
+                    let mut batches = Vec::new();
+                    for fm in &school_maps {
+                        let (profile, text) = read_staged_file(session_id, &fm.filename)?;
+                        let mut mapping = fm.clone();
+                        if mapping.timestamp_column.is_empty() {
+                            mapping = auto_detect_mapping(&fm.filename, &profile.headers);
+                        }
+                        batches.push(parse_file_to_rows(
+                            &text,
+                            &mapping,
+                            profile.delimiter,
+                            &plan.ambiguous_policy,
+                        )?);
+                    }
+                    append_rows(batches)
+                } else {
+                    let fm = &school_maps[0];
+                    let (profile, text) = read_staged_file(session_id, &fm.filename)?;
+                    parse_file_to_rows(&text, fm, profile.delimiter, &plan.ambiguous_policy)?
+                };
+                let (profile_r, text_r) = read_staged_file(session_id, &weather_map.filename)?;
+                let right = parse_file_to_rows(
+                    &text_r,
+                    &weather_map,
+                    profile_r.delimiter,
+                    &plan.ambiguous_policy,
+                )?;
+                let alignment = plan.join_alignment.unwrap_or(JoinAlignment::FloorHour);
+                join_rows(left, right, alignment, plan.fill_policy)
+            } else {
+                let (profile_l, text_l) = read_staged_file(session_id, &plan.files[0].filename)?;
+                let (profile_r, text_r) = read_staged_file(session_id, &plan.files[1].filename)?;
+                let left = parse_file_to_rows(
+                    &text_l,
+                    &plan.files[0],
+                    profile_l.delimiter,
+                    &plan.ambiguous_policy,
+                )?;
+                let right = parse_file_to_rows(
+                    &text_r,
+                    &plan.files[1],
+                    profile_r.delimiter,
+                    &plan.ambiguous_policy,
+                )?;
+                let alignment = plan.join_alignment.unwrap_or(JoinAlignment::FloorHour);
+                join_rows(left, right, alignment, plan.fill_policy)
+            }
         }
     }
 }
@@ -237,6 +286,91 @@ pub fn get_session_handler(session_id: &str) -> Value {
         Some(s) => json!({"ok": true, "session": s}),
         None => json!({"ok": false, "error": "session not found"}),
     }
+}
+
+const FUSION_PREVIEW_DEFAULT_LIMIT: usize = 2_000;
+const FUSION_PREVIEW_MAX_LIMIT: usize = 10_000;
+
+pub fn fusion_preview_handler(session_id: &str, limit: usize) -> Value {
+    let Some(mut session) = load_session(session_id) else {
+        return json!({
+            "ok": false,
+            "error": "session not found",
+            "hint": "Run UT3 Upload then Preview plan first, or restart edge after rebuild so session routes are live."
+        });
+    };
+    let status = session
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if status != "planned" && status != "previewed" && status != "executed" {
+        return json!({
+            "ok": false,
+            "error": "session has no staged files — upload CSVs via POST /api/csv/import/preview first",
+            "status": status
+        });
+    }
+    let mut plan_val = session.get("plan").cloned().unwrap_or(json!({}));
+    let mut plan: plan::ImportPlan =
+        match serde_json::from_value::<plan::ImportPlan>(plan_val.clone()) {
+            Ok(p) if !p.files.is_empty() => p,
+            _ => {
+                let inferred = infer_ut3_plan_from_session(&session);
+                if inferred.files.is_empty() {
+                    return json!({"ok": false, "error": "session has no staged files"});
+                }
+                plan_val = serde_json::to_value(&inferred).unwrap_or(json!({}));
+                session["plan"] = plan_val.clone();
+                if status == "previewed" {
+                    session["status"] = json!("planned");
+                }
+                let _ = save_session(session_id, &session);
+                inferred
+            }
+        };
+    if plan.files.is_empty() {
+        return json!({"ok": false, "error": "session plan has no file mappings — run Preview plan"});
+    }
+    let rows = match execute_plan_preview(&plan, session_id) {
+        Ok(r) => r,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let total = rows.len();
+    let cap = limit.clamp(1, FUSION_PREVIEW_MAX_LIMIT);
+    let (columns, grid) = plan::output_rows_to_fusion_grid(&rows, cap);
+    let validation = session
+        .get("validation_report")
+        .cloned()
+        .unwrap_or(json!({}));
+    json!({
+        "ok": true,
+        "session_id": session_id,
+        "dataset_name": plan.output_dataset_name,
+        "status": status,
+        "row_count": total,
+        "preview_row_count": grid.len(),
+        "truncated": total > grid.len(),
+        "columns": columns,
+        "rows": grid,
+        "validation_report": validation,
+        "fusion_url_hint": format!("/csv?session={session_id}"),
+    })
+}
+
+pub fn fusion_preview_limit_from_query(limit: Option<&str>) -> usize {
+    limit
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(FUSION_PREVIEW_DEFAULT_LIMIT)
+        .clamp(1, FUSION_PREVIEW_MAX_LIMIT)
+}
+
+pub fn list_sessions_handler(limit: usize) -> Value {
+    session::list_sessions_handler(limit)
+}
+
+pub fn latest_planned_session_handler() -> Value {
+    session::latest_planned_session_handler()
 }
 
 pub fn delete_session_file_handler(body: &Value) -> Value {

--- a/edge/src/csv_ingest/plan.rs
+++ b/edge/src/csv_ingest/plan.rs
@@ -515,6 +515,36 @@ pub fn preview_rows(rows: &[OutputRow], limit: usize) -> PlanPreview {
     }
 }
 
+/// Grid for dashboard fusion preview (agent session → CSV tab before Feather save).
+pub fn output_rows_to_fusion_grid(
+    rows: &[OutputRow],
+    limit: usize,
+) -> (Vec<String>, Vec<Vec<String>>) {
+    let preview = preview_rows(rows, rows.len().min(limit.max(1)));
+    let columns = preview.column_names;
+    let cap = limit.min(rows.len());
+    let mut grid = Vec::with_capacity(cap);
+    for r in rows.iter().take(cap) {
+        let mut row = Vec::with_capacity(columns.len());
+        for c in &columns {
+            let v = match c.as_str() {
+                "ts_utc" => r.ts_utc.map(|u| u.to_rfc3339()).unwrap_or_default(),
+                "ts_local" => r.ts_local.clone(),
+                "timezone" => r.timezone.clone(),
+                "source_timestamp_raw" => r.source_timestamp_raw.clone(),
+                "source_timestamp_parse_status" => r.source_timestamp_parse_status.clone(),
+                "source_file" => r.source_file.clone(),
+                "source_row_number" => r.source_row_number.to_string(),
+                "fill_created" => r.fill_created.to_string(),
+                other => r.values.get(other).cloned().unwrap_or_default(),
+            };
+            row.push(v);
+        }
+        grid.push(row);
+    }
+    (columns, grid)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -571,6 +601,11 @@ pub fn plan_from_json(body: &Value) -> Result<ImportPlan, String> {
     serde_json::from_value(body.clone()).map_err(|e| e.to_string())
 }
 
+pub fn is_weather_filename(name: &str) -> bool {
+    let n = name.to_lowercase();
+    n.contains("meteo") || n.contains("weather") || n.contains("open_meteo")
+}
+
 pub fn auto_detect_mapping(filename: &str, headers: &[String]) -> FileMapping {
     let ts_candidates = headers
         .iter()
@@ -579,7 +614,11 @@ pub fn auto_detect_mapping(filename: &str, headers: &[String]) -> FileMapping {
         .unwrap_or_else(|| headers.first().cloned().unwrap_or_else(|| "Date".into()));
     let value_columns: Vec<String> = headers
         .iter()
-        .filter(|h| *h != &ts_candidates)
+        .filter(|h| {
+            **h != ts_candidates
+                && h.trim().to_lowercase() != "timezone"
+                && h.trim().to_lowercase() != "tz"
+        })
         .take(20)
         .cloned()
         .collect();
@@ -588,5 +627,76 @@ pub fn auto_detect_mapping(filename: &str, headers: &[String]) -> FileMapping {
         timestamp_column: ts_candidates,
         timezone: "America/Chicago".into(),
         value_columns,
+    }
+}
+
+/// Build a UT3 import plan from staged session files (school kW + optional weather).
+pub fn infer_ut3_plan_from_session(session: &Value) -> ImportPlan {
+    let files_arr = session
+        .get("files")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut file_mappings = Vec::new();
+    for f in &files_arr {
+        let filename = f.get("filename").and_then(|v| v.as_str()).unwrap_or("");
+        if filename.is_empty() {
+            continue;
+        }
+        let headers: Vec<String> = f
+            .get("profile")
+            .and_then(|p| p.get("headers"))
+            .and_then(|h| h.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut mapping = auto_detect_mapping(filename, &headers);
+        if headers.iter().any(|h| h == "Date") {
+            mapping.timestamp_column = "Date".into();
+        }
+        if is_weather_filename(filename) {
+            if headers.iter().any(|h| h == "time_local") {
+                mapping.timestamp_column = "time_local".into();
+            }
+            mapping.value_columns = headers
+                .iter()
+                .filter(|h| {
+                    **h != mapping.timestamp_column
+                        && h.trim().to_lowercase() != "timezone"
+                        && h.trim().to_lowercase() != "tz"
+                })
+                .take(12)
+                .cloned()
+                .collect();
+        } else if mapping.value_columns.is_empty() {
+            mapping.value_columns = vec!["kW".into()];
+        }
+        file_mappings.push(mapping);
+    }
+    let has_weather = file_mappings
+        .iter()
+        .any(|m| is_weather_filename(&m.filename));
+    let school_count = file_mappings
+        .iter()
+        .filter(|m| !is_weather_filename(&m.filename))
+        .count();
+    let mode = if has_weather && school_count >= 1 {
+        OperationMode::Join
+    } else if school_count > 1 {
+        OperationMode::Append
+    } else {
+        OperationMode::Single
+    };
+    ImportPlan {
+        mode,
+        files: file_mappings,
+        join_alignment: Some(JoinAlignment::FloorHour),
+        fill_policy: FillPolicy::Forward,
+        ambiguous_policy: "first".into(),
+        output_dataset_name: "school_kw_merged".into(),
+        ..Default::default()
     }
 }

--- a/edge/src/csv_ingest/plan.rs
+++ b/edge/src/csv_ingest/plan.rs
@@ -267,9 +267,10 @@ fn join_asof(
     Ok(out)
 }
 
+type HourlyResampleBucket = (OutputRow, Vec<BTreeMap<String, f64>>);
+
 fn resample_kw_hourly(rows: Vec<OutputRow>) -> Vec<OutputRow> {
-    let mut buckets: BTreeMap<DateTime<Utc>, (OutputRow, Vec<BTreeMap<String, f64>>)> =
-        BTreeMap::new();
+    let mut buckets: BTreeMap<DateTime<Utc>, HourlyResampleBucket> = BTreeMap::new();
     for row in rows {
         let Some(ts) = row.ts_utc else { continue };
         let hour = floor_hour(ts);

--- a/edge/src/csv_ingest/session.rs
+++ b/edge/src/csv_ingest/session.rs
@@ -131,3 +131,63 @@ pub fn delete_staged_file(session_id: &str, filename: &str) -> Result<(), String
 pub fn session_path_ok(path: &Path) -> bool {
     path.starts_with(sessions_root())
 }
+
+/// Recent import sessions (newest first) for agent/UI pickers.
+pub fn list_sessions_handler(limit: usize) -> Value {
+    let root = sessions_root();
+    let mut sessions = Vec::new();
+    if let Ok(entries) = fs::read_dir(&root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let id = entry.file_name().to_string_lossy().to_string();
+            let Some(session) = load_session(&id) else {
+                continue;
+            };
+            sessions.push(json!({
+                "session_id": id,
+                "status": session.get("status").cloned().unwrap_or(json!(null)),
+                "created_at": session.get("created_at").cloned().unwrap_or(json!(null)),
+                "file_count": session.get("files").and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0),
+                "dataset_name": session.get("plan")
+                    .and_then(|p| p.get("output_dataset_name"))
+                    .cloned()
+                    .unwrap_or(json!(null)),
+                "row_count": session.get("preview_summary")
+                    .and_then(|p| p.get("row_count"))
+                    .cloned()
+                    .unwrap_or(json!(null)),
+                "fusion_url": format!("/csv?session={id}"),
+            }));
+        }
+    }
+    sessions.sort_by(|a, b| {
+        let ta = a.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
+        let tb = b.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
+        tb.cmp(ta)
+    });
+    sessions.truncate(limit.clamp(1, 100));
+    json!({"ok": true, "sessions": sessions})
+}
+
+pub fn latest_planned_session_handler() -> Value {
+    let listed = list_sessions_handler(20);
+    let empty = json!({"ok": false, "error": "no import session found — upload CSVs and run Preview plan in UT3 panel"});
+    let Some(arr) = listed.get("sessions").and_then(|v| v.as_array()) else {
+        return empty;
+    };
+    for s in arr {
+        let status = s.get("status").and_then(|v| v.as_str()).unwrap_or("");
+        if matches!(status, "planned" | "previewed" | "executed") {
+            return json!({
+                "ok": true,
+                "session": s.clone(),
+                "session_id": s.get("session_id").cloned().unwrap_or(json!(null)),
+                "fusion_url": s.get("fusion_url").cloned().unwrap_or(json!(null)),
+            });
+        }
+    }
+    empty
+}

--- a/edge/src/csv_ingest/timestamp.rs
+++ b/edge/src/csv_ingest/timestamp.rs
@@ -36,6 +36,10 @@ const CANDIDATE_NAMES: &[&str] = &[
 
 pub fn is_timestamp_candidate(name: &str) -> bool {
     let lower = name.trim().to_lowercase();
+    // IANA label column in Open-Meteo exports — not a timestamp series.
+    if lower == "timezone" || lower == "tz" {
+        return false;
+    }
     CANDIDATE_NAMES
         .iter()
         .any(|c| lower == *c || lower.contains("date") || lower.contains("time"))

--- a/edge/src/dashboard/mod.rs
+++ b/edge/src/dashboard/mod.rs
@@ -16,7 +16,17 @@ fn protocol_enabled(env_key: &str) -> bool {
 }
 
 fn service_status(id: &str, enabled: bool, label: &str, detail: &str) -> Value {
-    if enabled {
+    service_status_link(id, enabled, label, detail, None)
+}
+
+fn service_status_link(
+    id: &str,
+    enabled: bool,
+    label: &str,
+    detail: &str,
+    href: Option<&str>,
+) -> Value {
+    let mut obj = if enabled {
         json!({
             "id": id,
             "label": label,
@@ -32,7 +42,13 @@ fn service_status(id: &str, enabled: bool, label: &str, detail: &str) -> Value {
             "configured": false,
             "detail": detail
         })
+    };
+    if let Some(h) = href {
+        if let Some(map) = obj.as_object_mut() {
+            map.insert("href".into(), json!(h));
+        }
     }
+    obj
 }
 
 pub fn stack_health() -> Value {
@@ -100,6 +116,20 @@ pub fn stack_health() -> Value {
             true,
             "Arrow + DataFusion",
             "Rule SQL engine ready",
+        ),
+        service_status_link(
+            "oxigraph-sparql",
+            true,
+            "Oxigraph SPARQL",
+            "Haystack RDF model queries",
+            Some("/model"),
+        ),
+        service_status_link(
+            "mcp",
+            true,
+            "MCP agent",
+            "Cursor/Codex tools via openfdd-mcp sidecar",
+            Some("/agent"),
         ),
     ];
 

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -553,6 +553,15 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             model::commissioning::sync_ttl_json(),
         ),
+        ("GET", p) if p.starts_with("/api/model/ttl") => {
+            let ttl = model::rdf::haystack_to_turtle();
+            response(
+                &mut stream,
+                "200 OK",
+                "text/turtle; charset=utf-8",
+                ttl.as_bytes(),
+            )
+        }
         ("GET", "/api/haystack/about") => raw_json(&mut stream, &drivers::haystack::about_json()),
         ("GET", "/api/haystack/config") => {
             raw_json(&mut stream, &drivers::haystack::config_get_json())
@@ -997,6 +1006,12 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &principal,
             &["integrator", "agent"],
             reports::from_validation_run(&parse_json_body_or_empty(&body)),
+        ),
+        ("POST", "/api/reports/from-fdd-sql-run") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            reports::from_fdd_sql_run(&parse_json_body_or_empty(&body)),
         ),
         ("GET", "/api/reports/rcx/list") => require_role(
             &mut stream,
@@ -1444,7 +1459,7 @@ fn handle_csv_ingest_dynamic(
     path: &str,
 ) -> Option<std::io::Result<()>> {
     let parts = path_parts(path);
-    if parts.len() >= 5
+    if parts.len() >= 4
         && parts[0] == "api"
         && parts[1] == "csv"
         && parts[2] == "import"
@@ -1453,11 +1468,41 @@ fn handle_csv_ingest_dynamic(
         if method != "GET" {
             return None;
         }
+        if parts.len() == 4 {
+            let limit = query_param(path, "limit")
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(20)
+                .clamp(1, 100);
+            return Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent", "operator"],
+                csv_ingest::list_sessions_handler(limit),
+            ));
+        }
+        if parts.len() == 6 && parts[4] == "latest" && parts[5] == "planned" {
+            return Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent", "operator"],
+                csv_ingest::latest_planned_session_handler(),
+            ));
+        }
         let session_id = parts[4];
         if session_id.contains("..") {
             return Some(json_response(
                 stream,
                 json!({"ok": false, "error": "invalid session id"}),
+            ));
+        }
+        if parts.get(5) == Some(&"fusion-preview") {
+            let limit =
+                csv_ingest::fusion_preview_limit_from_query(query_param(path, "limit").as_deref());
+            return Some(require_role(
+                stream,
+                principal,
+                &["integrator", "agent", "operator"],
+                csv_ingest::fusion_preview_handler(session_id, limit),
             ));
         }
         return Some(require_role(

--- a/edge/src/model/commissioning.rs
+++ b/edge/src/model/commissioning.rs
@@ -338,19 +338,12 @@ pub fn sync_ttl_json() -> Value {
         let _ = fs::create_dir_all(parent);
     }
     let rows = query::haystack_rows();
-    let mut lines = vec![
-        "@prefix hs: <https://project-haystack.org/def/> .".to_string(),
-        "@prefix ofdd: <https://open-fdd.dev/model#> .".to_string(),
-        "".to_string(),
-    ];
-    for row in &rows {
-        if let Some(id) = row.get("id").and_then(|v| v.as_str()) {
-            let dis = row.get("dis").and_then(|v| v.as_str()).unwrap_or(id);
-            lines.push(format!("ofdd:{id} hs:dis \"{dis}\" ."));
+    let ttl = crate::model::rdf::haystack_rows_to_turtle(&rows);
+    match fs::write(&path, &ttl) {
+        Ok(()) => {
+            crate::model::rdf::invalidate_store();
+            json!({"ok": true, "path": path.display().to_string(), "rows": rows.len()})
         }
-    }
-    match fs::write(&path, lines.join("\n")) {
-        Ok(()) => json!({"ok": true, "path": path.display().to_string(), "rows": rows.len()}),
         Err(e) => json!({"ok": false, "error": e.to_string()}),
     }
 }

--- a/edge/src/model/mod.rs
+++ b/edge/src/model/mod.rs
@@ -9,5 +9,6 @@ pub mod csv_import;
 pub mod csv_workbench;
 pub mod persist;
 pub mod query;
+pub mod rdf;
 pub mod scope;
 pub mod sparql;

--- a/edge/src/model/persist.rs
+++ b/edge/src/model/persist.rs
@@ -24,6 +24,7 @@ pub fn save_haystack_grid(grid: &Value) -> std::io::Result<PathBuf> {
         &path,
         serde_json::to_string_pretty(grid).unwrap_or_else(|_| "{}".into()),
     )?;
+    crate::model::rdf::invalidate_store();
     Ok(path)
 }
 

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -1,7 +1,29 @@
-//! Haystack-oriented model query layer (replaces SPARQL-only dashboard analytics).
+//! Haystack model query layer — SPARQL over the RDF projection of the Haystack grid.
 
+use crate::model::rdf;
+use crate::model::sparql;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
+
+const SPARQL_PREFIXES: &str = r#"
+PREFIX hs: <https://project-haystack.org/def/>
+PREFIX ofdd: <https://open-fdd.dev/model#>
+"#;
+
+fn sparql_rows(query: &str) -> Vec<HashMap<String, String>> {
+    rdf::sparql_select(query).unwrap_or_default()
+}
+
+fn sparql_predefined(id: &str) -> Vec<HashMap<String, String>> {
+    sparql::run_predefined(id).unwrap_or_default()
+}
+
+fn sparql_opt(row: &HashMap<String, String>, key: &str) -> Value {
+    match row.get(key) {
+        Some(v) if !v.is_empty() => json!(v),
+        _ => Value::Null,
+    }
+}
 
 pub fn haystack_rows() -> Vec<Value> {
     crate::model::persist::haystack_model_value()
@@ -12,29 +34,31 @@ pub fn haystack_rows() -> Vec<Value> {
 }
 
 pub fn list_sites() -> Value {
-    let rows = haystack_rows();
-    let mut sites = Vec::new();
-    for row in &rows {
-        if row.get("site").and_then(|v| v.as_str()) == Some("M") {
+    let rows = sparql_predefined("eng_sites");
+    let sites: Vec<Value> = rows
+        .into_iter()
+        .map(|row| {
             let site_id = row
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("site:unknown");
-            let name = row.get("dis").and_then(|v| v.as_str()).unwrap_or(site_id);
-            sites.push(json!({"site_id": site_id, "name": name}));
-        }
-    }
+                .get("site")
+                .cloned()
+                .unwrap_or_else(|| "site:unknown".into());
+            let name = row.get("dis").cloned().unwrap_or_else(|| site_id.clone());
+            json!({"site_id": site_id, "name": name})
+        })
+        .collect();
     if sites.is_empty() {
         return json!({
             "ok": true,
             "sites": sites,
-            "active_site_id": Value::Null
+            "active_site_id": Value::Null,
+            "query_engine": "sparql"
         });
     }
     json!({
         "ok": true,
         "sites": sites,
-        "active_site_id": sites.first().and_then(|s| s.get("site_id").and_then(|v| v.as_str()))
+        "active_site_id": sites.first().and_then(|s| s.get("site_id").and_then(|v| v.as_str())),
+        "query_engine": "sparql"
     })
 }
 
@@ -80,73 +104,93 @@ pub fn list_equipment(site_id: &str) -> Value {
 
 pub fn list_equips(site_id: Option<&str>) -> Value {
     let sid = super::scope::resolve_site_id(site_id);
-    let mut equips = Vec::new();
-    for row in haystack_rows() {
-        if row.get("equip").and_then(|v| v.as_str()) == Some("M") {
-            let row_site = row.get("siteRef").and_then(|v| v.as_str());
-            if let Some(filter) = sid.as_deref() {
-                if row_site != Some(filter) {
-                    continue;
-                }
-            }
-            equips.push(json!({
-                "equipment_id": row.get("id").cloned().unwrap_or(json!(null)),
-                "name": row.get("dis").cloned().unwrap_or(json!(null)),
-                "site_id": row.get("siteRef").cloned().unwrap_or(json!(null)),
-                "equipment_type": infer_equip_type(&row)
-            }));
-        }
-    }
-    json!({"ok": true, "site_id": sid, "equips": equips, "count": equips.len()})
+    let filter = sid
+        .as_deref()
+        .map(|s| format!("FILTER (?site_id = \"{}\")", rdf::turtle_escape(s)))
+        .unwrap_or_default();
+    let query = format!(
+        "{SPARQL_PREFIXES}
+        SELECT ?equipment_id ?name ?site_id ?equipment_type WHERE {{
+          ?s a hs:Equip .
+          ?s ofdd:haystackId ?equipment_id .
+          OPTIONAL {{ ?s hs:dis ?name . }}
+          OPTIONAL {{ ?s hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
+          OPTIONAL {{ ?s ofdd:equipType ?equipment_type . }}
+          {filter}
+        }}"
+    );
+    let equips: Vec<Value> = sparql_rows(&query)
+        .into_iter()
+        .map(|row| {
+            json!({
+                "equipment_id": row.get("equipment_id").cloned().unwrap_or_default(),
+                "name": row.get("name").cloned().unwrap_or_default(),
+                "site_id": sparql_opt(&row, "site_id"),
+                "equipment_type": sparql_opt(&row, "equipment_type")
+            })
+        })
+        .collect();
+    json!({
+        "ok": true,
+        "site_id": sid,
+        "equips": equips,
+        "count": equips.len(),
+        "query_engine": "sparql"
+    })
 }
 
 pub fn list_points(site_id: Option<&str>) -> Value {
     let sid = super::scope::resolve_site_id(site_id);
-    let equip_site = super::scope::equip_site_map();
-    let mut points = Vec::new();
-    for row in haystack_rows() {
-        if row.get("point").and_then(|v| v.as_str()) == Some("M") {
-            let equip_ref = row.get("equipRef").and_then(|v| v.as_str());
-            let point_site = equip_ref.and_then(|e| equip_site.get(e).cloned());
-            if let Some(filter) = sid.as_deref() {
-                if point_site.as_deref() != Some(filter) {
-                    continue;
-                }
-            }
-            points.push(json!({
-                "point_id": row.get("id").cloned().unwrap_or(json!(null)),
-                "name": row.get("dis").cloned().unwrap_or(json!(null)),
-                "equip_ref": row.get("equipRef").cloned().unwrap_or(json!(null)),
-                "site_id": point_site,
-                "mapped": is_point_mapped(&row),
-                "fdd_input": row.get("fddInput").cloned().unwrap_or(json!(null))
-            }));
-        }
-    }
-    json!({"ok": true, "site_id": sid, "points": points, "count": points.len()})
+    let filter = sid
+        .as_deref()
+        .map(|s| format!("FILTER (?site_id = \"{}\")", rdf::turtle_escape(s)))
+        .unwrap_or_default();
+    let query = format!(
+        "{SPARQL_PREFIXES}
+        SELECT ?point_id ?name ?equip_ref ?site_id ?fdd_input ?bacnet_ref ?modbus_ref WHERE {{
+          ?p a hs:Point .
+          ?p ofdd:haystackId ?point_id .
+          OPTIONAL {{ ?p hs:dis ?name . }}
+          OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equip_ref . }}
+          OPTIONAL {{ ?eq hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
+          OPTIONAL {{ ?p hs:fddInput ?fdd_input . }}
+          OPTIONAL {{ ?p hs:bacnetRef ?bacnet_ref . }}
+          OPTIONAL {{ ?p hs:modbusRef ?modbus_ref . }}
+          {filter}
+        }}"
+    );
+    let points: Vec<Value> = sparql_rows(&query)
+        .into_iter()
+        .map(|row| {
+            let mapped = row.get("fdd_input").is_some()
+                || row.get("bacnet_ref").is_some()
+                || row.get("modbus_ref").is_some();
+            json!({
+                "point_id": row.get("point_id").cloned().unwrap_or_default(),
+                "name": row.get("name").cloned().unwrap_or_default(),
+                "equip_ref": sparql_opt(&row, "equip_ref"),
+                "site_id": sparql_opt(&row, "site_id"),
+                "mapped": mapped,
+                "fdd_input": sparql_opt(&row, "fdd_input")
+            })
+        })
+        .collect();
+    json!({
+        "ok": true,
+        "site_id": sid,
+        "points": points,
+        "count": points.len(),
+        "query_engine": "sparql"
+    })
 }
 
 pub fn model_coverage() -> Value {
-    let rows = haystack_rows();
-    let mut equipment_ids = HashSet::new();
-    let mut point_count = 0_usize;
-    let mut mapped = 0_usize;
-    let mut unmapped = 0_usize;
-    for row in &rows {
-        if row.get("equip").and_then(|v| v.as_str()) == Some("M") {
-            if let Some(id) = row.get("id").and_then(|v| v.as_str()) {
-                equipment_ids.insert(id.to_string());
-            }
-        }
-        if row.get("point").and_then(|v| v.as_str()) == Some("M") {
-            point_count += 1;
-            if is_point_mapped(row) {
-                mapped += 1;
-            } else {
-                unmapped += 1;
-            }
-        }
-    }
+    let equip_rows = sparql_predefined("hvac_equipment");
+    let point_rows = sparql_predefined("hvac_points");
+    let unmapped_rows = sparql_predefined("hvac_unmapped_points");
+    let point_count = point_rows.len();
+    let unmapped = unmapped_rows.len();
+    let mapped = point_count.saturating_sub(unmapped);
     let score = if point_count == 0 {
         0.0
     } else {
@@ -154,121 +198,118 @@ pub fn model_coverage() -> Value {
     };
     json!({
         "ok": true,
-        "equipment_count": equipment_ids.len(),
+        "equipment_count": equip_rows.len(),
         "point_count": point_count,
         "mapped_points": mapped,
         "unmapped_points": unmapped,
         "model_score": (score * 10.0).round() / 10.0,
-        "query_engine": "haystack"
+        "query_engine": "sparql"
     })
 }
 
 pub fn source_coverage() -> Value {
-    let rows = haystack_rows();
-    let mut by_protocol: HashMap<String, usize> = HashMap::new();
-    for row in &rows {
-        if row.get("point").and_then(|v| v.as_str()) != Some("M") {
-            continue;
-        }
-        let protocol = if row.get("csvRef").is_some() {
-            "csv"
-        } else if row.get("bacnetRef").is_some() {
-            "bacnet"
-        } else if row.get("modbusRef").is_some() {
-            "modbus"
-        } else if row.get("fddInput").is_some() {
-            "json_api"
-        } else {
-            "unmapped"
-        };
-        *by_protocol.entry(protocol.to_string()).or_insert(0) += 1;
-    }
-    let protocols: Vec<Value> = by_protocol
+    let query = format!(
+        "{SPARQL_PREFIXES}
+        SELECT ?protocol (COUNT(?point) AS ?point_count) WHERE {{
+          ?p a hs:Point .
+          ?p ofdd:haystackId ?point .
+          BIND(
+            IF(BOUND(?csv), \"csv\",
+              IF(BOUND(?bacnet), \"bacnet\",
+                IF(BOUND(?modbus), \"modbus\",
+                  IF(BOUND(?fdd), \"json_api\", \"unmapped\"))))
+            AS ?protocol)
+          OPTIONAL {{ ?p hs:csvRef ?csv . }}
+          OPTIONAL {{ ?p hs:bacnetRef ?bacnet . }}
+          OPTIONAL {{ ?p hs:modbusRef ?modbus . }}
+          OPTIONAL {{ ?p hs:fddInput ?fdd . }}
+        }} GROUP BY ?protocol"
+    );
+    let protocols: Vec<Value> = sparql_rows(&query)
         .into_iter()
-        .map(|(protocol, count)| json!({"protocol": protocol, "point_count": count}))
+        .map(|row| {
+            json!({
+                "protocol": row.get("protocol").cloned().unwrap_or_else(|| "unmapped".into()),
+                "point_count": row.get("point_count").and_then(|c| c.parse::<u64>().ok()).unwrap_or(0)
+            })
+        })
         .collect();
-    json!({"ok": true, "protocols": protocols})
+    json!({"ok": true, "protocols": protocols, "query_engine": "sparql"})
 }
 
 pub fn unmapped_points() -> Value {
-    let mut points = Vec::new();
-    for row in haystack_rows() {
-        if row.get("point").and_then(|v| v.as_str()) == Some("M") && !is_point_mapped(&row) {
-            points.push(json!({
-                "point_id": row.get("id").cloned().unwrap_or(json!(null)),
-                "name": row.get("dis").cloned().unwrap_or(json!(null)),
-                "equip_ref": row.get("equipRef").cloned().unwrap_or(json!(null))
-            }));
-        }
-    }
-    json!({"ok": true, "count": points.len(), "points": points})
+    let rows = sparql_predefined("hvac_unmapped_points");
+    let points: Vec<Value> = rows
+        .into_iter()
+        .map(|row| {
+            json!({
+                "point_id": row.get("point").cloned().unwrap_or_default(),
+                "name": row.get("dis").cloned().unwrap_or_default(),
+                "equip_ref": sparql_opt(&row, "equipRef")
+            })
+        })
+        .collect();
+    json!({
+        "ok": true,
+        "count": points.len(),
+        "points": points,
+        "query_engine": "sparql"
+    })
 }
 
 pub fn group_points_by_equip() -> Value {
+    let query = format!(
+        "{SPARQL_PREFIXES}
+        SELECT ?equip_ref ?point_id ?name ?mapped WHERE {{
+          ?p a hs:Point .
+          ?p ofdd:haystackId ?point_id .
+          OPTIONAL {{ ?p hs:dis ?name . }}
+          OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equip_ref . }}
+          BIND(
+            EXISTS {{ ?p hs:fddInput ?x }} ||
+            EXISTS {{ ?p hs:bacnetRef ?y }} ||
+            EXISTS {{ ?p hs:modbusRef ?z }}
+            AS ?mapped)
+        }}"
+    );
     let mut groups: HashMap<String, Vec<Value>> = HashMap::new();
-    for row in haystack_rows() {
-        if row.get("point").and_then(|v| v.as_str()) != Some("M") {
-            continue;
-        }
+    for row in sparql_rows(&query) {
         let equip = row
-            .get("equipRef")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unassigned")
-            .to_string();
+            .get("equip_ref")
+            .cloned()
+            .unwrap_or_else(|| "unassigned".into());
+        let mapped = row.get("mapped").map(|v| v == "true").unwrap_or(false);
         groups.entry(equip).or_default().push(json!({
-            "point_id": row.get("id").cloned().unwrap_or(json!(null)),
-            "name": row.get("dis").cloned().unwrap_or(json!(null)),
-            "mapped": is_point_mapped(&row)
+            "point_id": row.get("point_id").cloned().unwrap_or_default(),
+            "name": row.get("name").cloned().unwrap_or_default(),
+            "mapped": mapped
         }));
     }
     let grouped: Vec<Value> = groups
         .into_iter()
         .map(|(equip_ref, points)| json!({"equip_ref": equip_ref, "points": points, "count": points.len()}))
         .collect();
-    json!({"ok": true, "groups": grouped})
+    json!({"ok": true, "groups": grouped, "query_engine": "sparql"})
 }
 
-/// HVAC equipment counts and feeds chains for public dashboard context (Haystack grid, not SPARQL).
+/// HVAC equipment counts and feeds chains for public dashboard context (SPARQL over RDF).
 pub fn equipment_model_summary() -> Value {
-    let rows = haystack_rows();
+    let type_rows = sparql_predefined("hvac_equipment_types");
     let mut by_type: HashMap<String, usize> = HashMap::new();
-    let mut labels: HashMap<String, String> = HashMap::new();
-    let mut feed_edges: Vec<(String, String)> = Vec::new();
-
-    for row in &rows {
-        if row.get("equip").and_then(|v| v.as_str()) != Some("M") {
-            continue;
-        }
-        let id = row
-            .get("id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        if id.is_empty() {
-            continue;
-        }
-        let dis = row
-            .get("dis")
-            .and_then(|v| v.as_str())
-            .unwrap_or(&id)
-            .to_string();
-        let etype = infer_equip_type(row).to_string();
-        *by_type.entry(etype).or_insert(0) += 1;
-        labels.insert(id.clone(), dis);
-        if let Some(upstream) = row.get("feedRef").and_then(|v| v.as_str()) {
-            feed_edges.push((upstream.to_string(), id));
+    for row in type_rows {
+        if let (Some(etype), Some(count)) = (row.get("equipType"), row.get("count")) {
+            by_type.insert(etype.clone(), count.parse::<usize>().unwrap_or(0));
         }
     }
 
-    let feeds_chains: Vec<String> = feed_edges
-        .iter()
-        .map(|(from, to)| {
-            let from_label = labels
-                .get(from)
-                .map(String::as_str)
-                .unwrap_or(from.as_str());
-            let to_label = labels.get(to).map(String::as_str).unwrap_or(to.as_str());
-            format!("{from_label} feeds {to_label}")
+    let equip_rows = sparql_predefined("hvac_equipment");
+    let feeds_rows = sparql_predefined("hvac_feeds");
+    let feeds_chains: Vec<String> = feeds_rows
+        .into_iter()
+        .filter_map(|row| {
+            let from = row.get("fromLabel").or_else(|| row.get("from"))?;
+            let to = row.get("toLabel").or_else(|| row.get("to"))?;
+            Some(format!("{from} feeds {to}"))
         })
         .collect();
 
@@ -276,111 +317,102 @@ pub fn equipment_model_summary() -> Value {
         "ok": true,
         "equipment_by_type": by_type,
         "feeds_chains": feeds_chains,
-        "equipment_count": labels.len(),
-        "query_engine": "haystack"
+        "equipment_count": equip_rows.len(),
+        "query_engine": "sparql"
     })
 }
 
 /// Network graph for Model explorer and dashboard feeds visualization.
 pub fn network_graph(site_id: Option<&str>) -> Value {
     let sid = super::scope::resolve_site_id(site_id);
-    let rows = haystack_rows();
-    let mut equipment: Vec<Value> = Vec::new();
-    let mut feeds: Vec<Value> = Vec::new();
-    let mut points_by_equipment: HashMap<String, Vec<Value>> = HashMap::new();
-    let mut labels: HashMap<String, String> = HashMap::new();
+    let site_filter = sid
+        .as_deref()
+        .map(|s| format!("FILTER (?site_id = \"{}\")", rdf::turtle_escape(s)))
+        .unwrap_or_default();
 
-    for row in &rows {
-        if row.get("equip").and_then(|v| v.as_str()) == Some("M") {
-            let row_site = row.get("siteRef").and_then(|v| v.as_str());
-            if let Some(filter) = sid.as_deref() {
-                if row_site != Some(filter) {
-                    continue;
-                }
-            }
+    let equip_query = format!(
+        "{SPARQL_PREFIXES}
+        SELECT ?equipment_id ?name ?equipment_type ?site_id WHERE {{
+          ?s a hs:Equip .
+          ?s ofdd:haystackId ?equipment_id .
+          OPTIONAL {{ ?s hs:dis ?name . }}
+          OPTIONAL {{ ?s ofdd:equipType ?equipment_type . }}
+          OPTIONAL {{ ?s hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
+          {site_filter}
+        }}"
+    );
+    let equip_rows = sparql_rows(&equip_query);
+    let mut labels: HashMap<String, String> = HashMap::new();
+    let equipment: Vec<Value> = equip_rows
+        .iter()
+        .map(|row| {
             let equipment_id = row
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            if equipment_id.is_empty() {
-                continue;
-            }
+                .get("equipment_id")
+                .cloned()
+                .unwrap_or_default();
             let name = row
-                .get("dis")
-                .and_then(|v| v.as_str())
-                .unwrap_or(&equipment_id)
-                .to_string();
+                .get("name")
+                .cloned()
+                .unwrap_or_else(|| equipment_id.clone());
             labels.insert(equipment_id.clone(), name.clone());
-            equipment.push(json!({
+            json!({
                 "equipment_id": equipment_id,
                 "name": name,
                 "label": name,
-                "equipment_type": infer_equip_type(row)
-            }));
-            if let Some(upstream) = row.get("feedRef").and_then(|v| v.as_str()) {
-                feeds.push(json!({
-                    "from_equipment_id": upstream,
-                    "to_equipment_id": equipment_id
-                }));
-            }
-        }
-    }
+                "equipment_type": row.get("equipment_type").cloned().unwrap_or_else(|| "generic".into())
+            })
+        })
+        .collect();
 
-    let equip_site = super::scope::equip_site_map();
-    for row in &rows {
-        if row.get("point").and_then(|v| v.as_str()) != Some("M") {
-            continue;
-        }
-        let equip_ref = row
-            .get("equipRef")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        if equip_ref.is_empty() || !labels.contains_key(&equip_ref) {
-            continue;
-        }
-        let point_site = row
-            .get("equipRef")
-            .and_then(|v| v.as_str())
-            .and_then(|e| equip_site.get(e).cloned());
-        if let Some(filter) = sid.as_deref() {
-            if point_site.as_deref() != Some(filter) {
-                continue;
+    let equip_ids: HashSet<String> = labels.keys().cloned().collect();
+    let feeds: Vec<Value> = sparql_predefined("hvac_feeds")
+        .into_iter()
+        .filter_map(|row| {
+            let from = row.get("from")?.clone();
+            let to = row.get("to")?.clone();
+            if !equip_ids.contains(&to) {
+                return None;
             }
+            Some(json!({
+                "from_equipment_id": from.clone(),
+                "to_equipment_id": to.clone(),
+                "from_label": row.get("fromLabel").cloned().unwrap_or(from),
+                "to_label": row.get("toLabel").cloned().unwrap_or(to)
+            }))
+        })
+        .collect();
+
+    let points_query = format!(
+        "{SPARQL_PREFIXES}
+        SELECT ?equip_ref ?point_id ?name ?unit ?site_id WHERE {{
+          ?p a hs:Point .
+          ?p ofdd:haystackId ?point_id .
+          OPTIONAL {{ ?p hs:dis ?name . }}
+          OPTIONAL {{ ?p hs:unit ?unit . }}
+          ?p hs:equipRef ?eq .
+          ?eq ofdd:haystackId ?equip_ref .
+          OPTIONAL {{ ?eq hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
+          {site_filter}
+        }}"
+    );
+    let mut points_by_equipment: HashMap<String, Vec<Value>> = HashMap::new();
+    for row in sparql_rows(&points_query) {
+        let equip_ref = row.get("equip_ref").cloned().unwrap_or_default();
+        if equip_ref.is_empty() || !equip_ids.contains(&equip_ref) {
+            continue;
         }
-        let point_id = row
-            .get("id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let name = row
-            .get("dis")
-            .and_then(|v| v.as_str())
-            .unwrap_or(&point_id)
-            .to_string();
+        let point_id = row.get("point_id").cloned().unwrap_or_default();
+        let name = row.get("name").cloned().unwrap_or_else(|| point_id.clone());
         points_by_equipment
-            .entry(equip_ref)
+            .entry(equip_ref.clone())
             .or_default()
             .push(json!({
                 "point_id": point_id,
                 "name": name,
                 "label": name,
-                "equipment_id": row.get("equipRef").cloned().unwrap_or(json!(null)),
-                "unit": row.get("unit").cloned().unwrap_or(json!(null))
+                "equipment_id": equip_ref,
+                "unit": sparql_opt(&row, "unit")
             }));
-    }
-
-    for feed in &mut feeds {
-        if let Some(from) = feed.get("from_equipment_id").and_then(|v| v.as_str()) {
-            feed["from_label"] = json!(labels
-                .get(from)
-                .cloned()
-                .unwrap_or_else(|| from.to_string()));
-        }
-        if let Some(to) = feed.get("to_equipment_id").and_then(|v| v.as_str()) {
-            feed["to_label"] = json!(labels.get(to).cloned().unwrap_or_else(|| to.to_string()));
-        }
     }
 
     let points_map: Value = points_by_equipment
@@ -391,35 +423,11 @@ pub fn network_graph(site_id: Option<&str>) -> Value {
     json!({
         "ok": true,
         "site_id": sid,
-        "query_engine": "haystack",
+        "query_engine": "sparql",
         "equipment": equipment,
         "feeds": feeds,
         "points_by_equipment": points_map
     })
-}
-
-fn is_point_mapped(row: &Value) -> bool {
-    row.get("fddInput").is_some()
-        || row.get("bacnetRef").is_some()
-        || row.get("modbusRef").is_some()
-}
-
-fn infer_equip_type(row: &Value) -> &'static str {
-    if row.get("ahu").is_some() {
-        "ahu"
-    } else if row.get("vav").is_some() {
-        "vav"
-    } else if row.get("chiller").is_some() {
-        "chiller"
-    } else if row.get("boiler").is_some() {
-        "boiler"
-    } else if row.get("coolingTower").is_some() {
-        "cooling_tower"
-    } else if row.get("doas").is_some() {
-        "doas"
-    } else {
-        "generic"
-    }
 }
 
 #[cfg(test)]

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -162,9 +162,9 @@ pub fn list_points(site_id: Option<&str>) -> Value {
     let points: Vec<Value> = sparql_rows(&query)
         .into_iter()
         .map(|row| {
-            let mapped = row.get("fdd_input").is_some()
-                || row.get("bacnet_ref").is_some()
-                || row.get("modbus_ref").is_some();
+            let mapped = row.contains_key("fdd_input")
+                || row.contains_key("bacnet_ref")
+                || row.contains_key("modbus_ref");
             json!({
                 "point_id": row.get("point_id").cloned().unwrap_or_default(),
                 "name": row.get("name").cloned().unwrap_or_default(),

--- a/edge/src/model/rdf.rs
+++ b/edge/src/model/rdf.rs
@@ -1,0 +1,369 @@
+//! Haystack grid → RDF (Turtle) and in-memory Oxigraph store for SPARQL.
+
+use crate::model::query;
+use once_cell::sync::Lazy;
+use oxigraph::io::RdfFormat;
+use oxigraph::model::Term;
+use oxigraph::sparql::{QueryResults, SparqlEvaluator};
+use oxigraph::store::Store;
+use serde_json::Value;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::RwLock;
+
+pub const HS_PREFIX: &str = "https://project-haystack.org/def/";
+pub const OFDD_PREFIX: &str = "https://open-fdd.dev/model#";
+
+static STORE: Lazy<RwLock<StoreState>> = Lazy::new(|| RwLock::new(StoreState::empty()));
+
+struct StoreState {
+    grid_hash: u64,
+    store: Option<Store>,
+}
+
+impl StoreState {
+    fn empty() -> Self {
+        Self {
+            grid_hash: 0,
+            store: None,
+        }
+    }
+}
+
+/// Drop cached store so the next query reloads from the current Haystack grid.
+pub fn invalidate_store() {
+    if let Ok(mut guard) = STORE.write() {
+        *guard = StoreState::empty();
+    }
+}
+
+fn grid_fingerprint(rows: &[Value]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    serde_json::to_string(rows)
+        .unwrap_or_default()
+        .hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Turtle local name for a Haystack ref id (`site:lab` → `site_lab`).
+pub fn turtle_local(id: &str) -> String {
+    id.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+pub fn turtle_subject(id: &str) -> String {
+    format!("ofdd:{}", turtle_local(id))
+}
+
+pub fn turtle_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+fn is_marker(v: &Value) -> bool {
+    matches!(v.as_str(), Some("M")) || v.as_bool() == Some(true)
+}
+
+fn infer_equip_type(row: &Value) -> &'static str {
+    if row.get("ahu").is_some() {
+        "ahu"
+    } else if row.get("vav").is_some() {
+        "vav"
+    } else if row.get("chiller").is_some() {
+        "chiller"
+    } else if row.get("boiler").is_some() {
+        "boiler"
+    } else if row.get("coolingTower").is_some() {
+        "cooling_tower"
+    } else if row.get("doas").is_some() {
+        "doas"
+    } else {
+        "generic"
+    }
+}
+
+fn haystack_type_triples(row: &Value) -> Vec<String> {
+    let mut types = Vec::new();
+    if row.get("site").is_some() {
+        types.push("hs:Site".into());
+    }
+    if row.get("equip").is_some() {
+        types.push("hs:Equip".into());
+    }
+    if row.get("point").is_some() {
+        types.push("hs:Point".into());
+    }
+    for (tag, hs_type) in [
+        ("ahu", "hs:AHU"),
+        ("vav", "hs:VAV"),
+        ("chiller", "hs:Chiller"),
+        ("boiler", "hs:Boiler"),
+        ("coolingTower", "hs:CoolingTower"),
+        ("doas", "hs:DOAS"),
+    ] {
+        if row.get(tag).is_some() {
+            types.push(hs_type.into());
+        }
+    }
+    types
+}
+
+fn literal_object(v: &Value) -> Option<String> {
+    if let Some(s) = v.as_str() {
+        return Some(format!("\"{}\"", turtle_escape(s)));
+    }
+    if let Some(n) = v.as_f64() {
+        return Some(format!(
+            "\"{n}\"^^<http://www.w3.org/2001/XMLSchema#double>"
+        ));
+    }
+    if let Some(n) = v.as_i64() {
+        return Some(format!(
+            "\"{n}\"^^<http://www.w3.org/2001/XMLSchema#integer>"
+        ));
+    }
+    if let Some(b) = v.as_bool() {
+        return Some(format!(
+            "\"{}\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
+            b
+        ));
+    }
+    None
+}
+
+/// Build Turtle from Haystack grid rows (full semantic projection for SPARQL).
+pub fn haystack_rows_to_turtle(rows: &[Value]) -> String {
+    let mut lines = vec![
+        format!("@prefix hs: <{HS_PREFIX}> ."),
+        format!("@prefix ofdd: <{OFDD_PREFIX}> ."),
+        format!("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> ."),
+        String::new(),
+    ];
+
+    for row in rows {
+        let Some(id) = row.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if id.is_empty() {
+            continue;
+        }
+        let subj = turtle_subject(id);
+        let mut preds: Vec<String> = Vec::new();
+
+        preds.push(format!(
+            "{subj} ofdd:haystackId \"{}\" .",
+            turtle_escape(id)
+        ));
+
+        for rdf_type in haystack_type_triples(row) {
+            preds.push(format!("{subj} a {rdf_type} ."));
+        }
+
+        if row.get("equip").is_some() {
+            preds.push(format!(
+                "{subj} ofdd:equipType \"{}\" .",
+                turtle_escape(infer_equip_type(row))
+            ));
+        }
+
+        for (key, value) in row.as_object().into_iter().flatten() {
+            if key == "id" {
+                continue;
+            }
+            let pred = format!("hs:{key}");
+            if key.ends_with("Ref") {
+                if let Some(ref_id) = value.as_str() {
+                    if !ref_id.is_empty() {
+                        preds.push(format!("{subj} {pred} {} .", turtle_subject(ref_id)));
+                    }
+                }
+                continue;
+            }
+            if is_marker(value) {
+                // Marker tags are represented via rdf:type (hs:Site, hs:Equip, …) above.
+                continue;
+            }
+            if let Some(lit) = literal_object(value) {
+                preds.push(format!("{subj} {pred} {lit} ."));
+            }
+        }
+
+        lines.extend(preds);
+        lines.push(String::new());
+    }
+
+    lines.join("\n")
+}
+
+pub fn haystack_to_turtle() -> String {
+    haystack_rows_to_turtle(&query::haystack_rows())
+}
+
+fn ensure_store() -> Result<(), String> {
+    let rows = query::haystack_rows();
+    let hash = grid_fingerprint(&rows);
+    {
+        let guard = STORE
+            .read()
+            .map_err(|_| "RDF store lock poisoned".to_string())?;
+        if guard.grid_hash == hash && guard.store.is_some() {
+            return Ok(());
+        }
+    }
+
+    let turtle = haystack_rows_to_turtle(&rows);
+    let store = Store::new().map_err(|e| format!("RDF store init failed: {e}"))?;
+    store
+        .load_from_reader(RdfFormat::Turtle, turtle.as_bytes())
+        .map_err(|e| format!("Turtle load failed: {e}"))?;
+
+    let mut guard = STORE
+        .write()
+        .map_err(|_| "RDF store lock poisoned".to_string())?;
+    guard.grid_hash = hash;
+    guard.store = Some(store);
+    Ok(())
+}
+
+fn with_store<F, T>(f: F) -> Result<T, String>
+where
+    F: FnOnce(&Store) -> Result<T, String>,
+{
+    ensure_store()?;
+    let guard = STORE
+        .read()
+        .map_err(|_| "RDF store lock poisoned".to_string())?;
+    let store = guard
+        .store
+        .as_ref()
+        .ok_or_else(|| "RDF store unavailable".to_string())?;
+    f(store)
+}
+
+fn term_to_binding_string(term: &Term) -> String {
+    match term {
+        Term::Literal(lit) => lit.value().to_string(),
+        Term::NamedNode(node) => {
+            let iri = node.as_str();
+            if let Some(local) = iri.strip_prefix(OFDD_PREFIX) {
+                // Best-effort reverse: site_lab → site:lab is lossy; prefer haystackId in queries.
+                local.replace('_', ":")
+            } else if let Some(local) = iri.strip_prefix(HS_PREFIX) {
+                format!("hs:{local}")
+            } else {
+                iri.to_string()
+            }
+        }
+        Term::BlankNode(b) => format!("_:{b}"),
+    }
+}
+
+/// Execute a read-only SPARQL SELECT; returns variable → string bindings per row.
+pub fn sparql_select(
+    query_text: &str,
+) -> Result<Vec<std::collections::HashMap<String, String>>, String> {
+    let trimmed = query_text.trim();
+    if trimmed.is_empty() {
+        return Err("query required".into());
+    }
+    let upper = trimmed.to_uppercase();
+    if upper.contains("INSERT")
+        || upper.contains("DELETE")
+        || upper.contains("CREATE")
+        || upper.contains("DROP")
+        || upper.contains("LOAD")
+        || upper.contains("CLEAR")
+        || upper.contains("MOVE")
+        || upper.contains("COPY")
+        || upper.contains("ADD")
+    {
+        return Err("Only read-only SELECT queries are supported".into());
+    }
+
+    with_store(|store| {
+        let results = SparqlEvaluator::new()
+            .parse_query(trimmed)
+            .map_err(|e| format!("SPARQL parse error: {e}"))?
+            .on_store(store)
+            .execute()
+            .map_err(|e| format!("SPARQL execution error: {e}"))?;
+
+        match results {
+            QueryResults::Solutions(solutions) => {
+                let mut rows = Vec::new();
+                for sol in solutions {
+                    let sol = sol.map_err(|e| format!("SPARQL solution error: {e}"))?;
+                    let mut map = std::collections::HashMap::new();
+                    for (var, term) in sol.iter() {
+                        map.insert(var.as_str().to_string(), term_to_binding_string(term));
+                    }
+                    rows.push(map);
+                }
+                Ok(rows)
+            }
+            QueryResults::Boolean(_) => Err("Only SELECT queries are supported".into()),
+            QueryResults::Graph(_) => Err("Only SELECT queries are supported".into()),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn turtle_includes_types_and_refs() {
+        let rows = vec![
+            json!({
+                "id": "site:lab",
+                "dis": "Lab Site",
+                "site": "M"
+            }),
+            json!({
+                "id": "equip:ahu1",
+                "dis": "AHU-1",
+                "equip": "M",
+                "ahu": "M",
+                "siteRef": "site:lab"
+            }),
+            json!({
+                "id": "point:oa",
+                "dis": "OA Temp",
+                "point": "M",
+                "equipRef": "equip:ahu1",
+                "fddInput": "oa_t"
+            }),
+        ];
+        let ttl = haystack_rows_to_turtle(&rows);
+        assert!(ttl.contains("a hs:Site"));
+        assert!(ttl.contains("a hs:Equip"));
+        assert!(ttl.contains("hs:siteRef ofdd:site_lab"));
+        assert!(ttl.contains("hs:fddInput \"oa_t\""));
+        assert!(ttl.contains("ofdd:equipType \"ahu\""));
+    }
+
+    #[test]
+    fn sparql_select_sites_on_fixture() {
+        invalidate_store();
+        let q = r#"
+            PREFIX hs: <https://project-haystack.org/def/>
+            PREFIX ofdd: <https://open-fdd.dev/model#>
+            SELECT ?site ?dis WHERE {
+              ?s a hs:Site .
+              ?s ofdd:haystackId ?site .
+              OPTIONAL { ?s hs:dis ?dis . }
+            }
+        "#;
+        let _ = sparql_select(q);
+    }
+}

--- a/edge/src/model/sparql.rs
+++ b/edge/src/model/sparql.rs
@@ -1,13 +1,15 @@
-//! Haystack-grid SPARQL facade (predefined SELECT queries; read-only).
-//!
-//! Full RDF/SPARQL engine deferred — executes equivalent Haystack row filters and
-//! returns SPARQL-style bindings for the dashboard panel.
+//! SPARQL query API over the Haystack RDF projection (`data_model.ttl`).
 
-use crate::model::query;
+use crate::model::rdf;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
-const MAX_ROWS: usize = 500;
+const MAX_ROWS: usize = 5000;
+
+const PREFIXES: &str = r#"
+PREFIX hs: <https://project-haystack.org/def/>
+PREFIX ofdd: <https://open-fdd.dev/model#>
+"#;
 
 pub fn predefined() -> Value {
     let queries = catalog();
@@ -19,8 +21,9 @@ pub fn predefined() -> Value {
         "ok": true,
         "default_query": default,
         "queries": queries,
-        "query_engine": "haystack",
-        "note": "Predefined queries run against the Haystack grid; custom SPARQL subset limited to exact predefined text."
+        "query_engine": "sparql",
+        "rdf_source": "haystack_grid",
+        "note": "SELECT queries run against the in-memory RDF graph synced from the Haystack model (Turtle)."
     })
 }
 
@@ -34,28 +37,25 @@ pub fn execute(body: &Value) -> Value {
         return json!({"ok": false, "error": "query required", "bindings": []});
     }
 
-    let handler = resolve_handler(query_text);
-    let bindings = match handler {
-        Some(h) => h(),
-        None => {
-            return json!({
-                "ok": false,
-                "error": "Unsupported SPARQL — pick a predefined query or use POST /api/model/query for raw Haystack rows",
-                "bindings": [],
-                "query_engine": "haystack"
-            });
-        }
-    };
+    match rdf::sparql_select(query_text) {
+        Ok(bindings) => bindings_to_response(bindings),
+        Err(e) => json!({
+            "ok": false,
+            "error": e,
+            "bindings": [],
+            "query_engine": "sparql"
+        }),
+    }
+}
 
+fn bindings_to_response(bindings: Vec<HashMap<String, String>>) -> Value {
     let truncated = bindings.len() > MAX_ROWS;
     let rows: Vec<Value> = bindings
         .into_iter()
         .take(MAX_ROWS)
         .map(|m| {
-            let obj: serde_json::Map<String, Value> = m
-                .into_iter()
-                .map(|(k, v)| (k, Value::String(v)))
-                .collect();
+            let obj: serde_json::Map<String, Value> =
+                m.into_iter().map(|(k, v)| (k, Value::String(v))).collect();
             Value::Object(obj)
         })
         .collect();
@@ -65,359 +65,77 @@ pub fn execute(body: &Value) -> Value {
         "bindings": rows,
         "row_count": count,
         "truncated": truncated,
-        "query_engine": "haystack"
+        "query_engine": "sparql"
     })
 }
 
-fn resolve_handler(query: &str) -> Option<fn() -> Vec<HashMap<String, String>>> {
-    for item in catalog() {
-        for key in ["query", "query_with_bacnet"] {
-            if item.get(key).and_then(|v| v.as_str()) == Some(query) {
-                let id = item.get("id").and_then(|v| v.as_str()).unwrap_or("");
-                return handler_for_id(id);
-            }
-        }
-    }
-    handler_for_id(query)
-}
-
-fn handler_for_id(id: &str) -> Option<fn() -> Vec<HashMap<String, String>>> {
-    match id {
-        "hvac_equipment" => Some(bind_equipment),
-        "hvac_equipment_types" => Some(bind_equipment_types),
-        "hvac_points" => Some(bind_points),
-        "hvac_points_bacnet" => Some(bind_points_bacnet),
-        "hvac_unmapped_points" => Some(bind_unmapped_points),
-        "hvac_feeds" => Some(bind_feeds),
-        "eng_sites" => Some(bind_sites),
-        _ => None,
-    }
-}
-
-fn catalog() -> Vec<Value> {
+pub fn catalog() -> Vec<Value> {
     vec![
         json!({
             "id": "hvac_equipment",
             "label": "All equipment",
             "short_label": "Equipment",
             "category": "hvac",
-            "query": "SELECT ?equip ?dis ?equipType WHERE { ?equip a haystack:Equip . OPTIONAL { ?equip haystack:dis ?dis } }",
-            "query_with_bacnet": "SELECT ?equip ?dis ?equipType ?bacnetRef WHERE { ?equip a haystack:Equip . OPTIONAL { ?equip haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equip . ?point haystack:bacnetRef ?bacnetRef } }"
+            "query": format!("{PREFIXES}\nSELECT ?equip ?dis ?equipType WHERE {{\n  ?s a hs:Equip .\n  ?s ofdd:haystackId ?equip .\n  OPTIONAL {{ ?s hs:dis ?dis . }}\n  OPTIONAL {{ ?s ofdd:equipType ?equipType . }}\n}}"),
+            "query_with_bacnet": format!("{PREFIXES}\nSELECT ?equip ?dis ?equipType ?bacnetRef WHERE {{\n  ?s a hs:Equip .\n  ?s ofdd:haystackId ?equip .\n  OPTIONAL {{ ?s hs:dis ?dis . }}\n  OPTIONAL {{ ?s ofdd:equipType ?equipType . }}\n  OPTIONAL {{\n    ?p hs:equipRef ?s .\n    ?p hs:bacnetRef ?bacnetRef .\n  }}\n}}")
         }),
         json!({
             "id": "hvac_equipment_types",
             "label": "Equipment by HVAC type",
             "short_label": "Equip types",
             "category": "hvac",
-            "query": "SELECT ?equipType (COUNT(?equip) AS ?count) WHERE { ?equip a haystack:Equip . BIND(haystack:inferType(?equip) AS ?equipType) } GROUP BY ?equipType"
+            "query": format!("{PREFIXES}\nSELECT ?equipType (COUNT(?equip) AS ?count) WHERE {{\n  ?s a hs:Equip .\n  ?s ofdd:haystackId ?equip .\n  ?s ofdd:equipType ?equipType .\n}} GROUP BY ?equipType ORDER BY ?equipType")
         }),
         json!({
             "id": "hvac_points",
             "label": "All points",
             "short_label": "Points",
             "category": "hvac",
-            "query": "SELECT ?point ?dis ?equipRef ?fddInput WHERE { ?point a haystack:Point . OPTIONAL { ?point haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equipRef } . OPTIONAL { ?point haystack:fddInput ?fddInput } }"
+            "query": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef ?fddInput WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n  OPTIONAL {{ ?p hs:fddInput ?fddInput . }}\n}}")
         }),
         json!({
             "id": "hvac_points_bacnet",
             "label": "BACnet-mapped points",
             "short_label": "BACnet pts",
             "category": "hvac",
-            "query": "SELECT ?point ?dis ?equipRef ?bacnetRef WHERE { ?point a haystack:Point . ?point haystack:bacnetRef ?bacnetRef . OPTIONAL { ?point haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equipRef } }",
-            "query_with_bacnet": "SELECT ?point ?dis ?equipRef ?bacnetRef ?objectIdentifier WHERE { ?point a haystack:Point . ?point haystack:bacnetRef ?bacnetRef . OPTIONAL { ?point haystack:dis ?dis } . OPTIONAL { ?point haystack:equipRef ?equipRef } }"
+            "query": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef ?bacnetRef WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  ?p hs:bacnetRef ?bacnetRef .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n}}"),
+            "query_with_bacnet": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef ?bacnetRef WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  ?p hs:bacnetRef ?bacnetRef .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n}}")
         }),
         json!({
             "id": "hvac_unmapped_points",
             "label": "Unmapped points (no fddInput / driver ref)",
             "short_label": "Unmapped",
             "category": "engineering",
-            "query": "SELECT ?point ?dis ?equipRef WHERE { ?point a haystack:Point . FILTER NOT EXISTS { ?point haystack:fddInput ?x } FILTER NOT EXISTS { ?point haystack:bacnetRef ?y } }"
+            "query": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n  FILTER NOT EXISTS {{ ?p hs:fddInput ?x }}\n  FILTER NOT EXISTS {{ ?p hs:bacnetRef ?y }}\n  FILTER NOT EXISTS {{ ?p hs:modbusRef ?z }}\n  FILTER NOT EXISTS {{ ?p hs:csvRef ?w }}\n}}")
         }),
         json!({
             "id": "hvac_feeds",
             "label": "Equipment feeds relationships",
             "short_label": "Feeds",
             "category": "hvac",
-            "query": "SELECT ?from ?to ?fromLabel ?toLabel WHERE { ?to haystack:feedRef ?from . OPTIONAL { ?from haystack:dis ?fromLabel } . OPTIONAL { ?to haystack:dis ?toLabel } }"
+            "query": format!("{PREFIXES}\nSELECT ?from ?to ?fromLabel ?toLabel WHERE {{\n  ?toRes hs:feedRef ?fromRes .\n  ?fromRes ofdd:haystackId ?from .\n  ?toRes ofdd:haystackId ?to .\n  OPTIONAL {{ ?fromRes hs:dis ?fromLabel . }}\n  OPTIONAL {{ ?toRes hs:dis ?toLabel . }}\n}}")
         }),
         json!({
             "id": "eng_sites",
             "label": "Sites",
             "short_label": "Sites",
             "category": "engineering",
-            "query": "SELECT ?site ?dis WHERE { ?site a haystack:Site . OPTIONAL { ?site haystack:dis ?dis } }"
+            "query": format!("{PREFIXES}\nSELECT ?site ?dis WHERE {{\n  ?s a hs:Site .\n  ?s ofdd:haystackId ?site .\n  OPTIONAL {{ ?s hs:dis ?dis . }}\n}}")
         }),
     ]
 }
 
-fn bind_equipment() -> Vec<HashMap<String, String>> {
-    let summary = query::equipment_model_summary();
-    let mut labels: HashMap<String, String> = HashMap::new();
-    let mut types: HashMap<String, String> = HashMap::new();
-    for row in query::haystack_rows() {
-        if row.get("equip").and_then(|v| v.as_str()) != Some("M") {
-            continue;
-        }
-        let id = row
-            .get("id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        if id.is_empty() {
-            continue;
-        }
-        labels.insert(
-            id.clone(),
-            row.get("dis")
-                .and_then(|v| v.as_str())
-                .unwrap_or(&id)
-                .to_string(),
-        );
-        types.insert(id, infer_equip_type_label(&row));
-    }
-    let _ = summary;
-    labels
+/// Run a catalog query by id (used by query layer).
+pub fn run_predefined(id: &str) -> Result<Vec<HashMap<String, String>>, String> {
+    let item = catalog()
         .into_iter()
-        .map(|(equip, dis)| {
-            let mut m = HashMap::new();
-            m.insert("equip".into(), equip.clone());
-            m.insert("dis".into(), dis);
-            m.insert(
-                "equipType".into(),
-                types
-                    .get(&equip)
-                    .cloned()
-                    .unwrap_or_else(|| "generic".into()),
-            );
-            m
-        })
-        .collect()
-}
-
-fn bind_equipment_types() -> Vec<HashMap<String, String>> {
-    let summary = query::equipment_model_summary();
-    summary
-        .get("equipment_by_type")
-        .and_then(|v| v.as_object())
-        .map(|obj| {
-            obj.iter()
-                .map(|(etype, count)| {
-                    let mut m = HashMap::new();
-                    m.insert("equipType".into(), etype.clone());
-                    m.insert("count".into(), count.to_string());
-                    m
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn bind_points() -> Vec<HashMap<String, String>> {
-    query::haystack_rows()
-        .into_iter()
-        .filter(|r| r.get("point").and_then(|v| v.as_str()) == Some("M"))
-        .map(|row| {
-            let mut m = HashMap::new();
-            m.insert(
-                "point".into(),
-                row.get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "dis".into(),
-                row.get("dis")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "equipRef".into(),
-                row.get("equipRef")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "fddInput".into(),
-                row.get("fddInput")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m
-        })
-        .collect()
-}
-
-fn bind_points_bacnet() -> Vec<HashMap<String, String>> {
-    query::haystack_rows()
-        .into_iter()
-        .filter(|r| {
-            r.get("point").and_then(|v| v.as_str()) == Some("M") && r.get("bacnetRef").is_some()
-        })
-        .map(|row| {
-            let mut m = HashMap::new();
-            m.insert(
-                "point".into(),
-                row.get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "dis".into(),
-                row.get("dis")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "equipRef".into(),
-                row.get("equipRef")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "bacnetRef".into(),
-                row.get("bacnetRef")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m
-        })
-        .collect()
-}
-
-fn bind_unmapped_points() -> Vec<HashMap<String, String>> {
-    let unmapped = query::unmapped_points();
-    unmapped
-        .get("points")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|p| {
-            let mut m = HashMap::new();
-            m.insert(
-                "point".into(),
-                p.get("point_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "dis".into(),
-                p.get("name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "equipRef".into(),
-                p.get("equip_ref")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m
-        })
-        .collect()
-}
-
-fn bind_feeds() -> Vec<HashMap<String, String>> {
-    let summary = query::equipment_model_summary();
-    let mut labels: HashMap<String, String> = HashMap::new();
-    for row in query::haystack_rows() {
-        if row.get("equip").and_then(|v| v.as_str()) == Some("M") {
-            let id = row.get("id").and_then(|v| v.as_str()).unwrap_or("");
-            labels.insert(
-                id.to_string(),
-                row.get("dis")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or(id)
-                    .to_string(),
-            );
-        }
-    }
-    let mut out = Vec::new();
-    for row in query::haystack_rows() {
-        if let Some(from) = row.get("feedRef").and_then(|v| v.as_str()) {
-            let to = row.get("id").and_then(|v| v.as_str()).unwrap_or("");
-            let mut m = HashMap::new();
-            m.insert("from".into(), from.to_string());
-            m.insert("to".into(), to.to_string());
-            m.insert(
-                "fromLabel".into(),
-                labels
-                    .get(from)
-                    .cloned()
-                    .unwrap_or_else(|| from.to_string()),
-            );
-            m.insert(
-                "toLabel".into(),
-                labels.get(to).cloned().unwrap_or_else(|| to.to_string()),
-            );
-            out.push(m);
-        }
-    }
-    if out.is_empty() {
-        if let Some(chains) = summary.get("feeds_chains").and_then(|v| v.as_array()) {
-            for chain in chains {
-                if let Some(s) = chain.as_str() {
-                    let mut m = HashMap::new();
-                    m.insert("feeds_chain".into(), s.to_string());
-                    out.push(m);
-                }
-            }
-        }
-    }
-    out
-}
-
-fn bind_sites() -> Vec<HashMap<String, String>> {
-    query::list_sites()
-        .get("sites")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|s| {
-            let mut m = HashMap::new();
-            m.insert(
-                "site".into(),
-                s.get("site_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m.insert(
-                "dis".into(),
-                s.get("name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-            );
-            m
-        })
-        .collect()
-}
-
-fn infer_equip_type_label(row: &Value) -> String {
-    if row.get("ahu").is_some() {
-        "ahu".into()
-    } else if row.get("vav").is_some() {
-        "vav".into()
-    } else if row.get("chiller").is_some() {
-        "chiller".into()
-    } else if row.get("boiler").is_some() {
-        "boiler".into()
-    } else {
-        "generic".into()
-    }
+        .find(|q| q.get("id").and_then(|v| v.as_str()) == Some(id))
+        .ok_or_else(|| format!("unknown predefined query: {id}"))?;
+    let query = item
+        .get("query")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "query missing".to_string())?;
+    rdf::sparql_select(query)
 }
 
 #[cfg(test)]
@@ -428,6 +146,10 @@ mod tests {
     fn predefined_catalog_non_empty() {
         let p = predefined();
         assert!(p.get("queries").and_then(|v| v.as_array()).unwrap().len() >= 5);
+        assert_eq!(
+            p.get("query_engine").and_then(|v| v.as_str()),
+            Some("sparql")
+        );
     }
 
     #[test]
@@ -436,5 +158,15 @@ mod tests {
         let q = cat[0]["query"].as_str().unwrap();
         let out = execute(&json!({"query": q}));
         assert_eq!(out.get("ok").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(
+            out.get("query_engine").and_then(|v| v.as_str()),
+            Some("sparql")
+        );
+    }
+
+    #[test]
+    fn rejects_update_queries() {
+        let out = execute(&json!({"query": "DELETE WHERE { ?s ?p ?o }"}));
+        assert_eq!(out.get("ok").and_then(|v| v.as_bool()), Some(false));
     }
 }

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -737,6 +737,96 @@ pub fn from_validation_run(body: &Value) -> Value {
     })
 }
 
+/// Build a PDF report draft from an ad-hoc SQL FDD test run (SQL tab → Reports).
+pub fn from_fdd_sql_run(body: &Value) -> Value {
+    let rule_name = body
+        .get("rule_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("FDD SQL Rule");
+    let sql = body.get("sql").and_then(|v| v.as_str()).unwrap_or("");
+    let equipment_id = body
+        .get("equipment_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let fault_code = body
+        .get("fault_code")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let run = body.get("run_result").cloned().unwrap_or(json!({}));
+    let confirmation = run.get("confirmation").cloned().unwrap_or(json!({}));
+    let confirmed_count = confirmation
+        .get("confirmed_fault_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let raw_count = confirmation
+        .get("raw_fault_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let row_count = run.get("row_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let sample_rows: Vec<Value> = run
+        .get("rows")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().take(25).cloned().collect())
+        .unwrap_or_default();
+    let title = format!("FDD SQL Report — {rule_name}");
+    let doc = create_draft(&json!({
+        "template_id": "fdd-sql-run",
+        "title": title,
+    }));
+    if doc.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return doc;
+    }
+    let report_id = doc
+        .get("report_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if let Some(mut saved) = load_report(&report_id) {
+        saved["metadata"] = json!({
+            "rule_name": rule_name,
+            "equipment_id": equipment_id,
+            "fault_code": fault_code,
+            "confirmed_fault_count": confirmed_count,
+            "raw_fault_count": raw_count,
+            "row_count": row_count,
+            "created_at": Utc::now().to_rfc3339(),
+            "template_id": "fdd-sql-run",
+            "pdf_ready": false,
+        });
+        if let Some(sections) = saved.get_mut("sections").and_then(|v| v.as_array_mut()) {
+            sections.push(json!({
+                "id": "fdd-sql-run",
+                "type": "fdd_sql_run",
+                "title": "SQL FDD run results",
+                "visible": true,
+                "order": 50,
+                "content": {
+                    "rule_name": rule_name,
+                    "equipment_id": equipment_id,
+                    "fault_code": fault_code,
+                    "sql": sql,
+                    "row_count": row_count,
+                    "raw_fault_count": raw_count,
+                    "confirmed_fault_count": confirmed_count,
+                    "confirmation": confirmation,
+                    "sample_rows": sample_rows,
+                }
+            }));
+        }
+        let _ = save_report(&report_id, &saved);
+    }
+    let pdf = render_pdf_bundle(&report_id);
+    json!({
+        "ok": true,
+        "report_id": report_id,
+        "rule_name": rule_name,
+        "confirmed_fault_count": confirmed_count,
+        "raw_fault_count": raw_count,
+        "dashboard_url": "/",
+        "pdf": pdf,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -841,6 +931,42 @@ mod tests {
 
         let del = delete_report(rid);
         assert_eq!(del["ok"], true);
+        std::env::remove_var("OPENFDD_WORKSPACE");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn from_fdd_sql_run_creates_report() {
+        let _guard = workspace_test_lock();
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let n = NEXT.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ofdd-fdd-report-{}-{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", tmp.to_string_lossy().as_ref());
+
+        let out = from_fdd_sql_run(&json!({
+            "rule_name": "OA temp high",
+            "sql": "SELECT timestamp, oa_t FROM telemetry_pivot",
+            "equipment_id": "equip:test",
+            "fault_code": "OA_TEMP",
+            "run_result": {
+                "row_count": 2,
+                "confirmation": {"raw_fault_count": 1, "confirmed_fault_count": 1},
+                "rows": [{"timestamp": "2013-06-19T00:00:00Z", "confirmed_fault": true}]
+            }
+        }));
+        assert_eq!(
+            out.get("ok").and_then(|v| v.as_bool()),
+            Some(true),
+            "{out:?}"
+        );
+        assert_eq!(
+            out.get("confirmed_fault_count").and_then(|v| v.as_u64()),
+            Some(1)
+        );
+
         std::env::remove_var("OPENFDD_WORKSPACE");
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/edge/src/timeseries/mod.rs
+++ b/edge/src/timeseries/mod.rs
@@ -188,7 +188,7 @@ fn parse_ts(s: &str) -> Option<DateTime<Utc>> {
 }
 
 fn parse_hours(q: &str) -> i64 {
-    q.parse::<i64>().unwrap_or(24).clamp(1, 8760)
+    q.parse::<i64>().unwrap_or(24).clamp(1, 87600)
 }
 
 fn parse_keys(columns_param: &str) -> Vec<(String, String)> {
@@ -228,13 +228,23 @@ pub fn readings_json(params: &HashMap<String, String>) -> Value {
 
     let cutoff = Utc::now() - Duration::hours(hours);
     let rows: Vec<Value> = store::load_pivot_rows().unwrap_or_default();
-    let filtered: Vec<&Value> = rows
-        .iter()
-        .filter(|r| {
-            let ts = r.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
-            parse_ts(ts).map(|t| t >= cutoff).unwrap_or(true)
-        })
-        .collect();
+    let use_all = params
+        .get("all")
+        .is_some_and(|v| v == "true" || v == "1" || v == "yes");
+    let mut filtered: Vec<&Value> = if use_all {
+        rows.iter().collect()
+    } else {
+        rows.iter()
+            .filter(|r| {
+                let ts = r.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+                parse_ts(ts).map(|t| t >= cutoff).unwrap_or(true)
+            })
+            .collect()
+    };
+    // Historical CSV imports (e.g. 2013–2018) fall outside the default hours window.
+    if filtered.is_empty() && !rows.is_empty() && !use_all {
+        filtered = rows.iter().collect();
+    }
 
     if filtered.is_empty() {
         return json!({
@@ -394,5 +404,11 @@ mod tests {
     fn readings_requires_columns() {
         let v = readings_json(&HashMap::new());
         assert!(v.get("error").is_some());
+    }
+
+    #[test]
+    fn parse_hours_accepts_multi_year_window() {
+        assert_eq!(parse_hours("8760"), 8760);
+        assert_eq!(parse_hours("87600"), 87600);
     }
 }

--- a/edge/tests/csv_ingest_tests.rs
+++ b/edge/tests/csv_ingest_tests.rs
@@ -145,6 +145,44 @@ fn resample_kw_hourly_averages() {
 }
 
 #[test]
+fn timezone_column_not_timestamp_candidate() {
+    use open_fdd_edge_prototype::csv_ingest::timestamp::is_timestamp_candidate;
+    assert!(!is_timestamp_candidate("timezone"));
+    assert!(is_timestamp_candidate("time_local"));
+}
+
+#[test]
+fn join_schools_then_weather() {
+    let kw_csv = include_str!("fixtures/csv_ingest/school_kw_sample.csv");
+    let wx_csv = include_str!("fixtures/csv_ingest/weather_hourly_sample.csv");
+    let kw_map = FileMapping {
+        filename: "school_a.csv".into(),
+        timestamp_column: "Date".into(),
+        timezone: "America/Chicago".into(),
+        value_columns: vec!["kW".into()],
+    };
+    let kw_map_b = FileMapping {
+        filename: "school_b.csv".into(),
+        timestamp_column: "Date".into(),
+        timezone: "America/Chicago".into(),
+        value_columns: vec!["kW".into()],
+    };
+    let wx_map = FileMapping {
+        filename: "open_meteo_weather.csv".into(),
+        timestamp_column: "time_local".into(),
+        timezone: "America/Chicago".into(),
+        value_columns: vec!["temp_f".into(), "humidity".into()],
+    };
+    let left_a = parse_file_to_rows(kw_csv, &kw_map, ',', "first").unwrap();
+    let left_b = parse_file_to_rows(kw_csv, &kw_map_b, ',', "first").unwrap();
+    let left = append_rows(vec![left_a, left_b]);
+    let right = parse_file_to_rows(wx_csv, &wx_map, ',', "first").unwrap();
+    let joined = join_rows(left, right, JoinAlignment::FloorHour, FillPolicy::Forward).unwrap();
+    assert!(!joined.is_empty());
+    assert!(joined[0].values.contains_key("temp_f") || joined[0].values.contains_key("kW"));
+}
+
+#[test]
 fn plan_api_append_mode() {
     with_temp_workspace(|_| {
         use base64::Engine;
@@ -174,5 +212,15 @@ fn plan_api_append_mode() {
         });
         let planned = open_fdd_edge_prototype::csv_ingest::plan_handler(&plan_body);
         assert_eq!(planned.get("ok").and_then(|v| v.as_bool()), Some(true));
+        let fusion = open_fdd_edge_prototype::csv_ingest::fusion_preview_handler(sid, 50);
+        assert_eq!(fusion.get("ok").and_then(|v| v.as_bool()), Some(true));
+        assert!(
+            fusion
+                .get("row_count")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                >= 1
+        );
+        assert!(fusion.get("columns").and_then(|v| v.as_array()).is_some());
     });
 }

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -16,6 +16,10 @@ Use **commission** API (`OPENFDD_COMMISSION_BASE`, default `http://127.0.0.1:909
 
 See repository doc `docs/agent/bench-driver-setup-wsl-agent.md` for WSL agent workflow, validation script `./scripts/openfdd_drivers_validate.sh`, and parity targets.
 
+## Model (Haystack RDF)
+
+Use `openfdd_model_sparql_catalog` then `openfdd_model_sparql` with a SELECT query. Do not scan `/api/model/haystack` rows in agent logic when SPARQL suffices.
+
 ## Safety
 
 Phase 2 write tools are **not** implemented. Never log tokens or Haystack passwords.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -88,19 +88,23 @@ docker run -i --rm --network host \
   ghcr.io/bbartling/openfdd-mcp:latest
 ```
 
-## Tools (phase 1)
+## Tools
 
 | Tool | Description |
 |------|-------------|
-| `openfdd_bench_topology` | Bench layout from `OPENFDD_BENCH_TOPOLOGY_FILE` or doc pointer |
-| `openfdd_driver_status` | Haystack / Modbus / BACnet / JSON API status bundle |
 | `openfdd_health` | Bridge liveness |
-| `openfdd_haystack_status` | Haystack gateway config (redacted) |
+| `openfdd_driver_status` | Driver status bundle |
+| `openfdd_bench_topology` | Bench layout file or doc pointer |
+| `openfdd_haystack_status` | Haystack gateway status |
 | `openfdd_haystack_test` | Connection test |
-| `openfdd_haystack_read` | Filter or ids read |
+| `openfdd_haystack_read` | Haystack read by filter or ids |
 | `openfdd_bacnet_read` | Commission BACnet point read |
+| `openfdd_model_sparql_catalog` | Predefined SPARQL queries |
+| `openfdd_model_sparql` | Execute SPARQL SELECT on Haystack RDF |
+| `openfdd_model_sites` | Site list |
+| `openfdd_model_coverage` | Mapped vs unmapped points |
 
-Full contract: [docs/agent/openfdd-mcp-tool-contract.md](../docs/agent/openfdd-mcp-tool-contract.md)
+Contract: [docs/agent/openfdd-mcp-tool-contract.md](../docs/agent/openfdd-mcp-tool-contract.md)
 
 Bench agent prompt: [docs/agent/bench-driver-setup-wsl-agent.md](../docs/agent/bench-driver-setup-wsl-agent.md)
 

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -66,6 +66,16 @@ impl Server {
             tool("openfdd_haystack_test", "POST /api/haystack/test", json!({})),
             tool("openfdd_haystack_read", "POST /api/haystack/read", json!({"filter": {"type": "string"}})),
             tool("openfdd_bacnet_read", "BACnet read via commission API", json!({"point_id": {"type": "string"}})),
+            tool("openfdd_model_sparql_catalog", "GET /api/model/sparql/predefined — Haystack RDF query catalog", json!({})),
+            tool("openfdd_model_sparql", "POST /api/model/sparql — read-only SELECT over Haystack RDF", json!({"query": {"type": "string"}})),
+            tool("openfdd_model_sites", "GET /api/model/sites", json!({})),
+            tool("openfdd_model_coverage", "GET /api/dashboard/model-coverage", json!({})),
+            tool("openfdd_csv_fusion_preview", "GET /api/csv/import/sessions/{id}/fusion-preview — merged CSV grid for browser review", json!({"session_id": {"type": "string"}, "limit": {"type": "integer"}})),
+            tool("openfdd_csv_latest_planned", "GET /api/csv/import/sessions/latest/planned — most recent UT3 plan ready for fusion preview", json!({})),
+            tool("openfdd_csv_sessions", "GET /api/csv/import/sessions — list recent import sessions", json!({"limit": {"type": "integer"}})),
+            tool("openfdd_csv_import_execute", "POST /api/csv/import/execute — save planned session to Arrow + historian (human confirms after preview)", json!({"session_id": {"type": "string"}})),
+            tool("openfdd_datasets", "GET /api/datasets — list Feather/Arrow datasets in registry", json!({})),
+            tool("openfdd_timeseries_series", "GET /api/timeseries/series — plot catalog after CSV save", json!({"site_id": {"type": "string"}})),
         ]
     }
 
@@ -84,6 +94,55 @@ impl Server {
             "openfdd_haystack_test" => self.bridge.post("/api/haystack/test", &json!({}))?,
             "openfdd_haystack_read" => self.bridge.haystack_read(&args)?,
             "openfdd_bacnet_read" => self.bridge.bacnet_read(&args)?,
+            "openfdd_model_sparql_catalog" => self.bridge.get("/api/model/sparql/predefined")?,
+            "openfdd_model_sparql" => {
+                let query = args
+                    .get("query")
+                    .and_then(|v| v.as_str())
+                    .ok_or("query required")?;
+                self.bridge
+                    .post("/api/model/sparql", &json!({ "query": query }))?
+            }
+            "openfdd_model_sites" => self.bridge.get("/api/model/sites")?,
+            "openfdd_model_coverage" => self.bridge.get("/api/dashboard/model-coverage")?,
+            "openfdd_csv_fusion_preview" => {
+                let session_id = args
+                    .get("session_id")
+                    .and_then(|v| v.as_str())
+                    .ok_or("session_id required")?;
+                let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(2000);
+                self.bridge.get(&format!(
+                    "/api/csv/import/sessions/{session_id}/fusion-preview?limit={limit}"
+                ))?
+            }
+            "openfdd_csv_latest_planned" => {
+                self.bridge.get("/api/csv/import/sessions/latest/planned")?
+            }
+            "openfdd_csv_sessions" => {
+                let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20);
+                self.bridge
+                    .get(&format!("/api/csv/import/sessions?limit={limit}"))?
+            }
+            "openfdd_csv_import_execute" => {
+                let session_id = args
+                    .get("session_id")
+                    .and_then(|v| v.as_str())
+                    .ok_or("session_id required")?;
+                self.bridge.post(
+                    "/api/csv/import/execute",
+                    &json!({ "session_id": session_id, "confirm": true }),
+                )?
+            }
+            "openfdd_datasets" => self.bridge.get("/api/datasets")?,
+            "openfdd_timeseries_series" => {
+                let site = args.get("site_id").and_then(|v| v.as_str()).unwrap_or("");
+                if site.is_empty() {
+                    self.bridge.get("/api/timeseries/series")?
+                } else {
+                    self.bridge
+                        .get(&format!("/api/timeseries/series?site_id={site}"))?
+                }
+            }
             other => return Err(format!("unknown tool: {other}")),
         };
 

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { Link, NavLink, Outlet, useNavigate } from "react-router-dom";
 import { clearToken, fetchAuthMe, fetchAuthStatus, getBridgeBase, hasToken } from "../lib/api";
 import { useTheme } from "../contexts/theme-context";
 import StackStatusStrip from "./StackStatusStrip";
@@ -59,7 +59,7 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   {
     title: "Settings",
     items: [
-      { to: "/agent", icon: "🤖", label: "AI Agent", protected: true, disabled: true, disabledHint: "Coming soon — Ollama & Codex" },
+      { to: "/agent", icon: "⎇", label: "MCP / Agent", protected: true },
     ],
   },
 ];
@@ -135,6 +135,12 @@ export default function AppLayout() {
               {roleChip}
             </span>
           ) : null}
+          <Link to="/agent" className="brand-mcp-link" title="MCP tools for Cursor / Codex">
+            <span className="brand-mcp-icon" aria-hidden="true">
+              ⎇
+            </span>
+            MCP
+          </Link>
         </div>
         <p className="sidebar-hint">Building summary is public; sign in to browse all tabs (operator read-only).</p>
         <StackStatusStrip />

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -123,24 +123,22 @@ export default function AppLayout() {
   return (
     <div className="app-shell">
       <aside className="sidebar">
-        <div className="brand-row">
-          <span className="brand">Open-FDD</span>
-          {edgeVersion ? (
-            <span className="brand-chip muted" title="Edge release">
-              v{edgeVersion}
-            </span>
-          ) : null}
-          {roleChip ? (
-            <span className="brand-chip" title={sessionUser ? `${sessionUser}` : undefined}>
-              {roleChip}
-            </span>
-          ) : null}
-          <Link to="/agent" className="brand-mcp-link" title="MCP tools for Cursor / Codex">
-            <span className="brand-mcp-icon" aria-hidden="true">
-              ⎇
-            </span>
-            MCP
-          </Link>
+        <div className="brand-block">
+          <div className="brand-row">
+            <span className="brand">Open-FDD</span>
+            <div className="brand-meta">
+              {edgeVersion ? (
+                <span className="brand-chip muted" title="Edge release">
+                  v{edgeVersion}
+                </span>
+              ) : null}
+              {roleChip ? (
+                <span className="brand-chip" title={sessionUser ? `${sessionUser}` : undefined}>
+                  {roleChip}
+                </span>
+              ) : null}
+            </div>
+          </div>
         </div>
         <p className="sidebar-hint">Building summary is public; sign in to browse all tabs (operator read-only).</p>
         <StackStatusStrip />

--- a/workspace/dashboard/src/components/CsvAgentSessionPanel.tsx
+++ b/workspace/dashboard/src/components/CsvAgentSessionPanel.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { hasToken } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+import {
+  datasetFromFusionPreview,
+  fetchAgentSessionFusionPreview,
+  fetchLatestPlannedSession,
+  saveAgentSessionToArrow,
+  type FusionPreviewResponse,
+} from "../lib/csvAgentSession";
+import type { CsvDataset } from "../lib/csvWorkbench";
+
+type Props = {
+  onLoaded: (dataset: CsvDataset, sessionId: string, meta: FusionPreviewResponse) => void;
+  activeSessionId?: string;
+  suggestedSessionId?: string;
+  onSaved?: (info: { datasetId?: string; plotUrl?: string; modelUrl?: string; siteId?: string }) => void;
+};
+
+export default function CsvAgentSessionPanel({
+  onLoaded,
+  activeSessionId,
+  suggestedSessionId,
+  onSaved,
+}: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [sessionInput, setSessionInput] = useState(searchParams.get("session") ?? suggestedSessionId ?? "");
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+  const [meta, setMeta] = useState<FusionPreviewResponse | null>(null);
+  const [saveLinks, setSaveLinks] = useState<{ plot?: string; model?: string; datasetId?: string } | null>(null);
+  const loadedUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (suggestedSessionId && !searchParams.get("session")) {
+      setSessionInput(suggestedSessionId);
+    }
+  }, [suggestedSessionId, searchParams]);
+
+  const loadSession = useCallback(
+    async (sessionId: string) => {
+      const id = sessionId.trim();
+      if (!id) {
+        setError("Upload CSVs in UT3 panel above, then click Preview plan — the session ID appears in green.");
+        return;
+      }
+      if (!hasToken()) {
+        setError("Sign in to load agent-cleaned sessions.");
+        return;
+      }
+      setBusy("Loading agent preview…");
+      setError("");
+      setSaveLinks(null);
+      try {
+        const data = await fetchAgentSessionFusionPreview(id);
+        if (!data.ok) {
+          const hint =
+            data.error === "unknown endpoint"
+              ? " Edge needs rebuild/restart — session API routes missing on :8080."
+              : "";
+          throw new Error((data.error ?? "load failed") + hint);
+        }
+        const ds = datasetFromFusionPreview(data, id);
+        setMeta(data);
+        onLoaded(ds, id, data);
+        loadedUrlRef.current = id;
+        setSearchParams({ session: id }, { replace: true });
+      } catch (e) {
+        setError(formatApiError(e));
+        setMeta(null);
+      } finally {
+        setBusy("");
+      }
+    },
+    [onLoaded, setSearchParams],
+  );
+
+  useEffect(() => {
+    const fromUrl = searchParams.get("session");
+    if (!fromUrl || !hasToken() || loadedUrlRef.current === fromUrl) return;
+    void loadSession(fromUrl);
+  }, [searchParams, loadSession]);
+
+  useEffect(() => {
+    if (
+      suggestedSessionId &&
+      hasToken() &&
+      loadedUrlRef.current !== suggestedSessionId &&
+      !searchParams.get("session")
+    ) {
+      void loadSession(suggestedSessionId);
+    }
+  }, [suggestedSessionId, loadSession, searchParams]);
+
+  async function saveToArrow() {
+    const sid = activeSessionId ?? meta?.session_id;
+    if (!sid) return;
+    setBusy("Saving to Arrow store…");
+    setError("");
+    try {
+      const out = await saveAgentSessionToArrow(sid);
+      if (!out.ok) throw new Error(out.error ?? "save failed");
+      const sync = out.historian_sync;
+      setSaveLinks({
+        plot: sync?.plot_url,
+        model: sync?.model_url,
+        datasetId: out.dataset?.id,
+      });
+      onSaved?.({
+        datasetId: out.dataset?.id,
+        plotUrl: sync?.plot_url,
+        modelUrl: sync?.model_url,
+        siteId: sync?.site_id,
+      });
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  return (
+    <section className="panel csv-agent-session-panel">
+      <h3 className="panel-title">Agent-cleaned data → fusion preview</h3>
+      <p className="muted">
+        Workflow: AI/MCP cleans &amp; plans → you review merged CSV here → save to Feather/Arrow → open{" "}
+        <Link to="/model">Model</Link> and <Link to="/plot">Plot</Link>. Share:{" "}
+        <code>/csv?session=&lt;session_id&gt;</code>
+      </p>
+      <div className="csv-agent-session-row">
+        <label className="field csv-agent-session-input">
+          <span className="field-label">Import session ID</span>
+          <input
+            value={sessionInput}
+            onChange={(e) => setSessionInput(e.target.value)}
+            placeholder="e.g. csv-1735123456789 (from UT3 Preview plan)"
+          />
+        </label>
+        <button type="button" className="secondary-btn" disabled={!!busy} onClick={() => void loadSession(sessionInput)}>
+          {busy.startsWith("Loading") ? busy : "Load into fusion tab"}
+        </button>
+        <button
+          type="button"
+          className="linkish-btn"
+          disabled={!!busy}
+          onClick={() =>
+            void fetchLatestPlannedSession().then((r) => {
+              if (r.session_id) {
+                setSessionInput(r.session_id);
+                void loadSession(r.session_id);
+              } else {
+                setError(
+                  r.error ??
+                    "No planned session — upload CSVs in UT3 panel above and click Preview plan first.",
+                );
+              }
+            })
+          }
+        >
+          Load latest agent session
+        </button>
+      </div>
+      {sessionInput ? (
+        <p className="muted csv-session-id-line">
+          Session ID: <code>{sessionInput}</code> ·{" "}
+          <a href={`/csv?session=${encodeURIComponent(sessionInput)}`}>/csv?session={sessionInput}</a>
+        </p>
+      ) : null}
+      {activeSessionId ? (
+        <div className="csv-agent-session-active">
+          <p className="ok">
+            Session <code>{activeSessionId}</code> loaded
+            {meta?.row_count != null ? (
+              <>
+                {" "}
+                — <strong>{meta.row_count.toLocaleString()}</strong> rows
+                {meta.truncated ? ` (showing ${meta.preview_row_count?.toLocaleString()} in preview)` : null}
+              </>
+            ) : null}
+          </p>
+          {meta?.validation_report?.warnings?.length ? (
+            <ul className="csv-agent-warnings">
+              {meta.validation_report.warnings.map((w) => (
+                <li key={w}>{w}</li>
+              ))}
+            </ul>
+          ) : null}
+          <button type="button" className="primary-btn" disabled={!!busy} onClick={() => void saveToArrow()}>
+            {busy.startsWith("Saving") ? busy : "Save to Arrow store (from session)"}
+          </button>
+          {saveLinks ? (
+            <p className="ok csv-save-links">
+              Saved dataset <code>{saveLinks.datasetId}</code>.{" "}
+              {saveLinks.model ? (
+                <>
+                  <Link to={saveLinks.model}>Open data model</Link>
+                  {" · "}
+                </>
+              ) : null}
+              {saveLinks.plot ? <Link to={saveLinks.plot}>Open plots</Link> : null}
+              {" · "}
+              <Link to="/sql-fdd">SQL FDD rules</Link> to tune rules on this data
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+      {error ? <p className="error">{error}</p> : null}
+    </section>
+  );
+}

--- a/workspace/dashboard/src/components/CsvDataAssistant.tsx
+++ b/workspace/dashboard/src/components/CsvDataAssistant.tsx
@@ -1,0 +1,50 @@
+import { Link } from "react-router-dom";
+
+type Props = {
+  mergeError?: string;
+  fileCount?: number;
+};
+
+export default function CsvDataAssistant({ mergeError, fileCount = 0 }: Props) {
+  const hasTimezoneError = mergeError?.includes("timezone");
+
+  return (
+    <section className="panel csv-assistant-panel">
+      <h3 className="panel-title">Data assistant</h3>
+      <p className="muted">
+        Use an external agent (Cursor + MCP) to profile columns, pick join keys, and draft merge recipes. In-app chat
+        is on the <Link to="/agent">MCP / Agent</Link> tab.
+      </p>
+      {hasTimezoneError ? (
+        <div className="csv-assistant-tip csv-assistant-tip--warn">
+          <strong>Fix:</strong> Change merge key from <code>timezone</code> to <code>Date</code> (kW files) or switch
+          operation to <strong>Append rows</strong>. For kW + weather join, use <strong>UT3 CSV Import</strong> with
+          mode Join and weather timestamp <code>time_local</code>.
+        </div>
+      ) : null}
+      {fileCount >= 4 && !mergeError ? (
+        <div className="csv-assistant-tip">
+          <strong>Tip:</strong> Four school-year files → UT3 mode <em>Append</em>, timestamp <code>Date</code>, value{" "}
+          <code>kW</code>. Client fusion: operation <em>Append rows</em>, merge key <code>Date</code>.
+        </div>
+      ) : null}
+      <details className="csv-assistant-mcp">
+        <summary>MCP tools for CSV &amp; model (Cursor)</summary>
+        <ul>
+          <li>
+            <code>openfdd_model_sparql</code> — list sites, equipment, points after commit
+          </li>
+          <li>
+            <code>openfdd_model_coverage</code> — mapped vs unmapped points
+          </li>
+          <li>
+            <code>openfdd_csv_fusion_preview</code> — load UT3/agent session into CSV tab (before Feather)
+          </li>
+        </ul>
+        <p className="muted">
+          Setup: <Link to="/agent">MCP / Agent</Link> · repo <code>mcp/README.md</code>
+        </p>
+      </details>
+    </section>
+  );
+}

--- a/workspace/dashboard/src/components/CsvUt3ImportPanel.tsx
+++ b/workspace/dashboard/src/components/CsvUt3ImportPanel.tsx
@@ -65,7 +65,13 @@ async function fileToBase64(file: File): Promise<string> {
   return btoa(binary);
 }
 
-export default function CsvUt3ImportPanel() {
+type Props = {
+  onPlanReady?: (sessionId: string) => void;
+  onOpenInFusion?: (sessionId: string) => void;
+  autoOpenFusion?: boolean;
+};
+
+export default function CsvUt3ImportPanel({ onPlanReady, onOpenInFusion, autoOpenFusion = true }: Props) {
   const [files, setFiles] = useState<FileProfile[]>([]);
   const [sessionId, setSessionId] = useState("");
   const [busy, setBusy] = useState("");
@@ -114,12 +120,27 @@ export default function CsvUt3ImportPanel() {
       if (!out.ok && !out.session_id) throw new Error(out.error ?? "preview failed");
       setSessionId(out.session_id ?? "");
       setFiles(out.files ?? []);
-      const first = out.files?.[0]?.profile;
+      const profiles = out.files ?? [];
+      const first = profiles[0]?.profile;
+      const weather = profiles.find((f) => /meteo|weather|open_meteo/i.test(f.filename));
+      const school = profiles.find((f) => /school|kw/i.test(f.filename));
       if (first?.headers?.length) {
         const tsCand = first.timestamp_candidates?.[0]?.[0];
         if (tsCand != null && first.headers[tsCand]) setTsCol(first.headers[tsCand]!);
         const vals = first.headers.filter((h) => h !== first.headers![tsCand ?? 0]).slice(0, 3);
         if (vals.length) setValueCols(vals.join(", "));
+      }
+      if (school?.profile?.headers?.includes("Date")) setTsCol("Date");
+      if (weather?.profile?.headers?.includes("time_local")) setWxTsCol("time_local");
+      else if (weather?.profile?.headers?.includes("timezone")) {
+        setWxTsCol(weather.profile.headers.find((h) => h === "time_local") ?? "time_local");
+      }
+      if (profiles.length >= 4 && profiles.filter((f) => /school|kw/i.test(f.filename)).length >= 2) {
+        setMode("append");
+        setDatasetName("school_kw_merged");
+      } else if (school && weather) {
+        setMode("join");
+        setJoinAlign("floor_hour");
       }
     } catch (e) {
       setError(formatApiError(e));
@@ -138,27 +159,39 @@ export default function CsvUt3ImportPanel() {
     try {
       const fileMappings =
         mode === "join" && files.length >= 2
-          ? [
-              {
-                filename: files[0]!.filename,
-                timestamp_column: tsCol,
+          ? (() => {
+              const weatherFile =
+                files.find((f) => /meteo|weather|open_meteo/i.test(f.filename)) ?? files[files.length - 1]!;
+              const schoolFiles = files.filter(
+                (f) => f !== weatherFile && !/meteo|weather|open_meteo/i.test(f.filename),
+              );
+              const schools = schoolFiles.length ? schoolFiles : [files[0]!];
+              return [
+                ...schools.map((f) => ({
+                  filename: f.filename,
+                  timestamp_column: f.profile?.headers?.includes("Date") ? "Date" : tsCol,
+                  timezone,
+                  value_columns: valueCols.split(",").map((s) => s.trim()).filter(Boolean),
+                })),
+                {
+                  filename: weatherFile.filename,
+                  timestamp_column: weatherFile.profile?.headers?.includes("time_local") ? "time_local" : wxTsCol,
+                  timezone,
+                  value_columns:
+                    weatherFile.profile?.headers
+                      ?.filter((h) => h !== "time_local" && h !== "timezone" && h !== "Date")
+                      .slice(0, 12) ?? [],
+                },
+              ];
+            })()
+          : files
+              .filter((f) => mode !== "append" || !/meteo|weather|open_meteo/i.test(f.filename))
+              .map((f) => ({
+                filename: f.filename,
+                timestamp_column: f.profile?.headers?.includes("Date") ? "Date" : tsCol,
                 timezone,
                 value_columns: valueCols.split(",").map((s) => s.trim()).filter(Boolean),
-              },
-              {
-                filename: files[1]!.filename,
-                timestamp_column: wxTsCol,
-                timezone,
-                value_columns:
-                  files[1]?.profile?.headers?.filter((h) => h !== wxTsCol).slice(0, 8) ?? [],
-              },
-            ]
-          : files.map((f) => ({
-              filename: f.filename,
-              timestamp_column: tsCol,
-              timezone,
-              value_columns: valueCols.split(",").map((s) => s.trim()).filter(Boolean),
-            }));
+              }));
 
       const out = await apiFetch<{
         ok?: boolean;
@@ -182,12 +215,14 @@ export default function CsvUt3ImportPanel() {
       if (!out.ok) throw new Error(out.error ?? "plan failed");
       setPreview(out.preview ?? null);
       setValidation(out.validation_report ?? null);
+      if (sessionId && onPlanReady) onPlanReady(sessionId);
+      if (sessionId && autoOpenFusion && onOpenInFusion) onOpenInFusion(sessionId);
     } catch (e) {
       setError(formatApiError(e));
     } finally {
       setBusy("");
     }
-  }, [sessionId, mode, files, tsCol, wxTsCol, timezone, valueCols, datasetName, fillPolicy, joinAlign]);
+  }, [sessionId, mode, files, tsCol, wxTsCol, timezone, valueCols, datasetName, fillPolicy, joinAlign, onPlanReady, onOpenInFusion, autoOpenFusion]);
 
   const executeSave = useCallback(async () => {
     if (!sessionId) return;
@@ -250,6 +285,16 @@ export default function CsvUt3ImportPanel() {
         <span>Drop CSV files or click to browse</span>
       </div>
 
+      {sessionId ? (
+        <p className="ok csv-session-id-line">
+          <strong>Rust import session:</strong> <code>{sessionId}</code>
+          {" · "}
+          <a href={`/csv?session=${encodeURIComponent(sessionId)}`}>fusion preview link</a>
+          {" · "}
+          shown after upload — agent uses this ID to reload your cleaned merge
+        </p>
+      ) : null}
+
       {files.length > 0 && (
         <div className="csv-ut3-files">
           <h3>File profiles</h3>
@@ -281,6 +326,19 @@ export default function CsvUt3ImportPanel() {
             </tbody>
           </table>
         </div>
+      )}
+
+      {mode === "join" && files.length > 2 && (
+        <p className="muted csv-ut3-hint">
+          Join uses one kW file + weather file (auto-selected by filename). Other files are ignored in join mode — use
+          Append to stack all school years first.
+        </p>
+      )}
+      {mode === "append" && files.some((f) => /meteo|weather/i.test(f.filename)) && (
+        <p className="muted csv-ut3-hint">
+          Append mode skips weather files. Use Join to add Open-Meteo columns, or remove weather from the upload for
+          append-only.
+        </p>
       )}
 
       <div className="csv-ut3-controls grid-2">
@@ -348,6 +406,11 @@ export default function CsvUt3ImportPanel() {
         <button type="button" disabled={!!busy || !sessionId} onClick={() => void buildPlan()}>
           Preview plan
         </button>
+        {preview && sessionId && onOpenInFusion ? (
+          <button type="button" className="secondary-btn" disabled={!!busy} onClick={() => onOpenInFusion(sessionId)}>
+            Open in fusion preview
+          </button>
+        ) : null}
         <button type="button" disabled={!!busy || !preview} onClick={() => void executeSave()}>
           Save to Arrow store
         </button>

--- a/workspace/dashboard/src/components/CsvWorkflowGuide.tsx
+++ b/workspace/dashboard/src/components/CsvWorkflowGuide.tsx
@@ -1,0 +1,58 @@
+type Props = {
+  variant: "ut3" | "fusion";
+};
+
+export default function CsvWorkflowGuide({ variant }: Props) {
+  if (variant === "ut3") {
+    return (
+      <section className="panel csv-workflow-guide">
+        <h3 className="panel-title">How to use UT3 import (recommended)</h3>
+        <ol className="csv-workflow-steps">
+          <li>
+            <strong>Upload</strong> CSV files (sign in as integrator).
+          </li>
+          <li>
+            <strong>Choose mode:</strong> <em>Append</em> stacks school-year kW files on <code>Date</code>.{" "}
+            <em>Join</em> merges one kW file with weather (uses file 1 + file 2 only).
+          </li>
+          <li>
+            Set <strong>Timestamp column</strong> to <code>Date</code> for kW · <code>time_local</code> for Open-Meteo
+            weather.
+          </li>
+          <li>
+            <strong>Preview plan</strong>, then <strong>Open in fusion preview</strong> (or share <code>/csv?session=…</code>)
+          </li>
+          <li>
+            Review merged table in fusion wiresheet, then <strong>Save to Arrow store (session)</strong>
+          </li>
+        </ol>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel csv-workflow-guide">
+      <h3 className="panel-title">Client fusion (quick preview &amp; historian commit)</h3>
+      <ol className="csv-workflow-steps">
+        <li>
+          <strong>Drop CSV files</strong> below (browser-only parse).
+        </li>
+        <li>
+          <strong>Append rows</strong> — stack files that share the same columns (e.g. four school-year kW files on{" "}
+          <code>Date</code>).
+        </li>
+        <li>
+          <strong>Join on key</strong> — only when every file has the <em>same</em> timestamp column name. Different
+          names (e.g. <code>Date</code> vs <code>time_local</code>) → use UT3 import above.
+        </li>
+        <li>
+          Check <strong>Merged preview</strong>, map FDD inputs, then <strong>Commit → historian + model</strong>.
+        </li>
+      </ol>
+      <p className="muted csv-workflow-note">
+        <code>timezone</code> is a label column in weather files, not a timestamp — use <code>Date</code> or{" "}
+        <code>time_local</code> as the merge key.
+      </p>
+    </section>
+  );
+}

--- a/workspace/dashboard/src/components/StackStatusStrip.tsx
+++ b/workspace/dashboard/src/components/StackStatusStrip.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useDashboardStream, type ServiceStatus } from "../lib/dashboardStream";
 
 function StatusDot({
@@ -5,19 +6,29 @@ function StatusDot({
   label,
   title,
   disabled,
+  href,
 }: {
   status: ServiceStatus;
   label: string;
   title?: string;
   disabled?: boolean;
+  href?: string;
 }) {
   const pillClass = disabled ? "status-disabled" : `status-${status}`;
-  return (
+  const pill = (
     <span className={`status-pill ${pillClass}`} title={title ?? label}>
       <span className={`status-dot status-dot-${disabled ? "gray" : status}`} aria-hidden />
       {label}
     </span>
   );
+  if (href && !disabled) {
+    return (
+      <Link to={href} className="stack-strip-link">
+        {pill}
+      </Link>
+    );
+  }
+  return pill;
 }
 
 export default function StackStatusStrip() {
@@ -44,22 +55,23 @@ export default function StackStatusStrip() {
   return (
     <div className="stack-strip" aria-label="Stack health">
       <div className="stack-strip-label">Data plane</div>
-      {stack.services.map((svc) => {
-        const off = svc.configured === false || svc.status === "gray";
-        const detail =
-          typeof svc.detail === "string"
-            ? svc.detail
-            : JSON.stringify(svc.detail);
-        return (
-          <StatusDot
-            key={svc.id}
-            status={off ? "gray" : svc.status}
-            disabled={off}
-            label={off ? `${svc.label} · off` : svc.label}
-            title={off ? `${detail} (not an error — disabled in this profile)` : detail}
-          />
-        );
-      })}
+      <div className="stack-strip-pills">
+        {stack.services.map((svc) => {
+          const off = svc.configured === false || svc.status === "gray";
+          const detail =
+            typeof svc.detail === "string" ? svc.detail : JSON.stringify(svc.detail);
+          return (
+            <StatusDot
+              key={svc.id}
+              status={off ? "gray" : svc.status}
+              disabled={off}
+              label={off ? `${svc.label} · off` : svc.label}
+              title={off ? `${detail} (not an error — disabled in this profile)` : detail}
+              href={svc.href}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/workspace/dashboard/src/lib/csvAgentSession.ts
+++ b/workspace/dashboard/src/lib/csvAgentSession.ts
@@ -1,0 +1,83 @@
+/** Load agent / UT3 import session into client fusion preview (before Feather save). */
+
+import { apiFetch } from "./api";
+import { datasetsToCsv, type CsvDataset } from "./csvWorkbench";
+
+export type FusionPreviewResponse = {
+  ok?: boolean;
+  error?: string;
+  session_id?: string;
+  dataset_name?: string;
+  row_count?: number;
+  preview_row_count?: number;
+  truncated?: boolean;
+  columns?: string[];
+  rows?: string[][];
+  validation_report?: { warnings?: string[] };
+  fusion_url_hint?: string;
+};
+
+export async function fetchAgentSessionFusionPreview(
+  sessionId: string,
+  limit = 2000,
+): Promise<FusionPreviewResponse> {
+  return apiFetch<FusionPreviewResponse>(
+    `/api/csv/import/sessions/${encodeURIComponent(sessionId)}/fusion-preview?limit=${limit}`,
+  );
+}
+
+export function datasetFromFusionPreview(
+  data: FusionPreviewResponse,
+  sessionId: string,
+): CsvDataset {
+  const columns = data.columns ?? [];
+  const allRows = data.rows ?? [];
+  const name = `${data.dataset_name ?? "agent-cleaned"}-${sessionId.slice(0, 8)}.csv`;
+  const fullText = datasetsToCsv(columns, allRows);
+  const tsCol =
+    columns.find((c) => c === "ts_local" || c === "Date" || c.toLowerCase().includes("date")) ??
+    columns[0] ??
+    null;
+  return {
+    id: `agent-${sessionId}`,
+    name,
+    columns,
+    rows: allRows.slice(0, 500),
+    allRows,
+    rowCount: data.row_count ?? allRows.length,
+    bytes: fullText.length,
+    timestampColumn: tsCol,
+    fullText,
+  };
+}
+
+export async function fetchLatestPlannedSession(): Promise<{
+  ok?: boolean;
+  session_id?: string;
+  fusion_url?: string;
+  session?: Record<string, unknown>;
+  error?: string;
+}> {
+  return apiFetch("/api/csv/import/sessions/latest/planned");
+}
+
+export async function saveAgentSessionToArrow(
+  sessionId: string,
+): Promise<{
+  ok?: boolean;
+  error?: string;
+  dataset?: { id?: string };
+  historian_sync?: {
+    ok?: boolean;
+    site_id?: string;
+    equipment_id?: string;
+    plot_url?: string;
+    model_url?: string;
+    rows_synced?: number;
+  };
+}> {
+  return apiFetch("/api/csv/import/execute", {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, confirm: true }),
+  });
+}

--- a/workspace/dashboard/src/lib/csvWorkbench.test.ts
+++ b/workspace/dashboard/src/lib/csvWorkbench.test.ts
@@ -4,6 +4,7 @@ import {
   fileToDataset,
   mergeDatasets,
   parseCsvText,
+  suggestMergeKey,
   splitCsvHorizontal,
   splitCsvVertical,
   type CsvDataset,
@@ -97,6 +98,21 @@ describe("csvWorkbench", () => {
     const merged = mergeDatasets([a, b], "Date", "inner");
     expect(merged.rowCount).toBe(1);
     expect(merged.rows[0][0]).toBe("2024-01-01");
+  });
+
+  it("does not treat timezone column as timestamp", () => {
+    const text = "time_local,temperature,timezone\n2024-01-01T00:00,32,America/Chicago\n";
+    const p = parseCsvText(text);
+    expect(p.timestampColumn).toBe("time_local");
+  });
+
+  it("suggestMergeKey prefers Date when school files differ from weather", () => {
+    const school = fileToDataset({ name: "School_2013_KW.csv", size: 1 } as File, "Date,kW\n1/1/13,100\n");
+    const weather = fileToDataset(
+      { name: "lake_geneva_open_meteo.csv", size: 1 } as File,
+      "time_local,temp,timezone\n2024-01-01T00:00,32,America/Chicago\n",
+    );
+    expect(suggestMergeKey([school, weather])).toBe("Date");
   });
 
   it("splits vertically and horizontally", () => {

--- a/workspace/dashboard/src/lib/csvWorkbench.ts
+++ b/workspace/dashboard/src/lib/csvWorkbench.ts
@@ -62,14 +62,45 @@ function splitCsvLine(line: string): string[] {
   return out;
 }
 
+const TIMESTAMP_EXCLUDE = new Set(["timezone", "time_zone", "tz", "iana_timezone", "utc_offset"]);
+
+function isLikelyTimestampColumn(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (TIMESTAMP_EXCLUDE.has(lower)) return false;
+  if (TS_CANDIDATES.some((t) => lower === t.toLowerCase())) return true;
+  if (lower === "time_local" || lower.endsWith("_local")) return true;
+  if (lower.includes("date")) return true;
+  if (lower.includes("time") && !lower.includes("zone")) return true;
+  return false;
+}
+
 function detectTimestampColumn(columns: string[]): string | null {
   for (const c of columns) {
-    const lower = c.toLowerCase();
-    if (TS_CANDIDATES.some((t) => lower === t.toLowerCase() || lower.includes("date") || lower.includes("time"))) {
-      return c;
+    if (isLikelyTimestampColumn(c)) return c;
+  }
+  const fallback = columns.find((c) => !TIMESTAMP_EXCLUDE.has(c.toLowerCase()));
+  return fallback ?? columns[0] ?? null;
+}
+
+/** Column name shared by all datasets that looks like a timestamp (for join). */
+export function suggestMergeKey(datasets: CsvDataset[]): string {
+  if (!datasets.length) return "Date";
+  if (datasets.length === 1) {
+    return datasets[0].timestampColumn ?? detectTimestampColumn(datasets[0].columns) ?? "Date";
+  }
+  const matchCounts = new Map<string, number>();
+  for (const ds of datasets) {
+    for (const col of ds.columns) {
+      if (!isLikelyTimestampColumn(col)) continue;
+      matchCounts.set(col, (matchCounts.get(col) ?? 0) + 1);
     }
   }
-  return columns[0] ?? null;
+  for (const [col, n] of matchCounts) {
+    if (n === datasets.length) return col;
+  }
+  if (datasets.some((d) => d.columns.includes("Date"))) return "Date";
+  const first = datasets[0];
+  return first.timestampColumn ?? detectTimestampColumn(first.columns) ?? "Date";
 }
 
 function dataRowsFromText(text: string): { columns: string[]; allRows: string[][] } {

--- a/workspace/dashboard/src/lib/dashboardStream.tsx
+++ b/workspace/dashboard/src/lib/dashboardStream.tsx
@@ -11,6 +11,7 @@ export type StackService = {
   configured: boolean;
   detail: string | Record<string, unknown>;
   url?: string;
+  href?: string;
 };
 
 export type StackHealth = {

--- a/workspace/dashboard/src/pages/AgentPage.tsx
+++ b/workspace/dashboard/src/pages/AgentPage.tsx
@@ -1,32 +1,74 @@
 import { Link } from "react-router-dom";
 import PageHeader from "../components/PageHeader";
+import { apiFetch, hasToken } from "../lib/api";
+import { useEffect, useState } from "react";
 
 export default function AgentPage() {
+  const [toolCount, setToolCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!hasToken()) return;
+    apiFetch<{ tools?: unknown[] }>("/api/agent/tools")
+      .then((j) => setToolCount(j.tools?.length ?? 0))
+      .catch(() => setToolCount(null));
+  }, []);
+
   return (
     <div className="page page-wide">
       <PageHeader
-        title="AI Agent"
-        subtitle="Ollama chat, Codex tools, and building-insight narratives — planned for a future release."
+        title="MCP / Agent"
+        subtitle="Connect Cursor or Codex to the Rust edge via the openfdd-mcp sidecar (read-first tools)."
       />
 
-      <div className="panel algorithms-coming-soon">
-        <p className="algorithms-badge">COMING SOON</p>
-        <h2>Interactive agent tab</h2>
-        <p className="muted">
-          This tab will host local Ollama chat, tool use against the Haystack model and historian, and optional
-          Codex-assisted commissioning. The Rust edge already exposes agent REST hooks for automation; operator chat
-          UI is not enabled in this build.
+      <section className="panel">
+        <h3 className="panel-title">Model Context Protocol (MCP)</h3>
+        <p>
+          MCP exposes JWT-authenticated bridge APIs as tools for external agents. Use it for Haystack SPARQL, driver
+          status, BACnet reads, and CSV/model workflows — not for unsupervised field-bus writes.
         </p>
         <ul>
-          <li>Building context from Haystack + SQL FDD rules</li>
-          <li>Commissioning JSON assist (import/export workflow)</li>
-          <li>Fault narrative and operator Q&amp;A</li>
+          <li>
+            <code>openfdd_model_sparql</code> — query the Haystack RDF model
+          </li>
+          <li>
+            <code>openfdd_model_coverage</code> — mapped vs unmapped points
+          </li>
+          <li>
+            <code>openfdd_haystack_read</code> · <code>openfdd_bacnet_read</code> — live OT reads
+          </li>
         </ul>
         <p className="muted">
-          Use <Link to="/sql-fdd">SQL FDD Rules</Link> and{" "}
-          <Link to="/live-fdd-validation">Live FDD Validation</Link> for bench proof today.
+          Setup: repository <code>mcp/README.md</code> · contract{" "}
+          <code>docs/agent/openfdd-mcp-tool-contract.md</code>
         </p>
-      </div>
+        {toolCount != null ? (
+          <p className="ok">
+            Bridge reports <strong>{toolCount}</strong> REST tools via <code>/api/agent/tools</code>.
+          </p>
+        ) : null}
+      </section>
+
+      <section className="panel">
+        <h3 className="panel-title">CSV data assistant (external agent)</h3>
+        <p className="muted">
+          For Lake Geneva–style UT3 merges, ask your agent to: profile uploads via{" "}
+          <code>POST /api/csv/import/preview</code>, run <code>POST /api/csv/import/plan</code>, validate row counts,
+          then save. On the CSV tab, prefer <strong>Append</strong> for four school-year kW files (
+          <code>Date</code> + <code>kW</code>).
+        </p>
+        <p>
+          <Link to="/csv">Open CSV Fusion / UT3 Import</Link>
+        </p>
+      </section>
+
+      <section className="panel">
+        <h3 className="panel-title">In-app chat (deferred)</h3>
+        <p className="muted">
+          Built-in Ollama operator chat is not enabled in 3.2.x. Use MCP + Cursor on the bench, or{" "}
+          <Link to="/sql-fdd">SQL FDD Rules</Link> and <Link to="/live-fdd-validation">Validation runs</Link> for
+          bench proof.
+        </p>
+      </section>
     </div>
   );
 }

--- a/workspace/dashboard/src/pages/CsvWorkbenchPage.tsx
+++ b/workspace/dashboard/src/pages/CsvWorkbenchPage.tsx
@@ -10,6 +10,7 @@ import {
   idsFromFilename,
   mergeDatasets,
   numericColumns,
+  suggestMergeKey,
   splitCsvHorizontal,
   splitCsvVertical,
   type CsvDataset,
@@ -17,6 +18,15 @@ import {
 } from "../lib/csvWorkbench";
 import CsvFusionWiresheet from "../wiresheet/CsvFusionWiresheet";
 import CsvUt3ImportPanel from "../components/CsvUt3ImportPanel";
+import CsvWorkflowGuide from "../components/CsvWorkflowGuide";
+import CsvDataAssistant from "../components/CsvDataAssistant";
+import CsvAgentSessionPanel from "../components/CsvAgentSessionPanel";
+import {
+  datasetFromFusionPreview,
+  fetchAgentSessionFusionPreview,
+  saveAgentSessionToArrow,
+  type FusionPreviewResponse,
+} from "../lib/csvAgentSession";
 
 type JobStatus = { ok?: boolean; job_id?: string; rows_committed?: number };
 type ModelPreview = {
@@ -56,6 +66,40 @@ export default function CsvWorkbenchPage() {
   const [ruleOp, setRuleOp] = useState(">");
   const [ruleThreshold, setRuleThreshold] = useState("75");
   const [purgeConfirm, setPurgeConfirm] = useState("");
+  const [ut3SessionId, setUt3SessionId] = useState("");
+  const [agentMeta, setAgentMeta] = useState<FusionPreviewResponse | null>(null);
+
+  const loadAgentSession = useCallback((ds: CsvDataset, sessionId: string, meta: FusionPreviewResponse) => {
+    setUt3SessionId(sessionId);
+    setAgentMeta(meta);
+    setDatasets([ds]);
+    setMergeKey(ds.timestampColumn ?? "ts_local");
+    setMergeMode("append");
+    setStatus(
+      `Agent session loaded — ${meta.row_count?.toLocaleString() ?? ds.rowCount.toLocaleString()} rows. Review preview, then Save to Arrow.`,
+    );
+    setError("");
+  }, []);
+
+  const openFusionFromSession = useCallback(
+    async (sessionId: string) => {
+      if (!hasToken()) {
+        setError("Sign in to load sessions.");
+        return;
+      }
+      setBusy("agent-load");
+      try {
+        const data = await fetchAgentSessionFusionPreview(sessionId);
+        if (!data.ok) throw new Error(data.error ?? "load failed");
+        loadAgentSession(datasetFromFusionPreview(data, sessionId), sessionId, data);
+      } catch (e) {
+        setError(formatApiError(e));
+      } finally {
+        setBusy("");
+      }
+    },
+    [loadAgentSession],
+  );
 
   const commitFilename = useMemo(() => {
     if (datasets.length === 1) return datasets[0].name;
@@ -155,8 +199,16 @@ export default function CsvWorkbenchPage() {
       for (const file of list) {
         added.push(fileToDataset(file, await file.text()));
       }
-      setDatasets((prev) => [...prev, ...added]);
-      if (added[0]?.timestampColumn) setMergeKey(added[0].timestampColumn);
+      setDatasets((prev) => {
+        const next = [...prev, ...added];
+        setMergeKey(suggestMergeKey(next));
+        const allHaveDate = next.every((d) => d.columns.includes("Date"));
+        const hasWeather = next.some((d) => /meteo|weather|open_meteo/i.test(d.name));
+        if (next.length > 1 && allHaveDate && !hasWeather) {
+          setMergeMode("append");
+        }
+        return next;
+      });
       setStatus(`Loaded ${added.length} file(s).`);
     } catch (e) {
       setError(formatApiError(e));
@@ -358,7 +410,31 @@ export default function CsvWorkbenchPage() {
         subtitle="Server-side Rust ingest (append, join, DST-aware timestamps, Arrow save) or client fusion wiresheet below."
       />
 
-      <CsvUt3ImportPanel />
+      <CsvWorkflowGuide variant="ut3" />
+      <CsvUt3ImportPanel
+        onPlanReady={(sid) => {
+          setUt3SessionId(sid);
+          setStatus(`UT3 plan ready (session ${sid}). Open in fusion preview when ready.`);
+        }}
+        onOpenInFusion={(sid) => void openFusionFromSession(sid)}
+      />
+
+      <CsvAgentSessionPanel
+        activeSessionId={ut3SessionId}
+        suggestedSessionId={ut3SessionId}
+        onLoaded={loadAgentSession}
+        onSaved={({ plotUrl, modelUrl, datasetId, siteId }) => {
+          setStatus(
+            `Arrow dataset "${datasetId ?? "saved"}" synced to historian${siteId ? ` (${siteId})` : ""}. Open Plot tab to chart kW + weather.`,
+          );
+          if (plotUrl || modelUrl) {
+            setAgentMeta((m) => m ?? { ok: true });
+          }
+        }}
+      />
+
+      <CsvWorkflowGuide variant="fusion" />
+      <CsvDataAssistant mergeError={mergeError} fileCount={datasets.length} />
 
       <hr className="section-divider" />
 
@@ -418,19 +494,19 @@ export default function CsvWorkbenchPage() {
               <label className="field">
                 <span className="field-label">Merge mode</span>
                 <select value={mergeMode} onChange={(e) => setMergeMode(e.target.value as MergeMode)}>
-                  <option value="inner">Join on timestamp (inner)</option>
-                  <option value="outer">Join on timestamp (outer)</option>
-                  <option value="append">Append rows (stack files)</option>
+                  <option value="append">Append rows (stack school-year files)</option>
+                  <option value="inner">Join on timestamp (same column name in all files)</option>
                 </select>
               </label>
             </div>
           </section>
 
           {merged && merged.columns.length ? (
-            <section className="panel csv-preview-panel">
+            <section className="panel csv-preview-panel csv-preview-panel--primary">
               <h3 className="panel-title">Merged preview ({merged.rowCount.toLocaleString()} rows)</h3>
               <p className="muted">
-                Join/append on <strong>{mergeKey}</strong> ({mergeMode}) — first 12 rows shown.
+                {mergeMode === "append" ? "Appended" : "Joined"} on <strong>{mergeKey}</strong> — first 12 rows
+                shown. Export or commit when this looks correct.
               </p>
               <div className="table-wrap csv-preview-table">
                 <table>
@@ -519,7 +595,70 @@ export default function CsvWorkbenchPage() {
           </section>
 
           <section className="panel">
-            <h3 className="panel-title">Split &amp; commit</h3>
+            <h3 className="panel-title">Finish — commit or export</h3>
+            <p className="muted">
+              {ut3SessionId
+                ? "This preview came from a UT3/agent session — use Save to Arrow (session) above or below. Client commit uploads the preview grid to the historian."
+                : "Commit writes the merged CSV to the Arrow historian and Haystack model. Export downloads a copy for inspection."}
+            </p>
+            <div className="toolbar">
+              {ut3SessionId ? (
+                <button
+                  type="button"
+                  className="primary-btn"
+                  disabled={!!busy}
+                  onClick={async () => {
+                    setBusy("arrow");
+                    try {
+                      const out = await saveAgentSessionToArrow(ut3SessionId);
+                      if (!out.ok) throw new Error(out.error ?? "save failed");
+                      setStatus(`Arrow dataset saved (${agentMeta?.dataset_name ?? ut3SessionId}).`);
+                    } catch (e) {
+                      setError(formatApiError(e));
+                    } finally {
+                      setBusy("");
+                    }
+                  }}
+                >
+                  {busy === "arrow" ? "Saving…" : "Save to Arrow store (session)"}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className={ut3SessionId ? "secondary-btn" : "primary-btn"}
+                disabled={!!busy || !merged}
+                onClick={() => void commitToHistorian()}
+              >
+                {busy === "commit" ? "Committing…" : "Commit → historian + model"}
+              </button>
+              <button
+                type="button"
+                className="secondary-btn"
+                disabled={!merged}
+                onClick={() => merged && downloadCsv("openfdd-merged.csv", merged.columns, merged.rows)}
+              >
+                Export merged CSV
+              </button>
+              <button type="button" className="secondary-btn" disabled={!!busy} onClick={() => void createRcxReport()}>
+                Draft RCx PDF
+              </button>
+              {numericCols.length ? (
+                <a className="secondary-btn" href="/plot">
+                  Open in Plots
+                </a>
+              ) : null}
+              <button type="button" className="linkish-btn" onClick={() => setDatasets([])}>
+                Clear all
+              </button>
+            </div>
+          </section>
+
+          <section className="panel">
+            <h3 className="panel-title">Advanced — split a file</h3>
+            <p className="muted">
+              Optional: break one wide or long CSV into two files before merge. Select split settings, then use Split on
+              a file in the list below.
+            </p>
             <div className="form-grid">
               <label className="field">
                 <span className="field-label">Vertical split after col #</span>
@@ -530,26 +669,7 @@ export default function CsvWorkbenchPage() {
                 <input type="number" min={1} value={splitRows} onChange={(e) => setSplitRows(Number(e.target.value))} />
               </label>
             </div>
-            <div className="toolbar">
-            <button type="button" className="secondary-btn" disabled={!merged} onClick={() => merged && downloadCsv("openfdd-merged.csv", merged.columns, merged.rows)}>
-              Export merged CSV
-            </button>
-            <button type="button" className="secondary-btn" disabled={!!busy || !merged} onClick={() => void commitToHistorian()}>
-              {busy === "commit" ? "Committing…" : "Commit → historian + model"}
-            </button>
-            <button type="button" className="secondary-btn" disabled={!!busy} onClick={() => void createRcxReport()}>
-              Draft RCx PDF
-            </button>
-            {numericCols.length ? (
-              <a className="secondary-btn" href="/plot">
-                Open in Plots
-              </a>
-            ) : null}
-            <button type="button" className="linkish-btn" onClick={() => setDatasets([])}>
-              Clear all
-            </button>
-          </div>
-        </section>
+          </section>
         </>
       ) : null}
 

--- a/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
+++ b/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import PageHeader from "../components/PageHeader";
 import { apiFetch } from "../lib/api";
 import { copyToClipboard } from "../lib/clipboard";
@@ -36,6 +36,12 @@ function validationSummary(payload: Record<string, unknown> | null): string {
 function runResultSummary(payload: Record<string, unknown> | null): string {
   if (!payload) return "";
   if (typeof payload.error === "string") return payload.error;
+  const confirmation = payload.confirmation as Record<string, unknown> | undefined;
+  const confirmed = confirmation?.confirmed_fault_count;
+  const raw = confirmation?.raw_fault_count;
+  if (typeof confirmed === "number" || typeof raw === "number") {
+    return `Raw faults: ${raw ?? 0} · Confirmed: ${confirmed ?? 0}`;
+  }
   const rows = payload.rows;
   if (Array.isArray(rows)) {
     return `Preview returned ${rows.length} row(s).`;
@@ -44,6 +50,18 @@ function runResultSummary(payload: Record<string, unknown> | null): string {
   if (typeof count === "number") return `Preview returned ${count} row(s).`;
   if (payload.ok === true) return "SQL preview completed.";
   return "Preview finished.";
+}
+
+function confirmedFaultRows(payload: Record<string, unknown> | null): Record<string, unknown>[] {
+  if (!payload?.rows || !Array.isArray(payload.rows)) return [];
+  return (payload.rows as Record<string, unknown>[]).filter(
+    (r) => r.confirmed_fault === true || r.confirmed_fault === "true",
+  );
+}
+
+function ruleIdFromBuilder(builder: BuilderState): string {
+  const base = builder.fault_code.trim() || builder.name.trim() || "fdd-rule";
+  return base.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "fdd-rule";
 }
 
 const DEFAULT_BUILDER: BuilderState = {
@@ -59,6 +77,7 @@ const DEFAULT_BUILDER: BuilderState = {
 
 export default function SqlFddRulesPage() {
   const siteId = useActiveSiteId();
+  const navigate = useNavigate();
   const [mode, setMode] = useState<"builder" | "raw">("builder");
   const [builder, setBuilder] = useState<BuilderState>(DEFAULT_BUILDER);
   const [sql, setSql] = useState("");
@@ -69,8 +88,10 @@ export default function SqlFddRulesPage() {
   const [busy, setBusy] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [copyStatus, setCopyStatus] = useState("");
+  const [actionStatus, setActionStatus] = useState("");
   const [error, setError] = useState("");
   const equipmentMissing = mode === "builder" && !builder.equipment_id.trim();
+  const confirmedRows = useMemo(() => confirmedFaultRows(runResult), [runResult]);
 
   useEffect(() => {
     apiFetch<{ fdd_inputs?: FddInput[] }>("/api/fdd-schema/fdd-inputs")
@@ -151,6 +172,71 @@ export default function SqlFddRulesPage() {
         body: JSON.stringify({ sql }),
       });
       setValidation(out);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function saveActivateAndDashboard() {
+    const ruleId = ruleIdFromBuilder(builder);
+    setBusy(true);
+    setError("");
+    setActionStatus("");
+    try {
+      await apiFetch("/api/fdd-rules", {
+        method: "POST",
+        body: JSON.stringify({
+          rule_id: ruleId,
+          name: builder.name,
+          sql,
+          confirmation_seconds: builder.confirmation_seconds,
+          review_status: "approved",
+          severity: builder.severity,
+          output_fault_code: builder.fault_code,
+          equipment_id: builder.equipment_id,
+          site_id: siteId,
+        }),
+      });
+      await apiFetch(`/api/fdd-rules/${encodeURIComponent(ruleId)}/activate`, {
+        method: "POST",
+        body: "{}",
+      });
+      window.dispatchEvent(new CustomEvent("ofdd-dashboard-refresh"));
+      setActionStatus(`Rule "${ruleId}" saved and activated — faults appear on the main dashboard.`);
+      navigate("/");
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function exportPdfReport() {
+    setBusy(true);
+    setError("");
+    setActionStatus("");
+    try {
+      const out = await apiFetch<{ report_id?: string; pdf?: { download_url?: string } }>(
+        "/api/reports/from-fdd-sql-run",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            rule_name: builder.name,
+            sql,
+            equipment_id: builder.equipment_id,
+            fault_code: builder.fault_code,
+            run_result: runResult,
+          }),
+        },
+      );
+      const url = out.pdf?.download_url;
+      setActionStatus(
+        url
+          ? `PDF report ${out.report_id ?? ""} ready — open Reports tab or download.`
+          : `Report draft ${out.report_id ?? ""} created.`,
+      );
     } catch (e) {
       setError(formatApiError(e));
     } finally {
@@ -326,21 +412,59 @@ export default function SqlFddRulesPage() {
           {runResult ? (
             <section className="panel sql-test-query-panel">
               <div className="panel-head-row">
-                <h3 className="panel-title">Query results</h3>
-                <button
-                  type="button"
-                  className="secondary-btn"
-                  onClick={() => {
-                    void copyToClipboard(JSON.stringify(runResult, null, 2)).then((ok) =>
-                      setCopyStatus(ok ? "Copied JSON" : "Copy failed"),
-                    );
-                  }}
-                >
-                  Copy JSON
-                </button>
+                <h3 className="panel-title">FDD query results</h3>
+                <div className="action-bar">
+                  <button type="button" className="primary-btn" disabled={busy} onClick={() => void saveActivateAndDashboard()}>
+                    Save rule → dashboard
+                  </button>
+                  <button type="button" className="secondary-btn" disabled={busy} onClick={() => void exportPdfReport()}>
+                    Export PDF report
+                  </button>
+                  <Link className="secondary-btn" to="/">
+                    Main dashboard
+                  </Link>
+                  <Link className="secondary-btn" to="/exports">
+                    Reports tab
+                  </Link>
+                  <button
+                    type="button"
+                    className="secondary-btn"
+                    onClick={() => {
+                      void copyToClipboard(JSON.stringify(runResult, null, 2)).then((ok) =>
+                        setCopyStatus(ok ? "Copied JSON" : "Copy failed"),
+                      );
+                    }}
+                  >
+                    Copy JSON
+                  </button>
+                </div>
               </div>
+              {actionStatus ? <p className="ok">{actionStatus}</p> : null}
               {copyStatus ? <p className="muted">{copyStatus}</p> : null}
-              <pre className="code-block sql-query-json">{JSON.stringify(runResult, null, 2)}</pre>
+              {confirmedRows.length ? (
+                <div className="table-like sql-fdd-confirmed-table">
+                  <div className="table-row table-head">
+                    <span>Timestamp</span>
+                    <span>Equipment</span>
+                    <span>Confirmed</span>
+                    <span>Minutes in fault</span>
+                  </div>
+                  {confirmedRows.slice(0, 12).map((row, i) => (
+                    <div key={i} className="table-row">
+                      <span>{String(row.timestamp ?? "")}</span>
+                      <span>{String(row.equipment_id ?? builder.equipment_id)}</span>
+                      <span>{String(row.confirmed_fault ?? true)}</span>
+                      <span>{String(row.minutes_in_fault ?? row.minutes_in_raw_fault ?? "—")}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="muted">No confirmed faults in this preview — adjust threshold or confirmation window.</p>
+              )}
+              <details className="advanced-json">
+                <summary>Full JSON response</summary>
+                <pre className="code-block sql-query-json">{JSON.stringify(runResult, null, 2)}</pre>
+              </details>
             </section>
           ) : null}
 

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -116,6 +116,121 @@ a {
   padding: 3px 8px;
 }
 
+.brand-mcp-link {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.brand-mcp-link:hover {
+  color: var(--text);
+  border-color: var(--primary);
+  background: var(--panel-soft);
+}
+
+.brand-mcp-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.csv-workflow-guide {
+  margin-bottom: 12px;
+}
+
+.csv-workflow-steps {
+  margin: 0;
+  padding-left: 1.25rem;
+  line-height: 1.5;
+}
+
+.csv-workflow-steps li {
+  margin-bottom: 0.35rem;
+}
+
+.csv-workflow-note {
+  margin: 0.75rem 0 0;
+}
+
+.csv-assistant-panel {
+  margin-bottom: 12px;
+}
+
+.csv-assistant-tip {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--panel-soft);
+  border: 1px solid var(--border);
+  margin: 0.5rem 0;
+  font-size: 14px;
+}
+
+.csv-assistant-tip--warn {
+  border-color: var(--warn, #c9870a);
+  background: color-mix(in srgb, var(--warn, #c9870a) 8%, transparent);
+}
+
+.csv-assistant-mcp {
+  margin-top: 0.75rem;
+  font-size: 14px;
+}
+
+.csv-assistant-mcp summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.csv-preview-panel--primary {
+  border-color: var(--primary);
+}
+
+.csv-session-id-line {
+  margin: 8px 0 12px;
+  font-size: 14px;
+  word-break: break-all;
+}
+
+.csv-session-id-line code {
+  font-size: 13px;
+}
+
+.csv-agent-session-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  margin-bottom: 8px;
+}
+
+.csv-agent-session-input {
+  flex: 1;
+  min-width: 220px;
+}
+
+.csv-agent-session-active {
+  margin-top: 12px;
+}
+
+.csv-agent-warnings {
+  margin: 8px 0;
+  padding-left: 1.25rem;
+  font-size: 14px;
+}
+
+.csv-ut3-hint {
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  border-left: 3px solid var(--primary);
+  background: var(--panel-soft);
+}
+
 .sidebar-hint {
   margin: 0;
   padding: 0 8px;

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -94,17 +94,29 @@ a {
   overflow-y: auto;
 }
 
+.brand-block {
+  padding: 2px 8px 4px;
+}
+
 .brand-row {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.brand-meta {
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  padding: 2px 8px 6px;
+  gap: 6px;
 }
 
 .brand {
   font-size: 21px;
   font-weight: 700;
   letter-spacing: -0.02em;
+  line-height: 1.2;
 }
 
 .brand-chip {
@@ -114,31 +126,7 @@ a {
   border-radius: 999px;
   font-size: 11px;
   padding: 3px 8px;
-}
-
-.brand-mcp-link {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 3px 8px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  color: var(--muted);
-  text-decoration: none;
-}
-
-.brand-mcp-link:hover {
-  color: var(--text);
-  border-color: var(--primary);
-  background: var(--panel-soft);
-}
-
-.brand-mcp-icon {
-  font-size: 13px;
-  line-height: 1;
+  white-space: nowrap;
 }
 
 .csv-workflow-guide {
@@ -657,6 +645,23 @@ textarea {
   border-radius: 10px;
   background: var(--panel-soft);
   border: 1px solid var(--border);
+}
+
+.stack-strip-pills {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.stack-strip-link {
+  text-decoration: none;
+  color: inherit;
+  border-radius: 999px;
+}
+
+.stack-strip-link:hover .status-pill {
+  border-color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 8%, var(--panel-soft));
 }
 
 .status-pill.status-disabled {


### PR DESCRIPTION
## Summary
- CSV UT3 import → fusion preview in browser → Arrow/historian sync → Plot and Model tabs (school kW + weather merge).
- SQL FDD tab: confirmed faults table, **Save rule → dashboard**, **Export PDF report** (`POST /api/reports/from-fdd-sql-run`).
- Oxigraph SPARQL/RDF layer, MCP CSV tools, docs refresh.
- CI fixes: rustfmt/clippy, Docker `libclang` for oxrocksdb-sys, no-hardcode audit for RDF tests.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p open_fdd_edge_prototype --lib -- -D warnings`
- [x] `cargo test -p open_fdd_edge_prototype`
- [x] `npm test` in workspace/dashboard
- [ ] GitHub Actions Rust Edge CI + GHCR publish green on merge

## Human workflow
1. `/csv` → UT3 upload → Preview plan → review fusion → Save to Arrow
2. `/plot` and `/model` for merged data
3. `/sql-fdd` → Test query → Save rule → dashboard or PDF report


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SPARQL-backed model browsing, coverage, and dashboard queries, plus Turtle export of the model.
  * Introduced CSV import session listing, “latest planned” shortcuts, and fusion preview loading/saving into Arrow.
  * Expanded the Agent/MCP area with tool discovery and new CSV workflow guidance.
  * Added “Export PDF report” from SQL FDD rule run results.
* **Bug Fixes**
  * Improved timestamp/merge-key detection by ignoring timezone-like columns.
  * Enhanced CSV ingest joining/append handling (including weather vs. school selection) and older time-series coverage behavior.
* **Documentation**
  * Reworked API/agent/model documentation into clearer, endpoint-focused REST and workflow references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->