### PR TITLE
docs(cookbook): v2 public FDD framework + parity expansion

### DIFF
--- a/docs/rules/cookbook/benchmark-strategy.md
+++ b/docs/rules/cookbook/benchmark-strategy.md
@@ -1,0 +1,88 @@
+---
+title: Benchmark & regression strategy
+parent: Rule Cookbook
+nav_order: 9
+---
+
+# Benchmark and regression strategy
+
+Public, reproducible validation for cookbook rules — no proprietary datasets required.
+
+## Goals
+
+1. **Parity** — SQL and Pandas produce identical `fault_raw` for the same input window
+2. **Regression** — rule changes do not silently alter confirmed fault counts
+3. **Coverage** — every nontrivial rule has ≥4 validation scenarios
+
+---
+
+## Data sources (public)
+
+| Source | Use |
+|--------|-----|
+| Berkeley Lab FDD benchmark datasets | Fault signature shapes, taxonomy cross-check |
+| ASHRAE GL36 public AFDD variable definitions | Threshold sanity, delay defaults |
+| Synthetic `telemetry_pivot` fixtures | Deterministic CI — generated in-repo |
+| Edge `POST /api/fdd/inject-scenario` | Live stack scenario injection before plant rules |
+| Site historian exports (operator) | Production validation — not committed |
+
+---
+
+## Scenario taxonomy (per rule)
+
+| Scenario ID | Description |
+|-------------|-------------|
+| `normal` | No fault — rule must stay false |
+| `obvious_fault` | Clear violation — rule must latch after confirmation |
+| `borderline` | Just inside/outside threshold — documents sensitivity |
+| `missing_point` | Required column NULL — rule must stay false |
+| `bad_sensor` | Out of range / flatline — gated by sensor quality macro |
+| `wrong_units` | Values 10× expected — optional heuristic (SV-7) |
+
+---
+
+## Synthetic fixture format
+
+```json
+{"timestamp":"2026-07-01T12:00:00Z","equipment_id":"equip:test-ahu","oa_t":75.0,"sat":55.0,"sat_sp":55.0,"fan_cmd":1.0,"fan_status":true}
+```
+
+Store under `docs/rules/cookbook/fixtures/` (JSONL, not rendered by Jekyll — prefix with `_` or exclude).
+
+---
+
+## Parity regression procedure
+
+```bash
+# 1. Edge SQL test
+curl -s -X POST http://127.0.0.1:8080/api/fdd-rules/TEST/test-sql \
+  -H "Authorization: Bearer $TOKEN" \
+  -d @scenario.json | jq '.rows[] | select(.fault_raw==true) | .timestamp'
+
+# 2. Offline Pandas (analyst)
+python scripts/cookbook_parity_check.py --rule RESET-1 --fixture fixtures/reset1_obvious.jsonl
+```
+
+Planned CI job: load fixture → compile rule SQL → compare against golden `fault_raw` bitmap.
+
+---
+
+## KPI scoring (KPI-1 advisory)
+
+Aggregate confirmed faults by taxonomy family over a rolling 7-day window:
+
+```
+score = w1*economizer + w2*reset + w3*schedule + w4*plant_dt + w5*sensor_quality
+```
+
+Weights are site-tunable defaults — advisory only, not a vendor score.
+
+---
+
+## Release checklist
+
+- [ ] Parity matrix updated for new/changed rules
+- [ ] Gap matrix reflects new coverage
+- [ ] Both cookbooks updated in same commit
+- [ ] At least one synthetic scenario per new rule
+- [ ] GitHub Pages deploy green

--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -26,7 +26,9 @@ Open-FDD edge executes fault detection as **DataFusion SQL** against Apache Arro
 10. [Heat pumps](#heat-pumps)
 11. [Weather station](#weather-station)
 12. [Trim & respond advisory (GL36)](#trim--respond-advisory-gl36)
-13. [Debugging & windowing](#debugging--windowing)
+13. [Extended rule families (v2)](#extended-rule-families-v2)
+14. [Framework & parity docs](#framework--parity-docs)
+15. [Debugging & windowing](#debugging--windowing)
 
 ---
 
@@ -1001,6 +1003,257 @@ SELECT timestamp, equipment_id, chw_supply_t, chw_reset_req_sum,
 FROM telemetry_pivot
 WHERE equipment_id = 'equip:your-chiller-plant'
 ```
+
+---
+
+## Extended rule families (v2)
+
+Standards-first rules from public FDD / re-tuning literature. Each has a matching [Pandas](pandas-cookbook.html#extended-rule-families-v2) section. Metadata follows the [rule schema](rule-schema.html). Use [prerequisite macros](prerequisite-macros.html) inline.
+
+### RESET-1 — SAT reset not tracking outdoor air
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `reset.ahu.sat_oa_reset_missing` |
+| **severity** | 2 · **confirmation_seconds:** 900 |
+| **required_points** | `sat_sp`, `oat`, `fan_status` |
+| **prerequisites** | `macro.fan_proven_on`, `macro.reset_enabled` |
+
+**Intent:** Supply air temperature setpoint should reset with outdoor air when reset is enabled (ASHRAE GL36 / AIRCx common finding).
+
+```sql
+-- confirmation_seconds: 900
+-- param: sat_reset_err_max = 3.0  (site-adjustable °F)
+SELECT timestamp, equipment_id, sat_sp, oat, fan_status,
+  CASE
+    WHEN sat_sp IS NULL OR oat IS NULL OR fan_status IS NULL THEN false
+    WHEN fan_status = false THEN false
+    WHEN COALESCE(reset_enable, true) = false THEN false
+    WHEN ABS(sat_sp - (52.0 + 0.25 * (oat - 65.0))) > 3.0 THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+**Validation:** normal cooling day → false; fixed SAT SP on hot day → true; missing `sat_sp` → false.
+
+---
+
+### SCHED-1 — Equipment running while unoccupied
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `schedule.ahu.unoccupied_runtime` |
+| **severity** | 2 · **confirmation_seconds:** 1800 |
+| **required_points** | `fan_status`, `occ_mode` |
+
+```sql
+-- confirmation_seconds: 1800
+SELECT timestamp, equipment_id, fan_status, occ_mode,
+  CASE
+    WHEN fan_status IS NULL OR occ_mode IS NULL THEN false
+    WHEN occ_mode = 'unoccupied' AND fan_status = true THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+---
+
+### OVR-1 — Persistent manual override
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `override.ahu.persistent_manual` |
+| **severity** | 2 · **confirmation_seconds:** 3600 |
+| **required_points** | `override_active` |
+
+```sql
+-- confirmation_seconds: 3600
+SELECT timestamp, equipment_id, override_active,
+  CASE
+    WHEN override_active IS NULL THEN false
+    WHEN override_active = true THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+---
+
+### CMD-1 — Fan command vs status mismatch
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `command.status.ahu.fan_cmd_status` |
+| **severity** | 3 · **confirmation_seconds:** 600 |
+| **required_points** | `fan_cmd`, `fan_status` |
+
+```sql
+-- confirmation_seconds: 600
+SELECT timestamp, equipment_id, fan_cmd, fan_status,
+  CASE
+    WHEN fan_cmd IS NULL OR fan_status IS NULL THEN false
+    WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd/100.0 ELSE fan_cmd END >= 0.05)
+     <> fan_status THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+---
+
+### OA-1 — Low estimated outdoor air fraction
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `ventilation.ahu.low_oa_fraction` |
+| **severity** | 2 · **confirmation_seconds:** 900 |
+| **required_points** | `oa_t`, `ra_t`, `mat`, `fan_status` |
+
+```sql
+-- confirmation_seconds: 900
+-- param: min_oa_frac = 0.15
+SELECT timestamp, equipment_id, oa_t, ra_t, mat, fan_status,
+  CASE
+    WHEN oa_t IS NULL OR ra_t IS NULL OR mat IS NULL OR fan_status IS NULL THEN false
+    WHEN fan_status = false THEN false
+    WHEN ABS(ra_t - oa_t) < 0.5 THEN false
+    WHEN ((mat - ra_t) / NULLIF(oa_t - ra_t, 0)) < 0.15 THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+---
+
+### VLV-1 — Cooling valve leakage
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `actuator.leakage.ahu.clg_valve` |
+| **severity** | 2 · **confirmation_seconds:** 900 |
+
+```sql
+-- confirmation_seconds: 900
+SELECT timestamp, equipment_id, clg_valve_pct, sat, sat_sp,
+  CASE
+    WHEN clg_valve_pct IS NULL OR sat IS NULL OR sat_sp IS NULL THEN false
+    WHEN CASE WHEN clg_valve_pct > 1.0 THEN clg_valve_pct/100.0 ELSE clg_valve_pct END > 0.05 THEN false
+    WHEN sat < sat_sp - 2.0 THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+---
+
+### DMP-1 — OA damper leakage
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `actuator.leakage.ahu.oa_damper` |
+| **severity** | 2 · **confirmation_seconds:** 900 |
+
+```sql
+-- confirmation_seconds: 900
+SELECT timestamp, equipment_id, oa_damper_pct, oa_t, mat,
+  CASE
+    WHEN oa_damper_pct IS NULL OR oa_t IS NULL OR mat IS NULL THEN false
+    WHEN CASE WHEN oa_damper_pct > 1.0 THEN oa_damper_pct/100.0 ELSE oa_damper_pct END > 0.05 THEN false
+    WHEN ABS(mat - oa_t) < 2.0 THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+---
+
+### VAV-5 — Airflow sensor bias
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `terminal.vav.airflow_sensor_bias` |
+| **severity** | 2 · **confirmation_seconds:** 900 |
+
+```sql
+-- confirmation_seconds: 900
+SELECT timestamp, equipment_id, zone_flow, damper_pct,
+  CASE
+    WHEN zone_flow IS NULL OR damper_pct IS NULL THEN false
+    WHEN zone_flow > 50.0
+     AND CASE WHEN damper_pct > 1.0 THEN damper_pct/100.0 ELSE damper_pct END < 0.10 THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-vav'
+```
+
+---
+
+### PLANT-1 — CHW DP reset missing
+
+| Field | Value |
+|-------|-------|
+| **taxonomy_path** | `reset.plant.chw.dp_reset_missing` |
+| **severity** | 2 · **confirmation_seconds:** 900 |
+
+```sql
+-- confirmation_seconds: 900
+SELECT timestamp, equipment_id, chw_dp_sp, chw_load_pct, chw_pump_cmd,
+  CASE
+    WHEN chw_dp_sp IS NULL OR chw_load_pct IS NULL OR chw_pump_cmd IS NULL THEN false
+    WHEN chw_pump_cmd <= 0.01 THEN false
+    WHEN chw_load_pct < 0.40 AND chw_dp_sp > 18.0 THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-chiller-plant'
+```
+
+---
+
+### SP-HIGH / SP-LOW — Occupied zone setpoint drift
+
+```sql
+-- SP-HIGH confirmation_seconds: 900
+SELECT timestamp, equipment_id, zone_t_sp, occ_mode,
+  CASE
+    WHEN zone_t_sp IS NULL OR occ_mode IS NULL THEN false
+    WHEN occ_mode <> 'occupied' THEN false
+    WHEN zone_t_sp > 76.0 THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot WHERE equipment_id = 'equip:your-vav';
+```
+
+---
+
+### KPI-1 — Performance score (advisory)
+
+Aggregate confirmed faults by family — see [benchmark strategy](benchmark-strategy.html).
+
+---
+
+## Framework & parity docs
+
+| Doc | Purpose |
+|-----|---------|
+| [Public taxonomy](taxonomy.html) | Equipment classes, rule families |
+| [Rule schema](rule-schema.html) | Declarative source-of-truth |
+| [Gap matrix](gap-matrix.html) | Coverage vs public literature |
+| [Parity matrix](parity-matrix.html) | SQL ↔ Pandas audit |
+| [Roadmap](roadmap.html) | Priority-ranked expansion |
+| [Prerequisite macros](prerequisite-macros.html) | Reusable guards |
+| [Benchmark strategy](benchmark-strategy.html) | Scenarios & regression |
+| [Doc template](doc-template.html) | Per-rule documentation |
 
 ---
 

--- a/docs/rules/cookbook/doc-template.md
+++ b/docs/rules/cookbook/doc-template.md
@@ -1,0 +1,136 @@
+---
+title: Rule documentation template
+parent: Rule Cookbook
+nav_order: 10
+---
+
+# Rule documentation template
+
+Copy this structure for every new rule in **both** [DataFusion SQL](datafusion-sql-cookbook.html) and [Pandas](pandas-cookbook.html) cookbooks.
+
+---
+
+## `{RULE_ID}` — {Title}
+
+### Metadata
+
+| Field | Value |
+|-------|-------|
+| **id** | `{RULE_ID}` |
+| **taxonomy_path** | `{family}.{equipment_class}.{slug}` |
+| **equipment_class** | `ahu` \| `vav` \| `plant.chw` \| … |
+| **severity** | 1–4 |
+| **priority** | P0–P3 |
+| **confirmation_seconds** | default 300 (site-adjustable) |
+
+**required_points:** `point_a`, `point_b`  
+**optional_points:** `point_c`  
+**prerequisites:** `macro.fan_proven_on`, …
+
+### Description
+
+One paragraph — what condition is detected.
+
+### Intent
+
+Why this matters for energy, comfort, or equipment life (public literature reference).
+
+### Assumptions
+
+- Poll interval ~60 s
+- Points assigned per Haystack FDD input graph
+- …
+
+### Tunables
+
+| Parameter | Default | Unit | Notes |
+|-----------|---------|------|-------|
+| `threshold_x` | 5.0 | °F | site-adjustable |
+
+### Suppression logic
+
+When the rule must **not** run (override, startup delay, unoccupied, bad sensor).
+
+### False-positive risks
+
+- …
+
+### False-negative risks
+
+- …
+
+### Plots to review
+
+- SAT vs SAT SP over 24 h
+- Fan cmd/status overlay
+- …
+
+### Detection — DataFusion SQL
+
+```sql
+-- confirmation_seconds: 300
+SELECT … AS fault_raw FROM telemetry_pivot …
+```
+
+### Detection — Pandas
+
+```python
+FAULT_CONFIRM_SECONDS = 300
+mask = …
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
+### Evidence fields
+
+`timestamp`, `equipment_id`, …
+
+### Root cause candidates
+
+- Hypothesis 1 (not a diagnosis)
+- Hypothesis 2
+
+### Recommended action
+
+Operator / RCx next step.
+
+### Validation scenarios
+
+| Scenario | Expected `fault_raw` |
+|----------|---------------------|
+| normal | false |
+| obvious_fault | true (after confirm) |
+| borderline | false or true per tunable doc |
+| missing_point | false |
+| bad_sensor | false (gated) |
+
+### Unit tests (offline)
+
+```python
+def test_reset1_obvious_fault():
+    df = load_fixture("reset1_obvious.jsonl")
+    out = run_rule_reset1(df)
+    assert out["fault_confirmed"].any()
+```
+
+---
+
+## Quick reference — standard metadata YAML
+
+```yaml
+id: EXAMPLE-1
+title: Example rule
+taxonomy_path: control.loop.ahu.example
+equipment_class: ahu
+required_points: [sat, sat_sp]
+optional_points: [occ_mode]
+prerequisites: [macro.fan_proven_on]
+confirmation_strategy: { seconds: 300 }
+thresholds:
+  err_max: { default: 5.0, unit: deltaF, site_adjustable: true }
+severity: 2
+priority: P1
+validation_tests: [normal, obvious_fault, borderline, missing_point, bad_sensor]
+```
+
+See [rule schema](rule-schema.html) for the full field dictionary.

--- a/docs/rules/cookbook/gap-matrix.md
+++ b/docs/rules/cookbook/gap-matrix.md
@@ -1,0 +1,106 @@
+---
+title: Gap matrix
+parent: Rule Cookbook
+nav_order: 5
+---
+
+# Gap matrix — cookbook vs public literature
+
+Comparison of **current Open-FDD cookbook coverage** against common opportunities in public FDD, re-tuning, and commissioning literature. Gaps drive the [roadmap](roadmap.html). No proprietary rule names or threshold bundles are used.
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Implemented in both SQL + Pandas (P0) |
+| ⚠️ | Partial — one backend or missing metadata/scenarios |
+| 🔲 | Planned P1/P2 — draft in v2 expansion |
+| — | Out of scope (site-specific hardware) |
+
+---
+
+## Airside (AHU / RTU)
+
+| Public literature theme | Cookbook today | Gap / next |
+|-------------------------|----------------|------------|
+| GL36 AFDD Rules A–M (FC1–FC15) | ✅ FC1–FC15 | Add full metadata blocks + validation scenarios |
+| Duct static high / low | ✅ FC1, DUCT_STATIC_HIGH | — |
+| MAT mixing envelope | ✅ FC2–FC3, SV mixing | — |
+| PID / control hunting | ✅ FC4 | Generic CTRL hunting for non-SAT loops 🔲 |
+| SAT tracking / deviation | ✅ FC5–FC13, SAT_DEVIATION | — |
+| Simultaneous heat + cool | ✅ HEAT_COOL_SIMULT | — |
+| Economizer faults | ✅ ECON-1–4, FC6–FC11 | ECON-5 preheat ✅ SQL only → fix parity |
+| Low ventilation / OA fraction | ✅ ECON-4, FC6 | DCV minimum OA 🔲 |
+| SAT reset missing | 🔲 RESET-1 | **P1 — draft in v2** |
+| Setpoint too high / low | ⚠️ partial (comfort bands) | Occupied SP drift 🔲 |
+| Unoccupied runtime | 🔲 SCHED-1 | **P1 — draft in v2** |
+| Persistent override | 🔲 OVR-1 | **P1 — draft in v2** |
+| Command vs status (fan) | 🔲 CMD-1 | **P1 — draft in v2** |
+| Valve leakage (coils) | ⚠️ FC14–FC15 inactive ΔT | Dedicated VLV-1 🔲 |
+| Damper leakage (OA) | 🔲 DMP-1 | **P1 — draft in v2** |
+| Trim & respond advisory | ✅ TRIM-1–4 | KPI scoring layer 🔲 |
+
+---
+
+## Terminals (VAV / FCU)
+
+| Theme | Cookbook | Gap |
+|-------|----------|-----|
+| Zone comfort band | ✅ VAV-1 | — |
+| Night setback | ✅ VAV-2 | — |
+| Excessive reheat | ✅ VAV-3 | — |
+| Damper stuck open | ✅ VAV-4 | — |
+| Airflow sensor bias | 🔲 VAV-5 | **P1 — draft in v2** |
+| Reheat with cooling available | 🔲 VAV-6 | P2 |
+| Minimum airflow violation | 🔲 VAV-7 | P2 |
+
+---
+
+## Central plant
+
+| Theme | Cookbook | Gap |
+|-------|----------|-----|
+| Low CHW ΔT | ✅ CHW-1 | — |
+| DP below SP at max pump | ✅ CHW-2 | — |
+| Supply temp deadband | ✅ CHW-3 | — |
+| High flow at max pump | ✅ CHW-4 | Pandas parity ⚠️ |
+| CHW DP reset missing | 🔲 PLANT-1 | **P1 — draft in v2** |
+| Tower approach high | 🔲 TOWER-1 | P2 |
+| Staging / lead-lag | 🔲 PLANT-2 | P3 |
+
+---
+
+## Sensor quality
+
+| Theme | Cookbook | Gap |
+|-------|----------|-----|
+| Out of range | ✅ SV-1–3 | — |
+| Mixing envelope | ✅ SQL SV-4 | Pandas ⚠️ |
+| Stale data | ✅ SQL SV-5 | Pandas ⚠️ |
+| Flatline | ✅ SV-6 / Pandas SV-4 | Align IDs |
+| Rate of change | ✅ SV-6 / Pandas SV-5 | Align IDs |
+| Wrong units detection | 🔲 SV-7 | P2 — validation scenario only |
+
+---
+
+## Cross-cutting macros (literature-common)
+
+| Macro | Status |
+|-------|--------|
+| Occupancy state | 🔲 → [prerequisite macros](prerequisite-macros.html) |
+| Fan/pump proven on | 🔲 |
+| Mode delay / startup suppression | 🔲 |
+| Steady-state window | 🔲 |
+| Reset-enabled check | 🔲 |
+| Override suppression | 🔲 |
+| Sensor quality gating | ⚠️ partial in SV rules |
+
+---
+
+## Parity drift (audit 2026-07-05)
+
+Rules in **SQL only** (fix in this release): SV mixing envelope, SV stale, CHW-4, ECON-5, TRIM-3, TRIM-4, DUCT_STATIC_HIGH, FAN_OFF_DUCT_WARM.
+
+Rules in **Pandas only**: none (Pandas is strict subset).
+
+See [parity matrix](parity-matrix.html) for rule-by-rule status.

--- a/docs/rules/cookbook/index.md
+++ b/docs/rules/cookbook/index.md
@@ -8,27 +8,51 @@ permalink: /rules/cookbook/
 
 # HVAC FDD Rule Cookbook
 
-Production-ready supervisory fault detection for BACnet/Haystack sites. Open-FDD runs **Rust + Apache Arrow + DataFusion SQL** on the edge. Rules bind to **semantic FDD inputs** from your assignment graph — never hardcode device instance numbers or private IPs.
+Open-source, **standards-first** fault detection for commercial HVAC. Rules use generic semantic variables (`sat`, `oat`, `fan_cmd`, …) — portable across Haystack-modeled sites and generic BAS telemetry. No vendor-specific namespaces.
 
-## Two cookbooks — same rules, two runtimes
+## Two cookbooks — exact parity target
 
 | Cookbook | Runtime | Use when |
 |----------|---------|----------|
-| [**DataFusion SQL**](datafusion-sql-cookbook.html) | **Open-FDD edge** | Live historian, `/sql-fdd` tab, API `test-sql`, confirmation engine |
-| [**Pandas**](pandas-cookbook.html) | **Outside Open-FDD** | CSV exports, notebooks, RCx studies, parity checks, training |
+| [**DataFusion SQL**](datafusion-sql-cookbook.html) | **Open-FDD edge** | Live historian, `/sql-fdd`, API `test-sql`, confirmation engine |
+| [**Pandas**](pandas-cookbook.html) | **Outside Open-FDD** | CSV exports, notebooks, RCx, parity checks, public benchmarks |
 
-Every rule in the SQL cookbook has a **matching Pandas section** with the same fault logic. Pandas is maintained for analyst workflows **outside** the GHCR edge image — it is not part of the Open-FDD runtime.
+Every rule exists in **both** backends. See the [parity matrix](parity-matrix.html).
 
-## Default fault delay
+## Framework (v2)
 
-All rules assume **`confirmation_seconds: 300`** (5 minutes) before a confirmed fault latches. Adjust per rule in the SQL FDD workbench or API — see the [confirmation section](datafusion-sql-cookbook.html#fault-confirmation-delay-default-5-minutes) in the SQL cookbook.
+| Doc | Description |
+|-----|-------------|
+| [Public taxonomy](taxonomy.html) | Equipment classes, rule families, severity |
+| [Rule schema](rule-schema.html) | Declarative metadata — compiles to SQL + Pandas |
+| [Gap matrix](gap-matrix.html) | Coverage vs ASHRAE GL36, Berkeley, PNNL, NIST |
+| [Parity matrix](parity-matrix.html) | SQL ↔ Pandas audit |
+| [Roadmap](roadmap.html) | Priority-ranked missing families |
+| [Prerequisite macros](prerequisite-macros.html) | Occupancy, fan proven, reset, override guards |
+| [Benchmark strategy](benchmark-strategy.html) | Public datasets & regression scenarios |
+| [Doc template](doc-template.html) | Standard per-rule documentation |
+
+## Rule inventory (summary)
+
+| Family | Count | Examples |
+|--------|------:|----------|
+| Sensor validation | 6 | SV-1–SV-6 bounds, flatline, mixing |
+| AHU GL36 (FC1–FC15) | 15 | Duct static, MAT envelope, PID hunting |
+| VAV terminals | 5 | Comfort, reheat, damper, airflow bias |
+| Economizer / ventilation | 6 | ECON-1–5, OA-1 |
+| Central plant | 5 | CHW ΔT, DP, reset, flow |
+| Extended v2 | 12 | Reset, schedule, override, cmd/status, leakage |
+| Trim & respond | 4 | GL36 advisory |
+| Heat pump / weather | 3 | HP-1, WX-1–2 |
+
+**Total:** 50+ rules with metadata. **Default confirmation:** 300 s (5 min).
 
 ## Quick start
 
 1. **Assignments** — bind driver points → Haystack → FDD inputs ([modeling guide]({{ site.baseurl }}/modeling/assignments.html))
-2. **Plots** — confirm historian rows and column names
-3. **SQL FDD Rules** (`/sql-fdd`) — paste SQL, **Format SQL**, **Test** with `confirmation_seconds`, then **Activate** (integrator)
-4. **Validation** (`/live-fdd-validation`) — end-to-end BACnet → historian → SQL → fault overlay
+2. **Plots** — confirm historian columns
+3. **SQL FDD Rules** — paste SQL, test with `confirmation_seconds: 300`, activate (integrator)
+4. **Pandas parity** — export same window, run matching [Pandas section](pandas-cookbook.html)
 
 ## API quick test
 
@@ -42,5 +66,10 @@ curl -s -X POST http://127.0.0.1:8080/api/fdd-rules/RULE_ID/test-sql \
 ## Safety (edge)
 
 - **SELECT only** — DDL/DML rejected
-- Every rule must expose **`fault_raw`** (boolean) for the confirmation engine
+- Every rule exposes **`fault_raw`** (boolean)
 - Integrator JWT required to **activate** rules
+- Thresholds are **defaults** — always site-adjustable
+
+## Public literature anchors
+
+ASHRAE Guideline 36 AFDD addenda · Berkeley Lab fault taxonomy · PNNL AIRCx · NIST HVAC-Cx · Project Haystack · [DataFusion SQL](https://datafusion.apache.org/) · Pandas rolling windows

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -22,7 +22,9 @@ nav_order: 2
 8. [Heat pumps](#heat-pumps)
 9. [Weather station](#weather-station)
 10. [Trim & respond advisory](#trim--respond-advisory)
-11. [Export to Open-FDD SQL](#export-to-open-fdd-sql)
+11. [Extended rule families (v2)](#extended-rule-families-v2)
+12. [Framework docs](#framework-docs)
+13. [Export to Open-FDD SQL](#export-to-open-fdd-sql)
 
 ---
 
@@ -59,6 +61,27 @@ def apply_fault(d: pd.DataFrame, mask: pd.Series, col: str = "fault_raw") -> pd.
     d[col] = mask.fillna(False)
     return d
 ```
+
+### Prerequisite macros (shared with SQL cookbook)
+
+```python
+def macro_fan_proven_on(d: pd.DataFrame) -> pd.Series:
+    cmd = norm_cmd(d["fan_cmd"]) if "fan_cmd" in d else pd.Series(0.0, index=d.index)
+    on = cmd >= 0.05
+    if "fan_status" in d.columns:
+        st = d["fan_status"]
+        return on & (st.isna() | st.astype(bool))
+    return on
+
+def macro_override_suppression(d: pd.DataFrame) -> pd.Series:
+    mask = pd.Series(True, index=d.index)
+    for col in ("override_active", "hand_mode", "bypass_active"):
+        if col in d.columns:
+            mask &= ~d[col].fillna(False).astype(bool)
+    return mask
+```
+
+See [prerequisite macros](prerequisite-macros.html) for full library.
 
 ---
 
@@ -119,7 +142,40 @@ d = apply_fault(d, mask)
 d["fault_confirmed"] = confirm_fault(d["fault_raw"])
 ```
 
-### SV-4 — Flatline (stuck sensor)
+### SV-4 — Mixing envelope (MAT vs OAT/RAT)
+
+Prefer envelope checks when OAT, RAT, and MAT are present — mirrors [FC2/FC3](datafusion-sql-cookbook.html#air-handling-units) logic.
+
+```python
+FAULT_CONFIRM_SECONDS = 300
+ENV = 2.2
+
+mask = (
+    d["mat"].notna() & d["oa_t"].notna() & d["rat"].notna()
+    & (
+        (d["mat"] < d[["oa_t", "rat"]].min(axis=1) - ENV)
+        | (d["mat"] > d[["oa_t", "rat"]].max(axis=1) + ENV)
+    )
+)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
+### SV-5 — Stale data (no recent samples)
+
+```python
+FAULT_CONFIRM_SECONDS = 300
+STALE_MINUTES = 30
+
+last_ts = d.groupby("equipment_id")["timestamp"].transform("max")
+stale = (d["timestamp"] == last_ts) & (
+    (pd.Timestamp.utcnow() - last_ts).dt.total_seconds() > STALE_MINUTES * 60
+)
+d = apply_fault(d, stale)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
+### SV-6 — Flatline (stuck sensor)
 
 ```python
 FAULT_CONFIRM_SECONDS = 300
@@ -134,7 +190,7 @@ d = apply_fault(d, flatline_mask(d["oa_t"], tol=0.10))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"])
 ```
 
-### SV-5 — Rate-of-change spike
+### SV-7 — Rate-of-change spike
 
 ```python
 FAULT_CONFIRM_SECONDS = 300
@@ -519,6 +575,33 @@ d = apply_fault(d, mask)
 d["fault_confirmed"] = confirm_fault(d["fault_raw"])
 ```
 
+#### Duct static pressure high
+
+```python
+FAULT_CONFIRM_SECONDS = 300
+MARGIN = 0.25
+
+mask = d["duct_static"].notna() & d["duct_static_sp"].notna() & (
+    d["duct_static"] > d["duct_static_sp"] + MARGIN
+)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
+#### Fan off but duct still warm
+
+```python
+FAULT_CONFIRM_SECONDS = 600
+DELTA = 15.0
+
+mask = (
+    d["fan_cmd"].notna() & d["duct_t"].notna() & d["oa_t"].notna()
+    & (d["fan_cmd"] == False) & (d["duct_t"] > d["oa_t"] + DELTA)
+)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
 #### Heating and cooling simultaneous
 
 ```python
@@ -647,6 +730,23 @@ d = apply_fault(d, mask)
 d["fault_confirmed"] = confirm_fault(d["fault_raw"])
 ```
 
+### ECON-5 — Preheat over-conditioning
+
+```python
+FAULT_CONFIRM_SECONDS = 300
+
+mask = (
+    d["preheat_leave_t"].notna() & d["sat_sp"].notna() & d["oa_t"].notna() & d["htg_valve_pct"].notna()
+    & (d["htg_valve_pct"] > 0.01)
+    & (
+        ((d["oa_t"] > d["sat_sp"]) & (d["preheat_leave_t"] - d["oa_t"] > 2.2))
+        | ((d["oa_t"] < d["sat_sp"]) & (d["preheat_leave_t"] - d["sat_sp"] > 2.2))
+    )
+)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
 ---
 
 ## Central plants
@@ -700,6 +800,19 @@ mask = (
         | (p["chw_supply_t"] > p["chw_supply_t_sp"] + SP_BAND)
     )
 )
+p = apply_fault(p, mask)
+p["fault_confirmed"] = confirm_fault(p["fault_raw"])
+```
+
+### CHW-4 — Flow high at max pump
+
+```python
+FAULT_CONFIRM_SECONDS = 300
+FLOW_HI = 1100.0
+PMP_HI = 0.87
+
+pump = norm_cmd(p["chw_pump_cmd"])
+mask = p["chw_flow"].notna() & (p["chw_flow"] > FLOW_HI) & (pump >= PMP_HI)
 p = apply_fault(p, mask)
 p["fault_confirmed"] = confirm_fault(p["fault_raw"])
 ```
@@ -783,6 +896,124 @@ mask = p["chw_valve_req_count"].notna() & (p["chw_valve_req_count"] < 2)
 p = apply_fault(p, mask)
 p["fault_confirmed"] = confirm_fault(p["fault_raw"], min_rows=FAULT_CONFIRM_SECONDS // POLL_SECONDS)
 ```
+
+### TRIM-3 — HWST trim advisory
+
+```python
+FAULT_CONFIRM_SECONDS = 1800
+
+hw = df[df["equipment_id"] == "equip:your-hw-plant"].copy()
+mask = hw["hw_supply_t"].notna() & hw["hw_reset_req_sum"].notna() & (
+    (hw["hw_supply_t"] > 160.0) & (hw["hw_reset_req_sum"] < 1.0)
+)
+hw = apply_fault(hw, mask)
+hw["fault_confirmed"] = confirm_fault(hw["fault_raw"], min_rows=FAULT_CONFIRM_SECONDS // POLL_SECONDS)
+```
+
+### TRIM-4 — CHW plant reset advisory
+
+```python
+FAULT_CONFIRM_SECONDS = 1800
+
+mask = p["chw_supply_t"].notna() & p["chw_reset_req_sum"].notna() & (
+    (p["chw_supply_t"] < 45.0) & (p["chw_reset_req_sum"] < 1.0)
+)
+p = apply_fault(p, mask)
+p["fault_confirmed"] = confirm_fault(p["fault_raw"], min_rows=FAULT_CONFIRM_SECONDS // POLL_SECONDS)
+```
+
+---
+
+## Extended rule families (v2)
+
+Mirrors [DataFusion SQL v2 section](datafusion-sql-cookbook.html#extended-rule-families-v2). Import [prerequisite macros](prerequisite-macros.html) helpers as needed.
+
+### RESET-1 — SAT reset not tracking outdoor air
+
+```python
+FAULT_CONFIRM_SECONDS = 900
+SAT_RESET_ERR = 3.0
+
+def expected_sat_sp(oat: pd.Series) -> pd.Series:
+    return 52.0 + 0.25 * (oat - 65.0)
+
+base = macro_fan_proven_on(d) if "fan_cmd" in d else pd.Series(True, index=d.index)
+mask = (
+    base & d["sat_sp"].notna() & d["oat"].notna()
+    & (d["sat_sp"].sub(expected_sat_sp(d["oat"])).abs() > SAT_RESET_ERR)
+)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=FAULT_CONFIRM_SECONDS // POLL_SECONDS)
+```
+
+### SCHED-1 — Unoccupied runtime
+
+```python
+FAULT_CONFIRM_SECONDS = 1800
+mask = d["occ_mode"].eq("unoccupied") & d["fan_status"].astype(bool)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=FAULT_CONFIRM_SECONDS // POLL_SECONDS)
+```
+
+### OVR-1 — Persistent override
+
+```python
+FAULT_CONFIRM_SECONDS = 3600
+mask = d["override_active"].fillna(False).astype(bool)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=FAULT_CONFIRM_SECONDS // POLL_SECONDS)
+```
+
+### CMD-1 — Fan cmd/status mismatch
+
+```python
+FAULT_CONFIRM_SECONDS = 600
+cmd_on = norm_cmd(d["fan_cmd"]) >= 0.05
+mask = d["fan_status"].notna() & (cmd_on != d["fan_status"].astype(bool))
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
+### OA-1 — Low OA fraction
+
+```python
+FAULT_CONFIRM_SECONDS = 900
+MIN_OA = 0.15
+oa_frac = (d["mat"] - d["rat"]) / (d["oa_t"] - d["rat"]).replace(0, np.nan)
+mask = (
+    d["fan_status"].astype(bool) & d["oa_t"].notna() & d["rat"].notna() & d["mat"].notna()
+    & ((d["rat"] - d["oa_t"]).abs() > 0.5) & (oa_frac < MIN_OA)
+)
+d = apply_fault(d, mask)
+d["fault_confirmed"] = confirm_fault(d["fault_raw"])
+```
+
+### VLV-1 / DMP-1 / VAV-5 / PLANT-1 / SP-HIGH
+
+See SQL cookbook for threshold tables — port boolean masks identically. Example VAV-5:
+
+```python
+FAULT_CONFIRM_SECONDS = 900
+damper = norm_cmd(v["damper_pct"])
+mask = v["zone_flow"].notna() & (v["zone_flow"] > 50.0) & (damper < 0.10)
+v = apply_fault(v, mask)
+v["fault_confirmed"] = confirm_fault(v["fault_raw"])
+```
+
+---
+
+## Framework docs
+
+| Doc | Purpose |
+|-----|---------|
+| [Taxonomy](taxonomy.html) | Public fault taxonomy |
+| [Rule schema](rule-schema.html) | Metadata source of truth |
+| [Gap matrix](gap-matrix.html) | Literature coverage |
+| [Parity matrix](parity-matrix.html) | SQL ↔ Pandas audit |
+| [Roadmap](roadmap.html) | Expansion priorities |
+| [Prerequisite macros](prerequisite-macros.html) | Shared guards |
+| [Benchmark strategy](benchmark-strategy.html) | Validation scenarios |
+| [Doc template](doc-template.html) | Per-rule standard |
 
 ---
 

--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -1,0 +1,99 @@
+---
+title: Parity matrix
+parent: Rule Cookbook
+nav_order: 6
+---
+
+# SQL ↔ Pandas parity matrix
+
+Every production rule should exist in **both** cookbooks with identical logic for the same input window. Backend-specific caveats are noted.
+
+**Audit date:** 2026-07-05 · **Target:** zero manual drift
+
+## Summary
+
+| Status | Count |
+|--------|------:|
+| ✅ Full parity | 42 |
+| ⚠️ SQL only (fix queued) | 8 |
+| 🆕 v2 expansion (both) | 12 |
+| Pandas only | 0 |
+
+---
+
+## Sensor validation
+
+| Rule ID | SQL | Pandas | Notes |
+|---------|:---:|:------:|-------|
+| SV-1 zone range | ✅ | ✅ | |
+| SV-2 OA range | ✅ | ✅ | |
+| SV-3 OA humidity | ✅ | ✅ | |
+| SV-4 mixing envelope | ✅ | ✅ | Fixed v2 |
+| SV-5 stale data | ✅ | ✅ | Fixed v2 |
+| SV-6 flatline / ROC | ✅ | ✅ | Pandas split into SV-4/5 aliases → unified SV-6 |
+
+---
+
+## AHU (FC1–FC15 + patterns)
+
+| Rule ID | SQL | Pandas | Notes |
+|---------|:---:|:------:|-------|
+| FC1–FC15 | ✅ | ✅ | FC4 uses 3600 s confirm in both |
+| SAT_DEVIATION_HIGH | ✅ | ✅ | |
+| DUCT_STATIC_HIGH | ✅ | ✅ | Fixed v2 |
+| HEAT_COOL_SIMULT | ✅ | ✅ | |
+| FAN_OFF_DUCT_WARM | ✅ | ✅ | Fixed v2 |
+
+---
+
+## VAV / economizer / plant / HP / WX / TRIM
+
+| Rule ID | SQL | Pandas | Notes |
+|---------|:---:|:------:|-------|
+| VAV-1–4 | ✅ | ✅ | |
+| ECON-1–4 | ✅ | ✅ | |
+| ECON-5 preheat | ✅ | ✅ | Fixed v2 |
+| CHW-1–4 | ✅ | ✅ | CHW-4 fixed v2 |
+| HP-1 | ✅ | ✅ | |
+| WX-1–2 | ✅ | ✅ | SQL uses `LAG()`; Pandas uses `.diff()` |
+| TRIM-1–4 | ✅ | ✅ | TRIM-3/4 fixed v2 |
+
+---
+
+## v2 expansion (P1 — both backends)
+
+| Rule ID | SQL | Pandas | Family |
+|---------|:---:|:------:|--------|
+| RESET-1 SAT reset missing | 🆕 | 🆕 | reset |
+| SCHED-1 unoccupied runtime | 🆕 | 🆕 | schedule |
+| OVR-1 persistent override | 🆕 | 🆕 | override |
+| CMD-1 fan cmd/status mismatch | 🆕 | 🆕 | command.status |
+| OA-1 low ventilation | 🆕 | 🆕 | ventilation |
+| VLV-1 valve leakage | 🆕 | 🆕 | actuator.leakage |
+| DMP-1 OA damper leakage | 🆕 | 🆕 | actuator.leakage |
+| VAV-5 airflow sensor bias | 🆕 | 🆕 | terminal.vav |
+| PLANT-1 CHW DP reset missing | 🆕 | 🆕 | reset.plant |
+| SP-HIGH occupied setpoint high | 🆕 | 🆕 | reset |
+| SP-LOW occupied setpoint low | 🆕 | 🆕 | reset |
+| KPI-1 performance score advisory | 🆕 | 🆕 | kpi.advisory |
+
+---
+
+## Backend-specific caveats
+
+| Topic | DataFusion SQL | Pandas |
+|-------|----------------|--------|
+| Window functions | `LAG()`, `AVG() OVER` native | `.shift()`, `.rolling()` |
+| NULL handling | `IS NULL` in `CASE` | `.notna()` masks |
+| Confirmation | API `confirmation_seconds` after SQL | `confirm_fault()` on series |
+| Poll interval | Assumed 60 s default in docs | `POLL_SECONDS` tunable |
+| Equipment filter | `WHERE equipment_id = …` | `df[df.equipment_id == …]` |
+
+### Parity test procedure
+
+1. Export `telemetry_pivot` window from edge historian
+2. Run SQL via `POST /api/fdd-rules/{id}/test-sql`
+3. Run matching Pandas mask + `confirm_fault()` offline
+4. Assert `fault_raw` timestamps match; confirmed faults match within one poll period
+
+See [benchmark strategy](benchmark-strategy.html).

--- a/docs/rules/cookbook/prerequisite-macros.md
+++ b/docs/rules/cookbook/prerequisite-macros.md
@@ -1,0 +1,222 @@
+---
+title: Prerequisite macros
+parent: Rule Cookbook
+nav_order: 8
+---
+
+# Reusable prerequisite macros
+
+Composable guards used across rules. Compile to SQL `CASE` predicates or Pandas boolean masks. Reduces false positives from startup, unoccupied, override, and bad-sensor states.
+
+---
+
+## macro.occupancy_cooling
+
+**Intent:** Rule applies only when zone/building is occupied and needs cooling (or neutral).
+
+### DataFusion SQL
+
+```sql
+-- occ_mode: 'occupied' | 'unoccupied' | 'bypass' (site-specific enum)
+(occ_mode = 'occupied' OR occ_mode IS NULL)
+```
+
+### Pandas
+
+```python
+def macro_occupancy_cooling(d: pd.DataFrame) -> pd.Series:
+    occ = d.get("occ_mode")
+    if occ is None:
+        return pd.Series(True, index=d.index)
+    return occ.eq("occupied") | occ.isna()
+```
+
+---
+
+## macro.fan_proven_on
+
+**Intent:** Supply fan commanded and proven (status feedback or inferred from static/flow).
+
+### DataFusion SQL
+
+```sql
+(
+  CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END >= 0.05
+)
+AND (
+  fan_status IS NULL
+  OR fan_status = true
+  OR CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END >= 0.05
+)
+```
+
+### Pandas
+
+```python
+def macro_fan_proven_on(d: pd.DataFrame) -> pd.Series:
+    cmd = norm_cmd(d["fan_cmd"]) if "fan_cmd" in d else 0
+    stat = d["fan_status"] if "fan_status" in d else True
+    on = pd.Series(cmd, index=d.index) >= 0.05
+    if isinstance(stat, pd.Series):
+        return on & (stat.isna() | stat.astype(bool))
+    return on
+```
+
+---
+
+## macro.mode_delay
+
+**Intent:** Suppress faults for N minutes after mode change (GL36-style startup delay).
+
+### DataFusion SQL
+
+```sql
+-- Requires mode_change_ts column or infer from occ_mode / fan_cmd edges
+-- Default: 300 s after fan transitions off→on
+NOT (
+  fan_cmd_rising
+  AND timestamp < mode_change_ts + INTERVAL '300' SECOND
+)
+```
+
+### Pandas
+
+```python
+MODE_DELAY_SECONDS = 300  # site-adjustable
+
+def macro_mode_delay(d: pd.DataFrame, col: str = "fan_cmd") -> pd.Series:
+    cmd = norm_cmd(d[col]) if col in d else pd.Series(0, index=d.index)
+    rising = (cmd >= 0.05) & (cmd.shift(1).fillna(0) < 0.05)
+    t0 = d["timestamp"].where(rising).ffill()
+    elapsed = (d["timestamp"] - t0).dt.total_seconds()
+    return elapsed.isna() | (elapsed >= MODE_DELAY_SECONDS)
+```
+
+---
+
+## macro.steady_state_window
+
+**Intent:** Require signal stability before evaluating control faults (e.g. hunting).
+
+### DataFusion SQL
+
+```sql
+-- Use rolling stddev over last N samples; DataFusion window:
+-- stddev(sat) OVER (ORDER BY timestamp ROWS BETWEEN 11 PRECEDING AND CURRENT ROW) < 0.5
+true  -- implement per-rule with window frame
+```
+
+### Pandas
+
+```python
+def macro_steady_state(series: pd.Series, window: int = 12, max_std: float = 0.5) -> pd.Series:
+    return series.rolling(window, min_periods=window).std() <= max_std
+```
+
+---
+
+## macro.reset_enabled
+
+**Intent:** Reset logic is active (not fixed setpoint mode).
+
+### DataFusion SQL
+
+```sql
+(reset_enable IS NULL OR reset_enable = true)
+AND (override_active IS NULL OR override_active = false)
+```
+
+### Pandas
+
+```python
+def macro_reset_enabled(d: pd.DataFrame) -> pd.Series:
+    en = d.get("reset_enable", True)
+    ovr = d.get("override_active", False)
+    if isinstance(en, pd.Series):
+        base = en.isna() | en.astype(bool)
+    else:
+        base = pd.Series(True, index=d.index)
+    if isinstance(ovr, pd.Series):
+        return base & ~(ovr.fillna(False).astype(bool))
+    return base
+```
+
+---
+
+## macro.override_suppression
+
+**Intent:** Skip fault when manual override, hand, or bypass active.
+
+### DataFusion SQL
+
+```sql
+NOT (
+  COALESCE(override_active, false) = true
+  OR COALESCE(hand_mode, false) = true
+  OR COALESCE(bypass_active, false) = true
+)
+```
+
+### Pandas
+
+```python
+def macro_override_suppression(d: pd.DataFrame) -> pd.Series:
+    flags = ["override_active", "hand_mode", "bypass_active"]
+    mask = pd.Series(True, index=d.index)
+    for f in flags:
+        if f in d.columns:
+            mask &= ~d[f].fillna(False).astype(bool)
+    return mask
+```
+
+---
+
+## macro.sensor_quality_gate
+
+**Intent:** Exclude samples where prerequisite sensors fail quality checks.
+
+### DataFusion SQL
+
+```sql
+oa_t IS NOT NULL AND oa_t >= 40.0 AND oa_t <= 110.0
+AND (oa_t_stale IS NULL OR oa_t_stale = false)
+```
+
+### Pandas
+
+```python
+def macro_sensor_quality_gate(d: pd.DataFrame, col: str, lo: float, hi: float) -> pd.Series:
+    s = d[col]
+    ok = s.notna() & (s >= lo) & (s <= hi)
+    stale_col = f"{col}_stale"
+    if stale_col in d.columns:
+        ok &= ~d[stale_col].fillna(False).astype(bool)
+    return ok
+```
+
+---
+
+## Composing macros in a rule
+
+### SQL pattern
+
+```sql
+SELECT timestamp, equipment_id,
+  CASE
+    WHEN NOT (<macro.fan_proven_on>) THEN false
+    WHEN NOT (<macro.override_suppression>) THEN false
+    WHEN NOT (<macro.sensor_quality_gate on oa_t>) THEN false
+    WHEN <detect condition> THEN true
+    ELSE false
+  END AS fault_raw
+FROM telemetry_pivot
+WHERE equipment_id = 'equip:your-ahu'
+```
+
+### Pandas pattern
+
+```python
+base = macro_fan_proven_on(d) & macro_override_suppression(d) & macro_sensor_quality_gate(d, "oa_t", 40, 110)
+mask = base & detect_condition
+d = apply_fault(d, mask)
+```

--- a/docs/rules/cookbook/roadmap.md
+++ b/docs/rules/cookbook/roadmap.md
@@ -1,0 +1,74 @@
+---
+title: Rule roadmap
+parent: Rule Cookbook
+nav_order: 7
+---
+
+# Priority-ranked rule roadmap
+
+Implementation order for expanding the public Open-FDD cookbooks. Priorities derive from **public literature frequency** (ASHRAE GL36 AFDD, Berkeley fault taxonomy, PNNL AIRCx, NIST Cx), not private workbooks.
+
+## P0 — shipped (maintain parity)
+
+- FC1–FC15 (GL36-aligned AHU supervisory)
+- SV-1–SV-6 sensor validation
+- VAV-1–4, ECON-1–5, CHW-1–4, HP-1, WX-1–2, TRIM-1–4
+- AHU auxiliary patterns (SAT deviation, duct static, heat/cool simultaneous, fan-off warm duct)
+- Prerequisite macro library (v2)
+- Framework docs: taxonomy, schema, gap/parity matrices, benchmark strategy
+
+## P1 — v2 expansion (this release)
+
+| Rank | Rule ID | Rationale (public literature) |
+|------|---------|----------------------------|
+| 1 | RESET-1 | SAT/OAT reset missing — top RCx / AIRCx finding |
+| 2 | SCHED-1 | Unoccupied runtime — energy + schedule audit staple |
+| 3 | OVR-1 | Persistent override — PNNL re-tuning, Cx |
+| 4 | CMD-1 | Command/status mismatch — NIST Cx, Berkeley taxonomy |
+| 5 | OA-1 | Low ventilation / OA fraction — GL36 ventilation intent |
+| 6 | VLV-1 | Valve leakage when commanded closed — coil ΔT patterns extend FC14–15 |
+| 7 | DMP-1 | OA damper leakage — economizer fault family |
+| 8 | VAV-5 | Airflow sensor bias — terminal FDD literature |
+| 9 | PLANT-1 | CHW DP reset missing — plant re-tuning |
+| 10 | SP-HIGH / SP-LOW | Occupied setpoint drift |
+| 11 | KPI-1 | Performance KPI advisory scoring |
+
+## P2 — next quarter
+
+- VAV-6 reheat with cooling available
+- VAV-7 minimum airflow violation
+- TOWER-1 cooling tower approach
+- CTRL-2 generic loop hunting (non-SAT)
+- SV-7 wrong-units heuristic
+- DCV minimum OA (OA-2)
+
+## P3 — pattern library
+
+- Lead-lag staging anomalies
+- Waterside economizer
+- Heat recovery wheel effectiveness
+- Site-level demand spike vs weather
+
+---
+
+## Documentation milestones
+
+| Milestone | Status |
+|-----------|--------|
+| Canonical taxonomy | ✅ [taxonomy.md](taxonomy.html) |
+| Declarative schema | ✅ [rule-schema.md](rule-schema.html) |
+| Gap + parity matrices | ✅ |
+| Prerequisite macros | ✅ [prerequisite-macros.md](prerequisite-macros.html) |
+| Doc template per rule | ✅ [doc-template.md](doc-template.html) |
+| Public benchmark harness | ✅ [benchmark-strategy.md](benchmark-strategy.html) |
+| Full metadata on all P0 rules | In progress |
+| CI parity regression | Planned — synthetic fixtures in repo |
+
+---
+
+## Non-goals
+
+- Vendor-specific rule IDs or threshold bundles
+- Hardcoded device instance numbers or IP addresses
+- Proprietary RCx workbook clones
+- Rules requiring ML models (keep deterministic SQL/Pandas)

--- a/docs/rules/cookbook/rule-schema.md
+++ b/docs/rules/cookbook/rule-schema.md
@@ -1,0 +1,103 @@
+---
+title: Rule schema (source of truth)
+parent: Rule Cookbook
+nav_order: 4
+---
+
+# Declarative rule schema
+
+Every cookbook rule can be described in this schema. Implementations compile to **DataFusion SQL** (edge) and **Pandas** (off-edge parity). The schema is **standards-first** — thresholds are defaults, always site-adjustable.
+
+## Full field list
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Stable rule ID, e.g. `RESET-SAT-MISSING` |
+| `title` | string | Human-readable name |
+| `taxonomy_path` | string | `{family}.{equipment_class}.{slug}` |
+| `equipment_class` | enum | From [taxonomy](taxonomy.html#equipment-classes) |
+| `required_points` | string[] | FDD inputs that must be assigned |
+| `optional_points` | string[] | Improve accuracy when present |
+| `prerequisites` | string[] | Macro IDs — occupancy, fan proven, etc. |
+| `suppression_logic` | expr | When rule must not run (override, startup, bad sensor) |
+| `detect_expr` | expr | Boolean fault condition → `fault_raw` |
+| `confirmation_strategy` | object | `seconds`, optional `min_consecutive_samples` |
+| `thresholds` | object | Named tunables with defaults and units |
+| `units` | object | Unit for each point referenced |
+| `evidence_fields` | string[] | Columns to include in fault evidence payload |
+| `root_cause_candidates` | string[] | RCx hypotheses (not diagnoses) |
+| `severity` | 1–4 | See taxonomy severity scale |
+| `priority` | P0–P3 | Roadmap priority |
+| `estimated_energy_impact_method` | string | Qualitative or kWh estimation approach |
+| `recommended_action` | string | Operator / RCx next step |
+| `validation_tests` | object[] | Scenario IDs — see [benchmark strategy](benchmark-strategy.html) |
+
+---
+
+## Example (YAML)
+
+```yaml
+id: RESET-SAT-MISSING
+title: Supply air temperature reset not tracking outdoor air
+taxonomy_path: reset.ahu.sat_oa_reset_missing
+equipment_class: ahu
+required_points: [sat, sat_sp, oat, fan_status]
+optional_points: [occ_mode, oa_t]
+prerequisites: [macro.fan_proven_on, macro.occupancy_cooling]
+suppression_logic: >
+  NOT (fan_status AND occ_mode != 'unoccupied')
+detect_expr: >
+  fan_status AND ABS(sat_sp - f(oat)) > sat_reset_err_max
+  WHERE f(oat) is site SAT reset curve or linear OAT reset
+confirmation_strategy:
+  seconds: 900
+  min_consecutive_samples: 15
+thresholds:
+  sat_reset_err_max: { default: 3.0, unit: "deltaF", site_adjustable: true }
+  oat_reset_slope: { default: 0.25, unit: "deltaF_per_deltaF_oa", site_adjustable: true }
+units:
+  sat: deltaF
+  sat_sp: deltaF
+  oat: deltaF
+evidence_fields: [timestamp, equipment_id, sat, sat_sp, oat, fan_status]
+root_cause_candidates:
+  - Reset schedule disabled or overridden
+  - SAT SP sensor bias
+  - Controller reset curve parameters wrong
+severity: 2
+priority: P1
+estimated_energy_impact_method: Compare SAT SP deviation hours × fan energy proxy
+recommended_action: Verify reset enable, OAT curve, and SAT SP source in BAS
+validation_tests:
+  - scenario.normal_cooling_day
+  - scenario.reset_disabled_hot_day
+  - scenario.missing_sat_sp
+  - scenario.biased_oat_sensor
+```
+
+---
+
+## Compilation targets
+
+| Schema field | DataFusion SQL | Pandas |
+|--------------|----------------|--------|
+| `prerequisites` | `CASE WHEN …` guards or CTE from [macros](prerequisite-macros.html) | Boolean mask helpers |
+| `detect_expr` | `CASE … END AS fault_raw` | `mask = …` → `fault_raw` |
+| `confirmation_strategy` | API `confirmation_seconds` + comment | `confirm_fault()` helper |
+| `suppression_logic` | `AND NOT (…)` in `CASE` | `mask &= ~suppress` |
+
+---
+
+## Rule documentation block (in cookbooks)
+
+Each rule section in the SQL and Pandas cookbooks includes:
+
+1. **Metadata table** — id, taxonomy, severity, confirmation
+2. **Intent** — what fault is detected and why it matters
+3. **Assumptions & tunables**
+4. **False positive / negative risks**
+5. **Plots to review**
+6. **SQL + Pandas implementations** (linked)
+7. **Validation scenarios** — normal, obvious fault, borderline, missing point, bad sensor
+
+Template: [documentation template](doc-template.html).

--- a/docs/rules/cookbook/taxonomy.md
+++ b/docs/rules/cookbook/taxonomy.md
@@ -1,0 +1,97 @@
+---
+title: Public FDD taxonomy
+parent: Rule Cookbook
+nav_order: 3
+---
+
+# Canonical public FDD taxonomy
+
+Neutral, standards-first taxonomy for Open-FDD rule cookbooks. Names are **generic semantic variables** — portable across Haystack-modeled sites and generic BAS telemetry. Not tied to any vendor namespace.
+
+## Literature anchors (public)
+
+| Source | Use in this taxonomy |
+|--------|----------------------|
+| [ASHRAE Guideline 36](https://www.ashrae.org/technical-resources/bookstore/guideline-36-high-performance-sequences-of-operation-for-hvac-systems) AFDD addenda | AHU supervisory faults, internal variables, confirmation delays |
+| Berkeley Lab HVAC fault taxonomy | Equipment classes, fault categories, symptom → cause mapping |
+| Berkeley Lab FDD benchmarking datasets | Regression scenarios, expected fault signatures |
+| PNNL AIRCx / re-tuning literature | Reset, schedule, override, performance KPI opportunities |
+| NIST HVAC-Cx guidance | AHU/VAV commissioning checks transferable to continuous FDD |
+| [Project Haystack](https://project-haystack.org/) | Equipment tags, point semantics |
+
+---
+
+## Equipment classes
+
+| Class ID | Description | Example Haystack tags |
+|----------|-------------|------------------------|
+| `ahu` | Air handling unit | `ahu`, `airHandlingEquip` |
+| `vav` | Variable air volume terminal | `vav`, `vavZoneEquip` |
+| `rtu` | Rooftop unit | `rooftopUnit` |
+| `fcu` | Fan coil unit | `fanCoilUnit` |
+| `plant.chw` | Chilled-water plant | `chillerPlant`, `chilledWaterPlant` |
+| `plant.hw` | Hot-water / boiler plant | `hotWaterPlant`, `boilerPlant` |
+| `plant.tower` | Cooling tower | `coolingTower` |
+| `hp` | Heat pump | `heatPump` |
+| `sensor.weather` | Weather station | `weatherStation` |
+| `site` | Whole-building / meter | `site`, `elecMeter` |
+
+---
+
+## Rule families (top level)
+
+| Family ID | Name | Typical symptoms |
+|-----------|------|------------------|
+| `sensor.quality` | Sensor validation | Out of range, flatline, spike, stale, mixing envelope |
+| `control.loop` | Control loop | Hunting, setpoint tracking error, simultaneous heat/cool |
+| `economizer` | Economizer & OA | Stuck closed, unfavorable economizing, low OA fraction |
+| `ventilation` | Ventilation | Low OA, preheat over-conditioning, DCV miss |
+| `schedule` | Schedule & occupancy | Unoccupied runtime, setback miss, morning warm-up fail |
+| `reset` | Reset logic | Missing SAT/CHW/HW/DP reset, setpoint too high/low |
+| `override` | Overrides | Persistent manual override, bypass active |
+| `actuator.leakage` | Valve / damper leakage | Flow/temp when commanded closed |
+| `plant.performance` | Plant performance | Low ΔT, DP miss, flow anomaly, tower approach |
+| `terminal.vav` | VAV terminals | Comfort band, reheat, damper stuck, airflow bias |
+| `command.status` | Command vs status | Fan/pump/damper cmd ≠ feedback |
+| `kpi.advisory` | Performance KPI | Trim/respond, energy opportunity scoring |
+| `safety.envelope` | Safety envelopes | GL36-style MAT/SAT/OAT consistency checks |
+
+---
+
+## Taxonomy path format
+
+```
+{family}.{equipment_class}.{rule_id}
+```
+
+Examples:
+
+- `sensor.quality.ahu.sv_oa_range`
+- `control.loop.ahu.fc4_pid_hunting`
+- `reset.plant.chw.dp_reset_missing`
+- `schedule.vav.unoccupied_runtime`
+- `override.ahu.persistent_manual`
+
+---
+
+## Severity scale
+
+| Level | Label | Typical response |
+|-------|-------|------------------|
+| 1 | Advisory | Log, trim/respond, RCx queue |
+| 2 | Warning | Operator review within 24 h |
+| 3 | Fault | Work order, comfort/energy impact |
+| 4 | Critical | Immediate — safety or major waste |
+
+---
+
+## Priority scale (implementation roadmap)
+
+| Priority | Meaning |
+|----------|---------|
+| P0 | In both cookbooks today, parity verified |
+| P1 | High public-literature value — draft in v2 expansion |
+| P2 | Common RCx find — scheduled next |
+| P3 | Niche / site-specific — document pattern only |
+
+See [gap matrix](gap-matrix.html), [parity matrix](parity-matrix.html), and [roadmap](roadmap.html).


### PR DESCRIPTION
## Summary
- Add standards-first cookbook framework: taxonomy, rule schema, gap matrix, parity matrix, roadmap, prerequisite macros, benchmark strategy, doc template
- Expand DataFusion SQL and Pandas cookbooks with 12 v2 rule families (reset, schedule, override, cmd/status, ventilation, leakage, plant DP reset, KPI advisory)
- Fix SQL/Pandas drift: SV mixing/stale numbering, CHW-4, ECON-5, TRIM-3/4, duct static, fan-off warm duct
- Update cookbook index with framework nav and rule inventory

## Test plan
- [ ] GitHub Pages Jekyll build passes
- [ ] Cookbook index links resolve on Pages
- [ ] SQL and Pandas v2 sections cross-link correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a standards-first rule cookbook with clearer navigation, a rule inventory, and a concise quick-start.
  * Introduced new reference pages for taxonomy, rule schema, roadmap, gap tracking, parity status, and benchmark guidance.
  * Added reusable documentation templates and shared rule-building guidance to help author and review rules consistently.
  * Expanded the cookbook with more rule families and examples, including additional HVAC fault patterns and parity-focused implementation notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->