### PR TITLE
Haystack RDF semantic model cleanup for OxiGraph

### DIFF
--- a/docs/ai-agent/haystack-and-assignments.md
+++ b/docs/ai-agent/haystack-and-assignments.md
@@ -24,7 +24,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 # Sites
 curl -s -X POST http://127.0.0.1:8080/api/model/sparql \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d '{"query":"PREFIX hs: <https://project-haystack.org/def/> PREFIX ofdd: <https://open-fdd.dev/model#> SELECT ?point ?dis ?equipRef ?fddInput WHERE { ?p a hs:Point . ?p ofdd:haystackId ?point . OPTIONAL { ?p hs:dis ?dis . } OPTIONAL { ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . } OPTIONAL { ?p hs:fddInput ?fddInput . } }"}'
+  -d '{"query":"PREFIX hs: <https://project-haystack.org/def/> PREFIX ofdd: <https://open-fdd.dev/model#> SELECT ?point ?dis ?equipRef ?fddInput WHERE { ?p a hs:Point . ?p ofdd:haystackId ?point . OPTIONAL { ?p hs:dis ?dis . } OPTIONAL { ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . } OPTIONAL { ?p ofdd:fddInput ?fddInput . } }"}'
 ```
 
 Turtle export: `GET /api/model/ttl` · Coverage: `GET /api/dashboard/model-coverage`

--- a/docs/modeling/haystack_dashboard_model.md
+++ b/docs/modeling/haystack_dashboard_model.md
@@ -1,17 +1,38 @@
 # Haystack model and SPARQL
 
-Open-FDD stores the site model as a **Project Haystack grid** (`workspace/data/model/haystack_grid.json`). The edge projects that grid to **RDF (Turtle)** and serves **read-only SPARQL SELECT** queries via Oxigraph.
+Open-FDD stores the site model as a **Project Haystack grid** (`workspace/data/model/haystack_grid.json`). The edge projects that grid to **RDF (Turtle)** compatible with **OxiGraph** and serves **read-only SPARQL SELECT** queries.
+
+## Vocabulary
+
+| Prefix | Namespace | Use |
+|--------|-----------|-----|
+| `hs:` | `https://project-haystack.org/def/` | Project Haystack tags (`dis`, `siteRef`, `equipRef`, `kind`, `unit`, point roles) |
+| `ofdd:` | `https://open-fdd.dev/model#` | Open-FDD application metadata (`haystackId`, `equipType`, `csvRef`, `fddInput`, …) |
+
+Open-FDD-only predicates are **not** emitted under `hs:`:
+
+- `ofdd:csvRef`, `ofdd:fddInput`, `ofdd:importJob`, `ofdd:protocol`
+
+Haystack relationship tags stay under `hs:`:
+
+- `hs:dis`, `hs:siteRef`, `hs:equipRef`, `hs:sourceRef`, `hs:kind`, `hs:unit`
+
+Every `hs:Point` includes **both** `hs:siteRef` and `hs:equipRef`, plus at least one role marker (`hs:sensor`, `hs:cmd`, `hs:sp`, or `hs:synthetic`). CSV telemetry defaults to `hs:sensor true`.
+
+Optional legacy duplicates (`hs:csvRef`, …) are available when `OPENFDD_RDF_LEGACY_HS_CUSTOM_TAGS=1`.
 
 ## Data flow
 
 ```text
 Haystack grid JSON
-  → RDF projection (hs: + ofdd: prefixes)
+  → RDF projection (hs: + ofdd: prefixes, compact Turtle)
   → in-memory Oxigraph store (reloaded on grid save)
   → SPARQL SELECT → JSON bindings
 ```
 
 Assignments (`/api/model/assignments`) layer driver refs and FDD inputs on top of Haystack point IDs. See [ASSIGNMENT_MODEL.md](../ASSIGNMENT_MODEL.md).
+
+Example fixture: `edge/tests/fixtures/rdf/school_kw_merged_expected.ttl`
 
 ## HTTP API
 
@@ -28,24 +49,57 @@ Assignments (`/api/model/assignments`) layer driver refs and FDD inputs on top o
 
 Dashboard list/coverage/graph endpoints use the same SPARQL layer internally (`query_engine: "sparql"` in responses).
 
-## SPARQL vocabulary
+## Example SPARQL
 
 ```sparql
 PREFIX hs: <https://project-haystack.org/def/>
 PREFIX ofdd: <https://open-fdd.dev/model#>
+
+# All points for a site (direct siteRef on each point)
+SELECT ?point ?dis ?equipRef WHERE {
+  ?p a hs:Point .
+  ?p ofdd:haystackId ?point .
+  ?p hs:siteRef ?site .
+  ?site ofdd:haystackId "site:school-kw-merged" .
+  OPTIONAL { ?p hs:dis ?dis . }
+  OPTIONAL { ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }
+}
+
+# Points on one equipment
+SELECT ?point ?dis WHERE {
+  ?p a hs:Point .
+  ?p ofdd:haystackId ?point .
+  ?p hs:equipRef ?eq .
+  ?eq ofdd:haystackId "equip:school-kw-merged" .
+  OPTIONAL { ?p hs:dis ?dis . }
+}
+
+# CSV source lineage for a point
+SELECT ?csvRef ?source ?importJob WHERE {
+  ?p a hs:Point .
+  ?p ofdd:haystackId "point:school-kw-merged-temp_f" .
+  ?p ofdd:csvRef ?csv .
+  ?csv ofdd:haystackId ?csvRef .
+  OPTIONAL { ?p hs:sourceRef ?src . ?src ofdd:haystackId ?source . }
+  OPTIONAL { ?src ofdd:importJob ?importJob . }
+}
+
+# FDD input mapping
+SELECT ?fddInput WHERE {
+  ?p a hs:Point .
+  ?p ofdd:haystackId "point:school-kw-merged-temp_f" .
+  ?p ofdd:fddInput ?fddInput .
+}
 ```
 
-- `?s a hs:Site` / `hs:Equip` / `hs:Point` — entity types
-- `?s ofdd:haystackId ?id` — Haystack ref (`site:demo`, `point:oa-t`)
-- `?s hs:dis ?label` — display name
-- `?s hs:equipRef ?eq` — point → equipment (object IRI; join `ofdd:haystackId` for string id)
-- `?s ofdd:equipType ?type` — inferred HVAC type (`ahu`, `vav`, …)
-
-## Example
+## curl
 
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" \
   http://127.0.0.1:8080/api/model/sparql/predefined | jq '.queries[0].id'
+
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8080/api/model/ttl
 
 curl -s -H "Authorization: Bearer $TOKEN" \
   http://127.0.0.1:8080/api/dashboard/model-coverage | jq .

--- a/edge/src/model/csv_import.rs
+++ b/edge/src/model/csv_import.rs
@@ -239,6 +239,7 @@ pub fn import_from_csv_commit(
             "sensor": "M",
             "kind": "Number",
             "unit": infer_unit(slug),
+            "siteRef": site_id,
             "equipRef": equip_id,
             "sourceRef": source_id,
             "fddInput": fdd_input,

--- a/edge/src/model/query.rs
+++ b/edge/src/model/query.rs
@@ -151,9 +151,9 @@ pub fn list_points(site_id: Option<&str>) -> Value {
           ?p a hs:Point .
           ?p ofdd:haystackId ?point_id .
           OPTIONAL {{ ?p hs:dis ?name . }}
+          OPTIONAL {{ ?p hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
           OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equip_ref . }}
-          OPTIONAL {{ ?eq hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
-          OPTIONAL {{ ?p hs:fddInput ?fdd_input . }}
+          OPTIONAL {{ ?p ofdd:fddInput ?fdd_input . }}
           OPTIONAL {{ ?p hs:bacnetRef ?bacnet_ref . }}
           OPTIONAL {{ ?p hs:modbusRef ?modbus_ref . }}
           {filter}
@@ -219,10 +219,10 @@ pub fn source_coverage() -> Value {
                 IF(BOUND(?modbus), \"modbus\",
                   IF(BOUND(?fdd), \"json_api\", \"unmapped\"))))
             AS ?protocol)
-          OPTIONAL {{ ?p hs:csvRef ?csv . }}
+          OPTIONAL {{ ?p ofdd:csvRef ?csv . }}
           OPTIONAL {{ ?p hs:bacnetRef ?bacnet . }}
           OPTIONAL {{ ?p hs:modbusRef ?modbus . }}
-          OPTIONAL {{ ?p hs:fddInput ?fdd . }}
+          OPTIONAL {{ ?p ofdd:fddInput ?fdd . }}
         }} GROUP BY ?protocol"
     );
     let protocols: Vec<Value> = sparql_rows(&query)
@@ -266,9 +266,10 @@ pub fn group_points_by_equip() -> Value {
           OPTIONAL {{ ?p hs:dis ?name . }}
           OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equip_ref . }}
           BIND(
-            EXISTS {{ ?p hs:fddInput ?x }} ||
+            EXISTS {{ ?p ofdd:fddInput ?x }} ||
             EXISTS {{ ?p hs:bacnetRef ?y }} ||
-            EXISTS {{ ?p hs:modbusRef ?z }}
+            EXISTS {{ ?p hs:modbusRef ?z }} ||
+            EXISTS {{ ?p ofdd:csvRef ?w }}
             AS ?mapped)
         }}"
     );
@@ -391,7 +392,7 @@ pub fn network_graph(site_id: Option<&str>) -> Value {
           OPTIONAL {{ ?p hs:unit ?unit . }}
           ?p hs:equipRef ?eq .
           ?eq ofdd:haystackId ?equip_ref .
-          OPTIONAL {{ ?eq hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
+          OPTIONAL {{ ?p hs:siteRef ?siteRes . ?siteRes ofdd:haystackId ?site_id . }}
           {site_filter}
         }}"
     );

--- a/edge/src/model/rdf.rs
+++ b/edge/src/model/rdf.rs
@@ -7,7 +7,7 @@ use oxigraph::model::Term;
 use oxigraph::sparql::{QueryResults, SparqlEvaluator};
 use oxigraph::store::Store;
 use serde_json::Value;
-use std::collections::hash_map::DefaultHasher;
+use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::RwLock;
 
@@ -30,6 +30,23 @@ impl StoreState {
     }
 }
 
+/// Open-FDD application metadata uses `ofdd:` in Turtle (not Project Haystack `hs:`).
+const OFDD_LITERAL_KEYS: &[&str] = &["fddInput", "importJob", "protocol"];
+const OFDD_REF_KEYS: &[&str] = &["csvRef"];
+const TYPE_MARKER_KEYS: &[&str] = &[
+    "site",
+    "equip",
+    "point",
+    "ahu",
+    "vav",
+    "chiller",
+    "boiler",
+    "coolingTower",
+    "doas",
+    "source",
+];
+const POINT_ROLE_KEYS: &[&str] = &["sensor", "cmd", "sp", "synthetic"];
+
 /// Drop cached store so the next query reloads from the current Haystack grid.
 pub fn invalidate_store() {
     if let Ok(mut guard) = STORE.write() {
@@ -43,6 +60,10 @@ fn grid_fingerprint(rows: &[Value]) -> u64 {
         .unwrap_or_default()
         .hash(&mut hasher);
     hasher.finish()
+}
+
+fn legacy_hs_custom_tags() -> bool {
+    std::env::var("OPENFDD_RDF_LEGACY_HS_CUSTOM_TAGS").as_deref() == Ok("1")
 }
 
 /// Turtle local name for a Haystack ref id (`site:lab` → `site_lab`).
@@ -71,6 +92,18 @@ pub fn turtle_escape(s: &str) -> String {
 
 fn is_marker(v: &Value) -> bool {
     matches!(v.as_str(), Some("M")) || v.as_bool() == Some(true)
+}
+
+fn is_ofdd_key(key: &str) -> bool {
+    OFDD_LITERAL_KEYS.contains(&key) || OFDD_REF_KEYS.contains(&key)
+}
+
+fn predicate_for_key(key: &str) -> String {
+    if is_ofdd_key(key) {
+        format!("ofdd:{key}")
+    } else {
+        format!("hs:{key}")
+    }
 }
 
 fn infer_equip_type(row: &Value) -> &'static str {
@@ -132,16 +165,77 @@ fn literal_object(v: &Value) -> Option<String> {
         ));
     }
     if let Some(b) = v.as_bool() {
-        return Some(format!(
-            "\"{}\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
-            b
-        ));
+        return Some(if b { "true".into() } else { "false".into() });
     }
     None
 }
 
+fn enrich_rows(rows: &[Value]) -> Vec<Value> {
+    let mut equip_site: HashMap<String, String> = HashMap::new();
+    for row in rows {
+        let Some(eid) = row.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if row.get("equip").is_some() {
+            if let Some(site) = row.get("siteRef").and_then(|v| v.as_str()) {
+                equip_site.insert(eid.to_string(), site.to_string());
+            }
+        }
+    }
+
+    rows.iter()
+        .map(|row| {
+            if row.get("point").is_none() {
+                return row.clone();
+            }
+            if row.get("siteRef").is_some() {
+                return row.clone();
+            }
+            let Some(equip_ref) = row.get("equipRef").and_then(|v| v.as_str()) else {
+                return row.clone();
+            };
+            let Some(site) = equip_site.get(equip_ref) else {
+                return row.clone();
+            };
+            let mut obj = row
+                .as_object()
+                .cloned()
+                .unwrap_or_else(serde_json::Map::new);
+            obj.insert("siteRef".into(), Value::String(site.clone()));
+            Value::Object(obj)
+        })
+        .collect()
+}
+
+fn point_has_role_marker(row: &Value) -> bool {
+    POINT_ROLE_KEYS.iter().any(|key| row.get(*key).is_some())
+}
+
+fn format_subject_block(subj: &str, triples: &[(String, String)]) -> String {
+    if triples.is_empty() {
+        return String::new();
+    }
+    let mut lines = vec![subj.to_string()];
+    for (i, (pred, obj)) in triples.iter().enumerate() {
+        let end = if i + 1 == triples.len() { " ." } else { " ;" };
+        lines.push(format!("  {pred} {obj}{end}"));
+    }
+    lines.join("\n")
+}
+
+fn push_triple(triples: &mut Vec<(String, String)>, pred: String, obj: String) {
+    triples.push((pred, obj));
+}
+
+fn push_legacy_hs_triple(triples: &mut Vec<(String, String)>, key: &str, obj: String) {
+    if legacy_hs_custom_tags() && is_ofdd_key(key) {
+        triples.push((format!("hs:{key}"), obj));
+    }
+}
+
 /// Build Turtle from Haystack grid rows (full semantic projection for SPARQL).
 pub fn haystack_rows_to_turtle(rows: &[Value]) -> String {
+    let rows = enrich_rows(rows);
     let mut lines = vec![
         format!("@prefix hs: <{HS_PREFIX}> ."),
         format!("@prefix ofdd: <{OFDD_PREFIX}> ."),
@@ -149,7 +243,7 @@ pub fn haystack_rows_to_turtle(rows: &[Value]) -> String {
         String::new(),
     ];
 
-    for row in rows {
+    for row in &rows {
         let Some(id) = row.get("id").and_then(|v| v.as_str()) else {
             continue;
         };
@@ -157,48 +251,64 @@ pub fn haystack_rows_to_turtle(rows: &[Value]) -> String {
             continue;
         }
         let subj = turtle_subject(id);
-        let mut preds: Vec<String> = Vec::new();
-
-        preds.push(format!(
-            "{subj} ofdd:haystackId \"{}\" .",
-            turtle_escape(id)
-        ));
+        let mut triples: Vec<(String, String)> = Vec::new();
 
         for rdf_type in haystack_type_triples(row) {
-            preds.push(format!("{subj} a {rdf_type} ."));
+            push_triple(&mut triples, "a".into(), rdf_type);
         }
 
+        push_triple(
+            &mut triples,
+            "ofdd:haystackId".into(),
+            format!("\"{}\"", turtle_escape(id)),
+        );
+
         if row.get("equip").is_some() {
-            preds.push(format!(
-                "{subj} ofdd:equipType \"{}\" .",
-                turtle_escape(infer_equip_type(row))
-            ));
+            push_triple(
+                &mut triples,
+                "ofdd:equipType".into(),
+                format!("\"{}\"", turtle_escape(infer_equip_type(row))),
+            );
         }
 
         for (key, value) in row.as_object().into_iter().flatten() {
-            if key == "id" {
+            if key == "id" || TYPE_MARKER_KEYS.contains(&key.as_str()) {
                 continue;
             }
-            let pred = format!("hs:{key}");
+            if POINT_ROLE_KEYS.contains(&key.as_str()) && is_marker(value) {
+                push_triple(&mut triples, format!("hs:{key}"), "true".into());
+                continue;
+            }
+            if is_marker(value) {
+                continue;
+            }
             if key.ends_with("Ref") {
                 if let Some(ref_id) = value.as_str() {
                     if !ref_id.is_empty() {
-                        preds.push(format!("{subj} {pred} {} .", turtle_subject(ref_id)));
+                        let obj = turtle_subject(ref_id);
+                        let pred = predicate_for_key(key);
+                        push_triple(&mut triples, pred, obj.clone());
+                        push_legacy_hs_triple(&mut triples, key, obj);
                     }
                 }
                 continue;
             }
-            if is_marker(value) {
-                // Marker tags are represented via rdf:type (hs:Site, hs:Equip, …) above.
-                continue;
-            }
             if let Some(lit) = literal_object(value) {
-                preds.push(format!("{subj} {pred} {lit} ."));
+                let pred = predicate_for_key(key);
+                push_triple(&mut triples, pred.clone(), lit.clone());
+                push_legacy_hs_triple(&mut triples, key, lit);
             }
         }
 
-        lines.extend(preds);
-        lines.push(String::new());
+        if row.get("point").is_some() && !point_has_role_marker(row) {
+            push_triple(&mut triples, "hs:sensor".into(), "true".into());
+        }
+
+        let block = format_subject_block(&subj, &triples);
+        if !block.is_empty() {
+            lines.push(block);
+            lines.push(String::new());
+        }
     }
 
     lines.join("\n")
@@ -321,6 +431,42 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn school_kw_fixture_rows() -> Vec<Value> {
+        vec![
+            json!({
+                "id": "site:school-kw-merged",
+                "dis": "school_kw_merged",
+                "site": "M"
+            }),
+            json!({
+                "id": "source:csv:school-kw-merged",
+                "dis": "CSV source (school-kw-merged)",
+                "source": "M",
+                "protocol": "csv",
+                "importJob": "dataset-school_kw_merged"
+            }),
+            json!({
+                "id": "equip:school-kw-merged",
+                "dis": "school_kw_merged",
+                "equip": "M",
+                "siteRef": "site:school-kw-merged",
+                "sourceRef": "source:csv:school-kw-merged"
+            }),
+            json!({
+                "id": "point:school-kw-merged-temp_f",
+                "dis": "temp_f",
+                "point": "M",
+                "sensor": "M",
+                "kind": "Number",
+                "unit": "°F",
+                "equipRef": "equip:school-kw-merged",
+                "sourceRef": "source:csv:school-kw-merged",
+                "fddInput": "temp_f",
+                "csvRef": "csv:source:csv:school-kw-merged:temp_f"
+            }),
+        ]
+    }
+
     #[test]
     fn turtle_includes_types_and_refs() {
         let rows = vec![
@@ -348,8 +494,75 @@ mod tests {
         assert!(ttl.contains("a hs:Site"));
         assert!(ttl.contains("a hs:Equip"));
         assert!(ttl.contains("hs:siteRef ofdd:site_lab"));
-        assert!(ttl.contains("hs:fddInput \"oa_t\""));
+        assert!(ttl.contains("ofdd:fddInput \"oa_t\""));
         assert!(ttl.contains("ofdd:equipType \"ahu\""));
+        assert!(ttl.contains("hs:sensor true"));
+        Store::new()
+            .unwrap()
+            .load_from_reader(RdfFormat::Turtle, ttl.as_bytes())
+            .expect("turtle parses");
+    }
+
+    #[test]
+    fn csv_import_fixture_semantic_shape() {
+        let ttl = haystack_rows_to_turtle(&school_kw_fixture_rows());
+        assert!(ttl.contains("hs:siteRef ofdd:site_school_kw_merged"));
+        assert!(ttl.contains("hs:equipRef ofdd:equip_school_kw_merged"));
+        assert!(ttl.contains("ofdd:csvRef ofdd:csv_source_csv_school_kw_merged_temp_f"));
+        assert!(ttl.contains("ofdd:fddInput \"temp_f\""));
+        assert!(ttl.contains("ofdd:importJob \"dataset-school_kw_merged\""));
+        assert!(ttl.contains("ofdd:protocol \"csv\""));
+        assert!(ttl.contains("hs:sensor true"));
+        assert!(!ttl.contains("hs:csvRef"));
+        assert!(!ttl.contains("hs:fddInput"));
+        assert!(!ttl.contains("hs:importJob"));
+        assert!(!ttl.contains("hs:protocol"));
+
+        let store = Store::new().unwrap();
+        store
+            .load_from_reader(RdfFormat::Turtle, ttl.as_bytes())
+            .expect("fixture turtle parses");
+
+        let q = r#"
+            PREFIX hs: <https://project-haystack.org/def/>
+            PREFIX ofdd: <https://open-fdd.dev/model#>
+            SELECT ?point WHERE {
+              ?p a hs:Point .
+              ?p ofdd:haystackId ?point .
+              ?p hs:siteRef ?site .
+              ?p hs:equipRef ?eq .
+              ?p hs:dis ?dis .
+              ?p hs:sensor ?role .
+              ?p ofdd:fddInput ?fdd .
+              ?p ofdd:csvRef ?csv .
+            }
+        "#;
+        let rows = SparqlEvaluator::new()
+            .parse_query(q)
+            .unwrap()
+            .on_store(&store)
+            .execute()
+            .unwrap();
+        match rows {
+            QueryResults::Solutions(solutions) => {
+                let count = solutions.into_iter().count();
+                assert_eq!(count, 1);
+            }
+            _ => panic!("expected SELECT results"),
+        }
+    }
+
+    #[test]
+    fn every_point_has_site_ref_via_enrichment() {
+        let rows = vec![
+            json!({"id": "site:a", "dis": "A", "site": "M"}),
+            json!({"id": "equip:e1", "dis": "E1", "equip": "M", "siteRef": "site:a"}),
+            json!({"id": "point:p1", "dis": "P1", "point": "M", "equipRef": "equip:e1"}),
+        ];
+        let ttl = haystack_rows_to_turtle(&rows);
+        assert!(ttl.contains("ofdd:point_p1"));
+        assert!(ttl.contains("hs:siteRef ofdd:site_a"));
+        assert!(ttl.contains("hs:equipRef ofdd:equip_e1"));
     }
 
     #[test]

--- a/edge/src/model/sparql.rs
+++ b/edge/src/model/sparql.rs
@@ -91,7 +91,7 @@ pub fn catalog() -> Vec<Value> {
             "label": "All points",
             "short_label": "Points",
             "category": "hvac",
-            "query": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef ?fddInput WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n  OPTIONAL {{ ?p hs:fddInput ?fddInput . }}\n}}")
+            "query": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef ?siteRef ?fddInput WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n  OPTIONAL {{ ?p hs:siteRef ?site . ?site ofdd:haystackId ?siteRef . }}\n  OPTIONAL {{ ?p ofdd:fddInput ?fddInput . }}\n}}")
         }),
         json!({
             "id": "hvac_points_bacnet",
@@ -106,7 +106,7 @@ pub fn catalog() -> Vec<Value> {
             "label": "Unmapped points (no fddInput / driver ref)",
             "short_label": "Unmapped",
             "category": "engineering",
-            "query": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n  FILTER NOT EXISTS {{ ?p hs:fddInput ?x }}\n  FILTER NOT EXISTS {{ ?p hs:bacnetRef ?y }}\n  FILTER NOT EXISTS {{ ?p hs:modbusRef ?z }}\n  FILTER NOT EXISTS {{ ?p hs:csvRef ?w }}\n}}")
+            "query": format!("{PREFIXES}\nSELECT ?point ?dis ?equipRef WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n  OPTIONAL {{ ?p hs:equipRef ?eq . ?eq ofdd:haystackId ?equipRef . }}\n  FILTER NOT EXISTS {{ ?p ofdd:fddInput ?x }}\n  FILTER NOT EXISTS {{ ?p hs:bacnetRef ?y }}\n  FILTER NOT EXISTS {{ ?p hs:modbusRef ?z }}\n  FILTER NOT EXISTS {{ ?p ofdd:csvRef ?w }}\n}}")
         }),
         json!({
             "id": "hvac_feeds",
@@ -114,6 +114,13 @@ pub fn catalog() -> Vec<Value> {
             "short_label": "Feeds",
             "category": "hvac",
             "query": format!("{PREFIXES}\nSELECT ?from ?to ?fromLabel ?toLabel WHERE {{\n  ?toRes hs:feedRef ?fromRes .\n  ?fromRes ofdd:haystackId ?from .\n  ?toRes ofdd:haystackId ?to .\n  OPTIONAL {{ ?fromRes hs:dis ?fromLabel . }}\n  OPTIONAL {{ ?toRes hs:dis ?toLabel . }}\n}}")
+        }),
+        json!({
+            "id": "eng_points_by_site",
+            "label": "Points by site",
+            "short_label": "Pts / site",
+            "category": "engineering",
+            "query": format!("{PREFIXES}\nSELECT ?siteRef ?point ?dis WHERE {{\n  ?p a hs:Point .\n  ?p ofdd:haystackId ?point .\n  ?p hs:siteRef ?site .\n  ?site ofdd:haystackId ?siteRef .\n  OPTIONAL {{ ?p hs:dis ?dis . }}\n}} ORDER BY ?siteRef ?point")
         }),
         json!({
             "id": "eng_sites",

--- a/edge/tests/fixtures/rdf/school_kw_merged_expected.ttl
+++ b/edge/tests/fixtures/rdf/school_kw_merged_expected.ttl
@@ -1,0 +1,35 @@
+@prefix hs: <https://project-haystack.org/def/> .
+@prefix ofdd: <https://open-fdd.dev/model#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ofdd:site_school_kw_merged
+  a hs:Site ;
+  ofdd:haystackId "site:school-kw-merged" ;
+  hs:dis "school_kw_merged" .
+
+ofdd:source_csv_school_kw_merged
+  ofdd:haystackId "source:csv:school-kw-merged" ;
+  hs:dis "CSV source (school-kw-merged)" ;
+  ofdd:importJob "dataset-school_kw_merged" ;
+  ofdd:protocol "csv" .
+
+ofdd:equip_school_kw_merged
+  a hs:Equip ;
+  ofdd:haystackId "equip:school-kw-merged" ;
+  ofdd:equipType "generic" ;
+  hs:dis "school_kw_merged" ;
+  hs:siteRef ofdd:site_school_kw_merged ;
+  hs:sourceRef ofdd:source_csv_school_kw_merged .
+
+ofdd:point_school_kw_merged_temp_f
+  a hs:Point ;
+  ofdd:haystackId "point:school-kw-merged-temp_f" ;
+  hs:dis "temp_f" ;
+  hs:siteRef ofdd:site_school_kw_merged ;
+  hs:equipRef ofdd:equip_school_kw_merged ;
+  hs:sourceRef ofdd:source_csv_school_kw_merged ;
+  ofdd:csvRef ofdd:csv_source_csv_school_kw_merged_temp_f ;
+  ofdd:fddInput "temp_f" ;
+  hs:sensor true ;
+  hs:kind "Number" ;
+  hs:unit "°F" .

--- a/edge/tests/fixtures/rdf/school_kw_merged_grid.json
+++ b/edge/tests/fixtures/rdf/school_kw_merged_grid.json
@@ -1,0 +1,36 @@
+{
+  "rows": [
+    {
+      "id": "site:school-kw-merged",
+      "dis": "school_kw_merged",
+      "site": "M"
+    },
+    {
+      "id": "source:csv:school-kw-merged",
+      "dis": "CSV source (school-kw-merged)",
+      "source": "M",
+      "protocol": "csv",
+      "importJob": "dataset-school_kw_merged"
+    },
+    {
+      "id": "equip:school-kw-merged",
+      "dis": "school_kw_merged",
+      "equip": "M",
+      "siteRef": "site:school-kw-merged",
+      "sourceRef": "source:csv:school-kw-merged"
+    },
+    {
+      "id": "point:school-kw-merged-temp_f",
+      "dis": "temp_f",
+      "point": "M",
+      "sensor": "M",
+      "kind": "Number",
+      "unit": "°F",
+      "siteRef": "site:school-kw-merged",
+      "equipRef": "equip:school-kw-merged",
+      "sourceRef": "source:csv:school-kw-merged",
+      "fddInput": "temp_f",
+      "csvRef": "csv:source:csv:school-kw-merged:temp_f"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Move Open-FDD metadata to `ofdd:` predicates (`csvRef`, `fddInput`, `importJob`, `protocol`) while keeping Project Haystack tags under `hs:`
- Every `hs:Point` gets `hs:siteRef` and `hs:equipRef`; default CSV telemetry role `hs:sensor true`
- Compact semicolon Turtle blocks with OxiGraph parse tests and CSV import fixture
- Update SPARQL queries and modeling docs

## Test plan
- [x] `cargo test -p open_fdd_edge_prototype --lib rdf`
- [x] `cargo test -p open_fdd_edge_prototype --lib query::tests`
- [x] `cargo test -p open_fdd_edge_prototype --test csv_pipeline_integration`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer site-aware point coverage and query support, including results grouped by site and new ways to inspect point-to-site relationships.
  * Expanded RDF/Turtle output support for Open-FDD fields and legacy tag compatibility.

* **Bug Fixes**
  * Improved how imported CSV points are linked to their site and equipment, making model queries and coverage more accurate.
  * Updated unmapped and protocol coverage logic so CSV and FDD inputs are categorized consistently.

* **Documentation**
  * Enhanced dashboard and API docs with more complete SPARQL examples, RDF projection details, and vocabulary guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->