### PR TITLE
Docs: edge retest prompt for 3.2.11 @ dfde570

### DIFF
--- a/docs/agent/linux-edge-tester-nightly-retest-prompt.md
+++ b/docs/agent/linux-edge-tester-nightly-retest-prompt.md
@@ -1,8 +1,8 @@
-# Linux edge tester — nightly retest @ `38df801` (paste prompt)
+# Linux edge tester — nightly retest @ `dfde570` (paste prompt)
 
-**Repo-only** (not on GitHub Pages). Paste into Cursor on **`/home/ben/open-fdd`** when product confirms `:nightly` is green and bench must re-gate after P0 fixes (#451).
+**Repo-only** (not on GitHub Pages). Paste into Cursor on **`/home/ben/open-fdd`** when product confirms `:nightly` is green on **`dfde570`** (or later master SHA that includes **3.2.11** edge).
 
-Full charter: [linux-edge-tester-prompt.md](./linux-edge-tester-prompt.md)
+Full charter: [linux-edge-tester-prompt.md](./linux-edge-tester-prompt.md) · GH Actions watch: [linux-edge-tester-gh-actions-watch-prompt.md](./linux-edge-tester-gh-actions-watch-prompt.md)
 
 ---
 
@@ -12,10 +12,10 @@ You are the Open-FDD Linux edge tester on /home/ben/open-fdd.
 Charter: TEST, DOCUMENT, REPORT — no Rust/TS edits, no git push, no upstream PR.
 Bench has insufficient RAM — GHCR pull only (never docker build / cargo build).
 
-Your job NOW: git pull bench scripts → deploy :nightly @ 38df801 → run gates → post GitHub evidence → report what is STILL NOT WORKING.
+Your job NOW: sync bench scripts → deploy :nightly @ dfde570 (3.2.11) → run gates → post GitHub evidence → report what is STILL NOT WORKING.
 
-Acknowledged. Bench /home/ben/open-fdd. Channel: nightly. Target SHA: 38df801. Gate: #429.
-Will comment #429 (always), #433 (BACnet/drivers), #452/#453 (P0 verify), #431 if agent/validate changes.
+Acknowledged. Bench /home/ben/open-fdd. Channel: nightly. Target SHA: dfde570 (3.2.11). Gate: #429.
+Will comment #429 (always), #433 (drivers/BACnet/historian/Haystack), #452/#453 (P0 verify).
 No git push. No product code edits on bench.
 ```
 
@@ -25,34 +25,48 @@ No git push. No product code edits on bench.
 
 | Item | Value |
 |------|-------|
-| **Expected `git_sha` prefix** | latest green nightly (was `38df801` / **3.2.10** bench fixes) |
-| **Includes** | #451 P0 BACnet server runtime + poll historian persist; #455/#456 CI fixes |
-| **Last bench test** | `f5f66bd` (pre-#451 — FAIL server panic + historian stuck) |
+| **Expected `git_sha` prefix** | `dfde570` (minimum) — **3.2.11** via [#461](https://github.com/bbartling/open-fdd/pull/461) |
+| **Includes** | Haystack Basic-auth `text/zinc` POST (#461); BACnet server dedicated thread; pivot append error logging; headless CSV batch (no `/csv` UI) |
+| **Last bench test** | `d1483d0` @ 3.2.10 — partial: samples ↑, Who-Is 599999, **server panic**, **pivot frozen Jul 3**, Haystack **HTTP 415** on poll-once |
 | **GHCR tag** | `ghcr.io/bbartling/openfdd-edge-rust:nightly` |
-| **GHCR publish** | [run 28745276684](https://github.com/bbartling/open-fdd/actions/runs/28745276684) — success |
+| **Vibe16 lab** | [openfdd-bacnet-feather-concept](https://github.com/bbartling/py-bacnet-stacks-playground/tree/develop/vibe_code_apps_16/openfdd-bacnet-feather-concept) — kill before BACnet tests |
 
-Confirm CI before deploy (optional):
+Confirm CI before deploy:
 
 ```bash
-gh run list --repo bbartling/open-fdd --workflow rust-ghcr.yml --branch master --limit 1 \
-  --json conclusion,headSha | jq '.[0] | {conclusion, sha: .headSha[0:7]}'
-# expect: success, 38df801
+gh run list --repo bbartling/open-fdd --workflow rust-ghcr.yml --branch master --limit 3 \
+  --json conclusion,headSha,status | jq '.[] | select(.headSha|startswith("dfde570") or startswith("802258a7")) | {conclusion, sha: .headSha[0:7], status}'
+# expect: conclusion success on dfde570 or later master (802258a7 docs-only is OK — same edge binary)
 ```
+
+**Abort** deploy if `/api/health` `git_sha` prefix is still `d1483d0` or older — nightly not refreshed.
+
+---
+
+## Open issues — still legit @ 2026-07-06
+
+| Issue | Status | Retest focus |
+|-------|--------|--------------|
+| **[#429](https://github.com/bbartling/open-fdd/issues/429)** | OPEN — sign-off **NO** | Full iteration report every run |
+| **[#452](https://github.com/bbartling/open-fdd/issues/452)** | OPEN — P0 | Bridge logs: **zero panic**; Who-Is → 599999; server on UDP :47808 |
+| **[#453](https://github.com/bbartling/open-fdd/issues/453)** | OPEN — P0 partial | **samples ↑** (was fixed @ d1483d0); **`telemetry_pivot.jsonl` mtime must advance** |
+| **[#433](https://github.com/bbartling/open-fdd/issues/433)** | OPEN — P1 | Haystack poll-once/read (was HTTP 415); bridge field Who-Is; driver tree |
+| **#430–#437** | OPEN — 3.2.8 backlog | Defer unless in scope; not blocking #429 A′ |
+
+Do **not** close P0 issues yourself. Comment PASS/FAIL with evidence.
 
 ---
 
 ## Step 0 — Sync bench tree (scripts + docs only)
 
-Pull latest **bench repo** for scripts, compose, and agent prompts. **Do not** build containers from source.
-
 ```bash
 cd /home/ben/open-fdd
 git fetch origin
-git pull --ff-only origin master   # or your bench tracking branch
-git log -1 --oneline
+git pull --ff-only origin master 2>/dev/null || echo "Note: bench may not be a git repo — scripts from product handoff OK"
+git log -1 --oneline 2>/dev/null || true
 ```
 
-If `git pull` fails (bench-only commits), note in #429 and continue with local scripts — deploy still uses **GHCR**, not local Rust.
+Deploy uses **GHCR**, not local Rust.
 
 ---
 
@@ -63,18 +77,17 @@ cd /home/ben/open-fdd
 export OPENFDD_IMAGE_TAG=nightly
 export OPENFDD_COMPOSE_ROOT="$PWD"
 
-# Kill vibe16 lab — steals UDP 47808
+# Kill vibe16 — steals UDP :47808
 pkill -f 'target/release/bacnet_app' || true
-pkill -f 'openfdd-bacnet-feather-concept.*bacnet_app' || true
+pkill -f 'openfdd-bacnet-feather-concept' || true
 pgrep -af bacnet_app || echo "OK: no stray bacnet_app"
 
-# BACnet env split
-echo "=== bridge (expect SERVER=1 via compose) ==="
-docker exec openfdd-bridge printenv OPENFDD_BACNET_SERVER_ENABLED 2>/dev/null || echo "(stack down)"
+# Auth readable by container uid 10001 (3.2.10+)
+chmod 644 workspace/auth.env.local 2>/dev/null || true
 
-echo "=== commission.env (expect 0) ==="
-grep OPENFDD_BACNET_SERVER_ENABLED workspace/bacnet/commissioning/commission.env 2>/dev/null \
-  || echo "MISSING — set OPENFDD_BACNET_SERVER_ENABLED=0"
+# BACnet env split
+docker exec openfdd-bridge printenv OPENFDD_BACNET_SERVER_ENABLED 2>/dev/null || echo "(stack down)"
+grep OPENFDD_BACNET_SERVER_ENABLED workspace/bacnet/commissioning/commission.env 2>/dev/null || true
 ```
 
 ---
@@ -82,30 +95,12 @@ grep OPENFDD_BACNET_SERVER_ENABLED workspace/bacnet/commissioning/commission.env
 ## Step 2 — Deploy `:nightly` (GHCR pull only)
 
 ```bash
-cd /home/ben/open-fdd
-export OPENFDD_IMAGE_TAG=nightly
-export OPENFDD_COMPOSE_ROOT="$PWD"
-
-# Pull pre-built image + recreate stack (preserves historian per bench policy)
 REQUIRE_BACKUP=0 ./scripts/openfdd_rust_site_update.sh
-
 ./scripts/openfdd_rust_edge_validate.sh
-
-# Confirm SHA advanced past f5f66bd
 curl -s http://127.0.0.1:8080/api/health | jq '{git_sha, image_tag, status, version}'
 ```
 
-**Abort** if `git_sha` prefix is not `38df801` — nightly not refreshed; do not claim re-test.
-
-Expected:
-
-```json
-{
-  "git_sha": "38df801…",
-  "image_tag": "nightly",
-  "status": "ok"
-}
-```
+Expected: `version` **3.2.11**, `git_sha` prefix **`dfde570`** or later, `image_tag` **nightly**.
 
 ---
 
@@ -131,60 +126,47 @@ Never print `$TOKEN` in GitHub comments.
 
 ### 4a — P0 re-checks (#452, #453)
 
-These map directly to open P0 issues. **PASS** = close-worthy after maintainer review; **FAIL** = product handoff.
-
-| Issue | What to prove | Commands |
-|-------|---------------|----------|
-| **[#452](https://github.com/bbartling/open-fdd/issues/452)** | BACnet server starts — no tokio panic; **599999** on wire | `docker logs openfdd-bridge 2>&1 \| grep -E 'panic\|BACnet server' \| tail -10` — expect **"BACnet server on UDP"**, **no panic** |
-| **[#453](https://github.com/bbartling/open-fdd/issues/453)** | Poll reads persist to historian | `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/poll/status \| jq '{samples,last_poll,errors}'` — expect **samples ↑** over 2–3 cycles; check pivot/feather mtime |
+| Issue | What to prove |
+|-------|---------------|
+| **#452** | No tokio panic in bridge logs; **599999** in Who-Is; `/api/bacnet/server/points` OK |
+| **#453** | Poll **samples ↑**; **`telemetry_pivot.jsonl` mtime advances** after 90s poll; feather shards grow |
 
 ```bash
-# #452 — server + Who-Is on bridge (local 599999)
-docker logs openfdd-bridge 2>&1 | tail -80 > /tmp/bridge-tail.log
-grep -E 'panic|BACnet server' /tmp/bridge-tail.log | tail -10
+docker logs openfdd-bridge 2>&1 | grep -E 'panic|BACnet server' | tail -10
 
-time curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   http://127.0.0.1:8080/api/bacnet/whois \
   -d '{"low":599990,"high":600000}' | jq .
 
-# #453 — poll + historian
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/poll/status | jq .
-sleep 30
+sleep 90
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/poll/status | jq .
+
+find workspace/data/pivot -name 'telemetry_pivot.jsonl' -printf '%T+ %p\n' 2>/dev/null
 ls -lt workspace/data/feather_store/bacnet/*/*/*.feather 2>/dev/null | head -5
-find workspace/data/pivot -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -3
 ```
 
-### 4b — Phase A′ / drivers ([#433](https://github.com/bbartling/open-fdd/issues/433))
+### 4b — Haystack (#433) — **new @ 3.2.11**
 
-| Check | Pass |
-|-------|------|
-| `POST /api/bacnet/whois` | JSON in ~30s; lists field device(s) |
-| `GET /api/bacnet/driver/tree` | JSON; field instances present (not only 599999) |
-| Commission Who-Is (if used) | Non-empty when field devices on wire |
-| Bridge vs commission env split | bridge `SERVER=1`, commission `SERVER=0` |
+Niagara nHaystack was **HTTP 415** on `read`/`poll-once` @ d1483d0. #461 sends **`text/zinc`** for Basic auth POST.
 
 ```bash
-time curl -s -H "Authorization: Bearer $TOKEN" \
-  http://127.0.0.1:8080/api/bacnet/driver/tree | jq .
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/haystack/status | jq .
+curl -s -X POST -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/haystack/test | jq '{ok,message}'
+curl -s -X POST -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/haystack/poll-once | jq '{ok,message,records: (.records|length)?}'
+```
+
+### 4c — Drivers matrix → **#429**
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/driver/tree | jq '.devices|length?'
 
 ./scripts/openfdd_polling_feather_validate.sh
-./scripts/openfdd_drivers_validate.sh || true   # note E2BIG if tree huge
-```
+./scripts/openfdd_drivers_validate.sh || true
+./scripts/openfdd_docker_health_audit.sh || true
 
-### 4c — All-drivers matrix → **#429**
-
-```bash
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/modbus/poll/status | jq '{samples,last_poll}'
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/agent/validate | jq .
-
-echo "=== Modbus ==="
-curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/modbus/poll/status | jq .
-
-echo "=== Haystack ==="
-curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/haystack/status | jq .
-
-echo "=== Health ==="
-curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/health | jq '{status,image_tag,git_sha,version}'
 ```
 
 ### 4d — Phase B soak (only if A + A′ PASS)
@@ -197,94 +179,60 @@ OPENFDD_SOAK_MINUTES=10 ./scripts/openfdd_stores_fdd_soak.sh
 
 ## Step 5 — GitHub issues to respond on
 
-Post evidence on **every issue whose status changed**. Minimum set for this iteration:
-
-| Issue | When to comment | What to include |
-|-------|-----------------|-----------------|
-| **[#429](https://github.com/bbartling/open-fdd/issues/429)** | **Always** | Full iteration report + sign-off NO/YES |
-| **[#433](https://github.com/bbartling/open-fdd/issues/433)** | BACnet / drivers / historian changed | Who-Is JSON, tree snippet, poll/feather evidence |
-| **[#452](https://github.com/bbartling/open-fdd/issues/452)** | Server panic fixed or still failing | bridge log grep, Who-Is 599999 |
-| **[#453](https://github.com/bbartling/open-fdd/issues/453)** | Historian persist fixed or still failing | samples count, pivot mtime, feather paths |
-| **[#431](https://github.com/bbartling/open-fdd/issues/431)** | `/api/agent/validate` rollup changed | validate JSON |
-| **#430, #432, #434–#437** | Only if in scope / phase reached | Defer until #429 A′ green unless asked |
+| Issue | When |
+|-------|------|
+| **#429** | **Always** — full report + sign-off NO/YES |
+| **#452, #453** | P0 server + pivot evidence |
+| **#433** | Haystack poll-once, Who-Is/tree, historian |
+| **#431** | If `/api/agent/validate` rollup changed |
 
 ```bash
-REPO=bbartling/open-fdd
-gh issue comment 429 --repo "$REPO" --body-file /tmp/edge-iteration-38df801.md
-gh issue comment 433 --repo "$REPO" --body-file /tmp/bacnet-evidence.md
-gh issue comment 452 --repo "$REPO" --body-file /tmp/p452-server.md
-gh issue comment 453 --repo "$REPO" --body-file /tmp/p453-historian.md
+gh issue comment 429 --repo bbartling/open-fdd --body-file /tmp/edge-iteration-dfde570.md
 ```
 
-Do **not** close issues yourself. Do **not** claim **Sign-off: YES** on #429 unless all rubric items pass (see main prompt).
+Do **not** claim **Sign-off: YES** unless all rubric items pass.
 
 ---
 
-## Step 6 — Report template (paste on #429)
-
-Fill every section. **Required:** explicit **"Still not working"** list even if mostly PASS.
+## Step 6 — Report template (#429)
 
 ```markdown
-## Edge iteration — nightly @ `38df801`
+## Edge iteration — nightly @ `dfde570` (3.2.11)
 
-**Deploy:** `git pull` @ `<bench_git_sha>` · GHCR `:nightly` via `openfdd_rust_site_update.sh`
-**Health:** `image_tag` / `git_sha` / `status` from `/api/health`
-**Previous test:** `f5f66bd` · **Poll daemon:** running | stopped
+**Deploy:** GHCR `:nightly` · **Health:** (git_sha / version / status)
+**Previous test:** `d1483d0` @ 3.2.10 · **Poll daemon:** running | stopped
 
-### P0 verification (#451)
+### P0 / drivers
 
 | Gate | Issue | Result | Evidence |
 |------|-------|--------|----------|
-| BACnet server — no panic, 599999 on wire | #452 | PASS / FAIL | bridge log / Who-Is |
-| Poll → historian persist | #453 | PASS / FAIL | samples, pivot mtime, feather |
-| Who-Is + driver tree (field devices) | #433 | PASS / FAIL | whois + tree JSON |
-| polling_feather_validate | #429 | pass=X fail=Y | script output |
-| openfdd_drivers_validate | #429 | PASS / FAIL / E2BIG | script output |
-| Modbus poll | #429 | PASS / FAIL | poll/status |
-| Haystack | #429 | PASS / FAIL | status/test |
-| agent/validate rollup | #431 | PASS / FAIL | validate JSON |
+| BACnet server — no panic | #452 | PASS/FAIL | bridge log |
+| Who-Is 599999 | #452 | PASS/FAIL | whois JSON |
+| Poll samples ↑ | #453 | PASS/FAIL | poll/status ×2 |
+| Pivot JSONL mtime advances | #453 | PASS/FAIL | find mtime |
+| Haystack poll-once | #433 | PASS/FAIL | was 415 @ d1483d0 |
+| Haystack test/connection | #433 | PASS/FAIL | test JSON |
+| polling_feather_validate | #429 | pass=X fail=Y | script |
+| Modbus samples | #429 | PASS/FAIL | poll/status |
 
 ### Still not working
 
-List every FAIL or degraded item — be explicit:
-
 1. …
-2. …
-
-*(If all PASS: write "None observed this iteration" and list deferred P1 items separately.)*
-
-### Deferred / P1 (not blocking sign-off unless noted)
-
-- Bridge Who-Is returned `[]` on f5f66bd — retest result: …
-- vibe16 `bacnet_app` UDP contention — preflight: …
-- Weather AVs / feather retention / UX (#433) — …
 
 ### Sign-off
 
-**Sign-off: NO** / **YES** (maintainer only for YES)
+**Sign-off: NO** / **YES**
 
-**Artifacts:** `workspace/logs/` or `/tmp/bridge-tail.log` paths (no secrets)
-
-**Product handoff:** @vibe16 if any P0/P1 FAIL — WSL PR + new nightly; bench waits for GHCR green.
-```
-
-### Product handoff (if any FAIL)
-
-```markdown
-### Product handoff — edge FAIL @ `38df801`
-
-**Blocked:** #452 server | #453 historian | #433 Who-Is/tree | Modbus | Haystack
-**Evidence:** (redacted jq + log excerpts)
-**Request:** fix on WSL, merge, publish `:nightly`. Bench re-runs when `git_sha` advances.
+**Artifacts:** `workspace/logs/nightly_retest_*` (no secrets)
 ```
 
 ---
 
-## Step 7 — Save artifacts
+## Step 7 — Artifacts
 
 ```bash
 STAMP=$(date -u +%Y%m%dT%H%M%SZ)
-LOGDIR=workspace/logs/nightly_38df801_${STAMP}
+LOGDIR=workspace/logs/nightly_retest_${STAMP}
 mkdir -p "$LOGDIR"
 curl -s http://127.0.0.1:8080/api/health | jq . > "$LOGDIR/health.json"
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/bacnet/poll/status | jq . > "$LOGDIR/bacnet_poll.json"
@@ -297,7 +245,6 @@ echo "Artifacts: $LOGDIR"
 ## Rules
 
 - **GHCR pull only** — never `docker build` or `cargo build` on bench.
-- **git pull** updates scripts/docs; **image** comes from GHCR `:nightly`.
-- Preflight kill vibe16 `bacnet_app` every iteration.
+- Preflight: kill vibe16 `bacnet_app`; `chmod 644 workspace/auth.env.local`.
 - Never `docker compose down -v` · never delete `workspace/` · never print tokens.
-- Update `LAST_TESTED_SHA=38df801` in your #429 comment after this run.
+- Record `LAST_TESTED_SHA=dfde570` in #429 comment after deploy confirms health SHA.


### PR DESCRIPTION
## Summary
- Refresh `linux-edge-tester-nightly-retest-prompt.md` for **3.2.11** @ `dfde570` (#461).
- Open-issue map (#429, #452, #453, #433), Haystack zinc poll-once gate, pivot mtime check, vibe16 preflight.

## Test plan
- [x] Markdown only


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Linux edge tester nightly retest prompt for the latest target build and version.
  * Clarified deployment, health-check, and validation steps, including updated evidence requirements and abort conditions.
  * Expanded guidance for several validation scenarios so nightly retests follow the current expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->