### PR TITLE
fix(docs): restore GitHub Pages Jekyll build

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
 gem "just-the-docs", "~> 0.10"
+gem "jekyll-seo-tag"
+gem "jekyll-github-metadata"


### PR DESCRIPTION
## Summary
- Adds `jekyll-github-metadata` and `jekyll-seo-tag` to `docs/Gemfile` — both are declared in `docs/_config.yml` plugins but were missing from the bundle, causing **Docs (GitHub Pages)** to fail with `LoadError: jekyll-github-metadata` (e.g. run 28535260914 on the 3.2.6 merge).

## Test plan
- [ ] Merge and confirm **Docs (GitHub Pages)** workflow succeeds on `master`
- [ ] Verify https://bbartling.github.io/open-fdd/ updates


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two Jekyll-related dependencies to improve the documentation site’s build and metadata support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->