### PR TITLE
fix(edge): bench closeout 3.2.12 — MSTP 5007, FDD profile, commission proxy

### DIFF
--- a/.github/workflows/rust-ghcr.yml
+++ b/.github/workflows/rust-ghcr.yml
@@ -46,6 +46,7 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -70,6 +71,7 @@ jobs:
             org.opencontainers.image.version=nightly
 
       - uses: docker/build-push-action@v6
+        timeout-minutes: 240
         with:
           context: .
           file: Dockerfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open_fdd_edge_prototype"
-version = "3.2.11"
+version = "3.2.12"
 dependencies = [
  "arrow",
  "bacnet-client",

--- a/docs/agent/WSL_CURSOR_AGENT_ISSUES.md
+++ b/docs/agent/WSL_CURSOR_AGENT_ISSUES.md
@@ -1,0 +1,44 @@
+# WSL Cursor Agent — GitHub Issue Index
+
+**Bench:** `/home/ben/open-fdd` (GHCR pull only) · **Source:** `/home/ben/open-fdd-src` or this repo  
+**Umbrella:** [#429](https://github.com/bbartling/open-fdd/issues/429)
+
+## Fix priority (3.2.12 cycle)
+
+| Issue | Pri | Status in 3.2.12 PR |
+|-------|-----|---------------------|
+| [#466](https://github.com/bbartling/open-fdd/issues/466) | P0 | `active_profile()` honors `OPENFDD_VALIDATION_PROFILE` |
+| [#464](https://github.com/bbartling/open-fdd/issues/464) | P0 | MSTP routing persisted; `read_property_routed` poll/read |
+| [#467](https://github.com/bbartling/open-fdd/issues/467) | P1 | Persistent `Arc<Mutex<BACnetClient>>` |
+| [#465](https://github.com/bbartling/open-fdd/issues/465) | P1 | Bridge→commission proxy (whois/read/discovery) |
+| [#469](https://github.com/bbartling/open-fdd/issues/469) | P1 | `auth.env.local` mode 644; handoff merge on partial rotate |
+| [#470](https://github.com/bbartling/open-fdd/issues/470) | P1 | `scripts/bench/` restored |
+
+## Bench deploy after `:nightly` publish
+
+```bash
+cd /home/ben/open-fdd
+NEW_TAG=nightly ./scripts/openfdd_rust_site_update.sh
+chmod 644 workspace/auth.env.local
+curl -fsS http://127.0.0.1:8080/health | jq '{ok,version,git_sha_short}'
+```
+
+## 5007 acceptance gates
+
+```bash
+TOK=$(curl -fsS -X POST http://127.0.0.1:8080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"integrator","password":"..."}' | jq -r .token)
+curl -fsS -X POST http://127.0.0.1:8080/api/bacnet/whois \
+  -H "Authorization: Bearer $TOK" -d '{"low":5007,"high":5007}'
+curl -fsS -X POST http://127.0.0.1:8080/api/bacnet/read \
+  -H "Authorization: Bearer $TOK" -d '{"point_id":"bacnet:5007:analog-input:1173"}'
+```
+
+## Deep-sleep GHCR watch (product agent)
+
+```bash
+./scripts/openfdd_product_ghcr_deep_sleep.sh
+```
+
+Posts to #429 on publish success/fail; 30-minute wake interval.

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open_fdd_edge_prototype"
-version = "3.2.11"
+version = "3.2.12"
 edition = "2021"
 
 [[bin]]

--- a/edge/src/commission_proxy.rs
+++ b/edge/src/commission_proxy.rs
@@ -1,0 +1,48 @@
+//! Bridge → commission HTTP proxy for field BACnet when the local server shadows Who-Is.
+
+use std::env;
+use std::time::Duration;
+
+pub fn commission_base() -> String {
+    env::var("OPENFDD_COMMISSION_BASE").unwrap_or_else(|_| "http://127.0.0.1:9091".into())
+}
+
+pub fn should_proxy_bacnet() -> bool {
+    if env::var("OPENFDD_BACNET_COMMISSION_PROXY")
+        .map(|v| v == "0" || v.eq_ignore_ascii_case("false"))
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    env::var("SERVICE_MODE").unwrap_or_else(|_| "bridge".into()) == "bridge"
+}
+
+pub fn proxy_auth_header(headers: &[(String, String)]) -> Option<String> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+        .map(|(_, v)| v.clone())
+}
+
+pub fn proxy_post(path: &str, body: &str, auth: Option<&str>) -> Result<String, String> {
+    let url = format!("{}{}", commission_base().trim_end_matches('/'), path);
+    let mut req = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()
+        .map_err(|e| e.to_string())?
+        .post(url)
+        .header("Content-Type", "application/json");
+    if let Some(token) = auth {
+        req = req.header("Authorization", token);
+    }
+    let resp = req
+        .body(body.to_string())
+        .send()
+        .map_err(|e| e.to_string())?;
+    let status = resp.status();
+    let text = resp.text().map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("commission proxy {path} -> HTTP {status}: {text}"));
+    }
+    Ok(text)
+}

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -696,7 +696,7 @@ pub fn merge_live_discovery_into_registry(device_instance: u32) -> Value {
         .and_then(|p| p.get("address"))
         .cloned()
         .unwrap_or(json!(""));
-    let discovery_routing = discovered.first().and_then(|p| routing_from_whois_json(p));
+    let discovery_routing = discovered.first().and_then(routing_from_whois_json);
 
     if let Some(drivers) = registry.get_mut("drivers").and_then(|v| v.as_array_mut()) {
         for driver in drivers {

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -267,6 +267,136 @@ fn cached_whois_instances() -> Vec<u32> {
         .unwrap_or_default()
 }
 
+/// Routed MSTP field device metadata (vibe16 / driver_tree parity).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldDeviceRouting {
+    pub router_address: String,
+    pub mstp_network: u16,
+    pub mstp_mac: Vec<u8>,
+}
+
+fn parse_mstp_mac(value: &Value) -> Option<Vec<u8>> {
+    if let Some(arr) = value.as_array() {
+        let mac: Vec<u8> = arr
+            .iter()
+            .filter_map(|x| x.as_u64().map(|n| n as u8))
+            .collect();
+        if !mac.is_empty() {
+            return Some(mac);
+        }
+    }
+    if let Some(s) = value.as_str() {
+        if let Ok(bytes) = hex::decode(s) {
+            if !bytes.is_empty() {
+                return Some(bytes);
+            }
+        }
+    }
+    None
+}
+
+fn routing_from_whois_json(dev: &Value) -> Option<FieldDeviceRouting> {
+    let addr = dev.get("address").and_then(|a| a.as_str())?;
+    if addr.is_empty() {
+        return None;
+    }
+    let mstp_network = dev
+        .get("mstp_network")
+        .or_else(|| dev.get("source_network"))
+        .and_then(|v| v.as_u64())
+        .map(|n| n as u16)?;
+    let mstp_mac = dev
+        .get("mstp_mac")
+        .or_else(|| dev.get("source_address"))
+        .and_then(parse_mstp_mac)?;
+    if mstp_mac.is_empty() {
+        return None;
+    }
+    Some(FieldDeviceRouting {
+        router_address: addr.to_string(),
+        mstp_network,
+        mstp_mac,
+    })
+}
+
+fn routing_from_registry_device(device: &Value) -> Option<FieldDeviceRouting> {
+    let addr = device.get("address").and_then(|a| a.as_str())?;
+    if addr.is_empty() {
+        return None;
+    }
+    let mstp_network = device
+        .get("mstp_network")
+        .or_else(|| device.get("source_network"))
+        .and_then(|v| v.as_u64())
+        .map(|n| n as u16)?;
+    let mstp_mac = device
+        .get("mstp_mac")
+        .or_else(|| device.get("source_address"))
+        .and_then(parse_mstp_mac)?;
+    if mstp_mac.is_empty() {
+        return None;
+    }
+    Some(FieldDeviceRouting {
+        router_address: addr.to_string(),
+        mstp_network,
+        mstp_mac,
+    })
+}
+
+fn cached_whois_device(device_instance: u32) -> Option<Value> {
+    let path = whois_cache_path();
+    let text = fs::read_to_string(path).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    let devices = v.get("devices")?.as_array()?;
+    for dev in devices {
+        let inst = dev
+            .get("object_identifier")
+            .and_then(|o| o.get("instance"))
+            .and_then(|x| x.as_u64())
+            .or_else(|| dev.get("device_instance").and_then(|x| x.as_u64()))
+            .map(|n| n as u32);
+        if inst == Some(device_instance) {
+            return Some(dev.clone());
+        }
+    }
+    None
+}
+
+/// Config-driven MSTP routing for a field device (registry first, then Who-Is cache).
+pub fn field_device_routing(device_instance: u32) -> Option<FieldDeviceRouting> {
+    let registry = read_registry();
+    if let Some(drivers) = registry.get("drivers").and_then(|v| v.as_array()) {
+        for driver in drivers {
+            if driver.get("id").and_then(|v| v.as_str()) != Some("bacnet-ip") {
+                continue;
+            }
+            if let Some(devs) = driver.get("devices").and_then(|v| v.as_array()) {
+                for device in devs {
+                    if device
+                        .get("device_instance")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as u32
+                        == device_instance
+                    {
+                        if let Some(r) = routing_from_registry_device(device) {
+                            return Some(r);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    cached_whois_device(device_instance).and_then(|dev| routing_from_whois_json(&dev))
+}
+
+fn apply_routing_to_device(device: &mut Value, routing: &FieldDeviceRouting) {
+    device["address"] = json!(routing.router_address);
+    device["mstp_network"] = json!(routing.mstp_network);
+    device["source_network"] = json!(routing.mstp_network);
+    device["mstp_mac"] = json!(routing.mstp_mac);
+    device["source_address"] = json!(hex::encode(&routing.mstp_mac));
+}
+
 /// Address from Who-Is cache for a field instance (if known).
 pub fn cached_field_device_address(device_instance: u32) -> Option<String> {
     let path = whois_cache_path();
@@ -323,14 +453,20 @@ fn ensure_field_device_shell(device_instance: u32, address: Option<String>) -> b
         let addr = address
             .or_else(|| cached_field_device_address(device_instance))
             .unwrap_or_default();
-        devices.push(json!({
+        let mut shell = json!({
             "device_instance": device_instance,
             "name": format!("BACnet Device {device_instance}"),
             "address": addr,
             "polling_enabled": true,
             "points": [],
             "source": "whois-shell"
-        }));
+        });
+        if let Some(dev) = cached_whois_device(device_instance) {
+            if let Some(r) = routing_from_whois_json(&dev) {
+                apply_routing_to_device(&mut shell, &r);
+            }
+        }
+        devices.push(shell);
         driver["devices"] = json!(devices);
         write_registry(&registry);
         return true;
@@ -350,6 +486,41 @@ fn merge_missing_field_devices_from_cache() {
     for inst in candidates {
         if !existing.contains(&inst) {
             let _ = ensure_field_device_shell(inst, cached_field_device_address(inst));
+        } else {
+            refresh_field_device_routing(inst);
+        }
+    }
+}
+
+fn refresh_field_device_routing(device_instance: u32) {
+    let Some(routing) =
+        cached_whois_device(device_instance).and_then(|d| routing_from_whois_json(&d))
+    else {
+        return;
+    };
+    let mut registry = read_registry();
+    let Some(drivers) = registry.get_mut("drivers").and_then(|v| v.as_array_mut()) else {
+        return;
+    };
+    for driver in drivers {
+        if driver.get("id").and_then(|v| v.as_str()) != Some("bacnet-ip") {
+            continue;
+        }
+        let Some(devs) = driver.get_mut("devices").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+        for device in devs.iter_mut() {
+            if device
+                .get("device_instance")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32
+                != device_instance
+            {
+                continue;
+            }
+            apply_routing_to_device(device, &routing);
+            write_registry(&registry);
+            return;
         }
     }
 }
@@ -525,6 +696,7 @@ pub fn merge_live_discovery_into_registry(device_instance: u32) -> Value {
         .and_then(|p| p.get("address"))
         .cloned()
         .unwrap_or(json!(""));
+    let discovery_routing = discovered.first().and_then(|p| routing_from_whois_json(p));
 
     if let Some(drivers) = registry.get_mut("drivers").and_then(|v| v.as_array_mut()) {
         for driver in drivers {
@@ -591,6 +763,9 @@ pub fn merge_live_discovery_into_registry(device_instance: u32) -> Value {
                 })
             };
             device["points"] = json!(points);
+            if let Some(r) = discovery_routing.as_ref() {
+                apply_routing_to_device(&mut device, r);
+            }
             if let Some(idx) = existing_idx {
                 devices[idx] = device;
             } else {
@@ -2458,7 +2633,9 @@ mod override_export_tests {
                     "instances": [inst],
                     "devices": [{
                         "object_identifier": {"type": "device", "instance": inst},
-                        "address": addr
+                        "address": addr,
+                        "source_network": 2000,
+                        "source_address": "07"
                     }]
                 }))
                 .unwrap(),
@@ -2477,6 +2654,16 @@ mod override_export_tests {
             assert!(field.is_some(), "Who-Is instance must appear in tree");
             assert_eq!(field.unwrap()["address"].as_str(), Some(addr));
             assert_eq!(field.unwrap()["source"].as_str(), Some("whois-shell"));
+            assert_eq!(
+                field.unwrap()["mstp_network"].as_u64(),
+                Some(2000),
+                "Who-Is MSTP network must persist in driver tree"
+            );
+            assert_eq!(
+                field.unwrap()["mstp_mac"],
+                json!([7]),
+                "Who-Is MSTP MAC must persist in driver tree"
+            );
             // Second call is a no-op (already present).
             pin_ws();
             assert!(!ensure_field_device_shell(inst, None));

--- a/edge/src/drivers/bacnet_live.rs
+++ b/edge/src/drivers/bacnet_live.rs
@@ -452,7 +452,7 @@ pub async fn read_priority_array(
     object_type: ObjectType,
     instance: u32,
 ) -> Result<Vec<(u8, Value)>, String> {
-    let mut client = client_lock().await?;
+    let client = client_lock().await?;
     let (low, high) = discover_low_high();
     client
         .who_is(Some(low), Some(high))
@@ -489,7 +489,7 @@ pub async fn read_priority_array(
 }
 
 pub async fn discover_device_points(device_instance: u32) -> Result<Vec<Value>, String> {
-    let mut client = client_lock().await?;
+    let client = client_lock().await?;
     let (low, high) = discover_low_high();
     client
         .who_is(Some(low), Some(high))
@@ -685,11 +685,11 @@ pub async fn discover_device_points_rpm(device_instance: u32) -> Result<Vec<Valu
             )
             .await
             {
-                if let Ok((val, _)) = decode_application_value(&name_ack.property_value, 0) {
-                    if let PropertyValue::CharacterString(s) = val {
+                    if let Ok((PropertyValue::CharacterString(s), _)) =
+                        decode_application_value(&name_ack.property_value, 0)
+                    {
                         name = s;
                     }
-                }
             }
             if let Ok(pv_ack) = read_property_for_device(
                 &mut client,

--- a/edge/src/drivers/bacnet_live.rs
+++ b/edge/src/drivers/bacnet_live.rs
@@ -685,11 +685,11 @@ pub async fn discover_device_points_rpm(device_instance: u32) -> Result<Vec<Valu
             )
             .await
             {
-                    if let Ok((PropertyValue::CharacterString(s), _)) =
-                        decode_application_value(&name_ack.property_value, 0)
-                    {
-                        name = s;
-                    }
+                if let Ok((PropertyValue::CharacterString(s), _)) =
+                    decode_application_value(&name_ack.property_value, 0)
+                {
+                    name = s;
+                }
             }
             if let Ok(pv_ack) = read_property_for_device(
                 &mut client,

--- a/edge/src/drivers/bacnet_live.rs
+++ b/edge/src/drivers/bacnet_live.rs
@@ -17,11 +17,13 @@ use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 use serde_json::{json, Value};
 use std::env;
 use std::net::Ipv4Addr;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
+use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+static PERSISTENT_CLIENT: OnceLock<Arc<Mutex<BACnetClient<BipTransport>>>> = OnceLock::new();
 
 fn runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| {
@@ -174,6 +176,9 @@ async fn prepare_device_for_read(
         }
         return Ok(());
     }
+    if super::bacnet::field_device_routing(device_instance).is_some() {
+        return Ok(());
+    }
     if client.get_device(device_instance).await.is_none() {
         if let Some(addr) = super::bacnet::cached_field_device_address(device_instance) {
             if let Some(mac) = bip_mac_from_address(&addr) {
@@ -194,8 +199,66 @@ async fn prepare_device_for_read(
     Ok(())
 }
 
-async fn stop_client(mut client: BACnetClient<BipTransport>) {
-    let _ = client.stop().await;
+async fn read_property_for_device(
+    client: &mut BACnetClient<BipTransport>,
+    device_instance: u32,
+    oid: ObjectIdentifier,
+    property_identifier: PropertyIdentifier,
+    property_array_index: Option<u32>,
+) -> Result<bacnet_services::read_property::ReadPropertyACK, String> {
+    if let Some(r) = super::bacnet::field_device_routing(device_instance) {
+        let mac = bip_mac_from_address(&r.router_address)
+            .ok_or_else(|| format!("invalid router address {}", r.router_address))?;
+        client
+            .read_property_routed(
+                &mac,
+                r.mstp_network,
+                &r.mstp_mac,
+                oid,
+                property_identifier,
+                property_array_index,
+            )
+            .await
+            .map_err(|e| e.to_string())
+    } else {
+        client
+            .read_property_from_device(
+                device_instance,
+                oid,
+                property_identifier,
+                property_array_index,
+            )
+            .await
+            .map_err(|e| e.to_string())
+    }
+}
+
+async fn read_present_value_inner(
+    client: &mut BACnetClient<BipTransport>,
+    device_instance: u32,
+    object_type: ObjectType,
+    instance: u32,
+) -> Result<Value, String> {
+    if super::bacnet::field_device_routing(device_instance).is_none() {
+        prepare_device_for_read(client, device_instance).await?;
+    }
+    let oid = ObjectIdentifier::new(object_type, instance).map_err(|e| e.to_string())?;
+    let ack = read_property_for_device(
+        client,
+        device_instance,
+        oid,
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+    )
+    .await?;
+    let (value, _) = decode_application_value(&ack.property_value, 0).map_err(|e| e.to_string())?;
+    Ok(json!({
+        "device_instance": device_instance,
+        "object_id": [object_type.to_raw(), instance],
+        "value": property_value_to_json(&value),
+        "source": "rusty-bacnet",
+        "routed": super::bacnet::field_device_routing(device_instance).is_some()
+    }))
 }
 
 fn discover_timeout_secs() -> u64 {
@@ -224,6 +287,19 @@ async fn build_client() -> Result<BACnetClient<BipTransport>, bacnet_types::erro
         .apdu_timeout_ms(6000)
         .build()
         .await
+}
+
+async fn client_lock(
+) -> Result<tokio::sync::MutexGuard<'static, BACnetClient<BipTransport>>, String> {
+    if PERSISTENT_CLIENT.get().is_none() {
+        let built = build_client().await.map_err(|e| e.to_string())?;
+        let _ = PERSISTENT_CLIENT.set(Arc::new(Mutex::new(built)));
+    }
+    Ok(PERSISTENT_CLIENT
+        .get()
+        .expect("persistent BACnet client")
+        .lock()
+        .await)
 }
 
 fn mac_to_address(mac: &[u8]) -> String {
@@ -343,16 +419,11 @@ pub async fn whois_devices_with_range(
     // Hard ceiling so API callers never hang forever (bind / OT / router issues).
     let budget = Duration::from_secs(discover_timeout_secs().saturating_add(5).max(10));
     let work = async {
-        let mut client = build_client().await.map_err(|e| e.to_string())?;
-        let result = async {
-            run_whois(&mut client, low, high).await?;
-            sleep(Duration::from_secs(discover_timeout_secs())).await;
-            let devices = client.discovered_devices().await;
-            Ok(devices.iter().map(device_to_json).collect())
-        }
-        .await;
-        stop_client(client).await;
-        result
+        let mut client = client_lock().await?;
+        run_whois(&mut client, low, high).await?;
+        sleep(Duration::from_secs(discover_timeout_secs())).await;
+        let devices = client.discovered_devices().await;
+        Ok(devices.iter().map(device_to_json).collect())
     };
     match tokio::time::timeout(budget, work).await {
         Ok(inner) => inner,
@@ -372,32 +443,8 @@ pub async fn read_present_value(
     object_type: ObjectType,
     instance: u32,
 ) -> Result<Value, String> {
-    let mut client = build_client().await.map_err(|e| e.to_string())?;
-    let result = async {
-        prepare_device_for_read(&mut client, device_instance).await?;
-
-        let oid = ObjectIdentifier::new(object_type, instance).map_err(|e| e.to_string())?;
-        let ack = client
-            .read_property_from_device(
-                device_instance,
-                oid,
-                PropertyIdentifier::PRESENT_VALUE,
-                None,
-            )
-            .await
-            .map_err(|e| e.to_string())?;
-        let (value, _) =
-            decode_application_value(&ack.property_value, 0).map_err(|e| e.to_string())?;
-        Ok(json!({
-            "device_instance": device_instance,
-            "object_id": [object_type.to_raw(), instance],
-            "value": property_value_to_json(&value),
-            "source": "rusty-bacnet"
-        }))
-    }
-    .await;
-    stop_client(client).await;
-    result
+    let mut client = client_lock().await?;
+    read_present_value_inner(&mut client, device_instance, object_type, instance).await
 }
 
 pub async fn read_priority_array(
@@ -405,137 +452,131 @@ pub async fn read_priority_array(
     object_type: ObjectType,
     instance: u32,
 ) -> Result<Vec<(u8, Value)>, String> {
-    let client = build_client().await.map_err(|e| e.to_string())?;
-    let result = async {
-        let (low, high) = discover_low_high();
-        client
-            .who_is(Some(low), Some(high))
-            .await
-            .map_err(|e| e.to_string())?;
-        if let Some((_, mstp_net)) = router_network() {
-            let _ = client.who_is_network(mstp_net, Some(low), Some(high)).await;
-        }
-        sleep(Duration::from_secs(2)).await;
-
-        let oid = ObjectIdentifier::new(object_type, instance).map_err(|e| e.to_string())?;
-        let ack = client
-            .read_property_from_device(
-                device_instance,
-                oid,
-                PropertyIdentifier::PRIORITY_ARRAY,
-                None,
-            )
-            .await
-            .map_err(|e| e.to_string())?;
-        let items = decode_value_sequence(&ack.property_value)?;
-
-        let mut out = Vec::new();
-        for (idx, item) in items.iter().enumerate() {
-            let priority = (idx + 1) as u8;
-            if priority > 16 {
-                continue;
-            }
-            if !matches!(item, PropertyValue::Null) {
-                out.push((priority, property_value_to_json(item)));
-            }
-        }
-        Ok(out)
+    let mut client = client_lock().await?;
+    let (low, high) = discover_low_high();
+    client
+        .who_is(Some(low), Some(high))
+        .await
+        .map_err(|e| e.to_string())?;
+    if let Some((_, mstp_net)) = router_network() {
+        let _ = client.who_is_network(mstp_net, Some(low), Some(high)).await;
     }
-    .await;
-    stop_client(client).await;
-    result
+    sleep(Duration::from_secs(2)).await;
+
+    let oid = ObjectIdentifier::new(object_type, instance).map_err(|e| e.to_string())?;
+    let ack = client
+        .read_property_from_device(
+            device_instance,
+            oid,
+            PropertyIdentifier::PRIORITY_ARRAY,
+            None,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    let items = decode_value_sequence(&ack.property_value)?;
+
+    let mut out = Vec::new();
+    for (idx, item) in items.iter().enumerate() {
+        let priority = (idx + 1) as u8;
+        if priority > 16 {
+            continue;
+        }
+        if !matches!(item, PropertyValue::Null) {
+            out.push((priority, property_value_to_json(item)));
+        }
+    }
+    Ok(out)
 }
 
 pub async fn discover_device_points(device_instance: u32) -> Result<Vec<Value>, String> {
-    let client = build_client().await.map_err(|e| e.to_string())?;
-    let result = async {
-        let (low, high) = discover_low_high();
+    let mut client = client_lock().await?;
+    let (low, high) = discover_low_high();
+    client
+        .who_is(Some(low), Some(high))
+        .await
+        .map_err(|e| e.to_string())?;
+    if let Some((_, mstp_net)) = router_network() {
         client
-            .who_is(Some(low), Some(high))
+            .who_is_network(mstp_net, Some(low), Some(high))
             .await
             .map_err(|e| e.to_string())?;
-        if let Some((_, mstp_net)) = router_network() {
-            client
-                .who_is_network(mstp_net, Some(low), Some(high))
-                .await
-                .map_err(|e| e.to_string())?;
+    }
+    sleep(Duration::from_secs(discover_timeout_secs())).await;
+
+    let dev = client
+        .get_device(device_instance)
+        .await
+        .ok_or_else(|| format!("device {device_instance} not discovered"))?;
+
+    let device_oid =
+        ObjectIdentifier::new(ObjectType::DEVICE, device_instance).map_err(|e| e.to_string())?;
+    let list_ack = client
+        .read_property_from_device(
+            device_instance,
+            device_oid,
+            PropertyIdentifier::OBJECT_LIST,
+            None,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    let list_items = decode_value_sequence(&list_ack.property_value)?;
+
+    let mut points = Vec::new();
+    for item in list_items {
+        let oid = match item {
+            PropertyValue::ObjectIdentifier(o) => o,
+            _ => continue,
+        };
+        if oid.object_type() == ObjectType::DEVICE {
+            continue;
         }
-        sleep(Duration::from_secs(discover_timeout_secs())).await;
 
-        let dev = client
-            .get_device(device_instance)
-            .await
-            .ok_or_else(|| format!("device {device_instance} not discovered"))?;
-
-        let device_oid =
-            ObjectIdentifier::new(ObjectType::DEVICE, device_instance).map_err(|e| e.to_string())?;
-        let list_ack = client
+        let name_ack = client
+            .read_property_from_device(device_instance, oid, PropertyIdentifier::OBJECT_NAME, None)
+            .await;
+        let pv_ack = client
             .read_property_from_device(
                 device_instance,
-                device_oid,
-                PropertyIdentifier::OBJECT_LIST,
+                oid,
+                PropertyIdentifier::PRESENT_VALUE,
                 None,
             )
-            .await
-            .map_err(|e| e.to_string())?;
-        let list_items = decode_value_sequence(&list_ack.property_value)?;
+            .await;
+        let wp_ack = client
+            .read_property_from_device(device_instance, oid, PropertyIdentifier::OBJECT_TYPE, None)
+            .await;
 
-        let mut points = Vec::new();
-        for item in list_items {
-            let oid = match item {
-                PropertyValue::ObjectIdentifier(o) => o,
-                _ => continue,
-            };
-            if oid.object_type() == ObjectType::DEVICE {
-                continue;
-            }
-
-            let name_ack = client
-                .read_property_from_device(device_instance, oid, PropertyIdentifier::OBJECT_NAME, None)
-                .await;
-            let pv_ack = client
-                .read_property_from_device(
-                    device_instance,
-                    oid,
-                    PropertyIdentifier::PRESENT_VALUE,
-                    None,
+        let name = name_ack
+            .ok()
+            .and_then(|a| decode_application_value(&a.property_value, 0).ok())
+            .map(|(v, _)| match v {
+                PropertyValue::CharacterString(s) => s,
+                other => format!("{other:?}"),
+            })
+            .unwrap_or_else(|| {
+                format!(
+                    "{}:{}",
+                    object_type_name(oid.object_type()),
+                    oid.instance_number()
                 )
-                .await;
-            let wp_ack = client
-                .read_property_from_device(device_instance, oid, PropertyIdentifier::OBJECT_TYPE, None)
-                .await;
+            });
 
-            let name = name_ack
-                .ok()
-                .and_then(|a| decode_application_value(&a.property_value, 0).ok())
-                .map(|(v, _)| match v {
-                    PropertyValue::CharacterString(s) => s,
-                    other => format!("{other:?}"),
-                })
-                .unwrap_or_else(|| {
-                    format!(
-                        "{}:{}",
-                        object_type_name(oid.object_type()),
-                        oid.instance_number()
-                    )
-                });
+        let value = pv_ack
+            .ok()
+            .and_then(|a| decode_application_value(&a.property_value, 0).ok())
+            .map(|(v, _)| property_value_to_json(&v));
 
-            let value = pv_ack
-                .ok()
-                .and_then(|a| decode_application_value(&a.property_value, 0).ok())
-                .map(|(v, _)| property_value_to_json(&v));
+        let writable = matches!(
+            oid.object_type(),
+            ObjectType::ANALOG_VALUE
+                | ObjectType::ANALOG_OUTPUT
+                | ObjectType::BINARY_VALUE
+                | ObjectType::BINARY_OUTPUT
+                | ObjectType::MULTI_STATE_VALUE
+                | ObjectType::MULTI_STATE_OUTPUT
+        ) || wp_ack.is_ok();
 
-            let writable = matches!(
-                oid.object_type(),
-                ObjectType::ANALOG_VALUE
-                    | ObjectType::ANALOG_OUTPUT
-                    | ObjectType::BINARY_VALUE
-                    | ObjectType::BINARY_OUTPUT
-                    | ObjectType::MULTI_STATE_VALUE
-                    | ObjectType::MULTI_STATE_OUTPUT
-            ) || wp_ack.is_ok();
-
-            points.push(json!({
+        points.push(json!({
                 "id": format!("bacnet:{}:{}:{}", device_instance, object_type_name(oid.object_type()), oid.instance_number()),
                 "device_instance": device_instance,
                 "object_id": [oid.object_type().to_raw(), oid.instance_number()],
@@ -546,12 +587,8 @@ pub async fn discover_device_points(device_instance: u32) -> Result<Vec<Value>, 
                 "address": mac_to_address(dev.mac_address.as_slice()),
                 "source_network": dev.source_network,
             }));
-        }
-        Ok(points)
     }
-    .await;
-    stop_client(client).await;
-    result
+    Ok(points)
 }
 
 pub fn point_object_from_json(point: &Value) -> Option<(u32, ObjectType, u32)> {
@@ -583,8 +620,8 @@ fn decode_prop(bytes: &[u8]) -> Option<PropertyValue> {
 }
 
 pub async fn discover_device_points_rpm(device_instance: u32) -> Result<Vec<Value>, String> {
-    let client = build_client().await.map_err(|e| e.to_string())?;
-    let result = async {
+    let mut client = client_lock().await?;
+    if super::bacnet::field_device_routing(device_instance).is_none() {
         let (low, high) = discover_low_high();
         client
             .who_is(Some(low), Some(high))
@@ -594,92 +631,77 @@ pub async fn discover_device_points_rpm(device_instance: u32) -> Result<Vec<Valu
             let _ = client.who_is_network(mstp_net, Some(low), Some(high)).await;
         }
         sleep(Duration::from_secs(discover_timeout_secs())).await;
+    } else {
+        prepare_device_for_read(&mut client, device_instance).await?;
+    }
 
-        let dev = client
-            .get_device(device_instance)
-            .await
-            .ok_or_else(|| format!("device {device_instance} not discovered"))?;
+    let address = super::bacnet::field_device_routing(device_instance)
+        .map(|r| r.router_address)
+        .or_else(|| super::bacnet::cached_field_device_address(device_instance))
+        .unwrap_or_default();
+    let source_network =
+        super::bacnet::field_device_routing(device_instance).map(|r| r.mstp_network);
 
-        let device_oid =
-            ObjectIdentifier::new(ObjectType::DEVICE, device_instance).map_err(|e| e.to_string())?;
-        let list_ack = client
-            .read_property_from_device(
-                device_instance,
-                device_oid,
-                PropertyIdentifier::OBJECT_LIST,
-                None,
-            )
-            .await
-            .map_err(|e| e.to_string())?;
-        let list_items = decode_value_sequence(&list_ack.property_value)?;
+    let device_oid =
+        ObjectIdentifier::new(ObjectType::DEVICE, device_instance).map_err(|e| e.to_string())?;
+    let list_ack = read_property_for_device(
+        &mut client,
+        device_instance,
+        device_oid,
+        PropertyIdentifier::OBJECT_LIST,
+        None,
+    )
+    .await?;
+    let list_items = decode_value_sequence(&list_ack.property_value)?;
 
-        let object_ids: Vec<ObjectIdentifier> = list_items
-            .into_iter()
-            .filter_map(|item| match item {
-                PropertyValue::ObjectIdentifier(o) if o.object_type() != ObjectType::DEVICE => Some(o),
-                _ => None,
-            })
-            .collect();
+    let object_ids: Vec<ObjectIdentifier> = list_items
+        .into_iter()
+        .filter_map(|item| match item {
+            PropertyValue::ObjectIdentifier(o) if o.object_type() != ObjectType::DEVICE => Some(o),
+            _ => None,
+        })
+        .collect();
 
-        if object_ids.is_empty() {
-            return Ok(Vec::new());
-        }
+    if object_ids.is_empty() {
+        return Ok(Vec::new());
+    }
 
-        let specs: Vec<ReadAccessSpecification> = object_ids
-            .iter()
-            .map(|oid| ReadAccessSpecification {
-                object_identifier: *oid,
-                list_of_property_references: vec![
-                    PropertyReference {
-                        property_identifier: PropertyIdentifier::OBJECT_NAME,
-                        property_array_index: None,
-                    },
-                    PropertyReference {
-                        property_identifier: PropertyIdentifier::PRESENT_VALUE,
-                        property_array_index: None,
-                    },
-                    PropertyReference {
-                        property_identifier: PropertyIdentifier::OBJECT_TYPE,
-                        property_array_index: None,
-                    },
-                ],
-            })
-            .collect();
-
-        let rpm = client
-            .read_property_multiple_from_device(device_instance, specs)
-            .await
-            .map_err(|e| e.to_string())?;
-
-        let mut points = Vec::new();
-        for result in rpm.list_of_read_access_results {
-            let oid = result.object_identifier;
+    let routed = super::bacnet::field_device_routing(device_instance).is_some();
+    let mut points = Vec::new();
+    if routed {
+        for oid in &object_ids {
             let mut name = format!(
                 "{}:{}",
                 object_type_name(oid.object_type()),
                 oid.instance_number()
             );
             let mut value: Option<Value> = None;
-            for prop in result.list_of_results {
-                if prop.error.is_some() {
-                    continue;
+            if let Ok(name_ack) = read_property_for_device(
+                &mut client,
+                device_instance,
+                *oid,
+                PropertyIdentifier::OBJECT_NAME,
+                None,
+            )
+            .await
+            {
+                if let Ok((val, _)) = decode_application_value(&name_ack.property_value, 0) {
+                    if let PropertyValue::CharacterString(s) = val {
+                        name = s;
+                    }
                 }
-                let Some(bytes) = prop.property_value.as_ref() else {
-                    continue;
-                };
-                let Some(val) = decode_prop(bytes) else {
-                    continue;
-                };
-                match prop.property_identifier {
-                    PropertyIdentifier::OBJECT_NAME => {
-                        if let PropertyValue::CharacterString(s) = val {
-                            name = s;
-                        }
-                    }
-                    PropertyIdentifier::PRESENT_VALUE => {
-                        value = Some(property_value_to_json(&val));
-                    }
-                    _ => {}
+            }
+            if let Ok(pv_ack) = read_property_for_device(
+                &mut client,
+                device_instance,
+                *oid,
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+            )
+            .await
+            {
+                if let Ok((val, _)) = decode_application_value(&pv_ack.property_value, 0) {
+                    value = Some(property_value_to_json(&val));
                 }
             }
             let writable = matches!(
@@ -692,6 +714,88 @@ pub async fn discover_device_points_rpm(device_instance: u32) -> Result<Vec<Valu
                     | ObjectType::MULTI_STATE_OUTPUT
             );
             points.push(json!({
+                    "id": format!("bacnet:{}:{}:{}", device_instance, object_type_name(oid.object_type()), oid.instance_number()),
+                    "device_instance": device_instance,
+                    "object_id": [oid.object_type().to_raw(), oid.instance_number()],
+                    "name": name,
+                    "polling_enabled": true,
+                    "writable": writable,
+                    "present_value": value,
+                    "address": address,
+                    "source_network": source_network,
+                    "read_method": "ReadPropertyRouted"
+                }));
+        }
+        return Ok(points);
+    }
+
+    let specs: Vec<ReadAccessSpecification> = object_ids
+        .iter()
+        .map(|oid| ReadAccessSpecification {
+            object_identifier: *oid,
+            list_of_property_references: vec![
+                PropertyReference {
+                    property_identifier: PropertyIdentifier::OBJECT_NAME,
+                    property_array_index: None,
+                },
+                PropertyReference {
+                    property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                    property_array_index: None,
+                },
+                PropertyReference {
+                    property_identifier: PropertyIdentifier::OBJECT_TYPE,
+                    property_array_index: None,
+                },
+            ],
+        })
+        .collect();
+
+    let rpm = client
+        .read_property_multiple_from_device(device_instance, specs)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut points = Vec::new();
+    for result in rpm.list_of_read_access_results {
+        let oid = result.object_identifier;
+        let mut name = format!(
+            "{}:{}",
+            object_type_name(oid.object_type()),
+            oid.instance_number()
+        );
+        let mut value: Option<Value> = None;
+        for prop in result.list_of_results {
+            if prop.error.is_some() {
+                continue;
+            }
+            let Some(bytes) = prop.property_value.as_ref() else {
+                continue;
+            };
+            let Some(val) = decode_prop(bytes) else {
+                continue;
+            };
+            match prop.property_identifier {
+                PropertyIdentifier::OBJECT_NAME => {
+                    if let PropertyValue::CharacterString(s) = val {
+                        name = s;
+                    }
+                }
+                PropertyIdentifier::PRESENT_VALUE => {
+                    value = Some(property_value_to_json(&val));
+                }
+                _ => {}
+            }
+        }
+        let writable = matches!(
+            oid.object_type(),
+            ObjectType::ANALOG_VALUE
+                | ObjectType::ANALOG_OUTPUT
+                | ObjectType::BINARY_VALUE
+                | ObjectType::BINARY_OUTPUT
+                | ObjectType::MULTI_STATE_VALUE
+                | ObjectType::MULTI_STATE_OUTPUT
+        );
+        points.push(json!({
                 "id": format!("bacnet:{}:{}:{}", device_instance, object_type_name(oid.object_type()), oid.instance_number()),
                 "device_instance": device_instance,
                 "object_id": [oid.object_type().to_raw(), oid.instance_number()],
@@ -699,16 +803,12 @@ pub async fn discover_device_points_rpm(device_instance: u32) -> Result<Vec<Valu
                 "polling_enabled": true,
                 "writable": writable,
                 "present_value": value,
-                "address": mac_to_address(dev.mac_address.as_slice()),
-                "source_network": dev.source_network,
+                "address": address,
+                "source_network": source_network,
                 "read_method": "ReadPropertyMultiple"
             }));
-        }
-        Ok(points)
     }
-    .await;
-    stop_client(client).await;
-    result
+    Ok(points)
 }
 
 fn priority_slots_from_bytes(data: &[u8]) -> Result<Vec<(u8, Value)>, String> {
@@ -733,17 +833,9 @@ pub async fn read_priority_arrays_rpm(
     if objects.is_empty() {
         return Ok(std::collections::HashMap::new());
     }
-    let client = build_client().await.map_err(|e| e.to_string())?;
-    let (low, high) = discover_low_high();
-    client
-        .who_is(Some(low), Some(high))
-        .await
-        .map_err(|e| e.to_string())?;
-    if let Some((_, mstp_net)) = router_network() {
-        let _ = client.who_is_network(mstp_net, Some(low), Some(high)).await;
-    }
-    sleep(Duration::from_secs(2)).await;
-
+    let objects = objects.to_vec();
+    let mut client = client_lock().await?;
+    prepare_device_for_read(&mut client, device_instance).await?;
     let specs: Vec<ReadAccessSpecification> = objects
         .iter()
         .filter_map(|(object_type, instance)| {
@@ -783,7 +875,6 @@ pub async fn read_priority_arrays_rpm(
             }
         }
     }
-    stop_client(client).await;
     Ok(out)
 }
 
@@ -795,61 +886,81 @@ pub async fn poll_present_values_rpm(
         return Ok(Vec::new());
     }
     let objects = objects.to_vec();
-    let mut client = build_client().await.map_err(|e| e.to_string())?;
-    let result = async {
-        prepare_device_for_read(&mut client, device_instance).await?;
-
-        let specs: Vec<ReadAccessSpecification> = objects
-            .iter()
-            .filter_map(|(object_type, instance)| {
-                ObjectIdentifier::new(*object_type, *instance)
-                    .ok()
-                    .map(|oid| ReadAccessSpecification {
-                        object_identifier: oid,
-                        list_of_property_references: vec![PropertyReference {
-                            property_identifier: PropertyIdentifier::PRESENT_VALUE,
-                            property_array_index: None,
-                        }],
-                    })
-            })
-            .collect();
-
-        let rpm = client
-            .read_property_multiple_from_device(device_instance, specs)
-            .await
-            .map_err(|e| e.to_string())?;
-
+    let mut client = client_lock().await?;
+    prepare_device_for_read(&mut client, device_instance).await?;
+    let at = chrono::Utc::now().to_rfc3339();
+    if super::bacnet::field_device_routing(device_instance).is_some() {
         let mut samples = Vec::new();
-        let at = chrono::Utc::now().to_rfc3339();
-        for result in rpm.list_of_read_access_results {
-            let ot = result.object_identifier.object_type();
-            let inst = result.object_identifier.instance_number();
-            let mut value = Value::Null;
-            for prop in result.list_of_results {
-                if prop.error.is_some() {
-                    continue;
-                }
-                let Some(bytes) = prop.property_value.as_ref() else {
-                    continue;
-                };
-                if let Some(val) = decode_prop(bytes) {
-                    value = property_value_to_json(&val);
-                }
-            }
+        for (object_type, instance) in &objects {
+            let oid = ObjectIdentifier::new(*object_type, *instance).map_err(|e| e.to_string())?;
+            let ack = read_property_for_device(
+                &mut client,
+                device_instance,
+                oid,
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+            )
+            .await?;
+            let (val, _) =
+                decode_application_value(&ack.property_value, 0).map_err(|e| e.to_string())?;
             samples.push(json!({
-                "device_instance": device_instance,
-                "object_id": [ot.to_raw(), inst],
-                "id": format!("bacnet:{}:{}:{}", device_instance, object_type_name(ot), inst),
-                "present_value": value,
-                "last_read_at": at,
-                "read_method": "ReadPropertyMultiple"
-            }));
+                    "device_instance": device_instance,
+                    "object_id": [object_type.to_raw(), instance],
+                    "id": format!("bacnet:{}:{}:{}", device_instance, object_type_name(*object_type), instance),
+                    "present_value": property_value_to_json(&val),
+                    "last_read_at": at,
+                    "read_method": "ReadPropertyRouted"
+                }));
         }
-        Ok(samples)
+        return Ok(samples);
     }
-    .await;
-    stop_client(client).await;
-    result
+
+    let specs: Vec<ReadAccessSpecification> = objects
+        .iter()
+        .filter_map(|(object_type, instance)| {
+            ObjectIdentifier::new(*object_type, *instance)
+                .ok()
+                .map(|oid| ReadAccessSpecification {
+                    object_identifier: oid,
+                    list_of_property_references: vec![PropertyReference {
+                        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                        property_array_index: None,
+                    }],
+                })
+        })
+        .collect();
+
+    let rpm = client
+        .read_property_multiple_from_device(device_instance, specs)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut samples = Vec::new();
+    for result in rpm.list_of_read_access_results {
+        let ot = result.object_identifier.object_type();
+        let inst = result.object_identifier.instance_number();
+        let mut value = Value::Null;
+        for prop in result.list_of_results {
+            if prop.error.is_some() {
+                continue;
+            }
+            let Some(bytes) = prop.property_value.as_ref() else {
+                continue;
+            };
+            if let Some(val) = decode_prop(bytes) {
+                value = property_value_to_json(&val);
+            }
+        }
+        samples.push(json!({
+            "device_instance": device_instance,
+            "object_id": [ot.to_raw(), inst],
+            "id": format!("bacnet:{}:{}:{}", device_instance, object_type_name(ot), inst),
+            "present_value": value,
+            "last_read_at": at,
+            "read_method": "ReadPropertyMultiple"
+        }));
+    }
+    Ok(samples)
 }
 
 pub async fn write_present_value(
@@ -859,41 +970,31 @@ pub async fn write_present_value(
     value: &PropertyValue,
     priority: Option<u8>,
 ) -> Result<Value, String> {
-    let client = build_client().await.map_err(|e| e.to_string())?;
-    let result = async {
-        let (low, high) = discover_low_high();
-        client
-            .who_is(Some(low), Some(high))
-            .await
-            .map_err(|e| e.to_string())?;
-        sleep(Duration::from_secs(2)).await;
+    let mut client = client_lock().await?;
+    prepare_device_for_read(&mut client, device_instance).await?;
 
-        let oid = ObjectIdentifier::new(object_type, instance).map_err(|e| e.to_string())?;
-        let mut buf = bytes::BytesMut::new();
-        encode_property_value(&mut buf, value).map_err(|e| e.to_string())?;
-        client
-            .write_property_to_device(
-                device_instance,
-                oid,
-                PropertyIdentifier::PRESENT_VALUE,
-                None,
-                buf.to_vec(),
-                priority,
-            )
-            .await
-            .map_err(|e| e.to_string())?;
+    let oid = ObjectIdentifier::new(object_type, instance).map_err(|e| e.to_string())?;
+    let mut buf = bytes::BytesMut::new();
+    encode_property_value(&mut buf, value).map_err(|e| e.to_string())?;
+    client
+        .write_property_to_device(
+            device_instance,
+            oid,
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            buf.to_vec(),
+            priority,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
 
-        Ok(json!({
-            "ok": true,
-            "device_instance": device_instance,
-            "object_id": [object_type.to_raw(), instance],
-            "priority": priority,
-            "source": "rusty-bacnet-write"
-        }))
-    }
-    .await;
-    stop_client(client).await;
-    result
+    Ok(json!({
+        "ok": true,
+        "device_instance": device_instance,
+        "object_id": [object_type.to_raw(), instance],
+        "priority": priority,
+        "source": "rusty-bacnet-write"
+    }))
 }
 
 /// RPM-first discovery; falls back to sequential ReadProperty when RPM fails.

--- a/edge/src/lib.rs
+++ b/edge/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod bench;
+pub mod commission_proxy;
 pub mod control;
 pub mod csv_ingest;
 pub mod dashboard;

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -7,8 +7,8 @@ use crate::auth::config::Principal;
 use crate::auth::login::{authenticate, login_response};
 use crate::auth::rbac::{can_write_field_bus, role_allowed};
 use crate::{
-    bench, control, csv_ingest, dashboard, data_management, drivers, export, faults, fdd,
-    historian, import, ingest, model, ops, reports, timeseries, validation, version,
+    bench, commission_proxy, control, csv_ingest, dashboard, data_management, drivers, export,
+    faults, fdd, historian, import, ingest, model, ops, reports, timeseries, validation, version,
 };
 
 use serde_json::{json, Value};
@@ -782,6 +782,14 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             ),
         ),
         ("POST", "/api/bacnet/whois") => {
+            if commission_proxy::should_proxy_bacnet() {
+                let auth = commission_proxy::proxy_auth_header(&headers);
+                if let Ok(proxy_body) =
+                    commission_proxy::proxy_post("/api/bacnet/whois", &body, auth.as_deref())
+                {
+                    return raw_json(&mut stream, &proxy_body);
+                }
+            }
             let body = drivers::bacnet::whois_json(&parse_json_body_or_empty(&body));
             raw_json(&mut stream, &body)
         }
@@ -853,6 +861,16 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
         }
         ("POST", "/api/bacnet/point-discovery") => {
             let payload: Value = serde_json::from_str(&body).unwrap_or(json!({}));
+            if commission_proxy::should_proxy_bacnet() {
+                let auth = commission_proxy::proxy_auth_header(&headers);
+                if let Ok(proxy_body) = commission_proxy::proxy_post(
+                    "/api/bacnet/point-discovery",
+                    &body,
+                    auth.as_deref(),
+                ) {
+                    return raw_json(&mut stream, &proxy_body);
+                }
+            }
             require_role(
                 &mut stream,
                 &principal,
@@ -861,6 +879,14 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             )
         }
         ("POST", "/api/bacnet/read") => {
+            if commission_proxy::should_proxy_bacnet() {
+                let auth = commission_proxy::proxy_auth_header(&headers);
+                if let Ok(proxy_body) =
+                    commission_proxy::proxy_post("/api/bacnet/read", &body, auth.as_deref())
+                {
+                    return raw_json(&mut stream, &proxy_body);
+                }
+            }
             let payload: Value = serde_json::from_str(&body).unwrap_or(json!({}));
             let response_body = drivers::bacnet::read_present_value_json(&payload);
             raw_json(&mut stream, &response_body)

--- a/edge/src/validation/profile.rs
+++ b/edge/src/validation/profile.rs
@@ -102,7 +102,7 @@ pub fn is_profile_configured(p: &SiteConfig) -> bool {
 }
 
 pub fn active_profile() -> SiteConfig {
-    load_profile_from_path(&profile_path())
+    load_profile_from_path(&validation_profile_path())
 }
 
 pub fn load_profile_from_path(path: &Path) -> SiteConfig {
@@ -214,6 +214,13 @@ fn apply_env_overrides(p: &mut SiteConfig) {
     if let Ok(v) = env::var("OPENFDD_HAYSTACK_PASS") {
         if !v.is_empty() {
             p.haystack_password = v;
+        }
+    }
+    if let Ok(v) = env::var("OPENFDD_SMOKE_DEVICE_INSTANCE") {
+        if let Ok(inst) = v.parse::<u32>() {
+            if inst > 0 {
+                p.device_instance = inst;
+            }
         }
     }
 }
@@ -558,6 +565,57 @@ point.oa_t = "OA Temp|1001|oa_t"
         let p = active_profile();
         assert!(!is_modbus_configured(&p));
         std::env::remove_var("OPENFDD_WORKSPACE");
+    }
+
+    #[test]
+    fn validation_profile_env_overrides_site_local_path() {
+        let _lock = test_lock();
+        std::env::remove_var("OPENFDD_SITE_CONFIG_PATH");
+        std::env::remove_var("OPENFDD_SMOKE_DEVICE_INSTANCE");
+        let ws = std::env::temp_dir().join(format!("ofdd-valprof-{}", std::process::id()));
+        let profile_dir = ws.join("smoke-profiles/local");
+        fs::create_dir_all(&profile_dir).unwrap();
+        let profile_path = profile_dir.join("local_validation_profile.local.toml");
+        fs::write(
+            &profile_path,
+            r#"profile_id = "bench-smoke"
+device_instance = 5007
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(ws.join("config")).unwrap();
+        fs::write(
+            ws.join("config/site.local.toml"),
+            r#"device_instance = 99
+"#,
+        )
+        .unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", &ws);
+        std::env::set_var(
+            "OPENFDD_VALIDATION_PROFILE",
+            profile_path.display().to_string(),
+        );
+        let p = active_profile();
+        assert_eq!(p.device_instance, 5007);
+        assert_eq!(p.profile_id, "bench-smoke");
+        std::env::remove_var("OPENFDD_WORKSPACE");
+        std::env::remove_var("OPENFDD_VALIDATION_PROFILE");
+        let _ = fs::remove_dir_all(ws);
+    }
+
+    #[test]
+    fn smoke_device_instance_env_override() {
+        let _lock = test_lock();
+        std::env::remove_var("OPENFDD_VALIDATION_PROFILE");
+        std::env::remove_var("OPENFDD_SITE_CONFIG_PATH");
+        let ws = std::env::temp_dir().join(format!("ofdd-smoke-inst-{}", std::process::id()));
+        std::env::set_var("OPENFDD_WORKSPACE", &ws);
+        std::env::set_var("OPENFDD_SMOKE_DEVICE_INSTANCE", "3456790");
+        let p = active_profile();
+        assert_eq!(p.device_instance, 3456790);
+        std::env::remove_var("OPENFDD_WORKSPACE");
+        std::env::remove_var("OPENFDD_SMOKE_DEVICE_INSTANCE");
+        let _ = fs::remove_dir_all(ws);
     }
 
     fn test_lock() -> std::sync::MutexGuard<'static, ()> {

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,19 @@
+# Bench-only validation scripts
+
+These scripts are **not** required for production edge deploy. They live under `scripts/bench/` so upstream `rsync` from product source does not delete bench orchestrators on the Linux edge tester.
+
+| Script | Purpose |
+|--------|---------|
+| `openfdd_bacnet_poll_daemon.sh` | Persistent OT poll loop (BACnet + Modbus + FDD status) |
+| `openfdd_stores_fdd_soak.sh` | Short FDD historian soak wrapper |
+
+Run from bench root (`~/open-fdd`):
+
+```bash
+./scripts/bench/openfdd_bacnet_poll_daemon.sh start
+OPENFDD_SOAK_MINUTES=10 ./scripts/bench/openfdd_stores_fdd_soak.sh
+```
+
+Symlink or copy into `scripts/` on the bench if older prompts reference top-level paths.
+
+Fixes #470.

--- a/scripts/bench/openfdd_bacnet_poll_daemon.sh
+++ b/scripts/bench/openfdd_bacnet_poll_daemon.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Persistent OT polling for bench — simulates production bootstrap (always on).
+#
+# Start (default: unlimited cycles — leave running):
+#   ./scripts/openfdd_bacnet_poll_daemon.sh start
+#
+# Bounded window for a single test phase only:
+#   OPENFDD_BACNET_DAEMON_MAX_CYCLES=5 ./scripts/openfdd_bacnet_poll_daemon.sh run-for 5
+#
+# Stop immediately:
+#   ./scripts/openfdd_bacnet_poll_daemon.sh stop
+#
+# Status:
+#   ./scripts/openfdd_bacnet_poll_daemon.sh status
+#
+# One-shot foreground run (no background pid):
+#   ./scripts/openfdd_bacnet_poll_daemon.sh run-for 5
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+# shellcheck source=scripts/openfdd_bench_lib.sh
+source "$ROOT/scripts/openfdd_bench_lib.sh"
+
+openfdd_bench_load_profile "$ROOT" || true
+
+BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
+COMMISSION="${OPENFDD_COMMISSION_BASE:-http://127.0.0.1:9091}"
+AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
+INTERVAL="${OPENFDD_DRIVER_POLL_INTERVAL_SEC:-60}"
+MAX_CYCLES="${OPENFDD_BACNET_DAEMON_MAX_CYCLES:-0}"
+OUT="${OPENFDD_BACNET_DAEMON_DIR:-$ROOT/workspace/logs/bacnet_poll_daemon}"
+PID_FILE="$OUT/daemon.pid"
+LOG_FILE="$OUT/daemon.log"
+
+CURL_TLS=()
+[[ "$BASE" == https://* ]] && CURL_TLS=(-k)
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG_FILE"; }
+
+poll_loop() {
+  mkdir -p "$OUT"
+  : >"$OUT/cycles.jsonl"
+  local limit="${1:-$MAX_CYCLES}"
+  log "daemon start interval=${INTERVAL}s max_cycles=${limit:-unlimited} base=$BASE commission=$COMMISSION out=$OUT"
+
+  local n=0
+  while true; do
+    n=$((n + 1))
+    local ts token stack_ok bacnet_whois_ok bacnet_poll_ok modbus_ok fdd_ok
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    stack_ok=false
+    bacnet_whois_ok=false
+    bacnet_poll_ok=false
+    modbus_ok=false
+    fdd_ok=false
+
+    token="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator 2>/dev/null || true)"
+    if [[ -n "$token" ]]; then
+      local hdr=(-H "Authorization: Bearer $token")
+      local live modbus_read_ok=false bacnet_read_ok=false modbus_value="" bacnet_value=""
+      jq -e '.ok == true' <<< "$(curl "${CURL_TLS[@]}" -fsS "${hdr[@]}" "$BASE/api/health" 2>/dev/null || echo '{}')" \
+        >/dev/null 2>&1 && stack_ok=true
+
+      live="$(openfdd_bench_live_ot_poll "$BASE" "$COMMISSION" "$token" "$ROOT")"
+      echo "$live" >"$OUT/live_ot_cycle_${n}.json"
+      jq -e '.modbus_read_ok == true' <<<"$live" >/dev/null 2>&1 && { modbus_read_ok=true; modbus_ok=true; }
+      jq -e '.bacnet_read_ok == true' <<<"$live" >/dev/null 2>&1 && bacnet_read_ok=true
+      jq -e '.bacnet_whois_ok == true' <<<"$live" >/dev/null 2>&1 && bacnet_whois_ok=true
+      modbus_value="$(jq -r '.modbus_value // empty' <<<"$live")"
+      bacnet_value="$(jq -r '.bacnet_value // empty' <<<"$live")"
+
+      jq -e '.ok == true or (.last_poll.ok // false) == true' <<< "$(curl "${CURL_TLS[@]}" -fsS \
+        "${hdr[@]}" "$BASE/api/bacnet/poll/status" 2>/dev/null || echo '{}')" \
+        >/dev/null 2>&1 && bacnet_poll_ok=true
+
+      jq -e '.ok == true or .status != null or .run_id != null' <<< "$(curl "${CURL_TLS[@]}" -fsS \
+        "${hdr[@]}" "$BASE/api/validation-runs/current/status" 2>/dev/null || echo '{}')" \
+        >/dev/null 2>&1 && fdd_ok=true
+    fi
+
+    jq -nc \
+      --arg ts "$ts" --argjson cycle "$n" \
+      --argjson stack "$stack_ok" --argjson whois "$bacnet_whois_ok" \
+      --argjson bacnet_poll "$bacnet_poll_ok" --argjson modbus_read "$modbus_read_ok" \
+      --argjson bacnet_read "$bacnet_read_ok" --argjson fdd "$fdd_ok" \
+      --arg modbus_value "$modbus_value" --arg bacnet_value "$bacnet_value" \
+      '{timestamp_utc:$ts,cycle:$cycle,stack_ok:$stack,bacnet_whois_ok:$whois,
+        bacnet_poll_ok:$bacnet_poll,modbus_read_ok:$modbus_read,bacnet_read_ok:$bacnet_read,
+        modbus_poll_ok:$modbus_read,modbus_value:$modbus_value,bacnet_value:$bacnet_value,
+        fdd_status_ok:$fdd}' \
+      >>"$OUT/cycles.jsonl"
+
+    log "cycle=$n stack=$stack_ok bacnet_read=$bacnet_read_ok(${bacnet_value:-?}) whois=$bacnet_whois_ok modbus_read=$modbus_read_ok(${modbus_value:-?}) fdd=$fdd_ok"
+    if [[ -n "${limit:-}" && "$limit" -gt 0 && "$n" -ge "$limit" ]]; then
+      log "daemon stop after max_cycles=$limit"
+      break
+    fi
+    sleep "$INTERVAL"
+  done
+}
+
+cmd="${1:-start}"
+
+case "$cmd" in
+  start)
+    mkdir -p "$OUT"
+    if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "already running pid=$(cat "$PID_FILE") log=$LOG_FILE"
+      exit 0
+    fi
+    export OPENFDD_BACNET_DAEMON_MAX_CYCLES="${OPENFDD_BACNET_DAEMON_MAX_CYCLES:-0}"
+    nohup bash "$0" run >>"$LOG_FILE" 2>&1 &
+    echo $! >"$PID_FILE"
+    echo "started pid=$(cat "$PID_FILE") interval=${INTERVAL}s max_cycles=${OPENFDD_BACNET_DAEMON_MAX_CYCLES} log=$LOG_FILE"
+    ;;
+  run-for)
+    cycles="${2:-${OPENFDD_BACNET_DAEMON_MAX_CYCLES:-5}}"
+    poll_loop "$cycles"
+    ;;
+  run)
+    poll_loop "${OPENFDD_BACNET_DAEMON_MAX_CYCLES:-0}"
+    ;;
+  stop)
+    if [[ -f "$PID_FILE" ]]; then
+      kill "$(cat "$PID_FILE")" 2>/dev/null || true
+      rm -f "$PID_FILE"
+      echo "stopped"
+    else
+      echo "not running"
+    fi
+    ;;
+  status)
+    if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "running pid=$(cat "$PID_FILE") log=$LOG_FILE"
+      tail -3 "$LOG_FILE" 2>/dev/null || true
+    else
+      echo "not running"
+    fi
+    ;;
+  *)
+    echo "usage: $0 {start|stop|status|run-for [cycles]}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/bench/openfdd_stores_fdd_soak.sh
+++ b/scripts/bench/openfdd_stores_fdd_soak.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Soak test: every 60s verify historian/Arrow stores grow + FDD cycle runs + drivers poll.
+#
+# Usage:
+#   ./scripts/openfdd_stores_fdd_soak.sh
+#   OPENFDD_SOAK_MINUTES=10 OPENFDD_SOAK_INTERVAL_SEC=60 ./scripts/openfdd_stores_fdd_soak.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/openfdd_auth_lib.sh
+source "$ROOT/scripts/openfdd_auth_lib.sh"
+# shellcheck source=scripts/openfdd_bench_lib.sh
+source "$ROOT/scripts/openfdd_bench_lib.sh"
+
+openfdd_bench_load_profile "$ROOT" || true
+
+BASE="${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
+COMMISSION="${OPENFDD_COMMISSION_BASE:-http://127.0.0.1:9091}"
+AUTH="${OPENFDD_AUTH_ENV:-$ROOT/workspace/auth.env.local}"
+MINUTES="${OPENFDD_SOAK_MINUTES:-10}"
+INTERVAL="${OPENFDD_SOAK_INTERVAL_SEC:-60}"
+CYCLES=$(( (MINUTES * 60) / INTERVAL ))
+[[ "$CYCLES" -lt 1 ]] && CYCLES=1
+
+RUN_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="${OPENFDD_SOAK_DIR:-$ROOT/workspace/logs/soak_${MINUTES}m_${RUN_TS}}"
+HIST_DIR="${OPENFDD_HISTORIAN_HOST_PATH:-$ROOT/workspace/data/historian/validation}"
+
+mkdir -p "$OUT"
+CURL_TLS=()
+[[ "$BASE" == https://* ]] && CURL_TLS=(-k)
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$OUT/soak.log"; }
+
+TOKEN="$(openfdd_auth_login_token "$BASE" "$AUTH" integrator)" || {
+  echo "ERROR: login failed" >&2; exit 1
+}
+AGENT_TOKEN="$(openfdd_auth_login_token "$BASE" "$AUTH" agent 2>/dev/null || true)"
+[[ -n "$AGENT_TOKEN" ]] || AGENT_TOKEN="$TOKEN"
+auth=(-H "Authorization: Bearer $TOKEN")
+auth_agent=(-H "Authorization: Bearer $AGENT_TOKEN")
+
+arrow_bytes() {
+  local f="$HIST_DIR/telemetry_pivot.arrow"
+  [[ -f "$f" ]] && wc -c <"$f" | tr -d ' ' || echo 0
+}
+
+jsonl_lines() {
+  local f="$HIST_DIR/telemetry_pivot.jsonl"
+  [[ -f "$f" ]] && wc -l <"$f" | tr -d ' ' || echo 0
+}
+
+log "Soak ${MINUTES}m (${CYCLES} samples @ ${INTERVAL}s) → $OUT"
+: >"$OUT/soak_samples.jsonl"
+
+prev_rows=0
+prev_arrow=0
+prev_jsonl=0
+stalls=0
+FAIL=0
+
+for n in $(seq 1 "$CYCLES"); do
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  hist="$(curl "${CURL_TLS[@]}" -fsS "${auth[@]}" "$BASE/api/historian/validation/status" 2>/dev/null || echo '{}')"
+  vr="$(curl "${CURL_TLS[@]}" -fsS "${auth[@]}" "$BASE/api/validation-runs/current/status" 2>/dev/null || echo '{}')"
+  modbus_ok=false haystack_ok=false bacnet_ok=false fdd_ok=false
+  curl "${CURL_TLS[@]}" -fsS "${auth[@]}" "$BASE/api/modbus/poll/status" 2>/dev/null | jq -e '.ok==true' >/dev/null && modbus_ok=true
+  # Generate OT wire traffic for pcap validation (status alone does not poll the field device).
+  curl "${CURL_TLS[@]}" -fsS -X POST "${auth[@]}" -H 'Content-Type: application/json' \
+    "$BASE/api/modbus/read" \
+    -d '{"register":30001,"function":"input_register","scale":0.1,"unit":"degF"}' \
+    2>/dev/null | jq -e '.ok==true' >/dev/null && modbus_ok=true
+  curl "${CURL_TLS[@]}" -fsS -X POST "${auth[@]}" -H 'Content-Type: application/json' \
+    "$BASE/api/haystack/test" -d '{}' 2>/dev/null | jq -e '.ok==true' >/dev/null && haystack_ok=true
+  curl "${CURL_TLS[@]}" -fsS -X POST "${auth[@]}" -H 'Content-Type: application/json' \
+    "$COMMISSION/api/bacnet/whois" -d "$(openfdd_bench_whois_json)" 2>/dev/null \
+    | jq -e 'type=="array" and length>0' >/dev/null && bacnet_ok=true
+
+  cycle="$(curl "${CURL_TLS[@]}" -fsS -X POST "${auth_agent[@]}" -H 'Content-Type: application/json' \
+    "$BASE/api/validation-runs/current/cycle" -d '{}' 2>/dev/null || echo '{}')"
+  echo "$cycle" >"$OUT/cycle_${n}.json"
+  jq -e '.ok==true' <<<"$cycle" >/dev/null 2>&1 && fdd_ok=true
+
+  rows="$(jq -r '.row_count // 0' <<<"$hist")"
+  arrow="$(arrow_bytes)"
+  jsonl="$(jsonl_lines)"
+  rows_delta=$(( rows - prev_rows ))
+  arrow_delta=$(( arrow - prev_arrow ))
+  jsonl_delta=$(( jsonl - prev_jsonl ))
+
+  growing=true
+  if [[ "$n" -gt 1 && "$rows_delta" -le 0 && "$arrow_delta" -le 0 && "$jsonl_delta" -le 0 ]]; then
+    growing=false
+    stalls=$((stalls + 1))
+  fi
+
+  jq -nc \
+    --arg ts "$ts" --argjson n "$n" \
+    --argjson rows "$rows" --argjson rows_delta "$rows_delta" \
+    --argjson arrow "$arrow" --argjson arrow_delta "$arrow_delta" \
+    --argjson jsonl "$jsonl" --argjson jsonl_delta "$jsonl_delta" \
+    --argjson modbus "$modbus_ok" --argjson haystack "$haystack_ok" \
+    --argjson bacnet "$bacnet_ok" --argjson fdd "$fdd_ok" \
+    --argjson growing "$growing" \
+    --argjson raw_fault "$(jq -r '.proof.raw_fault_samples // 0' <<<"$cycle")" \
+    --argjson fdd_sql "$(jq -r '.fdd_eval.ok // false' <<<"$cycle")" \
+    '{timestamp_utc:$ts,sample:$n,historian_row_count:$rows,historian_row_delta:$rows_delta,
+      arrow_bytes:$arrow,arrow_delta:$arrow_delta,jsonl_lines:$jsonl,jsonl_delta:$jsonl_delta,
+      modbus_poll_ok:$modbus,haystack_ok:$haystack,bacnet_whois_ok:$bacnet,fdd_cycle_ok:$fdd,
+      stores_growing:$growing,raw_fault_samples:$raw_fault,fdd_sql_ok:$fdd_sql}' \
+    >>"$OUT/soak_samples.jsonl"
+
+  log "sample=$n rows=$rows (+$rows_delta) arrow=$arrow (+$arrow_delta) modbus=$modbus_ok haystack=$haystack_ok bacnet=$bacnet_ok fdd=$fdd_ok growing=$growing"
+
+  prev_rows=$rows prev_arrow=$arrow prev_jsonl=$jsonl
+  [[ "$n" -lt "$CYCLES" ]] && sleep "$INTERVAL"
+done
+
+# Allow 1 flat minute; fail if >2 consecutive stalls or final rows==0
+flat_limit="${OPENFDD_SOAK_MAX_STALLS:-2}"
+if [[ "$stalls" -gt "$flat_limit" ]]; then
+  log "FAIL: stores stalled $stalls samples (max $flat_limit)"
+  FAIL=1
+fi
+if [[ "$prev_rows" -eq 0 ]]; then
+  log "FAIL: historian row_count still 0 after soak"
+  FAIL=1
+fi
+
+driver_fails="$(jq -s '[.[] | select(.modbus_poll_ok==false or .haystack_ok==false or .bacnet_whois_ok==false)] | length' "$OUT/soak_samples.jsonl")"
+if [[ "$driver_fails" -gt 0 ]]; then
+  log "FAIL: $driver_fails soak samples had driver poll failure"
+  FAIL=1
+fi
+
+jq -nc \
+  --arg dir "$OUT" --argjson cycles "$CYCLES" --argjson stalls "$stalls" \
+  --argjson fail "$FAIL" --argjson final_rows "$prev_rows" \
+  '{artifact_dir:$dir,cycles:$cycles,stall_count:$stalls,final_historian_rows:$final_rows,passed:($fail==0)}' \
+  >"$OUT/soak_result.json"
+
+log "Soak complete stalls=$stalls fail=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/openfdd_auth_init.sh
+++ b/scripts/openfdd_auth_init.sh
@@ -83,21 +83,30 @@ trap 'rm -f "$AUTH_LOG"' EXIT
 write_bootstrap_handoff_from_log() {
   [[ "$SHOW_SECRETS" == "true" ]] || return 0
   local role line
-  local -a creds=()
+  declare -A merged=()
+  if [[ -f "$HANDOFF" ]]; then
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^(operator|integrator|agent|admin):[[:space:]]+(.+)$ ]]; then
+        merged["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
+      fi
+    done < <(grep -E '^(operator|integrator|agent|admin):' "$HANDOFF" 2>/dev/null || true)
+  fi
   while IFS= read -r line; do
     if [[ "$line" =~ ^[[:space:]]*(operator|integrator|agent|admin):[[:space:]]+(.+)$ ]]; then
       role="${BASH_REMATCH[1]}"
-      creds+=("${role}: ${BASH_REMATCH[2]}")
+      merged["$role"]="${BASH_REMATCH[2]}"
     fi
   done < <(grep -E '^[[:space:]]*(operator|integrator|agent|admin):' "$AUTH_LOG" 2>/dev/null || true)
-  [[ ${#creds[@]} -eq 0 ]] && return 0
+  [[ ${#merged[@]} -eq 0 ]] && return 0
   {
     echo "# Open-FDD one-time bootstrap credentials — DELETE after saving to your password manager."
     echo "# Do NOT paste bcrypt hashes from auth.env.local as login passwords."
     echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "# Rotate again: ./scripts/openfdd_auth_init.sh --rotate --all --show-secrets --restart"
     echo
-    printf '%s\n' "${creds[@]}"
+    for role in operator integrator agent admin; do
+      [[ -n "${merged[$role]:-}" ]] && echo "${role}: ${merged[$role]}"
+    done
     echo
     echo "# After saving passwords, delete this file:"
     echo "#   rm workspace/bootstrap_credentials.once.txt"
@@ -194,7 +203,7 @@ else
 fi
 write_bootstrap_handoff_from_log
 
-chmod 600 "$AUTH_PATH" 2>/dev/null || true
+chmod 644 "$AUTH_PATH" 2>/dev/null || true
 echo "==> Auth env: $AUTH_PATH"
 if [[ "$RESTART" == "true" ]]; then
   export OPENFDD_RUN_UID="${OPENFDD_RUN_UID:-$(id -u)}"

--- a/scripts/openfdd_product_ghcr_deep_sleep.sh
+++ b/scripts/openfdd_product_ghcr_deep_sleep.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Deep-sleep GHCR gate: one API call per wake; exit 0 + #429 comment when :nightly published.
+# Usage: OPENFDD_GHCR_RUN_ID=28815109155 ./scripts/openfdd_product_ghcr_deep_sleep.sh
+set -euo pipefail
+
+RUN_ID="${OPENFDD_GHCR_RUN_ID:?set OPENFDD_GHCR_RUN_ID}"
+REPO="${OPENFDD_GH_REPO:-bbartling/open-fdd}"
+ISSUE="${OPENFDD_GH_ISSUE:-429}"
+INTERVAL="${OPENFDD_GH_SLEEP_SEC:-1800}"
+MAX_WAKES="${OPENFDD_GH_MAX_WAKES:-48}"
+LOG="${OPENFDD_GH_SLEEP_LOG:-/tmp/openfdd_ghcr_deep_sleep.log}"
+PIDFILE="${OPENFDD_GH_SLEEP_PIDFILE:-/tmp/openfdd_ghcr_deep_sleep.pid}"
+
+if [[ -f "$PIDFILE" ]]; then
+  old="$(cat "$PIDFILE" 2>/dev/null || true)"
+  if [[ -n "$old" ]] && kill -0 "$old" 2>/dev/null; then
+    exit 0
+  fi
+fi
+echo $$ >"$PIDFILE"
+trap 'rm -f "$PIDFILE"' EXIT
+
+echo "deep_sleep start run=$RUN_ID interval=${INTERVAL}s $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$LOG"
+
+for ((i = 1; i <= MAX_WAKES; i++)); do
+  con="$(gh run view "$RUN_ID" --repo "$REPO" --json conclusion --jq '.conclusion // empty' 2>>"$LOG" || true)"
+  echo "wake=$i $(date -u +%Y-%m-%dT%H:%M:%SZ) conclusion=${con:-pending}" >>"$LOG"
+  case "$con" in
+  success)
+    gh issue comment "$ISSUE" --repo "$REPO" --body "**NIGHTLY READY** — GHCR run ${RUN_ID} success. Bench: \`OPENFDD_IMAGE_TAG=nightly ./scripts/openfdd_rust_site_update.sh\` then \`docs/agent/linux-edge-tester-nightly-retest-prompt.md\`." >>"$LOG" 2>&1 || true
+    exit 0
+    ;;
+  failure | cancelled)
+    gh issue comment "$ISSUE" --repo "$REPO" --body "**GHCR FAIL** run ${RUN_ID} (${con}). Product wake." >>"$LOG" 2>&1 || true
+    exit 1
+    ;;
+  esac
+  sleep "$INTERVAL"
+done
+echo "deep_sleep timeout wakes=$MAX_WAKES" >>"$LOG"
+exit 2


### PR DESCRIPTION
## Summary

- **#466 P0:** `active_profile()` loads `OPENFDD_VALIDATION_PROFILE`; `OPENFDD_SMOKE_DEVICE_INSTANCE` env override + tests
- **#464 P0:** Persist `mstp_network` / `mstp_mac` / router address from Who-Is into `driver_tree.json`; config-driven `read_property_routed` for poll/read/discovery
- **#467 P1:** Reuse persistent `Arc<Mutex<BACnetClient>>` across BACnet I/O (no per-call stop/build)
- **#465 P1:** Bridge `SERVICE_MODE=bridge` proxies `/api/bacnet/whois`, `/read`, `/point-discovery` → commission `:9091`
- **#469 P1:** `openfdd_auth_init.sh` writes `auth.env.local` mode **644**; partial rotate merges bootstrap handoff roles
- **#470 P1:** Restore bench scripts under `scripts/bench/`
- **Ops:** GHCR publish job timeouts (300m job / 240m build-push); `openfdd_product_ghcr_deep_sleep.sh`; agent issue index doc

Version **3.2.12** · 146 edge unit tests pass locally.

## Test plan

- [x] `cargo test --lib` in `edge/` (146 passed)
- [ ] CI green (rust test + GHCR publish)
- [ ] Bench after `:nightly`: Who-Is 5007 on `:8080`, read AI:1173 ~71°F, poll samples ↑ for 5007
- [ ] FDD single cycle with only `OPENFDD_VALIDATION_PROFILE` (no manual `site.local.toml`)
- [ ] Auth rotate + bridge restart without manual chmod
- [ ] CodeRabbit review triage

Closes #464 #466 #465 #467 #469 #470 · tracks #429


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional proxying for selected BACnet API endpoints to an external commission service, with automatic fallback to local handling.
  * Enhanced BACnet routing so routed devices are read/discovered using routing-aware behavior.
  * Added new bench/soak scripts for continuous polling and longer-running soak validation.
* **Bug Fixes**
  * Improved BACnet read behavior by reusing a shared client across requests.
  * Added validation profile and device-instance overrides via environment variables.
* **Tests**
  * Updated fixtures and assertions for routing-related fields.
* **Documentation**
  * Added/expanded bench guidance, operational runbooks, and issue-index documentation.
* **Chores**
  * Bumped version to 3.2.12 and added publishing timeout limits for GHCR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->