### PR TITLE
Apply rustfmt to whois-shell test (unblock GHCR nightly)

### DIFF
--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -2354,7 +2354,11 @@ mod override_export_tests {
             // Generic instance + TEST-NET address — no site-specific OT hardcoding.
             let inst = 987_654_u32;
             let addr = "198.51.100.50:47808";
-            let reg_path = root.join("data").join("drivers").join("bacnet").join("driver_tree.json");
+            let reg_path = root
+                .join("data")
+                .join("drivers")
+                .join("bacnet")
+                .join("driver_tree.json");
             let cache = root
                 .join("data")
                 .join("drivers")


### PR DESCRIPTION
cargo fmt --check failed on #455 merge. One-line wrap fix.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted a test path construction for improved readability.
  * No behavior, assertions, or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->