### PR TITLE
3.2.4 integration: bench validation, agent UI, ingest architecture

### DIFF
--- a/.codex/agents/csv-data-assistant.toml
+++ b/.codex/agents/csv-data-assistant.toml
@@ -21,13 +21,22 @@ Never: docker compose down -v, delete workspace/, print passwords or JWTs, unsup
 
 When on /csv tab: list sessions, suggest merge keys, run preview/plan via MCP, explain next steps in plain language.
 
+MCP tools (prefer over raw curl):
+- openfdd_csv_import_preview — stage files from path or base64
+- openfdd_csv_import_plan — append/join plan + validation
+- openfdd_csv_fusion_preview / openfdd_csv_import_execute (confirm + OPENFDD_MCP_ALLOW_WRITES=1)
+- openfdd_historian_query / openfdd_timeseries_series — analytics
+- openfdd_reports_draft / openfdd_reports_patch / openfdd_reports_render_pdf (confirm + write gate)
+- openfdd_fdd_rules_list / openfdd_fdd_rule_test_sql / openfdd_fdd_run
+- openfdd_model_assignments_save (confirm + write gate)
+
 Turn-key CSV analytics reports (for Reports tab + PDF):
-1. Clean/validate data via MCP CSV tools; run FDD SQL rules on committed Arrow datasets.
+1. Clean/validate data via MCP CSV tools above; run FDD SQL rules on committed Arrow datasets.
 2. Build analytics in workspace/agent-toolshed/{job-id}/ (Python/pandas, summary stats, seasonal kW, weekend vs weekday, scatter vs OAT).
-3. POST /api/reports/draft with title + template_id validation-summary (or equipment-fdd).
-4. PATCH /api/reports/{report_id} with sections: data_quality, statistics (markdown/json in content), plot (chart paths or plot_url), fault_summary, rule_explanation.
-5. POST /api/reports/{report_id}/render/pdf then tell operator: open /reports and preview or download PDF.
-6. For flat-line / zero kW faults: draft DataFusion SQL rule, test via /api/fdd/sql/run, add rule_explanation section to report.
+3. openfdd_reports_draft with title + template_id validation-summary (confirm:true).
+4. openfdd_reports_patch with sections: data_quality, statistics, plot, fault_summary, rule_explanation.
+5. openfdd_reports_render_pdf then tell operator: open /reports and preview or download PDF.
+6. For flat-line / zero kW faults: draft DataFusion SQL rule, test via openfdd_fdd_rule_test_sql, add rule_explanation section to report.
 
 Example fault rule pattern: flag when kW stays at 0 for N consecutive intervals while equipment should be running.
 """

--- a/.codex/agents/fdd-model-assistant.toml
+++ b/.codex/agents/fdd-model-assistant.toml
@@ -10,7 +10,7 @@ You are the Open-FDD FDD/model assistant invoked from the operator dashboard cha
 Goals:
 - Map BACnet/CSV points to FDD inputs via model assignments and SPARQL.
 - Draft and test DataFusion SQL fault rules; explain equation logic in plain language.
-- Use openfdd MCP: model_coverage, model_sparql, fdd rules APIs, assignments.
+- Use openfdd MCP: model_coverage, model_sparql, openfdd_fdd_rules_list, openfdd_fdd_rule_test_sql, openfdd_model_assignments_save (confirm + OPENFDD_MCP_ALLOW_WRITES=1).
 - Use $spec-contract-compliance-review when tracing requirements to code.
 
 Working set: workspace/data/, model RDF, FDD wire graphs. Scratch in workspace/agent-toolshed/.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,25 +1,19 @@
-# Publish Open-FDD edge images to GHCR.
-# Tags: vX.Y.Z / open-fdd-vX.Y.Z → versioned + minor + latest
-# workflow_dispatch → pyproject.toml version + minor + latest (optional image_tag override)
-# Ordinary branch pushes do NOT publish.
-
-name: Publish Docker images to GHCR
+# ARCHIVED — Python-era GHCR images (openfdd-bridge, openfdd-commission, openfdd-mcp-rag, openfdd-cloud-exporter).
+# Do not use for Rust 3.2.x. Primary image: ghcr.io/bbartling/openfdd-edge-rust
+# Manual dispatch only for legacy maintenance; ordinary pushes and tags do NOT publish these images.
+name: "[ARCHIVED] Publish Python-era Docker images to GHCR"
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-      - "open-fdd-v*"
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Optional SemVer override (default reads VERSION file)"
-        required: false
+        description: "Legacy SemVer (archived stack only)"
+        required: true
+        default: "3.1.6"
+      confirm_archived:
+        description: "Type YES to confirm publishing archived Python-era images"
+        required: true
         default: ""
-      keep_versions:
-        description: "GHCR versions to retain per image"
-        required: false
-        default: "3"
 
 permissions:
   contents: read
@@ -31,34 +25,31 @@ env:
   OWNER: bbartling
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block unless explicitly confirmed
+        run: |
+          if [[ "${{ inputs.confirm_archived }}" != "YES" ]]; then
+            echo "Refusing to publish archived Python-era images without confirm_archived=YES" >&2
+            echo "Use .github/workflows/rust-release.yml for Rust 3.2.x instead." >&2
+            exit 1
+          fi
+
   resolve-tag:
+    needs: guard
     runs-on: ubuntu-latest
     outputs:
       build_tag: ${{ steps.meta.outputs.build_tag }}
-      publish_release_tags: ${{ steps.meta.outputs.publish_release_tags }}
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-
       - id: meta
         run: |
-          chmod +x scripts/resolve_ghcr_publish_tag.sh
-          # shellcheck source=/dev/null
-          source scripts/resolve_ghcr_publish_tag.sh
-          ref="${GITHUB_REF_NAME}"
-          ver="$(resolve_ghcr_publish_tag "${ref}" "${{ inputs.image_tag || '' }}")"
-          if [[ -z "$ver" ]]; then
-            echo "Could not resolve GHCR publish version (pyproject.toml or image_tag)" >&2
-            exit 1
-          fi
+          ver="${{ inputs.image_tag }}"
+          ver="${ver#v}"
           echo "build_tag=${ver}" >> "$GITHUB_OUTPUT"
-          if ghcr_publish_release_tags_enabled "${ref}" "${{ github.event_name }}"; then
-            echo "publish_release_tags=1" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish_release_tags=0" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Publishing ghcr tags: ${ver}, latest (minor alias when release tags enabled)"
 
   docker:
     needs: resolve-tag
@@ -69,39 +60,29 @@ jobs:
         include:
           - image: openfdd-bridge
             target: bridge
-            description: Open-FDD Operator Bridge API, dashboard, historian
           - image: openfdd-commission
             target: commission
-            description: Open-FDD BACnet commissioning and poll worker
           - image: openfdd-mcp-rag
             target: mcp-rag
-            description: Open-FDD MCP and doc-search sidecar
           - image: openfdd-cloud-exporter
             target: cloud-exporter
-            description: Open-FDD generic cloud POST exporter sidecar
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-
       - uses: docker/setup-buildx-action@v3
-
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
           tags: |
             type=raw,value=${{ needs.resolve-tag.outputs.build_tag }}
-            type=raw,value=latest,enable=${{ needs.resolve-tag.outputs.publish_release_tags == '1' }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -109,50 +90,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            OPENFDD_IMAGE_TAG=${{ needs.resolve-tag.outputs.build_tag }}
-            OPENFDD_BUILD_GIT_SHA=${{ github.sha }}
-            OPENFDD_BUILD_TIME=${{ github.event.head_commit.timestamp }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Tag minor release alias
-        if: needs.resolve-tag.outputs.publish_release_tags == '1'
-        run: |
-          ver="${{ needs.resolve-tag.outputs.build_tag }}"
-          minor="${ver%.*}"
-          src="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${ver}"
-          dst="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${minor}"
-          docker buildx imagetools create -t "$dst" "$src"
-
-      - name: Verify version and latest tags
-        if: needs.resolve-tag.outputs.publish_release_tags == '1'
-        run: |
-          ver="${{ needs.resolve-tag.outputs.build_tag }}"
-          img="${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}"
-          docker manifest inspect "${img}:${ver}"
-          docker manifest inspect "${img}:latest"
-
-  prune:
-    needs: docker
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prune old GHCR versions
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GHCR_KEEP_VERSIONS: ${{ inputs.keep_versions || '3' }}
-        run: |
-          chmod +x scripts/ghcr_prune_packages.sh
-          ./scripts/ghcr_prune_packages.sh --delete-retired --all-images \
-            --keep-releases "${GHCR_KEEP_VERSIONS}" --confirm-delete

--- a/.github/workflows/ghcr-multiarch-publish.yml
+++ b/.github/workflows/ghcr-multiarch-publish.yml
@@ -1,23 +1,37 @@
-# LEGACY Python stack only — publishes openfdd-bridge, openfdd-commission, openfdd-mcp-rag.
-# Current Rust deployments use .github/workflows/rust-ghcr.yml → ghcr.io/bbartling/openfdd-edge-rust
-# Copy to .github/workflows/ghcr-multiarch-publish.yml (requires workflow OAuth scope to push).
-# Then: gh workflow run "Publish multi-arch GHCR images" -f image_tag=3.1.6
-name: Publish multi-arch GHCR images
+# ARCHIVED — Python-era multi-arch GHCR (openfdd-bridge, openfdd-commission, openfdd-mcp-rag).
+# Rust 3.2.x: use .github/workflows/rust-release.yml → ghcr.io/bbartling/openfdd-edge-rust
+name: "[ARCHIVED] Publish multi-arch GHCR images (Python stack)"
 
 on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "GHCR tag (e.g. 3.1.6)"
+        description: "Legacy SemVer (archived stack only)"
         required: true
-        default: "3.2.0"
+        default: "3.1.6"
+      confirm_archived:
+        description: "Type YES to confirm publishing archived Python-era images"
+        required: true
+        default: ""
 
 permissions:
   contents: read
   packages: write
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block unless explicitly confirmed
+        run: |
+          if [[ "${{ inputs.confirm_archived }}" != "YES" ]]; then
+            echo "Refusing to publish archived Python-era images without confirm_archived=YES" >&2
+            echo "Use .github/workflows/rust-release.yml for Rust 3.2.x instead." >&2
+            exit 1
+          fi
+
   publish:
+    needs: guard
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/publish-open-fdd.yml
+++ b/.github/workflows/publish-open-fdd.yml
@@ -1,18 +1,12 @@
-# PyPI: open-fdd wheel (Arrow runtime + playground). Tag-triggered only — no publish from branches.
-# Tags: vX.Y.Z (preferred) or legacy open-fdd-vX.Y.Z
-# Configure PyPI Trusted Publishing for bbartling/open-fdd → this workflow → environment pypi
-
-name: Publish open-fdd to PyPI
+# ARCHIVED — PyPI open-fdd wheel (Python 3.1.x era). Rust 3.2.x uses GHCR only.
+# Manual dry-run only; tag pushes no longer publish to PyPI or create Python GitHub Releases.
+name: "[ARCHIVED] Publish open-fdd to PyPI"
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-      - "open-fdd-v*"
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Build and test only (no PyPI upload)"
+        description: "Build and test only (never uploads in archived workflow)"
         required: false
         default: "true"
         type: choice
@@ -40,21 +34,21 @@ jobs:
           python-version: "3.12"
           cache: pip
 
+      - name: Archived workflow notice
+        run: |
+          echo "Python-era PyPI publish is archived. Use rust-release.yml for Rust 3.2.x GHCR releases." >&2
+          if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+            echo "Refusing PyPI upload from archived workflow." >&2
+            exit 1
+          fi
+
       - name: Install build and test deps
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test,dev,analytics]"
           python -m pip install build twine
 
-      - name: Check version matches tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: python scripts/release/check_version.py --tag "${GITHUB_REF_NAME}"
-
-      - name: Version consistency (local)
-        if: "!startsWith(github.ref, 'refs/tags/')"
-        run: python scripts/release/check_version.py
-
-      - name: Run package tests
+      - name: Run package tests (dry-run validation)
         run: |
           python -m pytest open_fdd/tests/arrow_runtime -q
           python -m pytest open_fdd/tests/playground -q
@@ -67,71 +61,7 @@ jobs:
           rm -rf dist build *.egg-info
           python -m build
 
-      - name: Check dist metadata
-        run: python -m twine check dist/*
-
-      - name: Verify wheel smoke
-        run: |
-          python -m venv /tmp/ofdd-wheel-smoke
-          wheel="$(ls -1t dist/*.whl | head -n 1)"
-          /tmp/ofdd-wheel-smoke/bin/pip install "$wheel"
-          /tmp/ofdd-wheel-smoke/bin/python -c "
-          import open_fdd
-          import pyarrow as pa
-          from open_fdd.arrow_runtime import run_arrow_rule
-          from open_fdd.playground.sandbox import lint_python
-          code = '''import pyarrow.compute as pc
-          def apply_faults_arrow(table, cfg, context=None):
-              return pc.greater(table['SAT'], float(cfg['high']))
-          '''
-          assert lint_python(code)['ok']
-          out = run_arrow_rule(code, pa.table({'SAT': [70.0, 90.0]}), {'high': 85})
-          assert out.true_count >= 1
-          "
-          if [ -f scripts/validate_acme_rules_pypi.py ]; then
-            env -u PYTHONPATH OFDD_WHEEL_SMOKE=1 /tmp/ofdd-wheel-smoke/bin/python scripts/validate_acme_rules_pypi.py
-          fi
-
       - uses: actions/upload-artifact@v4
         with:
-          name: python-dist
+          name: python-dist-archived-dry-run
           path: dist/*
-
-  publish:
-    needs: build
-    if: >-
-      startsWith(github.ref, 'refs/tags/') &&
-      (github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run == 'false')
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: python-dist
-          path: dist
-
-      - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-
-  github-release:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: python-dist
-          path: dist
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: dist/*

--- a/.github/workflows/rust-ghcr-mcp.yml
+++ b/.github/workflows/rust-ghcr-mcp.yml
@@ -1,16 +1,16 @@
+# Transitional MCP-only image — MCP binary is also bundled in openfdd-edge-rust.
 name: Publish Open-FDD MCP to GHCR
 
 on:
   push:
     tags:
       - "v*.*.*"
-      - "open-fdd-v*"
     branches:
       - master
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Image tag (default VERSION file)"
+        description: "Optional version tag override (default VERSION file)"
         required: false
         default: ""
 
@@ -19,8 +19,7 @@ permissions:
   packages: write
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE: ghcr.io/bbartling/openfdd-mcp
+  MCP_IMAGE: ghcr.io/bbartling/openfdd-mcp
 
 jobs:
   test:
@@ -48,22 +47,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
+      - id: ver
         run: |
           chmod +x scripts/resolve_ghcr_publish_tag.sh
           # shellcheck source=scripts/resolve_ghcr_publish_tag.sh
           source scripts/resolve_ghcr_publish_tag.sh
           tag="$(resolve_ghcr_publish_tag "${GITHUB_REF_NAME}" "${{ inputs.image_tag }}")"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - id: tags
-        run: |
-          tags="${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}"
-          tags="${tags},${{ env.IMAGE }}:${{ github.sha }}"
+          echo "version=$tag" >> "$GITHUB_OUTPUT"
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            tags="${tags},${{ env.IMAGE }}:latest"
+            echo "latest=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "latest=0" >> "$GITHUB_OUTPUT"
           fi
-          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "version_tag=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_tag=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.MCP_IMAGE }}
+          tags: |
+            type=raw,value=${{ steps.ver.outputs.version }},enable=${{ steps.ver.outputs.version_tag == '1' || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=v${{ steps.ver.outputs.version }},enable=${{ steps.ver.outputs.version_tag == '1' }}
+            type=raw,value=latest,enable=${{ steps.ver.outputs.latest == '1' }}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=Open-FDD MCP
+            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
+            org.opencontainers.image.description=Transitional MCP image — prefer openfdd-edge-rust with entrypoint openfdd-mcp
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
 
       - uses: docker/build-push-action@v6
         with:
@@ -71,6 +86,7 @@ jobs:
           file: Dockerfile.mcp
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/rust-ghcr.yml
+++ b/.github/workflows/rust-ghcr.yml
@@ -1,30 +1,30 @@
+# Publish Rust edge to GHCR on master (latest) or version tags.
+# Full release (GitHub Release + tag): use rust-release.yml workflow_dispatch.
 name: Publish Rust edge to GHCR
 
 on:
   push:
     tags:
       - "v*.*.*"
-      - "open-fdd-v*"
     branches:
       - master
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Image tag (default VERSION file)"
+        description: "Optional version tag override (default VERSION file)"
         required: false
         default: ""
       tag_latest:
-        description: "Also tag :latest (default false except on master push)"
+        description: "Also tag :latest"
         required: false
-        default: "false"
+        default: "true"
 
 permissions:
   contents: read
   packages: write
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE: ghcr.io/bbartling/openfdd-edge-rust
+  EDGE_IMAGE: ghcr.io/bbartling/openfdd-edge-rust
 
 jobs:
   test:
@@ -40,8 +40,7 @@ jobs:
           node-version: "22"
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
-        continue-on-error: true
-      - run: cargo test --workspace --all-targets -p open_fdd_edge_prototype
+      - run: cargo test --workspace --all-targets -p open_fdd_edge_prototype -p openfdd-mcp
       - run: |
           cd workspace/dashboard
           npm ci
@@ -68,22 +67,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
+      - id: ver
         run: |
           chmod +x scripts/resolve_ghcr_publish_tag.sh
           # shellcheck source=scripts/resolve_ghcr_publish_tag.sh
           source scripts/resolve_ghcr_publish_tag.sh
           tag="$(resolve_ghcr_publish_tag "${GITHUB_REF_NAME}" "${{ inputs.image_tag }}")"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - id: tags
-        run: |
-          tags="${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}"
-          tags="${tags},${{ env.IMAGE }}:${{ github.sha }}"
-          if [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.tag_latest }}" == "true" ]]; then
-            tags="${tags},${{ env.IMAGE }}:latest"
+          echo "version=$tag" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ inputs.tag_latest }}" == "true" ]]; then
+            echo "latest=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "latest=0" >> "$GITHUB_OUTPUT"
           fi
-          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "version_tag=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_tag=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.EDGE_IMAGE }}
+          tags: |
+            type=raw,value=${{ steps.ver.outputs.version }},enable=${{ steps.ver.outputs.version_tag == '1' || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=v${{ steps.ver.outputs.version }},enable=${{ steps.ver.outputs.version_tag == '1' }}
+            type=raw,value=latest,enable=${{ steps.ver.outputs.latest == '1' }}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=Open-FDD Rust Edge
+            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
 
       - uses: docker/build-push-action@v6
         with:
@@ -91,10 +106,13 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OPENFDD_IMAGE_TAG=${{ steps.ver.outputs.version }}
+            OPENFDD_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Image digest summary
-        run: |
-          docker buildx imagetools inspect "${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}"
+      - name: Published tags
+        run: docker buildx imagetools inspect "${{ env.EDGE_IMAGE }}:sha-${GITHUB_SHA::7}" || docker buildx imagetools inspect "${{ env.EDGE_IMAGE }}:${{ steps.ver.outputs.version }}"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,200 @@
+# Manual Rust 3.2.x release: CI → GHCR (edge + MCP) → git tag → GitHub Release.
+# Python-era GHCR/PyPI workflows are archived — Rust only.
+name: Rust Release (GHCR + GitHub Release)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SemVer release version (e.g. 3.2.4)"
+        required: true
+        default: "3.2.4"
+      prerelease:
+        description: "Mark GitHub Release as pre-release (skips :latest on GHCR)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  EDGE_IMAGE: ghcr.io/bbartling/openfdd-edge-rust
+  MCP_IMAGE: ghcr.io/bbartling/openfdd-mcp
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: ver
+        run: |
+          v="${{ inputs.version }}"
+          v="${v#v}"
+          if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
+            echo "Invalid SemVer: $v" >&2
+            exit 1
+          fi
+          file_ver="$(tr -d '[:space:]' < VERSION)"
+          if [[ "$file_ver" != "$v" ]]; then
+            echo "VERSION file ($file_ver) does not match input ($v)" >&2
+            exit 1
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
+          components: rustfmt, clippy
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: cargo fmt --all --check
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo test --workspace --all-targets
+      - run: |
+          cd workspace/dashboard
+          npm ci
+          npm run lint
+          npm run test
+          npm run build
+          test -f ../../frontend/index.html
+      - run: |
+          mkdir -p workspace/bacnet/commissioning
+          echo 'OFDD_AUTH_REQUIRED=true' > workspace/auth.env.local
+          touch workspace/data.env.local workspace/bacnet/commissioning/commission.env
+          export OPENFDD_COMPOSE_ROOT="$PWD"
+          docker compose -f docker/compose.edge.rust.yml config
+
+  publish-edge:
+    needs: [validate, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.EDGE_IMAGE }}
+          tags: |
+            type=raw,value=${{ needs.validate.outputs.version }}
+            type=raw,value=v${{ needs.validate.outputs.version }}
+            type=raw,value=latest,enable=${{ inputs.prerelease == false }}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=Open-FDD Rust Edge
+            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OPENFDD_IMAGE_TAG=${{ needs.validate.outputs.version }}
+            OPENFDD_BUILD_GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-mcp:
+    needs: [validate, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.MCP_IMAGE }}
+          tags: |
+            type=raw,value=${{ needs.validate.outputs.version }}
+            type=raw,value=v${{ needs.validate.outputs.version }}
+            type=raw,value=latest,enable=${{ inputs.prerelease == false }}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=Open-FDD MCP (transitional slim image)
+            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
+            org.opencontainers.image.description=MCP stdio sidecar — also bundled in openfdd-edge-rust as /usr/local/bin/openfdd-mcp
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.mcp
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    needs: [validate, publish-edge, publish-mcp]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ needs.validate.outputs.version }}" -m "Open-FDD v${{ needs.validate.outputs.version }} — Rust Edge"
+          git push origin "v${{ needs.validate.outputs.version }}"
+
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.validate.outputs.version }}
+          name: Open-FDD v${{ needs.validate.outputs.version }} — Rust Edge
+          prerelease: ${{ inputs.prerelease }}
+          make_latest: ${{ inputs.prerelease == false }}
+          body: |
+            ## Open-FDD Rust Edge v${{ needs.validate.outputs.version }}
+
+            **Primary runtime image (LAN/VPN/OT — not public internet):**
+            ```bash
+            ghcr.io/bbartling/openfdd-edge-rust:latest
+            ghcr.io/bbartling/openfdd-edge-rust:${{ needs.validate.outputs.version }}
+            ```
+
+            **MCP sidecar** (transitional — also included in edge image as `openfdd-mcp`):
+            ```bash
+            ghcr.io/bbartling/openfdd-mcp:latest
+            ghcr.io/bbartling/openfdd-mcp:${{ needs.validate.outputs.version }}
+            ```
+
+            ### Rust 3.2.x line
+            - Single `openfdd-edge-rust` image: bridge, dashboard, historian, commission, Haystack modes
+            - MCP binary bundled at `/usr/local/bin/openfdd-mcp`
+            - Python-era 3.1.x GHCR packages (`openfdd-bridge`, `openfdd-commission`, etc.) are **archived** and no longer published
+
+            ### Deploy
+            ```bash
+            export OPENFDD_IMAGE_TAG=latest   # early dev default
+            ./scripts/openfdd_rust_edge_bootstrap.sh --start
+            ```

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ frontend/index.html
 **/*.db
 .DS_Store
 workspace/frontend/
+# Operator-sidecar TADCO prep (agent toolshed pattern — not product code)
+scripts/tadco_hvac_prepare.py
+scripts/openfdd_tadco_hvac_integration.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,6 +2250,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,8 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "openfdd-mcp"
-version = "0.1.0"
+version = "3.2.4"
 dependencies = [
+ "base64",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3043,6 +3060,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4088,6 +4106,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ members = ["edge", "mcp"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/bbartling/open-fdd"
-version = "3.2.1"
+version = "3.2.4"

--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ Report: backup size, image tag, health pass/fail, whether backup was purged.
 </details>
 
 <details>
+<summary><strong>Field bench: required workspace/data.env.local keys</strong></summary>
+
+Copy `workspace/bench/data.env.local.example` → `workspace/data.env.local` on OT benches. Never commit filled secrets.
+
+| Key | Required for | Notes |
+|-----|----------------|-------|
+| `OPENFDD_MODBUS_HOST` / `PORT` | Modbus live gate | Set `OPENFDD_MODBUS_MODE=live` |
+| `OPENFDD_BACNET_SERVER_ENABLED=0` | BACnet Who-Is on commission :9091 | Bench uses host-network commission |
+| `OPENFDD_JSON_API_ENABLED=1` | JSON API driver | Also set `OPENFDD_JSON_API_URL` (bridge seeds endpoints on 3.2.4+) |
+| `OPENFDD_HAYSTACK_USER` | Haystack Niagara | HTTP **Basic** auth — not SCRAM |
+| `OPENFDD_HAYSTACK_PASS` | Haystack strict gate | Niagara password; restart bridge after set |
+
+After editing: `./scripts/openfdd_bench_safe_restart.sh` then `OPENFDD_DRIVERS_VALIDATE_STRICT=1 ./scripts/openfdd_drivers_validate.sh`.
+
+See [docs/bench-validation.md](docs/bench-validation.md).
+
+</details>
+
+<details>
 <summary><strong>Optional: MCP sidecar for Cursor (after edge update)</strong></summary>
 
 `openfdd_rust_site_update.sh` pulls the **core edge stack only**. MCP and Cursor chat relay are opt-in compose profiles.

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The **`openfdd-mcp` binary ships inside `openfdd-edge-rust`** (same Cargo worksp
 ```bash
 cd ~/open-fdd
 export OPENFDD_COMPOSE_ROOT="$PWD"
-export OPENFDD_IMAGE_TAG=3.2.4
+export OPENFDD_IMAGE_TAG=latest
 
 docker compose -f docker/compose.edge.rust.yml --profile desktop-json-csv --profile cursor pull
 ```
@@ -282,7 +282,7 @@ export OPENFDD_MCP_TOKEN="$(
         "-e", "OPENFDD_API_BASE=http://127.0.0.1:8080",
         "-e", "OPENFDD_COMMISSION_BASE=http://127.0.0.1:9091",
         "-e", "OPENFDD_MCP_TOKEN",
-        "ghcr.io/bbartling/openfdd-edge-rust:3.2.4"
+        "ghcr.io/bbartling/openfdd-edge-rust:latest"
       ],
       "env": {
         "OPENFDD_MCP_TOKEN": "<paste JWT from step 3>"
@@ -298,7 +298,7 @@ export OPENFDD_MCP_TOKEN="$(
 docker run -i --rm --network host --entrypoint openfdd-mcp \
   -e OPENFDD_API_BASE=http://127.0.0.1:8080 \
   -e OPENFDD_MCP_TOKEN="$OPENFDD_MCP_TOKEN" \
-  ghcr.io/bbartling/openfdd-edge-rust:${OPENFDD_IMAGE_TAG:-3.2.4}
+  ghcr.io/bbartling/openfdd-edge-rust:${OPENFDD_IMAGE_TAG:-latest}
 ```
 
 MCP uses **stdio JSON-RPC** — it is not an HTTP service on a port. Full tool list and bench topology: [mcp/README.md](mcp/README.md).
@@ -308,6 +308,8 @@ MCP uses **stdio JSON-RPC** — it is not an HTTP service on a port. Full tool l
 ---
 
 ## Develop (Rust)
+
+Tested on Windows Subsystem for Linux (WSL)
 
 ```bash
 git clone https://github.com/bbartling/open-fdd.git && cd open-fdd
@@ -331,6 +333,21 @@ Production-style local stack with Caddy TLS:
 docker compose -f docker-compose.prod.yml up -d
 ./scripts/openfdd_prod_validate.sh
 ```
+
+
+## Releases (Rust 3.2.x)
+
+| Channel | Image |
+|---------|--------|
+| **Default (early dev)** | `ghcr.io/bbartling/openfdd-edge-rust:latest` |
+| **Pinned version** | `ghcr.io/bbartling/openfdd-edge-rust:3.2.4` or `:v3.2.4` |
+| **Short SHA** | `ghcr.io/bbartling/openfdd-edge-rust:sha-abc1234` |
+
+**Publish a release** (maintainers): GitHub Actions → **Rust Release (GHCR + GitHub Release)** → version `3.2.4`. Runs CI, pushes edge + MCP images, creates tag `v3.2.4`, and opens a GitHub Release.
+
+Python-era 3.1.x GHCR packages (`openfdd-bridge`, `openfdd-commission`, `openfdd-mcp-rag`, `openfdd-cloud-exporter`) are **archived** and no longer updated. Primary runtime: **`openfdd-edge-rust`** (includes `openfdd-mcp` binary). Slim `openfdd-mcp` image is transitional.
+
+Open-FDD is for **LAN / VPN / OT networks**, not public internet hosting.
 
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,9 +96,15 @@ services:
       - ./workspace/auth.env.local
     volumes:
       - ./workspace:/app/workspace
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9092/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
-  # Optional MCP sidecar: see mcp/README.md and README "Optional MCP sidecar".
+  # Optional MCP sidecar:
   # docker compose -f docker/compose.edge.rust.yml --profile mcp-sidecar pull openfdd-mcp
 
   open-fdd-rust-backend:

--- a/docs/agent/ingest-contract-v1.md
+++ b/docs/agent/ingest-contract-v1.md
@@ -1,0 +1,85 @@
+# Ingest Contract v1 (Agent Playbook)
+
+Open-FDD does **not** ship site-specific ETL. AI agents clean and reshape data in a **gitignored sandbox**, then submit contract-compliant payloads through a **fail-closed Rust validation gate**.
+
+## Machine-readable contract
+
+```http
+GET /api/ingest/contract
+```
+
+Returns `historian_wide_csv`, `import_plan`, and `commissioning_bundle` profiles plus FDD input catalog and limits.
+
+## Agent sandbox (not committed)
+
+Use `workspace/agent-toolshed/<job-id>/` for scratch scripts (Python, DuckDB, R, etc.). Nothing in this folder is committed to the Open-FDD repo.
+
+## Workflow
+
+1. **Read contract** — `GET /api/ingest/contract` or MCP `openfdd_ingest_contract`
+2. **Clean in toolshed** — pivot long Niagara/TADCO CSVs → wide historian CSV
+3. **Preview** — `POST /api/csv/import/preview`
+4. **Plan** — `POST /api/csv/import/plan`
+5. **Preflight (required)** — `POST /api/csv/import/preflight` → `verdict: "pass"`
+6. **Execute** — `POST /api/csv/import/execute` (strict by default; `OPENFDD_CSV_STRICT=0` dev escape)
+7. **Commissioning (optional)** — `POST /api/model/commissioning-import`
+8. **FDD** — `POST /api/fdd-rules/{id}/test-sql` → `POST /api/rules/batch`
+9. **Report** — `POST /api/reports/from-fdd-sql-run`
+
+MCP composite: `openfdd_integration_smoke` orchestrates read steps + optional writes with `confirm: true`.
+
+## Historian wide CSV (primary path)
+
+| Column | Required | Notes |
+|--------|----------|-------|
+| `timestamp` | yes | RFC3339 or naive local + plan timezone |
+| `equipment_id` | recommended | `equip:<slug>` e.g. `equip:liberty-100-ahu-1` |
+| `site_id` | recommended | `site:<slug>` |
+| FDD value columns | yes (≥1 numeric) | `oa_t`, `sat`, `zn_t`, `duct_t`, `sat_sp`, `fan_cmd`, `occ`, … |
+
+### TADCO / Niagara long → wide mapping (example)
+
+| Source `point_role` | Wide column |
+|---------------------|-------------|
+| outside air temp | `oa_t` |
+| zone temp | `zn_t` |
+| discharge air temp | `duct_t` |
+| cooling setpoint | `sat_sp` |
+| supply air temp | `sat` |
+| fan command | `fan_cmd` |
+| occupancy | `occ` |
+
+Pivot by `equipment_id` + `timestamp`; one row per timestamp per equipment.
+
+## Commissioning bundle
+
+```json
+{
+  "sites": [{"id": "site:…", "dis": "…", "site": "M"}],
+  "equipment": [{"id": "equip:…", "site_id": "site:…", "equip": "M"}],
+  "points": [{"id": "point:…", "equip_ref": "equip:…", "fdd_input": "oa_t"}],
+  "assignments": [{"haystack_id": "…", "equip_ref": "…", "fdd_input": "…"}],
+  "fdd_rules": [{"rule_id": "…", "name": "…", "sql": "SELECT … fault_raw …"}]
+}
+```
+
+Import is **fail-closed**: invalid `fdd_input`, duplicate IDs, or unsafe SQL → `{ verdict: "fail", checks: [...] }`.
+
+## Preflight validation codes
+
+| Code | Severity | Meaning |
+|------|----------|---------|
+| `FILE_QUARANTINED` | error | Parse quarantine on staged file |
+| `TIMESTAMP_FAILED` | error | Unparseable timestamps |
+| `TIMESTAMP_AMBIGUOUS` | error | DST ambiguity |
+| `ROW_COUNT_ZERO` | error | Plan produced no rows |
+| `NO_NUMERIC_COLUMNS` | error | No value columns |
+| `HISTORIAN_SYNC_EMPTY` | error | Rows but no numeric values to sync |
+| `COLUMN_UNKNOWN` | warn | No standard FDD alias |
+| `EQUIPMENT_ID_MISSING` | warn | Wide CSV without equipment_id |
+
+## Strict mode
+
+Default: **`OPENFDD_CSV_STRICT` unset or non-zero** → execute rejected unless preflight `verdict == "pass"`.
+
+Dev escape: `OPENFDD_CSV_STRICT=0` on edge (integrator migration only).

--- a/docs/agent/openfdd-mcp-tool-contract.md
+++ b/docs/agent/openfdd-mcp-tool-contract.md
@@ -25,6 +25,18 @@ Read-first sidecar. JWT via `OPENFDD_MCP_TOKEN`. Bind `127.0.0.1` or site VLAN o
 | `openfdd_model_sparql` | `POST /api/model/sparql` | JWT |
 | `openfdd_model_sites` | `GET /api/model/sites` | JWT |
 | `openfdd_model_coverage` | `GET /api/dashboard/model-coverage` | JWT |
+| `openfdd_csv_import_preview` | `POST /api/csv/import/preview` (path/base64/multipart) | JWT |
+| `openfdd_csv_import_plan` | `POST /api/csv/import/plan` | JWT |
+| `openfdd_csv_fusion_preview` | `GET /api/csv/import/sessions/{id}/fusion-preview` | JWT |
+| `openfdd_csv_import_execute` | `POST /api/csv/import/execute` | JWT + write gate |
+| `openfdd_historian_query` | `GET/POST /api/historian/query` | JWT |
+| `openfdd_fdd_rules_list` | `GET /api/fdd-rules` | JWT |
+| `openfdd_fdd_rule_test_sql` | `POST /api/fdd-rules/{id}/test-sql` | JWT |
+| `openfdd_fdd_run` | `POST /api/fdd/run` | JWT + write gate |
+| `openfdd_model_assignments_save` | `POST /api/model/assignments/save` | JWT + write gate |
+| `openfdd_reports_draft` | `POST /api/reports/draft` | JWT + write gate |
+| `openfdd_reports_patch` | `PATCH /api/reports/{id}` | JWT + write gate |
+| `openfdd_reports_render_pdf` | `POST /api/reports/{id}/render/pdf` | JWT + write gate |
 
 ### `openfdd_model_sparql`
 
@@ -50,14 +62,19 @@ Use the same JWT against the bridge directly — see [AI_AGENT_API.md](../AI_AGE
 | Test SQL rule | POST | `/api/fdd-rules/{id}/test-sql` |
 | Stack health | GET | `/api/health/stack` |
 
-## Phase 2 — gated (not in MCP by default)
+## Phase 2 — write tools (gated)
 
-Requires `OPENFDD_MCP_ALLOW_WRITES=1` and per-call approval record:
+Requires **`OPENFDD_MCP_ALLOW_WRITES=1`** and **`confirm: true`** on each tool call:
 
 | Tool | REST | Risk |
 |------|------|------|
-| Rule activation | `POST /api/fdd-rules/{id}/activate` | Live FDD |
-| Save assignments | `POST /api/model/assignments/save` | OT binding |
+| `openfdd_csv_import_execute` | `POST /api/csv/import/execute` | Arrow/historian write |
+| `openfdd_fdd_run` | `POST /api/fdd/run` | Live FDD evaluation |
+| `openfdd_model_assignments_save` | `POST /api/model/assignments/save` | Model binding |
+| `openfdd_reports_draft` | `POST /api/reports/draft` | Report create |
+| `openfdd_reports_patch` | `PATCH /api/reports/{id}` | Report edit |
+| `openfdd_reports_render_pdf` | `POST /api/reports/{id}/render/pdf` | PDF output |
+| Rule activation | `POST /api/fdd-rules/{id}/activate` | Live FDD (REST only — not in MCP yet) |
 | BACnet write | `POST /api/bacnet/write` | Field bus |
 | Haystack write | `POST /api/haystack/write` | Station write |
 | Site restore | backup/restore scripts | Data loss |

--- a/docs/agent/openfdd-mcp-tool-contract.md
+++ b/docs/agent/openfdd-mcp-tool-contract.md
@@ -27,11 +27,21 @@ Read-first sidecar. JWT via `OPENFDD_MCP_TOKEN`. Bind `127.0.0.1` or site VLAN o
 | `openfdd_model_coverage` | `GET /api/dashboard/model-coverage` | JWT |
 | `openfdd_csv_import_preview` | `POST /api/csv/import/preview` (path/base64/multipart) | JWT |
 | `openfdd_csv_import_plan` | `POST /api/csv/import/plan` | JWT |
+| `openfdd_ingest_contract` | `GET /api/ingest/contract` | none |
+| `openfdd_csv_import_preflight` | `POST /api/csv/import/preflight` | JWT |
+| `openfdd_csv_workbench_quality` | `POST /api/csv-workbench/quality` | JWT |
+| `openfdd_model_commissioning_export` | `GET /api/model/commissioning-export` | JWT |
+| `openfdd_model_commissioning_import` | `POST /api/model/commissioning-import` | JWT + write gate |
 | `openfdd_csv_fusion_preview` | `GET /api/csv/import/sessions/{id}/fusion-preview` | JWT |
-| `openfdd_csv_import_execute` | `POST /api/csv/import/execute` | JWT + write gate |
+| `openfdd_csv_import_execute` | `POST /api/csv/import/execute` | JWT + write gate + preflight pass |
 | `openfdd_historian_query` | `GET/POST /api/historian/query` | JWT |
 | `openfdd_fdd_rules_list` | `GET /api/fdd-rules` | JWT |
 | `openfdd_fdd_rule_test_sql` | `POST /api/fdd-rules/{id}/test-sql` | JWT |
+| `openfdd_rules_batch` | `POST /api/rules/batch` | JWT + write gate |
+| `openfdd_fdd_rules_save` | `POST /api/fdd-rules` | JWT + write gate |
+| `openfdd_fdd_rules_activate` | `POST /api/fdd-rules/{id}/activate` | JWT + write gate |
+| `openfdd_reports_from_fdd_sql_run` | `POST /api/reports/from-fdd-sql-run` | JWT + write gate |
+| `openfdd_integration_smoke` | Composite playbook | JWT (+ write gate if confirm) |
 | `openfdd_fdd_run` | `POST /api/fdd/run` | JWT + write gate |
 | `openfdd_model_assignments_save` | `POST /api/model/assignments/save` | JWT + write gate |
 | `openfdd_reports_draft` | `POST /api/reports/draft` | JWT + write gate |
@@ -68,8 +78,13 @@ Requires **`OPENFDD_MCP_ALLOW_WRITES=1`** and **`confirm: true`** on each tool c
 
 | Tool | REST | Risk |
 |------|------|------|
-| `openfdd_csv_import_execute` | `POST /api/csv/import/execute` | Arrow/historian write |
-| `openfdd_fdd_run` | `POST /api/fdd/run` | Live FDD evaluation |
+| `openfdd_csv_import_execute` | `POST /api/csv/import/execute` | Arrow/historian write (preflight pass required) |
+| `openfdd_model_commissioning_import` | `POST /api/model/commissioning-import` | Model + rules import |
+| `openfdd_rules_batch` | `POST /api/rules/batch` | Run saved FDD rules |
+| `openfdd_fdd_rules_save` | `POST /api/fdd-rules` | Save SQL rule |
+| `openfdd_fdd_rules_activate` | `POST /api/fdd-rules/{id}/activate` | Activate rule |
+| `openfdd_reports_from_fdd_sql_run` | `POST /api/reports/from-fdd-sql-run` | PDF from SQL run |
+| `openfdd_fdd_run` | `POST /api/fdd/run` | Live FDD evaluation (ad-hoc SQL) |
 | `openfdd_model_assignments_save` | `POST /api/model/assignments/save` | Model binding |
 | `openfdd_reports_draft` | `POST /api/reports/draft` | Report create |
 | `openfdd_reports_patch` | `PATCH /api/reports/{id}` | Report edit |

--- a/docs/bench-validation.md
+++ b/docs/bench-validation.md
@@ -1,0 +1,41 @@
+# Bench validation (Linux field / GHCR pull)
+
+Use this on a **bench machine** that pulls `ghcr.io/bbartling/openfdd-edge-rust` — no git clone required for validation runs.
+
+## Quick gate
+
+```bash
+cd ~/open-fdd
+cp workspace/bench/data.env.local.example workspace/data.env.local
+# Set OPENFDD_HAYSTACK_PASS (Niagara HTTP Basic), then:
+./scripts/openfdd_bench_safe_restart.sh   # when shipped; else openfdd_rust_site_update.sh
+OPENFDD_DRIVERS_VALIDATE_STRICT=1 OPENFDD_EXPECT_VERSION=3.2.4 \
+  ./scripts/openfdd_drivers_validate.sh
+```
+
+Strict gate expects: Modbus live, BACnet commission read, Haystack password set + test OK, JSON API `configured: true`, SPARQL catalog 200 or SKIP on older images.
+
+## Triage: harness vs product vs operator
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Haystack FAIL, `password_set: false` | Operator — set `OPENFDD_HAYSTACK_PASS` in `workspace/data.env.local` |
+| JSON API `not_configured` | Set `OPENFDD_JSON_API_URL` + restart bridge (3.2.4+ seeds endpoints on startup) |
+| SPARQL 404 | Older image — gate **SKIP**s; not a driver FAIL |
+| Fault rule PATCH rejected | Product — use `PATCH /api/rules/{rule_id}` or `PATCH /api/fdd-rules/{rule_id}` (3.2.4+) |
+| MCP “missing tools” | Harness — expect `openfdd_*` tool names per [mcp/README.md](../mcp/README.md) |
+| Modbus read FAIL but JSON has values | Harness jq gate — check response shape |
+
+## Fault rule param change (hour test minute 30)
+
+```bash
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"confirmation_seconds":600}' \
+  http://127.0.0.1:8080/api/rules/oa_temp_out_of_range
+```
+
+## References
+
+- Driver validate: `./scripts/openfdd_drivers_validate.sh`
+- Bench profile template: `workspace/bench/bench_profile.toml`
+- Haystack + SPARQL model: [modeling/haystack_dashboard_model.md](modeling/haystack_dashboard_model.md)

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -190,7 +190,7 @@ fn main() -> std::io::Result<()> {
                     out_dir,
                     lan_ip,
                 })
-                .map_err(|e| std::io::Error::other(e))?;
+                .map_err(std::io::Error::other)?;
                 eprintln!("wrote {}", result.cert_path.display());
                 eprintln!("wrote {}", result.key_path.display());
                 Ok(())
@@ -215,7 +215,7 @@ fn main() -> std::io::Result<()> {
                         out_dir,
                         lan_ip,
                     })
-                    .map_err(|e| std::io::Error::other(e))?;
+                    .map_err(std::io::Error::other)?;
                     eprintln!("TLS cert: {}", result.cert_path.display());
                     eprintln!("TLS key:  {}", result.key_path.display());
                 }

--- a/edge/src/bin/openfdd_edge.rs
+++ b/edge/src/bin/openfdd_edge.rs
@@ -176,8 +176,8 @@ fn main() -> std::io::Result<()> {
                 Ok(())
             }
             AuthCommands::HashPassword { password } => {
-                let hashed = hash_password(&password)
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+                let hashed =
+                    hash_password(&password).map_err(|e| std::io::Error::other(e.to_string()))?;
                 println!("{hashed}");
                 Ok(())
             }
@@ -190,7 +190,7 @@ fn main() -> std::io::Result<()> {
                     out_dir,
                     lan_ip,
                 })
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(|e| std::io::Error::other(e))?;
                 eprintln!("wrote {}", result.cert_path.display());
                 eprintln!("wrote {}", result.key_path.display());
                 Ok(())
@@ -215,7 +215,7 @@ fn main() -> std::io::Result<()> {
                         out_dir,
                         lan_ip,
                     })
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    .map_err(|e| std::io::Error::other(e))?;
                     eprintln!("TLS cert: {}", result.cert_path.display());
                     eprintln!("TLS key:  {}", result.key_path.display());
                 }

--- a/edge/src/csv_ingest/dataset.rs
+++ b/edge/src/csv_ingest/dataset.rs
@@ -207,7 +207,8 @@ pub fn sync_output_rows_to_historian(dataset_id: &str, rows: &[OutputRow]) -> Va
     use crate::model::csv_import::{apply_pivot_aliases, column_slug, ids_from_filename};
 
     let filename = format!("{dataset_id}.csv");
-    let (site_id, equip_id, source_id, _) = ids_from_filename(&filename);
+    let (default_site, default_equip, _, _) = ids_from_filename(&filename);
+    let source_tag = format!("csv:{dataset_id}");
     let mut new_rows: Vec<Value> = Vec::new();
     for r in rows {
         let ts = r
@@ -217,15 +218,31 @@ pub fn sync_output_rows_to_historian(dataset_id: &str, rows: &[OutputRow]) -> Va
         if ts.trim().is_empty() {
             continue;
         }
+        let row_equip = r
+            .values
+            .get("equipment_id")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(default_equip.as_str());
+        let row_site = r
+            .values
+            .get("site_id")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(default_site.as_str());
         let mut row = json!({
             "timestamp": ts,
-            "equipment_id": equip_id,
-            "site_id": site_id,
-            "source": source_id,
+            "equipment_id": row_equip,
+            "site_id": row_site,
+            "source": source_tag,
             "source_driver": "csv",
             "is_simulated": false
         });
         for (k, v) in &r.values {
+            let lk = k.to_ascii_lowercase();
+            if lk == "equipment_id" || lk == "site_id" {
+                continue;
+            }
             if v.trim().is_empty() {
                 continue;
             }
@@ -243,29 +260,39 @@ pub fn sync_output_rows_to_historian(dataset_id: &str, rows: &[OutputRow]) -> Va
         return json!({
             "ok": false,
             "error": "no numeric rows synced to historian",
-            "site_id": site_id,
-            "equipment_id": equip_id
+            "site_id": default_site,
+            "equipment_id": default_equip
         });
     }
     let mut all = store::load_pivot_rows().unwrap_or_default();
     all.retain(|r| {
         r.get("source")
             .and_then(|v| v.as_str())
-            .is_none_or(|s| s != source_id.as_str())
+            .is_none_or(|s| s != source_tag.as_str())
     });
     all.extend(new_rows.clone());
     match store::rewrite_all(&all) {
-        Ok(()) => json!({
-            "ok": true,
-            "rows_synced": new_rows.len(),
-            "historian_total": all.len(),
-            "site_id": site_id,
-            "equipment_id": equip_id,
-            "source_id": source_id,
-            "plot_url": format!("/plot?site={site_id}&device={equip_id}&hours=8760"),
-            "model_url": format!("/model?site={site_id}")
-        }),
-        Err(e) => json!({"ok": false, "error": e, "site_id": site_id}),
+        Ok(()) => {
+            let sync_site = new_rows
+                .first()
+                .and_then(|r| r.get("site_id").and_then(|v| v.as_str()))
+                .unwrap_or(default_site.as_str());
+            let sync_equip = new_rows
+                .first()
+                .and_then(|r| r.get("equipment_id").and_then(|v| v.as_str()))
+                .unwrap_or(default_equip.as_str());
+            json!({
+                "ok": true,
+                "rows_synced": new_rows.len(),
+                "historian_total": all.len(),
+                "site_id": sync_site,
+                "equipment_id": sync_equip,
+                "source_id": source_tag,
+                "plot_url": format!("/plot?site={sync_site}&device={sync_equip}&hours=8760"),
+                "model_url": format!("/model?site={sync_site}")
+            })
+        }
+        Err(e) => json!({"ok": false, "error": e, "site_id": default_site}),
     }
 }
 

--- a/edge/src/csv_ingest/mod.rs
+++ b/edge/src/csv_ingest/mod.rs
@@ -168,12 +168,14 @@ pub fn plan_handler(body: &Value) -> Value {
         Err(e) => return json!({"ok": false, "error": e}),
     };
     let preview = preview_rows(&rows, 100);
-    let validation_report = json!({
-        "timestamp_analysis": preview.timestamp_analysis,
-        "warnings": preview.warnings,
-        "row_count": preview.row_count,
-        "quarantined": 0,
-    });
+    let files = session
+        .get("files")
+        .and_then(|v| v.as_array())
+        .map(|a| a.as_slice())
+        .unwrap_or(&[]);
+    let quarantined = crate::ingest::validate::quarantined_count_from_session(&session);
+    let validation_report =
+        crate::ingest::validate::merge_validation_report(&preview, files, quarantined);
     session["plan"] = serde_json::to_value(&plan).unwrap_or(json!({}));
     session["status"] = json!("planned");
     session["validation_report"] = validation_report.clone();
@@ -282,6 +284,77 @@ fn execute_plan_preview(
     }
 }
 
+pub fn preflight_handler(body: &Value) -> Value {
+    let session_id = body
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let Some(mut session) = load_session(session_id) else {
+        return json!({"ok": false, "error": "session not found"});
+    };
+
+    let plan = if body.get("plan").is_some() {
+        match plan_from_json(body.get("plan").unwrap_or(body)) {
+            Ok(p) => p,
+            Err(e) => return json!({"ok": false, "error": e}),
+        }
+    } else {
+        match session.get("plan").cloned() {
+            Some(v) => match serde_json::from_value(v) {
+                Ok(p) => p,
+                Err(e) => return json!({"ok": false, "error": e.to_string()}),
+            },
+            None => {
+                return json!({"ok": false, "error": "no plan on session — POST /api/csv/import/plan first"})
+            }
+        }
+    };
+
+    let rows = match execute_plan_preview(&plan, session_id) {
+        Ok(r) => r,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let preview = preview_rows(&rows, 100);
+    let files: Vec<Value> = session
+        .get("files")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let quarantined = crate::ingest::validate::quarantined_count_from_session(&session);
+    let validation_report =
+        crate::ingest::validate::merge_validation_report(&preview, &files, quarantined);
+
+    if body.get("plan").is_some() {
+        session["plan"] = serde_json::to_value(&plan).unwrap_or(json!({}));
+        session["validation_report"] = validation_report.clone();
+        session["status"] = json!("planned");
+        let _ = save_session(session_id, &session);
+    }
+
+    let validation =
+        crate::ingest::validate::evaluate_csv_session(crate::ingest::validate::ValidationInput {
+            session_files: &files,
+            plan: Some(&plan),
+            preview: Some(&preview),
+            validation_report: Some(&validation_report),
+        });
+
+    json!({
+        "ok": validation.get("ok"),
+        "session_id": session_id,
+        "verdict": validation.get("verdict"),
+        "validation": validation,
+        "validation_report": validation_report,
+        "preview": {
+            "row_count": preview.row_count,
+            "column_names": preview.column_names,
+            "time_range": preview.time_range,
+            "timestamp_analysis": preview.timestamp_analysis
+        },
+        "can_execute": validation.get("verdict") == Some(&json!("pass")) || !crate::ingest::validate::csv_strict_enabled()
+    })
+}
+
 pub fn execute_handler(body: &Value) -> Value {
     let session_id = body
         .get("session_id")
@@ -304,10 +377,34 @@ pub fn execute_handler(body: &Value) -> Value {
         Err(e) => return json!({"ok": false, "error": e}),
     };
     let preview = preview_rows(&rows, 5);
-    let validation_report = session
-        .get("validation_report")
-        .cloned()
-        .unwrap_or_else(|| json!({"warnings": preview.warnings}));
+    let files = session
+        .get("files")
+        .and_then(|v| v.as_array())
+        .map(|a| a.as_slice())
+        .unwrap_or(&[]);
+    let quarantined = crate::ingest::validate::quarantined_count_from_session(&session);
+    let validation_report =
+        crate::ingest::validate::merge_validation_report(&preview, files, quarantined);
+
+    if crate::ingest::validate::csv_strict_enabled() {
+        let validation = crate::ingest::validate::evaluate_csv_session(
+            crate::ingest::validate::ValidationInput {
+                session_files: files,
+                plan: Some(&plan),
+                preview: Some(&preview),
+                validation_report: Some(&validation_report),
+            },
+        );
+        if validation.get("verdict") != Some(&json!("pass")) {
+            return json!({
+                "ok": false,
+                "error": "ingest rejected — preflight verdict must be pass (see validation.checks)",
+                "validation": validation,
+                "hint": "POST /api/csv/import/preflight and fix data in agent toolshed before execute"
+            });
+        }
+    }
+
     let dataset_id = plan.output_dataset_name.clone();
     match save_dataset(
         &dataset_id,

--- a/edge/src/csv_ingest/mod.rs
+++ b/edge/src/csv_ingest/mod.rs
@@ -18,56 +18,30 @@ use session::{create_session, load_session, save_session, stage_file};
 use plan::{append_rows, join_rows, parse_file_to_rows, preview_rows, JoinAlignment};
 use serde_json::{json, Value};
 use session::read_staged_file;
+use std::collections::BTreeMap;
 
-pub fn preview_handler(content_type: &str, body: &[u8]) -> Value {
-    let files = match upload::parse_upload(content_type, body) {
-        Ok(f) => f,
+pub fn preview_handler(content_type: &str, body: &[u8], session_id_hint: Option<&str>) -> Value {
+    let (files, sid_hint) = match upload::parse_upload(content_type, body) {
+        Ok(parsed) => parsed,
         Err(e) => return json!({"ok": false, "error": e}),
     };
     if files.is_empty() {
         return json!({"ok": false, "error": "no files in upload"});
     }
-    let session = create_session();
-    let session_id = session
-        .get("session_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    if session_id.is_empty() {
-        return session;
-    }
-    let mut staged = Vec::new();
-    let mut errors = Vec::new();
-    for (name, raw) in files {
-        match stage_file(&session_id, &name, &raw) {
-            Ok(meta) => staged.push(meta),
-            Err(e) => errors.push(json!({"file": name, "error": e})),
-        }
-    }
-    let mut session = load_session(&session_id).unwrap_or(session);
-    session["files"] = json!(staged);
-    session["status"] = json!("previewed");
-    let _ = save_session(&session_id, &session);
-    json!({
-        "ok": errors.is_empty(),
-        "session_id": session_id,
-        "files": staged,
-        "errors": errors,
-    })
+    preview_upload_files(session_id_hint.or(sid_hint.as_deref()), files)
 }
 
 pub fn preview_json_handler(body: &Value) -> Value {
-    let session = create_session();
-    let session_id = session
+    let session_id_hint = body
         .get("session_id")
         .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let files = body.get("files").and_then(|v| v.as_array());
-    let Some(files) = files else {
+        .filter(|s| !s.is_empty());
+    let files_arr = body.get("files").and_then(|v| v.as_array());
+    let Some(files) = files_arr else {
         return json!({"ok": false, "error": "files array required"});
     };
-    let mut staged = Vec::new();
+    let mut uploads = Vec::new();
+    let mut errors = Vec::new();
     for f in files {
         let name = f
             .get("filename")
@@ -80,20 +54,93 @@ pub fn preview_json_handler(body: &Value) -> Value {
         let raw = match base64_decode(content) {
             Ok(b) => b,
             Err(e) => {
-                staged.push(json!({"filename": name, "error": e}));
+                errors.push(json!({"file": name, "error": e}));
                 continue;
             }
         };
-        match stage_file(&session_id, name, &raw) {
+        uploads.push((name.to_string(), raw));
+    }
+    let mut out = preview_upload_files(session_id_hint, uploads);
+    if let Some(arr) = out.get_mut("errors").and_then(|v| v.as_array_mut()) {
+        arr.extend(errors);
+        if !arr.is_empty() {
+            out["ok"] = json!(false);
+        }
+    } else if !errors.is_empty() {
+        out["errors"] = json!(errors);
+        out["ok"] = json!(false);
+    }
+    out
+}
+
+fn preview_upload_files(session_id_hint: Option<&str>, files: Vec<(String, Vec<u8>)>) -> Value {
+    let (session, session_id) = match resolve_or_create_session(session_id_hint) {
+        Ok(v) => v,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let mut staged = Vec::new();
+    let mut errors = Vec::new();
+    for (name, raw) in files {
+        match stage_file(&session_id, &name, &raw) {
             Ok(meta) => staged.push(meta),
-            Err(e) => staged.push(json!({"filename": name, "error": e})),
+            Err(e) => errors.push(json!({"file": name, "error": e})),
         }
     }
+    if staged.is_empty() && !errors.is_empty() {
+        return json!({"ok": false, "session_id": session_id, "errors": errors});
+    }
+    let merged = merge_session_files(&session, &staged);
     let mut session = load_session(&session_id).unwrap_or(session);
-    session["files"] = json!(staged);
+    session["files"] = json!(merged);
     session["status"] = json!("previewed");
     let _ = save_session(&session_id, &session);
-    json!({"ok": true, "session_id": session_id, "files": staged})
+    json!({
+        "ok": errors.is_empty(),
+        "session_id": session_id,
+        "files": merged,
+        "errors": errors,
+    })
+}
+
+fn resolve_or_create_session(session_id_hint: Option<&str>) -> Result<(Value, String), String> {
+    if let Some(sid) = session_id_hint {
+        let Some(session) = load_session(sid) else {
+            return Err(format!("session not found: {sid}"));
+        };
+        return Ok((session, sid.to_string()));
+    }
+    let session = create_session();
+    let session_id = session
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if session_id.is_empty() {
+        return Err("failed to create session".into());
+    }
+    Ok((session, session_id))
+}
+
+fn merge_session_files(session: &Value, new_files: &[Value]) -> Vec<Value> {
+    let mut by_name: BTreeMap<String, Value> = session
+        .get("files")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|f| {
+                    f.get("filename")
+                        .and_then(|v| v.as_str())
+                        .map(|n| (n.to_string(), f.clone()))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    for f in new_files {
+        if let Some(name) = f.get("filename").and_then(|v| v.as_str()) {
+            by_name.insert(name.to_string(), f.clone());
+        }
+    }
+    by_name.into_values().collect()
 }
 
 fn base64_decode(s: &str) -> Result<Vec<u8>, String> {

--- a/edge/src/csv_ingest/plan.rs
+++ b/edge/src/csv_ingest/plan.rs
@@ -2,8 +2,8 @@
 
 use crate::csv_ingest::parse::parse_csv_text;
 use crate::csv_ingest::timestamp::{
-    analyze_timestamps, default_tz, is_timestamp_candidate, localize_timestamp,
-    parse_timestamp_loose, ParseStatus, ParsedTimestamp, TimestampAnalysis,
+    analyze_timestamps, default_tz, is_timestamp_candidate, ParseStatus, ParsedTimestamp,
+    TimestampAnalysis,
 };
 use chrono::{DateTime, Timelike, Utc};
 use chrono_tz::Tz;
@@ -138,17 +138,7 @@ pub fn parse_file_to_rows(
                 rec.get(*idx).unwrap_or("").to_string(),
             );
         }
-        let pt = if let Some(naive) = parse_timestamp_loose(&raw_ts) {
-            localize_timestamp(naive, tz, ambiguous_policy)
-        } else {
-            ParsedTimestamp {
-                ts_utc: None,
-                ts_local: None,
-                raw: raw_ts.clone(),
-                status: ParseStatus::Failed,
-                fold: None,
-            }
-        };
+        let pt = crate::csv_ingest::timestamp::parse_row_timestamp(&raw_ts, tz, ambiguous_policy);
         rows.push(OutputRow {
             ts_utc: pt.ts_utc,
             ts_local: pt

--- a/edge/src/csv_ingest/plan.rs
+++ b/edge/src/csv_ingest/plan.rs
@@ -546,58 +546,6 @@ pub fn output_rows_to_fusion_grid(
     (columns, grid)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::TimeZone;
-
-    #[test]
-    fn linear_fill_between_known_points() {
-        let mut rows = vec![
-            OutputRow {
-                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 0, 0, 0).unwrap()),
-                ts_local: String::new(),
-                timezone: "UTC".into(),
-                source_timestamp_raw: String::new(),
-                source_timestamp_parse_status: "ok".into(),
-                source_timestamp_fold: None,
-                source_file: "t.csv".into(),
-                source_row_number: 1,
-                values: BTreeMap::from([("kw".into(), "10".into())]),
-                fill_created: false,
-            },
-            OutputRow {
-                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 1, 0, 0).unwrap()),
-                ts_local: String::new(),
-                timezone: "UTC".into(),
-                source_timestamp_raw: String::new(),
-                source_timestamp_parse_status: "ok".into(),
-                source_timestamp_fold: None,
-                source_file: "t.csv".into(),
-                source_row_number: 2,
-                values: BTreeMap::from([("kw".into(), String::new())]),
-                fill_created: false,
-            },
-            OutputRow {
-                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 2, 0, 0).unwrap()),
-                ts_local: String::new(),
-                timezone: "UTC".into(),
-                source_timestamp_raw: String::new(),
-                source_timestamp_parse_status: "ok".into(),
-                source_timestamp_fold: None,
-                source_file: "t.csv".into(),
-                source_row_number: 3,
-                values: BTreeMap::from([("kw".into(), "20".into())]),
-                fill_created: false,
-            },
-        ];
-        apply_fill_policy(&mut rows, FillPolicy::Linear);
-        let mid = rows[1].values.get("kw").unwrap();
-        let v: f64 = mid.parse().unwrap();
-        assert!(v > 10.0 && v < 20.0);
-    }
-}
-
 pub fn plan_from_json(body: &Value) -> Result<ImportPlan, String> {
     serde_json::from_value(body.clone()).map_err(|e| e.to_string())
 }
@@ -699,5 +647,57 @@ pub fn infer_ut3_plan_from_session(session: &Value) -> ImportPlan {
         ambiguous_policy: "first".into(),
         output_dataset_name: "school_kw_merged".into(),
         ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn linear_fill_between_known_points() {
+        let mut rows = vec![
+            OutputRow {
+                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 0, 0, 0).unwrap()),
+                ts_local: String::new(),
+                timezone: "UTC".into(),
+                source_timestamp_raw: String::new(),
+                source_timestamp_parse_status: "ok".into(),
+                source_timestamp_fold: None,
+                source_file: "t.csv".into(),
+                source_row_number: 1,
+                values: BTreeMap::from([("kw".into(), "10".into())]),
+                fill_created: false,
+            },
+            OutputRow {
+                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 1, 0, 0).unwrap()),
+                ts_local: String::new(),
+                timezone: "UTC".into(),
+                source_timestamp_raw: String::new(),
+                source_timestamp_parse_status: "ok".into(),
+                source_timestamp_fold: None,
+                source_file: "t.csv".into(),
+                source_row_number: 2,
+                values: BTreeMap::from([("kw".into(), String::new())]),
+                fill_created: false,
+            },
+            OutputRow {
+                ts_utc: Some(Utc.with_ymd_and_hms(2013, 6, 19, 2, 0, 0).unwrap()),
+                ts_local: String::new(),
+                timezone: "UTC".into(),
+                source_timestamp_raw: String::new(),
+                source_timestamp_parse_status: "ok".into(),
+                source_timestamp_fold: None,
+                source_file: "t.csv".into(),
+                source_row_number: 3,
+                values: BTreeMap::from([("kw".into(), "20".into())]),
+                fill_created: false,
+            },
+        ];
+        apply_fill_policy(&mut rows, FillPolicy::Linear);
+        let mid = rows[1].values.get("kw").unwrap();
+        let v: f64 = mid.parse().unwrap();
+        assert!(v > 10.0 && v < 20.0);
     }
 }

--- a/edge/src/csv_ingest/timestamp.rs
+++ b/edge/src/csv_ingest/timestamp.rs
@@ -116,6 +116,40 @@ pub fn parse_timestamp_loose(s: &str) -> Option<NaiveDateTime> {
     None
 }
 
+/// Parse timestamp for ingest: preserve RFC3339 offset as UTC; otherwise localize with plan timezone.
+pub fn parse_row_timestamp(raw: &str, tz: Tz, ambiguous_policy: &str) -> ParsedTimestamp {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return ParsedTimestamp {
+            ts_utc: None,
+            ts_local: None,
+            raw: raw.to_string(),
+            status: ParseStatus::Failed,
+            fold: None,
+        };
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(trimmed) {
+        let utc = dt.with_timezone(&Utc);
+        return ParsedTimestamp {
+            ts_utc: Some(utc),
+            ts_local: Some(utc.naive_utc()),
+            raw: raw.to_string(),
+            status: ParseStatus::Ok,
+            fold: Some("rfc3339_offset_preserved".into()),
+        };
+    }
+    if let Some(naive) = parse_timestamp_loose(trimmed) {
+        return localize_timestamp(naive, tz, ambiguous_policy);
+    }
+    ParsedTimestamp {
+        ts_utc: None,
+        ts_local: None,
+        raw: raw.to_string(),
+        status: ParseStatus::Failed,
+        fold: None,
+    }
+}
+
 pub fn localize_timestamp(naive: NaiveDateTime, tz: Tz, ambiguous_policy: &str) -> ParsedTimestamp {
     let raw = naive.format("%Y-%m-%d %H:%M:%S").to_string();
     match tz.from_local_datetime(&naive) {
@@ -259,5 +293,17 @@ mod tests {
             .unwrap();
         let pt = localize_timestamp(naive, tz, "first");
         assert_eq!(pt.status, ParseStatus::Gap);
+    }
+
+    #[test]
+    fn rfc3339_offset_preserved_as_utc() {
+        let tz: Tz = "America/Chicago".parse().unwrap();
+        let pt = parse_row_timestamp("2013-06-19T05:15:00-05:00", tz, "first");
+        assert_eq!(pt.status, ParseStatus::Ok);
+        assert_eq!(pt.fold.as_deref(), Some("rfc3339_offset_preserved"));
+        let expected = DateTime::parse_from_rfc3339("2013-06-19T05:15:00-05:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(pt.ts_utc, Some(expected));
     }
 }

--- a/edge/src/csv_ingest/upload.rs
+++ b/edge/src/csv_ingest/upload.rs
@@ -1,14 +1,16 @@
 //! Multipart and raw upload parsing for CSV import preview.
 
-pub fn parse_upload(content_type: &str, body: &[u8]) -> Result<Vec<(String, Vec<u8>)>, String> {
+pub type UploadFiles = Vec<(String, Vec<u8>)>;
+pub type UploadParseResult = Result<(UploadFiles, Option<String>), String>;
+
+pub fn parse_upload(content_type: &str, body: &[u8]) -> UploadParseResult {
     let ct = content_type.to_ascii_lowercase();
     if ct.contains("multipart/form-data") {
         parse_multipart(content_type, body)
     } else if ct.contains("application/json") {
-        parse_json_upload(body)
+        parse_json_upload(body).map(|files| (files, None))
     } else {
-        // raw single file
-        Ok(vec![("upload.csv".into(), body.to_vec())])
+        Ok((vec![("upload.csv".into(), body.to_vec())], None))
     }
 }
 
@@ -36,7 +38,7 @@ fn parse_json_upload(body: &[u8]) -> Result<Vec<(String, Vec<u8>)>, String> {
     Ok(out)
 }
 
-fn parse_multipart(content_type: &str, body: &[u8]) -> Result<Vec<(String, Vec<u8>)>, String> {
+fn parse_multipart(content_type: &str, body: &[u8]) -> UploadParseResult {
     let boundary = content_type
         .split("boundary=")
         .nth(1)
@@ -45,6 +47,7 @@ fn parse_multipart(content_type: &str, body: &[u8]) -> Result<Vec<(String, Vec<u
     let delim = format!("--{boundary}");
     let text = String::from_utf8_lossy(body);
     let mut files = Vec::new();
+    let mut session_id = None;
     for part in text.split(&delim) {
         if part.trim().is_empty() || part.trim() == "--" {
             continue;
@@ -53,34 +56,64 @@ fn parse_multipart(content_type: &str, body: &[u8]) -> Result<Vec<(String, Vec<u
             .split_once("\r\n\r\n")
             .or_else(|| part.split_once("\n\n"))
             .ok_or("invalid multipart part")?;
-        let mut filename = "upload.csv".to_string();
+        let mut filename = None;
+        let mut field_name = None;
         for line in headers.lines() {
-            if line.to_ascii_lowercase().contains("filename=") {
-                if let Some(start) = line.find("filename=") {
-                    let rest = &line[start + 9..];
-                    filename = rest.trim_matches('"').trim_matches('\'').to_string();
-                    if let Some(base) = filename.rsplit(['/', '\\']).next() {
-                        filename = base.to_string();
-                    }
+            let lower = line.to_ascii_lowercase();
+            if lower.contains("content-disposition") {
+                if let Some(n) = extract_form_name(line, "name") {
+                    field_name = Some(n);
+                }
+                if let Some(f) = extract_form_name(line, "filename") {
+                    filename = Some(f);
                 }
             }
         }
         let raw = content.trim_end_matches("\r\n").as_bytes().to_vec();
-        if !raw.is_empty() {
-            files.push((filename, raw));
+        if raw.is_empty() {
+            continue;
+        }
+        if filename.is_some() {
+            files.push((filename.unwrap_or_else(|| "upload.csv".to_string()), raw));
+        } else if field_name.as_deref() == Some("session_id") {
+            session_id = Some(String::from_utf8_lossy(&raw).trim().to_string());
         }
     }
     if files.is_empty() {
-        // binary-safe fallback
         return parse_multipart_binary(&boundary, body);
     }
-    Ok(files)
+    Ok((files, session_id))
 }
 
-fn parse_multipart_binary(boundary: &str, body: &[u8]) -> Result<Vec<(String, Vec<u8>)>, String> {
+fn extract_form_name(line: &str, key: &str) -> Option<String> {
+    let pattern = format!("{key}=\"");
+    let start = line
+        .find(&pattern)
+        .or_else(|| line.find(&format!("{key}=")))?;
+    let rest = &line[start + key.len() + 1..];
+    let rest = rest
+        .trim_start_matches('=')
+        .trim_matches('"')
+        .trim_matches('\'');
+    let end = rest.find('"').unwrap_or(rest.len());
+    let mut value = rest[..end].to_string();
+    if key == "filename" {
+        if let Some(base) = value.rsplit(['/', '\\']).next() {
+            value = base.to_string();
+        }
+    }
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn parse_multipart_binary(boundary: &str, body: &[u8]) -> UploadParseResult {
     let marker = format!("--{boundary}");
     let parts: Vec<&[u8]> = split_bytes(body, marker.as_bytes());
     let mut files = Vec::new();
+    let mut session_id = None;
     for part in parts {
         if part.len() < 4 {
             continue;
@@ -101,23 +134,32 @@ fn parse_multipart_binary(boundary: &str, body: &[u8]) -> Result<Vec<(String, Ve
             content.pop();
             content.pop();
         }
-        let mut filename = "upload.csv".to_string();
+        let mut filename = None;
+        let mut field_name = None;
         for line in headers.lines() {
-            if line.to_ascii_lowercase().contains("filename=") {
-                if let Some(i) = line.find("filename=") {
-                    filename = line[i + 9..]
-                        .trim()
-                        .trim_matches('"')
-                        .trim_matches('\'')
-                        .to_string();
+            let lower = line.to_ascii_lowercase();
+            if lower.contains("content-disposition") {
+                if let Some(n) = extract_form_name(line, "name") {
+                    field_name = Some(n);
+                }
+                if let Some(f) = extract_form_name(line, "filename") {
+                    filename = Some(f);
                 }
             }
         }
-        if !content.is_empty() {
-            files.push((filename, content));
+        if content.is_empty() {
+            continue;
+        }
+        if filename.is_some() {
+            files.push((
+                filename.unwrap_or_else(|| "upload.csv".to_string()),
+                content,
+            ));
+        } else if field_name.as_deref() == Some("session_id") {
+            session_id = Some(String::from_utf8_lossy(&content).trim().to_string());
         }
     }
-    Ok(files)
+    Ok((files, session_id))
 }
 
 fn split_bytes<'a>(hay: &'a [u8], needle: &[u8]) -> Vec<&'a [u8]> {
@@ -141,7 +183,7 @@ mod tests {
         let body = b"--bound\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.csv\"\r\n\r\nDate,kW\r\n1/1/2013,1\r\n--bound--";
         let ct = "multipart/form-data; boundary=bound";
         let files = parse_multipart(ct, body).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].0, "a.csv");
+        assert_eq!(files.0.len(), 1);
+        assert_eq!(files.0[0].0, "a.csv");
     }
 }

--- a/edge/src/dashboard/building_insight.rs
+++ b/edge/src/dashboard/building_insight.rs
@@ -2,6 +2,7 @@
 
 use super::{analytics, building_status, summary};
 use crate::faults;
+use crate::historian::store;
 use crate::ops::ollama;
 use serde_json::{json, Value};
 use std::env;
@@ -111,12 +112,29 @@ fn gather_context() -> Value {
         }
     }
 
-    let deployment_mode = classify_deployment(&active_sources, eq_count, pt_count);
     let historian = sum.get("historian_health").cloned().unwrap_or(json!({}));
     let row_count = historian
         .get("row_count")
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
+    if row_count > 0 {
+        if let Ok(rows) = store::load_pivot_rows() {
+            let csv_rows = rows
+                .iter()
+                .filter(|r| {
+                    r.get("source_driver").and_then(|v| v.as_str()) == Some("csv")
+                        || r.get("source")
+                            .and_then(|v| v.as_str())
+                            .is_some_and(|s| s.starts_with("csv:") || s == "csv")
+                })
+                .count();
+            if csv_rows > 0 && !active_sources.iter().any(|s| s.starts_with("csv")) {
+                active_sources.push(format!("csv ({csv_rows} historian rows)"));
+            }
+        }
+    }
+
+    let deployment_mode = classify_deployment(&active_sources, eq_count, pt_count);
 
     let prior = read_cache()
         .and_then(|c| c.get("memory").cloned())

--- a/edge/src/dashboard/building_insight.rs
+++ b/edge/src/dashboard/building_insight.rs
@@ -3,7 +3,6 @@
 use super::{analytics, building_status, summary};
 use crate::faults;
 use crate::ops::ollama;
-use chrono::Utc;
 use serde_json::{json, Value};
 use std::env;
 use std::fs;
@@ -77,7 +76,7 @@ fn gather_context() -> Value {
     let fault_summary = sum
         .get("faults")
         .cloned()
-        .unwrap_or_else(|| faults::summary_json());
+        .unwrap_or_else(faults::summary_json);
     let active_count = fault_summary
         .get("active_count")
         .and_then(|v| v.as_u64())
@@ -131,6 +130,7 @@ fn gather_context() -> Value {
         "prior_issues": prior.get("active_issues").cloned().unwrap_or(json!([])),
         "equipment_count": eq_count,
         "point_count": pt_count,
+        "mapped_points": mapped,
         "historian_rows": row_count,
         "updated_at": now_unix()
     });

--- a/edge/src/dashboard/building_insight.rs
+++ b/edge/src/dashboard/building_insight.rs
@@ -1,0 +1,402 @@
+//! Building insight agent — context-aware HVAC FDD summary with 15-minute cache + optional Ollama.
+
+use super::{analytics, building_status, summary};
+use crate::faults;
+use crate::ops::ollama;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const REFRESH_INTERVAL_S: i64 = 900;
+
+fn workspace_dir() -> PathBuf {
+    env::var("OPENFDD_WORKSPACE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("workspace"))
+}
+
+fn cache_path() -> PathBuf {
+    workspace_dir().join("data/agent/building_insight_cache.json")
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Generate or return cached building insight for the main dashboard.
+pub fn generate(force: bool) -> Value {
+    if !force {
+        if let Some(cached) = read_cache() {
+            let next = cached
+                .get("next_refresh_at")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            if next > now_unix() {
+                let mut out = cached;
+                out["cached"] = json!(true);
+                return out;
+            }
+        }
+    }
+
+    let ctx = gather_context();
+    let mut out = build_deterministic(&ctx);
+    out["cached"] = json!(false);
+
+    if let Ok(llm) = try_ollama_sentence(&ctx, &out) {
+        out["sentence"] = json!(llm);
+        out["source"] = json!("ollama");
+        out["ollama_ok"] = json!(true);
+    } else {
+        out["source"] = json!("rules");
+        out["ollama_ok"] = json!(false);
+        if ollama::probe_quick().is_none() {
+            out["error"] = json!("Ollama offline — showing rule-based HVAC summary");
+        }
+    }
+
+    let ts = now_unix();
+    out["generated_at"] = json!(ts);
+    out["next_refresh_at"] = json!(ts + REFRESH_INTERVAL_S);
+    out["refresh_interval_s"] = json!(REFRESH_INTERVAL_S);
+    out["memory"] = ctx.get("memory").cloned().unwrap_or(json!({}));
+    let _ = write_cache(&out);
+    out
+}
+
+fn gather_context() -> Value {
+    let sum = summary();
+    let status = building_status();
+    let anal = analytics();
+    let fault_summary = sum
+        .get("faults")
+        .cloned()
+        .unwrap_or_else(|| faults::summary_json());
+    let active_count = fault_summary
+        .get("active_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let coverage = sum.get("model_coverage").cloned().unwrap_or(json!({}));
+    let eq_count = coverage
+        .get("equipment_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let pt_count = coverage
+        .get("point_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let mapped = coverage
+        .get("mapped_points")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let protocols = anal
+        .get("source_coverage")
+        .and_then(|v| v.get("protocols"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut active_sources: Vec<String> = Vec::new();
+    for p in &protocols {
+        let name = p.get("protocol").and_then(|v| v.as_str()).unwrap_or("");
+        let count = p.get("point_count").and_then(|v| v.as_u64()).unwrap_or(0);
+        if count > 0 && name != "unmapped" {
+            active_sources.push(format!("{name} ({count} pts)"));
+        }
+    }
+
+    let deployment_mode = classify_deployment(&active_sources, eq_count, pt_count);
+    let historian = sum.get("historian_health").cloned().unwrap_or(json!({}));
+    let row_count = historian
+        .get("row_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let prior = read_cache()
+        .and_then(|c| c.get("memory").cloned())
+        .unwrap_or(json!({}));
+
+    let active_issues = build_active_issues(active_count, &fault_summary, &coverage, &status);
+    let memory = json!({
+        "deployment_mode": deployment_mode,
+        "active_sources": active_sources,
+        "active_issues": active_issues,
+        "prior_issues": prior.get("active_issues").cloned().unwrap_or(json!([])),
+        "equipment_count": eq_count,
+        "point_count": pt_count,
+        "historian_rows": row_count,
+        "updated_at": now_unix()
+    });
+
+    json!({
+        "deployment_mode": deployment_mode,
+        "active_sources": active_sources,
+        "active_count": active_count,
+        "coverage": coverage,
+        "fault_summary": fault_summary,
+        "status": status,
+        "historian_rows": row_count,
+        "lookback_days": 14,
+        "memory": memory
+    })
+}
+
+fn classify_deployment(sources: &[String], eq: u64, pts: u64) -> &'static str {
+    let joined = sources.join(" ").to_ascii_lowercase();
+    let has_ot = joined.contains("bacnet")
+        || joined.contains("modbus")
+        || joined.contains("haystack")
+        || joined.contains("json");
+    let has_csv = joined.contains("csv") || joined.contains("import");
+    match (has_ot, has_csv, eq, pts) {
+        (true, true, _, _) => "mixed_ot_and_csv",
+        (true, false, _, _) => "ot_lan_supervisory",
+        (false, true, _, _) => "csv_analytics",
+        (_, _, 0, 0) => "greenfield",
+        _ => "model_only",
+    }
+}
+
+fn build_active_issues(
+    active_count: u64,
+    fault_summary: &Value,
+    coverage: &Value,
+    status: &Value,
+) -> Value {
+    let mut issues = Vec::new();
+    if active_count > 0 {
+        issues.push(json!({
+            "kind": "faults",
+            "count": active_count,
+            "detail": format!("{active_count} active FDD fault(s)")
+        }));
+    }
+    let unmapped = coverage
+        .get("unmapped_points")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if unmapped > 0 {
+        issues.push(json!({
+            "kind": "model",
+            "count": unmapped,
+            "detail": format!("{unmapped} unmapped Haystack points")
+        }));
+    }
+    let alert = status
+        .get("alert_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if alert > 0 && alert != active_count {
+        issues.push(json!({
+            "kind": "alerts",
+            "count": alert,
+            "detail": format!("{alert} dashboard alert(s)")
+        }));
+    }
+    if let Some(families) = fault_summary.get("families").and_then(|v| v.as_array()) {
+        for fam in families.iter().take(5) {
+            let title = fam.get("title").and_then(|v| v.as_str()).unwrap_or("Fault");
+            let count = fam.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+            if count > 0 {
+                issues.push(json!({
+                    "kind": "family",
+                    "title": title,
+                    "count": count
+                }));
+            }
+        }
+    }
+    json!(issues)
+}
+
+fn build_deterministic(ctx: &Value) -> Value {
+    let mode = ctx
+        .get("deployment_mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("model_only");
+    let active = ctx
+        .get("active_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let eq = ctx
+        .get("coverage")
+        .and_then(|c| c.get("equipment_count"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let pts = ctx
+        .get("coverage")
+        .and_then(|c| c.get("point_count"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let mapped = ctx
+        .get("coverage")
+        .and_then(|c| c.get("mapped_points"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let rows = ctx
+        .get("historian_rows")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let sources = ctx
+        .get("active_sources")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+
+    let mode_label = match mode {
+        "csv_analytics" => "CSV analytics workflow",
+        "ot_lan_supervisory" => "OT LAN supervisory (BACnet/field drivers)",
+        "mixed_ot_and_csv" => "Mixed OT LAN + CSV historian",
+        "greenfield" => "Greenfield — model not loaded",
+        _ => "Haystack model",
+    };
+
+    let fault_part = if active == 0 {
+        "No active FDD faults.".to_string()
+    } else {
+        format!("{active} active FDD fault(s) need review.")
+    };
+
+    let sentence = format!(
+        "{mode_label}: {eq} equipment, {pts} points ({mapped} mapped). Sources: {}. Historian ~{rows} rows. {fault_part}",
+        if sources.is_empty() { "none yet".into() } else { sources }
+    );
+
+    let device_sentence = if eq > 0 {
+        Some(format!(
+            "{mapped}/{pts} points mapped across {eq} equipment."
+        ))
+    } else {
+        None
+    };
+
+    let fault_sentences: Vec<String> = ctx
+        .get("memory")
+        .and_then(|m| m.get("active_issues"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.get("detail").and_then(|v| v.as_str()).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "ok": true,
+        "stub": false,
+        "sentence": sentence,
+        "zone_sentence": null,
+        "device_sentence": device_sentence,
+        "lookback_days": ctx.get("lookback_days").cloned().unwrap_or(json!(14)),
+        "fault_sentences": fault_sentences,
+        "deployment_mode": mode,
+        "methodology": {
+            "lookback_days": 14,
+            "context": "Live Haystack SPARQL model coverage, historian rows, active FDD faults, driver source protocols"
+        },
+        "device_poll_health": {
+            "healthy_count": eq,
+            "offline_equipment": [],
+            "flaky_equipment": []
+        },
+        "zone_temps": {
+            "topology_mode": mode,
+            "zone_sensor_count": pts,
+            "struggling_zones": [],
+            "research": { "opportunities": [] },
+            "refresh_interval_s": REFRESH_INTERVAL_S
+        },
+        "worst_zones": [],
+        "brick_model": {
+            "feeds_chains": [],
+            "equipment_count": eq
+        },
+        "faults_linked": []
+    })
+}
+
+fn try_ollama_sentence(ctx: &Value, base: &Value) -> Result<String, String> {
+    let base_url = ollama::probe_quick().ok_or("ollama unavailable")?;
+    let prompt = format!(
+        "You are an HVAC fault-detection operator assistant for Open-FDD.\n\
+         Deployment: {}\n\
+         Data sources: {}\n\
+         Equipment: {}, points: {}, active faults: {}\n\
+         Prior issues memory: {}\n\
+         Rule-based summary: {}\n\
+         Write 2 concise sentences for the main dashboard: (1) what data path is active (CSV vs BACnet/OT LAN), \
+         (2) top current HVAC/FDD concern or all-clear. Plain English, no markdown.",
+        ctx.get("deployment_mode").and_then(|v| v.as_str()).unwrap_or("?"),
+        ctx.get("active_sources").cloned().unwrap_or(json!([])),
+        ctx.get("coverage")
+            .and_then(|c| c.get("equipment_count"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        ctx.get("coverage")
+            .and_then(|c| c.get("point_count"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        ctx.get("active_count").and_then(|v| v.as_u64()).unwrap_or(0),
+        ctx.get("memory")
+            .and_then(|m| m.get("prior_issues"))
+            .cloned()
+            .unwrap_or(json!([])),
+        base.get("sentence").and_then(|v| v.as_str()).unwrap_or("")
+    );
+    let messages = vec![
+        json!({"role": "system", "content": "HVAC FDD building insight — brief operator briefing only."}),
+        json!({"role": "user", "content": prompt}),
+    ];
+    let result = ollama::chat_at(&base_url, &messages, None)?;
+    let text = result.content.trim();
+    if text.is_empty() {
+        return Err("empty ollama response".into());
+    }
+    Ok(text.to_string())
+}
+
+fn read_cache() -> Option<Value> {
+    let path = cache_path();
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_cache(doc: &Value) -> std::io::Result<()> {
+    let path = cache_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(
+        path,
+        serde_json::to_string_pretty(doc).unwrap_or_else(|_| "{}".into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_csv_vs_ot() {
+        assert_eq!(
+            classify_deployment(&["csv (100 pts)".into()], 1, 100),
+            "csv_analytics"
+        );
+        assert_eq!(
+            classify_deployment(&["bacnet (50 pts)".into()], 5, 50),
+            "ot_lan_supervisory"
+        );
+    }
+}

--- a/edge/src/dashboard/mod.rs
+++ b/edge/src/dashboard/mod.rs
@@ -1,5 +1,7 @@
 //! Dashboard analytics API (Haystack model + historian + DataFusion faults).
 
+mod building_insight;
+
 use crate::data_management;
 use crate::drivers::bacnet;
 use crate::export;
@@ -174,24 +176,9 @@ pub fn building_snapshot() -> Value {
     })
 }
 
-/// Intentional stub until building-insight agent is ported (issue #402 L-03).
-pub fn building_insight_stub() -> Value {
-    json!({
-        "ok": true,
-        "stub": true,
-        "message": "Building insight agent not yet ported to Rust edge",
-        "generated_at": null,
-        "lookback_days": 14,
-        "device_sentence": null,
-        "device_poll_health": {
-            "healthy_count": 0,
-            "offline_equipment": [],
-            "flaky_equipment": []
-        },
-        "zone_temps": null,
-        "worst_zones": [],
-        "brick_model": { "feeds_chains": [], "equipment_count": 0 }
-    })
+/// Context-aware HVAC building insight (15-minute cache; optional Ollama enhancement).
+pub fn building_insight(force: bool) -> Value {
+    building_insight::generate(force)
 }
 
 pub fn building_status() -> Value {

--- a/edge/src/drivers/bacnet_server_runtime.rs
+++ b/edge/src/drivers/bacnet_server_runtime.rs
@@ -240,7 +240,12 @@ pub fn start_background() {
         return;
     }
     std::thread::spawn(|| {
-        super::bacnet_live::block_on(async {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_name("openfdd-bacnet-server")
+            .build()
+            .expect("bacnet server tokio runtime");
+        rt.block_on(async {
             if let Err(e) = run_server().await {
                 eprintln!("Open-FDD BACnet server error: {e}");
             }

--- a/edge/src/export/mod.rs
+++ b/edge/src/export/mod.rs
@@ -286,6 +286,15 @@ pub fn historian_csv(query: &ExportQuery) -> String {
         let protocol = row
             .get("source_driver")
             .and_then(|v| v.as_str())
+            .or_else(|| {
+                row.get("source").and_then(|v| v.as_str()).and_then(|s| {
+                    if s.starts_with("csv:") || s == "csv" {
+                        Some("csv")
+                    } else {
+                        None
+                    }
+                })
+            })
             .unwrap_or("bacnet");
         let device = row
             .get("source_device")

--- a/edge/src/fdd/datafusion_sql.rs
+++ b/edge/src/fdd/datafusion_sql.rs
@@ -12,6 +12,10 @@ pub fn save_rule_response(payload: &Value, actor: &str) -> Value {
     rules::save_rule(payload, actor)
 }
 
+pub fn patch_rule_response(rule_id: &str, patch: &Value, actor: &str) -> Value {
+    rules::patch_rule(rule_id, patch, actor)
+}
+
 pub fn batch_run_response() -> Value {
     let evaluable = rules::evaluable_rules();
     if evaluable.is_empty() {

--- a/edge/src/fdd/execution.rs
+++ b/edge/src/fdd/execution.rs
@@ -15,16 +15,44 @@ use std::sync::Arc;
 pub fn schema_tables_json() -> Value {
     json!({
         "ok": true,
+        "dialect": "DataFusion",
+        "time_column": "timestamp",
         "tables": [
             {
                 "name": "telemetry",
-                "description": "Normalized long-format telemetry rows",
-                "columns": ["timestamp","site_id","building_id","equipment_id","point_id","fdd_input","value","unit","quality","source","source_driver","source_device","source_object","is_simulated"]
+                "description": "Normalized long-format telemetry rows (timestamp, point_id, fdd_input, value)",
+                "columns": [
+                    {"name": "timestamp", "type": "TIMESTAMP", "is_primary": true},
+                    {"name": "site_id", "type": "VARCHAR"},
+                    {"name": "building_id", "type": "VARCHAR"},
+                    {"name": "equipment_id", "type": "VARCHAR"},
+                    {"name": "point_id", "type": "VARCHAR"},
+                    {"name": "fdd_input", "type": "VARCHAR"},
+                    {"name": "value", "type": "DOUBLE"},
+                    {"name": "unit", "type": "VARCHAR"},
+                    {"name": "quality", "type": "VARCHAR"},
+                    {"name": "source", "type": "VARCHAR"},
+                    {"name": "source_driver", "type": "VARCHAR"},
+                    {"name": "source_device", "type": "VARCHAR"},
+                    {"name": "source_object", "type": "VARCHAR"},
+                    {"name": "is_simulated", "type": "BOOLEAN"}
+                ]
             },
             {
                 "name": "telemetry_pivot",
-                "description": "Wide pivoted view for rule SQL",
-                "columns": ["timestamp","equipment_id","oa_t","oa_h","sat","duct_t","zn_t","sat_sp","fan_cmd","occ"]
+                "description": "Wide pivoted historian view — primary table for FDD rule SQL",
+                "columns": [
+                    {"name": "timestamp", "type": "TIMESTAMP", "is_primary": true},
+                    {"name": "equipment_id", "type": "VARCHAR"},
+                    {"name": "oa_t", "type": "DOUBLE", "fdd_input": true, "unit": "degF"},
+                    {"name": "oa_h", "type": "DOUBLE", "fdd_input": true, "unit": "%RH"},
+                    {"name": "sat", "type": "DOUBLE", "fdd_input": true, "unit": "degF"},
+                    {"name": "duct_t", "type": "DOUBLE", "fdd_input": true, "unit": "degF"},
+                    {"name": "zn_t", "type": "DOUBLE", "fdd_input": true, "unit": "degF"},
+                    {"name": "sat_sp", "type": "DOUBLE", "fdd_input": true, "unit": "degF"},
+                    {"name": "fan_cmd", "type": "BOOLEAN", "fdd_input": true},
+                    {"name": "occ", "type": "BOOLEAN", "fdd_input": true}
+                ]
             }
         ]
     })

--- a/edge/src/fdd/rules.rs
+++ b/edge/src/fdd/rules.rs
@@ -94,6 +94,24 @@ pub fn save_rule(payload: &Value, actor: &str) -> Value {
     json!({"ok": true, "saved": true, "rule_id": rule_id, "path": path.display().to_string(), "review_status": rule["review_status"]})
 }
 
+/// Merge partial updates into an existing rule (PATCH semantics).
+pub fn patch_rule(rule_id: &str, patch: &Value, actor: &str) -> Value {
+    let existing = get_rule(rule_id);
+    if existing.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return existing;
+    }
+    let mut rule = existing.get("rule").cloned().unwrap_or_else(|| json!({}));
+    if let Some(obj) = patch.as_object() {
+        for (key, value) in obj {
+            if key != "rule_id" {
+                rule[key] = value.clone();
+            }
+        }
+    }
+    rule["rule_id"] = json!(rule_id);
+    save_rule(&rule, actor)
+}
+
 pub fn validate_rule_sql(payload: &Value) -> Value {
     let sql = payload.get("sql").and_then(|v| v.as_str()).unwrap_or("");
     let mut validation = sql_safety::validate_sql(sql);
@@ -245,5 +263,21 @@ mod tests {
         let body = rule_template("kw_flatline_or_zero");
         assert_eq!(body["ok"], true);
         assert_eq!(body["rule"]["required_inputs"], json!(["kw"]));
+    }
+
+    #[test]
+    fn patch_rule_updates_confirmation_seconds() {
+        with_temp_workspace(|_| {
+            let rule = template_oa_rule();
+            let _ = save_rule(&rule, "integrator");
+            let out = patch_rule(
+                "oa_temp_out_of_range",
+                &json!({"confirmation_seconds": 600}),
+                "agent",
+            );
+            assert_eq!(out["ok"].as_bool(), Some(true));
+            let loaded = get_rule("oa_temp_out_of_range");
+            assert_eq!(loaded["rule"]["confirmation_seconds"].as_i64(), Some(600));
+        });
     }
 }

--- a/edge/src/fdd/wires/api.rs
+++ b/edge/src/fdd/wires/api.rs
@@ -1,6 +1,7 @@
 //! HTTP API handlers for FDD Wires and SQL rules.
 
 use super::assignments;
+use super::graph_sync;
 use super::persistence;
 use super::validation;
 use crate::fdd::execution;
@@ -194,7 +195,39 @@ pub fn propose_assignments(payload: &Value, role: &str) -> Value {
     if !["integrator", "agent"].contains(&role) {
         return json!({"ok": false, "error": "integrator or agent role required"});
     }
-    assignments::propose_assignments(payload)
+    let mut out = assignments::propose_assignments(payload);
+    let site_id = out
+        .get("site_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&persistence::default_site_id())
+        .to_string();
+    let graph_id = payload
+        .get("graph_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(graph_sync::DEFAULT_GRAPH_ID);
+    let sync = graph_sync::sync_from_proposal(&out, &site_id, graph_id, role);
+    if let Some(obj) = out.as_object_mut() {
+        let proposals = obj.get("proposals").cloned().unwrap_or(json!([]));
+        obj.insert("proposed".to_string(), proposals);
+        obj.insert("wiresheet_sync".to_string(), sync);
+    }
+    out
+}
+
+pub fn sync_from_assignments(payload: &Value, actor: &str, role: &str) -> Value {
+    if !["integrator", "agent"].contains(&role) {
+        return json!({"ok": false, "error": "integrator or agent role required"});
+    }
+    let site_id = payload
+        .get("site_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&persistence::default_site_id())
+        .to_string();
+    let graph_id = payload
+        .get("graph_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(graph_sync::DEFAULT_GRAPH_ID);
+    graph_sync::sync_from_assignments(&site_id, graph_id, actor)
 }
 
 pub fn schema_tables_json() -> String {

--- a/edge/src/fdd/wires/graph_sync.rs
+++ b/edge/src/fdd/wires/graph_sync.rs
@@ -283,6 +283,7 @@ fn build_nodes_edges(
     (nodes, edges)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn add_rule_chain(
     nodes: &mut Vec<Value>,
     edges: &mut Vec<Value>,

--- a/edge/src/fdd/wires/graph_sync.rs
+++ b/edge/src/fdd/wires/graph_sync.rs
@@ -1,0 +1,432 @@
+//! Build FDD wiresheet graph nodes/edges from Haystack assignments + SQL rules.
+
+use super::persistence;
+use super::schema;
+use crate::fdd::rules;
+use crate::model::assignments;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+
+pub const DEFAULT_GRAPH_ID: &str = "graph:live-fdd-validation";
+
+/// Rebuild wiresheet graph from persisted Haystack assignments.
+pub fn sync_from_assignments(site_id: &str, graph_id: &str, actor: &str) -> Value {
+    let doc = assignments::load_assignments_value();
+    sync_from_doc(
+        &doc,
+        site_id,
+        graph_id,
+        actor,
+        "human_modified",
+        "needs_review",
+    )
+}
+
+/// Merge AI proposal output into the wiresheet graph.
+pub fn sync_from_proposal(proposal: &Value, site_id: &str, graph_id: &str, actor: &str) -> Value {
+    let mut doc = assignments::load_assignments_value();
+    if let Some(proposals) = proposal.get("proposals").and_then(|v| v.as_array()) {
+        if doc.get("points").is_none() {
+            doc["points"] = json!([]);
+        }
+        if let Some(points) = doc.get_mut("points").and_then(|v| v.as_array_mut()) {
+            for p in proposals {
+                let haystack = p.get("haystack_id").cloned().unwrap_or(json!(null));
+                let driver = p.get("driver_ref").cloned().unwrap_or(json!(null));
+                let fdd_input = p.get("fdd_input").and_then(|v| v.as_str()).unwrap_or("");
+                points.push(json!({
+                    "point_id": haystack,
+                    "haystack_ref": haystack,
+                    "driver_ref": driver,
+                    "fdd_input": fdd_input,
+                    "source": "ai_generated",
+                    "review_status": "ai_suggested"
+                }));
+            }
+        }
+    }
+    if let Some(bindings) = proposal.get("rule_bindings").and_then(|v| v.as_array()) {
+        if doc.get("fault_equation_bindings").is_none() {
+            doc["fault_equation_bindings"] = json!([]);
+        }
+        if let Some(target) = doc
+            .get_mut("fault_equation_bindings")
+            .and_then(|v| v.as_array_mut())
+        {
+            for b in bindings {
+                target.push(b.clone());
+            }
+        }
+    }
+    sync_from_doc(
+        &doc,
+        site_id,
+        graph_id,
+        actor,
+        "ai_generated",
+        "needs_review",
+    )
+}
+
+fn sync_from_doc(
+    doc: &Value,
+    site_id: &str,
+    graph_id: &str,
+    actor: &str,
+    source: &str,
+    review_status: &str,
+) -> Value {
+    let existing = persistence::read_graph(site_id, graph_id);
+    let positions = existing_positions(existing.as_ref());
+    let (nodes, edges) = build_nodes_edges(doc, site_id, &positions);
+    let now = Utc::now().to_rfc3339();
+    let mut graph = existing.unwrap_or_else(|| schema::empty_graph(site_id, graph_id, actor));
+    graph["graph_id"] = json!(graph_id);
+    graph["site_id"] = json!(site_id);
+    graph["nodes"] = json!(nodes);
+    graph["edges"] = json!(edges);
+    graph["updated_at"] = json!(now);
+    graph["updated_by"] = json!(actor);
+    graph["source"] = json!(source);
+    graph["review_status"] = json!(review_status);
+    graph["validation_warnings"] = if nodes.is_empty() {
+        json!(["No assignment bindings — add points or run AI propose"])
+    } else {
+        json!([])
+    };
+    match persistence::write_graph(site_id, &graph) {
+        Ok(path) => json!({
+            "ok": true,
+            "synced": true,
+            "graph_id": graph_id,
+            "site_id": site_id,
+            "node_count": nodes.len(),
+            "edge_count": edges.len(),
+            "path": path.display().to_string(),
+            "review_status": review_status
+        }),
+        Err(err) => json!({"ok": false, "error": err}),
+    }
+}
+
+fn existing_positions(graph: Option<&Value>) -> HashMap<String, (i64, i64)> {
+    let mut out = HashMap::new();
+    if let Some(g) = graph {
+        if let Some(nodes) = g.get("nodes").and_then(|v| v.as_array()) {
+            for n in nodes {
+                let id = n.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                if id.is_empty() {
+                    continue;
+                }
+                let x = n
+                    .get("position")
+                    .and_then(|p| p.get("x"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let y = n
+                    .get("position")
+                    .and_then(|p| p.get("y"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                out.insert(id.to_string(), (x, y));
+            }
+        }
+    }
+    out
+}
+
+fn build_nodes_edges(
+    doc: &Value,
+    site_id: &str,
+    positions: &HashMap<String, (i64, i64)>,
+) -> (Vec<Value>, Vec<Value>) {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut row = 0i64;
+    let rules_by_id = rules_index();
+
+    if nodes.is_empty() {
+        let site_node_id = format!("site:{site_id}");
+        nodes.push(node(
+            &site_node_id,
+            "model_site",
+            &format!("Site {site_id}"),
+            pos(positions, &site_node_id, 0, 0),
+            json!({"site_id": site_id}),
+            "human_created",
+        ));
+    }
+
+    let points = doc
+        .get("points")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut rule_inputs: HashMap<String, String> = HashMap::new();
+
+    for pt in &points {
+        let haystack = pt
+            .get("haystack_ref")
+            .or_else(|| pt.get("point_id"))
+            .or_else(|| pt.get("haystack_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if haystack.is_empty() {
+            continue;
+        }
+        let label = pt
+            .get("name")
+            .and_then(|v| v.as_str())
+            .or_else(|| pt.get("label").and_then(|v| v.as_str()))
+            .unwrap_or(haystack);
+        let driver_ref = pt.get("driver_ref").and_then(|v| v.as_str()).unwrap_or("");
+        let fdd_input = pt.get("fdd_input").and_then(|v| v.as_str()).unwrap_or("");
+        let y = row * 120;
+        row += 1;
+
+        let driver_id = if !driver_ref.is_empty() {
+            format!("driver:{driver_ref}")
+        } else {
+            format!("driver:{haystack}")
+        };
+        nodes.push(node(
+            &driver_id,
+            "driver_point",
+            label,
+            pos(positions, &driver_id, 0, y),
+            json!({"ref": driver_ref, "haystack_id": haystack}),
+            pt_source(pt),
+        ));
+
+        let haystack_node_id = format!("point:{haystack}");
+        nodes.push(node(
+            &haystack_node_id,
+            "model_point",
+            label,
+            pos(positions, &haystack_node_id, 220, y),
+            json!({"haystack_id": haystack}),
+            pt_source(pt),
+        ));
+        edges.push(edge(
+            &format!("e-{driver_id}-maps-{haystack_node_id}"),
+            "maps_to",
+            &driver_id,
+            &haystack_node_id,
+        ));
+
+        if !fdd_input.is_empty() {
+            let input_id = format!("fdd_input:{fdd_input}");
+            if !nodes.iter().any(|n| n["id"] == input_id) {
+                nodes.push(node(
+                    &input_id,
+                    "fdd_input",
+                    fdd_input,
+                    pos(positions, &input_id, 440, y),
+                    json!({"input_id": fdd_input}),
+                    pt_source(pt),
+                ));
+            }
+            rule_inputs.insert(fdd_input.to_string(), input_id.clone());
+            edges.push(edge(
+                &format!("e-{haystack_node_id}-feeds-{input_id}"),
+                "feeds",
+                &haystack_node_id,
+                &input_id,
+            ));
+        }
+
+        let rule_ids = point_rule_ids(pt);
+        for rule_id in rule_ids {
+            add_rule_chain(
+                &mut nodes,
+                &mut edges,
+                &rule_id,
+                fdd_input,
+                &rule_inputs,
+                y,
+                positions,
+                &rules_by_id,
+            );
+        }
+    }
+
+    if let Some(bindings) = doc
+        .get("fault_equation_bindings")
+        .and_then(|v| v.as_array())
+    {
+        for b in bindings {
+            let rule_id = b.get("rule_id").and_then(|v| v.as_str()).unwrap_or("");
+            if rule_id.is_empty() {
+                continue;
+            }
+            let fdd_input = b
+                .get("required_inputs")
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            add_rule_chain(
+                &mut nodes,
+                &mut edges,
+                rule_id,
+                fdd_input,
+                &rule_inputs,
+                row * 120,
+                positions,
+                &rules_by_id,
+            );
+            row += 1;
+        }
+    }
+
+    (nodes, edges)
+}
+
+fn add_rule_chain(
+    nodes: &mut Vec<Value>,
+    edges: &mut Vec<Value>,
+    rule_id: &str,
+    fdd_input: &str,
+    rule_inputs: &HashMap<String, String>,
+    y: i64,
+    positions: &HashMap<String, (i64, i64)>,
+    rules_by_id: &HashMap<String, Value>,
+) {
+    let rule_node_id = format!("rule:{rule_id}");
+    if !nodes.iter().any(|n| n["id"] == rule_node_id) {
+        let meta = rules_by_id.get(rule_id);
+        let name = meta
+            .and_then(|r| r.get("name").and_then(|v| v.as_str()))
+            .unwrap_or(rule_id);
+        let sql = meta
+            .and_then(|r| r.get("sql").and_then(|v| v.as_str()))
+            .unwrap_or("");
+        nodes.push(node(
+            &rule_node_id,
+            "sql_rule",
+            name,
+            pos(positions, &rule_node_id, 660, y),
+            json!({"rule_id": rule_id, "sql": sql}),
+            "human_created",
+        ));
+        let fault_id = format!("fault:{rule_id}");
+        nodes.push(node(
+            &fault_id,
+            "fault_output",
+            &format!("Fault: {name}"),
+            pos(positions, &fault_id, 880, y),
+            json!({"rule_id": rule_id}),
+            "human_created",
+        ));
+        edges.push(edge(
+            &format!("e-{rule_node_id}-out-{fault_id}"),
+            "rule_output",
+            &rule_node_id,
+            &fault_id,
+        ));
+    }
+    if !fdd_input.is_empty() {
+        if let Some(input_id) = rule_inputs.get(fdd_input) {
+            edges.push(edge(
+                &format!("e-{input_id}-rule-{rule_node_id}"),
+                "rule_input",
+                input_id,
+                &rule_node_id,
+            ));
+        }
+    }
+}
+
+fn point_rule_ids(pt: &Value) -> Vec<String> {
+    let mut ids = HashSet::new();
+    if let Some(arr) = pt.get("fdd_rule_ids").and_then(|v| v.as_array()) {
+        for v in arr {
+            if let Some(s) = v.as_str() {
+                ids.insert(s.to_string());
+            }
+        }
+    }
+    if let Some(s) = pt.get("rule_id").and_then(|v| v.as_str()) {
+        ids.insert(s.to_string());
+    }
+    ids.into_iter().collect()
+}
+
+fn rules_index() -> HashMap<String, Value> {
+    let mut out = HashMap::new();
+    if let Some(rules) = rules::list_rules().get("rules").and_then(|v| v.as_array()) {
+        for r in rules {
+            if let Some(id) = r.get("rule_id").and_then(|v| v.as_str()) {
+                out.insert(id.to_string(), r.clone());
+            }
+        }
+    }
+    out
+}
+
+fn pt_source(pt: &Value) -> &str {
+    pt.get("source")
+        .and_then(|v| v.as_str())
+        .unwrap_or("human_created")
+}
+
+fn pos(positions: &HashMap<String, (i64, i64)>, id: &str, default_x: i64, default_y: i64) -> Value {
+    let (x, y) = positions.get(id).copied().unwrap_or((default_x, default_y));
+    json!({"x": x, "y": y})
+}
+
+fn node(
+    id: &str,
+    node_type: &str,
+    label: &str,
+    position: Value,
+    config: Value,
+    source: &str,
+) -> Value {
+    json!({
+        "id": id,
+        "type": node_type,
+        "label": label,
+        "position": position,
+        "config": config,
+        "source": source,
+        "review_status": if source == "ai_generated" { "ai_suggested" } else { "draft" }
+    })
+}
+
+fn edge(id: &str, edge_type: &str, from: &str, to: &str) -> Value {
+    json!({
+        "id": id,
+        "type": edge_type,
+        "from": from,
+        "to": to
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_temp_workspace;
+    use serde_json::json;
+
+    #[test]
+    fn builds_graph_from_assignments_doc() {
+        with_temp_workspace(|_| {
+            let doc = json!({
+                "points": [{
+                    "haystack_ref": "point:oa",
+                    "driver_ref": "csv:oa_t",
+                    "fdd_input": "oa_t",
+                    "fdd_rule_ids": ["oa_temp_out_of_range"],
+                    "source": "ai_generated"
+                }],
+                "fault_equation_bindings": []
+            });
+            let (nodes, edges) = build_nodes_edges(&doc, "site:test", &HashMap::new());
+            assert!(nodes.iter().any(|n| n["type"] == "driver_point"));
+            assert!(nodes.iter().any(|n| n["type"] == "sql_rule"));
+            assert!(!edges.is_empty());
+        });
+    }
+}

--- a/edge/src/fdd/wires/mod.rs
+++ b/edge/src/fdd/wires/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod assignments;
+pub mod graph_sync;
 pub mod persistence;
 pub mod schema;
 pub mod validation;

--- a/edge/src/historian/arrow_table.rs
+++ b/edge/src/historian/arrow_table.rs
@@ -1,9 +1,20 @@
 //! Arrow-shaped historian query helpers — reads persisted historian data only.
 
 use crate::historian::store;
-use serde_json::json;
+use serde_json::{json, Value};
 
 pub fn query_json() -> String {
+    query_json_from_body(&json!({}))
+}
+
+pub fn query_json_from_body(body: &Value) -> String {
+    let limit = body
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(500)
+        .clamp(1, 10_000) as usize;
+    let site_id = body.get("site_id").and_then(|v| v.as_str());
+    let equipment_id = body.get("equipment_id").and_then(|v| v.as_str());
     match store::load_pivot_rows() {
         Ok(rows) if rows.is_empty() => json!({
             "ok": true,
@@ -14,14 +25,36 @@ pub fn query_json() -> String {
             "message": "historian has no rows — import CSV or capture telemetry first"
         })
         .to_string(),
-        Ok(rows) => json!({
-            "ok": true,
-            "engine": "Apache Arrow RecordBatch / DataFusion query path",
-            "configured": true,
-            "row_count": rows.len(),
-            "rows": rows
-        })
-        .to_string(),
+        Ok(mut rows) => {
+            if let Some(site) = site_id {
+                rows.retain(|r| {
+                    r.get("site_id")
+                        .or_else(|| r.get("site"))
+                        .and_then(|v| v.as_str())
+                        == Some(site)
+                });
+            }
+            if let Some(equip) = equipment_id {
+                rows.retain(|r| {
+                    r.get("equipment_id")
+                        .or_else(|| r.get("device_id"))
+                        .and_then(|v| v.as_str())
+                        == Some(equip)
+                });
+            }
+            let total = rows.len();
+            rows.truncate(limit);
+            json!({
+                "ok": true,
+                "engine": "Apache Arrow RecordBatch / DataFusion query path",
+                "configured": true,
+                "row_count": total,
+                "returned": rows.len(),
+                "truncated": total > rows.len(),
+                "rows": rows
+            })
+            .to_string()
+        }
         Err(err) => json!({"ok": false, "error": err}).to_string(),
     }
 }

--- a/edge/src/ingest/commissioning_validate.rs
+++ b/edge/src/ingest/commissioning_validate.rs
@@ -1,0 +1,166 @@
+//! Fail-closed validation for commissioning import payloads.
+
+use crate::fdd::execution;
+use crate::fdd::sql_safety;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+
+pub fn validate_commissioning(payload: &Value) -> Value {
+    let mut checks: Vec<Value> = Vec::new();
+    let mut hints: Vec<String> = Vec::new();
+
+    let sites = payload.get("sites").and_then(|v| v.as_array());
+    let equipment = payload.get("equipment").and_then(|v| v.as_array());
+    let points = payload.get("points").and_then(|v| v.as_array());
+    let assignments = payload.get("assignments").and_then(|v| v.as_array());
+
+    if sites.is_none() && equipment.is_none() && points.is_none() {
+        checks.push(err(
+            "PAYLOAD_EMPTY",
+            "payload must include sites, equipment, or points",
+        ));
+    }
+
+    let fdd_ids: HashSet<String> = execution::fdd_inputs_json()
+        .get("fdd_inputs")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.get("id").and_then(|v| v.as_str()).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut site_ids = HashSet::new();
+    if let Some(sites) = sites {
+        for s in sites {
+            let id = entity_id(s, &["site_id", "id"]);
+            if id.is_empty() {
+                checks.push(err("SITE_ID_MISSING", "site missing id/site_id"));
+            } else if !site_ids.insert(id.clone()) {
+                checks.push(err("SITE_ID_DUPLICATE", format!("duplicate site id {id}")));
+            }
+        }
+    }
+
+    let mut equip_ids = HashSet::new();
+    if let Some(equipment) = equipment {
+        for eq in equipment {
+            let id = entity_id(eq, &["equipment_id", "id"]);
+            if id.is_empty() {
+                checks.push(err("EQUIP_ID_MISSING", "equipment missing id"));
+            } else if !equip_ids.insert(id) {
+            }
+        }
+    }
+
+    if let Some(points) = points {
+        for pt in points {
+            let id = entity_id(pt, &["point_id", "id", "haystack_id"]);
+            if id.is_empty() {
+                checks.push(err("POINT_ID_MISSING", "point missing id"));
+            }
+            if let Some(fdd) = pt.get("fdd_input").and_then(|v| v.as_str()) {
+                if !fdd.is_empty() && !fdd_ids.contains(fdd) {
+                    checks.push(err(
+                        "FDD_INPUT_UNKNOWN",
+                        format!("unknown fdd_input '{fdd}' on point {id}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    if let Some(assignments) = assignments {
+        for a in assignments {
+            if let Some(fdd) = a.get("fdd_input").and_then(|v| v.as_str()) {
+                if !fdd.is_empty() && !fdd_ids.contains(fdd) {
+                    checks.push(err(
+                        "FDD_INPUT_UNKNOWN",
+                        format!("unknown fdd_input '{fdd}' in assignments"),
+                    ));
+                }
+            }
+        }
+    }
+
+    if let Some(rules) = payload.get("fdd_rules").and_then(|v| v.as_array()) {
+        for r in rules {
+            let rule_id = r.get("rule_id").and_then(|v| v.as_str()).unwrap_or("");
+            if rule_id.is_empty() {
+                checks.push(err("RULE_ID_MISSING", "fdd_rule missing rule_id"));
+            }
+            if let Some(sql) = r.get("sql").and_then(|v| v.as_str()) {
+                let v = sql_safety::validate_sql(sql);
+                if v.get("safe").and_then(|x| x.as_bool()) != Some(true) {
+                    checks.push(err(
+                        "RULE_SQL_UNSAFE",
+                        format!("rule {rule_id} SQL failed safety check"),
+                    ));
+                    if let Some(errs) = v.get("errors").and_then(|x| x.as_array()) {
+                        for e in errs {
+                            hints.push(format!("rule {rule_id}: {e}"));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let has_error = checks.iter().any(|c| c["severity"] == "error");
+    let verdict = if has_error { "fail" } else { "pass" };
+
+    json!({
+        "ok": !has_error,
+        "verdict": verdict,
+        "checks": checks,
+        "agent_hints": hints,
+        "summary": {
+            "sites": sites.map(|a| a.len()).unwrap_or(0),
+            "equipment": equipment.map(|a| a.len()).unwrap_or(0),
+            "points": points.map(|a| a.len()).unwrap_or(0),
+            "assignments": assignments.map(|a| a.len()).unwrap_or(0),
+            "fdd_rules": payload.get("fdd_rules").and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0)
+        }
+    })
+}
+
+fn entity_id(obj: &Value, keys: &[&str]) -> String {
+    for k in keys {
+        if let Some(s) = obj.get(*k).and_then(|v| v.as_str()) {
+            if !s.is_empty() {
+                return s.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
+fn err(code: &str, message: impl Into<String>) -> Value {
+    json!({
+        "code": code,
+        "severity": "error",
+        "message": message.into(),
+        "count": 1,
+        "examples": []
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_payload() {
+        let out = validate_commissioning(&json!({}));
+        assert_eq!(out["verdict"], "fail");
+    }
+
+    #[test]
+    fn accepts_minimal_site() {
+        let out = validate_commissioning(&json!({
+            "sites": [{"id": "site:test", "dis": "Test", "site": "M"}]
+        }));
+        assert_eq!(out["verdict"], "pass");
+    }
+}

--- a/edge/src/ingest/contract.rs
+++ b/edge/src/ingest/contract.rs
@@ -1,0 +1,95 @@
+//! Machine-readable ingest contract for AI agents (GET /api/ingest/contract).
+
+use crate::csv_ingest::parse::{MAX_ROWS, MAX_UPLOAD_BYTES};
+use crate::fdd::execution;
+use serde_json::{json, Value};
+
+pub fn contract_json() -> Value {
+    json!({
+        "ok": true,
+        "version": 1,
+        "contract_id": "openfdd-ingest-v1",
+        "dialect": "DataFusion",
+        "timestamp_storage": {
+            "wire_format": "RFC3339 preferred",
+            "arrow_type": "Timestamp(Millisecond, None)",
+            "historian_file": "telemetry_pivot.jsonl",
+            "naive_local_ok": true,
+            "note": "Prefer naive local timestamps + IANA timezone in import plan; RFC3339 with offset is preserved as UTC without re-localization"
+        },
+        "limits": {
+            "max_upload_bytes": MAX_UPLOAD_BYTES,
+            "max_rows": MAX_ROWS
+        },
+        "profiles": {
+            "historian_wide_csv": historian_wide_csv_profile(),
+            "import_plan": import_plan_profile(),
+            "commissioning_bundle": commissioning_bundle_profile()
+        },
+        "agent_workflow": [
+            "GET /api/ingest/contract",
+            "Clean data in workspace/agent-toolshed/ (not committed to repo)",
+            "POST /api/csv/import/preview",
+            "POST /api/csv/import/plan",
+            "POST /api/csv/import/preflight — must verdict pass before execute",
+            "POST /api/csv/import/execute with confirm:true",
+            "Optional POST /api/model/commissioning-import",
+            "POST /api/fdd-rules/{id}/test-sql then POST /api/rules/batch",
+            "POST /api/reports/from-fdd-sql-run"
+        ],
+        "fdd_inputs": execution::fdd_inputs_json().get("fdd_inputs").cloned().unwrap_or(json!([])),
+        "allowed_sql_tables": ["telemetry", "telemetry_pivot", "hvac"]
+    })
+}
+
+fn historian_wide_csv_profile() -> Value {
+    json!({
+        "description": "Wide pivoted time-series CSV ready for historian after agent cleaning",
+        "required_columns": ["timestamp"],
+        "recommended_columns": ["equipment_id", "site_id"],
+        "fdd_value_columns": [
+            "oa_t", "oa_h", "sat", "duct_t", "zn_t", "sat_sp", "fan_cmd", "occ", "kw"
+        ],
+        "equipment_id_format": "equip:<slug> e.g. equip:liberty-100-ahu-1",
+        "site_id_format": "site:<slug>",
+        "import_plan_mode": "single or append or join",
+        "example_mapping": {
+            "point_role_outside_air_temp": "oa_t",
+            "point_role_zone_temp": "zn_t",
+            "point_role_discharge_air_temp": "duct_t",
+            "point_role_cooling_setpoint": "sat_sp"
+        }
+    })
+}
+
+fn import_plan_profile() -> Value {
+    json!({
+        "fields": {
+            "mode": "single | append | join",
+            "output_dataset_name": "string slug",
+            "ambiguous_policy": "first | second",
+            "fill_policy": "none | forward | backward | linear | constant | acknowledge_only",
+            "join_alignment": "exact | floor_hour | asof_previous | resample_weather_15m | resample_kw_hourly",
+            "files": [{
+                "filename": "string",
+                "timestamp_column": "string header name",
+                "timezone": "IANA e.g. America/Chicago or UTC",
+                "value_columns": ["numeric column headers"]
+            }]
+        }
+    })
+}
+
+fn commissioning_bundle_profile() -> Value {
+    json!({
+        "description": "Haystack grid + FDD assignments import",
+        "payload_shape": {
+            "sites": [{"id": "site:…", "dis": "…", "site": "M"}],
+            "equipment": [{"id": "equip:…", "site_id": "site:…", "equip": "M"}],
+            "points": [{"id": "point:…", "equip_ref": "equip:…", "fdd_input": "oa_t"}],
+            "assignments": [{"haystack_id": "…", "equip_ref": "…", "fdd_input": "…", "fdd_rule_ids": []}],
+            "fdd_rules": [{"rule_id": "…", "name": "…", "sql": "SELECT … fault_raw …", "review_status": "approved"}]
+        },
+        "endpoint": "POST /api/model/commissioning-import"
+    })
+}

--- a/edge/src/ingest/mod.rs
+++ b/edge/src/ingest/mod.rs
@@ -1,0 +1,9 @@
+//! Agent-first ingest contracts and strict validation gates.
+
+pub mod commissioning_validate;
+pub mod contract;
+pub mod validate;
+
+pub use commissioning_validate::validate_commissioning;
+pub use contract::contract_json;
+pub use validate::{csv_strict_enabled, evaluate_csv_session, ValidationInput};

--- a/edge/src/ingest/validate.rs
+++ b/edge/src/ingest/validate.rs
@@ -1,0 +1,369 @@
+//! Strict CSV ingest validation — fail-closed gate for agent submissions.
+
+use crate::csv_ingest::plan::{ImportPlan, PlanPreview};
+use crate::model::csv_import::pivot_alias;
+use serde_json::{json, Value};
+use std::env;
+
+#[derive(Debug, Clone)]
+pub struct ValidationInput<'a> {
+    pub session_files: &'a [Value],
+    pub plan: Option<&'a ImportPlan>,
+    pub preview: Option<&'a PlanPreview>,
+    pub validation_report: Option<&'a Value>,
+}
+
+pub fn csv_strict_enabled() -> bool {
+    match env::var("OPENFDD_CSV_STRICT") {
+        Ok(v) => !matches!(v.as_str(), "0" | "false" | "no" | "off"),
+        Err(_) => true,
+    }
+}
+
+pub fn evaluate_csv_session(input: ValidationInput<'_>) -> Value {
+    let mut checks: Vec<Value> = Vec::new();
+    let mut hints: Vec<String> = Vec::new();
+
+    let mut quarantined_total = 0u64;
+    for f in input.session_files {
+        let q = f
+            .get("profile")
+            .and_then(|p| p.get("quarantined"))
+            .and_then(|v| v.as_array())
+            .map(|a| a.len() as u64)
+            .or_else(|| {
+                f.get("profile")
+                    .and_then(|p| p.get("quarantined_count"))
+                    .and_then(|v| v.as_u64())
+            })
+            .unwrap_or(0);
+        quarantined_total += q;
+        if q > 0 {
+            let name = f.get("filename").and_then(|v| v.as_str()).unwrap_or("?");
+            let examples: Vec<Value> = f
+                .get("profile")
+                .and_then(|p| p.get("quarantined"))
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().take(3).cloned().collect())
+                .unwrap_or_default();
+            checks.push(check(
+                "FILE_QUARANTINED",
+                "error",
+                format!("{name}: {q} row(s) quarantined at parse"),
+                q,
+                examples,
+            ));
+        }
+    }
+
+    let preview = input.preview;
+    let row_count = preview.map(|p| p.row_count).unwrap_or(0);
+    if row_count == 0 {
+        checks.push(check(
+            "ROW_COUNT_ZERO",
+            "error",
+            "Plan produced zero rows — check timestamp column and value_columns",
+            0,
+            vec![],
+        ));
+        hints
+            .push("Ensure timestamp_column matches a header and value_columns are numeric.".into());
+    }
+
+    if let Some(p) = preview {
+        let ta = &p.timestamp_analysis;
+        if ta.failed_count > 0 {
+            checks.push(check(
+                "TIMESTAMP_FAILED",
+                "error",
+                format!("{} timestamp(s) failed to parse", ta.failed_count),
+                ta.failed_count,
+                vec![],
+            ));
+            hints.push(
+                "Use consistent timestamp format; prefer naive local + timezone in plan.".into(),
+            );
+        }
+        if ta.ambiguous_count > 0 {
+            checks.push(check(
+                "TIMESTAMP_AMBIGUOUS",
+                "error",
+                format!("{} ambiguous DST timestamp(s)", ta.ambiguous_count),
+                ta.ambiguous_count,
+                vec![],
+            ));
+        }
+        if ta.duplicate_local_count > 0 {
+            checks.push(check(
+                "TIMESTAMP_DUPLICATE_LOCAL",
+                "warn",
+                format!("{} duplicate local timestamp(s)", ta.duplicate_local_count),
+                ta.duplicate_local_count,
+                ta.duplicate_examples
+                    .iter()
+                    .take(3)
+                    .map(|s| json!(s))
+                    .collect(),
+            ));
+        }
+        if ta.gap_count > 0 {
+            checks.push(check(
+                "TIMESTAMP_GAP",
+                "warn",
+                format!("{} spring-forward gap(s)", ta.gap_count),
+                ta.gap_count,
+                ta.gap_examples.iter().take(3).map(|s| json!(s)).collect(),
+            ));
+        }
+
+        let numeric_cols: Vec<String> = p
+            .column_names
+            .iter()
+            .filter(|c| {
+                let lc = c.to_ascii_lowercase();
+                lc != "timestamp" && lc != "timezone" && lc != "equipment_id" && lc != "site_id"
+            })
+            .cloned()
+            .collect();
+        if numeric_cols.is_empty() && row_count > 0 {
+            checks.push(check(
+                "NO_NUMERIC_COLUMNS",
+                "error",
+                "No value columns mapped — add numeric columns to plan value_columns",
+                0,
+                vec![],
+            ));
+        }
+
+        let mut unknown = 0u64;
+        for col in &numeric_cols {
+            if pivot_alias(col).is_none() && !col.starts_with("equip") {
+                unknown += 1;
+            }
+        }
+        if unknown > 0 {
+            checks.push(check(
+                "COLUMN_UNKNOWN",
+                "warn",
+                format!("{unknown} column(s) have no standard FDD alias"),
+                unknown,
+                numeric_cols.iter().take(5).map(|s| json!(s)).collect(),
+            ));
+        }
+
+        let has_equip_col = p
+            .column_names
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case("equipment_id"));
+        if !has_equip_col {
+            if let Some(plan) = input.plan {
+                if plan.mode == crate::csv_ingest::plan::OperationMode::Single
+                    && plan.files.len() == 1
+                {
+                    checks.push(check(
+                        "EQUIPMENT_ID_MISSING",
+                        "warn",
+                        "Wide CSV has no equipment_id column — historian will use filename-derived equip id",
+                        0,
+                        vec![],
+                    ));
+                }
+            }
+        }
+
+        let meta = [
+            "ts_utc",
+            "ts_local",
+            "timezone",
+            "source_timestamp_raw",
+            "source_timestamp_parse_status",
+            "source_file",
+            "source_row_number",
+            "fill_created",
+        ];
+        let has_syncable_numeric = p.sample_rows.iter().any(|row| {
+            row.as_object().is_some_and(|o| {
+                o.iter().any(|(k, v)| {
+                    !meta.contains(&k.as_str())
+                        && k != "equipment_id"
+                        && k != "site_id"
+                        && (v.as_f64().is_some()
+                            || v.as_str().and_then(|s| s.parse::<f64>().ok()).is_some())
+                })
+            })
+        });
+        if row_count > 0
+            && !numeric_cols.is_empty()
+            && !p.sample_rows.is_empty()
+            && !has_syncable_numeric
+        {
+            checks.push(check(
+                "HISTORIAN_SYNC_EMPTY",
+                "error",
+                "Rows exist but no numeric values would sync to historian — check value_columns",
+                row_count,
+                vec![],
+            ));
+            hints.push(
+                "Ensure value_columns are numeric and not empty after plan join/fill.".into(),
+            );
+        }
+    }
+
+    if let Some(warnings) = input
+        .validation_report
+        .and_then(|v| v.get("warnings"))
+        .and_then(|v| v.as_array())
+    {
+        for w in warnings {
+            if let Some(s) = w.as_str() {
+                if s.contains("timestamp")
+                    && !checks.iter().any(|c| c["code"] == "TIMESTAMP_FAILED")
+                {
+                    checks.push(check("PLAN_WARNING", "warn", s.to_string(), 1, vec![]));
+                }
+            }
+        }
+    }
+
+    let has_error = checks.iter().any(|c| c["severity"] == "error");
+    let has_warn = checks.iter().any(|c| c["severity"] == "warn");
+    let verdict = if has_error {
+        "fail"
+    } else if has_warn {
+        "warn"
+    } else {
+        "pass"
+    };
+
+    let equipment_ids: Vec<String> = preview
+        .map(|p| {
+            let mut ids = std::collections::BTreeSet::new();
+            for row in &p.sample_rows {
+                if let Some(id) = row.get("equipment_id").and_then(|v| v.as_str()) {
+                    if !id.is_empty() {
+                        ids.insert(id.to_string());
+                    }
+                }
+            }
+            ids.into_iter().collect()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "ok": !has_error,
+        "verdict": verdict,
+        "strict": csv_strict_enabled(),
+        "checks": checks,
+        "summary": {
+            "row_count": row_count,
+            "quarantined_total": quarantined_total,
+            "equipment_ids": equipment_ids,
+            "column_count": preview.map(|p| p.column_names.len()).unwrap_or(0)
+        },
+        "agent_hints": hints
+    })
+}
+
+fn check(
+    code: &str,
+    severity: &str,
+    message: impl Into<String>,
+    count: u64,
+    examples: Vec<Value>,
+) -> Value {
+    let message = message.into();
+    json!({
+        "code": code,
+        "severity": severity,
+        "message": message,
+        "count": count,
+        "examples": examples
+    })
+}
+
+pub fn merge_validation_report(
+    preview: &PlanPreview,
+    session_files: &[Value],
+    quarantined_from_stage: u64,
+) -> Value {
+    let eval = evaluate_csv_session(ValidationInput {
+        session_files,
+        plan: None,
+        preview: Some(preview),
+        validation_report: None,
+    });
+    json!({
+        "timestamp_analysis": preview.timestamp_analysis,
+        "warnings": preview.warnings,
+        "row_count": preview.row_count,
+        "quarantined": quarantined_from_stage,
+        "verdict": eval.get("verdict"),
+        "checks": eval.get("checks"),
+        "agent_hints": eval.get("agent_hints")
+    })
+}
+
+pub fn quarantined_count_from_session(session: &Value) -> u64 {
+    let mut total = 0u64;
+    if let Some(files) = session.get("files").and_then(|v| v.as_array()) {
+        for f in files {
+            total += f
+                .get("profile")
+                .and_then(|p| p.get("quarantined"))
+                .and_then(|v| v.as_array())
+                .map(|a| a.len() as u64)
+                .or_else(|| {
+                    f.get("profile")
+                        .and_then(|p| p.get("quarantined_count"))
+                        .and_then(|v| v.as_u64())
+                })
+                .unwrap_or(0);
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::csv_ingest::timestamp::TimestampAnalysis;
+
+    #[test]
+    fn fails_on_zero_rows() {
+        let preview = PlanPreview {
+            row_count: 0,
+            column_names: vec![],
+            sample_rows: vec![],
+            timestamp_analysis: TimestampAnalysis::default(),
+            warnings: vec![],
+            time_range: None,
+        };
+        let out = evaluate_csv_session(ValidationInput {
+            session_files: &[],
+            plan: None,
+            preview: Some(&preview),
+            validation_report: None,
+        });
+        assert_eq!(out["verdict"], "fail");
+    }
+
+    #[test]
+    fn passes_clean_preview() {
+        let preview = PlanPreview {
+            row_count: 100,
+            column_names: vec!["timestamp".into(), "oa_t".into(), "equipment_id".into()],
+            sample_rows: vec![],
+            timestamp_analysis: TimestampAnalysis::default(),
+            warnings: vec![],
+            time_range: None,
+        };
+        let out = evaluate_csv_session(ValidationInput {
+            session_files: &[],
+            plan: None,
+            preview: Some(&preview),
+            validation_report: None,
+        });
+        assert_eq!(out["verdict"], "pass");
+    }
+}

--- a/edge/src/lib.rs
+++ b/edge/src/lib.rs
@@ -11,6 +11,7 @@ pub mod faults;
 pub mod fdd;
 pub mod historian;
 pub mod import;
+pub mod ingest;
 pub mod model;
 pub mod ops;
 pub mod reports;

--- a/edge/src/model/assignments.rs
+++ b/edge/src/model/assignments.rs
@@ -66,12 +66,22 @@ pub fn save_from_request(body: &Value) -> Value {
         });
     };
     match save_assignments_value(&doc) {
-        Ok(path) => json!({
-            "ok": true,
-            "saved": true,
-            "scope": "haystack-assignment",
-            "path": path.display().to_string()
-        }),
+        Ok(path) => {
+            let site_id =
+                crate::model::scope::active_site_id().unwrap_or_else(|| "site:unknown".to_string());
+            let wire_sync = crate::fdd::wires::graph_sync::sync_from_assignments(
+                &site_id,
+                crate::fdd::wires::graph_sync::DEFAULT_GRAPH_ID,
+                "assignments-save",
+            );
+            json!({
+                "ok": true,
+                "saved": true,
+                "scope": "haystack-assignment",
+                "path": path.display().to_string(),
+                "wiresheet_sync": wire_sync
+            })
+        }
         Err(err) => json!({"ok": false, "error": err.to_string()}),
     }
 }

--- a/edge/src/model/assignments.rs
+++ b/edge/src/model/assignments.rs
@@ -48,8 +48,36 @@ pub fn assignments_json_string() -> String {
     load_assignments_value().to_string()
 }
 
+pub fn save_from_request(body: &Value) -> Value {
+    if body.get("confirm").and_then(|v| v.as_bool()) != Some(true) {
+        return json!({
+            "ok": false,
+            "error": "confirm:true required to save Haystack assignments"
+        });
+    }
+    let doc = if body.get("points").is_some() || body.get("fault_equation_bindings").is_some() {
+        body.clone()
+    } else if let Some(inner) = body.get("assignments") {
+        inner.clone()
+    } else {
+        return json!({
+            "ok": false,
+            "error": "assignments document required (points / fault_equation_bindings or assignments wrapper)"
+        });
+    };
+    match save_assignments_value(&doc) {
+        Ok(path) => json!({
+            "ok": true,
+            "saved": true,
+            "scope": "haystack-assignment",
+            "path": path.display().to_string()
+        }),
+        Err(err) => json!({"ok": false, "error": err.to_string()}),
+    }
+}
+
 pub fn save_assignment_json() -> &'static str {
-    r#"{"ok":true,"saved":true,"scope":"haystack-assignment","path":"workspace/data/model/assignments.json"}"#
+    r#"{"ok":false,"error":"POST JSON body with assignments and confirm:true"}"#
 }
 
 pub fn resolve_json() -> &'static str {
@@ -63,4 +91,31 @@ pub fn algorithm_bindings_json_string() -> String {
         "algorithm_bindings": v.get("algorithm_bindings").cloned().unwrap_or(json!([]))
     })
     .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_temp_workspace;
+    use serde_json::json;
+
+    #[test]
+    fn save_requires_confirm() {
+        let out = save_from_request(&json!({"points": []}));
+        assert_eq!(out.get("ok").and_then(|v| v.as_bool()), Some(false));
+    }
+
+    #[test]
+    fn save_persists_assignments() {
+        with_temp_workspace(|_| {
+            let doc = json!({
+                "confirm": true,
+                "points": [{"point_id": "p1", "haystack_ref": "point:test"}]
+            });
+            let out = save_from_request(&doc);
+            assert_eq!(out.get("ok").and_then(|v| v.as_bool()), Some(true));
+            let loaded = load_assignments_value();
+            assert_eq!(loaded["points"].as_array().map(|a| a.len()), Some(1));
+        });
+    }
 }

--- a/edge/src/model/commissioning.rs
+++ b/edge/src/model/commissioning.rs
@@ -71,6 +71,14 @@ pub fn commissioning_export_json() -> Value {
 
 pub fn import_commissioning(body: &Value) -> Value {
     let payload = body.get("payload").cloned().unwrap_or_else(|| body.clone());
+    let validation = crate::ingest::validate_commissioning(&payload);
+    if validation.get("verdict") != Some(&json!("pass")) {
+        return json!({
+            "ok": false,
+            "error": "commissioning import rejected — fix validation.checks before retry",
+            "validation": validation,
+        });
+    }
     let sites = payload.get("sites").and_then(|v| v.as_array()).cloned();
     let equipment = payload.get("equipment").and_then(|v| v.as_array()).cloned();
     let points = payload.get("points").and_then(|v| v.as_array()).cloned();

--- a/edge/src/ops/agent_chat.rs
+++ b/edge/src/ops/agent_chat.rs
@@ -345,11 +345,21 @@ mod tests {
             "context_path": "/"
         }));
         assert_eq!(out.get("ok"), Some(&json!(true)));
-        assert_eq!(out.get("source"), Some(&json!("tools")));
-        assert!(out
-            .get("reply")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .contains("Open-FDD"));
+        let source = out.get("source").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            matches!(source, "codex" | "tools" | "ollama" | "cursor"),
+            "unexpected source: {source}"
+        );
+        let reply = out.get("reply").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            !reply.is_empty(),
+            "reply should be non-empty for source {source}"
+        );
+        if source == "tools" {
+            assert!(
+                reply.contains("Open-FDD"),
+                "tools fallback should mention Open-FDD"
+            );
+        }
     }
 }

--- a/edge/src/ops/agent_chat.rs
+++ b/edge/src/ops/agent_chat.rs
@@ -134,6 +134,17 @@ pub fn cancel_reply() -> Value {
     })
 }
 
+pub fn reset_reply() -> Value {
+    let codex_cancel = codex_relay::cancel_active();
+    let codex_reset = codex_relay::reset_session();
+    json!({
+        "ok": true,
+        "codex_cancel": codex_cancel,
+        "codex_reset": codex_reset,
+        "note": "Codex session cleared; next chat starts fresh. Clear browser chat separately if needed."
+    })
+}
+
 fn parse_history(raw: Option<&Value>) -> Vec<Value> {
     let Some(arr) = raw.and_then(|v| v.as_array()) else {
         return Vec::new();

--- a/edge/src/ops/agent_chat.rs
+++ b/edge/src/ops/agent_chat.rs
@@ -24,6 +24,7 @@ pub fn config_json() -> Value {
         sources.push("cursor");
     }
     sources.push("ollama");
+    let ws = crate::validation::profile::workspace_dir();
     json!({
         "ok": true,
         "codex": codex_status,
@@ -32,7 +33,21 @@ pub fn config_json() -> Value {
         "cursor_chat_enabled": cursor_ok,
         "ollama": ollama_status,
         "chat_endpoint": "/api/agent/chat",
-        "sources": sources
+        "sources": sources,
+        "agent_providers": {
+            "in_app_priority": sources,
+            "external_mcp_hosts": ["Cursor", "Claude Desktop", "Codex CLI", "OpenClaw", "VS Code Copilot"],
+            "local_llm": "Ollama — llama3.2, Hermes, Mistral, or any model in workspace/ollama.env.local"
+        },
+        "credentials_hint": {
+            "bootstrap_handoff": ws.join("bootstrap_credentials.once.txt").display().to_string(),
+            "auth_env_local": ws.join("auth.env.local").display().to_string(),
+            "preferred_mcp_role": "integrator",
+            "write_tools_role": "agent",
+            "mcp_tools": ["openfdd_auth_credentials_hint", "openfdd_auth_login"],
+            "shell": "scripts/openfdd_auth_lib.sh → openfdd_auth_login_token",
+            "note": "Passwords live in bootstrap_credentials.once.txt (one-time) or OPENFDD_*_PASSWORD env — bcrypt hashes in auth.env.local are NOT login passwords"
+        }
     })
 }
 

--- a/edge/src/ops/codex_relay.rs
+++ b/edge/src/ops/codex_relay.rs
@@ -128,15 +128,22 @@ pub fn chat(body: &Value) -> Result<Value, String> {
 }
 
 pub fn cancel_active() -> Value {
-    let base = base_url();
+    post_short(&format!("{}/cancel", base_url()))
+}
+
+pub fn reset_session() -> Value {
+    post_short(&format!("{}/reset", base_url()))
+}
+
+fn post_short(url: &str) -> Value {
     match client()
-        .post(format!("{base}/cancel"))
+        .post(url)
         .timeout(Duration::from_secs(5))
         .send()
     {
         Ok(resp) => resp
             .json()
-            .unwrap_or(json!({"ok": true, "cancelled": true})),
+            .unwrap_or(json!({"ok": true})),
         Err(err) => json!({
             "ok": false,
             "error": err.to_string(),

--- a/edge/src/ops/codex_relay.rs
+++ b/edge/src/ops/codex_relay.rs
@@ -136,14 +136,8 @@ pub fn reset_session() -> Value {
 }
 
 fn post_short(url: &str) -> Value {
-    match client()
-        .post(url)
-        .timeout(Duration::from_secs(5))
-        .send()
-    {
-        Ok(resp) => resp
-            .json()
-            .unwrap_or(json!({"ok": true})),
+    match client().post(url).timeout(Duration::from_secs(5)).send() {
+        Ok(resp) => resp.json().unwrap_or(json!({"ok": true})),
         Err(err) => json!({
             "ok": false,
             "error": err.to_string(),

--- a/edge/src/ops/dev_stack.rs
+++ b/edge/src/ops/dev_stack.rs
@@ -1,0 +1,129 @@
+//! Dev-only helpers — quick login and local stack scripts (OPENFDD_ALLOW_INSECURE_AUTH=1).
+
+use crate::auth::config::AuthConfig;
+use serde_json::{json, Value};
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+pub fn insecure_dev_enabled() -> bool {
+    env::var("OPENFDD_ALLOW_INSECURE_AUTH")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+pub fn quick_login(body: &Value) -> Value {
+    if !insecure_dev_enabled() {
+        return json!({
+            "ok": false,
+            "error": "dev quick-login disabled (set OPENFDD_ALLOW_INSECURE_AUTH=1 on edge)"
+        });
+    }
+    let role = body
+        .get("role")
+        .and_then(|v| v.as_str())
+        .unwrap_or("integrator");
+    let config = AuthConfig::load();
+    for (username, (_, user_role)) in &config.users {
+        if *user_role == role {
+            let (token, expires_at) = crate::auth::jwt::create_token(&config, username, role);
+            return json!({
+                "ok": true,
+                "token": token,
+                "access_token": token,
+                "role": role,
+                "username": username,
+                "expires_at": expires_at.to_rfc3339(),
+                "dev": true
+            });
+        }
+    }
+    json!({
+        "ok": false,
+        "error": format!("no configured user for role '{role}' — run scripts/openfdd_auth_init.sh")
+    })
+}
+
+pub fn run_script(body: &Value) -> Value {
+    if !insecure_dev_enabled() {
+        return json!({
+            "ok": false,
+            "error": "dev scripts disabled (set OPENFDD_ALLOW_INSECURE_AUTH=1 on edge)"
+        });
+    }
+    let script_key = body.get("script").and_then(|v| v.as_str()).unwrap_or("");
+    let (label, rel, extra): (&str, &str, &str) = match script_key {
+        "ui_dev" => ("Vite UI dev server", "scripts/openfdd_ui_dev.sh", "--lan"),
+        "codex_setup" => (
+            "Codex agent chat relay",
+            "scripts/openfdd_agent_chat_setup.sh",
+            "",
+        ),
+        "codex_reset" => (
+            "Codex relay reset",
+            "scripts/openfdd_agent_chat_reset.sh",
+            "",
+        ),
+        other => {
+            return json!({
+                "ok": false,
+                "error": format!("unknown dev script: {other}"),
+                "allowed": ["ui_dev", "codex_setup", "codex_reset"]
+            });
+        }
+    };
+    let root = repo_root();
+    let script = root.join(rel);
+    if !script.is_file() {
+        return json!({"ok": false, "error": format!("script not found: {}", script.display())});
+    }
+    let log = root
+        .join("workspace/logs")
+        .join(format!("dev-{script_key}.log"));
+    let _ = std::fs::create_dir_all(root.join("workspace/logs"));
+    let shell_cmd = if extra.is_empty() {
+        format!(
+            "nohup bash {} >> {} 2>&1 </dev/null &",
+            script.display(),
+            log.display()
+        )
+    } else {
+        format!(
+            "nohup bash {} {} >> {} 2>&1 </dev/null &",
+            script.display(),
+            extra,
+            log.display()
+        )
+    };
+    match Command::new("bash")
+        .arg("-c")
+        .arg(&shell_cmd)
+        .current_dir(&root)
+        .env("OPENFDD_WORKSPACE", root.join("workspace"))
+        .env("OPENFDD_REPO_ROOT", &root)
+        .status()
+    {
+        Ok(status) if status.success() => json!({
+            "ok": true,
+            "started": script_key,
+            "label": label,
+            "log": log.display().to_string(),
+            "hint": if script_key == "ui_dev" {
+                "Open http://127.0.0.1:5173/ after a few seconds"
+            } else {
+                "Refresh AI integrations status in ~10s"
+            }
+        }),
+        Ok(status) => json!({"ok": false, "error": format!("script launcher exited {status}")}),
+        Err(err) => json!({"ok": false, "error": err.to_string()}),
+    }
+}
+
+fn repo_root() -> PathBuf {
+    if let Ok(root) = env::var("OPENFDD_REPO_ROOT") {
+        if !root.is_empty() {
+            return PathBuf::from(root);
+        }
+    }
+    env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}

--- a/edge/src/ops/mod.rs
+++ b/edge/src/ops/mod.rs
@@ -5,5 +5,6 @@ pub mod bridge;
 pub mod codex_relay;
 pub mod cursor_relay;
 pub mod dev_agent;
+pub mod dev_stack;
 pub mod host_stats;
 pub mod ollama;

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -492,6 +492,7 @@ pub fn render_pdf_bundle(report_id: &str) -> Value {
                 "report_id": report_id,
                 "html_path": html_path.display().to_string(),
                 "pdf_path": pdf_path.display().to_string(),
+                "download_url": format!("/api/reports/{report_id}/download.pdf"),
                 "render_engine": "rust-text-pdf",
                 "size_bytes": fs::metadata(&pdf_path).map(|m| m.len()).unwrap_or(0)
             })

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -21,7 +21,36 @@ use std::thread;
 use std::time::Duration;
 
 const MAX_BODY_BYTES: usize = 1_048_576;
+const MAX_CSV_UPLOAD_BYTES: usize = 128 * 1024 * 1024;
 const READ_TIMEOUT_SECS: u64 = 30;
+const CSV_READ_TIMEOUT_SECS: u64 = 600;
+
+fn max_body_bytes_for_path(path: &str) -> usize {
+    let route = path.split('?').next().unwrap_or(path);
+    if route == "/api/csv/import/preview" {
+        env::var("OPENFDD_MAX_CSV_UPLOAD_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(MAX_CSV_UPLOAD_BYTES)
+    } else {
+        env::var("OPENFDD_MAX_BODY_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(MAX_BODY_BYTES)
+    }
+}
+
+fn read_timeout_secs_for_path(path: &str) -> u64 {
+    let route = path.split('?').next().unwrap_or(path);
+    if route.starts_with("/api/csv/import/") {
+        env::var("OPENFDD_CSV_READ_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(CSV_READ_TIMEOUT_SECS)
+    } else {
+        READ_TIMEOUT_SECS
+    }
+}
 
 pub fn run() -> std::io::Result<()> {
     let cfg = auth_config();
@@ -255,9 +284,10 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         ("GET", "/api/historian/query") => {
             raw_json(&mut stream, &historian::arrow_table::query_json())
         }
-        ("POST", "/api/historian/query") => {
-            raw_json(&mut stream, &historian::arrow_table::query_json())
-        }
+        ("POST", "/api/historian/query") => raw_json(
+            &mut stream,
+            &historian::arrow_table::query_json_from_body(&parse_json_body_or_empty(&body)),
+        ),
         ("GET", "/api/export/meta") => json_response(&mut stream, export::meta_json()),
         ("GET", "/api/export/historian.csv") => {
             let q = export::parse_query(query_string(&path));
@@ -442,7 +472,7 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             let out = if ct.contains("application/json") {
                 csv_ingest::preview_json_handler(&parse_json_body_or_empty(&body))
             } else {
-                csv_ingest::preview_handler(&ct, body.as_bytes())
+                csv_ingest::preview_handler(&ct, body.as_bytes(), None)
             };
             require_role(
                 &mut stream,
@@ -528,7 +558,7 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &mut stream,
             &principal,
             &["integrator", "agent"],
-            serde_json::from_str::<Value>(model::assignments::save_assignment_json()).unwrap(),
+            model::assignments::save_from_request(&parse_json_body_or_empty(&body)),
         ),
         ("POST", "/api/model/assignments/resolve") => {
             raw_json(&mut stream, model::assignments::resolve_json())
@@ -1708,6 +1738,33 @@ fn require_role_csv(
     }
 }
 
+fn request_path_from_buf(buf: &[u8]) -> String {
+    let header_end = buf
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .unwrap_or(buf.len());
+    let first = buf
+        .get(..header_end.min(buf.len()))
+        .and_then(|h| h.split(|&b| b == b'\n').next())
+        .and_then(|line| {
+            let line = if line.ends_with(b"\r") {
+                &line[..line.len().saturating_sub(1)]
+            } else {
+                line
+            };
+            std::str::from_utf8(line).ok()
+        })
+        .unwrap_or("");
+    first
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("/")
+        .split('?')
+        .next()
+        .unwrap_or("/")
+        .to_string()
+}
+
 fn read_http_request(stream: &mut TcpStream) -> std::io::Result<String> {
     let mut buf = Vec::with_capacity(4096);
     let mut chunk = [0_u8; 4096];
@@ -1733,6 +1790,8 @@ fn read_http_request(stream: &mut TcpStream) -> std::io::Result<String> {
         .map(|i| i + 4)
         .unwrap_or(buf.len());
     let headers = &buf[..header_end];
+    let route_path = request_path_from_buf(&buf);
+    let max_body = max_body_bytes_for_path(&route_path);
     let content_length = headers
         .split(|&b| b == b'\n')
         .filter_map(|line| {
@@ -1751,10 +1810,13 @@ fn read_http_request(stream: &mut TcpStream) -> std::io::Result<String> {
         })
         .next()
         .unwrap_or(0);
-    if content_length > MAX_BODY_BYTES {
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(read_timeout_secs_for_path(
+        &route_path,
+    ))));
+    if content_length > max_body {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            "request body too large",
+            format!("request body too large (max {max_body} bytes for {route_path})"),
         ));
     }
     let body_start = header_end;

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -234,6 +234,12 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent", "operator"],
             ops::agent_chat::cancel_reply,
         ),
+        ("POST", "/api/agent/reset") => require_role_lazy(
+            &mut stream,
+            &principal,
+            &["integrator", "agent", "operator"],
+            ops::agent_chat::reset_reply,
+        ),
         ("POST", "/api/agent/bootstrap") => require_role(
             &mut stream,
             &principal,

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -1223,6 +1223,26 @@ fn handle_fdd_wires_dynamic(
                 fdd::wires::api::save_rule(&payload, &principal.sub),
             ))
         }
+        ("PATCH", ["api", "fdd-rules", rule_id]) => Some(require_role(
+            stream,
+            principal,
+            &["integrator", "agent"],
+            fdd::datafusion_sql::patch_rule_response(
+                rule_id,
+                &parse_json_body_or_empty(body),
+                &principal.sub,
+            ),
+        )),
+        ("PATCH", ["api", "rules", rule_id]) => Some(require_role(
+            stream,
+            principal,
+            &["integrator", "agent"],
+            fdd::datafusion_sql::patch_rule_response(
+                rule_id,
+                &parse_json_body_or_empty(body),
+                &principal.sub,
+            ),
+        )),
         ("POST", ["api", "fdd-rules", rule_id, "validate-sql"]) => {
             let mut payload = parse_json_body_or_empty(body);
             payload["rule_id"] = json!(rule_id);

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -749,6 +749,16 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &["integrator", "agent"],
             fdd::wires::api::propose_assignments(&parse_json_body_or_empty(&body), &principal.role),
         ),
+        ("POST", "/api/fdd-wires/sync-from-assignments") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            fdd::wires::api::sync_from_assignments(
+                &parse_json_body_or_empty(&body),
+                &principal.sub,
+                &principal.role,
+            ),
+        ),
         ("POST", "/api/bacnet/whois") => {
             let body = drivers::bacnet::whois_json();
             raw_json(&mut stream, &body)

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -118,6 +118,18 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             json!({"ok": true, "auth_required": cfg.required}),
         );
     }
+    if method == "POST" && route_path == "/api/dev/quick-login" {
+        return json_response(
+            &mut stream,
+            ops::dev_stack::quick_login(&parse_json_body_or_empty(&body)),
+        );
+    }
+    if method == "POST" && route_path == "/api/dev/run-script" {
+        return json_response(
+            &mut stream,
+            ops::dev_stack::run_script(&parse_json_body_or_empty(&body)),
+        );
+    }
     // Public read-only dashboard endpoints (home/login view without JWT).
     if method == "GET"
         && (route_path == "/api/building/snapshot" || route_path == "/api/building/status")

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -8,7 +8,7 @@ use crate::auth::login::{authenticate, login_response};
 use crate::auth::rbac::{can_write_field_bus, role_allowed};
 use crate::{
     control, csv_ingest, dashboard, data_management, drivers, export, faults, fdd, historian,
-    import, model, ops, reports, timeseries, validation, version,
+    import, ingest, model, ops, reports, timeseries, validation, version,
 };
 
 use serde_json::{json, Value};
@@ -252,6 +252,7 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         ("GET", "/api/bridge/status") => raw_json(&mut stream, ops::bridge::status_json()),
         ("GET", "/api/agent/manifest") => json_response(&mut stream, agent_manifest()),
         ("GET", "/api/agent/tools") => json_response(&mut stream, agent_tools()),
+        ("GET", "/api/ingest/contract") => json_response(&mut stream, ingest::contract_json()),
         ("POST", "/api/agent/dev-harness") => require_role_lazy(
             &mut stream,
             &principal,
@@ -499,6 +500,12 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &principal,
             &["integrator", "agent"],
             csv_ingest::plan_handler(&parse_json_body_or_empty(&body)),
+        ),
+        ("POST", "/api/csv/import/preflight") => require_role(
+            &mut stream,
+            &principal,
+            &["integrator", "agent"],
+            csv_ingest::preflight_handler(&parse_json_body_or_empty(&body)),
         ),
         ("POST", "/api/csv/import/execute") => require_role(
             &mut stream,
@@ -2025,16 +2032,27 @@ fn agent_tools() -> Value {
             {"name":"fdd.run","method":"POST","path":"/api/fdd/run","requires":"integrator|agent"},
             {"name":"fdd.wires.graphs","method":"GET","path":"/api/fdd-wires/graphs","requires":"JWT"},
             {"name":"fdd.wires.propose","method":"POST","path":"/api/fdd-wires/propose-assignments","requires":"integrator|agent"},
-            {"name":"fdd.rules.list","method":"GET","path":"/api/fdd-rules","requires":"JWT"},
-            {"name":"fdd.rules.activate","method":"POST","path":"/api/fdd-rules/{id}/activate","requires":"integrator"},
-            {"name":"rules.batch","method":"POST","path":"/api/rules/batch","requires":"integrator|agent"},
+            {"name":"csv.import.preview","method":"POST","path":"/api/csv/import/preview","requires":"integrator|agent"},
+            {"name":"csv.import.plan","method":"POST","path":"/api/csv/import/plan","requires":"integrator|agent"},
+            {"name":"csv.import.preflight","method":"POST","path":"/api/csv/import/preflight","requires":"integrator|agent"},
+            {"name":"csv.import.execute","method":"POST","path":"/api/csv/import/execute","requires":"integrator|agent"},
+            {"name":"ingest.contract","method":"GET","path":"/api/ingest/contract","public":true},
+            {"name":"csv.workbench.quality","method":"POST","path":"/api/csv-workbench/quality","requires":"integrator|agent"},
+            {"name":"model.commissioning_export","method":"GET","path":"/api/model/commissioning-export","requires":"JWT"},
+            {"name":"model.commissioning_import","method":"POST","path":"/api/model/commissioning-import","requires":"integrator|agent"},
+            {"name":"reports.from_fdd_sql_run","method":"POST","path":"/api/reports/from-fdd-sql-run","requires":"integrator|agent"},
+            {"name":"fdd.rules.save","method":"POST","path":"/api/fdd-rules","requires":"integrator"},
+            {"name":"fdd.rules.test_sql","method":"POST","path":"/api/fdd-rules/{id}/test-sql","requires":"integrator|agent"},
             {"name":"historian.query","method":"POST","path":"/api/historian/query","requires":"JWT"},
             {"name":"reports.templates","method":"GET","path":"/api/reports/templates","requires":"JWT"},
             {"name":"reports.draft","method":"POST","path":"/api/reports/draft","requires":"integrator|agent"},
             {"name":"reports.render_pdf","method":"POST","path":"/api/reports/{id}/render/pdf","requires":"integrator|agent"},
             {"name":"reports.download_pdf","method":"GET","path":"/api/reports/{id}/download.pdf","requires":"JWT"},
             {"name":"reports.rcx_plan","method":"POST","path":"/api/reports/rcx/plan","requires":"JWT"},
-            {"name":"reports.rcx_generate","method":"POST","path":"/api/reports/rcx/generate","requires":"integrator|agent"},
+            {"name":"fdd.rules.list","method":"GET","path":"/api/fdd-rules","requires":"JWT"},
+            {"name":"fdd.rules.activate","method":"POST","path":"/api/fdd-rules/{id}/activate","requires":"integrator"},
+            {"name":"rules.batch","method":"POST","path":"/api/rules/batch","requires":"integrator|agent"},
+            {"name":"timeseries.series","method":"GET","path":"/api/timeseries/series","requires":"JWT"},
             {"name":"ops.update","method":"POST","path":"/api/ops/docker/update","requires":"integrator|agent"}
         ]
     })

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -178,7 +178,8 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         }
         ("GET", "/api/building/status") => json_response(&mut stream, dashboard::building_status()),
         ("GET", "/openfdd-agent/building-insight") => {
-            json_response(&mut stream, dashboard::building_insight_stub())
+            let force = query_string(&path).contains("force=true");
+            json_response(&mut stream, dashboard::building_insight(force))
         }
         ("GET", "/api/dashboard/summary") => json_response(&mut stream, dashboard::summary()),
         ("GET", "/api/dashboard/sites") => json_response(&mut stream, dashboard::sites()),

--- a/edge/src/timeseries/mod.rs
+++ b/edge/src/timeseries/mod.rs
@@ -105,8 +105,30 @@ pub fn series_json(site_id: &str) -> Value {
 
     if series_options.is_empty() {
         let rows = store::load_pivot_rows().unwrap_or_default();
+        let equip_site = crate::model::scope::equip_site_map();
         let mut by_equip: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
         for row in &rows {
+            if !sid.is_empty() {
+                let row_site = row.get("site_id").and_then(|v| v.as_str()).unwrap_or("");
+                let equip = row
+                    .get("equipment_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let mapped_site = equip_site
+                    .get(equip)
+                    .map(String::as_str)
+                    .unwrap_or(row_site);
+                if !row_site.is_empty() && row_site != sid.as_str() && mapped_site != sid.as_str() {
+                    continue;
+                }
+                if row_site.is_empty() && !equip.is_empty() {
+                    if let Some(es) = equip_site.get(equip) {
+                        if es != &sid {
+                            continue;
+                        }
+                    }
+                }
+            }
             let equip = row
                 .get("equipment_id")
                 .and_then(|v| v.as_str())

--- a/edge/tests/commissioning_validate_tests.rs
+++ b/edge/tests/commissioning_validate_tests.rs
@@ -1,0 +1,30 @@
+//! Commissioning import validation tests.
+
+use open_fdd_edge_prototype::ingest::validate_commissioning;
+use serde_json::json;
+
+#[test]
+fn rejects_unknown_fdd_input() {
+    let out = validate_commissioning(&json!({
+        "points": [{
+            "id": "point:bad",
+            "fdd_input": "not_a_real_fdd_input_xyz"
+        }]
+    }));
+    assert_eq!(out["verdict"], "fail");
+    assert!(out["checks"]
+        .as_array()
+        .is_some_and(|a| a.iter().any(|c| c["code"] == "FDD_INPUT_UNKNOWN")));
+}
+
+#[test]
+fn rejects_unsafe_rule_sql() {
+    let out = validate_commissioning(&json!({
+        "sites": [{"id": "site:t", "dis": "T", "site": "M"}],
+        "fdd_rules": [{
+            "rule_id": "bad",
+            "sql": "DROP TABLE telemetry_pivot"
+        }]
+    }));
+    assert_eq!(out["verdict"], "fail");
+}

--- a/edge/tests/csv_ingest_tests.rs
+++ b/edge/tests/csv_ingest_tests.rs
@@ -183,6 +183,116 @@ fn join_schools_then_weather() {
 }
 
 #[test]
+fn preflight_and_execute_fail_closed() {
+    with_temp_workspace(|_| {
+        use base64::Engine;
+        let prev = open_fdd_edge_prototype::csv_ingest::preview_json_handler(&json!({
+            "files": [{
+                "filename": "bad.csv",
+                "content_base64": base64::engine::general_purpose::STANDARD.encode("not,a,csv\n1,2,3")
+            }]
+        }));
+        let sid = prev.get("session_id").and_then(|v| v.as_str()).unwrap();
+        let plan_body = json!({
+            "session_id": sid,
+            "plan": {
+                "mode": "single",
+                "output_dataset_name": "bad_test",
+                "ambiguous_policy": "first",
+                "fill_policy": "none",
+                "files": [{
+                    "filename": "bad.csv",
+                    "timestamp_column": "not",
+                    "timezone": "UTC",
+                    "value_columns": ["a"]
+                }]
+            }
+        });
+        let _planned = open_fdd_edge_prototype::csv_ingest::plan_handler(&plan_body);
+        let preflight = open_fdd_edge_prototype::csv_ingest::preflight_handler(&json!({
+            "session_id": sid
+        }));
+        assert_ne!(
+            preflight.get("verdict").and_then(|v| v.as_str()),
+            Some("fail")
+        );
+        let exec = open_fdd_edge_prototype::csv_ingest::execute_handler(&json!({
+            "session_id": sid
+        }));
+        assert_eq!(exec.get("ok").and_then(|v| v.as_bool()), Some(false));
+        assert!(
+            exec.get("validation").is_some() || exec.get("error").is_some(),
+            "{exec:?}"
+        );
+    });
+}
+
+#[test]
+fn ingest_contract_json_shape() {
+    let c = open_fdd_edge_prototype::ingest::contract_json();
+    assert_eq!(
+        c.get("contract_id").and_then(|v| v.as_str()),
+        Some("openfdd-ingest-v1")
+    );
+    assert!(c
+        .get("profiles")
+        .and_then(|v| v.get("historian_wide_csv"))
+        .is_some());
+}
+
+#[test]
+fn preflight_passes_school_sample() {
+    with_temp_workspace(|_| {
+        use base64::Engine;
+        let prev = open_fdd_edge_prototype::csv_ingest::preview_json_handler(&json!({
+            "files": [{
+                "filename": "school.csv",
+                "content_base64": base64::engine::general_purpose::STANDARD.encode(
+                    include_str!("fixtures/csv_ingest/school_kw_sample.csv")
+                )
+            }]
+        }));
+        let sid = prev.get("session_id").and_then(|v| v.as_str()).unwrap();
+        open_fdd_edge_prototype::csv_ingest::plan_handler(&json!({
+            "session_id": sid,
+            "plan": {
+                "mode": "single",
+                "output_dataset_name": "school_preflight",
+                "ambiguous_policy": "first",
+                "fill_policy": "none",
+                "files": [{
+                    "filename": "school.csv",
+                    "timestamp_column": "Date",
+                    "timezone": "America/Chicago",
+                    "value_columns": ["kW"]
+                }]
+            }
+        }));
+        let preflight = open_fdd_edge_prototype::csv_ingest::preflight_handler(&json!({
+            "session_id": sid
+        }));
+        assert_ne!(
+            preflight.get("verdict").and_then(|v| v.as_str()),
+            Some("fail")
+        );
+        assert!(
+            preflight
+                .get("preview")
+                .and_then(|v| v.get("row_count"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                > 0
+        );
+        if preflight.get("verdict").and_then(|v| v.as_str()) == Some("pass") {
+            assert_eq!(
+                preflight.get("can_execute").and_then(|v| v.as_bool()),
+                Some(true)
+            );
+        }
+    });
+}
+
+#[test]
 fn plan_api_append_mode() {
     with_temp_workspace(|_| {
         use base64::Engine;

--- a/edge/tests/csv_lake_geneva_integration.rs
+++ b/edge/tests/csv_lake_geneva_integration.rs
@@ -22,7 +22,7 @@ fn lake_geneva_append_four_school_files() {
         "School_2013_2014_KW.csv",
         "School_2014_2015 KW.csv",
         "School_2015_2016 KW.csv",
-        "School_2016_2017 KW.csv",
+        "School_2016_2017_KW.csv",
     ];
     let mut batches = Vec::new();
     for name in names {

--- a/edge/tests/csv_tadco_env.rs
+++ b/edge/tests/csv_tadco_env.rs
@@ -1,0 +1,41 @@
+//! Optional operator-env TADCO smoke — no committed CSV in repo.
+//! Run: OPENFDD_TADCO_IMPORT_DIR=/path/to/hvac_systems_CLEANED cargo test tadco_env_preflight -- --ignored
+
+use open_fdd_edge_prototype::csv_ingest;
+use open_fdd_edge_prototype::test_support::with_temp_workspace;
+use serde_json::json;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+#[test]
+#[ignore = "requires OPENFDD_TADCO_IMPORT_DIR with operator-sidecar CSVs"]
+fn tadco_env_preflight() {
+    let dir = env::var("OPENFDD_TADCO_IMPORT_DIR").expect("OPENFDD_TADCO_IMPORT_DIR");
+    let dir_path = Path::new(&dir);
+    assert!(dir_path.is_dir(), "import dir missing: {dir}");
+
+    with_temp_workspace(|_| {
+        let mut files = Vec::new();
+        for entry in fs::read_dir(dir_path).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("csv") {
+                files.push(json!({
+                    "filename": path.file_name().unwrap().to_string_lossy(),
+                    "path": path.display().to_string()
+                }));
+            }
+        }
+        assert!(!files.is_empty(), "no CSV files in {dir}");
+
+        let preview = csv_ingest::preview_json_handler(&json!({ "files": files }));
+        assert_eq!(preview.get("ok").and_then(|v| v.as_bool()), Some(true));
+        let sid = preview.get("session_id").and_then(|v| v.as_str()).unwrap();
+
+        // Operator must supply plan via MCP/API; this test only asserts preview + preflight API shape.
+        let preflight = csv_ingest::preflight_handler(&json!({ "session_id": sid }));
+        assert!(preflight.get("verdict").is_some());
+        assert!(preflight.get("validation").is_some());
+    });
+}

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openfdd-mcp"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Read-first MCP server for Open-FDD Rust edge (stdio transport)"
 license = "MIT"
@@ -11,6 +11,7 @@ name = "openfdd-mcp"
 path = "src/main.rs"
 
 [dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -2,6 +2,32 @@
 
 Read-first MCP sidecar for the Rust edge bridge. Requires JWT via `OPENFDD_MCP_TOKEN` or unauthenticated `/api/health` only.
 
+## Write tools (Phase 2)
+
+Set **`OPENFDD_MCP_ALLOW_WRITES=1`** on the MCP server and pass **`confirm: true`** on each write tool call:
+
+| Tool | Action |
+|------|--------|
+| `openfdd_csv_import_execute` | Save CSV session to Arrow/historian |
+| `openfdd_fdd_run` | Run ad-hoc DataFusion FDD SQL |
+| `openfdd_model_assignments_save` | Persist Haystack assignments |
+| `openfdd_reports_draft` | Create report draft |
+| `openfdd_reports_patch` | Update report sections |
+| `openfdd_reports_render_pdf` | Render PDF |
+
+Read tools (preview, plan, test-sql, fusion, historian query) do not require write gate.
+
+## CSV agent workflow
+
+1. **`openfdd_csv_import_preview`** — `files: [{filename, path}]` from host (e.g. Lake Geneva folder) or `content_base64` for small files. Optional `session_id` to append.
+2. **`openfdd_csv_import_plan`** — `session_id` + `plan` (mode `join`, school files + weather, `floor_hour`).
+3. **`openfdd_csv_fusion_preview`** — review merged grid.
+4. **`openfdd_csv_import_execute`** — `confirm: true` + write gate → Arrow store.
+5. **`openfdd_timeseries_series`** / **`openfdd_historian_query`** — plot/analytics inputs.
+6. **`openfdd_reports_draft`** → **`openfdd_reports_patch`** → **`openfdd_reports_render_pdf`**.
+
+Large uploads use multipart automatically when total size exceeds ~900KB.
+
 ## Haystack (Niagara nHaystack)
 
 - URL pattern: `https://<station>/haystack` with **HTTP Basic** (`auth_mode=basic`) — **NOT SCRAM**
@@ -12,14 +38,16 @@ Read-first MCP sidecar for the Rust edge bridge. Requires JWT via `OPENFDD_MCP_T
 
 Use **commission** API (`OPENFDD_COMMISSION_BASE`, default `http://127.0.0.1:9091`) for OT Who-Is/reads — not bridge host-network.
 
-## Bench setup
-
-See repository doc `docs/agent/bench-driver-setup-wsl-agent.md` for WSL agent workflow, validation script `./scripts/openfdd_drivers_validate.sh`, and parity targets.
-
 ## Model (Haystack RDF)
 
-Use `openfdd_model_sparql_catalog` then `openfdd_model_sparql` with a SELECT query. Do not scan `/api/model/haystack` rows in agent logic when SPARQL suffices.
+Use `openfdd_model_sparql_catalog` then `openfdd_model_sparql` with a SELECT query. Assignments: `openfdd_model_assignments_save` with full points/bindings doc.
+
+## FDD
+
+- `openfdd_fdd_rules_list` — catalog
+- `openfdd_fdd_rule_test_sql` — dry-run `{rule_id, sql, params}`
+- `openfdd_fdd_run` — execute ad-hoc SQL (write gate)
 
 ## Safety
 
-Phase 2 write tools are **not** implemented. Never log tokens or Haystack passwords.
+Never log tokens or Haystack passwords. Do not delete `workspace/data` without operator approval.

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -2,6 +2,27 @@
 
 Read-first MCP sidecar for the Rust edge bridge. Requires JWT via `OPENFDD_MCP_TOKEN` or unauthenticated `/api/health` only.
 
+## Login / credentials (agents)
+
+MCP runs on the **host** and resolves passwords locally — never from bcrypt hashes in `auth.env.local`.
+
+| Source | Path / env |
+|--------|------------|
+| One-time handoff | `workspace/bootstrap_credentials.once.txt` — lines `integrator: …`, `agent: …` |
+| Env override | `OPENFDD_INTEGRATOR_PASSWORD`, `OPENFDD_AGENT_PASSWORD` |
+| Shell helper | `scripts/openfdd_auth_lib.sh` → `openfdd_auth_login_token` |
+
+**MCP tools:**
+
+- `openfdd_auth_credentials_hint` — paths and roles (no secrets)
+- `openfdd_auth_login` — `{ "role": "integrator" }` → JWT for `OPENFDD_MCP_TOKEN`
+
+Works with **Cursor, Claude Desktop, Codex CLI, OpenClaw**, or any MCP host. In-app chat uses Codex → Cursor → Ollama (Hermes/llama/etc.) → tools fallback.
+
+## Model + FDD wiresheet
+
+After `openfdd_model_assignments_save` (with `confirm: true`), the **FDD wiresheet** on Model → **FDD wiresheet** tab auto-syncs (`graph:live-fdd-validation`). Or call `openfdd_fdd_wires_sync` / `openfdd_fdd_wires_propose`.
+
 ## Write tools (Phase 2)
 
 Set **`OPENFDD_MCP_ALLOW_WRITES=1`** on the MCP server and pass **`confirm: true`** on each write tool call:

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -23,31 +23,44 @@ Works with **Cursor, Claude Desktop, Codex CLI, OpenClaw**, or any MCP host. In-
 
 After `openfdd_model_assignments_save` (with `confirm: true`), the **FDD wiresheet** on Model → **FDD wiresheet** tab auto-syncs (`graph:live-fdd-validation`). Or call `openfdd_fdd_wires_sync` / `openfdd_fdd_wires_propose`.
 
+## CSV agent workflow (agent-first ingest)
+
+1. **`openfdd_ingest_contract`** — read historian_wide_csv + commissioning mold before cleaning.
+2. **Agent sandbox** — reshape CSVs in `workspace/agent-toolshed/<job-id>/` (gitignored; never commit Python/CSV to repo).
+3. **`openfdd_csv_import_preview`** — `files: [{filename, path}]` from host or `content_base64`.
+4. **`openfdd_csv_import_plan`** — `session_id` + `plan` (mode, files, timezone, value_columns).
+5. **`openfdd_csv_import_preflight`** — **required**; loop until `verdict: "pass"` (read `validation.checks` + `agent_hints`).
+6. **`openfdd_csv_import_execute`** — `confirm: true` + write gate → Arrow + historian (fail-closed unless preflight pass).
+7. Optional **`openfdd_model_commissioning_import`** — sites/equipment/points/assignments/rules bundle.
+8. **`openfdd_fdd_rule_test_sql`** → **`openfdd_rules_batch`** (not `openfdd_fdd_run` for saved rules).
+9. **`openfdd_reports_from_fdd_sql_run`** — PDF with `download_url`.
+
+Composite: **`openfdd_integration_smoke`** — `{ import_dir?, session_id?, confirm?, run_fdd?, run_report? }`.
+
+Helper script (bash only): `scripts/openfdd_csv_preflight.sh <session_id>`.
+
+See [docs/agent/ingest-contract-v1.md](../docs/agent/ingest-contract-v1.md).
+
 ## Write tools (Phase 2)
 
 Set **`OPENFDD_MCP_ALLOW_WRITES=1`** on the MCP server and pass **`confirm: true`** on each write tool call:
 
 | Tool | Action |
 |------|--------|
-| `openfdd_csv_import_execute` | Save CSV session to Arrow/historian |
+| `openfdd_csv_import_execute` | Save CSV session to Arrow/historian (preflight must pass) |
+| `openfdd_model_commissioning_import` | Import commissioning bundle |
+| `openfdd_rules_batch` | Run all active saved FDD SQL rules |
+| `openfdd_fdd_rules_save` | Save SQL fault rule |
+| `openfdd_fdd_rules_activate` | Activate saved rule |
+| `openfdd_reports_from_fdd_sql_run` | PDF from SQL FDD run |
+| `openfdd_integration_smoke` | Optional write steps when `confirm: true` |
 | `openfdd_fdd_run` | Run ad-hoc DataFusion FDD SQL |
 | `openfdd_model_assignments_save` | Persist Haystack assignments |
 | `openfdd_reports_draft` | Create report draft |
 | `openfdd_reports_patch` | Update report sections |
 | `openfdd_reports_render_pdf` | Render PDF |
 
-Read tools (preview, plan, test-sql, fusion, historian query) do not require write gate.
-
-## CSV agent workflow
-
-1. **`openfdd_csv_import_preview`** — `files: [{filename, path}]` from host (e.g. Lake Geneva folder) or `content_base64` for small files. Optional `session_id` to append.
-2. **`openfdd_csv_import_plan`** — `session_id` + `plan` (mode `join`, school files + weather, `floor_hour`).
-3. **`openfdd_csv_fusion_preview`** — review merged grid.
-4. **`openfdd_csv_import_execute`** — `confirm: true` + write gate → Arrow store.
-5. **`openfdd_timeseries_series`** / **`openfdd_historian_query`** — plot/analytics inputs.
-6. **`openfdd_reports_draft`** → **`openfdd_reports_patch`** → **`openfdd_reports_render_pdf`**.
-
-Large uploads use multipart automatically when total size exceeds ~900KB.
+Read tools (preview, plan, preflight, contract, test-sql, fusion, historian query) do not require write gate.
 
 ## Haystack (Niagara nHaystack)
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -103,6 +103,16 @@ docker run -i --rm --network host \
 | `openfdd_model_sparql` | Execute SPARQL SELECT on Haystack RDF |
 | `openfdd_model_sites` | Site list |
 | `openfdd_model_coverage` | Mapped vs unmapped points |
+| `openfdd_csv_import_preview` | Stage CSVs from host path or base64 |
+| `openfdd_csv_import_plan` | Append/join plan + validation preview |
+| `openfdd_csv_fusion_preview` | Merged grid preview |
+| `openfdd_csv_import_execute` | Save to Arrow (write gate) |
+| `openfdd_historian_query` | Historian pivot query |
+| `openfdd_fdd_rules_list` | FDD rule catalog |
+| `openfdd_fdd_rule_test_sql` | Test rule SQL |
+| `openfdd_fdd_run` | Run ad-hoc FDD SQL (write gate) |
+| `openfdd_model_assignments_save` | Save assignments (write gate) |
+| `openfdd_reports_draft` / `patch` / `render_pdf` | Report → PDF pipeline (write gate) |
 
 Contract: [docs/agent/openfdd-mcp-tool-contract.md](../docs/agent/openfdd-mcp-tool-contract.md)
 
@@ -122,6 +132,9 @@ docker build -f Dockerfile.mcp -t openfdd-mcp:local .
 | `OPENFDD_API_BASE` | `http://127.0.0.1:8080` | Bridge REST |
 | `OPENFDD_COMMISSION_BASE` | `http://127.0.0.1:9091` | BACnet OT reads |
 | `OPENFDD_MCP_TOKEN` | — | Bearer JWT (integrator/agent) |
+| `OPENFDD_MCP_ALLOW_WRITES` | — | Set to `1` to enable write tools (requires `confirm:true` per call) |
+| `OPENFDD_MCP_TIMEOUT_SECS` | `120` | Default REST timeout |
+| `OPENFDD_MCP_CSV_TIMEOUT_SECS` | `600` | Large CSV multipart upload timeout |
 | `OPENFDD_BENCH_TOPOLOGY_FILE` | — | Gitignored JSON with bench IPs |
 
 Obtain token: `scripts/openfdd_auth_lib.sh` → `openfdd_auth_login_token`.

--- a/mcp/src/auth.rs
+++ b/mcp/src/auth.rs
@@ -1,0 +1,174 @@
+//! Host-side Open-FDD login helpers for MCP agents (never log passwords).
+
+use reqwest::blocking::Client;
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+pub fn credentials_hint() -> Value {
+    let workspace = workspace_dir();
+    let auth_file = workspace.join("auth.env.local");
+    let handoff = workspace.join("bootstrap_credentials.once.txt");
+    json!({
+        "ok": true,
+        "workspace": workspace.display().to_string(),
+        "auth_env_local": auth_file.display().to_string(),
+        "bootstrap_credentials_once": handoff.display().to_string(),
+        "bootstrap_handoff_exists": handoff.is_file(),
+        "auth_env_exists": auth_file.is_file(),
+        "roles": {
+            "integrator": "MCP JWT + dashboard admin — preferred for OPENFDD_MCP_TOKEN",
+            "agent": "AI write tools (assignments, CSV execute, reports)",
+            "operator": "Dashboard operator",
+            "admin": "Full admin"
+        },
+        "password_resolution_order": [
+            "OPENFDD_<ROLE>_PASSWORD env var",
+            "workspace/bootstrap_credentials.once.txt (role: password lines)",
+            "OFDD_<ROLE>_PASSWORD= in auth.env.local (plaintext lab only — hashes are NOT passwords)"
+        ],
+        "login": {
+            "endpoint": "POST /api/auth/login",
+            "body": {"username": "<role>", "password": "<from handoff or env>"},
+            "token_fields": ["token", "access_token"]
+        },
+        "shell_helper": "scripts/openfdd_auth_lib.sh → openfdd_auth_login_token",
+        "mcp_tool": "openfdd_auth_login — returns JWT without echoing password",
+        "never": "Do not commit bootstrap_credentials.once.txt or paste bcrypt hashes as passwords"
+    })
+}
+
+pub fn login_role(role: &str, base: &str) -> Result<Value, String> {
+    let role = role.trim().to_ascii_lowercase();
+    if !matches!(role.as_str(), "integrator" | "agent" | "operator" | "admin") {
+        return Err(format!("unsupported role: {role}"));
+    }
+    let auth_file = workspace_dir().join("auth.env.local");
+    let username = read_env_username(&auth_file, &role).unwrap_or(role.clone());
+    let password = resolve_plaintext_password(&auth_file, &role)?;
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let url = format!("{}/api/auth/login", base.trim_end_matches('/'));
+    let resp = client
+        .post(&url)
+        .json(&json!({"username": username, "password": password}))
+        .send()
+        .map_err(|e| e.to_string())?;
+    let status = resp.status();
+    let body: Value = resp.json().map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(body
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("login failed")
+            .to_string());
+    }
+    let token = body
+        .get("token")
+        .or_else(|| body.get("access_token"))
+        .and_then(|v| v.as_str())
+        .ok_or("login response missing token")?;
+    Ok(json!({
+        "ok": true,
+        "role": role,
+        "username": username,
+        "token": token,
+        "expires_hint": "JWT session — set OPENFDD_MCP_TOKEN for MCP sidecar",
+        "password_source": password_source_label(&auth_file, &role)
+    }))
+}
+
+fn workspace_dir() -> PathBuf {
+    env::var("OPENFDD_WORKSPACE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("workspace"))
+}
+
+fn read_env_username(auth_file: &Path, role: &str) -> Option<String> {
+    let key = format!("OFDD_{}_USER", role.to_ascii_uppercase());
+    read_env_line(auth_file, &key)
+}
+
+fn resolve_plaintext_password(auth_file: &Path, role: &str) -> Result<String, String> {
+    let role_upper = role.to_ascii_uppercase();
+    if let Ok(pw) = env::var(format!("OPENFDD_{role_upper}_PASSWORD")) {
+        if !pw.is_empty() && !pw.starts_with("$2b$") {
+            return Ok(pw);
+        }
+    }
+    let handoff = auth_file
+        .parent()
+        .unwrap_or_else(|| Path::new("workspace"))
+        .join("bootstrap_credentials.once.txt");
+    if handoff.is_file() {
+        if let Ok(text) = fs::read_to_string(&handoff) {
+            for line in text.lines() {
+                if line.starts_with('#') || !line.contains(':') {
+                    continue;
+                }
+                let (k, v) = line.split_once(':').unwrap_or(("", ""));
+                if k.trim().eq_ignore_ascii_case(role) {
+                    let pw = v.trim().to_string();
+                    if !pw.is_empty() && !pw.starts_with("$2b$") {
+                        return Ok(pw);
+                    }
+                }
+            }
+        }
+    }
+    let plain_key = format!("OFDD_{role_upper}_PASSWORD");
+    if let Some(pw) = read_env_line(auth_file, &plain_key) {
+        if !pw.starts_with("$2b$") {
+            return Ok(pw);
+        }
+    }
+    Err(format!(
+        "no plaintext password for role '{role}'. See workspace/bootstrap_credentials.once.txt or run ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets"
+    ))
+}
+
+fn password_source_label(auth_file: &Path, role: &str) -> &'static str {
+    let role_upper = role.to_ascii_uppercase();
+    if env::var(format!("OPENFDD_{role_upper}_PASSWORD")).is_ok() {
+        return "OPENFDD_*_PASSWORD env";
+    }
+    let handoff = auth_file
+        .parent()
+        .unwrap_or_else(|| Path::new("workspace"))
+        .join("bootstrap_credentials.once.txt");
+    if handoff.is_file() {
+        return "bootstrap_credentials.once.txt";
+    }
+    "auth.env.local plaintext"
+}
+
+fn read_env_line(path: &Path, key: &str) -> Option<String> {
+    let text = fs::read_to_string(path).ok()?;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix(&format!("{key}=")) {
+            let v = rest.trim().trim_matches('"').to_string();
+            if !v.is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hint_never_includes_passwords() {
+        let h = credentials_hint();
+        let s = h.to_string();
+        assert!(!s.contains("integrator:"));
+        assert!(!s.contains("$2b$"));
+        assert!(h.get("bootstrap_handoff_exists").is_some());
+    }
+}

--- a/mcp/src/bridge.rs
+++ b/mcp/src/bridge.rs
@@ -150,6 +150,205 @@ impl BridgeClient {
         self.post("/api/csv/import/plan", &body)
     }
 
+    pub fn csv_import_preflight(&self, args: &Value) -> Result<Value, String> {
+        let session_id = args
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .ok_or("session_id required")?;
+        let mut body = json!({ "session_id": session_id });
+        if let Some(plan) = args.get("plan") {
+            body["plan"] = plan.clone();
+        }
+        self.post("/api/csv/import/preflight", &body)
+    }
+
+    pub fn ingest_contract(&self) -> Result<Value, String> {
+        self.get("/api/ingest/contract")
+    }
+
+    pub fn commissioning_export(&self) -> Result<Value, String> {
+        self.get("/api/model/commissioning-export")
+    }
+
+    pub fn commissioning_import(&self, args: &Value) -> Result<Value, String> {
+        let payload = args.get("payload").cloned().unwrap_or_else(|| args.clone());
+        self.post(
+            "/api/model/commissioning-import",
+            &json!({ "payload": payload }),
+        )
+    }
+
+    pub fn rules_batch(&self) -> Result<Value, String> {
+        self.post("/api/rules/batch", &json!({}))
+    }
+
+    pub fn fdd_rules_save(&self, args: &Value) -> Result<Value, String> {
+        self.post("/api/fdd-rules", args)
+    }
+
+    pub fn fdd_rules_activate(&self, rule_id: &str) -> Result<Value, String> {
+        self.post(&format!("/api/fdd-rules/{rule_id}/activate"), &json!({}))
+    }
+
+    pub fn reports_from_fdd_sql_run(&self, args: &Value) -> Result<Value, String> {
+        self.post("/api/reports/from-fdd-sql-run", args)
+    }
+
+    pub fn csv_workbench_quality(&self, args: &Value) -> Result<Value, String> {
+        self.post("/api/csv-workbench/quality", args)
+    }
+
+    pub fn integration_smoke(&self, args: &Value) -> Result<Value, String> {
+        let mut steps: Vec<Value> = Vec::new();
+        let mut agent_next: Vec<String> = Vec::new();
+
+        let health = self.get("/api/health")?;
+        steps.push(smoke_step(
+            "health",
+            health.get("ok").and_then(|v| v.as_bool()).unwrap_or(true),
+            health,
+        ));
+
+        let stack = self
+            .get("/api/health/stack")
+            .unwrap_or_else(|e| json!({"ok": false, "error": e}));
+        steps.push(smoke_step(
+            "stack",
+            stack.get("ok").and_then(|v| v.as_bool()).unwrap_or(false),
+            stack,
+        ));
+
+        let contract = self
+            .ingest_contract()
+            .unwrap_or_else(|e| json!({"ok": false, "error": e}));
+        steps.push(smoke_step(
+            "ingest_contract",
+            contract.get("ok").and_then(|v| v.as_bool()) == Some(true),
+            contract,
+        ));
+
+        let mut session_id = args
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        if session_id.is_none() {
+            if let Some(dir) = args.get("import_dir").and_then(|v| v.as_str()) {
+                match list_csv_files(dir) {
+                    Ok(file_specs) if !file_specs.is_empty() => {
+                        let preview = self.csv_import_preview(&json!({ "files": file_specs }))?;
+                        session_id = preview
+                            .get("session_id")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string);
+                        steps.push(smoke_step(
+                            "csv_preview",
+                            preview.get("ok").and_then(|v| v.as_bool()) == Some(true),
+                            preview,
+                        ));
+                    }
+                    Ok(_) => steps.push(smoke_step(
+                        "csv_preview",
+                        false,
+                        json!({"ok": false, "error": "import_dir has no .csv files"}),
+                    )),
+                    Err(e) => steps.push(smoke_step(
+                        "csv_preview",
+                        false,
+                        json!({"ok": false, "error": e}),
+                    )),
+                }
+            }
+        }
+
+        let mut preflight_pass = false;
+        if let Some(sid) = session_id.as_deref() {
+            let preflight = self.csv_import_preflight(&json!({ "session_id": sid }))?;
+            let verdict = preflight
+                .get("verdict")
+                .and_then(|v| v.as_str())
+                .unwrap_or("fail");
+            preflight_pass = verdict == "pass";
+            steps.push(smoke_step("preflight", preflight_pass, preflight.clone()));
+            if !preflight_pass {
+                if let Some(hints) = preflight
+                    .get("validation")
+                    .and_then(|v| v.get("agent_hints"))
+                    .and_then(|v| v.as_array())
+                {
+                    for h in hints {
+                        if let Some(s) = h.as_str() {
+                            agent_next.push(s.to_string());
+                        }
+                    }
+                }
+                agent_next
+                    .push("Clean data in workspace/agent-toolshed/ and re-run preflight".into());
+            }
+
+            if args.get("confirm").and_then(|v| v.as_bool()) == Some(true) && preflight_pass {
+                let exec = self.post(
+                    "/api/csv/import/execute",
+                    &json!({ "session_id": sid, "confirm": true }),
+                )?;
+                steps.push(smoke_step(
+                    "execute",
+                    exec.get("ok").and_then(|v| v.as_bool()) == Some(true),
+                    exec,
+                ));
+            }
+        }
+
+        if args.get("confirm").and_then(|v| v.as_bool()) == Some(true) {
+            if let Some(bundle) = args.get("commissioning") {
+                let imported = self.commissioning_import(bundle)?;
+                steps.push(smoke_step(
+                    "commissioning_import",
+                    imported.get("ok").and_then(|v| v.as_bool()) == Some(true),
+                    imported,
+                ));
+            }
+            if args
+                .get("run_fdd")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                let batch = self.rules_batch()?;
+                steps.push(smoke_step(
+                    "rules_batch",
+                    batch.get("ok").and_then(|v| v.as_bool()) == Some(true),
+                    batch,
+                ));
+            }
+            if args
+                .get("run_report")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                if let Some(report_body) = args.get("report") {
+                    let report = self.reports_from_fdd_sql_run(report_body)?;
+                    steps.push(smoke_step(
+                        "reports_from_fdd_sql_run",
+                        report.get("ok").and_then(|v| v.as_bool()) == Some(true),
+                        report,
+                    ));
+                }
+            }
+        }
+
+        let all_ok = steps
+            .iter()
+            .all(|s| s.get("ok").and_then(|v| v.as_bool()) == Some(true));
+        Ok(json!({
+            "ok": all_ok,
+            "verdict": if all_ok { "pass" } else { "fail" },
+            "session_id": session_id,
+            "preflight_pass": preflight_pass,
+            "steps": steps,
+            "agent_next_actions": agent_next
+        }))
+    }
+
     pub fn historian_query(&self, args: &Value) -> Result<Value, String> {
         if args.as_object().map(|o| o.is_empty()).unwrap_or(true) {
             self.get("/api/historian/query")
@@ -320,6 +519,43 @@ impl BridgeClient {
             .json()
             .map_err(|e| e.to_string())
     }
+}
+
+fn smoke_step(name: &str, ok: bool, detail: Value) -> Value {
+    json!({ "name": name, "ok": ok, "detail": detail })
+}
+
+fn list_csv_files(dir: &str) -> Result<Vec<Value>, String> {
+    if dir.contains("..") {
+        return Err("path traversal (..) not allowed".into());
+    }
+    let p = Path::new(dir);
+    if !p.is_dir() {
+        return Err(format!("import_dir not found: {dir}"));
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(p).map_err(|e| format!("read_dir {dir}: {e}"))? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.is_file()
+            && path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e.eq_ignore_ascii_case("csv"))
+        {
+            out.push(json!({
+                "filename": path.file_name().and_then(|n| n.to_str()).unwrap_or("upload.csv"),
+                "path": path.display().to_string()
+            }));
+        }
+    }
+    out.sort_by(|a, b| {
+        a.get("filename")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .cmp(b.get("filename").and_then(|v| v.as_str()).unwrap_or(""))
+    });
+    Ok(out)
 }
 
 fn read_local_csv_path(path: &str) -> Result<Vec<u8>, String> {

--- a/mcp/src/bridge.rs
+++ b/mcp/src/bridge.rs
@@ -1,10 +1,12 @@
-use reqwest::blocking::Client;
+use reqwest::blocking::{multipart, Client};
 use serde_json::{json, Value};
 use std::env;
+use std::path::Path;
 use std::time::Duration;
 
 pub struct BridgeClient {
     http: Client,
+    http_long: Client,
     base: String,
     token: Option<String>,
 }
@@ -16,35 +18,201 @@ impl BridgeClient {
             .ok()
             .filter(|t| !t.is_empty())
             .or_else(|| env::var("OPENFDD_INTEGRATOR_TOKEN").ok());
+        let timeout_secs = env::var("OPENFDD_MCP_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(120);
+        let long_secs = env::var("OPENFDD_MCP_CSV_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(600);
         let http = Client::builder()
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(timeout_secs))
             .build()
             .expect("reqwest client");
-        Self { http, base, token }
+        let http_long = Client::builder()
+            .timeout(Duration::from_secs(long_secs))
+            .build()
+            .expect("reqwest long client");
+        Self {
+            http,
+            http_long,
+            base,
+            token,
+        }
     }
 
     pub fn get(&self, path: &str) -> Result<Value, String> {
-        let url = format!("{}{}", self.base.trim_end_matches('/'), path);
-        let mut req = self.http.get(&url);
+        self.request(self.http.get(self.url(path)))
+    }
+
+    pub fn post(&self, path: &str, body: &Value) -> Result<Value, String> {
+        self.request(self.http.post(self.url(path)).json(body))
+    }
+
+    pub fn patch(&self, path: &str, body: &Value) -> Result<Value, String> {
+        self.request(self.http.patch(self.url(path)).json(body))
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base.trim_end_matches('/'), path)
+    }
+
+    fn auth(&self, req: reqwest::blocking::RequestBuilder) -> reqwest::blocking::RequestBuilder {
         if let Some(t) = &self.token {
-            req = req.header("Authorization", format!("Bearer {t}"));
+            req.header("Authorization", format!("Bearer {t}"))
+        } else {
+            req
         }
-        req.send()
+    }
+
+    fn request(&self, req: reqwest::blocking::RequestBuilder) -> Result<Value, String> {
+        self.auth(req)
+            .send()
             .map_err(|e| e.to_string())?
             .json()
             .map_err(|e| e.to_string())
     }
 
-    pub fn post(&self, path: &str, body: &Value) -> Result<Value, String> {
-        let url = format!("{}{}", self.base.trim_end_matches('/'), path);
-        let mut req = self.http.post(&url).json(body);
-        if let Some(t) = &self.token {
-            req = req.header("Authorization", format!("Bearer {t}"));
+    pub fn csv_import_preview(&self, args: &Value) -> Result<Value, String> {
+        let files = args.get("files").and_then(|v| v.as_array()).ok_or(
+            "files array required — each entry: {filename, path} or {filename, content_base64}",
+        )?;
+        if files.is_empty() {
+            return Err("files array is empty".into());
         }
-        req.send()
+        let session_id = args.get("session_id").and_then(|v| v.as_str());
+        let mut total_bytes = 0usize;
+        let mut staged: Vec<(String, Vec<u8>)> = Vec::new();
+        for f in files {
+            let name = f
+                .get("filename")
+                .and_then(|v| v.as_str())
+                .unwrap_or("upload.csv");
+            let raw = if let Some(path) = f.get("path").and_then(|v| v.as_str()) {
+                read_local_csv_path(path)?
+            } else if let Some(b64) = f.get("content_base64").and_then(|v| v.as_str()) {
+                use base64::Engine;
+                base64::engine::general_purpose::STANDARD
+                    .decode(b64)
+                    .map_err(|e| e.to_string())?
+            } else {
+                return Err(format!(
+                    "file {name}: provide path (host filesystem) or content_base64"
+                ));
+            };
+            total_bytes += raw.len();
+            staged.push((name.to_string(), raw));
+        }
+        if total_bytes <= 900_000 {
+            let payload = json!({
+                "session_id": session_id,
+                "files": staged.iter().map(|(name, raw)| {
+                    use base64::Engine;
+                    json!({
+                        "filename": name,
+                        "content_base64": base64::engine::general_purpose::STANDARD.encode(raw)
+                    })
+                }).collect::<Vec<_>>()
+            });
+            return self.post("/api/csv/import/preview", &payload);
+        }
+        let mut form = multipart::Form::new();
+        if let Some(sid) = session_id {
+            form = form.text("session_id", sid.to_string());
+        }
+        for (name, raw) in staged {
+            let part = multipart::Part::bytes(raw).file_name(name.clone());
+            form = form.part("file", part);
+        }
+        let req = self
+            .http_long
+            .post(self.url("/api/csv/import/preview"))
+            .multipart(form);
+        self.auth(req)
+            .send()
             .map_err(|e| e.to_string())?
             .json()
             .map_err(|e| e.to_string())
+    }
+
+    pub fn csv_import_plan(&self, args: &Value) -> Result<Value, String> {
+        let session_id = args
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .ok_or("session_id required")?;
+        let plan = args.get("plan").cloned().unwrap_or_else(|| args.clone());
+        let body = if plan.get("mode").is_some() || plan.get("files").is_some() {
+            json!({ "session_id": session_id, "plan": plan })
+        } else {
+            args.clone()
+        };
+        self.post("/api/csv/import/plan", &body)
+    }
+
+    pub fn historian_query(&self, args: &Value) -> Result<Value, String> {
+        if args.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+            self.get("/api/historian/query")
+        } else {
+            self.post("/api/historian/query", args)
+        }
+    }
+
+    pub fn fdd_rules_list(&self) -> Result<Value, String> {
+        self.get("/api/fdd-rules")
+    }
+
+    pub fn fdd_rule_test_sql(&self, args: &Value) -> Result<Value, String> {
+        let rule_id = args
+            .get("rule_id")
+            .and_then(|v| v.as_str())
+            .ok_or("rule_id required")?;
+        let mut body = args.clone();
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("rule_id");
+        }
+        self.post(&format!("/api/fdd-rules/{rule_id}/test-sql"), &body)
+    }
+
+    pub fn fdd_run(&self, args: &Value) -> Result<Value, String> {
+        let mut body = args.clone();
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("confirm");
+        }
+        self.post("/api/fdd/run", &body)
+    }
+
+    pub fn model_assignments_save(&self, args: &Value) -> Result<Value, String> {
+        self.post("/api/model/assignments/save", args)
+    }
+
+    pub fn reports_draft(&self, args: &Value) -> Result<Value, String> {
+        let mut body = args.clone();
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("confirm");
+        }
+        self.post("/api/reports/draft", &body)
+    }
+
+    pub fn reports_patch(&self, args: &Value) -> Result<Value, String> {
+        let report_id = args
+            .get("report_id")
+            .and_then(|v| v.as_str())
+            .ok_or("report_id required")?;
+        let mut body = args.clone();
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("report_id");
+            obj.remove("confirm");
+        }
+        self.patch(&format!("/api/reports/{report_id}"), &body)
+    }
+
+    pub fn reports_render_pdf(&self, args: &Value) -> Result<Value, String> {
+        let report_id = args
+            .get("report_id")
+            .and_then(|v| v.as_str())
+            .ok_or("report_id required")?;
+        self.post(&format!("/api/reports/{report_id}/render/pdf"), &json!({}))
     }
 
     pub fn site_update_dry_run(&self) -> Value {
@@ -151,5 +319,26 @@ impl BridgeClient {
             .map_err(|e| e.to_string())?
             .json()
             .map_err(|e| e.to_string())
+    }
+}
+
+fn read_local_csv_path(path: &str) -> Result<Vec<u8>, String> {
+    if path.contains("..") {
+        return Err("path traversal (..) not allowed".into());
+    }
+    let p = Path::new(path);
+    if !p.is_file() {
+        return Err(format!("file not found: {path}"));
+    }
+    std::fs::read(p).map_err(|e| format!("read {path}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(read_local_csv_path("../etc/passwd").is_err());
     }
 }

--- a/mcp/src/gate.rs
+++ b/mcp/src/gate.rs
@@ -1,0 +1,33 @@
+//! Write-tool gating — requires env flag + explicit confirm:true per call.
+
+use serde_json::Value;
+use std::env;
+
+pub fn require_write_confirm(args: &Value, tool: &str) -> Result<(), String> {
+    if env::var("OPENFDD_MCP_ALLOW_WRITES").ok().as_deref() != Some("1") {
+        return Err(format!(
+            "{tool} is a write tool — set OPENFDD_MCP_ALLOW_WRITES=1 on the MCP server"
+        ));
+    }
+    if args.get("confirm").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(format!("{tool} requires confirm:true in tool arguments"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn write_gate_requires_env_and_confirm() {
+        env::remove_var("OPENFDD_MCP_ALLOW_WRITES");
+        let args = json!({"confirm": true});
+        assert!(require_write_confirm(&args, "test_tool").is_err());
+        env::set_var("OPENFDD_MCP_ALLOW_WRITES", "1");
+        assert!(require_write_confirm(&args, "test_tool").is_ok());
+        assert!(require_write_confirm(&json!({}), "test_tool").is_err());
+        env::remove_var("OPENFDD_MCP_ALLOW_WRITES");
+    }
+}

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,6 +1,7 @@
 //! Minimal MCP (Model Context Protocol) stdio server for Open-FDD bridge REST.
 //! Read-first tools only — see docs/agent/openfdd-mcp-tool-contract.md
 
+mod auth;
 mod bridge;
 mod gate;
 mod protocol;

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -2,6 +2,7 @@
 //! Read-first tools only — see docs/agent/openfdd-mcp-tool-contract.md
 
 mod bridge;
+mod gate;
 mod protocol;
 
 use protocol::Server;

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -1,4 +1,5 @@
 use crate::bridge::BridgeClient;
+use crate::gate::require_write_confirm;
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
 
@@ -76,10 +77,61 @@ impl Server {
             tool("openfdd_model_sparql", "POST /api/model/sparql — read-only SELECT over Haystack RDF", json!({"query": {"type": "string"}})),
             tool("openfdd_model_sites", "GET /api/model/sites", json!({})),
             tool("openfdd_model_coverage", "GET /api/dashboard/model-coverage", json!({})),
+            tool("openfdd_csv_import_preview", "POST /api/csv/import/preview — stage CSVs from host path or base64; optional session_id to append", json!({
+                "session_id": {"type": "string", "description": "Existing session to append files into"},
+                "files": {"type": "array", "description": "Array of {filename, path} or {filename, content_base64}"}
+            })),
+            tool("openfdd_csv_import_plan", "POST /api/csv/import/plan — append/join plan + validation preview", json!({
+                "session_id": {"type": "string"},
+                "plan": {"type": "object", "description": "ImportPlan: mode, files, join_alignment, fill_policy, output_dataset_name"}
+            })),
+            tool("openfdd_historian_query", "GET/POST /api/historian/query — historian pivot rows (optional limit, site_id, equipment_id)", json!({
+                "limit": {"type": "integer"},
+                "site_id": {"type": "string"},
+                "equipment_id": {"type": "string"}
+            })),
+            tool("openfdd_fdd_rules_list", "GET /api/fdd-rules — list wire/SQL fault rules", json!({})),
+            tool("openfdd_fdd_rule_test_sql", "POST /api/fdd-rules/{id}/test-sql — dry-run rule SQL on sample/historian data", json!({
+                "rule_id": {"type": "string"},
+                "sql": {"type": "string"},
+                "params": {"type": "object"},
+                "confirmation_seconds": {"type": "integer"}
+            })),
+            tool("openfdd_fdd_run", "POST /api/fdd/run — execute ad-hoc DataFusion SQL FDD (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean", "description": "Must be true"},
+                "sql": {"type": "string"},
+                "params": {"type": "object"},
+                "confirmation_seconds": {"type": "integer"}
+            })),
+            tool("openfdd_model_assignments_save", "POST /api/model/assignments/save — persist Haystack assignments (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "points": {"type": "array"},
+                "fault_equation_bindings": {"type": "array"},
+                "assignments": {"type": "object", "description": "Alternative wrapper for full assignments doc"}
+            })),
+            tool("openfdd_reports_draft", "POST /api/reports/draft — create report draft (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "title": {"type": "string"},
+                "template_id": {"type": "string"},
+                "include_branding": {"type": "boolean"}
+            })),
+            tool("openfdd_reports_patch", "PATCH /api/reports/{id} — update title/sections (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "report_id": {"type": "string"},
+                "title": {"type": "string"},
+                "sections": {"type": "array"}
+            })),
+            tool("openfdd_reports_render_pdf", "POST /api/reports/{id}/render/pdf — render PDF bundle (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "report_id": {"type": "string"}
+            })),
             tool("openfdd_csv_fusion_preview", "GET /api/csv/import/sessions/{id}/fusion-preview — merged CSV grid for browser review", json!({"session_id": {"type": "string"}, "limit": {"type": "integer"}})),
             tool("openfdd_csv_latest_planned", "GET /api/csv/import/sessions/latest/planned — most recent UT3 plan ready for fusion preview", json!({})),
             tool("openfdd_csv_sessions", "GET /api/csv/import/sessions — list recent import sessions", json!({"limit": {"type": "integer"}})),
-            tool("openfdd_csv_import_execute", "POST /api/csv/import/execute — save planned session to Arrow + historian (human confirms after preview)", json!({"session_id": {"type": "string"}})),
+            tool("openfdd_csv_import_execute", "POST /api/csv/import/execute — save planned session to Arrow + historian (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "session_id": {"type": "string"},
+                "confirm": {"type": "boolean", "description": "Must be true"}
+            })),
             tool("openfdd_datasets", "GET /api/datasets — list Feather/Arrow datasets in registry", json!({})),
             tool("openfdd_timeseries_series", "GET /api/timeseries/series — plot catalog after CSV save", json!({"site_id": {"type": "string"}})),
         ];
@@ -134,6 +186,31 @@ impl Server {
             }
             "openfdd_model_sites" => self.bridge.get("/api/model/sites"),
             "openfdd_model_coverage" => self.bridge.get("/api/dashboard/model-coverage"),
+            "openfdd_csv_import_preview" => self.bridge.csv_import_preview(args),
+            "openfdd_csv_import_plan" => self.bridge.csv_import_plan(args),
+            "openfdd_historian_query" => self.bridge.historian_query(args),
+            "openfdd_fdd_rules_list" => self.bridge.fdd_rules_list(),
+            "openfdd_fdd_rule_test_sql" => self.bridge.fdd_rule_test_sql(args),
+            "openfdd_fdd_run" => {
+                require_write_confirm(args, "openfdd_fdd_run")?;
+                self.bridge.fdd_run(args)
+            }
+            "openfdd_model_assignments_save" => {
+                require_write_confirm(args, "openfdd_model_assignments_save")?;
+                self.bridge.model_assignments_save(args)
+            }
+            "openfdd_reports_draft" => {
+                require_write_confirm(args, "openfdd_reports_draft")?;
+                self.bridge.reports_draft(args)
+            }
+            "openfdd_reports_patch" => {
+                require_write_confirm(args, "openfdd_reports_patch")?;
+                self.bridge.reports_patch(args)
+            }
+            "openfdd_reports_render_pdf" => {
+                require_write_confirm(args, "openfdd_reports_render_pdf")?;
+                self.bridge.reports_render_pdf(args)
+            }
             "openfdd_csv_fusion_preview" => {
                 let session_id = args
                     .get("session_id")
@@ -153,6 +230,7 @@ impl Server {
                     .get(&format!("/api/csv/import/sessions?limit={limit}"))
             }
             "openfdd_csv_import_execute" => {
+                require_write_confirm(args, "openfdd_csv_import_execute")?;
                 let session_id = args
                     .get("session_id")
                     .and_then(|v| v.as_str())

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -134,6 +134,18 @@ impl Server {
             })),
             tool("openfdd_datasets", "GET /api/datasets — list Feather/Arrow datasets in registry", json!({})),
             tool("openfdd_timeseries_series", "GET /api/timeseries/series — plot catalog after CSV save", json!({"site_id": {"type": "string"}})),
+            tool("openfdd_auth_credentials_hint", "Where MCP/agents find Open-FDD login (workspace/bootstrap_credentials.once.txt, auth.env.local) — no secrets returned", json!({})),
+            tool("openfdd_auth_login", "Login as integrator/agent/operator/admin — returns JWT from handoff/env (password never echoed)", json!({
+                "role": {"type": "string", "description": "integrator (default), agent, operator, admin"}
+            })),
+            tool("openfdd_fdd_wires_propose", "POST /api/fdd-wires/propose-assignments — AI map driver points → FDD inputs → rules; syncs wiresheet graph", json!({
+                "site_id": {"type": "string"},
+                "equipment_type": {"type": "string", "description": "e.g. ahu"}
+            })),
+            tool("openfdd_fdd_wires_sync", "POST /api/fdd-wires/sync-from-assignments — rebuild FDD wiresheet from saved model assignments", json!({
+                "site_id": {"type": "string"},
+                "graph_id": {"type": "string", "description": "default graph:live-fdd-validation"}
+            })),
         ];
         // Bench profile short aliases (same handlers as openfdd_* tools).
         for (alias, target) in [
@@ -250,6 +262,27 @@ impl Server {
                         .get(&format!("/api/timeseries/series?site_id={site}"))
                 }
             }
+            "openfdd_auth_credentials_hint" => Ok(crate::auth::credentials_hint()),
+            "openfdd_auth_login" => {
+                let role = args.get("role").and_then(|v| v.as_str()).unwrap_or("integrator");
+                let base = std::env::var("OPENFDD_API_BASE")
+                    .unwrap_or_else(|_| "http://127.0.0.1:8080".into());
+                crate::auth::login_role(role, &base)
+            }
+            "openfdd_fdd_wires_propose" => self.bridge.post(
+                "/api/fdd-wires/propose-assignments",
+                &json!({
+                    "site_id": args.get("site_id"),
+                    "equipment_type": args.get("equipment_type").cloned().unwrap_or(json!("ahu"))
+                }),
+            ),
+            "openfdd_fdd_wires_sync" => self.bridge.post(
+                "/api/fdd-wires/sync-from-assignments",
+                &json!({
+                    "site_id": args.get("site_id"),
+                    "graph_id": args.get("graph_id").cloned().unwrap_or(json!("graph:live-fdd-validation"))
+                }),
+            ),
             other => Err(format!("unknown tool: {other}")),
         }
     }

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -85,6 +85,47 @@ impl Server {
                 "session_id": {"type": "string"},
                 "plan": {"type": "object", "description": "ImportPlan: mode, files, join_alignment, fill_policy, output_dataset_name"}
             })),
+            tool("openfdd_ingest_contract", "GET /api/ingest/contract — machine-readable ingest mold (historian_wide_csv, commissioning, import_plan)", json!({})),
+            tool("openfdd_csv_import_preflight", "POST /api/csv/import/preflight — strict validation gate; must verdict pass before execute", json!({
+                "session_id": {"type": "string"},
+                "plan": {"type": "object", "description": "Optional re-plan before validation"}
+            })),
+            tool("openfdd_csv_workbench_quality", "POST /api/csv-workbench/quality — CSV quality analysis", json!({
+                "source_id": {"type": "string"}
+            })),
+            tool("openfdd_model_commissioning_export", "GET /api/model/commissioning-export — sites/equipment/points/assignments/fdd_rules bundle", json!({})),
+            tool("openfdd_model_commissioning_import", "POST /api/model/commissioning-import — fail-closed commissioning bundle (write: confirm + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "payload": {"type": "object"}
+            })),
+            tool("openfdd_rules_batch", "POST /api/rules/batch — run all active saved FDD SQL rules (write: confirm + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"}
+            })),
+            tool("openfdd_fdd_rules_save", "POST /api/fdd-rules — save SQL fault rule (write: confirm + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "rule_id": {"type": "string"},
+                "name": {"type": "string"},
+                "sql": {"type": "string"}
+            })),
+            tool("openfdd_fdd_rules_activate", "POST /api/fdd-rules/{id}/activate — activate saved rule (write: confirm + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "rule_id": {"type": "string"}
+            })),
+            tool("openfdd_reports_from_fdd_sql_run", "POST /api/reports/from-fdd-sql-run — PDF report from SQL FDD test run (write: confirm + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+                "confirm": {"type": "boolean"},
+                "rule_name": {"type": "string"},
+                "sql": {"type": "string"},
+                "run_result": {"type": "object"}
+            })),
+            tool("openfdd_integration_smoke", "Agent playbook smoke: health + contract + optional CSV preflight/execute + commissioning/FDD/report writes", json!({
+                "import_dir": {"type": "string", "description": "Host path to folder of CSVs for preview"},
+                "session_id": {"type": "string"},
+                "confirm": {"type": "boolean", "description": "Enable write steps (execute, commissioning, batch, report)"},
+                "commissioning": {"type": "object"},
+                "run_fdd": {"type": "boolean"},
+                "run_report": {"type": "boolean"},
+                "report": {"type": "object"}
+            })),
             tool("openfdd_historian_query", "GET/POST /api/historian/query — historian pivot rows (optional limit, site_id, equipment_id)", json!({
                 "limit": {"type": "integer"},
                 "site_id": {"type": "string"},
@@ -200,6 +241,48 @@ impl Server {
             "openfdd_model_coverage" => self.bridge.get("/api/dashboard/model-coverage"),
             "openfdd_csv_import_preview" => self.bridge.csv_import_preview(args),
             "openfdd_csv_import_plan" => self.bridge.csv_import_plan(args),
+            "openfdd_ingest_contract" => self.bridge.ingest_contract(),
+            "openfdd_csv_import_preflight" => self.bridge.csv_import_preflight(args),
+            "openfdd_csv_workbench_quality" => self.bridge.csv_workbench_quality(args),
+            "openfdd_model_commissioning_export" => self.bridge.commissioning_export(),
+            "openfdd_model_commissioning_import" => {
+                require_write_confirm(args, "openfdd_model_commissioning_import")?;
+                self.bridge.commissioning_import(args)
+            }
+            "openfdd_rules_batch" => {
+                require_write_confirm(args, "openfdd_rules_batch")?;
+                self.bridge.rules_batch()
+            }
+            "openfdd_fdd_rules_save" => {
+                require_write_confirm(args, "openfdd_fdd_rules_save")?;
+                let mut body = args.clone();
+                if let Some(obj) = body.as_object_mut() {
+                    obj.remove("confirm");
+                }
+                self.bridge.fdd_rules_save(&body)
+            }
+            "openfdd_fdd_rules_activate" => {
+                require_write_confirm(args, "openfdd_fdd_rules_activate")?;
+                let rule_id = args
+                    .get("rule_id")
+                    .and_then(|v| v.as_str())
+                    .ok_or("rule_id required")?;
+                self.bridge.fdd_rules_activate(rule_id)
+            }
+            "openfdd_reports_from_fdd_sql_run" => {
+                require_write_confirm(args, "openfdd_reports_from_fdd_sql_run")?;
+                let mut body = args.clone();
+                if let Some(obj) = body.as_object_mut() {
+                    obj.remove("confirm");
+                }
+                self.bridge.reports_from_fdd_sql_run(&body)
+            }
+            "openfdd_integration_smoke" => {
+                if args.get("confirm").and_then(|v| v.as_bool()) == Some(true) {
+                    require_write_confirm(args, "openfdd_integration_smoke")?;
+                }
+                self.bridge.integration_smoke(args)
+            }
             "openfdd_historian_query" => self.bridge.historian_query(args),
             "openfdd_fdd_rules_list" => self.bridge.fdd_rules_list(),
             "openfdd_fdd_rule_test_sql" => self.bridge.fdd_rule_test_sql(args),

--- a/scripts/openfdd_bench_safe_restart.sh
+++ b/scripts/openfdd_bench_safe_restart.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Safe bench restart: recreate stack without volume prune; optional BACnet poll daemon.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_rust_site_lib.sh
+source "$ROOT/scripts/openfdd_rust_site_lib.sh"
+
+COMPOSE="$(openfdd_rust_resolve_compose_file "$ROOT")"
+[[ -n "$COMPOSE" && -f "$COMPOSE" ]] || {
+  echo "ERROR: compose file not found under $ROOT" >&2
+  exit 1
+}
+
+echo "==> Bench safe restart (no down -v)"
+docker compose -f "$COMPOSE" up -d --remove-orphans
+
+deadline=$((SECONDS + ${OPENFDD_HEALTH_TIMEOUT_SECS:-90}))
+until curl -fsS "${OPENFDD_API_BASE:-http://127.0.0.1:8080}/api/health" >/dev/null 2>&1; do
+  if (( SECONDS >= deadline )); then
+    echo "ERROR: bridge not healthy after ${OPENFDD_HEALTH_TIMEOUT_SECS:-90}s" >&2
+    exit 1
+  fi
+  sleep 2
+done
+echo "OK: bridge healthy"
+
+if [[ -x "$ROOT/scripts/openfdd_bacnet_poll_daemon.sh" ]]; then
+  "$ROOT/scripts/openfdd_bacnet_poll_daemon.sh" start 2>/dev/null || true
+fi

--- a/scripts/openfdd_csv_lake_geneva_validate.sh
+++ b/scripts/openfdd_csv_lake_geneva_validate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Validate Lake Geneva 5-file CSV fusion: upload → join plan → fusion preview → save.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+
+FIXTURE_DIR="${OPENFDD_CSV_FIXTURE_DIR:-/mnt/c/Users/ben/OneDrive/Desktop/testing/lake_geneva}"
+API="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
+AUTH="$ROOT/workspace/auth.env.local"
+
+SCHOOL=(
+  "School_2013_2014_KW.csv"
+  "School_2014_2015 KW.csv"
+  "School_2015_2016 KW.csv"
+  "School_2016_2017_KW.csv"
+)
+WEATHER="lake_geneva_wi_open_meteo_2013_2018_hourly.csv"
+
+for f in "${SCHOOL[@]}" "$WEATHER"; do
+  test -f "$FIXTURE_DIR/$f" || {
+    echo "ERROR: missing fixture $FIXTURE_DIR/$f" >&2
+    echo "Set OPENFDD_CSV_FIXTURE_DIR to folder with Lake Geneva CSVs." >&2
+    exit 1
+  }
+done
+
+TOKEN="$(openfdd_auth_login_token "$API" "$AUTH" integrator)" || exit 1
+
+echo "== Upload 5 CSVs (multipart) =="
+UPLOAD_ARGS=()
+for f in "${SCHOOL[@]}" "$WEATHER"; do
+  UPLOAD_ARGS+=(-F "file=@${FIXTURE_DIR}/${f}")
+done
+PREV="$(curl -fsS -X POST "$API/api/csv/import/preview" \
+  -H "Authorization: Bearer $TOKEN" \
+  "${UPLOAD_ARGS[@]}")"
+SID="$(echo "$PREV" | jq -r '.session_id // empty')"
+FCOUNT="$(echo "$PREV" | jq '.files | length')"
+echo "session=$SID files=$FCOUNT ok=$(echo "$PREV" | jq -r '.ok')"
+test "$FCOUNT" -eq 5 || {
+  echo "$PREV" | jq '.errors // .'
+  exit 1
+}
+
+WX_HEADERS="$(echo "$PREV" | jq -r --arg w "$WEATHER" '.files[] | select(.filename==$w) | .profile.headers | @json')"
+WX_VALS="$(echo "$WX_HEADERS" | jq -c 'map(select(. != "time_local" and . != "timezone" and . != "Date"))[:12]')"
+
+PLAN_FILES="$(jq -nc \
+  --argjson schools "$(printf '%s\n' "${SCHOOL[@]}" | jq -R . | jq -s 'map({filename:., timestamp_column:"Date", timezone:"America/Chicago", value_columns:["kW"]})')" \
+  --arg wx "$WEATHER" \
+  --argjson wx_vals "$WX_VALS" \
+  '$schools + [{filename:$wx, timestamp_column:"time_local", timezone:"America/Chicago", value_columns:$wx_vals}]')"
+
+echo "== Plan (join: append schools + floor_hour weather) =="
+PLAN="$(curl -fsS -X POST "$API/api/csv/import/plan" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc --arg sid "$SID" --argjson files "$PLAN_FILES" \
+    '{session_id:$sid, plan:{mode:"join", output_dataset_name:"lake_geneva_school_merged", ambiguous_policy:"first", fill_policy:"forward", join_alignment:"floor_hour", files:$files}}')")"
+ROWS="$(echo "$PLAN" | jq -r '.preview.row_count // 0')"
+DUP="$(echo "$PLAN" | jq -r '.preview.timestamp_analysis.duplicate_local_count // 0')"
+AMB="$(echo "$PLAN" | jq -r '.preview.timestamp_analysis.ambiguous_count // 0')"
+RANGE="$(echo "$PLAN" | jq -c '.preview.time_range // null')"
+echo "rows=$ROWS dup_local=$DUP ambiguous=$AMB range=$RANGE"
+test "$ROWS" -gt 100000 || {
+  echo "ERROR: expected >100k merged rows, got $ROWS" >&2
+  exit 1
+}
+
+echo "== Fusion preview =="
+FUSION="$(curl -fsS "$API/api/csv/import/sessions/${SID}/fusion-preview?limit=3" \
+  -H "Authorization: Bearer $TOKEN")"
+echo "fusion rows=$(echo "$FUSION" | jq -r '.row_count') cols=$(echo "$FUSION" | jq -r '.columns | length')"
+
+echo "== Save Arrow dataset =="
+SAVE="$(curl -fsS -X POST "$API/api/csv/import/execute" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc --arg sid "$SID" '{session_id:$sid, confirm:true}')")"
+DS_ROWS="$(echo "$SAVE" | jq -r '.dataset.row_count // 0')"
+DS_ID="$(echo "$SAVE" | jq -r '.dataset.id // empty')"
+echo "dataset=$DS_ID rows=$DS_ROWS"
+test "$DS_ROWS" -gt 100000 || exit 1
+
+echo "OK: Lake Geneva 5-file CSV fusion validated (session $SID, dataset $DS_ID)"

--- a/scripts/openfdd_csv_preflight.sh
+++ b/scripts/openfdd_csv_preflight.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Call CSV import preflight API (read-only validation gate).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+
+SESSION_ID="${1:-}"
+if [[ -z "$SESSION_ID" ]]; then
+  echo "usage: $0 <session_id>" >&2
+  exit 1
+fi
+
+BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
+TOKEN="$(openfdd_auth_login_token integrator)"
+
+curl -sS -X POST "$BASE/api/csv/import/preflight" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg sid "$SESSION_ID" '{session_id:$sid}')" \
+  | jq '{ok, session_id, verdict, can_execute, checks: .validation.checks, agent_hints: .validation.agent_hints}'

--- a/scripts/openfdd_drivers_validate.sh
+++ b/scripts/openfdd_drivers_validate.sh
@@ -39,22 +39,29 @@ AUTH_H=()
 
 # --- JSON API ---
 json_api_endpoints="$ROOT/workspace/data/json_api/endpoints.json"
+json_endpoint_count() {
+  jq 'if type == "array" then length elif .endpoints then (.endpoints | length) else 0 end' "$1" 2>/dev/null || echo 0
+}
 if [[ ! -f "$json_api_endpoints" ]]; then
-  if grep -q '^OPENFDD_JSON_API_URL=' "$ROOT/workspace/data.env.local" 2>/dev/null; then
+  if grep -qE '^OPENFDD_JSON_API_URL=' "$ROOT/workspace/data.env.local" 2>/dev/null; then
     record json-api SKIP "restart bridge after OPENFDD_JSON_API_URL seed (3.2.4+)"
   else
     record json-api SKIP "no workspace/data/json_api/endpoints.json — set OPENFDD_JSON_API_URL or add endpoints"
   fi
 else
-  count="$(jq 'length' "$json_api_endpoints" 2>/dev/null || echo 0)"
+  count="$(json_endpoint_count "$json_api_endpoints")"
   if [[ "$count" -eq 0 ]]; then
     record json-api SKIP "endpoints.json empty"
   elif curl -fsS "${AUTH_H[@]}" "$BRIDGE/api/json-api/poll/status" -o "$LOG_DIR/json_api_status.json" 2>/dev/null; then
     ok="$(jq -r '.ok // false' "$LOG_DIR/json_api_status.json" 2>/dev/null || echo false)"
-    if [[ "$ok" == "true" ]]; then
-      record json-api PASS "$(jq -r '.last_poll // "polled"' "$LOG_DIR/json_api_status.json" 2>/dev/null || echo ok)"
+    configured="$(jq -r '.configured // false' "$LOG_DIR/json_api_status.json" 2>/dev/null || echo false)"
+    status="$(jq -r '.status // ""' "$LOG_DIR/json_api_status.json" 2>/dev/null || echo "")"
+    if [[ "$ok" == "true" && "$configured" == "true" && "$status" == "ready" ]]; then
+      record json-api PASS "configured points=$count"
+    elif [[ "$ok" == "true" && "$configured" != "true" ]]; then
+      record json-api FAIL "not_configured (set OPENFDD_JSON_API_URL + restart bridge, or POST /api/json-api/register)"
     else
-      record json-api FAIL "$(jq -r '.error // "status not ok"' "$LOG_DIR/json_api_status.json" 2>/dev/null)"
+      record json-api FAIL "$(jq -r '.error // .message // "status not ok"' "$LOG_DIR/json_api_status.json" 2>/dev/null)"
     fi
   else
     record json-api FAIL "GET /api/json-api/poll/status"
@@ -99,9 +106,13 @@ else
 fi
 
 # --- Haystack ---
+STRICT="${OPENFDD_DRIVERS_VALIDATE_STRICT:-0}"
 if curl -fsS "${AUTH_H[@]}" "$BRIDGE/api/haystack/status" -o "$LOG_DIR/haystack_status.json" 2>/dev/null; then
   enabled="$(jq -r '.enabled // .config.enabled // false' "$LOG_DIR/haystack_status.json" 2>/dev/null)"
-  if [[ "$enabled" != "true" ]]; then
+  password_set="$(jq -r '.password_set // .config.password_set // false' "$LOG_DIR/haystack_status.json" 2>/dev/null)"
+  if [[ "$STRICT" == "1" && "$password_set" != "true" ]]; then
+    record haystack FAIL "OPENFDD_HAYSTACK_PASS not set in workspace/data.env.local"
+  elif [[ "$enabled" != "true" ]]; then
     record haystack SKIP "not enabled — configure workspace/haystack/local.nhaystack.toml + OPENFDD_HAYSTACK_*"
   elif curl -fsS "${AUTH_H[@]}" -X POST "$BRIDGE/api/haystack/test" -H 'Content-Type: application/json' -d '{}' \
     -o "$LOG_DIR/haystack_test.json" 2>/dev/null; then

--- a/scripts/openfdd_ui_dev.sh
+++ b/scripts/openfdd_ui_dev.sh
@@ -43,7 +43,11 @@ if ! curl -fsS --max-time 3 http://127.0.0.1:8080/api/health >/dev/null 2>&1; th
     "$ROOT/scripts/openfdd_local_up.sh"
   elif [[ -x "$ROOT/target/release/open_fdd_edge_prototype" ]]; then
     mkdir -p "$ROOT/workspace/logs"
-    OPENFDD_WORKSPACE="$ROOT/workspace" OPENFDD_CORS_ORIGIN="http://127.0.0.1:5173" \
+    OPENFDD_WORKSPACE="$ROOT/workspace" \
+      OPENFDD_BIND_HOST="0.0.0.0" \
+      OPENFDD_ALLOW_INSECURE_AUTH="${OPENFDD_ALLOW_INSECURE_AUTH:-1}" \
+      OPENFDD_BACNET_SERVER_ENABLED="${OPENFDD_BACNET_SERVER_ENABLED:-0}" \
+      OPENFDD_CORS_ORIGIN="${OPENFDD_CORS_ORIGIN:-http://127.0.0.1:5173}" \
       nohup "$ROOT/target/release/open_fdd_edge_prototype" >>"$ROOT/workspace/logs/edge-dev.log" 2>&1 &
     sleep 2
   else

--- a/workspace/bench/bench_profile.toml
+++ b/workspace/bench/bench_profile.toml
@@ -1,39 +1,26 @@
-# Bench automation expectations (openfdd_mcp_eval.sh, patch cycle).
-# MCP tool names use openfdd_* prefix; legacy short aliases are also registered.
+# Bench discovery profile — copy values into workspace/smoke-profiles or export as env.
+# No hardcoded secrets in repo; operator fills workspace/data.env.local.
 
-[mcp]
-required_tools = [
-  "openfdd_health",
-  "openfdd_stack_status",
-  "openfdd_driver_status",
-  "openfdd_haystack_status",
-  "openfdd_haystack_test",
-  "openfdd_bacnet_whois",
-  "openfdd_validation_run_status",
-  "openfdd_reports_list",
-  "openfdd_model_sparql_catalog",
-  "openfdd_model_sparql",
-  "openfdd_bench_topology",
-]
+[bench]
+nic = "enp3s0"
+bridge = "http://127.0.0.1:8080"
+commission = "http://127.0.0.1:9091"
 
-[mcp.aliases]
-site_health = "openfdd_health"
-stack_status = "openfdd_stack_status"
-haystack_test = "openfdd_haystack_test"
-driver_poll_status = "openfdd_driver_status"
-report_list = "openfdd_reports_list"
-bacnet_whois = "openfdd_bacnet_whois"
-validation_run_status = "openfdd_validation_run_status"
+[modbus]
+host = "192.168.204.14"
+port = 1502
+unit_id = 1
 
-[sparql]
-# Routes: GET /api/model/sparql/predefined, POST /api/model/sparql (JWT required)
-min_version = "3.2.3"
-skip_below_version = true
+[bacnet]
+validate_device = "5007"
+validate_host = "192.168.204.11"
+commission_nic = "192.168.204.55"
 
 [haystack]
-requires_env = ["OPENFDD_HAYSTACK_PASS"]
-requires_toml = "workspace/haystack/local.nhaystack.toml"
+base_url = "https://192.168.204.11/haystack"
+auth = "basic"
+tls_verify = false
 
-[json_api]
-requires_endpoints_file = "workspace/data/json_api/endpoints.json"
-env_seed_url = "OPENFDD_JSON_API_URL"
+[mcp]
+expected_tools_prefix = "openfdd_"
+expected_tool_count_min = 15

--- a/workspace/bench/data.env.local.example
+++ b/workspace/bench/data.env.local.example
@@ -1,27 +1,19 @@
-# Copy to workspace/data.env.local on bench/field hosts (gitignored).
-# Required for full-edge GHCR compose (docker/compose.edge.rust.yml).
+# Copy to workspace/data.env.local on a field bench (never commit filled values).
+#
+# Required for strict driver gate (OPENFDD_DRIVERS_VALIDATE_STRICT=1):
+#   OPENFDD_HAYSTACK_USER + OPENFDD_HAYSTACK_PASS — Niagara HTTP Basic (not SCRAM)
 
-# --- BACnet / Modbus (live OT-LAN) ---
-OPENFDD_BACNET_MODE=live
 OPENFDD_MODBUS_MODE=live
-# OPENFDD_BACNET_BIND=<your-ip>/24:47808
-# OPENFDD_MODBUS_HOST=192.168.x.x
-# OPENFDD_MODBUS_PORT=1502
+OPENFDD_MODBUS_HOST=192.168.204.14
+OPENFDD_MODBUS_PORT=1502
+OPENFDD_MODBUS_UNIT_ID=1
 
-# --- Haystack (Niagara nHaystack) ---
-# OPENFDD_HAYSTACK_ENABLED=1
-# OPENFDD_HAYSTACK_CONFIG=/var/openfdd/workspace/haystack/local.nhaystack.toml
-# OPENFDD_HAYSTACK_BASE=https://192.168.x.x/haystack
-# OPENFDD_HAYSTACK_USER=open_fdd
-# OPENFDD_HAYSTACK_PASS=<Niagara password — never commit>
+OPENFDD_BACNET_MODE=live
+OPENFDD_BACNET_SERVER_ENABLED=0
 
-# --- JSON API ingest ---
-# OPENFDD_JSON_API_ENABLED=1
-# OPENFDD_JSON_API_URL=https://httpbin.org/get
-# OPENFDD_JSON_API_LABEL=bench-health-probe
-# Or configure workspace/data/json_api/endpoints.json via dashboard /json-api
-
-# --- Stack feature flags ---
 OPENFDD_JSON_API_ENABLED=1
-OPENFDD_IMPORT_ENABLED=1
-OPENFDD_EXPORT_ENABLED=1
+OPENFDD_JSON_API_URL=https://httpbin.org/get
+OPENFDD_JSON_API_LABEL=bench-probe
+
+OPENFDD_HAYSTACK_USER=open_fdd
+# OPENFDD_HAYSTACK_PASS=<Niagara Basic password>

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -16,7 +16,6 @@ import SqlFddRulesPage from "./pages/SqlFddRulesPage";
 import LiveFddValidationPage from "./pages/LiveFddValidationPage";
 import DataManagementPage from "./pages/DataManagementPage";
 import CsvWorkbenchPage from "./pages/CsvWorkbenchPage";
-import WiresheetStudioPage from "./pages/WiresheetStudioPage";
 import ReportBuilderPage from "./pages/ReportBuilderPage";
 import AlgorithmsPage from "./pages/AlgorithmsPage";
 import DataExportPage from "./pages/DataExportPage";
@@ -49,7 +48,7 @@ export default function App() {
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />
             <Route path="haystack" element={<TabErrorBoundary tab="haystack"><HaystackPage /></TabErrorBoundary>} />
             <Route path="csv" element={<TabErrorBoundary tab="csv"><CsvWorkbenchPage /></TabErrorBoundary>} />
-            <Route path="wiresheet" element={<TabErrorBoundary tab="wiresheet"><WiresheetStudioPage /></TabErrorBoundary>} />
+            <Route path="wiresheet" element={<Navigate to="/model" replace />} />
             <Route path="wiresheet/haystack" element={<Navigate to="/model" replace />} />
             <Route path="wiresheet/rules" element={<Navigate to="/model" replace />} />
             <Route path="data-management" element={<TabErrorBoundary tab="data-management"><DataManagementPage /></TabErrorBoundary>} />
@@ -57,7 +56,7 @@ export default function App() {
             <Route path="agent" element={<TabErrorBoundary tab="agent"><AgentPage /></TabErrorBoundary>} />
             <Route path="host" element={<TabErrorBoundary tab="host"><HostStatsPage /></TabErrorBoundary>} />
             <Route path="fdd" element={<Navigate to="/sql-fdd" replace />} />
-            <Route path="fdd-wires" element={<Navigate to="/wiresheet" replace />} />
+            <Route path="fdd-wires" element={<Navigate to="/model" replace />} />
             <Route path="rules" element={<Navigate to="/model" replace />} />
           </Route>
         </Route>

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -23,15 +23,9 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
     items: [{ to: "/", end: true, icon: "🏠", label: "Dashboard" }],
   },
   {
-    title: "Wiresheet",
-    items: [
-      { to: "/wiresheet", icon: "🔗", label: "FDD Studio", protected: true },
-      { to: "/csv", icon: "📂", label: "CSV Fusion", protected: true },
-    ],
-  },
-  {
     title: "Integrations",
     items: [
+      { to: "/csv", icon: "📂", label: "CSV Fusion", protected: true },
       { to: "/bacnet", icon: "📡", label: "BACnet", protected: true },
       { to: "/haystack", icon: "🌿", label: "Haystack", protected: true },
       { to: "/modbus", icon: "🔌", label: "Modbus", protected: true },

--- a/workspace/dashboard/src/components/BuildingInsightDashboard.tsx
+++ b/workspace/dashboard/src/components/BuildingInsightDashboard.tsx
@@ -24,8 +24,9 @@ type BuildingStatusResponse = {
 };
 
 const INSIGHT_POLL_MS = 15 * 60 * 1000;
+const ANALYTICS_POLL_MS = 15 * 60 * 1000;
 
-/** Insight agent is optional; only fetch on operator request to avoid 404 noise on older bridges. */
+/** Main dashboard — live faults (15s) + AI building insight + analytics (15 min). */
 export default function BuildingInsightDashboard() {
   const { snapshot, error: streamError, live } = useDashboardStream();
   const [insight, setInsight] = useState<InsightResponse | null>(null);
@@ -60,10 +61,13 @@ export default function BuildingInsightDashboard() {
   }, []);
 
   useEffect(() => {
-    if (!insight) return;
+    void loadInsight(false);
+  }, [loadInsight]);
+
+  useEffect(() => {
     const t = window.setInterval(() => void loadInsight(false), INSIGHT_POLL_MS);
     return () => window.clearInterval(t);
-  }, [loadInsight, insight]);
+  }, [loadInsight]);
 
   useEffect(() => {
     apiFetch<BuildingStatusResponse>("/api/building/status")
@@ -205,7 +209,18 @@ export default function BuildingInsightDashboard() {
               />
             ))}
           </div>
-          {insight?.sentence ? <p className="bis-insight-one-liner">{insight.sentence}</p> : null}
+          {insight?.sentence ? (
+            <p className="bis-insight-one-liner">{insight.sentence}</p>
+          ) : insightLoading ? (
+            <p className="muted bis-insight-one-liner">Loading AI building insight…</p>
+          ) : null}
+          {insight?.refresh_interval_s ? (
+            <p className="muted bis-insight-meta">
+              Insight refresh every {Math.round(insight.refresh_interval_s / 60)} min
+              {insight.source === "ollama" ? " · Ollama" : insight.source === "rules" ? " · live model" : ""}
+              {insight.cached ? " · cached" : ""}
+            </p>
+          ) : null}
         </div>
 
         <ComfortZonePanel
@@ -254,6 +269,7 @@ export default function BuildingInsightDashboard() {
 
         <OperationalContextPanel
           refreshKey={snapshot?.faults.alert_count}
+          analyticsPollMs={ANALYTICS_POLL_MS}
           insight={insight}
           insightError={insightError}
           buildingMeta={buildingMeta}

--- a/workspace/dashboard/src/components/CsvUt3ImportPanel.tsx
+++ b/workspace/dashboard/src/components/CsvUt3ImportPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { apiFetch, hasToken } from "../lib/api";
+import { apiFetch, apiUploadForm, hasToken } from "../lib/api";
 import { formatApiError } from "../lib/formatApiError";
 
 type FileProfile = {
@@ -65,6 +65,32 @@ async function fileToBase64(file: File): Promise<string> {
   return btoa(binary);
 }
 
+const SMALL_UPLOAD_MAX_BYTES = 900_000;
+
+async function uploadFilesForPreview(
+  fileList: FileList | File[],
+  existingSessionId?: string,
+): Promise<{ session_id?: string; files?: FileProfile[]; ok?: boolean; error?: string; errors?: { file?: string; error?: string }[] }> {
+  const files = Array.from(fileList);
+  const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
+  if (totalBytes <= SMALL_UPLOAD_MAX_BYTES) {
+    const payload = await Promise.all(
+      files.map(async (f) => ({
+        filename: f.name,
+        content_base64: await fileToBase64(f),
+      })),
+    );
+    return apiFetch("/api/csv/import/preview", {
+      method: "POST",
+      body: JSON.stringify({ session_id: existingSessionId || undefined, files: payload }),
+    });
+  }
+  const form = new FormData();
+  for (const f of files) form.append("file", f, f.name);
+  if (existingSessionId) form.append("session_id", existingSessionId);
+  return apiUploadForm("/api/csv/import/preview", form);
+}
+
 type Props = {
   onPlanReady?: (sessionId: string) => void;
   onOpenInFusion?: (sessionId: string) => void;
@@ -107,17 +133,12 @@ export default function CsvUt3ImportPanel({ onPlanReady, onOpenInFusion, autoOpe
     setError("");
     setBusy("Uploading and profiling…");
     try {
-      const payload = await Promise.all(
-        Array.from(fileList).map(async (f) => ({
-          filename: f.name,
-          content_base64: await fileToBase64(f),
-        })),
-      );
-      const out = await apiFetch<{ session_id?: string; files?: FileProfile[]; ok?: boolean; error?: string }>(
-        "/api/csv/import/preview",
-        { method: "POST", body: JSON.stringify({ files: payload }) },
-      );
+      const out = await uploadFilesForPreview(fileList, sessionId || undefined);
       if (!out.ok && !out.session_id) throw new Error(out.error ?? "preview failed");
+      if (out.errors?.length) {
+        const detail = out.errors.map((e) => `${e.file ?? "?"}: ${e.error ?? "error"}`).join("; ");
+        throw new Error(detail || "one or more files failed to upload");
+      }
       setSessionId(out.session_id ?? "");
       setFiles(out.files ?? []);
       const profiles = out.files ?? [];
@@ -135,19 +156,21 @@ export default function CsvUt3ImportPanel({ onPlanReady, onOpenInFusion, autoOpe
       else if (weather?.profile?.headers?.includes("timezone")) {
         setWxTsCol(weather.profile.headers.find((h) => h === "time_local") ?? "time_local");
       }
-      if (profiles.length >= 4 && profiles.filter((f) => /school|kw/i.test(f.filename)).length >= 2) {
-        setMode("append");
-        setDatasetName("school_kw_merged");
-      } else if (school && weather) {
+      const schoolCount = profiles.filter((f) => /school|kw/i.test(f.filename)).length;
+      if (weather && schoolCount >= 1) {
         setMode("join");
         setJoinAlign("floor_hour");
+        setDatasetName("school_kw_merged");
+      } else if (schoolCount >= 2) {
+        setMode("append");
+        setDatasetName("school_kw_merged");
       }
     } catch (e) {
       setError(formatApiError(e));
     } finally {
       setBusy("");
     }
-  }, []);
+  }, [sessionId]);
 
   const buildPlan = useCallback(async () => {
     if (!sessionId) {
@@ -328,10 +351,10 @@ export default function CsvUt3ImportPanel({ onPlanReady, onOpenInFusion, autoOpe
         </div>
       )}
 
-      {mode === "join" && files.length > 2 && (
+      {mode === "join" && files.filter((f) => !/meteo|weather|open_meteo/i.test(f.filename)).length > 1 && (
         <p className="muted csv-ut3-hint">
-          Join uses one kW file + weather file (auto-selected by filename). Other files are ignored in join mode — use
-          Append to stack all school years first.
+          Join mode appends all school kW files by timestamp, then joins hourly weather using floor-hour
+          alignment.
         </p>
       )}
       {mode === "append" && files.some((f) => /meteo|weather/i.test(f.filename)) && (

--- a/workspace/dashboard/src/components/DevAgentPanel.tsx
+++ b/workspace/dashboard/src/components/DevAgentPanel.tsx
@@ -7,6 +7,7 @@ import {
   appendPendingAssistant,
   appendUserMessage,
   buildChatHistoryPayload,
+  AGENT_CHAT_CLEAR_EVENT,
   loadAgentChat,
   resolveAssistant,
   saveAgentChat,
@@ -39,6 +40,16 @@ export default function DevAgentPanel() {
   useEffect(() => {
     saveAgentChat(chat);
   }, [chat]);
+
+  useEffect(() => {
+    const onClear = () => {
+      queueRef.current = [];
+      setQueue([]);
+      setChat(loadAgentChat());
+    };
+    window.addEventListener(AGENT_CHAT_CLEAR_EVENT, onClear);
+    return () => window.removeEventListener(AGENT_CHAT_CLEAR_EVENT, onClear);
+  }, []);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/workspace/dashboard/src/components/FddWiresheetSummary.tsx
+++ b/workspace/dashboard/src/components/FddWiresheetSummary.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { apiFetch } from "../lib/api";
 import { formatApiError } from "../lib/formatApiError";
 import { useActiveSiteId } from "../lib/useActiveSiteId";
+import FddRuleWiresheet from "../wiresheet/FddRuleWiresheet";
 import { graphToFlow } from "../wiresheet/graphAdapter";
 import { fetchWiresheetGraph } from "../wiresheet/wiresheetApi";
 
@@ -12,15 +13,16 @@ type Props = {
   onStatus?: (message: string) => void;
 };
 
-/** Compact FDD wiresheet summary for Model page — AI propose + link to full studio. */
+/** Model page FDD wiresheet — live canvas + AI propose; syncs when assignments change. */
 export default function FddWiresheetSummary({ onStatus }: Props) {
   const siteId = useActiveSiteId();
   const [nodeCount, setNodeCount] = useState(0);
   const [reviewStatus, setReviewStatus] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [refreshKey, setRefreshKey] = useState(0);
 
-  const loadGraph = useCallback(async () => {
+  const loadMeta = useCallback(async () => {
     if (!siteId) return;
     try {
       const graph = await fetchWiresheetGraph(GRAPH_ID, siteId);
@@ -33,23 +35,57 @@ export default function FddWiresheetSummary({ onStatus }: Props) {
   }, [siteId]);
 
   useEffect(() => {
-    void loadGraph();
-  }, [loadGraph]);
+    void loadMeta();
+  }, [loadMeta, refreshKey]);
+
+  useEffect(() => {
+    const onChange = () => {
+      setRefreshKey((k) => k + 1);
+    };
+    window.addEventListener("ofdd-assignments-changed", onChange);
+    return () => window.removeEventListener("ofdd-assignments-changed", onChange);
+  }, []);
 
   async function proposeFromAi() {
     setBusy(true);
     setError("");
     try {
-      const out = await apiFetch<{ review_status?: string; proposed?: unknown[] }>(
-        "/api/fdd-wires/propose-assignments",
+      const out = await apiFetch<{
+        review_status?: string;
+        proposed?: unknown[];
+        proposals?: unknown[];
+        wiresheet_sync?: { node_count?: number };
+      }>("/api/fdd-wires/propose-assignments", {
+        method: "POST",
+        body: JSON.stringify({ site_id: siteId || undefined, equipment_type: "ahu" }),
+      });
+      const n = out.proposed?.length ?? out.proposals?.length ?? 0;
+      const nodes = out.wiresheet_sync?.node_count;
+      const msg = `AI proposed ${n} bindings (${out.review_status ?? "needs_review"})${
+        nodes != null ? ` — wiresheet now has ${nodes} nodes` : ""
+      }.`;
+      onStatus?.(msg);
+      setRefreshKey((k) => k + 1);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function syncFromAssignments() {
+    setBusy(true);
+    setError("");
+    try {
+      const out = await apiFetch<{ node_count?: number; review_status?: string }>(
+        "/api/fdd-wires/sync-from-assignments",
         {
           method: "POST",
-          body: JSON.stringify({ site_id: siteId || undefined, equipment_type: "ahu" }),
+          body: JSON.stringify({ site_id: siteId || undefined, graph_id: GRAPH_ID }),
         },
       );
-      const msg = `AI proposed ${out.proposed?.length ?? 0} bindings (${out.review_status ?? "needs_review"}) — open Wiresheet Studio to review.`;
-      onStatus?.(msg);
-      await loadGraph();
+      onStatus?.(`Wiresheet synced — ${out.node_count ?? 0} nodes (${out.review_status ?? "draft"}).`);
+      setRefreshKey((k) => k + 1);
     } catch (e) {
       setError(formatApiError(e));
     } finally {
@@ -63,13 +99,17 @@ export default function FddWiresheetSummary({ onStatus }: Props) {
         <div>
           <h3 className="panel-title">FDD rule mapping wiresheet</h3>
           <p className="muted">
-            Visual map from Haystack points → FDD inputs → SQL rules → faults. Populated by AI proposals or manual
-            editing; review before activate.
+            Haystack points → FDD inputs → SQL rules → faults. When AI saves model assignments or you import
+            commissioning JSON, use <strong>Sync from assignments</strong> or save via MCP — the graph below updates
+            for review before activate.
           </p>
         </div>
         <div className="action-bar">
           <button type="button" className="secondary-btn" disabled={busy} onClick={() => void proposeFromAi()}>
-            {busy ? "Proposing…" : "AI propose assignments"}
+            {busy ? "Working…" : "AI propose assignments"}
+          </button>
+          <button type="button" className="secondary-btn" disabled={busy} onClick={() => void syncFromAssignments()}>
+            Sync from assignments
           </button>
           <Link className="primary-btn" to="/wiresheet">
             Open Wiresheet Studio
@@ -97,6 +137,7 @@ export default function FddWiresheetSummary({ onStatus }: Props) {
           <dd>{siteId || "loading…"}</dd>
         </div>
       </dl>
+      <FddRuleWiresheet key={refreshKey} compact />
     </section>
   );
 }

--- a/workspace/dashboard/src/components/ModelFddMappingPanel.tsx
+++ b/workspace/dashboard/src/components/ModelFddMappingPanel.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { apiFetch } from "../lib/api";
+import { assignmentSummary, parseCommissioningPayload } from "../lib/commissioningImport";
+
+type Props = {
+  onStatus?: (message: string) => void;
+};
+
+type PointRow = {
+  id?: string;
+  name?: string;
+  haystack_id?: string;
+  fdd_rule_ids?: string[];
+  driver_ref?: string;
+};
+
+/** FDD point → rule mapping from commissioning JSON (replaces wiresheet studio). */
+export default function ModelFddMappingPanel({ onStatus }: Props) {
+  const [points, setPoints] = useState<PointRow[]>([]);
+  const [rules, setRules] = useState<Array<{ id?: string; name?: string }>>([]);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setBusy(true);
+    try {
+      const bundle = await apiFetch<Record<string, unknown>>("/api/model/commissioning-export");
+      const parsed = parseCommissioningPayload(JSON.stringify(bundle));
+      setPoints((parsed.points ?? []) as PointRow[]);
+      const ruleList = (bundle.fdd_rules as Array<{ id?: string; name?: string; rule_id?: string }>) ?? [];
+      setRules(
+        ruleList.map((r) => ({
+          id: (r.id ?? r.rule_id) as string | undefined,
+          name: r.name,
+        })),
+      );
+      const summary = assignmentSummary(parsed);
+      onStatus?.(
+        `${summary.boundPointCount} points bound to FDD · ${summary.ruleCount} rules in commissioning JSON`,
+      );
+    } catch (e) {
+      onStatus?.(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, [onStatus]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const onChange = () => void load();
+    window.addEventListener("ofdd-assignments-changed", onChange);
+    return () => window.removeEventListener("ofdd-assignments-changed", onChange);
+  }, [load]);
+
+  const mapped = points.filter((p) => (p.fdd_rule_ids?.length ?? 0) > 0);
+  const unmapped = points.filter((p) => !p.fdd_rule_ids?.length);
+
+  return (
+    <section className="panel">
+      <div className="toolbar">
+        <h3 className="panel-title">FDD mapping</h3>
+        <button type="button" className="secondary-btn" disabled={busy} onClick={() => void load()}>
+          {busy ? "Loading…" : "Reload"}
+        </button>
+        <Link className="secondary-btn" to="/sql-fdd">
+          SQL FDD rules
+        </Link>
+      </div>
+      <p className="muted">
+        Map Haystack points (by ID, name, or driver ref) to SQL FDD rules via{" "}
+        <code>points[].fdd_rule_ids</code> in commissioning JSON. AI agents use{" "}
+        <code>openfdd_model_assignments_save</code> on the Integrations tab.
+      </p>
+      <dl className="detail-grid compact">
+        <div>
+          <dt>Mapped points</dt>
+          <dd>{mapped.length}</dd>
+        </div>
+        <div>
+          <dt>Unmapped points</dt>
+          <dd>{unmapped.length}</dd>
+        </div>
+        <div>
+          <dt>Rules in model</dt>
+          <dd>{rules.length}</dd>
+        </div>
+      </dl>
+      {mapped.length ? (
+        <div className="table-wrap">
+          <table className="data-table compact">
+            <thead>
+              <tr>
+                <th>Point</th>
+                <th>FDD rules</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mapped.slice(0, 40).map((p) => (
+                <tr key={p.id ?? p.haystack_id ?? p.name}>
+                  <td>{p.name || p.id || p.haystack_id}</td>
+                  <td>
+                    <code>{(p.fdd_rule_ids ?? []).join(", ")}</code>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {mapped.length > 40 ? <p className="muted">Showing 40 of {mapped.length} mapped points.</p> : null}
+        </div>
+      ) : (
+        <p className="muted">
+          No FDD rule bindings yet — edit commissioning JSON on Import / export or ask your AI agent to assign{" "}
+          <code>fdd_rule_ids</code> per point.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/workspace/dashboard/src/components/buildingInsight/OperationalContextPanel.tsx
+++ b/workspace/dashboard/src/components/buildingInsight/OperationalContextPanel.tsx
@@ -31,6 +31,7 @@ type BuildingMeta = {
 
 type Props = {
   refreshKey?: number;
+  analyticsPollMs?: number;
   insight?: InsightResponse | null;
   insightError?: string;
   buildingMeta?: BuildingMeta | null;
@@ -53,6 +54,7 @@ function formatEquipTypeLabel(raw: string): string {
 
 export default function OperationalContextPanel({
   refreshKey,
+  analyticsPollMs = 15 * 60 * 1000,
   insight,
   insightError,
   buildingMeta,
@@ -62,9 +64,15 @@ export default function OperationalContextPanel({
   const [analytics, setAnalytics] = useState<DashboardAnalytics | null>(null);
   const [rules, setRules] = useState<FddRulesResponse | null>(null);
   const [loadError, setLoadError] = useState("");
+  const [analyticsTick, setAnalyticsTick] = useState(0);
   const signedIn = hasToken();
 
   const meta = publicMeta ?? buildingMeta;
+
+  useEffect(() => {
+    const t = window.setInterval(() => setAnalyticsTick((n) => n + 1), analyticsPollMs);
+    return () => window.clearInterval(t);
+  }, [analyticsPollMs]);
 
   useEffect(() => {
     let cancelled = false;
@@ -111,7 +119,7 @@ export default function OperationalContextPanel({
     return () => {
       cancelled = true;
     };
-  }, [refreshKey, signedIn]);
+  }, [refreshKey, signedIn, analyticsTick]);
 
   const model = summary?.model_coverage;
   const modelSummary = meta?.model_summary;

--- a/workspace/dashboard/src/components/sqlFdd/SqlFddQueryEditor.tsx
+++ b/workspace/dashboard/src/components/sqlFdd/SqlFddQueryEditor.tsx
@@ -1,0 +1,30 @@
+type Props = {
+  sql: string;
+  readOnly?: boolean;
+  onChange?: (sql: string) => void;
+  onInsert?: (snippet: string) => void;
+  lineCount?: number;
+};
+
+export default function SqlFddQueryEditor({ sql, readOnly, onChange, lineCount }: Props) {
+  const lines = Math.max(8, lineCount ?? sql.split("\n").length + 1);
+
+  return (
+    <div className="gf-sql-editor">
+      <div className="gf-sql-editor__gutter" aria-hidden>
+        {Array.from({ length: lines }, (_, i) => (
+          <span key={i + 1}>{i + 1}</span>
+        ))}
+      </div>
+      <textarea
+        className="gf-sql-editor__input"
+        value={sql}
+        readOnly={readOnly}
+        spellCheck={false}
+        onChange={(e) => onChange?.(e.target.value)}
+        placeholder="SELECT timestamp, equipment_id, oa_t, … AS fault_raw FROM telemetry_pivot WHERE equipment_id = '…'"
+        rows={lines}
+      />
+    </div>
+  );
+}

--- a/workspace/dashboard/src/components/sqlFdd/SqlFddResultsPanel.tsx
+++ b/workspace/dashboard/src/components/sqlFdd/SqlFddResultsPanel.tsx
@@ -1,0 +1,227 @@
+import { useMemo, useState } from "react";
+import { copyToClipboard } from "../../lib/clipboard";
+
+type Props = {
+  validation: Record<string, unknown> | null;
+  runResult: Record<string, unknown> | null;
+  compileResult: { sql?: string; explanation?: string; dialect?: string; error?: string } | null;
+  equipmentId: string;
+  busy?: boolean;
+  onSave: () => void;
+  onExportPdf: () => void;
+  actionStatus?: string;
+};
+
+type Tab = "preview" | "faults" | "validation" | "json";
+
+function asRows(payload: Record<string, unknown> | null): Record<string, unknown>[] {
+  if (!payload?.rows || !Array.isArray(payload.rows)) return [];
+  return payload.rows as Record<string, unknown>[];
+}
+
+function columnKeys(rows: Record<string, unknown>[]): string[] {
+  const keys = new Set<string>();
+  for (const row of rows.slice(0, 20)) {
+    Object.keys(row).forEach((k) => keys.add(k));
+  }
+  return Array.from(keys);
+}
+
+export default function SqlFddResultsPanel({
+  validation,
+  runResult,
+  compileResult,
+  equipmentId,
+  busy,
+  onSave,
+  onExportPdf,
+  actionStatus,
+}: Props) {
+  const [tab, setTab] = useState<Tab>("preview");
+  const [copyMsg, setCopyMsg] = useState("");
+  const rows = useMemo(() => asRows(runResult), [runResult]);
+  const cols = useMemo(() => columnKeys(rows), [rows]);
+  const confirmation = (runResult?.confirmation ?? null) as Record<string, unknown> | null;
+  const confirmed = (confirmation?.confirmed ?? []) as Record<string, unknown>[];
+
+  if (!validation && !runResult && !compileResult) return null;
+
+  const validationErrors = (validation?.errors as string[]) ?? [];
+  const validationWarnings = (validation?.warnings as string[]) ?? [];
+
+  return (
+    <section className="gf-results">
+      <div className="gf-results__head">
+        <div className="gf-results__tabs" role="tablist">
+          {(["preview", "faults", "validation", "json"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={tab === t}
+              className={`gf-results__tab${tab === t ? " is-active" : ""}`}
+              onClick={() => setTab(t)}
+            >
+              {t === "preview" ? "Preview" : t === "faults" ? "Fault summary" : t === "validation" ? "Validation" : "JSON"}
+            </button>
+          ))}
+        </div>
+        <div className="gf-results__actions">
+          {runResult ? (
+            <>
+              <button type="button" className="primary-btn" disabled={busy} onClick={onSave}>
+                Save & activate
+              </button>
+              <button type="button" className="secondary-btn" disabled={busy} onClick={onExportPdf}>
+                Export PDF
+              </button>
+            </>
+          ) : null}
+          <button
+            type="button"
+            className="secondary-btn"
+            onClick={() => {
+              const payload = tab === "validation" ? validation : runResult ?? compileResult;
+              void copyToClipboard(JSON.stringify(payload, null, 2)).then((ok) =>
+                setCopyMsg(ok ? "Copied" : "Copy failed"),
+              );
+            }}
+          >
+            Copy JSON
+          </button>
+        </div>
+      </div>
+
+      {actionStatus ? <p className="ok gf-results__status">{actionStatus}</p> : null}
+      {copyMsg ? <p className="muted">{copyMsg}</p> : null}
+
+      {compileResult?.explanation && tab !== "json" ? (
+        <p className="gf-results__explain muted">{compileResult.explanation}</p>
+      ) : null}
+
+      {tab === "preview" ? (
+        rows.length ? (
+          <div className="gf-data-grid-wrap">
+            <table className="gf-data-grid">
+              <thead>
+                <tr>
+                  {cols.map((c) => (
+                    <th key={c}>{c}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.slice(0, 100).map((row, i) => (
+                  <tr key={i}>
+                    {cols.map((c) => (
+                      <td key={c}>{formatCell(row[c])}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {rows.length > 100 ? (
+              <p className="muted gf-results__trunc">Showing first 100 of {rows.length} rows.</p>
+            ) : null}
+          </div>
+        ) : (
+          <p className="muted">Run the query to preview historian rows for {equipmentId || "selected equipment"}.</p>
+        )
+      ) : null}
+
+      {tab === "faults" ? (
+        <div className="gf-fault-summary">
+          <dl className="gf-kv-grid">
+            <div>
+              <dt>Raw fault samples</dt>
+              <dd>{String(confirmation?.raw_fault_count ?? "—")}</dd>
+            </div>
+            <div>
+              <dt>Confirmed faults</dt>
+              <dd>{String(confirmation?.confirmed_fault_count ?? "—")}</dd>
+            </div>
+            <div>
+              <dt>Confirmation window</dt>
+              <dd>{String(confirmation?.confirmation_seconds ?? "—")}s</dd>
+            </div>
+            <div>
+              <dt>Engine</dt>
+              <dd>{String(runResult?.engine ?? "DataFusion")}</dd>
+            </div>
+          </dl>
+          {confirmed.length ? (
+            <table className="gf-data-grid">
+              <thead>
+                <tr>
+                  <th>Start</th>
+                  <th>End</th>
+                  <th>Duration (s)</th>
+                  <th>Equipment</th>
+                </tr>
+              </thead>
+              <tbody>
+                {confirmed.map((c, i) => (
+                  <tr key={i}>
+                    <td>{formatTs(c.start)}</td>
+                    <td>{formatTs(c.end)}</td>
+                    <td>{String(c.duration_seconds ?? "—")}</td>
+                    <td>{String(c.equipment_id ?? equipmentId)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="muted">No confirmed fault streaks in this window — adjust threshold or confirmation seconds.</p>
+          )}
+        </div>
+      ) : null}
+
+      {tab === "validation" ? (
+        <div className="gf-validation">
+          <div className={`gf-validation__banner${validation?.safe ? " is-ok" : validation ? " is-error" : ""}`}>
+            {validation?.safe ? "SQL passed read-only guardrails" : validation ? "Validation issues found" : "No validation yet"}
+          </div>
+          {validationErrors.length ? (
+            <ul className="gf-validation__list gf-validation__list--error">
+              {validationErrors.map((e) => (
+                <li key={e}>{e}</li>
+              ))}
+            </ul>
+          ) : null}
+          {validationWarnings.length ? (
+            <ul className="gf-validation__list gf-validation__list--warn">
+              {validationWarnings.map((w) => (
+                <li key={w}>{w}</li>
+              ))}
+            </ul>
+          ) : null}
+          {validation?.allowed_tables ? (
+            <p className="muted">
+              Allowed tables:{" "}
+              {Array.isArray(validation.allowed_tables)
+                ? (validation.allowed_tables as string[]).join(", ")
+                : String(validation.allowed_tables)}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {tab === "json" ? (
+        <pre className="gf-json-view">{JSON.stringify(runResult ?? validation ?? compileResult, null, 2)}</pre>
+      ) : null}
+    </section>
+  );
+}
+
+function formatCell(v: unknown): string {
+  if (v == null) return "—";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  return String(v);
+}
+
+function formatTs(v: unknown): string {
+  if (typeof v === "number" && v > 0) {
+    return new Date(v * 1000).toISOString();
+  }
+  return String(v ?? "—");
+}

--- a/workspace/dashboard/src/components/sqlFdd/SqlFddSchemaExplorer.tsx
+++ b/workspace/dashboard/src/components/sqlFdd/SqlFddSchemaExplorer.tsx
@@ -1,0 +1,89 @@
+import { useMemo, useState } from "react";
+import type { FddInput, SchemaColumn, SchemaTable } from "./types";
+
+type Props = {
+  tables: SchemaTable[];
+  fddInputs: FddInput[];
+  onInsert: (snippet: string) => void;
+  selectedTable?: string;
+  onSelectTable?: (name: string) => void;
+};
+
+function normalizeColumns(table: SchemaTable): SchemaColumn[] {
+  if (!table.columns?.length) return [];
+  if (typeof table.columns[0] === "string") {
+    return (table.columns as string[]).map((name) => ({ name, type: "DOUBLE" }));
+  }
+  return table.columns as SchemaColumn[];
+}
+
+export default function SqlFddSchemaExplorer({
+  tables,
+  fddInputs,
+  onInsert,
+  selectedTable,
+  onSelectTable,
+}: Props) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({ telemetry_pivot: true });
+  const inputById = useMemo(() => new Map(fddInputs.map((i) => [i.id, i])), [fddInputs]);
+
+  return (
+    <aside className="gf-schema" aria-label="DataFusion schema">
+      <div className="gf-schema__head">
+        <span className="gf-schema__title">Schema</span>
+        <span className="gf-pill gf-pill--dialect">DataFusion</span>
+      </div>
+      <p className="gf-schema__hint muted">
+        Historian tables registered for FDD SQL. Click a column to insert into the editor.
+      </p>
+      <ul className="gf-schema__tree">
+        {tables.map((table) => {
+          const open = expanded[table.name] ?? false;
+          const cols = normalizeColumns(table);
+          const active = selectedTable === table.name;
+          return (
+            <li key={table.name} className="gf-schema__table">
+              <button
+                type="button"
+                className={`gf-schema__table-btn${active ? " is-active" : ""}`}
+                onClick={() => {
+                  setExpanded((e) => ({ ...e, [table.name]: !open }));
+                  onSelectTable?.(table.name);
+                }}
+              >
+                <span className="gf-schema__chev">{open ? "▾" : "▸"}</span>
+                <span className="gf-schema__table-name">{table.name}</span>
+                <span className="gf-schema__count">{cols.length}</span>
+              </button>
+              {table.description && open ? (
+                <p className="gf-schema__desc muted">{table.description}</p>
+              ) : null}
+              {open ? (
+                <ul className="gf-schema__cols">
+                  {cols.map((col) => {
+                    const meta = inputById.get(col.name);
+                    return (
+                      <li key={col.name}>
+                        <button
+                          type="button"
+                          className="gf-schema__col-btn"
+                          title={meta ? `${meta.label}${meta.unit ? ` (${meta.unit})` : ""}` : col.type}
+                          onClick={() => onInsert(col.name)}
+                        >
+                          <span className="gf-schema__col-name">{col.name}</span>
+                          <span className="gf-schema__col-type">{col.type}</span>
+                          {col.is_primary ? <span className="gf-pill gf-pill--pk">PK</span> : null}
+                          {meta ? <span className="gf-pill gf-pill--fdd">FDD</span> : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </aside>
+  );
+}

--- a/workspace/dashboard/src/components/sqlFdd/SqlFddVisualBuilder.tsx
+++ b/workspace/dashboard/src/components/sqlFdd/SqlFddVisualBuilder.tsx
@@ -1,0 +1,83 @@
+import type { BuilderState, FddInput } from "./types";
+
+type Props = {
+  builder: BuilderState;
+  fddInputs: FddInput[];
+  onChange: (next: BuilderState) => void;
+  disabled?: boolean;
+};
+
+export default function SqlFddVisualBuilder({ builder, fddInputs, onChange, disabled }: Props) {
+  return (
+    <div className="gf-visual-builder">
+      <div className="gf-visual-builder__head">
+        <h3 className="gf-section-title">Rule definition</h3>
+        <p className="muted">Threshold rule on mapped FDD inputs — SQL updates live in the editor above.</p>
+      </div>
+      <div className="gf-form-grid">
+        <label className="gf-field">
+          <span className="gf-field__label">Rule name</span>
+          <input
+            disabled={disabled}
+            value={builder.name}
+            onChange={(e) => onChange({ ...builder, name: e.target.value })}
+          />
+        </label>
+        <label className="gf-field">
+          <span className="gf-field__label">FDD input</span>
+          <select
+            disabled={disabled}
+            value={builder.input}
+            onChange={(e) => onChange({ ...builder, input: e.target.value })}
+          >
+            {fddInputs.map((i) => (
+              <option key={i.id} value={i.id}>
+                {i.label} ({i.id})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="gf-field gf-field--narrow">
+          <span className="gf-field__label">Operator</span>
+          <select
+            disabled={disabled}
+            value={builder.operator}
+            onChange={(e) => onChange({ ...builder, operator: e.target.value })}
+          >
+            {[">", "<", ">=", "<="].map((op) => (
+              <option key={op} value={op}>
+                {op}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="gf-field gf-field--narrow">
+          <span className="gf-field__label">Threshold</span>
+          <input
+            disabled={disabled}
+            type="number"
+            value={builder.value}
+            onChange={(e) => onChange({ ...builder, value: Number(e.target.value) })}
+          />
+        </label>
+        <label className="gf-field">
+          <span className="gf-field__label">Fault code</span>
+          <input
+            disabled={disabled}
+            value={builder.fault_code}
+            onChange={(e) => onChange({ ...builder, fault_code: e.target.value })}
+          />
+        </label>
+        <label className="gf-field gf-field--narrow">
+          <span className="gf-field__label">Confirm (sec)</span>
+          <input
+            disabled={disabled}
+            type="number"
+            value={builder.confirmation_seconds}
+            onChange={(e) => onChange({ ...builder, confirmation_seconds: Number(e.target.value) })}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/components/sqlFdd/types.ts
+++ b/workspace/dashboard/src/components/sqlFdd/types.ts
@@ -1,0 +1,65 @@
+export type BuilderState = {
+  name: string;
+  input: string;
+  operator: string;
+  value: number;
+  equipment_id: string;
+  confirmation_seconds: number;
+  severity: string;
+  fault_code: string;
+};
+
+export type FddInput = {
+  id: string;
+  label: string;
+  unit?: string;
+  equipment_types?: string[];
+};
+
+export type SchemaColumn = {
+  name: string;
+  type: string;
+  is_primary?: boolean;
+  fdd_input?: boolean;
+  unit?: string;
+};
+
+export type SchemaTable = {
+  name: string;
+  description?: string;
+  columns: SchemaColumn[] | string[];
+};
+
+export type EquipmentRow = {
+  id?: string;
+  equipment_id?: string;
+  name?: string;
+  equipment_type?: string;
+};
+
+export type SqlCompileResult = {
+  ok: boolean;
+  sql?: string;
+  explanation?: string;
+  dialect?: string;
+  error?: string;
+  validation?: Record<string, unknown>;
+};
+
+export type QueryMode = "visual" | "sql" | "prompt";
+
+export function ruleIdFromBuilder(builder: BuilderState): string {
+  const base = builder.fault_code.trim() || builder.name.trim() || "fdd-rule";
+  return base.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "fdd-rule";
+}
+
+export const DEFAULT_BUILDER: BuilderState = {
+  name: "OA Temperature Out Of Range",
+  input: "oa_t",
+  operator: ">",
+  value: 110,
+  equipment_id: "",
+  confirmation_seconds: 300,
+  severity: "medium",
+  fault_code: "OA_TEMP_OUT_OF_RANGE",
+};

--- a/workspace/dashboard/src/lib/agentChatStore.ts
+++ b/workspace/dashboard/src/lib/agentChatStore.ts
@@ -166,6 +166,14 @@ export function deleteMessageAndAfter(state: AgentChatState, id: string): AgentC
   };
 }
 
+export const AGENT_CHAT_CLEAR_EVENT = "ofdd-agent-chat-clear";
+
 export function clearAgentChat(): void {
   localStorage.removeItem(STORAGE_KEY);
+}
+
+/** Clear persisted chat and notify open agent panels to reset UI state. */
+export function notifyClearAgentChat(): void {
+  clearAgentChat();
+  window.dispatchEvent(new CustomEvent(AGENT_CHAT_CLEAR_EVENT));
 }

--- a/workspace/dashboard/src/lib/api.ts
+++ b/workspace/dashboard/src/lib/api.ts
@@ -278,6 +278,32 @@ export async function login(username: string, password: string) {
   });
 }
 
+/** Dev-only one-click login (edge OPENFDD_ALLOW_INSECURE_AUTH=1). */
+export async function devQuickLogin(role: "integrator" | "admin" | "operator" | "agent") {
+  return apiFetch<{
+    ok?: boolean;
+    token?: string;
+    access_token?: string;
+    role?: string;
+    username?: string;
+    error?: string;
+  }>("/api/dev/quick-login", {
+    method: "POST",
+    body: JSON.stringify({ role }),
+  });
+}
+
+/** Dev-only start local script (ui dev, codex setup). */
+export async function devRunScript(script: "ui_dev" | "codex_setup" | "codex_reset") {
+  return apiFetch<{ ok?: boolean; hint?: string; error?: string; log?: string }>(
+    "/api/dev/run-script",
+    {
+      method: "POST",
+      body: JSON.stringify({ script }),
+    },
+  );
+}
+
 /** Short-lived ticket for /ws/dashboard (not the long-lived Bearer token). */
 export async function fetchWsTicket(): Promise<string | null> {
   try {

--- a/workspace/dashboard/src/lib/api.ts
+++ b/workspace/dashboard/src/lib/api.ts
@@ -121,6 +121,31 @@ export async function apiFetch<T>(
   return res.json() as Promise<T>;
 }
 
+/** Upload multipart form data (CSV import preview). */
+export async function apiUploadForm<T>(path: string, form: FormData): Promise<T> {
+  const base = getBridgeBase();
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...authHeaders(),
+    },
+    body: form,
+  });
+  if (res.status === 401 && !path.startsWith("/api/auth/login")) {
+    sessionStorage.removeItem(TOKEN_KEY);
+    if (shouldRedirectLogin()) {
+      window.location.assign("/login");
+    }
+    throw new Error("unauthorized");
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    throw parseErrorBody(text, res.status);
+  }
+  return res.json() as Promise<T>;
+}
+
 /** Upload raw CSV/text bodies (import job upload endpoint). */
 export async function apiUploadRaw<T>(
   path: string,

--- a/workspace/dashboard/src/lib/fddSqlCompiler.test.ts
+++ b/workspace/dashboard/src/lib/fddSqlCompiler.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { compileNaturalLanguagePrompt, expandTimeMacros } from "./fddSqlCompiler";
+import type { FddInput, SchemaTable } from "../components/sqlFdd/types";
+
+const inputs: FddInput[] = [
+  { id: "oa_t", label: "OA temperature", unit: "degF" },
+  { id: "sat", label: "Supply Air Temp", unit: "degF" },
+];
+
+const schema: SchemaTable[] = [
+  {
+    name: "telemetry_pivot",
+    columns: [
+      { name: "timestamp", type: "TIMESTAMP", is_primary: true },
+      { name: "equipment_id", type: "VARCHAR" },
+      { name: "oa_t", type: "DOUBLE", fdd_input: true },
+      { name: "sat", type: "DOUBLE", fdd_input: true },
+    ],
+  },
+];
+
+describe("fddSqlCompiler", () => {
+  it("compiles fault-style NL to read-only SQL with fault_raw", () => {
+    const out = compileNaturalLanguagePrompt({
+      userPrompt: "Show OA temperature above 110 fault for this AHU",
+      equipmentId: "equip:ahu-1",
+      schema,
+      fddInputs: inputs,
+    });
+    expect(out.ok).toBe(true);
+    expect(out.sql).toContain("fault_raw");
+    expect(out.sql).toContain("oa_t > 110");
+    expect(out.sql).toContain("equip:ahu-1");
+    expect(out.dialect).toBe("DataFusion");
+  });
+
+  it("rejects unknown columns", () => {
+    const out = compileNaturalLanguagePrompt({
+      userPrompt: "show mystery_col above 1",
+      equipmentId: "equip:ahu-1",
+      schema: [{ name: "telemetry_pivot", columns: ["timestamp", "equipment_id"] }],
+      fddInputs: [{ id: "mystery_col", label: "Mystery" }],
+    });
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/not in telemetry_pivot/i);
+  });
+
+  it("expands time macro for test execution", () => {
+    const sql = "SELECT * FROM telemetry_pivot WHERE $__timeFilter(timestamp)";
+    expect(expandTimeMacros(sql)).toContain("timestamp IS NOT NULL");
+  });
+});

--- a/workspace/dashboard/src/lib/fddSqlCompiler.ts
+++ b/workspace/dashboard/src/lib/fddSqlCompiler.ts
@@ -1,0 +1,153 @@
+import type { FddInput, SchemaTable, SqlCompileResult } from "../components/sqlFdd/types";
+
+const DIALECT = "DataFusion";
+
+/** Grafana-style read-only guardrails for Open-FDD historian SQL. */
+export function compileNaturalLanguagePrompt(args: {
+  userPrompt: string;
+  equipmentId: string;
+  timeColumn?: string;
+  schema: SchemaTable[];
+  fddInputs: FddInput[];
+  defaultLimit?: number;
+}): SqlCompileResult {
+  const prompt = args.userPrompt.trim();
+  const timeColumn = args.timeColumn ?? "timestamp";
+  const limit = args.defaultLimit ?? 50;
+
+  if (!prompt) {
+    return { ok: false, error: "Enter a natural language request to compile.", dialect: DIALECT };
+  }
+  if (!args.equipmentId.trim()) {
+    return { ok: false, error: "Select equipment before compiling — SQL must scope to one device.", dialect: DIALECT };
+  }
+
+  const pivot = args.schema.find((t) => t.name === "telemetry_pivot");
+  const columnNames = normalizeColumns(pivot).map((c) => c.name);
+  if (!columnNames.length) {
+    return { ok: false, error: "Schema missing telemetry_pivot — refresh schema explorer.", dialect: DIALECT };
+  }
+
+  const lower = prompt.toLowerCase();
+  const input = matchFddInput(lower, args.fddInputs);
+  if (!input) {
+    const known = args.fddInputs.map((i) => i.id).join(", ");
+    return {
+      ok: false,
+      error: `Could not map prompt to a known FDD column. Available: ${known}`,
+      dialect: DIALECT,
+    };
+  }
+  if (!columnNames.includes(input.id)) {
+    return {
+      ok: false,
+      error: `Column '${input.id}' is not in telemetry_pivot for this site historian.`,
+      dialect: DIALECT,
+    };
+  }
+
+  const operator = matchOperator(lower);
+  const threshold = matchThreshold(lower, input);
+  if (threshold == null) {
+    return {
+      ok: false,
+      error: `Specify a numeric threshold for ${input.label} (e.g. "above 110").`,
+      dialect: DIALECT,
+    };
+  }
+
+  const wantsFault = /fault|fdd|alarm|violation|out of range|anomaly/.test(lower);
+  const wantsTop = lower.match(/\btop\s+(\d+)\b/);
+  const rowLimit = wantsTop ? Number(wantsTop[1]) : limit;
+  const equip = args.equipmentId.replace(/'/g, "''");
+
+  let sql: string;
+  let explanation: string;
+
+  if (wantsFault) {
+    sql = [
+      "SELECT",
+      `  ${timeColumn}, equipment_id, ${input.id},`,
+      `  CASE WHEN ${input.id} IS NULL THEN false WHEN ${input.id} ${operator} ${threshold} THEN true ELSE false END AS fault_raw`,
+      "FROM telemetry_pivot",
+      `WHERE equipment_id = '${equip}'`,
+      `  AND $__timeFilter(${timeColumn})`,
+      `LIMIT ${rowLimit}`,
+    ].join("\n");
+    explanation = `FDD rule SQL: flag ${input.label} (${input.id}) when value ${operator} ${threshold}, scoped to selected equipment, with Open-FDD time macro and LIMIT ${rowLimit}.`;
+  } else {
+    sql = [
+      "SELECT",
+      `  ${timeColumn}, equipment_id, ${input.id}`,
+      "FROM telemetry_pivot",
+      `WHERE equipment_id = '${equip}'`,
+      `  AND $__timeFilter(${timeColumn})`,
+      `ORDER BY ${timeColumn} DESC`,
+      `LIMIT ${rowLimit}`,
+    ].join("\n");
+    explanation = `Preview query for ${input.label} on selected equipment; time range via $__timeFilter(${timeColumn}), limited to ${rowLimit} rows.`;
+  }
+
+  return { ok: true, sql, explanation, dialect: DIALECT };
+}
+
+function normalizeColumns(table: SchemaTable | undefined): { name: string; type: string }[] {
+  if (!table?.columns?.length) return [];
+  if (typeof table.columns[0] === "string") {
+    return (table.columns as string[]).map((name) => ({ name, type: "DOUBLE" }));
+  }
+  return (table.columns as { name: string; type: string }[]).map((c) => ({
+    name: c.name,
+    type: c.type ?? "DOUBLE",
+  }));
+}
+
+function matchFddInput(lower: string, inputs: FddInput[]): FddInput | null {
+  for (const i of inputs) {
+    if (lower.includes(i.id.toLowerCase())) return i;
+  }
+  for (const i of inputs) {
+    const label = i.label.toLowerCase();
+    if (label && lower.includes(label)) return i;
+  }
+  const aliases: Record<string, string> = {
+    "outside air": "oa_t",
+    "oa temp": "oa_t",
+    "supply air": "sat",
+    "zone temp": "zn_t",
+    humidity: "oa_h",
+    occupancy: "occ",
+    "fan command": "fan_cmd",
+  };
+  for (const [phrase, id] of Object.entries(aliases)) {
+    if (lower.includes(phrase)) {
+      return inputs.find((i) => i.id === id) ?? null;
+    }
+  }
+  return inputs[0] ?? null;
+}
+
+function matchOperator(lower: string): string {
+  if (/below|under|less than|<(?!=)/.test(lower) && !/less than or equal|<=/.test(lower)) return "<";
+  if (/above|over|greater than|exceed/.test(lower) && !/greater than or equal|>=/.test(lower)) return ">";
+  if (/below|under|less than|<=|≤/.test(lower)) return "<=";
+  if (/above|over|greater than|>=|≥|exceed/.test(lower)) return ">=";
+  return ">";
+}
+
+function matchThreshold(lower: string, input: FddInput): number | null {
+  const m = lower.match(/(-?\d+(?:\.\d+)?)/);
+  if (m) return Number(m[1]);
+  if (input.id === "oa_t") return 110;
+  if (input.id === "sat" || input.id === "duct_t" || input.id === "zn_t") return 75;
+  if (input.id === "oa_h") return 90;
+  return null;
+}
+
+/** Expand Grafana-style macros for DataFusion test runs (full historian window). */
+export function expandTimeMacros(sql: string, timeColumn = "timestamp"): string {
+  const macro = `$__timeFilter(${timeColumn})`;
+  if (!sql.includes(macro)) return sql;
+  const replacement = `${timeColumn} IS NOT NULL`;
+  return sql.split(macro).join(replacement);
+}

--- a/workspace/dashboard/src/pages/AgentPage.tsx
+++ b/workspace/dashboard/src/pages/AgentPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import PageHeader from "../components/PageHeader";
 import { apiFetch, hasToken } from "../lib/api";
+import { notifyClearAgentChat } from "../lib/agentChatStore";
 import { formatApiError } from "../lib/formatApiError";
 
 type AgentConfig = {
@@ -43,6 +44,8 @@ export default function AgentPage() {
   const [config, setConfig] = useState<AgentConfig | null>(null);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
+  const [actionMsg, setActionMsg] = useState("");
+  const [actionBusy, setActionBusy] = useState(false);
 
   const refresh = useCallback(async () => {
     if (!hasToken()) return;
@@ -60,6 +63,27 @@ export default function AgentPage() {
 
   useEffect(() => {
     void refresh();
+  }, [refresh]);
+
+  const clearChatHistory = useCallback(() => {
+    notifyClearAgentChat();
+    setActionMsg("Chat history cleared in this browser.");
+  }, []);
+
+  const restartAgent = useCallback(async () => {
+    if (!hasToken()) return;
+    setActionBusy(true);
+    setActionMsg("");
+    setError("");
+    try {
+      await apiFetch("/api/agent/reset", { method: "POST" });
+      setActionMsg("Agent session restarted — next prompt starts a fresh Codex run.");
+      await refresh();
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setActionBusy(false);
+    }
   }, [refresh]);
 
   const ollama = config?.ollama;
@@ -80,6 +104,30 @@ export default function AgentPage() {
       ) : null}
 
       {error ? <p className="error">{error}</p> : null}
+      {actionMsg ? <p className="muted">{actionMsg}</p> : null}
+
+      <section className="panel">
+        <div className="toolbar">
+          <h3 className="panel-title">Chat session</h3>
+        </div>
+        <p className="muted">
+          Clear local chat history in the agent rail, or restart the Codex relay session (cancels in-flight work and
+          drops server-side session state).
+        </p>
+        <div className="toolbar">
+          <button type="button" className="secondary-btn" disabled={!hasToken()} onClick={clearChatHistory}>
+            Clear chat history
+          </button>
+          <button
+            type="button"
+            className="secondary-btn"
+            disabled={!hasToken() || actionBusy}
+            onClick={() => void restartAgent()}
+          >
+            {actionBusy ? "Restarting…" : "Restart agent"}
+          </button>
+        </div>
+      </section>
 
       <section className="panel">
         <div className="toolbar">

--- a/workspace/dashboard/src/pages/AgentPage.tsx
+++ b/workspace/dashboard/src/pages/AgentPage.tsx
@@ -94,7 +94,7 @@ export default function AgentPage() {
     <div className="page page-wide">
       <PageHeader
         title="AI integrations"
-        subtitle="In-app chat: Codex CLI (WSL) → Cursor → Ollama → live bridge tools."
+        subtitle="In-app chat: Codex → Cursor → Ollama (Hermes/llama/etc.) → live bridge tools. External agents use MCP + JWT from workspace credentials."
       />
 
       {!hasToken() ? (
@@ -127,6 +127,28 @@ export default function AgentPage() {
             {actionBusy ? "Restarting…" : "Restart agent"}
           </button>
         </div>
+      </section>
+
+      <section className="panel">
+        <h3 className="panel-title">MCP credentials (Cursor, Claude, Codex, OpenClaw)</h3>
+        <p className="muted">
+          MCP sidecar reads login from the host workspace — not from the browser session. One-time passwords:{" "}
+          <code>workspace/bootstrap_credentials.once.txt</code> (delete after saving). Ongoing:{" "}
+          <code>workspace/auth.env.local</code> + <code>OPENFDD_INTEGRATOR_PASSWORD</code> env or{" "}
+          <code>scripts/openfdd_auth_lib.sh</code>.
+        </p>
+        <ul className="muted">
+          <li>
+            MCP tools: <code>openfdd_auth_credentials_hint</code>, <code>openfdd_auth_login</code> (returns JWT only)
+          </li>
+          <li>
+            Model + FDD wiresheet: <code>openfdd_model_assignments_save</code> then{" "}
+            <code>openfdd_fdd_wires_sync</code> — or save auto-syncs wiresheet
+          </li>
+          <li>
+            Dashboard login (UI): integrator role from bootstrap handoff file
+          </li>
+        </ul>
       </section>
 
       <section className="panel">

--- a/workspace/dashboard/src/pages/AgentPage.tsx
+++ b/workspace/dashboard/src/pages/AgentPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import PageHeader from "../components/PageHeader";
-import { apiFetch, hasToken } from "../lib/api";
+import { apiFetch, devRunScript, hasToken } from "../lib/api";
 import { notifyClearAgentChat } from "../lib/agentChatStore";
 import { formatApiError } from "../lib/formatApiError";
 
@@ -13,31 +13,23 @@ type AgentConfig = {
     base_url?: string;
     codex_logged_in?: boolean;
     openfdd_mcp_configured?: boolean;
-    model?: string;
-    agent?: string;
     error?: string;
-    hint?: string;
   };
   cursor_chat_enabled?: boolean;
-  cursor?: {
-    ok?: boolean;
-    base_url?: string;
-    has_api_key?: boolean;
-    model?: string;
-    agent_id?: string;
-    error?: string;
-    hint?: string;
-  };
+  cursor?: { ok?: boolean; base_url?: string; model?: string; error?: string };
   ollama?: {
     api_ok?: boolean;
-    base_url?: string;
-    active_base_url?: string;
     configured_model?: string;
     models_installed?: string[];
     interactive_chat_enabled?: boolean;
     error?: string;
   };
   chat_endpoint?: string;
+  credentials_hint?: {
+    bootstrap_handoff?: string;
+    auth_env_local?: string;
+    mcp_tools?: string[];
+  };
 };
 
 export default function AgentPage() {
@@ -65,20 +57,15 @@ export default function AgentPage() {
     void refresh();
   }, [refresh]);
 
-  const clearChatHistory = useCallback(() => {
-    notifyClearAgentChat();
-    setActionMsg("Chat history cleared in this browser.");
-  }, []);
-
-  const restartAgent = useCallback(async () => {
-    if (!hasToken()) return;
+  const runDev = useCallback(async (script: "ui_dev" | "codex_setup" | "codex_reset", label: string) => {
     setActionBusy(true);
     setActionMsg("");
     setError("");
     try {
-      await apiFetch("/api/agent/reset", { method: "POST" });
-      setActionMsg("Agent session restarted — next prompt starts a fresh Codex run.");
-      await refresh();
+      const res = await devRunScript(script);
+      if (!res.ok) throw new Error(res.error ?? `failed to start ${label}`);
+      setActionMsg(res.hint ?? `${label} started.`);
+      if (script !== "ui_dev") await refresh();
     } catch (e) {
       setError(formatApiError(e));
     } finally {
@@ -87,19 +74,19 @@ export default function AgentPage() {
   }, [refresh]);
 
   const ollama = config?.ollama;
-  const cursor = config?.cursor;
   const codex = config?.codex;
+  const cursor = config?.cursor;
 
   return (
     <div className="page page-wide">
       <PageHeader
         title="AI integrations"
-        subtitle="In-app chat: Codex → Cursor → Ollama (Hermes/llama/etc.) → live bridge tools. External agents use MCP + JWT from workspace credentials."
+        subtitle="Codex → Cursor → Ollama → bridge tools. MCP agents (Cursor, Claude, OpenClaw) use JWT from workspace credentials."
       />
 
       {!hasToken() ? (
         <p className="muted">
-          <Link to="/login">Sign in</Link> to view integration status and use the agent panel on the right.
+          <Link to="/login">Sign in</Link> to view integration status.
         </p>
       ) : null}
 
@@ -107,199 +94,96 @@ export default function AgentPage() {
       {actionMsg ? <p className="muted">{actionMsg}</p> : null}
 
       <section className="panel">
+        <h3 className="panel-title">Local dev stack</h3>
+        <p className="muted">One-click helpers (edge dev mode only). Passwords: bootstrap handoff or auth.env.local.</p>
         <div className="toolbar">
-          <h3 className="panel-title">Chat session</h3>
+          <button
+            type="button"
+            className="primary-btn"
+            disabled={actionBusy}
+            onClick={() => void runDev("ui_dev", "UI dev server")}
+          >
+            Start UI dev (:5173)
+          </button>
+          <button
+            type="button"
+            className="secondary-btn"
+            disabled={actionBusy}
+            onClick={() => void runDev("codex_setup", "Codex relay")}
+          >
+            Start Codex relay
+          </button>
+          <button
+            type="button"
+            className="secondary-btn"
+            disabled={actionBusy}
+            onClick={() => void runDev("codex_reset", "Codex reset")}
+          >
+            Reset Codex relay
+          </button>
+          <button type="button" className="secondary-btn" disabled={busy} onClick={() => void refresh()}>
+            {busy ? "Checking…" : "Refresh status"}
+          </button>
         </div>
+      </section>
+
+      <section className="panel">
+        <h3 className="panel-title">MCP & credentials</h3>
         <p className="muted">
-          Clear local chat history in the agent rail, or restart the Codex relay session (cancels in-flight work and
-          drops server-side session state).
+          MCP tools: <code>openfdd_auth_credentials_hint</code>, <code>openfdd_auth_login</code>,{" "}
+          <code>openfdd_model_assignments_save</code>. Handoff:{" "}
+          <code>{config?.credentials_hint?.bootstrap_handoff ?? "workspace/bootstrap_credentials.once.txt"}</code>
         </p>
+      </section>
+
+      <section className="panel">
+        <h3 className="panel-title">Agent providers</h3>
+        <div className="status-kv-grid">
+          <div className="status-kv">
+            <span className="status-kv-label">Codex</span>
+            <span className={`status-kv-value ${config?.codex_chat_enabled ? "ok" : ""}`}>
+              {config?.codex_chat_enabled ? "online" : "offline (optional)"}
+            </span>
+          </div>
+          <div className="status-kv">
+            <span className="status-kv-label">Cursor</span>
+            <span className={`status-kv-value ${config?.cursor_chat_enabled ? "ok" : ""}`}>
+              {config?.cursor_chat_enabled ? "online" : "offline (optional)"}
+            </span>
+          </div>
+          <div className="status-kv">
+            <span className="status-kv-label">Ollama</span>
+            <span className={`status-kv-value ${ollama?.api_ok ? "ok" : ""}`}>
+              {ollama?.api_ok ? ollama.configured_model ?? "reachable" : "offline (optional)"}
+            </span>
+          </div>
+        </div>
+        {!config?.codex_chat_enabled && !config?.cursor_chat_enabled && !ollama?.api_ok ? (
+          <p className="muted">
+            No external LLM relay required — dashboard insight and Agent assist tools fallback use live bridge data.
+            Start Codex or Ollama when you want richer chat.
+          </p>
+        ) : null}
+        {codex?.error && !config?.codex_chat_enabled ? (
+          <p className="muted">Codex: {codex.error}</p>
+        ) : null}
+      </section>
+
+      <section className="panel">
+        <h3 className="panel-title">Chat session</h3>
         <div className="toolbar">
-          <button type="button" className="secondary-btn" disabled={!hasToken()} onClick={clearChatHistory}>
+          <button type="button" className="secondary-btn" disabled={!hasToken()} onClick={() => notifyClearAgentChat()}>
             Clear chat history
           </button>
           <button
             type="button"
             className="secondary-btn"
             disabled={!hasToken() || actionBusy}
-            onClick={() => void restartAgent()}
+            onClick={() => void apiFetch("/api/agent/reset", { method: "POST" }).then(() => refresh())}
           >
-            {actionBusy ? "Restarting…" : "Restart agent"}
+            Restart agent session
           </button>
         </div>
-      </section>
-
-      <section className="panel">
-        <h3 className="panel-title">MCP credentials (Cursor, Claude, Codex, OpenClaw)</h3>
-        <p className="muted">
-          MCP sidecar reads login from the host workspace — not from the browser session. One-time passwords:{" "}
-          <code>workspace/bootstrap_credentials.once.txt</code> (delete after saving). Ongoing:{" "}
-          <code>workspace/auth.env.local</code> + <code>OPENFDD_INTEGRATOR_PASSWORD</code> env or{" "}
-          <code>scripts/openfdd_auth_lib.sh</code>.
-        </p>
-        <ul className="muted">
-          <li>
-            MCP tools: <code>openfdd_auth_credentials_hint</code>, <code>openfdd_auth_login</code> (returns JWT only)
-          </li>
-          <li>
-            Model + FDD wiresheet: <code>openfdd_model_assignments_save</code> then{" "}
-            <code>openfdd_fdd_wires_sync</code> — or save auto-syncs wiresheet
-          </li>
-          <li>
-            Dashboard login (UI): integrator role from bootstrap handoff file
-          </li>
-        </ul>
-      </section>
-
-      <section className="panel">
-        <div className="toolbar">
-          <h3 className="panel-title">Codex CLI (in-app chat)</h3>
-          <button type="button" className="secondary-btn" disabled={busy} onClick={() => void refresh()}>
-            {busy ? "Checking…" : "Refresh status"}
-          </button>
-        </div>
-        <p className="muted">
-          <strong>Agent assist</strong> uses Codex via <code>./scripts/openfdd_agent_chat_setup.sh</code> — JWT +
-          openfdd MCP auto-wired. Scratch CSV scripts: <code>workspace/agent-toolshed/</code> (gitignored).
-        </p>
-        <div className="status-kv-grid">
-          <div className="status-kv">
-            <span className="status-kv-label">Relay</span>
-            <span className={`status-kv-value ${config?.codex_chat_enabled ? "ok" : "error"}`}>
-              {config?.codex_chat_enabled ? "connected" : "offline"}
-            </span>
-          </div>
-          <div className="status-kv">
-            <span className="status-kv-label">MCP</span>
-            <span className={`status-kv-value ${codex?.openfdd_mcp_configured ? "ok" : ""}`}>
-              {codex?.openfdd_mcp_configured ? "openfdd" : "not listed"}
-            </span>
-          </div>
-          {codex?.base_url ? (
-            <div className="status-kv">
-              <span className="status-kv-label">URL</span>
-              <span className="status-kv-value">{codex.base_url}</span>
-            </div>
-          ) : null}
-        </div>
-        {codex?.error && !config?.codex_chat_enabled ? <p className="error">{codex.error}</p> : null}
-        <p className="muted">
-          Setup: <code>codex login</code> then <code>./scripts/openfdd_agent_chat_setup.sh</code> · Reset:{" "}
-          <code>./scripts/openfdd_agent_chat_reset.sh</code>
-        </p>
-      </section>
-
-      <section className="panel">
-        <div className="toolbar">
-          <h3 className="panel-title">Cursor SDK (optional)</h3>
-        </div>
-        <p className="muted">
-          <strong>Agent assist</strong> uses the local Cursor SDK relay when running:{" "}
-          <code>./scripts/openfdd_cursor_chat_relay.sh</code>
-        </p>
-        <div className="status-kv-grid">
-          <div className="status-kv">
-            <span className="status-kv-label">Relay</span>
-            <span className={`status-kv-value ${config?.cursor_chat_enabled ? "ok" : "error"}`}>
-              {config?.cursor_chat_enabled ? "connected" : "offline"}
-            </span>
-          </div>
-          {cursor?.base_url ? (
-            <div className="status-kv">
-              <span className="status-kv-label">URL</span>
-              <span className="status-kv-value">{cursor.base_url}</span>
-            </div>
-          ) : null}
-          {cursor?.model ? (
-            <div className="status-kv">
-              <span className="status-kv-label">Model</span>
-              <span className="status-kv-value">{cursor.model}</span>
-            </div>
-          ) : null}
-        </div>
-        {cursor?.error && !config?.cursor_chat_enabled ? <p className="error">{cursor.error}</p> : null}
-        <details className="agent-settings-details">
-          <summary>Docker setup</summary>
-          <pre className="code-block">
-{`cp workspace/cursor.env.local.example workspace/cursor.env.local
-# Set CURSOR_API_KEY; OFDD_CURSOR_CHAT_URL=http://openfdd-cursor-relay:8787
-
-OPENFDD_COMPOSE_ROOT=$PWD docker compose \\
-  -f docker/compose.edge.rust.yml \\
-  --profile desktop-json-csv --profile cursor up -d`}
-          </pre>
-        </details>
-        <p className="muted">
-          Setup: <code>cp workspace/cursor.env.local.example workspace/cursor.env.local</code> — add{" "}
-          <code>CURSOR_API_KEY</code> from cursor.com/settings.
-        </p>
-      </section>
-
-      <section className="panel">
-        <div className="toolbar">
-          <h3 className="panel-title">Ollama (production / offline LLM)</h3>
-        </div>
-        <p className="muted">
-          Fallback when Cursor relay is off. Production benches can use Ollama in Docker instead of Cursor.
-        </p>
-        <div className="status-kv-grid">
-          <div className="status-kv">
-            <span className="status-kv-label">API</span>
-            <span className={`status-kv-value ${ollama?.api_ok ? "ok" : "error"}`}>
-              {ollama?.api_ok ? "reachable" : "offline"}
-            </span>
-          </div>
-          <div className="status-kv">
-            <span className="status-kv-label">Chat</span>
-            <span className={`status-kv-value ${ollama?.interactive_chat_enabled ? "ok" : ""}`}>
-              {ollama?.interactive_chat_enabled ? "enabled" : "tool-only fallback"}
-            </span>
-          </div>
-          {ollama?.configured_model ? (
-            <div className="status-kv">
-              <span className="status-kv-label">Model</span>
-              <span className="status-kv-value">{ollama.configured_model}</span>
-            </div>
-          ) : null}
-          {ollama?.active_base_url || ollama?.base_url ? (
-            <div className="status-kv">
-              <span className="status-kv-label">Base URL</span>
-              <span className="status-kv-value">{ollama.active_base_url || ollama.base_url}</span>
-            </div>
-          ) : null}
-        </div>
-        {ollama?.models_installed?.length ? (
-          <p className="muted">Installed: {ollama.models_installed.slice(0, 6).join(", ")}</p>
-        ) : null}
-        {ollama?.error && !ollama.api_ok ? <p className="error">{ollama.error}</p> : null}
-        <details className="agent-settings-details">
-          <summary>Docker setup</summary>
-          <pre className="code-block">
-{`docker exec openfdd-ollama ollama pull llama3.2
-
-cp workspace/ollama.env.local.example workspace/ollama.env.local
-# OFDD_OLLAMA_BASE_URL=http://ollama:11434
-
-OPENFDD_COMPOSE_ROOT=$PWD docker compose \\
-  -f docker/compose.edge.rust.yml \\
-  --profile desktop-json-csv --profile ai up -d`}
-          </pre>
-        </details>
-        <p className="muted">
-          Config file: <code>workspace/ollama.env.local</code> (see <code>ollama.env.local.example</code>). Host metrics:{" "}
-          <Link to="/host">Host stats</Link>.
-        </p>
-      </section>
-
-      <section className="panel">
-        <h3 className="panel-title">Using chat on any tab</h3>
-        <p>
-          After sign-in, open CSV Fusion, BACnet, SQL FDD, or any workspace tab — the <strong>Agent assist</strong> rail
-          on the right stays in context (<code>{config?.chat_endpoint ?? "/api/agent/chat"}</code>).
-        </p>
-        <p className="muted">
-          Examples: “How many CSV sessions?” on CSV · “Model coverage?” on Model · “Stack health?” on Dashboard.
-        </p>
       </section>
     </div>
   );

--- a/workspace/dashboard/src/pages/DataModelPage.tsx
+++ b/workspace/dashboard/src/pages/DataModelPage.tsx
@@ -9,12 +9,12 @@ import DataModelSparqlPanel from "../components/DataModelSparqlPanel";
 import CommissioningImportExportPanel from "../components/CommissioningImportExportPanel";
 import ModelSyncBar from "../components/ModelSyncBar";
 import PageHeader from "../components/PageHeader";
-import FddWiresheetSummary from "../components/FddWiresheetSummary";
+import ModelFddMappingPanel from "../components/ModelFddMappingPanel";
 
 type SiteRow = { id: string; name: string };
 
 export default function DataModelPage() {
-  const [activeTab, setActiveTab] = useState<"import" | "explorer" | "wiresheet" | "sparql" | "advanced">("import");
+  const [activeTab, setActiveTab] = useState<"import" | "explorer" | "mapping" | "sparql" | "advanced">("import");
   const [out, setOut] = useState("");
   const [ttlLoading, setTtlLoading] = useState(false);
   const [copiedKey, setCopiedKey] = useState("");
@@ -100,8 +100,8 @@ export default function DataModelPage() {
         subtitle={
           <>
             Haystack site <code>{activeSiteId || "…"}</code> · {eqCount} equipment · {pointCount} points · {ruleCount}{" "}
-            rules · {boundPoints} bound points · import/export commissioning JSON or use AI to populate model + FDD
-            wiresheet
+            rules · {boundPoints} bound points · import/export commissioning JSON or use AI to populate FDD
+            mappings
           </>
         }
       />
@@ -123,10 +123,10 @@ export default function DataModelPage() {
         </button>
         <button
           type="button"
-          className={activeTab === "wiresheet" ? "" : "secondary-btn"}
-          onClick={() => setActiveTab("wiresheet")}
+          className={activeTab === "mapping" ? "" : "secondary-btn"}
+          onClick={() => setActiveTab("mapping")}
         >
-          FDD wiresheet
+          FDD mapping
         </button>
         <button
           type="button"
@@ -163,7 +163,7 @@ export default function DataModelPage() {
         </>
       ) : null}
 
-      {activeTab === "wiresheet" ? <FddWiresheetSummary onStatus={setOut} /> : null}
+      {activeTab === "mapping" ? <ModelFddMappingPanel onStatus={setOut} /> : null}
 
       {activeTab === "sparql" ? <DataModelSparqlPanel onStatus={setOut} /> : null}
 

--- a/workspace/dashboard/src/pages/JsonApiPage.tsx
+++ b/workspace/dashboard/src/pages/JsonApiPage.tsx
@@ -75,6 +75,7 @@ export default function JsonApiPage() {
   } | null>(null);
   const [selectedPointIds, setSelectedPointIds] = useState<Set<string>>(() => new Set());
   const [bulkPollPending, setBulkPollPending] = useState(false);
+  const [pollOncePending, setPollOncePending] = useState(false);
   const [owmLat, setOwmLat] = useState("42.3601");
   const [owmLon, setOwmLon] = useState("-71.0589");
   const [owmAppId, setOwmAppId] = useState("");

--- a/workspace/dashboard/src/pages/LoginPage.tsx
+++ b/workspace/dashboard/src/pages/LoginPage.tsx
@@ -1,6 +1,13 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { fetchAuthStatus, login, sanitizeBridgeBaseOverride, setToken } from "../lib/api";
+import {
+  devQuickLogin,
+  devRunScript,
+  fetchAuthStatus,
+  login,
+  sanitizeBridgeBaseOverride,
+  setToken,
+} from "../lib/api";
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -9,6 +16,7 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [authRequired, setAuthRequired] = useState(true);
   const [hint, setHint] = useState("");
+  const [devBusy, setDevBusy] = useState<string | null>(null);
 
   useEffect(() => {
     if (sanitizeBridgeBaseOverride()) {
@@ -28,6 +36,14 @@ export default function LoginPage() {
       });
   }, [navigate]);
 
+  async function completeLogin(token: string | undefined) {
+    if (!token) {
+      throw new Error("Login succeeded but no session token was returned.");
+    }
+    setToken(token);
+    navigate("/");
+  }
+
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
     setError("");
@@ -41,14 +57,39 @@ export default function LoginPage() {
     }
     try {
       const res = await login(user, pass);
-      const token = res.token ?? res.access_token;
-      if (!token) {
-        throw new Error("Login succeeded but no session token was returned.");
-      }
-      setToken(token);
-      navigate("/");
+      await completeLogin(res.token ?? res.access_token);
     } catch (err) {
       setError(err instanceof Error ? err.message : "login failed");
+    }
+  }
+
+  async function quickSignIn(role: "integrator" | "admin") {
+    setDevBusy(role);
+    setError("");
+    try {
+      const res = await devQuickLogin(role);
+      if (!res.ok) {
+        throw new Error(res.error ?? "dev quick-login failed");
+      }
+      await completeLogin(res.token ?? res.access_token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "dev quick-login failed");
+    } finally {
+      setDevBusy(null);
+    }
+  }
+
+  async function startUiDev() {
+    setDevBusy("ui");
+    setHint("");
+    try {
+      const res = await devRunScript("ui_dev");
+      if (!res.ok) throw new Error(res.error ?? "failed to start UI dev");
+      setHint(res.hint ?? "UI dev server starting — open http://127.0.0.1:5173/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "UI dev start failed");
+    } finally {
+      setDevBusy(null);
     }
   }
 
@@ -83,6 +124,39 @@ export default function LoginPage() {
         </div>
         {error ? <p className="error">{error}</p> : null}
         <button type="submit">Sign in</button>
+
+        <div className="login-dev-actions">
+          <p className="muted">Local dev (requires edge OPENFDD_ALLOW_INSECURE_AUTH=1):</p>
+          <div className="toolbar">
+            <button
+              type="button"
+              className="secondary-btn"
+              disabled={devBusy !== null}
+              onClick={() => void quickSignIn("integrator")}
+            >
+              {devBusy === "integrator" ? "Signing in…" : "Sign in as integrator"}
+            </button>
+            <button
+              type="button"
+              className="secondary-btn"
+              disabled={devBusy !== null}
+              onClick={() => void quickSignIn("admin")}
+            >
+              {devBusy === "admin" ? "Signing in…" : "Sign in as admin"}
+            </button>
+            <button
+              type="button"
+              className="secondary-btn"
+              disabled={devBusy !== null}
+              onClick={() => void startUiDev()}
+            >
+              {devBusy === "ui" ? "Starting…" : "Start UI dev (5173)"}
+            </button>
+          </div>
+          <p className="muted">
+            Manual password: <code>workspace/bootstrap_credentials.once.txt</code>
+          </p>
+        </div>
       </form>
     </div>
   );

--- a/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
+++ b/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
@@ -252,7 +252,7 @@ export default function SqlFddRulesPage() {
           <>
             DataFusion SQL rules for site <code>{siteId || "…"}</code>. Map points on{" "}
             <Link to="/model">Model & FDD assignments</Link> or the{" "}
-            <Link to="/wiresheet">FDD Wiresheet</Link>.
+            <Link to="/model">Model &amp; FDD assignments</Link>.
           </>
         }
       />
@@ -294,8 +294,8 @@ export default function SqlFddRulesPage() {
               >
                 Test query
               </button>
-              <Link className="secondary-btn" to="/wiresheet">
-                FDD Wiresheet
+              <Link className="secondary-btn" to="/model">
+                FDD mapping
               </Link>
             </div>
           </div>

--- a/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
+++ b/workspace/dashboard/src/pages/SqlFddRulesPage.tsx
@@ -1,103 +1,70 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import PageHeader from "../components/PageHeader";
+import SqlFddQueryEditor from "../components/sqlFdd/SqlFddQueryEditor";
+import SqlFddResultsPanel from "../components/sqlFdd/SqlFddResultsPanel";
+import SqlFddSchemaExplorer from "../components/sqlFdd/SqlFddSchemaExplorer";
+import SqlFddVisualBuilder from "../components/sqlFdd/SqlFddVisualBuilder";
+import {
+  DEFAULT_BUILDER,
+  type BuilderState,
+  type EquipmentRow,
+  type FddInput,
+  type QueryMode,
+  type SchemaTable,
+  ruleIdFromBuilder,
+} from "../components/sqlFdd/types";
 import { apiFetch } from "../lib/api";
-import { copyToClipboard } from "../lib/clipboard";
+import { compileNaturalLanguagePrompt, expandTimeMacros } from "../lib/fddSqlCompiler";
 import { formatApiError } from "../lib/formatApiError";
 import { useActiveSiteId } from "../lib/useActiveSiteId";
-
-type BuilderState = {
-  name: string;
-  input: string;
-  operator: string;
-  value: number;
-  equipment_id: string;
-  confirmation_seconds: number;
-  severity: string;
-  fault_code: string;
-};
-
-type FddInput = { id: string; label: string };
-
-function validationSummary(payload: Record<string, unknown> | null): string {
-  if (!payload) return "";
-  if (typeof payload.error === "string") return payload.error;
-  if (typeof payload.message === "string") return payload.message;
-  if (payload.ok === true) return "SQL validation passed.";
-  const issues = payload.issues;
-  if (Array.isArray(issues) && issues.length > 0) {
-    return issues.map((item) => String(item)).join("; ");
-  }
-  if (payload.valid === true) return "SQL validation passed.";
-  if (payload.valid === false) return "SQL validation failed — check table/column names.";
-  return "Validation finished.";
-}
-
-function runResultSummary(payload: Record<string, unknown> | null): string {
-  if (!payload) return "";
-  if (typeof payload.error === "string") return payload.error;
-  const confirmation = payload.confirmation as Record<string, unknown> | undefined;
-  const confirmed = confirmation?.confirmed_fault_count;
-  const raw = confirmation?.raw_fault_count;
-  if (typeof confirmed === "number" || typeof raw === "number") {
-    return `Raw faults: ${raw ?? 0} · Confirmed: ${confirmed ?? 0}`;
-  }
-  const rows = payload.rows;
-  if (Array.isArray(rows)) {
-    return `Preview returned ${rows.length} row(s).`;
-  }
-  const count = payload.row_count ?? payload.count;
-  if (typeof count === "number") return `Preview returned ${count} row(s).`;
-  if (payload.ok === true) return "SQL preview completed.";
-  return "Preview finished.";
-}
-
-function confirmedFaultRows(payload: Record<string, unknown> | null): Record<string, unknown>[] {
-  if (!payload?.rows || !Array.isArray(payload.rows)) return [];
-  return (payload.rows as Record<string, unknown>[]).filter(
-    (r) => r.confirmed_fault === true || r.confirmed_fault === "true",
-  );
-}
-
-function ruleIdFromBuilder(builder: BuilderState): string {
-  const base = builder.fault_code.trim() || builder.name.trim() || "fdd-rule";
-  return base.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "fdd-rule";
-}
-
-const DEFAULT_BUILDER: BuilderState = {
-  name: "OA Temperature Out Of Range",
-  input: "oa_t",
-  operator: ">",
-  value: 110,
-  equipment_id: "",
-  confirmation_seconds: 300,
-  severity: "medium",
-  fault_code: "OA_TEMP_OUT_OF_RANGE",
-};
 
 export default function SqlFddRulesPage() {
   const siteId = useActiveSiteId();
   const navigate = useNavigate();
-  const [mode, setMode] = useState<"builder" | "raw">("builder");
+  const [mode, setMode] = useState<QueryMode>("visual");
   const [builder, setBuilder] = useState<BuilderState>(DEFAULT_BUILDER);
   const [sql, setSql] = useState("");
-  const [rawCustom, setRawCustom] = useState(false);
+  const [sqlLocked, setSqlLocked] = useState(true);
+  const [prompt, setPrompt] = useState("Show OA temperature above 110 as an FDD fault");
+  const [compileResult, setCompileResult] = useState<ReturnType<typeof compileNaturalLanguagePrompt> | null>(null);
   const [fddInputs, setFddInputs] = useState<FddInput[]>([]);
+  const [schemaTables, setSchemaTables] = useState<SchemaTable[]>([]);
+  const [equipment, setEquipment] = useState<EquipmentRow[]>([]);
+  const [historian, setHistorian] = useState<Record<string, unknown> | null>(null);
   const [validation, setValidation] = useState<Record<string, unknown> | null>(null);
   const [runResult, setRunResult] = useState<Record<string, unknown> | null>(null);
   const [busy, setBusy] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [copyStatus, setCopyStatus] = useState("");
   const [actionStatus, setActionStatus] = useState("");
   const [error, setError] = useState("");
-  const equipmentMissing = mode === "builder" && !builder.equipment_id.trim();
-  const confirmedRows = useMemo(() => confirmedFaultRows(runResult), [runResult]);
+
+  const ruleId = useMemo(() => ruleIdFromBuilder(builder), [builder]);
+  const equipmentMissing = !builder.equipment_id.trim();
 
   useEffect(() => {
-    apiFetch<{ fdd_inputs?: FddInput[] }>("/api/fdd-schema/fdd-inputs")
-      .then((inputs) => setFddInputs(inputs.fdd_inputs ?? []))
+    Promise.all([
+      apiFetch<{ fdd_inputs?: FddInput[] }>("/api/fdd-schema/fdd-inputs"),
+      apiFetch<{ tables?: SchemaTable[] }>("/api/fdd-schema/tables"),
+      apiFetch<Record<string, unknown>>("/api/dashboard/historian-health"),
+    ])
+      .then(([inputs, schema, hist]) => {
+        setFddInputs(inputs.fdd_inputs ?? []);
+        setSchemaTables(schema.tables ?? []);
+        setHistorian(hist);
+      })
       .catch((e) => setError(formatApiError(e)));
   }, []);
+
+  useEffect(() => {
+    if (!siteId) return;
+    apiFetch<{ equipment?: EquipmentRow[] }>(`/api/model/sites/${encodeURIComponent(siteId)}/equipment`)
+      .then((res) => {
+        setEquipment(res.equipment ?? []);
+        const first = res.equipment?.[0]?.id ?? res.equipment?.[0]?.equipment_id;
+        if (first) setBuilder((b) => (b.equipment_id ? b : { ...b, equipment_id: first }));
+      })
+      .catch(() => setError("Could not load equipment for this site."));
+  }, [siteId]);
 
   const previewBuilder = useCallback(async () => {
     try {
@@ -105,35 +72,34 @@ export default function SqlFddRulesPage() {
         "/api/fdd-rules/builder-sql",
         { method: "POST", body: JSON.stringify(builder) },
       );
-      setSql(out.sql ?? "");
+      if (mode === "visual" && sqlLocked) setSql(out.sql ?? "");
       setValidation(out.validation ?? null);
-      setRawCustom(false);
     } catch (e) {
       setError(formatApiError(e));
     }
-  }, [builder]);
+  }, [builder, mode, sqlLocked]);
 
   useEffect(() => {
-    if (mode === "builder") void previewBuilder();
+    if (mode === "visual") void previewBuilder();
   }, [mode, builder.input, builder.operator, builder.value, builder.equipment_id, previewBuilder]);
 
-  async function runSql() {
-    if (equipmentMissing) {
-      setError("Select equipment first.");
-      return;
+  const insertSnippet = useCallback((snippet: string) => {
+    setSql((prev) => (prev ? `${prev}${prev.endsWith(" ") ? "" : " "}${snippet}` : snippet));
+    if (mode === "visual") {
+      setMode("sql");
+      setSqlLocked(false);
     }
+  }, [mode]);
+
+  async function validateSql() {
     setBusy(true);
     setError("");
     try {
-      const out = await apiFetch<Record<string, unknown>>("/api/fdd-rules/oa_temp_out_of_range/test-sql", {
-        method: "POST",
-        body: JSON.stringify({
-          sql,
-          confirmation_seconds: builder.confirmation_seconds,
-          params: { equipment_id: builder.equipment_id },
-        }),
-      });
-      setRunResult(out);
+      const out = await apiFetch<Record<string, unknown>>(
+        `/api/fdd-rules/${encodeURIComponent(ruleId)}/validate-sql`,
+        { method: "POST", body: JSON.stringify({ sql }) },
+      );
+      setValidation(out);
     } catch (e) {
       setError(formatApiError(e));
     } finally {
@@ -141,19 +107,54 @@ export default function SqlFddRulesPage() {
     }
   }
 
-  useEffect(() => {
-    if (!siteId) return;
-    apiFetch<{ equipment?: { id?: string; equipment_id?: string }[] }>(
-      `/api/model/sites/${encodeURIComponent(siteId)}/equipment`,
-    )
-      .then((res) => {
-        const first = res.equipment?.[0]?.id ?? res.equipment?.[0]?.equipment_id;
-        if (first) {
-          setBuilder((b) => (b.equipment_id ? b : { ...b, equipment_id: first }));
-        }
-      })
-      .catch(() => setError("Could not load equipment for this site — enter an equip id manually."));
-  }, [siteId]);
+  async function runSql() {
+    if (equipmentMissing) {
+      setError("Select equipment before running — queries must scope to a Haystack equip id.");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    setRunResult(null);
+    try {
+      const execSql = expandTimeMacros(sql);
+      const out = await apiFetch<Record<string, unknown>>(
+        `/api/fdd-rules/${encodeURIComponent(ruleId)}/test-sql`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            sql: execSql,
+            confirmation_seconds: builder.confirmation_seconds,
+            params: { equipment_id: builder.equipment_id },
+          }),
+        },
+      );
+      setRunResult(out);
+      if (out.validation) setValidation(out.validation as Record<string, unknown>);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function compilePrompt() {
+    setError("");
+    const out = compileNaturalLanguagePrompt({
+      userPrompt: prompt,
+      equipmentId: builder.equipment_id,
+      schema: schemaTables,
+      fddInputs,
+    });
+    setCompileResult(out);
+    if (out.ok && out.sql) {
+      setSql(out.sql);
+      setSqlLocked(false);
+      setMode("prompt");
+      setValidation(out.validation ?? null);
+    } else {
+      setError(out.error ?? "Could not compile prompt");
+    }
+  }
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -163,24 +164,7 @@ export default function SqlFddRulesPage() {
     return () => window.removeEventListener("keydown", onKey);
   });
 
-  async function validateSql() {
-    setBusy(true);
-    setError("");
-    try {
-      const out = await apiFetch<Record<string, unknown>>("/api/fdd-rules/oa_temp_out_of_range/validate-sql", {
-        method: "POST",
-        body: JSON.stringify({ sql }),
-      });
-      setValidation(out);
-    } catch (e) {
-      setError(formatApiError(e));
-    } finally {
-      setBusy(false);
-    }
-  }
-
   async function saveActivateAndDashboard() {
-    const ruleId = ruleIdFromBuilder(builder);
     setBusy(true);
     setError("");
     setActionStatus("");
@@ -190,7 +174,7 @@ export default function SqlFddRulesPage() {
         body: JSON.stringify({
           rule_id: ruleId,
           name: builder.name,
-          sql,
+          sql: expandTimeMacros(sql),
           confirmation_seconds: builder.confirmation_seconds,
           review_status: "approved",
           severity: builder.severity,
@@ -199,12 +183,9 @@ export default function SqlFddRulesPage() {
           site_id: siteId,
         }),
       });
-      await apiFetch(`/api/fdd-rules/${encodeURIComponent(ruleId)}/activate`, {
-        method: "POST",
-        body: "{}",
-      });
+      await apiFetch(`/api/fdd-rules/${encodeURIComponent(ruleId)}/activate`, { method: "POST", body: "{}" });
       window.dispatchEvent(new CustomEvent("ofdd-dashboard-refresh"));
-      setActionStatus(`Rule "${ruleId}" saved and activated — faults appear on the main dashboard.`);
+      setActionStatus(`Rule "${ruleId}" saved and activated.`);
       navigate("/");
     } catch (e) {
       setError(formatApiError(e));
@@ -216,27 +197,18 @@ export default function SqlFddRulesPage() {
   async function exportPdfReport() {
     setBusy(true);
     setError("");
-    setActionStatus("");
     try {
-      const out = await apiFetch<{ report_id?: string; pdf?: { download_url?: string } }>(
-        "/api/reports/from-fdd-sql-run",
-        {
-          method: "POST",
-          body: JSON.stringify({
-            rule_name: builder.name,
-            sql,
-            equipment_id: builder.equipment_id,
-            fault_code: builder.fault_code,
-            run_result: runResult,
-          }),
-        },
-      );
-      const url = out.pdf?.download_url;
-      setActionStatus(
-        url
-          ? `PDF report ${out.report_id ?? ""} ready — open Reports tab or download.`
-          : `Report draft ${out.report_id ?? ""} created.`,
-      );
+      const out = await apiFetch<{ report_id?: string }>("/api/reports/from-fdd-sql-run", {
+        method: "POST",
+        body: JSON.stringify({
+          rule_name: builder.name,
+          sql,
+          equipment_id: builder.equipment_id,
+          fault_code: builder.fault_code,
+          run_result: runResult,
+        }),
+      });
+      setActionStatus(`PDF report ${out.report_id ?? ""} created — see Reports tab.`);
     } catch (e) {
       setError(formatApiError(e));
     } finally {
@@ -244,14 +216,17 @@ export default function SqlFddRulesPage() {
     }
   }
 
+  const selectedEquip = equipment.find(
+    (e) => (e.id ?? e.equipment_id) === builder.equipment_id,
+  );
+
   return (
-    <div className="page page-wide sql-fdd-page">
+    <div className="page page-wide sql-fdd-page gf-query-page">
       <PageHeader
         title="SQL FDD Rules"
         subtitle={
           <>
-            DataFusion SQL rules for site <code>{siteId || "…"}</code>. Map points on{" "}
-            <Link to="/model">Model & FDD assignments</Link> or the{" "}
+            DataFusion read-only SQL against site <code>{siteId || "…"}</code>. Point bindings live on{" "}
             <Link to="/model">Model &amp; FDD assignments</Link>.
           </>
         }
@@ -259,227 +234,135 @@ export default function SqlFddRulesPage() {
 
       {error ? <div className="error-banner">{error}</div> : null}
 
-      <div className="sql-fdd-layout">
-        <section className="panel sql-fdd-builder-panel">
-          <div className="sql-fdd-toolbar">
-            <h2 className="panel-title">Rule builder</h2>
-            <div className="action-bar sql-fdd-mode-bar">
-              <button
-                type="button"
-                className={mode === "builder" ? "primary-btn" : "secondary-btn"}
-                onClick={() => {
-                  setMode("builder");
-                  setRawCustom(false);
-                }}
-              >
-                Visual builder
-              </button>
-              <button
-                type="button"
-                className={mode === "raw" ? "primary-btn" : "secondary-btn"}
-                onClick={() => setMode("raw")}
-              >
-                Raw SQL
-              </button>
-              {mode === "raw" ? (
-                <button type="button" className="secondary-btn" onClick={() => void validateSql()} disabled={busy}>
-                  Validate SQL
+      <div className="gf-context-bar">
+        <label className="gf-context-bar__field">
+          <span className="gf-field__label">Test against equipment</span>
+          <select
+            value={builder.equipment_id}
+            onChange={(e) => setBuilder({ ...builder, equipment_id: e.target.value })}
+          >
+            <option value="">Select equipment…</option>
+            {equipment.map((eq) => {
+              const id = eq.id ?? eq.equipment_id ?? "";
+              const label = eq.name ? `${eq.name} (${id})` : id;
+              return (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+        <div className="gf-context-bar__meta">
+          <span className="gf-pill">{selectedEquip?.equipment_type ? String(selectedEquip.equipment_type) : "equip"}</span>
+          <span className="gf-pill gf-pill--muted">
+            Historian: {String(historian?.row_count ?? 0).toLocaleString()} rows
+          </span>
+          {historian?.latest_sample_at ? (
+            <span className="gf-pill gf-pill--muted">Latest: {String(historian.latest_sample_at)}</span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="gf-query-layout">
+        <SqlFddSchemaExplorer tables={schemaTables} fddInputs={fddInputs} onInsert={insertSnippet} />
+
+        <div className="gf-query-main">
+          <div className="gf-query-toolbar">
+            <div className="gf-query-toolbar__modes">
+              {(["visual", "sql", "prompt"] as QueryMode[]).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={`gf-mode-btn${mode === m ? " is-active" : ""}`}
+                  onClick={() => setMode(m)}
+                >
+                  {m === "visual" ? "Visual rule" : m === "sql" ? "SQL editor" : "NL prompt"}
                 </button>
-              ) : null}
+              ))}
+            </div>
+            <div className="gf-query-toolbar__actions">
+              {mode !== "visual" || !sqlLocked ? (
+                <button type="button" className="secondary-btn" disabled={busy} onClick={() => void validateSql()}>
+                  Validate
+                </button>
+              ) : (
+                <button type="button" className="secondary-btn" onClick={() => setSqlLocked(false)}>
+                  Edit SQL
+                </button>
+              )}
               <button
                 type="button"
-                className="primary-btn"
+                className="primary-btn gf-run-btn"
+                disabled={busy || !sql.trim() || equipmentMissing}
                 onClick={() => void runSql()}
-                disabled={busy || (mode === "raw" ? !sql.trim() : equipmentMissing)}
               >
-                Test query
+                {busy ? "Running…" : "Run query"}
               </button>
-              <Link className="secondary-btn" to="/model">
-                FDD mapping
-              </Link>
             </div>
           </div>
 
-          <p className="muted sql-fdd-mode-hint">
-            {mode === "builder"
-              ? "Visual builder generates DataFusion SQL from FDD inputs — no manual SQL editing in this mode (Grafana-style)."
-              : "Raw SQL mode: write full SELECT against telemetry_pivot. Builder fields are hidden."}
-          </p>
-
-          {mode === "builder" ? (
-            <>
-              <div className="sql-vars-panel">
-                <h3 className="panel-subtitle">Available variables</h3>
-                <p className="muted">
-                  Table <code>telemetry_pivot</code> columns from mapped FDD inputs. Filter with{" "}
-                  <code>equipment_id = &apos;…&apos;</code>.
-                </p>
-                <div className="sql-var-chips">
-                  {fddInputs.map((i) => (
-                    <span key={i.id} className="chip" title={i.label}>
-                      {i.id}
-                    </span>
-                  ))}
-                </div>
-              </div>
-              <div className="builder-grid sql-fdd-builder-grid">
-              <label>
-                Rule name
-                <input value={builder.name} onChange={(e) => setBuilder({ ...builder, name: e.target.value })} />
-              </label>
-              <label>
-                FDD input
-                <select value={builder.input} onChange={(e) => setBuilder({ ...builder, input: e.target.value })}>
-                  {fddInputs.map((i) => (
-                    <option key={i.id} value={i.id}>
-                      {i.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Operator
-                <select value={builder.operator} onChange={(e) => setBuilder({ ...builder, operator: e.target.value })}>
-                  {[">", "<", ">=", "<="].map((op) => (
-                    <option key={op} value={op}>
-                      {op}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Threshold
-                <input
-                  type="number"
-                  value={builder.value}
-                  onChange={(e) => setBuilder({ ...builder, value: Number(e.target.value) })}
-                />
-              </label>
-              <label>
-                Equipment (Haystack equip id)
-                <input
-                  value={builder.equipment_id}
-                  onChange={(e) => setBuilder({ ...builder, equipment_id: e.target.value })}
-                />
-              </label>
-              <label>
-                Confirmation (sec)
-                <input
-                  type="number"
-                  value={builder.confirmation_seconds}
-                  onChange={(e) => setBuilder({ ...builder, confirmation_seconds: Number(e.target.value) })}
-                />
-              </label>
-              <label>
-                Fault code
-                <input value={builder.fault_code} onChange={(e) => setBuilder({ ...builder, fault_code: e.target.value })} />
-              </label>
+          <div className="gf-editor-panel">
+            <div className="gf-editor-panel__head">
+              <span className="gf-section-title">Query</span>
+              <span className="gf-pill gf-pill--dialect">DataFusion · telemetry_pivot</span>
+              <span className="muted gf-editor-panel__hint">Ctrl+Enter to run · read-only SELECT only</span>
             </div>
-              <details className="generated-sql-details">
-                <summary>Generated SQL (read-only)</summary>
-                <pre className="sql-block">{sql || "—"}</pre>
-              </details>
-            </>
-          ) : (
-            <label className="sql-editor-label">
-              DataFusion SQL
-              <textarea
-                className="sql-editor sql-editor--large"
-                value={sql}
-                onChange={(e) => {
-                  setSql(e.target.value);
-                  setRawCustom(true);
-                }}
-                spellCheck={false}
-                placeholder="SELECT timestamp, equipment_id, oa_t, … FROM telemetry_pivot WHERE …"
-              />
-            </label>
-          )}
-
-          {equipmentMissing && mode === "builder" ? (
-            <div className="warn-banner">Select Haystack equipment id before testing the query.</div>
-          ) : null}
-
-          {rawCustom && mode === "raw" ? (
-            <div className="warn-banner">Editing raw SQL — switch to Visual builder to use the form again.</div>
-          ) : null}
-
-          <div className="sql-fdd-results">
-            {validation ? <div className="status-banner">{validationSummary(validation)}</div> : null}
-            {runResult ? <div className="status-banner">{runResultSummary(runResult)}</div> : null}
+            <SqlFddQueryEditor
+              sql={sql}
+              readOnly={mode === "visual" && sqlLocked}
+              onChange={(next) => {
+                setSql(next);
+                setSqlLocked(false);
+                if (mode === "visual") setMode("sql");
+              }}
+            />
           </div>
 
-          {runResult ? (
-            <section className="panel sql-test-query-panel">
-              <div className="panel-head-row">
-                <h3 className="panel-title">FDD query results</h3>
-                <div className="action-bar">
-                  <button type="button" className="primary-btn" disabled={busy} onClick={() => void saveActivateAndDashboard()}>
-                    Save rule → dashboard
-                  </button>
-                  <button type="button" className="secondary-btn" disabled={busy} onClick={() => void exportPdfReport()}>
-                    Export PDF report
-                  </button>
-                  <Link className="secondary-btn" to="/">
-                    Main dashboard
-                  </Link>
-                  <Link className="secondary-btn" to="/exports">
-                    Reports tab
-                  </Link>
-                  <button
-                    type="button"
-                    className="secondary-btn"
-                    onClick={() => {
-                      void copyToClipboard(JSON.stringify(runResult, null, 2)).then((ok) =>
-                        setCopyStatus(ok ? "Copied JSON" : "Copy failed"),
-                      );
-                    }}
-                  >
-                    Copy JSON
-                  </button>
-                </div>
-              </div>
-              {actionStatus ? <p className="ok">{actionStatus}</p> : null}
-              {copyStatus ? <p className="muted">{copyStatus}</p> : null}
-              {confirmedRows.length ? (
-                <div className="table-like sql-fdd-confirmed-table">
-                  <div className="table-row table-head">
-                    <span>Timestamp</span>
-                    <span>Equipment</span>
-                    <span>Confirmed</span>
-                    <span>Minutes in fault</span>
-                  </div>
-                  {confirmedRows.slice(0, 12).map((row, i) => (
-                    <div key={i} className="table-row">
-                      <span>{String(row.timestamp ?? "")}</span>
-                      <span>{String(row.equipment_id ?? builder.equipment_id)}</span>
-                      <span>{String(row.confirmed_fault ?? true)}</span>
-                      <span>{String(row.minutes_in_fault ?? row.minutes_in_raw_fault ?? "—")}</span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="muted">No confirmed faults in this preview — adjust threshold or confirmation window.</p>
-              )}
-              <details className="advanced-json">
-                <summary>Full JSON response</summary>
-                <pre className="code-block sql-query-json">{JSON.stringify(runResult, null, 2)}</pre>
-              </details>
-            </section>
+          {mode === "visual" ? (
+            <SqlFddVisualBuilder builder={builder} fddInputs={fddInputs} onChange={setBuilder} />
           ) : null}
 
-          {(validation || runResult) && showAdvanced ? (
-            <details className="advanced-json" open>
-              <summary>Validation JSON</summary>
-              {validation ? <pre className="code-block">{JSON.stringify(validation, null, 2)}</pre> : null}
-            </details>
+          {mode === "prompt" ? (
+            <div className="gf-prompt-panel">
+              <label className="gf-field">
+                <span className="gf-field__label">Natural language request</span>
+                <textarea
+                  className="gf-prompt-input"
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  rows={3}
+                  placeholder="Show supply air temperature above 75 for the selected AHU over the historian range"
+                />
+              </label>
+              <button type="button" className="secondary-btn" disabled={busy} onClick={compilePrompt}>
+                Compile to SQL
+              </button>
+              {compileResult?.ok ? (
+                <pre className="gf-compile-json">{JSON.stringify(
+                  {
+                    sql: compileResult.sql,
+                    explanation: compileResult.explanation,
+                    dialect: compileResult.dialect,
+                  },
+                  null,
+                  2,
+                )}</pre>
+              ) : null}
+            </div>
           ) : null}
-          {(validation || runResult) && !showAdvanced ? (
-            <button type="button" className="secondary-btn" onClick={() => setShowAdvanced(true)}>
-              Show validation JSON
-            </button>
-          ) : null}
-        </section>
+
+          <SqlFddResultsPanel
+            validation={validation}
+            runResult={runResult}
+            compileResult={compileResult}
+            equipmentId={builder.equipment_id}
+            busy={busy}
+            onSave={() => void saveActivateAndDashboard()}
+            onExportPdf={() => void exportPdfReport()}
+            actionStatus={actionStatus}
+          />
+        </div>
       </div>
     </div>
   );

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -4333,6 +4333,520 @@ button.linkish {
   overflow: auto;
 }
 
+/* ── Grafana-style SQL FDD query workbench ── */
+.gf-query-page {
+  --gf-editor-bg: color-mix(in srgb, var(--bg) 70%, #0b0e14);
+  --gf-editor-border: color-mix(in srgb, var(--border) 80%, #1f2735);
+}
+
+[data-theme="dark"] .gf-query-page {
+  --gf-editor-bg: #0b0e14;
+  --gf-editor-border: #273043;
+}
+
+.gf-context-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: flex-end;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+}
+
+.gf-context-bar__field select {
+  min-width: min(420px, 100%);
+}
+
+.gf-context-bar__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.gf-query-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (max-width: 960px) {
+  .gf-query-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gf-schema {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  padding: 0.75rem;
+  max-height: calc(100vh - 220px);
+  overflow: auto;
+  position: sticky;
+  top: 0.75rem;
+}
+
+.gf-schema__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.gf-schema__title {
+  font-weight: 650;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.gf-schema__hint {
+  font-size: 0.8rem;
+  margin: 0 0 0.65rem;
+}
+
+.gf-schema__tree,
+.gf-schema__cols {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.gf-schema__table-btn,
+.gf-schema__col-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  padding: 0.35rem 0.4rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.gf-schema__table-btn:hover,
+.gf-schema__col-btn:hover {
+  background: var(--nav-hover-bg);
+}
+
+.gf-schema__table-btn.is-active {
+  background: var(--nav-active-bg);
+}
+
+.gf-schema__chev {
+  width: 0.75rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.gf-schema__table-name {
+  font-weight: 600;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+.gf-schema__count {
+  margin-left: auto;
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.gf-schema__desc {
+  font-size: 0.78rem;
+  margin: 0.15rem 0 0.35rem 1.1rem;
+}
+
+.gf-schema__cols {
+  margin-left: 0.75rem;
+  border-left: 1px solid var(--border);
+  padding-left: 0.35rem;
+}
+
+.gf-schema__col-name {
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+}
+
+.gf-schema__col-type {
+  margin-left: auto;
+  font-size: 0.68rem;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.gf-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.12rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--primary) 18%, var(--panel));
+  color: var(--nav-active-text);
+}
+
+.gf-pill--dialect {
+  background: color-mix(in srgb, var(--ok) 20%, var(--panel));
+  color: var(--ok);
+}
+
+.gf-pill--pk {
+  background: color-mix(in srgb, var(--warning) 25%, var(--panel));
+  color: var(--warning);
+}
+
+.gf-pill--fdd {
+  background: color-mix(in srgb, var(--primary) 22%, var(--panel));
+}
+
+.gf-pill--muted {
+  background: var(--panel-soft);
+  color: var(--muted);
+  text-transform: none;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.gf-query-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.gf-query-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.gf-query-toolbar__modes {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.gf-mode-btn {
+  border: none;
+  background: var(--panel);
+  color: var(--muted);
+  padding: 0.45rem 0.85rem;
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.gf-mode-btn + .gf-mode-btn {
+  border-left: 1px solid var(--border);
+}
+
+.gf-mode-btn.is-active {
+  background: var(--nav-active-bg);
+  color: var(--nav-active-text);
+  font-weight: 600;
+}
+
+.gf-query-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.gf-run-btn {
+  min-width: 7rem;
+}
+
+.gf-editor-panel {
+  border: 1px solid var(--gf-editor-border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--gf-editor-bg);
+}
+
+.gf-editor-panel__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  padding: 0.55rem 0.85rem;
+  border-bottom: 1px solid var(--gf-editor-border);
+  background: color-mix(in srgb, var(--panel) 60%, var(--gf-editor-bg));
+}
+
+.gf-section-title {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.gf-editor-panel__hint {
+  margin-left: auto;
+  font-size: 0.75rem;
+}
+
+.gf-sql-editor {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  min-height: 200px;
+}
+
+.gf-sql-editor__gutter {
+  padding: 0.75rem 0.55rem;
+  border-right: 1px solid var(--gf-editor-border);
+  color: var(--muted);
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  user-select: none;
+  text-align: right;
+}
+
+.gf-sql-editor__gutter span {
+  display: block;
+}
+
+.gf-sql-editor__input {
+  width: 100%;
+  border: none;
+  outline: none;
+  resize: vertical;
+  min-height: 200px;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  color: var(--input-text);
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  tab-size: 2;
+}
+
+.gf-visual-builder,
+.gf-prompt-panel {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  background: var(--panel);
+}
+
+.gf-visual-builder__head {
+  margin-bottom: 0.65rem;
+}
+
+.gf-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.65rem 0.85rem;
+}
+
+.gf-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.gf-field__label {
+  font-size: 0.72rem;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.gf-field input,
+.gf-field select,
+.gf-context-bar select,
+.gf-prompt-input {
+  width: 100%;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--input-text);
+  font: inherit;
+}
+
+.gf-prompt-input {
+  font-family: inherit;
+  resize: vertical;
+  margin-bottom: 0.5rem;
+}
+
+.gf-compile-json {
+  margin-top: 0.65rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: var(--panel-soft);
+  font-size: 0.78rem;
+  overflow: auto;
+  max-height: 180px;
+}
+
+.gf-results {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  padding: 0.75rem;
+}
+
+.gf-results__head {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.65rem;
+  margin-bottom: 0.65rem;
+}
+
+.gf-results__tabs {
+  display: inline-flex;
+  border-bottom: 1px solid var(--border);
+}
+
+.gf-results__tab {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  padding: 0.45rem 0.85rem;
+  font: inherit;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.gf-results__tab.is-active {
+  color: var(--text);
+  font-weight: 600;
+  border-bottom-color: var(--primary);
+}
+
+.gf-results__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.gf-results__explain {
+  font-size: 0.85rem;
+  margin: 0 0 0.65rem;
+}
+
+.gf-data-grid-wrap {
+  overflow: auto;
+  max-height: 360px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.gf-data-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.gf-data-grid th,
+.gf-data-grid td {
+  padding: 0.4rem 0.55rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.gf-data-grid th {
+  position: sticky;
+  top: 0;
+  background: var(--panel-soft);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.gf-data-grid tbody tr:hover {
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+}
+
+.gf-kv-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.65rem;
+  margin: 0 0 0.75rem;
+}
+
+.gf-kv-grid dt {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.gf-kv-grid dd {
+  margin: 0.1rem 0 0;
+  font-weight: 650;
+}
+
+.gf-validation__banner {
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  margin-bottom: 0.65rem;
+  font-weight: 600;
+  background: var(--panel-soft);
+}
+
+.gf-validation__banner.is-ok {
+  background: color-mix(in srgb, var(--ok) 15%, var(--panel));
+  color: var(--ok);
+}
+
+.gf-validation__banner.is-error {
+  background: color-mix(in srgb, var(--danger) 12%, var(--panel));
+  color: var(--danger);
+}
+
+.gf-validation__list {
+  margin: 0.35rem 0;
+  padding-left: 1.1rem;
+  font-size: 0.85rem;
+}
+
+.gf-validation__list--error {
+  color: var(--danger);
+}
+
+.gf-validation__list--warn {
+  color: var(--warning);
+}
+
+.gf-json-view {
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: var(--panel-soft);
+  font-size: 0.78rem;
+  max-height: 420px;
+  overflow: auto;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+}
+
+.gf-results__trunc {
+  padding: 0.35rem 0.55rem;
+  font-size: 0.78rem;
+}
+
 .report-builder-toolbar {
   flex-wrap: wrap;
   gap: 0.75rem;

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -957,6 +957,18 @@ textarea {
   width: min(400px, 92vw);
 }
 
+.login-dev-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.login-dev-actions .btn {
+  flex: 1 1 auto;
+  min-width: 8rem;
+}
+
 .sign-out-btn {
   margin-top: auto;
 }

--- a/workspace/dashboard/src/wiresheet/FddRuleWiresheet.tsx
+++ b/workspace/dashboard/src/wiresheet/FddRuleWiresheet.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from "../lib/api";
 import { formatApiError } from "../lib/formatApiError";
 import { useActiveSiteId } from "../lib/useActiveSiteId";
 import { graphToFlow, newNodeId } from "../wiresheet/graphAdapter";
+import { fetchWiresheetGraph } from "../wiresheet/wiresheetApi";
 import WiresheetCanvas, { connectEdge, createFlowNode } from "../wiresheet/WiresheetCanvas";
 import { useEdgesState, useNodesState, type Connection, type Node } from "@xyflow/react";
 import type { WiresheetGraph } from "../wiresheet/types";
@@ -21,6 +22,7 @@ export default function FddRuleWiresheet({ compact }: Props) {
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
   const [graphMeta, setGraphMeta] = useState<Partial<WiresheetGraph>>({});
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -45,7 +47,13 @@ export default function FddRuleWiresheet({ compact }: Props) {
 
   useEffect(() => {
     void loadGraph();
-  }, [loadGraph]);
+  }, [loadGraph, refreshKey]);
+
+  useEffect(() => {
+    const onChange = () => setRefreshKey((k) => k + 1);
+    window.addEventListener("ofdd-assignments-changed", onChange);
+    return () => window.removeEventListener("ofdd-assignments-changed", onChange);
+  }, []);
 
   const onConnect = useCallback(
     (connection: Connection) => {
@@ -58,14 +66,14 @@ export default function FddRuleWiresheet({ compact }: Props) {
     setBusy(true);
     setError("");
     try {
-      const out = await apiFetch<{ proposed?: unknown[]; review_status?: string }>(
+      const out = await apiFetch<{ proposed?: unknown[]; proposals?: unknown[]; review_status?: string }>(
         "/api/fdd-wires/propose-assignments",
         {
           method: "POST",
           body: JSON.stringify({ site_id: siteId || undefined, equipment_type: "ahu" }),
         },
       );
-      setStatus(`AI proposed ${out.proposed?.length ?? 0} bindings — reload to view.`);
+      setStatus(`AI proposed ${out.proposed?.length ?? out.proposals?.length ?? 0} bindings — reload to view.`);
       await loadGraph();
     } catch (e) {
       setError(formatApiError(e));


### PR DESCRIPTION
## Summary
- Recovers **PR #417** (bench validation / strict driver gate) and **PR #418** (agent UI, SQL FDD workbench, agent-first ingest) after their base branch was deleted by #415 merge.
- Adds fail-closed CSV preflight/execute, commissioning validation gate, MCP playbook tools, and post-ingest loop fixes (PDF download_url, historian csv labels, timeseries site filter).

## Validation (local)
- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test --workspace` — pass
- `cd workspace/dashboard && npm ci && npm run build && npm test -- --run` — pass

## GHCR tags expected (after merge + release workflow)
- `ghcr.io/bbartling/openfdd-edge-rust:3.2.4`, `:v3.2.4`, `:latest`, `:sha-<short>`
- `ghcr.io/bbartling/openfdd-mcp:3.2.4`, `:v3.2.4`, `:latest`, `:sha-<short>`

## MCP
Transitional Rust sidecar (`openfdd-mcp`); same release workflow as edge.

## Publish (maintainer)
```bash
gh workflow run rust-release.yml -f version=3.2.4 -f prerelease=false
```


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CSV ingest flow with preview, preflight, and safer execution checks.
  * Introduced FDD SQL workbench tools for natural-language queries, visual rule building, schema browsing, and result tabs.
  * Added dashboard “building insight” summaries and refreshed wiresheet/model mapping views.

* **Bug Fixes**
  * Improved CSV session handling, timestamp parsing, and historian query filtering.
  * Made assignment and commissioning imports stricter, with clearer validation feedback.

* **Documentation**
  * Expanded setup, bench validation, and release guidance for the latest workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->