### PR TITLE
fix(bacnet): Who-Is shell for field devices (5007) + edge issue iteration prompt

### DIFF
--- a/docker/compose.edge.rust.yml
+++ b/docker/compose.edge.rust.yml
@@ -42,12 +42,13 @@ services:
       OPENFDD_JSON_API_ENABLED: ${OPENFDD_JSON_API_ENABLED:-1}
       OPENFDD_IMPORT_ENABLED: ${OPENFDD_IMPORT_ENABLED:-1}
       OPENFDD_EXPORT_ENABLED: ${OPENFDD_EXPORT_ENABLED:-1}
+      # Bridge may run the diagnostic local device. Do not load commission.env here —
+      # that file's OPENFDD_BACNET_SERVER_ENABLED would override and steal OT Who-Is.
+      OPENFDD_BACNET_SERVER_ENABLED: ${OPENFDD_BRIDGE_BACNET_SERVER_ENABLED:-1}
     # Auth is read at runtime from OPENFDD_WORKSPACE/auth.env.local (do not use env_file —
     # Docker Compose mangles bcrypt `$` in hash values).
     env_file:
       - path: ${OPENFDD_COMPOSE_ROOT:?}/workspace/data.env.local
-        required: false
-      - path: ${OPENFDD_COMPOSE_ROOT:?}/workspace/bacnet/commissioning/commission.env
         required: false
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/api/health"]
@@ -73,6 +74,9 @@ services:
       OPENFDD_BACNET_MODE: ${OPENFDD_BACNET_MODE:-live}
       OPENFDD_BACNET_ENABLED: ${OPENFDD_BACNET_ENABLED:-1}
       OPENFDD_MODBUS_ENABLED: ${OPENFDD_MODBUS_ENABLED:-1}
+      # Commission owns OT Who-Is / ReadProperty on host-network UDP.
+      # Local BACnet server must stay off here (default 0) or field devices never appear.
+      OPENFDD_BACNET_SERVER_ENABLED: ${OPENFDD_COMMISSION_BACNET_SERVER_ENABLED:-0}
     env_file:
       - path: ${OPENFDD_COMPOSE_ROOT:?}/workspace/data.env.local
         required: false

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -47,6 +47,7 @@ exclude:
   - agent/bench-330-beta-cycle-agent-prompt.md
   - agent/bench-330-issue-iteration-agent-prompt.md
   - agent/vibe16-bacnet-feather-port-agent-prompt.md
+  - agent/linux-edge-tester-prompt.md
   - agent/bench-vs-source.md
   - agent/bench-driver-setup-wsl-agent.md
   - Gemfile

--- a/docs/agent/bench-330-beta-cycle-agent-prompt.md
+++ b/docs/agent/bench-330-beta-cycle-agent-prompt.md
@@ -93,14 +93,14 @@ OPENFDD_BACNET_DAEMON_MAX_CYCLES=0 ./scripts/openfdd_bacnet_poll_daemon.sh start
 | **After any test** | Verify daemon still running; restart if dead |
 | **Never** | Stop daemon at end of report "to save CPU" — charts/FDD need continuous ingest |
 
-**BACnet local server 599999 (critical split):**
+**BACnet local diagnostic server vs OT Who-Is (compose enforces defaults):**
 
-| File | Value | Why |
-|------|-------|-----|
-| `workspace/data.env.local` | `OPENFDD_BACNET_SERVER_ENABLED=1` | Bridge exposes diagnostic device **599999** |
-| `workspace/bacnet/commissioning/commission.env` | `OPENFDD_BACNET_SERVER_ENABLED=0` | Commission owns OT Who-Is on UDP 47808 — **must stay 0** or field device **5007** never appears |
+| Service | Default `OPENFDD_BACNET_SERVER_ENABLED` | Role |
+|---------|----------------------------------------|------|
+| `openfdd-bridge` | `1` (`OPENFDD_BRIDGE_BACNET_SERVER_ENABLED`) | Optional local diagnostic device (default instance **599999**) |
+| `openfdd-commission` | `0` (`OPENFDD_COMMISSION_BACNET_SERVER_ENABLED`) | OT Who-Is / ReadProperty on host-network UDP |
 
-If commission has `=1`, Who-Is only sees 599999 and Phase A BACnet stays FAIL. After env change: `openfdd_rust_dcompose up -d --force-recreate`.
+Field devices are **whatever Who-Is returns** on that site — never hardcoded in product code. Verify with `docker exec … printenv OPENFDD_BACNET_SERVER_ENABLED`. After env/compose change: `openfdd_rust_dcompose up -d --force-recreate`.
 
 ---
 

--- a/docs/agent/bench-330-beta-cycle-agent-prompt.md
+++ b/docs/agent/bench-330-beta-cycle-agent-prompt.md
@@ -93,7 +93,14 @@ OPENFDD_BACNET_DAEMON_MAX_CYCLES=0 ./scripts/openfdd_bacnet_poll_daemon.sh start
 | **After any test** | Verify daemon still running; restart if dead |
 | **Never** | Stop daemon at end of report "to save CPU" — charts/FDD need continuous ingest |
 
-**BACnet local server 599999:** `OPENFDD_BACNET_SERVER_ENABLED=1` in **both** `workspace/data.env.local` and `workspace/bacnet/commissioning/commission.env`.
+**BACnet local server 599999 (critical split):**
+
+| File | Value | Why |
+|------|-------|-----|
+| `workspace/data.env.local` | `OPENFDD_BACNET_SERVER_ENABLED=1` | Bridge exposes diagnostic device **599999** |
+| `workspace/bacnet/commissioning/commission.env` | `OPENFDD_BACNET_SERVER_ENABLED=0` | Commission owns OT Who-Is on UDP 47808 — **must stay 0** or field device **5007** never appears |
+
+If commission has `=1`, Who-Is only sees 599999 and Phase A BACnet stays FAIL. After env change: `openfdd_rust_dcompose up -d --force-recreate`.
 
 ---
 

--- a/docs/agent/bench-330-issue-iteration-agent-prompt.md
+++ b/docs/agent/bench-330-issue-iteration-agent-prompt.md
@@ -65,6 +65,13 @@ OPENFDD_IMAGE_TAG=nightly ./scripts/openfdd_src_sync_for_test.sh
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/health | jq '{status,image_tag,git_sha}'
 ```
 
+**BACnet env (must stay correct):**
+
+| File | Required |
+|------|----------|
+| `workspace/data.env.local` | `OPENFDD_BACNET_SERVER_ENABLED=1` (local diagnostic server on bridge) |
+| `workspace/bacnet/commissioning/commission.env` | `OPENFDD_BACNET_SERVER_ENABLED=0` (field Who-Is on commission) |
+
 ## Phase 2 — A′ BACnet (primary gate)
 
 ```bash
@@ -81,3 +88,12 @@ Post JSON snippets + verdict on **#429** and **#433**.
 ## Phase 3 — resume B–D
 
 Only after A′ **PASS**. Follow phases in [bench-330-beta-cycle-agent-prompt.md](./bench-330-beta-cycle-agent-prompt.md).
+
+Keep poll daemon running: `OPENFDD_BACNET_DAEMON_MAX_CYCLES=0 ./scripts/openfdd_bacnet_poll_daemon.sh start`
+
+## Never
+
+- `docker compose down -v` · delete `workspace/` · print tokens
+- Stop poll daemon after tests
+- Fix product code or `git push`
+- Close issues unless maintainer confirms PASS on pinned nightly

--- a/docs/agent/bench-vs-source.md
+++ b/docs/agent/bench-vs-source.md
@@ -36,7 +36,7 @@ OPENFDD_IMAGE_TAG="${OPENFDD_IMAGE_TAG:-nightly}" ./scripts/openfdd_src_sync_for
 | Poll daemon | Local `openfdd_bacnet_poll_daemon.sh` — **`OPENFDD_BACNET_DAEMON_MAX_CYCLES=0`** (unlimited) |
 | Bounded cycles | Only inside a single test phase (`run-for N`) |
 | After tests | Daemon **stays running** — do not stop overnight |
-| BACnet server 599999 | `OPENFDD_BACNET_SERVER_ENABLED=1` in `data.env.local` + `commission.env` |
+| BACnet server 599999 | Bridge compose default **SERVER_ENABLED=1**; **commission.env `=0`** |
 
 After env changes: `openfdd_rust_dcompose up -d --force-recreate`.
 

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -42,7 +42,8 @@ See [examples/external-agents.md](../examples/external-agents.md).
 | [openfdd-mcp-tool-contract.md](openfdd-mcp-tool-contract.md) | MCP tool surface |
 | [bench-vs-source.md](bench-vs-source.md) | Bench vs product source trees *(paste-only — not on Pages)* |
 | [vibe16-bacnet-feather-port-agent-prompt.md](vibe16-bacnet-feather-port-agent-prompt.md) | **Product agent** — vibe16 BACnet/Feather port cycle *(paste-only)* |
-| [bench-330-beta-cycle-agent-prompt.md](bench-330-beta-cycle-agent-prompt.md) | **Bench agent** — Linux edge tester *(paste-only)* |
+| [linux-edge-tester-prompt.md](linux-edge-tester-prompt.md) | **Linux edge tester** — turnkey copy-paste validation *(paste-only)* |
+| [bench-330-beta-cycle-agent-prompt.md](bench-330-beta-cycle-agent-prompt.md) | **Bench agent** — full 3.3.0-beta cycle *(paste-only)* |
 | [bench-330-issue-iteration-agent-prompt.md](bench-330-issue-iteration-agent-prompt.md) | Bench iteration loop after product merges *(paste-only)* |
 | [bench-driver-setup-wsl-agent.md](bench-driver-setup-wsl-agent.md) | WSL setup reference |
 

--- a/docs/agent/linux-edge-tester-prompt.md
+++ b/docs/agent/linux-edge-tester-prompt.md
@@ -1,0 +1,270 @@
+# Linux edge tester — turnkey prompt (paste into Cursor on `/home/ben/open-fdd`)
+
+**Copy everything below the line into a new Cursor chat on the bench Linux edge host.**
+
+---
+
+```
+You are the Open-FDD Linux edge tester on /home/ben/open-fdd.
+
+Charter: TEST, DOCUMENT, REPORT — no Rust/TS edits, no git push, no upstream PR.
+Product fixes ship from WSL/source (vibe16 product agent). You pull :nightly and sign off on GitHub.
+
+Acknowledged. Bench tree /home/ben/open-fdd. Channel: nightly. Primary gate #429.
+Will post evidence on #429, #433, and linked issues. No git push.
+```
+
+## Your job
+
+1. Deploy latest **GHCR `:nightly`** after each product merge
+2. Run gated validation phases (A → A′ → B → C → D)
+3. Post **copy-paste evidence** on GitHub issues (JSON snippets, pass/fail)
+4. Update `workspace/reports/REV_330_RIGOROUS_TEST_REPORT.md` when running local harness
+5. Keep **poll daemon running** permanently (production-like)
+
+**Never:** fix product code on bench · `docker compose down -v` · delete `workspace/` · print tokens
+
+---
+
+## Open GitHub issues (report on these)
+
+| Issue | What you prove | Close when |
+|-------|----------------|------------|
+| **[#429](https://github.com/bbartling/open-fdd/issues/429)** | **Sign-off gate** — always comment each iteration | Bench PASS on pinned nightly + maintainer YES |
+| **[#433](https://github.com/bbartling/open-fdd/issues/433)** | Drivers, BACnet Who-Is, driver tree, historian UX | A′ PASS: Who-Is JSON + field devices in tree |
+| **[#431](https://github.com/bbartling/open-fdd/issues/431)** | `/api/agent/validate`, bootstrap parity | After A′ green |
+| **[#430](https://github.com/bbartling/open-fdd/issues/430)** | README / MCP TLS docs | Doc review only (cookbook live on Pages) |
+| **[#432](https://github.com/bbartling/open-fdd/issues/432)** | Niagara pivot | When in scope after A′ |
+| **[#434](https://github.com/bbartling/open-fdd/issues/434)** | Selenium matrix | Phase C |
+| **[#435](https://github.com/bbartling/open-fdd/issues/435)** | ZAP security matrix | Phase D |
+| **[#437](https://github.com/bbartling/open-fdd/issues/437)** | oxigraph advisory | Note version from `/api/health` only |
+
+**Docs for you:** [FDD Rule Cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/) · [Release channels](https://bbartling.github.io/open-fdd/operations/release-channels.html)
+
+---
+
+## Turn-key session start (run every visit)
+
+```bash
+cd /home/ben/open-fdd
+export OPENFDD_IMAGE_TAG=nightly
+export OPENFDD_COMPOSE_ROOT="$PWD"
+
+# Auth (integrator — never echo token)
+INTEGRATOR_PW="$(grep '^OFDD_INTEGRATOR_PASSWORD=' workspace/auth.env.local | cut -d= -f2-)"
+TOKEN="$(curl -s -X POST http://127.0.0.1:8080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg u integrator --arg p "$INTEGRATOR_PW" '{username:$u,password:$p}')" \
+  | jq -r '.token // .access_token')"
+
+# Pull + deploy nightly
+OPENFDD_IMAGE_TAG=nightly ./scripts/openfdd_bench_pull_ghcr.sh
+NEW_TAG=nightly OPENFDD_RESTORE_HISTORIAN_AFTER_UPDATE=1 ./scripts/openfdd_rust_site_update.sh
+OPENFDD_IMAGE_TAG=nightly ./scripts/openfdd_src_sync_for_test.sh
+./scripts/openfdd_rust_dcompose up -d --force-recreate
+./scripts/openfdd_rust_edge_validate.sh
+
+# Record deploy identity
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/health \
+  | jq '{status,image_tag,version,git_sha}'
+```
+
+If `image_tag` is not `nightly` or health fails → stop and post on **#429**.
+
+---
+
+## BACnet env split (critical — verify before A′)
+
+Compose **splits** local diagnostic server vs field Who-Is:
+
+| Container | `OPENFDD_BACNET_SERVER_ENABLED` | Purpose |
+|-----------|----------------------------------|---------|
+| **openfdd-bridge** | **1** (via compose default) | Local diagnostic device **599999** |
+| **openfdd-commission** | **0** (via compose default) | Field Who-Is / ReadProperty on host UDP |
+
+Verify workspace files do **not** override compose incorrectly:
+
+```bash
+echo "=== data.env.local (bridge drivers) ==="
+grep -E 'BACNET_SERVER|BACNET_MODE|BACNET_BIND' workspace/data.env.local 2>/dev/null || echo "(missing OK if compose defaults)"
+
+echo "=== commission.env (OT commissioning) ==="
+grep -E 'BACNET_SERVER|BACNET_MODE|BACNET_BIND|BACNET_IFACE' \
+  workspace/bacnet/commissioning/commission.env 2>/dev/null || echo "MISSING — run bootstrap"
+
+# commission.env must NOT force SERVER_ENABLED=1 (blocks field Who-Is)
+if grep -q '^OPENFDD_BACNET_SERVER_ENABLED=1' workspace/bacnet/commissioning/commission.env 2>/dev/null; then
+  echo "FAIL: set OPENFDD_BACNET_SERVER_ENABLED=0 in commission.env then recreate stack"
+fi
+```
+
+After any env change:
+
+```bash
+./scripts/openfdd_rust_dcompose up -d --force-recreate
+```
+
+---
+
+## Poll daemon (keep running forever)
+
+```bash
+./scripts/openfdd_bacnet_poll_daemon.sh stop 2>/dev/null || true
+OPENFDD_BACNET_DAEMON_MAX_CYCLES=0 ./scripts/openfdd_bacnet_poll_daemon.sh start
+./scripts/openfdd_bacnet_poll_daemon.sh status
+```
+
+Do **not** stop daemon after tests. Use bounded cycles only inside a single phase script.
+
+---
+
+## Phase A — Modbus poll → Feather (P0)
+
+**Pass:** samples increment, feather files grow, historian rows increase.
+
+```bash
+OPENFDD_POLL_VALIDATE_CYCLES=5 ./scripts/openfdd_polling_feather_validate.sh
+
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/modbus/poll/status \
+  | jq '{samples,enabled_points,last_poll,errors}'
+
+find workspace/data/feather_store -name '*.feather' 2>/dev/null | wc -l
+
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/agent/validate \
+  | jq '{ok,modbus_poll,historian_row_count,feather_shards}'
+```
+
+---
+
+## Phase A′ — BACnet Who-Is + driver tree (PRIMARY GATE)
+
+**Pass criteria:**
+
+- `POST /api/bacnet/whois` returns JSON within **~30 seconds** (no hang, no empty response forever)
+- `GET /api/bacnet/driver/tree` returns JSON without hang
+- Tree lists **field device instance(s)** from Who-Is cache — not only local diagnostic **599999**
+
+```bash
+# Who-Is (commission path — may also test via bridge API)
+time curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  http://127.0.0.1:8080/api/bacnet/whois -d '{}' | jq .
+
+# Driver tree
+time curl -s -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8080/api/bacnet/driver/tree | jq .
+
+# Poll status + feather from BACnet
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/poll/status | jq .
+find workspace/data/feather_store/bacnet -name '*.feather' 2>/dev/null | wc -l
+```
+
+Your bench field device is an **acceptance example only** — product must work for any instance Who-Is returns. Record instances found, not hardcoded IDs in upstream.
+
+If FAIL → post evidence on **#433** and **#429**. Do **not** patch Rust on bench. Wait for new `:nightly` (poll GH Actions at most every 15–30 min):
+
+```bash
+gh run list --workflow=rust-ghcr.yml --branch master --limit 3 \
+  --json databaseId,status,conclusion,headSha,displayTitle
+```
+
+---
+
+## Phase B — FDD soak (after A + A′ PASS)
+
+```bash
+OPENFDD_SOAK_MINUTES=10 ./scripts/openfdd_stores_fdd_soak.sh
+```
+
+Comment **#431** if `/api/agent/validate` improves.
+
+---
+
+## Phase C — Full rigorous + Selenium (after A′ PASS)
+
+```bash
+OPENFDD_ALWAYS_POLL=1 OPENFDD_START_BACNET_DAEMON=1 \
+  ./scripts/openfdd_rigorous_full_run.sh
+```
+
+Track **#434**. Report: `workspace/reports/REV_330_RIGOROUS_TEST_REPORT.md`
+
+Or local closeout:
+
+```bash
+OPENFDD_BENCH_TAG=nightly OPENFDD_BENCH_POLL_CYCLES=5 \
+  ./scripts/openfdd_rigorous_bench_report.sh
+```
+
+---
+
+## Phase D — ZAP matrix (after A + B green)
+
+```bash
+OPENFDD_RUN_ZAP=1 OPENFDD_ZAP_CADDY_MATRIX=1 OPENFDD_SKIP_ZAP=0 \
+  ./scripts/openfdd_soak_pcap_zap_finalize.sh
+```
+
+Track **#435**.
+
+---
+
+## GitHub comment template (paste every iteration on #429)
+
+```markdown
+## Edge iteration — nightly @ `<git_sha>`
+
+**Deploy:** `image_tag` / `version` from `/api/health`
+**Poll daemon:** running | stopped
+**Compose:** full-edge recreated Y/N
+
+| Phase | Result | Evidence |
+|-------|--------|----------|
+| A modbus→feather | PASS/FAIL | samples=… feather_files=… |
+| A′ BACnet Who-Is | PASS/FAIL | whois returned in …s |
+| A′ driver tree | PASS/FAIL | instances=[…] |
+| B FDD soak | PASS/FAIL/SKIP | |
+| C rigorous | PASS/FAIL/SKIP | |
+| D ZAP | PASS/FAIL/SKIP | |
+
+**Sign-off:** YES / NO
+
+**Waiting on product:** #445 merged / none / <issue list>
+```
+
+Also comment on **#433** when BACnet status changes.
+
+---
+
+## When to close issues
+
+You **do not** close issues yourself unless maintainer confirms. Post PASS with pinned `git_sha`; maintainer closes when re-verified.
+
+---
+
+## Restore local harness (if scripts missing)
+
+Rigorous scripts are **bench-local** (Google Drive backup — not in upstream):
+
+```bash
+tar -xzf openfdd_rigorous_scripts_*.tar.gz -C /home/ben/open-fdd
+chmod +x /home/ben/open-fdd/scripts/openfdd_*.sh
+```
+
+Local profile: `workspace/bench/bench_profile.toml` (never commit — OT IPs, `results_issue = 429`).
+
+---
+
+## Reference links
+
+| Doc | URL |
+|-----|-----|
+| Product agent (WSL builds fixes) | https://github.com/bbartling/open-fdd/blob/master/docs/agent/vibe16-bacnet-feather-port-agent-prompt.md |
+| Full beta cycle | https://github.com/bbartling/open-fdd/blob/master/docs/agent/bench-330-beta-cycle-agent-prompt.md |
+| GHCR nightly workflow | https://github.com/bbartling/open-fdd/actions/workflows/rust-ghcr.yml |
+| Vibe16 BACnet lab | https://github.com/bbartling/py-bacnet-stacks-playground/tree/develop/vibe_code_apps_16 |
+
+---
+
+## Done when
+
+**#429** comment says **Sign-off: YES** with Phase A + A′ + B green (C/D per open issues), poll daemon running, and all blocking issues PASS or explicitly deferred by maintainer.

--- a/docs/drivers/bacnet.md
+++ b/docs/drivers/bacnet.md
@@ -10,8 +10,12 @@ BACnet/IP runs in the **commission** container (`network_mode: host`). The bridg
 
 ## Configuration
 
-- `workspace/bacnet/commissioning/commission.env` — NIC, BBMD, device filters
+- `workspace/bacnet/commissioning/commission.env` — NIC, BBMD, device filters (**`OPENFDD_BACNET_SERVER_ENABLED=0`** on commission)
+- `docker/compose.edge.rust.yml` — bridge vs commission server flags split (bridge **1**, commission **0**)
 - `OPENFDD_BACNET_MODE` — `live` for field buses
+
+{: .important }
+**Compose split:** bridge runs the local diagnostic device (599999). Commission runs field Who-Is — never enable the local BACnet server on the commission container.
 
 ## Key API routes
 

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -2344,8 +2344,13 @@ mod override_export_tests {
     #[test]
     fn whois_shell_adds_field_device_when_live_discovery_unavailable() {
         crate::test_support::with_temp_workspace(|root| {
+            let pin_ws = || std::env::set_var("OPENFDD_WORKSPACE", root);
+            let prev_inst = std::env::var("OPENFDD_BACNET_DEVICE_INSTANCE").ok();
+            std::env::set_var("OPENFDD_BACNET_DEVICE_INSTANCE", "599999");
+            pin_ws();
+            write_registry(&default_registry());
             // Generic instance + TEST-NET address — no site-specific OT hardcoding.
-            let inst = 424_242_u32;
+            let inst = 987_654_u32;
             let addr = "198.51.100.50:47808";
             let cache = root
                 .join("data")
@@ -2364,9 +2369,11 @@ mod override_export_tests {
                 }))
                 .unwrap(),
             );
+            pin_ws();
             assert!(ensure_field_device_shell(inst, Some(addr.to_string())));
+            pin_ws();
             let registry = read_registry();
-            let devices = registry["drivers"][0]["devices"].as_array().unwrap();
+            let devices = bacnet_devices_array(&registry);
             let field = devices
                 .iter()
                 .find(|d| d.get("device_instance").and_then(|v| v.as_u64()) == Some(inst as u64));
@@ -2374,15 +2381,39 @@ mod override_export_tests {
             assert_eq!(field.unwrap()["address"].as_str(), Some(addr));
             assert_eq!(field.unwrap()["source"].as_str(), Some("whois-shell"));
             // Second call is a no-op (already present).
+            pin_ws();
             assert!(!ensure_field_device_shell(inst, None));
             // Cache-only merge must not hang / invent devices beyond Who-Is.
+            pin_ws();
             merge_missing_field_devices_from_cache();
+            pin_ws();
             let again = read_registry();
-            let count = again["drivers"][0]["devices"]
-                .as_array()
-                .map(|a| a.len())
-                .unwrap_or(0);
-            assert!(count >= 1);
+            assert!(
+                bacnet_devices_array(&again)
+                    .iter()
+                    .any(|d| d.get("device_instance").and_then(|v| v.as_u64()) == Some(inst as u64)),
+                "Who-Is shell must survive cache merge"
+            );
+            if let Some(p) = prev_inst {
+                std::env::set_var("OPENFDD_BACNET_DEVICE_INSTANCE", p);
+            } else {
+                std::env::remove_var("OPENFDD_BACNET_DEVICE_INSTANCE");
+            }
         });
+    }
+
+    fn bacnet_devices_array(registry: &Value) -> &[Value] {
+        registry
+            .get("drivers")
+            .and_then(|v| v.as_array())
+            .and_then(|drivers| {
+                drivers
+                    .iter()
+                    .find(|d| d.get("id").and_then(|v| v.as_str()) == Some("bacnet-ip"))
+            })
+            .and_then(|d| d.get("devices"))
+            .and_then(|v| v.as_array())
+            .map(|a| a.as_slice())
+            .unwrap_or(&[])
     }
 }

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -267,6 +267,77 @@ fn cached_whois_instances() -> Vec<u32> {
         .unwrap_or_default()
 }
 
+/// Address from Who-Is cache for a field instance (if known).
+fn cached_whois_address(device_instance: u32) -> Option<String> {
+    let path = whois_cache_path();
+    let text = fs::read_to_string(path).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    let devices = v.get("devices")?.as_array()?;
+    for dev in devices {
+        let inst = dev
+            .get("object_identifier")
+            .and_then(|o| o.get("instance"))
+            .and_then(|x| x.as_u64())
+            .or_else(|| dev.get("device_instance").and_then(|x| x.as_u64()))
+            .map(|n| n as u32);
+        if inst == Some(device_instance) {
+            if let Some(addr) = dev.get("address").and_then(|a| a.as_str()) {
+                if !addr.is_empty() {
+                    return Some(addr.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Ensure a field device appears in the driver tree even when live point discovery fails.
+/// Who-Is alone must be enough for `GET /api/bacnet/driver/tree` to list the instance.
+fn ensure_field_device_shell(device_instance: u32, address: Option<String>) -> bool {
+    let local = bacnet_server::device_instance();
+    if device_instance == 0 || device_instance == local {
+        return false;
+    }
+    let mut registry = read_registry();
+    registry["bacnet_config"] = bacnet_config_value();
+    let Some(drivers) = registry.get_mut("drivers").and_then(|v| v.as_array_mut()) else {
+        return false;
+    };
+    for driver in drivers {
+        if driver.get("id").and_then(|v| v.as_str()).unwrap_or("") != "bacnet-ip" {
+            continue;
+        }
+        let mut devices = driver
+            .get("devices")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        if devices.iter().any(|d| {
+            d.get("device_instance")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32
+                == device_instance
+        }) {
+            return false;
+        }
+        let addr = address
+            .or_else(|| cached_whois_address(device_instance))
+            .unwrap_or_default();
+        devices.push(json!({
+            "device_instance": device_instance,
+            "name": format!("BACnet Device {device_instance}"),
+            "address": addr,
+            "polling_enabled": true,
+            "points": [],
+            "source": "whois-shell"
+        }));
+        driver["devices"] = json!(devices);
+        write_registry(&registry);
+        return true;
+    }
+    false
+}
+
 fn merge_missing_field_devices() {
     let existing = field_device_instances(&read_registry());
     let existing: std::collections::HashSet<u32> = existing.into_iter().collect();
@@ -282,8 +353,15 @@ fn merge_missing_field_devices() {
     candidates.sort_unstable();
     candidates.dedup();
     for inst in candidates {
-        if !existing.contains(&inst) {
-            merge_live_discovery_into_registry(inst);
+        if existing.contains(&inst) {
+            continue;
+        }
+        let merged = merge_live_discovery_into_registry(inst);
+        let ok = merged.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+        if !ok {
+            // Live object-list / RPM may fail (UDP bind conflict with local server, MSTP
+            // routing, etc.) but Who-Is already proved the instance exists — keep it in tree.
+            let _ = ensure_field_device_shell(inst, cached_whois_address(inst));
         }
     }
 }
@@ -2270,6 +2348,46 @@ mod override_export_tests {
             let pt = &device["points"][0];
             assert_eq!(pt["device_instance"].as_u64(), Some(5007));
             assert_eq!(pt["address"].as_str(), Some("198.51.100.50"));
+        });
+    }
+
+    #[test]
+    fn whois_shell_adds_field_device_when_live_discovery_unavailable() {
+        crate::test_support::with_temp_workspace(|root| {
+            let cache = root
+                .join("data")
+                .join("drivers")
+                .join("bacnet")
+                .join("whois_discovered.json");
+            let _ = fs::create_dir_all(cache.parent().unwrap());
+            let _ = fs::write(
+                &cache,
+                serde_json::to_string_pretty(&json!({
+                    "instances": [5007],
+                    "devices": [{
+                        "object_identifier": {"type": "device", "instance": 5007},
+                        "address": "192.168.204.200:47808"
+                    }]
+                }))
+                .unwrap(),
+            );
+            assert!(ensure_field_device_shell(
+                5007,
+                Some("192.168.204.200:47808".to_string())
+            ));
+            let registry = read_registry();
+            let devices = registry["drivers"][0]["devices"].as_array().unwrap();
+            let field = devices.iter().find(|d| {
+                d.get("device_instance").and_then(|v| v.as_u64()) == Some(5007)
+            });
+            assert!(field.is_some(), "field device 5007 must appear in tree");
+            assert_eq!(
+                field.unwrap()["address"].as_str(),
+                Some("192.168.204.200:47808")
+            );
+            assert_eq!(field.unwrap()["source"].as_str(), Some("whois-shell"));
+            // Second call is a no-op (already present).
+            assert!(!ensure_field_device_shell(5007, None));
         });
     }
 }

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -338,29 +338,17 @@ fn ensure_field_device_shell(device_instance: u32, address: Option<String>) -> b
     false
 }
 
-fn merge_missing_field_devices() {
+/// Fast path for GET tree: promote Who-Is cache entries into the registry **without**
+/// live BACnet I/O (live discovery can block for many seconds and must not hang the API).
+fn merge_missing_field_devices_from_cache() {
     let existing = field_device_instances(&read_registry());
     let existing: std::collections::HashSet<u32> = existing.into_iter().collect();
     let mut candidates = cached_whois_instances();
     candidates.extend(whois_discovered_instances());
-    if let Ok(v) = env::var("OPENFDD_BACNET_DISCOVER_LOW") {
-        if let Ok(inst) = v.parse::<u32>() {
-            if inst > 0 {
-                candidates.push(inst);
-            }
-        }
-    }
     candidates.sort_unstable();
     candidates.dedup();
     for inst in candidates {
-        if existing.contains(&inst) {
-            continue;
-        }
-        let merged = merge_live_discovery_into_registry(inst);
-        let ok = merged.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
-        if !ok {
-            // Live object-list / RPM may fail (UDP bind conflict with local server, MSTP
-            // routing, etc.) but Who-Is already proved the instance exists — keep it in tree.
+        if !existing.contains(&inst) {
             let _ = ensure_field_device_shell(inst, cached_whois_address(inst));
         }
     }
@@ -1023,9 +1011,9 @@ fn whois_discovered_instances() -> Vec<u32> {
     out
 }
 
-/// Merge Who-Is discoveries (live + cached commission results) into driver tree.
+/// Merge cached Who-Is results into driver tree (no live I/O — safe for GET handlers).
 fn ensure_field_devices_from_whois() {
-    merge_missing_field_devices();
+    merge_missing_field_devices_from_cache();
 }
 
 fn field_device_instances(registry: &Value) -> Vec<u32> {
@@ -1625,7 +1613,9 @@ pub fn whois_json(body: &Value) -> String {
     match bacnet_live::block_on(bacnet_live::whois_devices_with_range(low, high)) {
         Ok(devices) => {
             persist_whois_discoveries(&devices);
-            merge_missing_field_devices();
+            // Shells only — do not run live object-list here (can hang OT). Point
+            // discovery is POST /api/bacnet/driver/sync-discovery or poll paths.
+            merge_missing_field_devices_from_cache();
             serde_json::to_string(&devices).unwrap_or_else(|_| "[]".to_string())
         }
         Err(err) => serde_json::to_string(&json!({"ok": false, "error": err}))
@@ -2354,6 +2344,9 @@ mod override_export_tests {
     #[test]
     fn whois_shell_adds_field_device_when_live_discovery_unavailable() {
         crate::test_support::with_temp_workspace(|root| {
+            // Generic instance + TEST-NET address — no site-specific OT hardcoding.
+            let inst = 424_242_u32;
+            let addr = "198.51.100.50:47808";
             let cache = root
                 .join("data")
                 .join("drivers")
@@ -2363,31 +2356,33 @@ mod override_export_tests {
             let _ = fs::write(
                 &cache,
                 serde_json::to_string_pretty(&json!({
-                    "instances": [5007],
+                    "instances": [inst],
                     "devices": [{
-                        "object_identifier": {"type": "device", "instance": 5007},
-                        "address": "192.168.204.200:47808"
+                        "object_identifier": {"type": "device", "instance": inst},
+                        "address": addr
                     }]
                 }))
                 .unwrap(),
             );
-            assert!(ensure_field_device_shell(
-                5007,
-                Some("192.168.204.200:47808".to_string())
-            ));
+            assert!(ensure_field_device_shell(inst, Some(addr.to_string())));
             let registry = read_registry();
             let devices = registry["drivers"][0]["devices"].as_array().unwrap();
-            let field = devices.iter().find(|d| {
-                d.get("device_instance").and_then(|v| v.as_u64()) == Some(5007)
-            });
-            assert!(field.is_some(), "field device 5007 must appear in tree");
-            assert_eq!(
-                field.unwrap()["address"].as_str(),
-                Some("192.168.204.200:47808")
-            );
+            let field = devices
+                .iter()
+                .find(|d| d.get("device_instance").and_then(|v| v.as_u64()) == Some(inst as u64));
+            assert!(field.is_some(), "Who-Is instance must appear in tree");
+            assert_eq!(field.unwrap()["address"].as_str(), Some(addr));
             assert_eq!(field.unwrap()["source"].as_str(), Some("whois-shell"));
             // Second call is a no-op (already present).
-            assert!(!ensure_field_device_shell(5007, None));
+            assert!(!ensure_field_device_shell(inst, None));
+            // Cache-only merge must not hang / invent devices beyond Who-Is.
+            merge_missing_field_devices_from_cache();
+            let again = read_registry();
+            let count = again["drivers"][0]["devices"]
+                .as_array()
+                .map(|a| a.len())
+                .unwrap_or(0);
+            assert!(count >= 1);
         });
     }
 }

--- a/edge/src/drivers/bacnet_live.rs
+++ b/edge/src/drivers/bacnet_live.rs
@@ -309,16 +309,27 @@ pub async fn whois_devices_with_range(
     let (default_low, default_high) = discover_low_high();
     let low = low.unwrap_or(default_low);
     let high = high.unwrap_or(default_high);
-    let mut client = build_client().await.map_err(|e| e.to_string())?;
-    let result = async {
-        run_whois(&mut client, low, high).await?;
-        sleep(Duration::from_secs(discover_timeout_secs())).await;
-        let devices = client.discovered_devices().await;
-        Ok(devices.iter().map(device_to_json).collect())
+    // Hard ceiling so API callers never hang forever (bind / OT / router issues).
+    let budget = Duration::from_secs(discover_timeout_secs().saturating_add(5).max(10));
+    let work = async {
+        let mut client = build_client().await.map_err(|e| e.to_string())?;
+        let result = async {
+            run_whois(&mut client, low, high).await?;
+            sleep(Duration::from_secs(discover_timeout_secs())).await;
+            let devices = client.discovered_devices().await;
+            Ok(devices.iter().map(device_to_json).collect())
+        }
+        .await;
+        stop_client(client).await;
+        result
+    };
+    match tokio::time::timeout(budget, work).await {
+        Ok(inner) => inner,
+        Err(_) => Err(format!(
+            "BACnet Who-Is timed out after {}s (check bind NIC, UDP 47808 ownership, and that the local BACnet server is not enabled on the commission service)",
+            budget.as_secs()
+        )),
     }
-    .await;
-    stop_client(client).await;
-    result
 }
 
 pub async fn whois_devices() -> Result<Vec<Value>, String> {

--- a/edge/src/historian/feather_store.rs
+++ b/edge/src/historian/feather_store.rs
@@ -209,21 +209,19 @@ pub fn column_slug(label: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
 
     #[test]
     fn write_shard_creates_feather_file() {
-        let ws = env::temp_dir().join(format!("ofdd-feather-{}", std::process::id()));
-        env::set_var("OPENFDD_WORKSPACE", &ws);
-        let mut cols = BTreeMap::new();
-        cols.insert("temp-deg-f".into(), 72.5);
-        cols.insert("rh".into(), 45.0);
-        let path = write_wide_shard("modbus", "site:local", "2026-07-03T12:00:00Z", &cols)
-            .expect("write shard");
-        assert!(path.exists());
-        assert!(path.extension().is_some_and(|x| x == "feather"));
-        assert!(path.metadata().map(|m| m.len()).unwrap_or(0) > 0);
-        env::remove_var("OPENFDD_WORKSPACE");
-        let _ = fs::remove_dir_all(ws);
+        crate::test_support::with_temp_workspace(|ws| {
+            let mut cols = BTreeMap::new();
+            cols.insert("temp-deg-f".into(), 72.5);
+            cols.insert("rh".into(), 45.0);
+            let path = write_wide_shard("modbus", "site:local", "2026-07-03T12:00:00Z", &cols)
+                .expect("write shard");
+            assert!(path.exists());
+            assert!(path.extension().is_some_and(|x| x == "feather"));
+            assert!(path.metadata().map(|m| m.len()).unwrap_or(0) > 0);
+            let _ = ws;
+        });
     }
 }

--- a/scripts/openfdd_rust_edge_bootstrap.sh
+++ b/scripts/openfdd_rust_edge_bootstrap.sh
@@ -78,12 +78,16 @@ if [[ ! -f "$OPENFDD_ROOT/workspace/data.env.local" ]]; then
 OPENFDD_WORKSPACE=/var/openfdd/workspace
 OPENFDD_BACNET_MODE=live
 OPENFDD_MODBUS_MODE=live
+# Bridge diagnostic BACnet server (599999) — compose sets OPENFDD_BRIDGE_BACNET_SERVER_ENABLED=1
+OPENFDD_BACNET_SERVER_ENABLED=1
 EOF
 fi
 
 if [[ ! -f "$OPENFDD_ROOT/workspace/bacnet/commissioning/commission.env" ]]; then
   cat >"$OPENFDD_ROOT/workspace/bacnet/commissioning/commission.env" <<'EOF'
 # BACnet commissioning defaults — edit for live OT LAN
+# Commission container: field Who-Is only — local server MUST stay off (compose default 0).
+OPENFDD_BACNET_SERVER_ENABLED=0
 OPENFDD_BACNET_IFACE=<replace-with-iface>
 OPENFDD_BACNET_BIND=<replace-with-ip>/24:47808
 OPENFDD_BACNET_ROUTER_IP=<replace-with-router-ip>


### PR DESCRIPTION
## Summary

- When live BACnet point discovery fails after Who-Is, still add a **whois-shell** device so `GET /api/bacnet/driver/tree` lists field instances (e.g. **5007**), not only local **599999**
- Corrects bench prompt: `commission.env` must keep `OPENFDD_BACNET_SERVER_ENABLED=0` (field Who-Is); only bridge `data.env.local` uses `=1` for diagnostic 599999
- Adds `docs/agent/bench-330-issue-iteration-agent-prompt.md` for edge ↔ GH issue loop until #429 sign-off

## Context

Bench nightly @ `aa4baa13`: modbus poll→feather **PASS** (43 files); BACnet tree **FAIL** (only 599999). See #429 / #433.

## Test plan

- [x] `cargo test -p open_fdd_edge_prototype --lib whois_shell`
- [ ] Merge → nightly publish
- [ ] Edge: commission.env `SERVER_ENABLED=0`, Who-Is, confirm tree includes 5007
- [ ] Edge: paste issue-iteration prompt and continue Phases B–D


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BACnet device visibility by populating field devices from the Who-Is cache instead of relying on live discovery when it’s unavailable.
  * Added a hard timeout to Who-Is discovery to prevent the API from hanging indefinitely.
  * Updated runtime BACnet server defaults for bridge vs commission so the intended discovery behavior is preserved.
* **Documentation**
  * Added an operational guide for the bench agent issue-iteration workflow for the 3.3.0-beta cycle.
  * Updated BACnet prompt guidance and Jekyll build exclusions for the new/updated docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->