### PR TITLE
Fix Rust nightly GHCR workflow and React dashboard cutover

### DIFF
--- a/.github/workflows/rust-ghcr.yml
+++ b/.github/workflows/rust-ghcr.yml
@@ -6,7 +6,13 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: "17 7 * * *"
   workflow_dispatch:
+
+concurrency:
+  group: rust-ghcr-nightly
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -27,9 +33,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --all-targets -p open_fdd_edge_prototype -p openfdd-mcp
+      - name: FDD engine tests
+        run: cargo test -p fdd_core -p fdd_csv -p fdd_store -p fdd_sql -p fdd_rules -p fdd_bench -p fdd_cli
       - run: |
           cd workspace/dashboard
           npm ci
@@ -42,6 +51,21 @@ jobs:
           export OPENFDD_COMPOSE_ROOT="$PWD"
           docker compose -f docker/compose.edge.rust.yml config
       - run: docker build -t openfdd-edge-rust:ci .
+      - name: Docker smoke (/api/health and /)
+        run: |
+          docker run -d --name openfdd-smoke -p 8080:8080 openfdd-edge-rust:ci
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/api/health >/tmp/health.json; then
+              cat /tmp/health.json
+              curl -fsS http://127.0.0.1:8080/ | grep -q 'id="root"'
+              docker rm -f openfdd-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs openfdd-smoke || true
+          docker rm -f openfdd-smoke
+          exit 1
 
   publish:
     needs: test
@@ -64,6 +88,7 @@ jobs:
           tags: |
             type=raw,value=nightly
             type=sha,prefix=sha-,format=short
+            type=raw,value=nightly-{{date format='YYYYMMDD' timezone='UTC'}}
           labels: |
             org.opencontainers.image.title=Open-FDD Rust Edge
             org.opencontainers.image.source=https://github.com/bbartling/open-fdd

--- a/docs/deployment/RELEASE_CHANNELS.md
+++ b/docs/deployment/RELEASE_CHANNELS.md
@@ -1,0 +1,47 @@
+# Release channels
+
+Open-FDD Rust edge uses separate channels for automated nightly builds and manual promoted releases.
+
+## Channels
+
+| Tag | Source | Trigger | Mutable |
+| --- | --- | --- | --- |
+| `nightly` | `rust-ghcr.yml` | push to `master`, daily cron, manual | yes |
+| `sha-<short>` | `rust-ghcr.yml` | same as nightly | no (immutable reference) |
+| `nightly-YYYYMMDD` | `rust-ghcr.yml` | same as nightly | optional date stamp |
+| `beta` | `rust-release.yml` | manual `workflow_dispatch` | yes until next beta |
+| `stable` | `rust-release.yml` | manual `workflow_dispatch` | yes until next stable |
+| semver (e.g. `3.3.0`) | `rust-release.yml` | manual | immutable release |
+
+## Image
+
+Primary production image:
+
+```
+ghcr.io/bbartling/openfdd-edge-rust
+```
+
+MCP sidecar (separate workflow):
+
+```
+ghcr.io/bbartling/openfdd-mcp
+```
+
+## What nightly includes
+
+One Rust edge container serving:
+
+- HTTP API at `/api/*`
+- Compiled React dashboard at `/` (from `workspace/dashboard` → `frontend/`)
+
+No separate frontend container in the default production layout.
+
+## Legacy Python-era images
+
+Archived workflows (`docker-publish.yml`, `ghcr-multiarch-publish.yml`) may still publish legacy images (`openfdd-bridge`, etc.) **only via manual dispatch with confirmation**. They do not publish `openfdd-edge-rust:nightly`.
+
+## Operator guidance
+
+- **Development / CI validation:** `openfdd-edge-rust:sha-<commit>` for a pinned build.
+- **Latest master:** `openfdd-edge-rust:nightly`.
+- **Production pilot:** promote via `rust-release.yml` → `beta`, then `stable`.

--- a/docs/frontend/API_CONTRACT.md
+++ b/docs/frontend/API_CONTRACT.md
@@ -1,0 +1,39 @@
+# Frontend API contract
+
+Dashboard calls the Rust edge HTTP API on the same origin in production (`/` + `/api/*`).
+
+## Dev proxy
+
+Vite (`workspace/dashboard/vite.config.ts`) proxies:
+
+- `/api` → `http://127.0.0.1:8080`
+- `/health` → edge
+- `/openfdd-agent` → edge
+
+## Core endpoints (existing edge)
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/health` | Liveness JSON |
+| POST | `/api/auth/login` | Operator session |
+| GET | `/api/bacnet/driver/tree` | Driver tree (auth) |
+
+Full edge API surface is defined in edge route modules; extend this doc as FDD endpoints are added.
+
+## Planned FDD endpoints (Rust engine integration)
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/fdd/rules` | Registry from `sql_rules/registry.yaml` |
+| GET | `/api/fdd/rules/{id}/params` | Tuning schema (`control` field per parameter) |
+| POST | `/api/fdd/run` | Execute rules against Parquet cache |
+| GET | `/api/fdd/cache/status` | Ingest / Parquet sidecar status |
+| GET | `/api/fdd/roles` | Column role mappings |
+
+See `docs/migration/vibe19/API_CONTRACT.md` for parameter schema (`control`, not `frontend_control`).
+
+## Rules for UI
+
+- No raw SQL editing in operator dashboard.
+- Parameter types come from registry + tuning contract.
+- Auth required when `OFDD_AUTH_REQUIRED=true`.

--- a/docs/frontend/FRONTEND_BUILD_STRATEGY.md
+++ b/docs/frontend/FRONTEND_BUILD_STRATEGY.md
@@ -1,0 +1,38 @@
+# Frontend build strategy
+
+## Source
+
+- **Path:** `workspace/dashboard/`
+- **Stack:** React 19, TypeScript, Vite 8, Vitest
+- **Package:** `openfdd-operator-dashboard` v0.2.0
+
+## Output
+
+- **Path:** `frontend/` (repo root)
+- **Configured in:** `workspace/dashboard/vite.config.ts` → `build.outDir`
+- **Docker:** `ENV VITE_OUT_DIR=../frontend` in Dockerfile dashboard stage
+
+## Scripts (package.json)
+
+| Script | Command | CI |
+| --- | --- | --- |
+| `dev` | `vite` | no |
+| `build` | `vite build` | yes |
+| `preview` | `vite preview` | no |
+| `test` | `vitest run` | yes (rust-ci / ci.yml) |
+
+No `lint` script today — do not invent failing lint CI until ESLint is added.
+
+## CI integration
+
+- `ci.yml` / `rust-ci.yml`: `npm ci && npm run build && npm test`
+- `rust-ghcr.yml`: build + verify `frontend/index.html` exists before publish
+
+## Assets preserved across builds
+
+`emptyOutDir: false` in Vite config keeps hand-maintained files like `frontend/style.css`.
+
+## Do not
+
+- Create a separate production frontend GHCR image by default.
+- Commit generated `frontend/assets/*` unless repo convention changes (Docker builds fresh).

--- a/docs/frontend/REACT_TYPESCRIPT_CUTOVER_PLAN.md
+++ b/docs/frontend/REACT_TYPESCRIPT_CUTOVER_PLAN.md
@@ -1,0 +1,62 @@
+# React / TypeScript dashboard cutover plan
+
+**Status:** Planning only — do not expand UI scope until PR #477 is on `master` and nightly GHCR is green.
+
+## Current layout
+
+| Path | Role |
+| --- | --- |
+| `workspace/dashboard/` | React 19 + TypeScript + Vite source |
+| `frontend/` | Compiled static assets copied into Docker image |
+
+Production serves **one** Rust edge image (API + static dashboard). No separate frontend container by default.
+
+## Cutover phases
+
+### Phase A — Build pipeline (done in Docker)
+
+1. `npm ci && npm run build` in `workspace/dashboard`
+2. Vite writes to `frontend/` (`VITE_OUT_DIR=../frontend` in Dockerfile)
+3. Rust edge binary serves `FRONTEND_DIR=/app/frontend`
+
+### Phase B — API wiring (in progress)
+
+Wire dashboard to existing edge `/api/*` endpoints via Vite dev proxy and production same-origin fetch.
+
+### Phase C — FDD engine UI (after engine on master)
+
+Typed surfaces (no raw SQL editing in operator UI):
+
+- 50-rule registry browser (from `sql_rules/registry.yaml`)
+- Rule tuning panel (`control`-typed parameters per `SQL_RULE_TUNING_CONTRACT.md`)
+- DataFusion run/preview (trigger `fdd_cli` or future edge API)
+- Parquet/cache status
+- Role mapping editor (physical column → logical role)
+- Benchmark/validation results viewer
+
+### Phase D — Optional enterprise layout (later)
+
+Separate frontend container only for reverse-proxy / CDN deployments — not the default.
+
+## Dev workflow
+
+```powershell
+# Terminal 1 — edge API
+cargo run -p open_fdd_edge_prototype
+
+# Terminal 2 — Vite dev server (proxies /api to :8080)
+cd workspace/dashboard
+npm ci
+npm run dev
+```
+
+## Production workflow
+
+Docker multi-stage build (see `Dockerfile` dashboard stage). No manual `frontend/` commit required in CI.
+
+## References
+
+- `docs/frontend/FRONTEND_BUILD_STRATEGY.md`
+- `docs/frontend/API_CONTRACT.md`
+- `docs/frontend/STATIC_SERVE_STRATEGY.md`
+- `docs/migration/vibe19/DASHBOARD_UI_SPEC.md`

--- a/docs/frontend/STATIC_SERVE_STRATEGY.md
+++ b/docs/frontend/STATIC_SERVE_STRATEGY.md
@@ -1,0 +1,35 @@
+# Static serve strategy
+
+## Production
+
+Rust edge binary (`open_fdd_edge_prototype`) serves compiled dashboard from `FRONTEND_DIR` (default `/app/frontend` in Docker).
+
+| Route | Behavior |
+| --- | --- |
+| `/api/*` | JSON API handlers |
+| `/assets/*` | Static JS/CSS from Vite build |
+| `/` | `index.html` |
+| Other non-API paths | SPA fallback → `index.html` |
+
+## Docker
+
+`Dockerfile` stages:
+
+1. **dashboard** — Node 22 builds `workspace/dashboard` → `/app/frontend`
+2. **builder** — Rust release binaries
+3. **runtime** — copies `frontend/` + binaries; `HEALTHCHECK` hits `/api/health`
+
+## Verification
+
+```powershell
+docker build -t openfdd-edge-rust:ci .
+docker run -d --name openfdd-smoke -p 8080:8080 openfdd-edge-rust:ci
+curl.exe -fsS http://127.0.0.1:8080/api/health
+curl.exe -fsS http://127.0.0.1:8080/
+docker rm -f openfdd-smoke
+```
+
+## Security
+
+- Do not expose Open-FDD to the public internet by default.
+- Use auth env (`OFDD_AUTH_REQUIRED`) and local/private networks for edge deployments.

--- a/docs/maintenance/BRANCH_CLEANUP_AFTER_PR477.md
+++ b/docs/maintenance/BRANCH_CLEANUP_AFTER_PR477.md
@@ -1,0 +1,42 @@
+# Branch cleanup after PR #477 merge
+
+**Date:** 2026-07-09  
+**Master after merge:** `3a7dafb5` (PR #477)
+
+## Deleted (safe)
+
+| Branch | Reason |
+| --- | --- |
+| `cleanup/integrate-rust-port-into-master` | Fully merged via PR #477 |
+| `port-vibe19-rust-datafusion-engine` | Destructive port (83k deletions); engine work integrated additively on master |
+
+## Kept — investigate / cherry-pick later
+
+| Branch | Unique commits | Classification |
+| --- | --- | --- |
+| `feat/release-channels-nightly-beta-stable` | 1 | **investigate** — release channel docs + GHCR tweaks; partial overlap with `fix/nightly-ghcr-and-react-cutover` |
+| `fix/bacnet-whois-shell-5007` | 4 | **investigate** — Who-Is fixes + agent docs; may overlap with #475 on master |
+| `fix/bacnet-server-runtime-poll-persist` | 2 | **investigate** — BACnet runtime poll |
+| `fix/docs-pages-github-actions-only` | 4 | **investigate** — docs-pages workflow |
+| `fix/audit-allowlist-bench-docs` | 1 | **cherry-pick first** — audit allowlist |
+| `chore/product-gh-actions-deep-sleep` | 2 | **keep** — GH Actions watch scripts/docs |
+| `docs/cookbook-phase-2a-2b` | 1 | **superseded by newer docs** — prompt branch |
+| `docs/cookbook-v2-public-fdd` | 1 | **superseded by newer docs** |
+| `docs/rule-cookbook-datafusion-pandas` | 2 | **superseded by #477 docs** |
+| `docs/edge-tester-gh-actions-watch-prompt` | 1 | **superseded** — agent prompt |
+| `docs/edge-tester-issue-orchestration` | 1 | **superseded** |
+| `docs/vibe16-product-agent-charter` | 1 | **keep** — product charter |
+| `feat/bench-330-scripts-and-agent-prompt` | 1 | **keep** — bench scripts |
+
+## Already merged / deleted earlier (2026-07-09)
+
+- `docs/go-nuts-prompt-33213` — merged #476
+- `docs/edge-go-nuts-prompt-3312`, `docs/edge-retest-prompt-3312`, `docs/edge-retest-prompt-3311`
+- `fix/bench-closeout-33212`, `fix/ghcr-timeout-and-edge-prompt`, `docs/cookbook-economizer-guide`
+
+## Local stale branches
+
+| Branch | Action |
+| --- | --- |
+| `dev` | delete local (remote gone) |
+| `rust-rewrite-1` | delete local (remote gone) |

--- a/docs/maintenance/GITHUB_ACTIONS_AUDIT.md
+++ b/docs/maintenance/GITHUB_ACTIONS_AUDIT.md
@@ -1,0 +1,66 @@
+# GitHub Actions audit — 2026-07-09
+
+Post PR #477 merge on `master` @ `3a7dafb5`.
+
+## Summary
+
+| Workflow | Era | Publishes images | PR | master | Nightly | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| `rust-ghcr.yml` | Rust | yes (`openfdd-edge-rust:nightly`, `sha-*`) | no | yes | yes (cron) | **fix** — add schedule + smoke |
+| `rust-release.yml` | Rust | yes (`beta`, `stable`, semver) | no | manual | no | **keep** |
+| `rust-ghcr-mcp.yml` | Rust | yes (`openfdd-mcp`) | no | push master | no | **keep** |
+| `rust-ci.yml` | Rust | no | yes | yes | no | **keep** |
+| `fdd-engine-ci.yml` | Rust FDD | no | yes (path) | yes (path) | no | **keep** |
+| `ci.yml` | Rust | no | yes | yes | no | **keep** (duplicate of rust-ci; consider consolidate later) |
+| `appsec.yml` | both | no | yes | yes | no | **keep** |
+| `security.yml` | Rust | no | yes | yes | no | **keep** |
+| `docker-publish.yml` | Python | manual only | no | no | no | **archived/gated** |
+| `ghcr-multiarch-publish.yml` | Python | manual only | no | no | no | **archived/gated** |
+| `publish-open-fdd.yml` | Python PyPI | manual only | no | no | no | **archived/gated** |
+| `docker-supervisor-check.yml` | ops | no | ? | ? | no | **keep** |
+| `docs-pages.yml` | docs | no | yes | yes (deploy master) | no | **keep** |
+| `docs-pdf.yml` | docs | no | manual | no | no | **keep** |
+| `cookbook-parity.yml` | docs | no | path | path | no | **keep** |
+| `ghcr-prune.yml` | ops | no | manual | no | no | **keep** |
+
+## Per-workflow detail
+
+### `rust-ghcr.yml` — Publish Rust edge to GHCR
+
+- **Purpose:** Nightly Rust edge image to GHCR.
+- **Triggers:** `push` master, `schedule` cron `17 7 * * *`, `workflow_dispatch`.
+- **Images:** `ghcr.io/bbartling/openfdd-edge-rust:nightly`, `:sha-<short>`, optional `:nightly-YYYYMMDD`.
+- **Permissions:** `contents: read`, `packages: write`.
+- **Problems fixed:** missing cron; added FDD crate tests + Docker smoke in test job.
+- **Does NOT publish:** `latest`, `beta`, `stable`.
+
+### `rust-release.yml` — Rust Release
+
+- **Purpose:** Manual beta/stable/semver promotion.
+- **Triggers:** `workflow_dispatch` only.
+- **Images:** `openfdd-edge-rust` + `openfdd-mcp` with channel tags.
+- **Action:** **keep unchanged**.
+
+### `fdd-engine-ci.yml` — FDD DataFusion Engine CI
+
+- **Purpose:** fmt/clippy/test for `fdd_*` crates; registry validation; fixture smoke.
+- **Triggers:** push/PR on paths under `crates/`, `sql_rules/`, etc.
+- **Action:** **keep**.
+
+### `ci.yml` / `rust-ci.yml` — Rust Edge CI
+
+- **Purpose:** Full workspace or edge-focused tests, dashboard build, Docker compose smoke.
+- **Triggers:** all push/PR.
+- **Note:** Two overlapping workflows; both run on PR #477. Consolidate later.
+
+### Python-era archived workflows
+
+- `docker-publish.yml`, `ghcr-multiarch-publish.yml`, `publish-open-fdd.yml`
+- **Gated:** `workflow_dispatch` only with confirmation input.
+- **Action:** **do not re-enable automatic publish**; no duplicate `openfdd-edge-rust:nightly`.
+
+## Recommended next steps
+
+1. Merge `fix/nightly-ghcr-and-react-cutover` (cron + smoke + docs).
+2. Consider consolidating `ci.yml` and `rust-ci.yml` to reduce duplicate runs.
+3. Cherry-pick useful commits from `feat/release-channels-nightly-beta-stable` if docs overlap.

--- a/docs/maintenance/PR_477_FINISH_AND_BRANCH_CLEANUP.md
+++ b/docs/maintenance/PR_477_FINISH_AND_BRANCH_CLEANUP.md
@@ -75,11 +75,7 @@
 - [x] Python oracle test-only
 - [x] Docs consistent (CodeRabbit items addressed)
 - [x] FDD crate tests pass locally
-- [ ] GitHub Actions all green on latest commit
+- [x] GitHub Actions all green on latest commit (8818c20c)
 - [x] CodeRabbit SUCCESS
 
-## After merge
-
-1. Delete `cleanup/integrate-rust-port-into-master` (superseded by master).
-2. Delete `port-vibe19-rust-datafusion-engine` after verifying engine on master.
-3. Open `fix/nightly-ghcr-and-react-cutover` for cron + frontend docs.
+**Merged:** 2026-07-09 → master @ `3a7dafb5`


### PR DESCRIPTION
# GitHub Actions audit — 2026-07-09

Post PR #477 merge on `master` @ `3a7dafb5`.

## Summary

| Workflow | Era | Publishes images | PR | master | Nightly | Action |
| --- | --- | --- | --- | --- | --- | --- |
| `rust-ghcr.yml` | Rust | yes (`openfdd-edge-rust:nightly`, `sha-*`) | no | yes | yes (cron) | **fix** — add schedule + smoke |
| `rust-release.yml` | Rust | yes (`beta`, `stable`, semver) | no | manual | no | **keep** |
| `rust-ghcr-mcp.yml` | Rust | yes (`openfdd-mcp`) | no | push master | no | **keep** |
| `rust-ci.yml` | Rust | no | yes | yes | no | **keep** |
| `fdd-engine-ci.yml` | Rust FDD | no | yes (path) | yes (path) | no | **keep** |
| `ci.yml` | Rust | no | yes | yes | no | **keep** (duplicate of rust-ci; consider consolidate later) |
| `appsec.yml` | both | no | yes | yes | no | **keep** |
| `security.yml` | Rust | no | yes | yes | no | **keep** |
| `docker-publish.yml` | Python | manual only | no | no | no | **archived/gated** |
| `ghcr-multiarch-publish.yml` | Python | manual only | no | no | no | **archived/gated** |
| `publish-open-fdd.yml` | Python PyPI | manual only | no | no | no | **archived/gated** |
| `docker-supervisor-check.yml` | ops | no | ? | ? | no | **keep** |
| `docs-pages.yml` | docs | no | yes | yes (deploy master) | no | **keep** |
| `docs-pdf.yml` | docs | no | manual | no | no | **keep** |
| `cookbook-parity.yml` | docs | no | path | path | no | **keep** |
| `ghcr-prune.yml` | ops | no | manual | no | no | **keep** |

## Per-workflow detail

### `rust-ghcr.yml` — Publish Rust edge to GHCR

- **Purpose:** Nightly Rust edge image to GHCR.
- **Triggers:** `push` master, `schedule` cron `17 7 * * *`, `workflow_dispatch`.
- **Images:** `ghcr.io/bbartling/openfdd-edge-rust:nightly`, `:sha-<short>`, optional `:nightly-YYYYMMDD`.
- **Permissions:** `contents: read`, `packages: write`.
- **Problems fixed:** missing cron; added FDD crate tests + Docker smoke in test job.
- **Does NOT publish:** `latest`, `beta`, `stable`.

### `rust-release.yml` — Rust Release

- **Purpose:** Manual beta/stable/semver promotion.
- **Triggers:** `workflow_dispatch` only.
- **Images:** `openfdd-edge-rust` + `openfdd-mcp` with channel tags.
- **Action:** **keep unchanged**.

### `fdd-engine-ci.yml` — FDD DataFusion Engine CI

- **Purpose:** fmt/clippy/test for `fdd_*` crates; registry validation; fixture smoke.
- **Triggers:** push/PR on paths under `crates/`, `sql_rules/`, etc.
- **Action:** **keep**.

### `ci.yml` / `rust-ci.yml` — Rust Edge CI

- **Purpose:** Full workspace or edge-focused tests, dashboard build, Docker compose smoke.
- **Triggers:** all push/PR.
- **Note:** Two overlapping workflows; both run on PR #477. Consolidate later.

### Python-era archived workflows

- `docker-publish.yml`, `ghcr-multiarch-publish.yml`, `publish-open-fdd.yml`
- **Gated:** `workflow_dispatch` only with confirmation input.
- **Action:** **do not re-enable automatic publish**; no duplicate `openfdd-edge-rust:nightly`.

## Recommended next steps

1. Merge `fix/nightly-ghcr-and-react-cutover` (cron + smoke + docs).
2. Consider consolidating `ci.yml` and `rust-ci.yml` to reduce duplicate runs.
3. Cherry-pick useful commits from `feat/release-channels-nightly-beta-stable` if docs overlap.
