### PR TITLE
3.2.11: headless CSV batch, Haystack zinc, BACnet P0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open_fdd_edge_prototype"
-version = "3.2.10"
+version = "3.2.11"
 dependencies = [
  "arrow",
  "bacnet-client",

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -26,11 +26,12 @@ Field buses (BACnet / Modbus / Haystack / JSON / CSV)
 
 ## CSV path
 
-Engineering workstations can skip live drivers:
+Batch CSV loads use the headless import API (no dashboard UI):
 
-1. Import CSV via **CSV Fusion** tab or `/api/csv/import/*`
-2. Preflight validation (`/api/csv/import/preflight`) gates execute
-3. Historian rows carry `source_driver: csv` for downstream SQL
+1. Host script or sidecar delivers CSV → `POST /api/csv/import/preflight` → `execute`
+2. Historian rows carry `source_driver: csv` for downstream SQL
+
+Large CSV analysis belongs in the [Pandas cookbook]({{ site.baseurl }}/rules/cookbook/pandas-cookbook.html) outside the edge.
 
 ## Reports
 

--- a/docs/drivers/csv-batch.md
+++ b/docs/drivers/csv-batch.md
@@ -1,0 +1,49 @@
+---
+title: CSV batch import
+parent: Drivers
+nav_order: 5
+---
+
+# CSV batch import
+
+CSV is a **headless batch driver** — load pre-shaped telemetry into the historian for DataFusion FDD. Large CSV analysis, merges, and RCx studies belong in the [Pandas cookbook](../rules/cookbook/pandas-cookbook.html) outside the edge app.
+
+## Workflow
+
+1. Prepare CSV off-box (pandas, vendor export, or daily API pull script on the host OS).
+2. Drop files into a watched directory or call the import API directly.
+3. Preflight validates timestamps, columns, and duplicates (fail-closed).
+4. Execute writes Arrow/Feather historian rows with `source_driver: csv`.
+
+## API
+
+| Method | Path |
+|--------|------|
+| GET | `/api/ingest/contract` |
+| POST | `/api/csv/import/preflight` |
+| POST | `/api/csv/import/execute` |
+
+Execute requires preflight `verdict: pass` (or `warn` when strict mode allows).
+
+## Host batch (daily pull example)
+
+```bash
+# 1) Host script fetches CSV (cron) — outside Open-FDD
+curl -fsS -o /data/incoming/site-a-$(date +%F).csv "$EXTERNAL_API_URL"
+
+# 2) Sidecar or integrator calls preflight + execute
+./scripts/openfdd_csv_import_sidecar.sh
+```
+
+See [import sidecar overview](../archive/import_sidecar/overview.md) for directory layout and profiles.
+
+## Validation (Rust)
+
+Preflight checks include:
+
+- Timestamp column detection and parse quality
+- Duplicate keys and row counts
+- Equipment/site ID presence
+- Unit and column mapping sanity
+
+Bad timestamps or failed preflight **block** execute — no partial historian writes.

--- a/docs/drivers/csv.md
+++ b/docs/drivers/csv.md
@@ -1,37 +1,10 @@
 ---
-title: CSV
+title: CSV batch import
 parent: Drivers
 nav_order: 5
+redirect_from: /drivers/csv.html
 ---
 
-# CSV import
+# CSV batch import
 
-CSV is the primary path for **offline engineering** — import vendor exports without live BACnet/Modbus.
-
-## Formats
-
-Consult the ingest contract for required columns:
-
-```bash
-curl -s http://127.0.0.1:8080/api/ingest/contract | jq .
-```
-
-Supported shapes include historian-wide CSV and commissioning JSON (separate endpoint).
-
-## Validation
-
-Preflight checks timestamp columns, units, equipment/site IDs, and duplicate keys. Strict mode (`OPENFDD_CSV_STRICT`, default on) rejects execute on `fail` verdict.
-
-## API
-
-| Method | Path |
-|--------|------|
-| GET | `/api/ingest/contract` |
-| POST | `/api/csv/import/preflight` |
-| POST | `/api/csv/import/execute` |
-
-## Dashboard
-
-**CSV Fusion** tab (`/csv`) — visual import, wiresheet merge, append/join workflows.
-
-See [CSV import & preview]({{ site.baseurl }}/web-app/csv-import-and-preview.html).
+Headless batch driver for loading pre-shaped CSV into the historian. See [CSV batch import](csv-batch.html) for full details.

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -35,15 +35,21 @@ nav_order: 2
 import pandas as pd
 import numpy as np
 
-# Wide historian export (one row per timestamp × equipment)
-df = pd.read_json("telemetry_pivot.jsonl", lines=True)
-# Or: df = pd.read_feather("telemetry_pivot.feather")
+# Generic CSV (vendor export, BMS dump, Open-FDD batch export, etc.)
+df = pd.read_csv("your_building_data.csv")
 
-df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
-df = df.sort_values(["equipment_id", "timestamp"])
+# Optional: parse timestamp column (rename "timestamp" if your file uses another name)
+ts_col = "timestamp"  # e.g. "DateTime", "time", "ts"
+if ts_col in df.columns:
+    df[ts_col] = pd.to_datetime(df[ts_col], utc=True, errors="coerce")
+    df = df.dropna(subset=[ts_col]).sort_values(ts_col)
+else:
+    df = df.sort_index()
 
-EQUIP = "equip:your-ahu"
-d = df[df["equipment_id"] == EQUIP].copy()
+# Optional: filter one equipment / site column if present
+# EQUIP = "equip:your-ahu"
+# d = df[df["equipment_id"] == EQUIP].copy() if "equipment_id" in df.columns else df.copy()
+d = df.copy()
 ```
 
 ### Normalize command 0–100 → 0–1

--- a/docs/web-app/csv-batch-import.md
+++ b/docs/web-app/csv-batch-import.md
@@ -1,0 +1,23 @@
+---
+title: CSV batch import
+parent: Web App
+nav_order: 2
+---
+
+# CSV batch import
+
+CSV loading is **API-only** — no dashboard tab. Use host-side scripts or MCP for batch ingest.
+
+| Step | Method | Path |
+|------|--------|------|
+| Contract | GET | `/api/ingest/contract` |
+| Preflight | POST | `/api/csv/import/preflight` |
+| Execute | POST | `/api/csv/import/execute` |
+
+For large CSV analysis and FDD rule development, use the [Pandas cookbook](../rules/cookbook/pandas-cookbook.html) outside Open-FDD.
+
+For daily batch loads, see [CSV batch driver](../drivers/csv-batch.html) and the import sidecar scripts.
+
+```bash
+./scripts/openfdd_csv_preflight.sh /path/to/file.csv
+```

--- a/docs/web-app/csv-import-and-preview.md
+++ b/docs/web-app/csv-import-and-preview.md
@@ -1,43 +1,8 @@
 ---
-title: CSV import & preview
+title: CSV batch import
 parent: Web App
 nav_order: 2
+redirect_to: /web-app/csv-batch-import.html
 ---
 
-# CSV import & preview
-
-Use the **CSV Fusion** tab (`/csv`) or the REST ingest API for engineering imports.
-
-## UI workflow
-
-1. Drop or select CSV files
-2. Preview columns and timestamp mapping
-3. Run preflight validation
-4. Execute import into the Arrow historian
-
-## API workflow
-
-| Step | Method | Path |
-|------|--------|------|
-| Contract | GET | `/api/ingest/contract` |
-| Preflight | POST | `/api/csv/import/preflight` |
-| Plan | POST | `/api/csv/import/plan` |
-| Execute | POST | `/api/csv/import/execute` |
-
-Execute is **fail-closed**: preflight must return `verdict: pass` (or `warn` when strict mode allows).
-
-## Workbench
-
-Additional CSV tooling:
-
-- `POST /api/csv-workbench/preview` — column preview
-- `POST /api/csv-workbench/quality` — data quality checks
-- `GET/PUT /api/csv-workbench/column-mappings` — saved mappings
-
-## Shell helper
-
-```bash
-./scripts/openfdd_csv_preflight.sh /path/to/file.csv
-```
-
-See [Drivers → CSV]({{ site.baseurl }}/drivers/csv.html) for format expectations.
+Redirecting to [CSV batch import](csv-batch-import.html).

--- a/docs/web-app/index.md
+++ b/docs/web-app/index.md
@@ -14,5 +14,5 @@ The dashboard is a **React** SPA served by the bridge at port 8080. Most tabs re
 |-------|---------|
 | [Routes](routes.html) | Sidebar tabs and URLs |
 | [SQL FDD Rules](sql-fdd-rules.html) | Historian SQL workbench |
-| [CSV import & preview](csv-import-and-preview.html) | CSV Fusion workflow |
+| [CSV batch import](csv-batch-import.html) | Headless CSV ingest API |
 | [Plots & reports](plots-and-reports.html) | Trends and PDF builder |

--- a/docs/web-app/routes.md
+++ b/docs/web-app/routes.md
@@ -19,7 +19,7 @@ Routes are defined in `workspace/dashboard/src/App.tsx`. Sidebar sections come f
 
 | Route | Tab | Description |
 |-------|-----|-------------|
-| `/csv` | CSV Fusion | Import CSV, wiresheet merge, historian store |
+| `/csv` | — | Redirects to `/data-management` |
 | `/bacnet` | BACnet | Commissioning, device tree, poll rates |
 | `/haystack` | Haystack | Connect Haystack server, browse/import |
 | `/modbus` | Modbus | TCP register reads, tree, polling |

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open_fdd_edge_prototype"
-version = "3.2.10"
+version = "3.2.11"
 edition = "2021"
 
 [[bin]]

--- a/edge/src/csv_ingest/mod.rs
+++ b/edge/src/csv_ingest/mod.rs
@@ -192,7 +192,6 @@ pub fn plan_handler(body: &Value) -> Value {
         "plan": plan,
         "preview": preview,
         "validation_report": validation_report,
-        "fusion_url": format!("/csv?session={session_id}"),
     })
 }
 
@@ -502,7 +501,6 @@ pub fn fusion_preview_handler(session_id: &str, limit: usize) -> Value {
         "columns": columns,
         "rows": grid,
         "validation_report": validation,
-        "fusion_url_hint": format!("/csv?session={session_id}"),
     })
 }
 

--- a/edge/src/csv_ingest/session.rs
+++ b/edge/src/csv_ingest/session.rs
@@ -170,7 +170,6 @@ pub fn list_sessions_handler(limit: usize) -> Value {
                     .and_then(|p| p.get("row_count"))
                     .cloned()
                     .unwrap_or(json!(null)),
-                "fusion_url": format!("/csv?session={id}"),
             }));
         }
     }
@@ -185,7 +184,7 @@ pub fn list_sessions_handler(limit: usize) -> Value {
 
 pub fn latest_planned_session_handler() -> Value {
     let listed = list_sessions_handler(20);
-    let empty = json!({"ok": false, "error": "no import session found — upload CSVs and run Preview plan in UT3 panel"});
+    let empty = json!({"ok": false, "error": "no import session found — POST /api/csv/import/preview then preflight"});
     let Some(arr) = listed.get("sessions").and_then(|v| v.as_array()) else {
         return empty;
     };
@@ -196,7 +195,6 @@ pub fn latest_planned_session_handler() -> Value {
                 "ok": true,
                 "session": s.clone(),
                 "session_id": s.get("session_id").cloned().unwrap_or(json!(null)),
-                "fusion_url": s.get("fusion_url").cloned().unwrap_or(json!(null)),
             });
         }
     }

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -1874,7 +1874,10 @@ fn persist_bacnet_reads_to_historian(reads: &[Value]) {
     let mut wide_cols: BTreeMap<String, f64> = BTreeMap::new();
     let mut oa_t = None::<f64>;
     for read in reads {
-        let val = read.get("present_value").and_then(|v| v.as_f64());
+        let val = read
+            .get("present_value")
+            .and_then(|v| v.as_f64())
+            .or_else(|| read.get("value").and_then(|v| v.as_f64()));
         if val.is_none() {
             continue;
         }
@@ -1917,7 +1920,9 @@ fn persist_bacnet_reads_to_historian(reads: &[Value]) {
         source_driver: "bacnet",
         is_simulated: false,
     });
-    let _ = store::append_pivot_row(&row);
+    if let Err(e) = store::append_pivot_row(&row) {
+        eprintln!("Open-FDD BACnet poll: historian pivot append failed: {e}");
+    }
 }
 
 pub fn count_discovered_devices(registry: &Value) -> u64 {

--- a/edge/src/drivers/bacnet_server_runtime.rs
+++ b/edge/src/drivers/bacnet_server_runtime.rs
@@ -231,6 +231,8 @@ async fn run_server() -> Result<(), String> {
         bacnet_server::device_name()
     );
 
+    // Hold server for process lifetime (vibe16: single owner of :47808).
+    let _server = server;
     loop {
         sleep(Duration::from_secs(3600)).await;
     }
@@ -244,13 +246,13 @@ pub fn start_background() {
     if STARTED.swap(true, Ordering::SeqCst) {
         return;
     }
-    // BACnetServer::build() must not run on bacnet_live's worker pool — it creates an
-    // inner tokio runtime and panics ("Cannot start a runtime from within a runtime").
-    // Isolate the server on its own OS thread with a dedicated current-thread runtime.
+    // Dedicated OS thread owns the only BACnet server runtime (vibe16 bacnet_app pattern).
     thread::Builder::new()
         .name("openfdd-bacnet-server".into())
         .spawn(|| {
-            let rt = tokio::runtime::Builder::new_current_thread()
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .thread_name("bacnet-srv")
                 .enable_all()
                 .build()
                 .expect("bacnet server tokio runtime");

--- a/edge/src/drivers/haystack/client.rs
+++ b/edge/src/drivers/haystack/client.rs
@@ -44,6 +44,21 @@ struct BasicHaystackClient {
 }
 
 impl BasicHaystackClient {
+    fn wire_format(cfg: &HaystackConfig) -> String {
+        if let Ok(v) = std::env::var("OPENFDD_HAYSTACK_FORMAT") {
+            let v = v.trim().to_string();
+            if !v.is_empty() {
+                return v;
+            }
+        }
+        // Niagara nHaystack rejects application/json on POST read/nav — use Zinc.
+        if cfg.auth_mode.eq_ignore_ascii_case("basic") {
+            "text/zinc".to_string()
+        } else {
+            "application/json".to_string()
+        }
+    }
+
     fn new(cfg: &HaystackConfig, user: &str, pass: &str) -> Result<Self, String> {
         let mut builder = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(cfg.timeout_seconds.max(1)));
@@ -58,7 +73,7 @@ impl BasicHaystackClient {
             base_url: cfg.base_url.trim_end_matches('/').to_string(),
             username: user.to_string(),
             password: pass.to_string(),
-            format: "application/json".to_string(),
+            format: Self::wire_format(cfg),
         })
     }
 

--- a/edge/src/drivers/haystack/mock_server.rs
+++ b/edge/src/drivers/haystack/mock_server.rs
@@ -71,6 +71,7 @@ pub mod tests {
 
     #[test]
     fn mock_server_about_and_read() {
+        std::env::set_var("OPENFDD_HAYSTACK_FORMAT", "application/json");
         let (base, running) = spawn_mock_server();
         let cfg = mock_config(&base);
         let test = test_connection(&cfg);

--- a/edge/src/ops/dev_agent.rs
+++ b/edge/src/ops/dev_agent.rs
@@ -15,8 +15,7 @@ pub fn dev_harness_reply(body: &Value) -> Value {
         .unwrap_or("/");
 
     let hint = if path.starts_with("/csv") {
-        "CSV: drop files on the wiresheet, or use an external MCP agent with \
-         openfdd_csv_sessions / openfdd_csv_fusion_preview / openfdd_csv_import_execute."
+        "CSV batch import: MCP openfdd_csv_import_preflight / openfdd_csv_import_execute, or host scripts — see docs/drivers/csv-batch.html."
     } else if path.starts_with("/bacnet") {
         "BACnet: MCP openfdd_bacnet_whois or commission reads. Field writes need integrator + approved=true."
     } else if path.starts_with("/sql-fdd") {
@@ -31,13 +30,12 @@ pub fn dev_harness_reply(body: &Value) -> Value {
         format!("{hint} What do you want to do on {path}?")
     } else if message.contains("session") || message.contains("ut3") {
         format!(
-            "{hint} List sessions: GET /api/csv/import/sessions. Load fusion: \
-             /csv?session=<id> or MCP openfdd_csv_fusion_preview."
+            "{hint} List sessions: GET /api/csv/import/sessions. Preflight: MCP openfdd_csv_import_preflight."
         )
     } else if message.contains("save") || message.contains("arrow") || message.contains("feather") {
-        "Save merged data: MCP openfdd_csv_import_execute (after fusion preview) or Commit on CSV tab when preview looks right.".into()
+        "Persist CSV: MCP openfdd_csv_import_execute after preflight pass.".into()
     } else if message.contains("help") || message.contains("mcp") {
-        "MCP tools: openfdd_health, openfdd_stack_status, openfdd_driver_status, CSV fusion tools, Haystack/SPARQL. See mcp/README.md.".into()
+        "MCP tools: openfdd_health, openfdd_stack_status, openfdd_driver_status, openfdd_csv_*, Haystack/SPARQL. See mcp/README.md.".into()
     } else {
         format!("{hint} You asked: \"{message}\". Use MCP tools or the active tab APIs.")
     };

--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -15,7 +15,6 @@ import PlotPage from "./pages/PlotPage";
 import SqlFddRulesPage from "./pages/SqlFddRulesPage";
 import LiveFddValidationPage from "./pages/LiveFddValidationPage";
 import DataManagementPage from "./pages/DataManagementPage";
-import CsvWorkbenchPage from "./pages/CsvWorkbenchPage";
 import ReportBuilderPage from "./pages/ReportBuilderPage";
 import AlgorithmsPage from "./pages/AlgorithmsPage";
 import DataExportPage from "./pages/DataExportPage";
@@ -46,8 +45,7 @@ export default function App() {
             <Route path="bacnet" element={<TabErrorBoundary tab="bacnet"><BacnetPage /></TabErrorBoundary>} />
             <Route path="modbus" element={<TabErrorBoundary tab="modbus"><ModbusPage /></TabErrorBoundary>} />
             <Route path="json-api" element={<TabErrorBoundary tab="json-api"><JsonApiPage /></TabErrorBoundary>} />
-            <Route path="haystack" element={<TabErrorBoundary tab="haystack"><HaystackPage /></TabErrorBoundary>} />
-            <Route path="csv" element={<TabErrorBoundary tab="csv"><CsvWorkbenchPage /></TabErrorBoundary>} />
+            <Route path="csv" element={<Navigate to="/data-management" replace />} />
             <Route path="wiresheet" element={<Navigate to="/model" replace />} />
             <Route path="wiresheet/haystack" element={<Navigate to="/model" replace />} />
             <Route path="wiresheet/rules" element={<Navigate to="/model" replace />} />

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -24,7 +24,6 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   {
     title: "Integrations",
     items: [
-      { to: "/csv", icon: "📂", label: "CSV Fusion", protected: true },
       { to: "/bacnet", icon: "📡", label: "BACnet", protected: true },
       { to: "/haystack", icon: "🌿", label: "Haystack", protected: true },
       { to: "/modbus", icon: "🔌", label: "Modbus", protected: true },

--- a/workspace/dashboard/src/components/BuildingInsightDashboard.tsx
+++ b/workspace/dashboard/src/components/BuildingInsightDashboard.tsx
@@ -165,7 +165,7 @@ export default function BuildingInsightDashboard() {
           <p className="muted">
             No Haystack model loaded yet — stack health and gauges below reflect the live edge only.
             Sign in and import a model under{" "}
-            <Link to="/model">Model &amp; assignments</Link> (or CSV Fusion) to enable fault detection
+            <Link to="/model">Model &amp; assignments</Link> to enable fault detection
             and comfort analytics.
           </p>
         </div>

--- a/workspace/dashboard/src/pages/AgentPage.tsx
+++ b/workspace/dashboard/src/pages/AgentPage.tsx
@@ -166,10 +166,11 @@ export default function AgentPage() {
             {config.embedded_chat === false ? " · embedded chat disabled" : null}
           </p>
           <p className="muted">
-            CSV workflow: <Link to="/csv">CSV import tab</Link> · MCP tools <code>openfdd_csv_*</code> · see{" "}
-            <a href="https://github.com/bbartling/open-fdd/blob/master/mcp/README.md" target="_blank" rel="noreferrer">
-              mcp/README.md
+            CSV batch import uses MCP/API only — see{" "}
+            <a href="https://bbartling.github.io/open-fdd/drivers/csv-batch.html" target="_blank" rel="noreferrer">
+              CSV batch driver docs
             </a>
+            {" "}· MCP <code>openfdd_csv_*</code>
           </p>
           <button type="button" className="secondary-btn" disabled={busy} onClick={() => void refresh()}>
             Refresh


### PR DESCRIPTION
## Summary
- Remove CSV Fusion dashboard tab/routes; CSV ingest remains headless via REST/MCP with existing Rust preflight validation (timestamps, quarantine, strict execute gate).
- Fix Niagara nHaystack HTTP 415: Basic-auth POST ops use `text/zinc` (override via `OPENFDD_HAYSTACK_FORMAT`).
- BACnet P0 polish: dedicated server thread holds `BACnetServer` for process lifetime; poll persist logs pivot append errors and accepts `value` field.
- Docs: CSV batch driver guide, pandas cookbook generic `read_csv`, web-app route updates.

## Test plan
- [x] `cargo fmt`
- [x] `cargo test` (edge, all suites green)
- [ ] GHCR nightly publish
- [ ] Linux edge retest @ new SHA (#429, #452, #453, Haystack poll-once)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for a new CSV batch import flow with clear step-by-step guidance and API endpoints.
  * Updated the dashboard and web docs to point users to the new batch import experience.

* **Bug Fixes**
  * Removed outdated CSV import references and redirects to prevent confusion.
  * Improved CSV-related messaging across the app to reflect the current workflow.

* **Documentation**
  * Expanded CSV and Pandas guidance for batch-oriented data loading and validation.
  * Clarified that large CSV analysis should use the external cookbook workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->