### PR TITLE
fix(ci): GHCR prune bad substitution

### DIFF
--- a/scripts/ghcr_prune_packages.sh
+++ b/scripts/ghcr_prune_packages.sh
@@ -130,7 +130,7 @@ decide_action() {
     if [[ "$tag" == sha-* && "$age" -ge "$DELETE_SHA_DAYS" ]]; then
       has_sha_old=1
     fi
-    local key="${semver_key "$tag" || true}"
+    local key="$(semver_key "$tag" || true)"
     if [[ -n "$key" ]]; then
       local norm="${key#*|}"
       if [[ " ${SEMVER_KEEP[*]} " == *" $norm "* || " ${SEMVER_KEEP[*]} " == *" v$norm "* ]]; then


### PR DESCRIPTION
## Summary
Fixes `prune-ghcr` job failure from invalid bash on line 133 (`${semver_key ...}` → `$(semver_key ...)`). This caused the Rust Release workflow to report failure even after the GitHub Release and GHCR tags were published successfully (seen on 3.2.5).

## Test plan
- [ ] Merge and re-run Rust Release if needed; confirm `prune-ghcr` completes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how release tags are evaluated during cleanup, improving semver-based retention decisions.
  * Fixed an issue that could cause tags to be compared incorrectly when determining which releases to keep.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->