### PR TITLE
fix(ci): rust-ghcr Docker smoke auth/workspace

### DIFF
--- a/.github/workflows/rust-ghcr.yml
+++ b/.github/workflows/rust-ghcr.yml
@@ -53,7 +53,11 @@ jobs:
       - run: docker build -t openfdd-edge-rust:ci .
       - name: Docker smoke (/api/health and /)
         run: |
-          docker run -d --name openfdd-smoke -p 8080:8080 openfdd-edge-rust:ci
+          mkdir -p workspace/data workspace/logs workspace/overrides workspace/bacnet/commissioning
+          docker run -d --name openfdd-smoke -p 8080:8080 \
+            -e OFDD_AUTH_REQUIRED=false \
+            -v "$PWD/workspace:/var/openfdd/workspace" \
+            openfdd-edge-rust:ci
           for i in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:8080/api/health >/tmp/health.json; then
               cat /tmp/health.json


### PR DESCRIPTION
Fixes #484

## Problem
\ust-ghcr.yml\ Docker smoke fails: container exits with \OFDD_AUTH_SECRET is missing or too weak\.

## Fix
- Mount \workspace/\ to \/var/openfdd/workspace\
- Set \OFDD_AUTH_REQUIRED=false\ for CI smoke only

## Validation
Merge and re-run \gh workflow run rust-ghcr.yml --ref master\

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker smoke testing by preparing required workspace directories.
  * Updated container startup configuration to support workspace mounting and run without mandatory authentication during the test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->