### PR TITLE
fix(ci): isolate rust-ghcr Docker smoke workspace

### DIFF
--- a/.github/workflows/rust-ghcr.yml
+++ b/.github/workflows/rust-ghcr.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -53,10 +54,13 @@ jobs:
       - run: docker build -t openfdd-edge-rust:ci .
       - name: Docker smoke (/api/health and /)
         run: |
-          mkdir -p workspace/data workspace/logs workspace/overrides workspace/bacnet/commissioning
+          SMOKE_WORKSPACE="${RUNNER_TEMP}/openfdd-smoke-workspace"
+          rm -rf "$SMOKE_WORKSPACE"
+          mkdir -p "$SMOKE_WORKSPACE"/{data,logs,overrides,bacnet/commissioning}
+          docker rm -f openfdd-smoke 2>/dev/null || true
           docker run -d --name openfdd-smoke -p 8080:8080 \
             -e OFDD_AUTH_REQUIRED=false \
-            -v "$PWD/workspace:/var/openfdd/workspace" \
+            -v "$SMOKE_WORKSPACE:/var/openfdd/workspace" \
             openfdd-edge-rust:ci
           for i in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:8080/api/health >/tmp/health.json; then

--- a/docs/maintenance/OPEN_FDD_UNSTUCK_STATUS_2026_07_09.md
+++ b/docs/maintenance/OPEN_FDD_UNSTUCK_STATUS_2026_07_09.md
@@ -1,0 +1,90 @@
+# Open-FDD unstuck status — 2026-07-09
+
+**Updated:** after PR #487 merge; follow-up PR for isolated smoke workspace pending.
+
+## Repository state
+
+| Item | Value |
+| --- | --- |
+| Local branch | `fix/rust-ghcr-smoke-isolated-workspace` |
+| Master | `d6ec5fc2` — Merge PR #487 |
+| Open PRs | none (487 merged; follow-up branch opening) |
+
+## Merged PRs (confirmed)
+
+| PR | Title | Status |
+| --- | --- | --- |
+| #477 | Additive Vibe19 Rust/DataFusion engine | merged |
+| #478 | Nightly GHCR cron + frontend docs | merged |
+| #485 | Remaining action plan docs | merged |
+| #487 | rust-ghcr Docker smoke auth/workspace | merged (partial fix) |
+
+## PR #487 gap
+
+Merged workflow sets `-e OFDD_AUTH_REQUIRED=false` but mounts repo `workspace/` after compose step writes `workspace/auth.env.local` with `OFDD_AUTH_REQUIRED=true`. Edge `apply_env_file()` **overrides** docker `-e` for `OFDD_*` keys.
+
+**Follow-up:** Option B — isolated `$RUNNER_TEMP/openfdd-smoke-workspace` (no auth file).
+
+## `rust-ghcr.yml` on master (post #487)
+
+| Feature | Present |
+| --- | --- |
+| `schedule: cron "17 7 * * *"` | yes |
+| `concurrency: rust-ghcr-nightly` | yes |
+| FDD crate tests in test job | yes |
+| Docker smoke step | yes (needs isolated workspace) |
+| test job `timeout-minutes: 60` | **follow-up PR** |
+| publish `timeout-minutes: 300` | yes |
+
+## FDD engine location (Phase 1)
+
+| Crate | Package | Path |
+| --- | --- | --- |
+| fdd_core | fdd_core | crates/fdd_core |
+| fdd_csv | fdd_csv | crates/fdd_csv |
+| fdd_store | fdd_store | crates/fdd_store |
+| fdd_sql | fdd_sql | crates/fdd_sql |
+| fdd_rules | fdd_rules | crates/fdd_rules |
+| fdd_bench | fdd_bench | crates/fdd_bench |
+| fdd_cli | fdd_cli (bin: openfdd_cli) | crates/fdd_cli |
+
+Also: `sql_rules/`, `rule_tuning/`, `tools/python_oracle/` (oracle only).
+
+**Local FDD tests:** pass (all 7 crates).
+
+## Workflow runs
+
+| Run | Status | Notes |
+| --- | --- | --- |
+| 29058174607 | in_progress | manual dispatch post #487 |
+| 29053499719 | failure | auth smoke (pre #487) |
+| 29050366982, 29043288854 | cancelled | superseded by concurrency |
+
+## Open issues
+
+| Issue | Title |
+| --- | --- |
+| #479 | Duplicate CI workflows |
+| #480 | Stale remote branches |
+| #481 | React Phase B API wiring |
+| #482 | SQL rules 19→50 |
+| #483 | Dependabot |
+| #484 | Verify rust-ghcr nightly (open until green publish) |
+| #486 | Stuck rust-ghcr runs |
+| #488 | Flaky RDF parallel test |
+
+## Local validation
+
+| Check | Result |
+| --- | --- |
+| FDD crate tests | pass |
+| Dashboard build/test | pending this session |
+| Docker smoke | pending (Docker Desktop may be offline) |
+
+## React Phase B (#481)
+
+**Not ready** until rust-ghcr smoke + publish green on master (#484).
+
+## Next branch/PR
+
+`fix/rust-ghcr-smoke-isolated-workspace` → merge → manual `gh workflow run rust-ghcr.yml` → close #484/#486 if green.


### PR DESCRIPTION
Fixes auth override bug in merged #487.

## Problem
Compose config step writes \workspace/auth.env.local\ with \OFDD_AUTH_REQUIRED=true\. Docker smoke mounts repo \workspace/\; edge \pply_env_file()\ overrides \-e OFDD_AUTH_REQUIRED=false\.

## Fix (Option B)
- Use isolated \\/openfdd-smoke-workspace\ for smoke only
- Add \	imeout-minutes: 60\ on test job
- Status doc: \docs/maintenance/OPEN_FDD_UNSTUCK_STATUS_2026_07_09.md\

Closes #484 when publish succeeds after merge.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Docker smoke-test isolation by using a clean temporary workspace, preventing local authentication settings from affecting validation.
  - Added a 60-minute limit to test runs to prevent stalled checks from running indefinitely.

- **Documentation**
  - Added a maintenance status record covering current validation results, known issues, readiness criteria, and planned follow-up steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->