### PR TITLE
Docs: expand AHU economizer diagnostics in both cookbooks

### DIFF
--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -823,7 +823,7 @@ Open-FDD ships dry-bulb defaults; tune `oat_cutoff`, `dpr_min`, and `oa_min_pct`
 | OA-1 | Low OA fraction (extended) | [Extended v2 — OA-1](#oa-1--low-estimated-outdoor-air-fraction) |
 | OA-2 | DCV minimum OA not met | [Extended P2 — OA-2](#oa-2--dcv-minimum-outdoor-air-not-met) |
 | DMP-1 | OA damper leakage at commanded closed | [Extended v2 — DMP-1](#dmp-1--oa-damper-leakage) |
-| FC6 | OA fraction mismatch (GL36) | [FC6](#fc6--low-outside-air-fraction-gl36-rule-g) |
+| FC6 | OA fraction mismatch (GL36) | [FC6](#fc6--estimated-oa-fraction-mismatch) |
 | FC8–FC11 | SAT/MAT faults in economizer modes | [Air handling units](#air-handling-units) |
 
 ---

--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -22,6 +22,9 @@ Open-FDD edge executes fault detection as **DataFusion SQL** against Apache Arro
 6. [Air handling units (FC1–FC15 / GL36 A–M)](#air-handling-units)
 7. [VAV zones](#vav-zones)
 8. [Economizer & ventilation](#economizer--ventilation)
+   - [AHU economizer diagnostics guide](#ahu-economizer-diagnostics-guide)
+   - [ECON-1–5](#econ-1--economizer-stuck-closed)
+   - [Ventilation & leakage cross-rules](#rule-map-economizer-family)
 9. [Central plants](#central-plants)
 10. [Heat pumps](#heat-pumps)
 11. [Weather station](#weather-station)
@@ -740,6 +743,90 @@ WHERE equipment_id = 'equip:your-vav'
 ---
 
 ## Economizer & ventilation
+
+Continuous FDD and RCx checks for **air-side economizers**: use outdoor air when favorable, avoid mechanical cooling when economizing is available, and meet ventilation minimums.
+
+### AHU economizer diagnostics guide
+
+#### Operating modes (GL36-style)
+
+AHU supervisory logic cycles among heating-only, economizer, economizer + mechanical cooling, and mechanical-cooling-only bands. Mode misclassification drives false positives — normalize `fan_cmd`, `oa_damper_pct`, and valve commands to **0–1** before comparing thresholds.
+
+| Mode | Heating | Cooling | Supply fan | OA damper | Typical fault signals |
+|------|---------|---------|------------|-----------|------------------------|
+| **OS1** heating only | on | off | on | minimum | FC5, FC7, ECON-5 preheat waste |
+| **OS2** economizer (dry-bulb) | off | off | on | modulated (high) | ECON-1 stuck closed, ECON-2 unfavorable |
+| **OS3** econ + mech cool | off | on | on | modulated | ECON-3, FC8–FC11 SAT/MAT in econ |
+| **OS4** mech cool only | off | on | on | minimum | ECON-3 inverse, cooling valve faults |
+
+Mode-transition hunting is covered under [FC4 — PID / operating-mode hunting](#fc4--operating-mode-transition-hunting-gl36-rule-d).
+
+#### Required historian columns
+
+Assign Haystack (or BACnet) points to these semantic IDs before running economizer SQL:
+
+| Semantic ID | Common aliases | Used for |
+|-------------|----------------|----------|
+| `oa_t` | `oat`, outside air temp | Cutoffs, stuck-closed checks |
+| `oa_h` | outside air RH | Enthalpy economizer (optional) |
+| `mat` | mixed air temp | Blend envelope, OA fraction |
+| `rat` / `ra_t` | return air temp | OA fraction denominator |
+| `oa_damper_pct` | `econ`, OA damper | Modulation, stuck, leakage |
+| `clg_valve_pct`, `htg_valve_pct` | cooling/heating valves | Mode detection |
+| `fan_cmd`, `fan_status` | supply fan | Proving unit operation |
+| `sat`, `sat_sp` | supply air temp / setpoint | Preheat and SAT faults |
+| `preheat_leave_t` | preheat discharge temp | ECON-5 |
+
+#### Core formulas
+
+**Outdoor air fraction** (dry-bulb mass-flow proxy):
+
+```text
+oa_frac = (mat - rat) / (oa_t - rat)
+```
+
+Skip the sample when `ABS(rat - oa_t) < 2.2` °F — no usable mixing signal.
+
+**Expected mixed air at full economizer** (sanity plot): when `oa_damper_pct > 0.90` and `ABS(rat - oa_t) > 5` °F, expect `mat ≈ oa_t` (within sensor tolerance).
+
+**Dry-bulb economizer favorable** (cooling season, default cutoffs):
+
+```text
+fan_proven AND oa_t < oat_cutoff   -- default oat_cutoff = 63 °F
+```
+
+#### Dry-bulb vs enthalpy economizer
+
+Most packaged rules below use **dry-bulb** thresholds (OAT only). **Enthalpy** economizers compare outdoor vs return enthalpy and need `oa_h` plus return humidity (`ra_h` or derived). Favorable cooling when outdoor enthalpy is below return enthalpy — thresholds vary by climate and controller vendor.
+
+Open-FDD ships dry-bulb defaults; tune `oat_cutoff`, `dpr_min`, and `oa_min_pct` per site. For enthalpy parity in Pandas, compute enthalpy off-box (e.g. psychrometric library) and mirror the same boolean gate in SQL assignments.
+
+#### RCx diagnostic workflow
+
+1. **Sensor quality** — run SV-1–SV-4 on `oa_t`, `mat`, `rat` before economizer rules latch.
+2. **Trend review** — plot OAT, MAT, RAT, and OA damper % on a summer occupied day.
+3. **Mode bands** — shade OS2/OS3 from damper + valve positions; confirm transitions match expectations.
+4. **Core economizer** — ECON-1 → ECON-3 (stuck closed, unfavorable economizing, mech when econ available).
+5. **Ventilation** — ECON-4, OA-1, OA-2 for minimum OA / DCV.
+6. **Hardware** — DMP-1 damper leakage; FC14–FC15 valve/damper at minimum position.
+7. **Confirm** — default 300–600 s API confirmation; extend for advisory / trim rules.
+
+#### Rule map (economizer family)
+
+| Rule | Focus | Where |
+|------|-------|-------|
+| ECON-1 | Damper closed when OAT favorable | below |
+| ECON-2 | Damper open when OAT unfavorable (hot) | below |
+| ECON-3 | Mechanical cooling when OAT cold enough to economize | below |
+| ECON-4 | Estimated OA fraction below design | below |
+| ECON-5 | Preheat coil over-conditioning | below |
+| OA-1 | Low OA fraction (extended) | [Extended v2 — OA-1](#oa-1--low-estimated-outdoor-air-fraction) |
+| OA-2 | DCV minimum OA not met | [Extended P2 — OA-2](#oa-2--dcv-minimum-outdoor-air-not-met) |
+| DMP-1 | OA damper leakage at commanded closed | [Extended v2 — DMP-1](#dmp-1--oa-damper-leakage) |
+| FC6 | OA fraction mismatch (GL36) | [FC6](#fc6--low-outside-air-fraction-gl36-rule-g) |
+| FC8–FC11 | SAT/MAT faults in economizer modes | [Air handling units](#air-handling-units) |
+
+---
 
 ### ECON-1 — Economizer stuck closed
 

--- a/docs/rules/cookbook/index.md
+++ b/docs/rules/cookbook/index.md
@@ -40,7 +40,7 @@ Every rule exists in **both** backends. See the [parity matrix](parity-matrix.ht
 | Sensor validation | 7 | SV-1–SV-7 |
 | AHU GL36 (FC1–FC15) | 15 | Duct static, MAT envelope, PID hunting |
 | VAV terminals | 7 | Comfort, reheat, damper, airflow bias, min flow |
-| Economizer / ventilation | 7 | ECON-1–5, OA-1–2 |
+| Economizer / ventilation | 7+ | ECON-1–5, OA-1–2, [diagnostics guide](datafusion-sql-cookbook.html#ahu-economizer-diagnostics-guide) |
 | Central plant | 6 | CHW ΔT, DP, reset, tower approach |
 | Extended v2 | 12 | Reset, schedule, override, cmd/status, leakage |
 | Extended P2 | 6 | VAV-6/7, TOWER-1, CTRL-2, SV-7, OA-2 |

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -18,6 +18,9 @@ nav_order: 2
 4. [Air handling units (FC1–FC15)](#air-handling-units)
 5. [VAV zones](#vav-zones)
 6. [Economizer & ventilation](#economizer--ventilation)
+   - [AHU economizer diagnostics guide](#ahu-economizer-diagnostics-guide)
+   - [ECON-1–5](#econ-1--economizer-stuck-closed)
+   - [Ventilation & leakage cross-rules](#rule-map-economizer-family)
 7. [Central plants](#central-plants)
 8. [Heat pumps](#heat-pumps)
 9. [Weather station](#weather-station)
@@ -679,6 +682,81 @@ v["fault_confirmed"] = confirm_fault(v["fault_raw"])
 
 ## Economizer & ventilation
 
+Analyst mirror of the [DataFusion economizer section](datafusion-sql-cookbook.html#economizer--ventilation). Use the same semantic columns and thresholds; export CSV from Open-FDD or vendor BMS for off-box RCx.
+
+### AHU economizer diagnostics guide
+
+#### Operating modes (GL36-style)
+
+```python
+AHU_MIN_OA_DPR = 0.05  # minimum OA damper position (0–1), tune per site
+
+def operating_mode_row(row) -> str:
+    """Classify one sample into OS1–OS4 (simplified GL36 bands)."""
+    htg = norm_cmd(pd.Series([row.get("htg_valve_pct", 0)])).iloc[0]
+    clg = norm_cmd(pd.Series([row.get("clg_valve_pct", 0)])).iloc[0]
+    fan = norm_cmd(pd.Series([row.get("fan_cmd", 0)])).iloc[0]
+    econ = norm_cmd(pd.Series([row.get("oa_damper_pct", 0)])).iloc[0]
+    if fan < 0.05:
+        return "off"
+    if htg > 0 and clg == 0:
+        return "OS1_heating"
+    if htg == 0 and clg == 0 and econ > AHU_MIN_OA_DPR:
+        return "OS2_economizer"
+    if htg == 0 and clg > 0 and econ > AHU_MIN_OA_DPR:
+        return "OS3_econ_mech"
+    if htg == 0 and clg > 0 and econ <= AHU_MIN_OA_DPR + 0.02:
+        return "OS4_mech_only"
+    return "other"
+```
+
+| Mode | Typical fault rules |
+|------|---------------------|
+| OS1 | FC5, FC7, ECON-5 |
+| OS2 | ECON-1, ECON-2 |
+| OS3 | ECON-3, FC8–FC11 |
+| OS4 | ECON-3 (inverse), cooling valve faults |
+
+#### Required columns
+
+Same semantic IDs as SQL: `oa_t`, `mat`, `rat`/`ra_t`, `oa_damper_pct`, `clg_valve_pct`, `htg_valve_pct`, `fan_cmd`, `fan_status`, `sat`, `sat_sp`, optional `oa_h`/`ra_h` for enthalpy sites.
+
+#### Core formulas
+
+```python
+def estimate_oa_fraction(d: pd.DataFrame) -> pd.Series:
+    """Dry-bulb OA fraction; NaN when mixing signal too weak."""
+    denom = (d["oa_t"] - d["rat"]).replace(0, np.nan)
+    frac = (d["mat"] - d["rat"]) / denom
+    weak = (d["rat"] - d["oa_t"]).abs() < 2.2
+    return frac.where(~weak)
+
+d["oa_frac"] = estimate_oa_fraction(d)
+```
+
+**Dry-bulb favorable:** `fan_proven & (oa_t < 63.0)` — align `63` with site `oat_cutoff`.
+
+**Enthalpy (optional):** compute outdoor/return enthalpy in the notebook (psychrometric library); gate economizer rules on `h_oa < h_ra` instead of OAT-only when the controller uses enthalpy logic.
+
+#### RCx diagnostic workflow
+
+1. Filter one AHU: `d = df[df["equipment_id"] == "equip:your-ahu"].copy()`
+2. Run sensor validation masks (SV section) on `oa_t`, `mat`, `rat`.
+3. Plot `oa_t`, `mat`, `rat`, `oa_damper_pct` for a summer weekday.
+4. Apply ECON-1 → ECON-5 below; cross-check OA-1, DMP-1 in [Extended v2](#oa-1--low-oa-fraction).
+5. Export confirmed intervals to Open-FDD SQL via [Export to Open-FDD SQL](#export-to-open-fdd-sql).
+
+#### Rule map (economizer family)
+
+| Rule | Focus | Section |
+|------|-------|---------|
+| ECON-1–5 | Core economizer faults | below |
+| OA-1, OA-2 | Ventilation minimum / DCV | [Extended v2 / P2](#oa-1--low-oa-fraction) |
+| DMP-1 | OA damper leakage | [Extended v2](#dmp-1--oa-damper-leakage) |
+| FC6, FC8–FC11 | GL36 economizer-mode AHU faults | [Air handling units](#air-handling-units) |
+
+---
+
 ### ECON-1 — Economizer stuck closed
 
 ```python
@@ -740,7 +818,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"])
 ### ECON-5 — Preheat over-conditioning
 
 ```python
-FAULT_CONFIRM_SECONDS = 300
+FAULT_CONFIRM_SECONDS = 600
 
 mask = (
     d["preheat_leave_t"].notna() & d["sat_sp"].notna() & d["oa_t"].notna() & d["htg_valve_pct"].notna()


### PR DESCRIPTION
## Summary
- Add **AHU economizer diagnostics guide** to DataFusion SQL and Pandas cookbooks: GL36 operating modes, required points, OA fraction formulas, dry-bulb vs enthalpy notes, RCx workflow, and rule-family map (ECON, OA, DMP, FC cross-links).
- Link from cookbook index.
- Align ECON-5 pandas confirmation to 600 s (matches SQL).

ChatGPT share thread was not readable; this expansion uses existing Open-FDD rule inventory + standard RCx economizer practice. Paste thread content in a follow-up to merge any gaps.

## Test plan
- [x] Markdown only
- [ ] Docs Pages deploy after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new AHU economizer diagnostics guide to the cookbooks, including operating modes, required data fields, core formulas, and a diagnostic workflow.
  * Expanded navigation and rule references for economizer, ventilation, and leakage cross-rules.
  * Updated the rule inventory to reflect a broader economizer/ventilation set.
  * Refined one economizer fault example to use a longer confirmation window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->