### PR TITLE
Fix rust-release CI: remove missing npm lint step

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -63,7 +63,6 @@ jobs:
       - run: |
           cd workspace/dashboard
           npm ci
-          npm run lint
           npm run test
           npm run build
           test -f ../../frontend/index.html


### PR DESCRIPTION
## Summary
- `rust-release.yml` failed because `npm run lint` is not defined in `workspace/dashboard/package.json`.
- Align release frontend gate with `rust-ci.yml`: `npm ci`, `npm test`, `npm run build`.

## Test plan
- [ ] Merge and re-run: `gh workflow run rust-release.yml -f version=3.2.4 -f prerelease=false`


Made with [Cursor](https://cursor.com)