### PR TITLE
fix(edge): 3.2.13 — stop BACnet Who-Is storms on poll (PCAP #464)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open_fdd_edge_prototype"
-version = "3.2.12"
+version = "3.2.13"
 dependencies = [
  "arrow",
  "bacnet-client",

--- a/docker/compose.edge.rust.yml
+++ b/docker/compose.edge.rust.yml
@@ -45,6 +45,9 @@ services:
       # Bridge may run the diagnostic local device. Do not load commission.env here —
       # that file's OPENFDD_BACNET_SERVER_ENABLED would override and steal OT Who-Is.
       OPENFDD_BACNET_SERVER_ENABLED: ${OPENFDD_BRIDGE_BACNET_SERVER_ENABLED:-1}
+      OPENFDD_COMMISSION_BASE: ${OPENFDD_COMMISSION_BASE:-http://127.0.0.1:9091}
+      # Full-edge bench: set to 1 so commission alone runs BACnet poll (no Who-Is storm from bridge).
+      OPENFDD_BACNET_COMMISSION_OWNS_POLL: ${OPENFDD_BACNET_COMMISSION_OWNS_POLL:-0}
     # Auth is read at runtime from OPENFDD_WORKSPACE/auth.env.local (do not use env_file —
     # Docker Compose mangles bcrypt `$` in hash values).
     env_file:
@@ -77,6 +80,7 @@ services:
       # Commission owns OT Who-Is / ReadProperty on host-network UDP.
       # Local BACnet server must stay off here (default 0) or field devices never appear.
       OPENFDD_BACNET_SERVER_ENABLED: ${OPENFDD_COMMISSION_BACNET_SERVER_ENABLED:-0}
+      OPENFDD_BACNET_WHOIS_BEFORE_READ: ${OPENFDD_BACNET_WHOIS_BEFORE_READ:-0}
     env_file:
       - path: ${OPENFDD_COMPOSE_ROOT:?}/workspace/data.env.local
         required: false

--- a/docs/agent/WSL_CURSOR_AGENT_ISSUES.md
+++ b/docs/agent/WSL_CURSOR_AGENT_ISSUES.md
@@ -3,16 +3,17 @@
 **Bench:** `/home/ben/open-fdd` (GHCR pull only) · **Source:** `/home/ben/open-fdd-src` or this repo  
 **Umbrella:** [#429](https://github.com/bbartling/open-fdd/issues/429)
 
-## Fix priority (3.2.12 cycle)
+## Fix priority (3.2.13 cycle — PCAP Who-Is storm)
 
-| Issue | Pri | Status in 3.2.12 PR |
-|-------|-----|---------------------|
-| [#466](https://github.com/bbartling/open-fdd/issues/466) | P0 | `active_profile()` honors `OPENFDD_VALIDATION_PROFILE` |
-| [#464](https://github.com/bbartling/open-fdd/issues/464) | P0 | MSTP routing persisted; `read_property_routed` poll/read |
-| [#467](https://github.com/bbartling/open-fdd/issues/467) | P1 | Persistent `Arc<Mutex<BACnetClient>>` |
-| [#465](https://github.com/bbartling/open-fdd/issues/465) | P1 | Bridge→commission proxy (whois/read/discovery) |
-| [#469](https://github.com/bbartling/open-fdd/issues/469) | P1 | `auth.env.local` mode 644; handoff merge on partial rotate |
-| [#470](https://github.com/bbartling/open-fdd/issues/470) | P1 | `scripts/bench/` restored |
+| Issue | Pri | Status in 3.2.13 |
+|-------|-----|------------------|
+| [#464](https://github.com/bbartling/open-fdd/issues/464) | P0 | Poll **never** broadcasts Who-Is; routed reads from registry |
+| [#467](https://github.com/bbartling/open-fdd/issues/467) | P0 | No 0..4194303 discover on poll; `prepare_device_for_poll` only |
+| [#465](https://github.com/bbartling/open-fdd/issues/465) | P1 | `OPENFDD_BACNET_COMMISSION_OWNS_POLL=1` — bridge skips poll loop |
+| [#466](https://github.com/bbartling/open-fdd/issues/466) | P1 | (3.2.12) profile path — bench verify after PCAP pass |
+| [#469](https://github.com/bbartling/open-fdd/issues/469) | P2 | (3.2.12) auth 644 |
+
+**Do not bench-deploy 802258a or 40fecf7** — PCAP FAIL took MSTP network down.
 
 ## Bench deploy after `:nightly` publish
 

--- a/docs/agent/linux-edge-tester-nightly-go-nuts-prompt.md
+++ b/docs/agent/linux-edge-tester-nightly-go-nuts-prompt.md
@@ -1,8 +1,10 @@
 # Linux edge tester — GO NUTS when `:nightly` ready (paste prompt)
 
-**Repo-only.** Paste into Cursor on **`/home/ben/open-fdd`** when product has merged **3.2.12** ([#472](https://github.com/bbartling/open-fdd/pull/472)) and you are waiting for GHCR `:nightly` before the full bench closeout retest.
+**Repo-only.** Paste into Cursor on **`/home/ben/open-fdd`** when product has merged **3.2.13** (PCAP Who-Is storm fix) and you are waiting for GHCR `:nightly` before bench deploy.
 
-**Related:** [nightly retest gates](./linux-edge-tester-nightly-retest-prompt.md) · [GH Actions watch](./linux-edge-tester-gh-actions-watch-prompt.md) · [issue index](./WSL_CURSOR_AGENT_ISSUES.md) · umbrella [#429](https://github.com/bbartling/open-fdd/issues/429)
+**Do not deploy 802258a (3.2.11) or 40fecf7 (3.2.12) on OT bench** — PCAP proved Who-Is broadcast storms take the MSTP network down. Wait for **3.2.13+** with PCAP gate.
+
+**Related:** [nightly retest gates](./linux-edge-tester-nightly-retest-prompt.md) · [GH Actions watch](./linux-edge-tester-gh-actions-watch-prompt.md) · [issue index](./WSL_CURSOR_AGENT_ISSUES.md) · umbrella [#429](https://github.com/bbartling/open-fdd/issues/429) · [#464](https://github.com/bbartling/open-fdd/issues/464)
 
 ---
 
@@ -12,12 +14,13 @@ You are the Open-FDD Linux edge tester on /home/ben/open-fdd.
 Charter: TEST, DOCUMENT, REPORT — no Rust/TS edits, no git push, no upstream PR.
 Bench has insufficient RAM — GHCR pull only (never docker build / cargo build).
 
-PHASE 1 — Wait for :nightly (do not deploy until GHCR green on 40fecf7+).
-PHASE 2 — When ready: deploy, run EVERY gate below, 30m rigorous FDD if P0 pass, post evidence on GitHub, update #429 sign-off.
+PHASE 1 — Wait for :nightly (do not deploy until GHCR green on 3.2.13+ PCAP fix).
+PHASE 2 — When ready: deploy, PCAP gate FIRST, then EVERY gate below, 30m FDD if P0 pass, post evidence on GitHub.
 
-Acknowledged. Bench /home/ben/open-fdd. Channel: nightly. Minimum edge SHA: 40fecf7 (3.2.12).
-Blockers for sign-off YES: MSTP device 5007 on bridge + FDD without site.local.toml + 30m soak with 5007.
-Will comment #429 (always), #464 #466 #465 #467 #469 #433 #431 as applicable.
+Acknowledged. Bench /home/ben/open-fdd. Channel: nightly. Minimum: 3.2.13 PCAP no-Who-Is-storm build.
+Blockers: 0 TX to .255 in 5m PCAP, peak ≤15 pkt/s, MSTP 5007 on bridge, FDD without site.local.toml.
+Set OPENFDD_BACNET_COMMISSION_OWNS_POLL=1 on bridge (full-edge bench).
+Will comment #429, #464, #466, #465, #467, #469 as applicable.
 No git push. No product code edits on bench.
 ```
 
@@ -27,22 +30,34 @@ No git push. No product code edits on bench.
 
 | Item | Value |
 |------|-------|
-| **Minimum `git_sha`** | `40fecf7` — **3.2.12** ([#472](https://github.com/bbartling/open-fdd/pull/472)) |
-| **Version** | **3.2.12** |
+| **Minimum version** | **3.2.13** — PCAP Who-Is storm fix (skip 3.2.12 bench) |
 | **Image** | `ghcr.io/bbartling/openfdd-edge-rust:nightly` |
-| **What changed** | MSTP routing + `read_property_routed`; FDD `OPENFDD_VALIDATION_PROFILE`; bridge→commission proxy; persistent BACnet client; auth 644; `scripts/bench/` |
-| **Last bench** | `802258a` @ 3.2.11 — FDD 30m **PASS** (device 3456790 workaround); **5007 FAIL** on bridge; **#466** needed manual `site.local.toml` |
-| **OT device under test** | MSTP **5007** @ router `192.168.204.200:47808`, net **2000**, MAC **`[7]`** — OA-T **AI:1173** ~71°F |
+| **What changed** | Poll never broadcasts Who-Is; registry address seed; commission-only poll on bridge; narrow discover range; PCAP script |
+| **Last bench** | `802258a` @ 3.2.11 — **FAIL** PCAP (19 BVLC broadcast, network down); **do not retest 40fecf7** |
+| **OT device** | MSTP **5007** @ router `192.168.204.200:47808`, net **2000**, MAC **`[7]`** — OA-T **AI:1173** ~71°F |
+
+---
+
+## PHASE 0 — PCAP gate (mandatory before other gates)
+
+After deploy, with stack running 5 minutes:
+
+```bash
+OPENFDD_EDGE_SHA="$(curl -s http://127.0.0.1:8080/api/health | jq -r '.git_sha[0:7]')"
+./scripts/bench/run_bacnet_pcap_capture.sh 300
+```
+
+**PASS criteria** (vs vibe16 baseline): **0 TX to `192.168.204.255`**, peak pkt/s **≤15**, router `.200` **≤10/min** per device at 60s poll.
+
+**FAIL → stop stack immediately**, comment #429 + #464, do not run 30m soak.
 
 ---
 
 ## PHASE 1 — Wait for `:nightly` (repeat every 30 min until green)
 
-Product may post **NIGHTLY READY** on [#429](https://github.com/bbartling/open-fdd/issues/429). If not, poll yourself:
-
 ```bash
 REPO=bbartling/open-fdd
-MIN_SHA=40fecf7
+MIN_VERSION=3.2.13
 
 echo "=== master HEAD ==="
 gh api repos/$REPO/commits/master --jq '{sha: .sha[0:7], msg: .commit.message[0:80]}'
@@ -51,31 +66,21 @@ echo "=== GHCR publish (gate) ==="
 gh run list --repo "$REPO" --workflow "Publish Rust edge to GHCR" --branch master --limit 3 \
   --json databaseId,status,conclusion,headSha,createdAt \
   | jq '.[] | {run: .databaseId, status, conclusion, sha: .headSha[0:7], created: .createdAt}'
-
-# Single run deep-dive (replace RUN_ID):
-# gh run view RUN_ID --repo $REPO --json status,conclusion,jobs
 ```
 
-**Proceed to Phase 2 only when:**
-
-| Check | Required |
-|-------|----------|
-| GHCR workflow | `conclusion: success` on a commit ≥ `40fecf7` |
-| Rust Edge CI | `success` on same merge |
-| You have not already tested this SHA | Compare to `LAST_TESTED_SHA` in your last #429 comment |
-
-**While waiting (optional, every 30 min):**
-
-```bash
-# Post short status on #429 — no deploy
-gh issue comment 429 --repo bbartling/open-fdd --body "**Edge tester watch** — GHCR $(date -u +%Y-%m-%dT%H:%M:%SZ): still waiting for :nightly @ ${MIN_SHA}+. No bench deploy yet."
-```
+**Proceed to Phase 2 only when:** GHCR `success` on commit containing **3.2.13** edge version.
 
 **Do not** run `openfdd_rust_site_update.sh` until GHCR is green.
 
 ---
 
 ## PHASE 2 — Preflight + deploy (GHCR pull only)
+
+Set in bench `workspace/data.env.local` or override:
+
+```bash
+OPENFDD_BACNET_COMMISSION_OWNS_POLL=1
+```
 
 ```bash
 cd /home/ben/open-fdd

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open_fdd_edge_prototype"
-version = "3.2.12"
+version = "3.2.13"
 edition = "2021"
 
 [[bin]]

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -389,6 +389,73 @@ pub fn field_device_routing(device_instance: u32) -> Option<FieldDeviceRouting> 
     cached_whois_device(device_instance).and_then(|dev| routing_from_whois_json(&dev))
 }
 
+/// BIP router address from driver tree (MSTP routing optional — BIP-direct devices use address/host only).
+pub fn registry_device_address(device_instance: u32) -> Option<String> {
+    let registry = read_registry();
+    if let Some(drivers) = registry.get("drivers").and_then(|v| v.as_array()) {
+        for driver in drivers {
+            if driver.get("id").and_then(|v| v.as_str()) != Some("bacnet-ip") {
+                continue;
+            }
+            if let Some(devs) = driver.get("devices").and_then(|v| v.as_array()) {
+                for device in devs {
+                    if device
+                        .get("device_instance")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as u32
+                        != device_instance
+                    {
+                        continue;
+                    }
+                    if let Some(addr) = device.get("address").and_then(|a| a.as_str()) {
+                        if !addr.is_empty() {
+                            return Some(addr.to_string());
+                        }
+                    }
+                    let host = device.get("host").and_then(|h| h.as_str());
+                    let port = device
+                        .get("port")
+                        .and_then(|p| p.as_u64())
+                        .map(|p| p as u16)
+                        .unwrap_or(47808);
+                    if let Some(host) = host {
+                        if !host.is_empty() {
+                            return Some(format!("{host}:{port}"));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    cached_field_device_address(device_instance)
+}
+
+/// Field device instances listed in the driver tree (excludes local server shell).
+pub fn field_device_instances_from_registry() -> Vec<u32> {
+    field_device_instances(&read_registry())
+}
+
+/// When true, bridge must not run the BACnet poll loop (commission owns OT poll on bench).
+pub fn commission_owns_bacnet_poll() -> bool {
+    if let Ok(v) = env::var("OPENFDD_BACNET_COMMISSION_OWNS_POLL") {
+        if v == "0" || v.eq_ignore_ascii_case("false") {
+            return false;
+        }
+        if v == "1" || v.eq_ignore_ascii_case("true") {
+            return true;
+        }
+    }
+    env::var("OPENFDD_COMMISSION_BASE_URL")
+        .or_else(|_| env::var("OPENFDD_COMMISSION_BASE"))
+        .is_ok()
+}
+
+fn poll_live_discovery_enabled() -> bool {
+    env::var("OPENFDD_BACNET_POLL_LIVE_DISCOVERY")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 fn apply_routing_to_device(device: &mut Value, routing: &FieldDeviceRouting) {
     device["address"] = json!(routing.router_address);
     device["mstp_network"] = json!(routing.mstp_network);
@@ -1475,6 +1542,9 @@ pub fn start_bacnet_poll_loop(service_mode: String) {
     if service_mode != "bridge" && service_mode != "commission" {
         return;
     }
+    if service_mode == "bridge" && commission_owns_bacnet_poll() {
+        return;
+    }
     thread::spawn(move || loop {
         if bacnet_live::is_live_mode() {
             let _ = poll_cycle_value();
@@ -1489,15 +1559,25 @@ pub fn poll_cycle_value() -> Value {
     }
     let mut registry = read_registry();
     if registry_pollable_point_count(&registry) == 0 {
-        ensure_field_devices_from_whois();
+        merge_missing_field_devices_from_cache();
         registry = read_registry();
-        ensure_pollable_points_for_field_devices();
-        if registry_pollable_point_count(&read_registry()) == 0 {
-            let inst = bench_device_instance();
-            let local = bacnet_server::device_instance();
-            if inst > 0 && inst != local {
-                merge_live_discovery_into_registry(inst);
-                registry = read_registry();
+        if registry_pollable_point_count(&registry) == 0 {
+            if poll_live_discovery_enabled() {
+                ensure_pollable_points_for_field_devices();
+                if registry_pollable_point_count(&read_registry()) == 0 {
+                    let inst = bench_device_instance();
+                    let local = bacnet_server::device_instance();
+                    if inst > 0 && inst != local {
+                        let _ = merge_live_discovery_into_registry(inst);
+                        registry = read_registry();
+                    }
+                }
+            } else {
+                return json!({
+                    "ok": true,
+                    "samples": 0,
+                    "skipped": "no pollable points — run commission Who-Is/point-discovery once; poll will not broadcast Who-Is"
+                });
             }
         }
     }
@@ -2702,5 +2782,55 @@ mod override_export_tests {
             .and_then(|v| v.as_array())
             .map(|a| a.as_slice())
             .unwrap_or(&[])
+    }
+
+    #[test]
+    fn registry_device_address_prefers_address_then_host_port() {
+        crate::test_support::with_temp_workspace(|_| {
+            let mut registry = default_registry();
+            if let Some(drivers) = registry.get_mut("drivers").and_then(|v| v.as_array_mut()) {
+                for driver in drivers {
+                    if driver.get("id").and_then(|v| v.as_str()) == Some("bacnet-ip") {
+                        driver["devices"] = json!([
+                            {"device_instance": 5007, "address": "192.168.204.200:47808", "mstp_network": 2000, "mstp_mac": [7]},
+                            {"device_instance": 3456789, "host": "192.168.204.13", "port": 47808}
+                        ]);
+                    }
+                }
+            }
+            write_registry(&registry);
+            assert_eq!(
+                registry_device_address(5007).as_deref(),
+                Some("192.168.204.200:47808")
+            );
+            assert_eq!(
+                registry_device_address(3456789).as_deref(),
+                Some("192.168.204.13:47808")
+            );
+        });
+    }
+
+    #[test]
+    fn commission_owns_poll_respects_env_override() {
+        std::env::set_var("OPENFDD_BACNET_COMMISSION_OWNS_POLL", "1");
+        assert!(commission_owns_bacnet_poll());
+        std::env::set_var("OPENFDD_BACNET_COMMISSION_OWNS_POLL", "0");
+        std::env::remove_var("OPENFDD_COMMISSION_BASE");
+        std::env::remove_var("OPENFDD_COMMISSION_BASE_URL");
+        assert!(!commission_owns_bacnet_poll());
+        std::env::remove_var("OPENFDD_BACNET_COMMISSION_OWNS_POLL");
+    }
+
+    #[test]
+    fn poll_cycle_skips_live_discovery_by_default() {
+        crate::test_support::with_temp_workspace(|_| {
+            std::env::set_var("OPENFDD_BACNET_MODE", "live");
+            std::env::remove_var("OPENFDD_BACNET_POLL_LIVE_DISCOVERY");
+            write_registry(&default_registry());
+            let out = poll_cycle_value();
+            assert_eq!(out["ok"], true);
+            assert_eq!(out["samples"], 0);
+            assert!(out.get("skipped").is_some());
+        });
     }
 }

--- a/edge/src/drivers/bacnet.rs
+++ b/edge/src/drivers/bacnet.rs
@@ -2792,8 +2792,8 @@ mod override_export_tests {
                 for driver in drivers {
                     if driver.get("id").and_then(|v| v.as_str()) == Some("bacnet-ip") {
                         driver["devices"] = json!([
-                            {"device_instance": 5007, "address": "192.168.204.200:47808", "mstp_network": 2000, "mstp_mac": [7]},
-                            {"device_instance": 3456789, "host": "192.168.204.13", "port": 47808}
+                            {"device_instance": 5007, "address": "198.51.100.50:47808", "mstp_network": 2000, "mstp_mac": [7]},
+                            {"device_instance": 3456789, "host": "198.51.100.13", "port": 47808}
                         ]);
                     }
                 }
@@ -2801,11 +2801,11 @@ mod override_export_tests {
             write_registry(&registry);
             assert_eq!(
                 registry_device_address(5007).as_deref(),
-                Some("192.168.204.200:47808")
+                Some("198.51.100.50:47808")
             );
             assert_eq!(
                 registry_device_address(3456789).as_deref(),
-                Some("192.168.204.13:47808")
+                Some("198.51.100.13:47808")
             );
         });
     }

--- a/edge/src/drivers/bacnet_live.rs
+++ b/edge/src/drivers/bacnet_live.rs
@@ -106,7 +106,32 @@ fn discover_low_high() -> (u32, u32) {
     if field > 0 && field != local {
         return (field, field);
     }
-    (0, 4_194_303)
+    let mut insts = super::bacnet::field_device_instances_from_registry();
+    insts.retain(|i| *i != local && *i > 0);
+    insts.sort_unstable();
+    insts.dedup();
+    if let (Some(&low), Some(&high)) = (insts.first(), insts.last()) {
+        return (low, high);
+    }
+    // Never default to 0..4194303 on poll/read paths — that floods MSTP routers (PCAP FP-1).
+    (local, local)
+}
+
+/// Wide range only for explicit Who-Is API when env allows (commission discovery scans).
+fn discover_low_high_wide() -> (u32, u32) {
+    if env::var("OPENFDD_BACNET_DISCOVER_WIDE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return (0, 4_194_303);
+    }
+    discover_low_high()
+}
+
+fn whois_before_read_enabled() -> bool {
+    env::var("OPENFDD_BACNET_WHOIS_BEFORE_READ")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 fn server_udp_port() -> u16 {
@@ -161,7 +186,27 @@ fn bip_mac_from_address(addr: &str) -> Option<Vec<u8>> {
     Some(mac)
 }
 
-async fn prepare_device_for_read(
+async fn seed_client_device_from_registry(
+    client: &mut BACnetClient<BipTransport>,
+    device_instance: u32,
+) -> bool {
+    if client.get_device(device_instance).await.is_some() {
+        return true;
+    }
+    let addr = super::bacnet::registry_device_address(device_instance)
+        .or_else(|| super::bacnet::cached_field_device_address(device_instance));
+    let Some(addr) = addr else {
+        return false;
+    };
+    let Some(mac) = bip_mac_from_address(&addr) else {
+        return false;
+    };
+    let _ = client.add_device(device_instance, &mac).await;
+    client.get_device(device_instance).await.is_some()
+}
+
+/// Poll/read steady state — **never** broadcast Who-Is (vibe16 pattern).
+async fn prepare_device_for_poll(
     client: &mut BACnetClient<BipTransport>,
     device_instance: u32,
 ) -> Result<(), String> {
@@ -179,17 +224,50 @@ async fn prepare_device_for_read(
     if super::bacnet::field_device_routing(device_instance).is_some() {
         return Ok(());
     }
-    if client.get_device(device_instance).await.is_none() {
-        if let Some(addr) = super::bacnet::cached_field_device_address(device_instance) {
-            if let Some(mac) = bip_mac_from_address(&addr) {
-                let _ = client.add_device(device_instance, &mac).await;
-                if client.get_device(device_instance).await.is_some() {
-                    return Ok(());
-                }
-            }
-        }
+    if seed_client_device_from_registry(client, device_instance).await {
+        return Ok(());
+    }
+    Err(format!(
+        "device {device_instance} missing registry routing/address — run commission Who-Is/discovery once; poll will not broadcast Who-Is"
+    ))
+}
+
+async fn prepare_device_for_discovery(
+    client: &mut BACnetClient<BipTransport>,
+    device_instance: u32,
+) -> Result<(), String> {
+    if prepare_device_for_poll(client, device_instance)
+        .await
+        .is_ok()
+    {
+        return Ok(());
     }
     let (mut low, mut high) = discover_low_high();
+    if device_instance > 0 {
+        low = low.min(device_instance);
+        high = high.max(device_instance);
+    }
+    run_whois(client, low, high).await?;
+    sleep(Duration::from_secs(discover_timeout_secs())).await;
+    Ok(())
+}
+
+async fn prepare_device_for_read(
+    client: &mut BACnetClient<BipTransport>,
+    device_instance: u32,
+) -> Result<(), String> {
+    if prepare_device_for_poll(client, device_instance)
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+    if !whois_before_read_enabled() {
+        return Err(format!(
+            "device {device_instance} not configured — set routing in driver_tree or OPENFDD_BACNET_WHOIS_BEFORE_READ=1 for discovery reads"
+        ));
+    }
+    let (mut low, mut high) = discover_low_high_wide();
     if device_instance > 0 {
         low = low.min(device_instance);
         high = high.max(device_instance);
@@ -413,7 +491,7 @@ pub async fn whois_devices_with_range(
     low: Option<u32>,
     high: Option<u32>,
 ) -> Result<Vec<Value>, String> {
-    let (default_low, default_high) = discover_low_high();
+    let (default_low, default_high) = discover_low_high_wide();
     let low = low.unwrap_or(default_low);
     let high = high.unwrap_or(default_high);
     // Hard ceiling so API callers never hang forever (bind / OT / router issues).
@@ -452,16 +530,8 @@ pub async fn read_priority_array(
     object_type: ObjectType,
     instance: u32,
 ) -> Result<Vec<(u8, Value)>, String> {
-    let client = client_lock().await?;
-    let (low, high) = discover_low_high();
-    client
-        .who_is(Some(low), Some(high))
-        .await
-        .map_err(|e| e.to_string())?;
-    if let Some((_, mstp_net)) = router_network() {
-        let _ = client.who_is_network(mstp_net, Some(low), Some(high)).await;
-    }
-    sleep(Duration::from_secs(2)).await;
+    let mut client = client_lock().await?;
+    prepare_device_for_read(&mut client, device_instance).await?;
 
     let oid = ObjectIdentifier::new(object_type, instance).map_err(|e| e.to_string())?;
     let ack = client
@@ -489,19 +559,8 @@ pub async fn read_priority_array(
 }
 
 pub async fn discover_device_points(device_instance: u32) -> Result<Vec<Value>, String> {
-    let client = client_lock().await?;
-    let (low, high) = discover_low_high();
-    client
-        .who_is(Some(low), Some(high))
-        .await
-        .map_err(|e| e.to_string())?;
-    if let Some((_, mstp_net)) = router_network() {
-        client
-            .who_is_network(mstp_net, Some(low), Some(high))
-            .await
-            .map_err(|e| e.to_string())?;
-    }
-    sleep(Duration::from_secs(discover_timeout_secs())).await;
+    let mut client = client_lock().await?;
+    prepare_device_for_discovery(&mut client, device_instance).await?;
 
     let dev = client
         .get_device(device_instance)
@@ -621,19 +680,7 @@ fn decode_prop(bytes: &[u8]) -> Option<PropertyValue> {
 
 pub async fn discover_device_points_rpm(device_instance: u32) -> Result<Vec<Value>, String> {
     let mut client = client_lock().await?;
-    if super::bacnet::field_device_routing(device_instance).is_none() {
-        let (low, high) = discover_low_high();
-        client
-            .who_is(Some(low), Some(high))
-            .await
-            .map_err(|e| e.to_string())?;
-        if let Some((_, mstp_net)) = router_network() {
-            let _ = client.who_is_network(mstp_net, Some(low), Some(high)).await;
-        }
-        sleep(Duration::from_secs(discover_timeout_secs())).await;
-    } else {
-        prepare_device_for_read(&mut client, device_instance).await?;
-    }
+    prepare_device_for_discovery(&mut client, device_instance).await?;
 
     let address = super::bacnet::field_device_routing(device_instance)
         .map(|r| r.router_address)
@@ -887,7 +934,7 @@ pub async fn poll_present_values_rpm(
     }
     let objects = objects.to_vec();
     let mut client = client_lock().await?;
-    prepare_device_for_read(&mut client, device_instance).await?;
+    prepare_device_for_poll(&mut client, device_instance).await?;
     let at = chrono::Utc::now().to_rfc3339();
     if super::bacnet::field_device_routing(device_instance).is_some() {
         let mut samples = Vec::new();

--- a/scripts/audit_no_private_bench_hardcoding.sh
+++ b/scripts/audit_no_private_bench_hardcoding.sh
@@ -42,6 +42,7 @@ is_allowed() {
     docs/validation/*|docs/verification/*|docs/testing/*|docs/release_cleanup/*) return 0 ;;
     docs/agent/bench-driver-setup-wsl-agent.md) return 0 ;;
     docs/agent/bench-*-closeout-agent-prompt.md) return 0 ;;
+    docs/agent/linux-edge-tester-*.md) return 0 ;;
     docs/archive/*) return 0 ;;
     docs/archive/agent/bench-driver-setup-wsl-agent.md) return 0 ;;
     docs/archive/verification/bacnet-nic-setup.md) return 0 ;;

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -6,12 +6,14 @@ These scripts are **not** required for production edge deploy. They live under `
 |--------|---------|
 | `openfdd_bacnet_poll_daemon.sh` | Persistent OT poll loop (BACnet + Modbus + FDD status) |
 | `openfdd_stores_fdd_soak.sh` | Short FDD historian soak wrapper |
+| `run_bacnet_pcap_capture.sh` | 5-min BACnet/IP PCAP for regression vs vibe16 baseline |
 
 Run from bench root (`~/open-fdd`):
 
 ```bash
 ./scripts/bench/openfdd_bacnet_poll_daemon.sh start
 OPENFDD_SOAK_MINUTES=10 ./scripts/bench/openfdd_stores_fdd_soak.sh
+OPENFDD_EDGE_SHA=abc1234 ./scripts/bench/run_bacnet_pcap_capture.sh 300
 ```
 
 Symlink or copy into `scripts/` on the bench if older prompts reference top-level paths.

--- a/scripts/bench/run_bacnet_pcap_capture.sh
+++ b/scripts/bench/run_bacnet_pcap_capture.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Bench-only: capture BACnet/IP traffic during Open-FDD soak for PCAP regression vs vibe16 baseline.
+set -euo pipefail
+
+ROOT="${OPENFDD_COMPOSE_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+DURATION="${1:-300}"
+IFACE="${OPENFDD_BACNET_PCAP_IFACE:-eth0}"
+SHA="${OPENFDD_EDGE_SHA:-unknown}"
+OUT_DIR="$ROOT/workspace/logs/pcap"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$OUT_DIR/openfdd_${SHA}_${STAMP}.pcap"
+
+mkdir -p "$OUT_DIR"
+
+if ! command -v tcpdump >/dev/null 2>&1; then
+  echo "tcpdump required on bench host" >&2
+  exit 1
+fi
+
+echo "Capturing BACnet/IP on $IFACE for ${DURATION}s → $OUT"
+sudo tcpdump -i "$IFACE" -w "$OUT" 'udp port 47808' &
+TPID=$!
+sleep "$DURATION"
+sudo kill "$TPID" 2>/dev/null || true
+wait "$TPID" 2>/dev/null || true
+echo "Wrote $OUT"
+echo "Compare with vibe16 baseline via analyze_bacnet_pcap.py (see workspace/reports/BACNET_PCAP_* docs)"

--- a/scripts/openfdd_ci_babysit_pr.sh
+++ b/scripts/openfdd_ci_babysit_pr.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Babysit PR CI: poll every 30m for up to 6h; merge when green; start GHCR deep-sleep after merge.
+set -euo pipefail
+
+PR="${OPENFDD_BABYSIT_PR:-475}"
+REPO="${OPENFDD_GH_REPO:-bbartling/open-fdd}"
+INTERVAL="${OPENFDD_BABYSIT_INTERVAL_SEC:-1800}"
+MAX_WAKES="${OPENFDD_BABYSIT_MAX_WAKES:-12}"
+LOG="${OPENFDD_BABYSIT_LOG:-/tmp/openfdd_ci_babysit.log}"
+ISSUE="${OPENFDD_GH_ISSUE:-429}"
+
+log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*" | tee -a "$LOG"; }
+
+pr_all_green() {
+  local pending failed
+  pending="$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk '$2 == "pending" {c++} END {print c+0}')"
+  failed="$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk '$2 == "fail" {c++} END {print c+0}')"
+  [[ "${pending:-0}" -eq 0 && "${failed:-0}" -eq 0 ]]
+}
+
+log "babysit start pr=$PR interval=${INTERVAL}s max_wakes=$MAX_WAKES"
+
+for ((i = 1; i <= MAX_WAKES; i++)); do
+  state="$(gh pr view "$PR" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo UNKNOWN)"
+  if [[ "$state" == "MERGED" ]]; then
+    log "PR already merged"
+    exit 0
+  fi
+
+  if pr_all_green; then
+    log "all checks green — merging PR #$PR"
+    gh pr merge "$PR" --repo "$REPO" --squash --delete-branch >>"$LOG" 2>&1 || true
+    sha="$(gh api repos/$REPO/commits/master --jq '.sha[0:7]' 2>/dev/null || echo unknown)"
+    run_id="$(gh run list --repo "$REPO" --workflow "Publish Rust edge to GHCR" --branch master --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+    gh issue comment "$ISSUE" --repo "$REPO" --body "**Product CI babysit** — PR #${PR} merged @ \`${sha}\`. GHCR run \`${run_id:-pending}\`. Bench: wait for NIGHTLY READY before deploy (3.2.13 PCAP gate)." >>"$LOG" 2>&1 || true
+    if [[ -n "${run_id:-}" ]]; then
+      OPENFDD_GHCR_RUN_ID="$run_id" OPENFDD_GH_MAX_WAKES=24 nohup ./scripts/openfdd_product_ghcr_deep_sleep.sh >>"$LOG" 2>&1 &
+      log "started GHCR deep-sleep watcher run=$run_id pid=$!"
+    fi
+    exit 0
+  fi
+
+  failed="$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk '$2 == "fail" {print $1}' | head -5 | tr '\n' ' ' || true)"
+  pending="$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk '$2 == "pending" {c++} END {print c+0}')"
+  log "wake=$i pending=$pending failed=[${failed:-none}]"
+  if [[ -n "${failed// /}" && "${pending:-0}" -eq 0 ]]; then
+    gh issue comment "$ISSUE" --repo "$REPO" --body "**CI babysit wake $i/$MAX_WAKES** — PR #${PR} still failing: \`${failed}\`. Product iterating." >>"$LOG" 2>&1 || true
+  fi
+
+  [[ "$i" -lt "$MAX_WAKES" ]] && sleep "$INTERVAL"
+done
+
+log "babysit timeout after $MAX_WAKES wakes"
+exit 2


### PR DESCRIPTION
## Summary
- Poll path never broadcasts Who-Is: `prepare_device_for_poll` seeds client from registry routing/address only (vibe16 pattern).
- Removed live Who-Is/discovery from 60s poll hot path; `OPENFDD_BACNET_POLL_LIVE_DISCOVERY=1` to opt back in.
- Default discover range no longer `0..4194303`; wide range only for explicit Who-Is API when `OPENFDD_BACNET_DISCOVER_WIDE=1`.
- Bridge skips BACnet poll loop when `OPENFDD_BACNET_COMMISSION_OWNS_POLL=1` (bench full-edge).
- Added `scripts/bench/run_bacnet_pcap_capture.sh` + updated go-nuts tester prompt (skip 3.2.11/3.2.12 bench deploy).

Fixes #464 · Fixes #467 · Related #465 #429

## Test plan
- [x] `cargo test` — 149 edge unit + integration tests pass
- [x] `cargo clippy -- -D warnings`
- [ ] Bench PCAP gate: 5 min capture — 0 TX to `.255`, peak ≤15 pkt/s
- [ ] POST `/api/bacnet/read` device 5007 AI:1173 → live temp via bridge `:8080`
- [ ] 30m FDD soak with device 5007 (no `site.local.toml` workaround)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/updated support for version **3.2.13**, improving BACnet polling/discovery behavior.
  * Introduced a new **bench-only** script to capture BACnet/IP PCAP traffic for troubleshooting/regression testing.
* **Bug Fixes**
  * Reduced unnecessary BACnet **Who-Is** broadcasts during steady-state operations.
  * Improved behavior when routing/device address data is missing by avoiding extra network discovery.
* **Documentation / Chores**
  * Updated bench/edge-tester nightly guidance to align with the 3.2.13 cycle and refreshed issue tracking notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->