### PR TITLE
fix(ci): allowlist bench agent prompts in anti-hardcoding audit

### DIFF
--- a/scripts/audit_no_private_bench_hardcoding.sh
+++ b/scripts/audit_no_private_bench_hardcoding.sh
@@ -38,8 +38,11 @@ is_allowed() {
     workspace/smoke-profiles/local/local_5007_validation.local.toml.example) return 0 ;;
     workspace/smoke-profiles/local/local_haystack_5007_parity.local.toml.example) return 0 ;;
     tests/fixtures/*) return 0 ;;
+    edge/tests/fixtures/*) return 0 ;;
     docs/validation/*|docs/verification/*|docs/testing/*|docs/release_cleanup/*) return 0 ;;
     docs/agent/bench-driver-setup-wsl-agent.md) return 0 ;;
+    docs/agent/bench-*-closeout-agent-prompt.md) return 0 ;;
+    docs/archive/*) return 0 ;;
     docs/archive/agent/bench-driver-setup-wsl-agent.md) return 0 ;;
     docs/archive/verification/bacnet-nic-setup.md) return 0 ;;
     docs/archive/release_cleanup/current_pr_issue_ledger.md) return 0 ;;


### PR DESCRIPTION
## Summary
- Fixes **Rust Edge CI** failures on master caused by the anti-hardcoding audit flagging legitimate bench-only docs and edge test fixtures.
- Allowlists `docs/agent/bench-*-closeout-agent-prompt.md`, `docs/archive/*`, and `edge/tests/fixtures/*`.

## Test plan
- [ ] `./scripts/audit_no_private_bench_hardcoding.sh` passes locally
- [ ] Rust Edge CI green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the audit check’s allowed file patterns so certain fixture, documentation, and archived content is no longer flagged as a violation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->