### PR TITLE
Fix deterministic GHCR nightly publishing and workflow timeouts

### DIFF
--- a/.github/workflows/rust-ghcr.yml
+++ b/.github/workflows/rust-ghcr.yml
@@ -1,5 +1,10 @@
 # Publish Rust edge to GHCR on every green master push (nightly channel only).
 # Semver / beta / stable: use rust-release.yml workflow_dispatch.
+#
+# Concurrency: newest-run-wins for the single nightly publish lane.
+# Scheduled, manual (workflow_dispatch), and master push share one group so
+# overlapping publishes do not race GHCR tags. cancel-in-progress=true means
+# a newer run cancels an older in-flight run (not "serialize without cancel").
 name: Publish Rust edge to GHCR
 
 on:
@@ -26,38 +31,63 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.95.0
           components: rustfmt, clippy
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all --check
-      - run: cargo clippy --workspace --all-targets -- -D warnings
-      - run: cargo test --workspace --all-targets -p open_fdd_edge_prototype -p openfdd-mcp
+
+      - name: Format check
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Edge and MCP tests
+        run: cargo test --workspace --all-targets -p open_fdd_edge_prototype -p openfdd-mcp
+
       - name: FDD engine tests
         run: cargo test -p fdd_core -p fdd_csv -p fdd_store -p fdd_sql -p fdd_rules -p fdd_bench -p fdd_cli
-      - run: |
+
+      - name: Dashboard production build
+        run: |
           cd workspace/dashboard
           npm ci
           npm run build
           test -f ../../frontend/index.html
-      - run: |
+
+      - name: Compose config check
+        run: |
           mkdir -p workspace/bacnet/commissioning
           echo 'OFDD_AUTH_REQUIRED=true' > workspace/auth.env.local
           touch workspace/data.env.local workspace/bacnet/commissioning/commission.env
           export OPENFDD_COMPOSE_ROOT="$PWD"
           docker compose -f docker/compose.edge.rust.yml config
-      - run: docker build -t openfdd-edge-rust:ci .
-      - name: Docker smoke (/api/health and /)
+
+      - name: Docker image build
+        run: docker build -t openfdd-edge-rust:ci .
+
+      - name: Docker smoke (/api/health, /, React assets)
         run: |
+          set -euo pipefail
           SMOKE_WORKSPACE="${RUNNER_TEMP}/openfdd-smoke-workspace"
           rm -rf "$SMOKE_WORKSPACE"
-          mkdir -p "$SMOKE_WORKSPACE"/{data,logs,overrides,bacnet/commissioning}
+          mkdir -p \
+            "$SMOKE_WORKSPACE/data" \
+            "$SMOKE_WORKSPACE/logs" \
+            "$SMOKE_WORKSPACE/overrides" \
+            "$SMOKE_WORKSPACE/reports/generated" \
+            "$SMOKE_WORKSPACE/bacnet/commissioning"
           docker rm -f openfdd-smoke 2>/dev/null || true
+          cleanup() { docker rm -f openfdd-smoke 2>/dev/null || true; }
+          trap cleanup EXIT
           docker run -d --name openfdd-smoke -p 8080:8080 \
             -e OFDD_AUTH_REQUIRED=false \
             -v "$SMOKE_WORKSPACE:/var/openfdd/workspace" \
@@ -65,14 +95,20 @@ jobs:
           for i in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:8080/api/health >/tmp/health.json; then
               cat /tmp/health.json
+              # Container must still be running after health responds.
+              docker inspect -f '{{.State.Running}}' openfdd-smoke | grep -qx true
+              # React root + compiled asset reachable from same origin.
               curl -fsS http://127.0.0.1:8080/ | grep -q 'id="root"'
-              docker rm -f openfdd-smoke
+              ASSET="$(curl -fsS http://127.0.0.1:8080/ | sed -n 's/.*src="\(\/assets\/[^"]*\)".*/\1/p' | head -n1)"
+              test -n "$ASSET"
+              curl -fsS -o /dev/null -w "%{http_code}" "http://127.0.0.1:8080${ASSET}" | grep -Eq '200'
+              # Smoke must not mount repo auth.env.local (isolated temp workspace only).
+              test ! -f "$SMOKE_WORKSPACE/auth.env.local"
               exit 0
             fi
             sleep 2
           done
           docker logs openfdd-smoke || true
-          docker rm -f openfdd-smoke
           exit 1
 
   publish:
@@ -80,61 +116,57 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
       - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.EDGE_IMAGE }}
-          tags: |
-            type=raw,value=nightly
-            type=sha,prefix=sha-,format=short
-            type=raw,value=nightly-{{date format='YYYYMMDD' timezone='UTC'}}
-          labels: |
-            org.opencontainers.image.title=Open-FDD Rust Edge
-            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=nightly
+      # Deterministic tags — do not use docker/metadata-action here.
+      # metadata-action Handlebars {{date format=... timezone=...}} crashes with
+      # "Cannot read properties of undefined (reading 'hash')" on schedule and
+      # workflow_dispatch (see docs/maintenance/GHCR_PUBLISH_FAILURE_2026_07_10.md).
+      - name: Compute image tags
+        id: vars
+        shell: bash
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "date_tag=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@v6
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
         timeout-minutes: 240
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.EDGE_IMAGE }}:nightly
+            ${{ env.EDGE_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
+            ${{ env.EDGE_IMAGE }}:nightly-${{ steps.vars.outputs.date_tag }}
+          labels: |
+            org.opencontainers.image.title=Open-FDD Rust Edge
+            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=nightly
           build-args: |
             OPENFDD_IMAGE_TAG=nightly
             OPENFDD_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Publish success = image built, both platforms pushed, tags inspectable.
+      # GHCR pruning lives in ghcr-prune.yml and must not fail this job.
       - name: Published tags
         run: |
+          set -euo pipefail
           docker buildx imagetools inspect "${{ env.EDGE_IMAGE }}:nightly"
-          docker buildx imagetools inspect "${{ env.EDGE_IMAGE }}:sha-${GITHUB_SHA::7}"
-
-      - name: Prune stale GHCR versions
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          chmod +x scripts/ghcr_prune_packages.sh
-          ./scripts/ghcr_prune_packages.sh \
-            --all-images \
-            --keep-releases 3 \
-            --delete-untagged-older-than-days 7 \
-            --delete-sha-older-than-days 7 \
-            --protect-tag nightly \
-            --protect-tag beta \
-            --protect-tag latest \
-            --protected-tags-file scripts/ghcr-retention-protected-tags.txt \
-            --confirm-delete
+          docker buildx imagetools inspect "${{ env.EDGE_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
+          docker buildx imagetools inspect "${{ env.EDGE_IMAGE }}:nightly-${{ steps.vars.outputs.date_tag }}"

--- a/docs/maintenance/GHCR_PUBLISH_FAILURE_2026_07_10.md
+++ b/docs/maintenance/GHCR_PUBLISH_FAILURE_2026_07_10.md
@@ -1,0 +1,65 @@
+# GHCR Publish Failure — 2026-07-10
+
+## Symptom
+
+`Publish Rust edge to GHCR` (`rust-ghcr.yml`):
+
+- **test** job: success (fmt, clippy, cargo tests, dashboard build, Docker smoke)
+- **publish** job: fails in ~25s at `docker/metadata-action@v5`
+- Error: `Cannot read properties of undefined (reading 'hash')`
+
+## Confirmed runs
+
+| Run ID | Event | SHA | Result |
+| --- | --- | --- | --- |
+| [29086512922](https://github.com/bbartling/open-fdd/actions/runs/29086512922) | `schedule` | `52a7d2c` | test ✓ / publish ✗ |
+| [29060210628](https://github.com/bbartling/open-fdd/actions/runs/29060210628) | `workflow_dispatch` | `52a7d2c` | test ✓ / publish ✗ |
+
+## Log excerpt (both runs)
+
+```text
+Processing tags input
+  type=raw,value=nightly,enable=true,priority=200
+  type=raw,value=nightly-{{date format='YYYYMMDD' timezone='UTC'}},enable=true,priority=200
+  type=sha,prefix=sha-,format=short,enable=true,priority=100
+Processing flavor input
+  ...
+##[error]Cannot read properties of undefined (reading 'hash')
+```
+
+## Root cause
+
+`docker/metadata-action` Handlebars `date` helper signature is:
+
+```text
+{{date 'YYYYMMDD' tz='UTC'}}
+```
+
+(first positional = format; optional hash key `tz`).
+
+The workflow used:
+
+```text
+{{date format='YYYYMMDD' timezone='UTC'}}
+```
+
+With only named parameters, Handlebars passes the options object as the first argument; the helper then reads `options.hash` where `options` is undefined → TypeError on `.hash`.
+
+This is independent of QEMU/Buildx/login (those steps succeeded). Build-push never ran.
+
+## Secondary observations
+
+- Node.js 20 deprecation warnings on checkout/login/metadata/buildx/qemu actions.
+- Publish job still runs GHCR prune after push; a prune failure could mark an otherwise successful publish as failed (separate risk; dedicated `ghcr-prune.yml` already exists).
+- Concurrency group `rust-ghcr-nightly` with `cancel-in-progress: true` cancels overlapping push/schedule/dispatch runs (newest wins). Recent “stuck” concern (#486) shows completed cancelled/failed runs, not live hung jobs in the latest sample.
+- Timeouts already present: test 60m, publish 300m.
+- Docker smoke already uses isolated `$RUNNER_TEMP` workspace (PR #489).
+
+## Fix strategy (Phase 1)
+
+1. Remove dependency on `docker/metadata-action` for these three simple tags.
+2. Compute `short_sha` and `date_tag` in a bash step; pass explicit `tags` / `labels` to `docker/build-push-action`.
+3. Remove prune from the critical publish job (leave `ghcr-prune.yml`).
+4. Harden smoke (trap cleanup, `reports/generated`, asset checks).
+5. Bump Actions to current majors where compatible to clear Node 20 warnings.
+6. Validate with actionlint + manual workflow_dispatch after merge.

--- a/docs/maintenance/PROJECT_RECOVERY_2026_07_10.md
+++ b/docs/maintenance/PROJECT_RECOVERY_2026_07_10.md
@@ -1,0 +1,184 @@
+# Open-FDD Project Recovery Register — 2026-07-10
+
+Verified locally and via GitHub CLI. Do not treat prior chat summaries as source of truth without re-checking this file.
+
+## Snapshot
+
+| Field | Value |
+| --- | --- |
+| Current branch | `master` |
+| Current commit | `52a7d2c09ba714be22b7f4774edf957299da9b43` |
+| Dirty/clean | **clean** |
+| Default branch | `master` |
+| Open PR count | **0** |
+| Open issue count | **7** |
+| Working tree | up to date with `origin/master` |
+
+## Open issues
+
+| # | Title |
+| --- | --- |
+| 479 | Consolidate duplicate Rust Edge CI workflows (ci.yml vs rust-ci.yml) |
+| 480 | Review and cherry-pick stale remote branches post PR #477 |
+| 481 | React dashboard Phase B: wire FDD registry/tuning/run APIs |
+| 482 | Expand SQL rule registry from 19 to 50 rules (parity with cookbook) |
+| 483 | Address Dependabot moderate vulnerabilities on default branch |
+| 486 | Stuck in_progress rust-ghcr workflow runs on master (concurrency?) |
+| 488 | Flaky edge test: list_points_filters_by_csv_import_site (parallel CI) |
+
+## Recent merged PRs (recovery-relevant)
+
+| PR | Title | Notes |
+| --- | --- | --- |
+| #489 | isolate rust-ghcr Docker smoke workspace | Merged; HEAD of master |
+| #487 | rust-ghcr Docker smoke auth/workspace | Merged |
+| #485 | remaining action plan issues | Docs + issue tracker |
+| #478 | nightly GHCR and React cutover | Workflow + docs |
+| #477 | integrate rust port into master | FDD crates landed |
+
+## Recent workflows
+
+### Failed (blocking)
+
+| Run | Workflow | Event | Failure |
+| --- | --- | --- | --- |
+| [29086512922](https://github.com/bbartling/open-fdd/actions/runs/29086512922) | Publish Rust edge to GHCR | `schedule` | `docker/metadata-action@v5`: `Cannot read properties of undefined (reading 'hash')` after test green |
+| [29060210628](https://github.com/bbartling/open-fdd/actions/runs/29060210628) | Publish Rust edge to GHCR | `workflow_dispatch` | Same metadata-action crash |
+| [29058174607](https://github.com/bbartling/open-fdd/actions/runs/29058174607) | Publish Rust edge to GHCR | `workflow_dispatch` | Same class of publish failure |
+
+**Root cause (confirmed from logs):** publish job uses
+
+```yaml
+type=raw,value=nightly-{{date format='YYYYMMDD' timezone='UTC'}}
+```
+
+Handlebars helper expects positional format + `tz=` hash (`{{date 'YYYYMMDD' tz='UTC'}}`). Named `format=` / `timezone=` leaves `options` undefined → `.hash` TypeError. Affects schedule and workflow_dispatch (and any event that evaluates that raw tag).
+
+### Successful (recent)
+
+| Run | Workflow | Notes |
+| --- | --- | --- |
+| 29060193360 | Rust Edge CI | Success on #489 merge |
+| 29060193413 | Publish Open-FDD MCP to GHCR | Success |
+| 29058871945 / 29058871986 | Rust Edge CI (PR #489) | Success |
+| 28907372364 | Publish Rust edge to GHCR | Last successful edge publish (2026-07-08 push) |
+
+### Cancelled (concurrency)
+
+Multiple `rust-ghcr` push runs cancelled by `concurrency.group: rust-ghcr-nightly` + `cancel-in-progress: true` when a newer run starts. No currently `in_progress` stuck runs observed in the latest 30 `rust-ghcr` listings (all `completed`).
+
+## Remote branches (non-master)
+
+| Branch | Classification hint (pending Phase 4 audit) |
+| --- | --- |
+| `origin/fix/rust-ghcr-smoke-isolated-workspace` | MERGED (#489) — delete candidate |
+| `origin/fix/rust-ghcr-docker-smoke-auth` | MERGED (#487) — delete candidate |
+| `origin/fix/nightly-ghcr-and-react-cutover` | MERGED (#478) — delete candidate |
+| `origin/docs/remaining-action-plan-issues` | MERGED (#485) — delete candidate |
+| `origin/chore/product-gh-actions-deep-sleep` | Inspect |
+| `origin/docs/edge-tester-gh-actions-watch-prompt` | Likely superseded |
+| `origin/docs/cookbook-phase-2a-2b` | Likely merged |
+| `origin/docs/cookbook-v2-public-fdd` | Likely merged |
+| `origin/docs/edge-tester-issue-orchestration` | Likely merged |
+| `origin/docs/rule-cookbook-datafusion-pandas` | Likely merged |
+| `origin/docs/vibe16-product-agent-charter` | Likely merged |
+| `origin/feat/bench-330-scripts-and-agent-prompt` | Likely merged |
+| `origin/feat/release-channels-nightly-beta-stable` | Likely merged |
+| `origin/fix/audit-allowlist-bench-docs` | Likely merged |
+| `origin/fix/bacnet-server-runtime-poll-persist` | Inspect unique commits |
+| `origin/fix/bacnet-whois-shell-5007` | Inspect unique commits |
+| `origin/fix/docs-pages-github-actions-only` | Likely merged |
+
+Local-only / gone remotes: `cleanup/integrate-rust-port-into-master` (gone), `port-vibe19-rust-datafusion-engine` (gone — do not restore).
+
+## GHCR published tags
+
+`docker buildx imagetools inspect ghcr.io/bbartling/openfdd-edge-rust:nightly` **succeeds** (stale successful publish still present):
+
+- Digest: `sha256:3f60ca25f7b1afba297e5c5bb0648e4d4f375bcf23538f91c19f6ef878b32346`
+- Platforms: `linux/amd64`, `linux/arm64`
+- Package API listing: **403** (token lacks `read:packages`); inspect via Docker works.
+
+Nightly is **stale relative to master** — publish has failed since smoke fixes landed on `52a7d2c`.
+
+## Rust workspace
+
+Members (`Cargo.toml`):
+
+- `edge`
+- `mcp`
+- `crates/fdd_core`
+- `crates/fdd_csv`
+- `crates/fdd_store`
+- `crates/fdd_sql`
+- `crates/fdd_rules`
+- `crates/fdd_bench`
+- `crates/fdd_cli`
+
+## Edge package dependencies on `fdd_*`
+
+**None.** `edge/Cargo.toml` does not path-depend on any `fdd_*` crate. Edge still uses in-tree `edge/src/fdd` (rules, DataFusion SQL, wires, etc.). New crates are workspace members and tested in `rust-ghcr` / FDD CI, but **not integrated into the production edge HTTP API**.
+
+## React / frontend
+
+| Path | Role |
+| --- | --- |
+| `workspace/dashboard` | React/TypeScript/Vite source |
+| `frontend` | Compiled production assets served by edge |
+
+## Dockerfile stages
+
+1. **dashboard** — `node:22-bookworm`, `npm ci` + `npm run build` → `/app/frontend`
+2. **builder** — `rust:1.95-bookworm`, copies `Cargo.toml`/`Cargo.lock`, `edge/`, `mcp/`, `crates/`, release-builds edge + mcp
+3. **runtime** — `debian:bookworm-slim`, non-root `openfdd`, binaries + frontend
+
+**Not copied into runtime today:** `sql_rules/`, `rule_tuning/`.
+
+## SQL registry
+
+| Metric | Count |
+| --- | --- |
+| `rule_id` entries in `sql_rules/registry.yaml` | **19** |
+| `sql_rules/*.sql` files | **19** |
+| Target (issue #482) | **50** |
+
+## Python oracle
+
+Present under `tools/python_oracle/` (`export_pandas_oracle.py`, `validate_data.py`, `debug_rule_parity.py`, README). Allowed as oracle/test tooling only — not a production path.
+
+## BUILDING_100
+
+- Local cache path exists: `.cache/parquet/building=BUILDING_100` (must not be committed)
+- Docs: `docs/BUILDING_100_BENCHMARK.md`
+- CI must use synthetic fixtures only
+
+## Workflow inventory
+
+Active under `.github/workflows/`:
+
+- `ci.yml`, `rust-ci.yml`, `fdd-engine-ci.yml` — duplicate/overlapping Rust gates (#479)
+- `rust-ghcr.yml` — edge nightly publish (**broken on metadata**)
+- `rust-ghcr-mcp.yml`, `ghcr-prune.yml`, `ghcr-multiarch-publish.yml`
+- `docker-publish.yml`, `docker-supervisor-check.yml`, `publish-open-fdd.yml`
+- `rust-release.yml`, `security.yml`, `appsec.yml`
+- `docs-pages.yml`, `docs-pdf.yml`, `cookbook-parity.yml`
+
+## Blockers (severity order)
+
+1. **P0 — GHCR publish broken** on schedule + workflow_dispatch (metadata-action Handlebars). Blocks fresh multi-arch nightly for current master.
+2. **P1 — Duplicate CI** (`ci.yml` vs `rust-ci.yml`) wastes runners and confuses green/red (#479).
+3. **P1 — Flaky RDF test** under parallel cargo test (#488).
+4. **P1 — Stale remote branches** need audit/delete (#480).
+5. **P2 — Edge does not depend on `fdd_*` crates**; API/dashboard Phase B incomplete (#481).
+6. **P2 — SQL registry at 19/50** (#482).
+7. **P2 — Runtime image lacks `sql_rules` / `rule_tuning`**.
+8. **P3 — Dependabot moderate alerts** (#483).
+9. **P3 — Node 20 deprecation warnings** on Actions (action major bumps).
+10. **P3 — #486 stuck runs**: latest listing shows completed failures/cancels, not live stuck jobs; still needs concurrency/timeout documentation and closure evidence.
+
+## Architecture confirmation
+
+- Production: one Rust edge image, one API origin, compiled React dashboard in-image.
+- No separate frontend container by default.
+- No reintroduction of old Python FastAPI app.
+- Vibe Code App 19 remains external oracle/demo only.

--- a/docs/maintenance/PROJECT_RECOVERY_CHECKPOINTS.md
+++ b/docs/maintenance/PROJECT_RECOVERY_CHECKPOINTS.md
@@ -1,0 +1,22 @@
+# Project Recovery Checkpoints — 2026-07-10
+
+Track sequential PR merges. Update after each phase.
+
+| Phase | Branch / work | Status | Evidence |
+| --- | --- | --- | --- |
+| 0 | Recovery register | **DONE** | `docs/maintenance/PROJECT_RECOVERY_2026_07_10.md` @ `52a7d2c` |
+| 1 | `fix/ghcr-publish-metadata-and-timeouts` | IN PROGRESS | Explicit tags; prune removed from publish; failure doc written |
+| 2 | Stale/stuck Action runs + #486 | PENDING | — |
+| 3 | `fix/consolidate-ci-and-isolate-rdf-tests` | PENDING | #479 #488 |
+| 4 | Remote branch audit/cleanup | PENDING | #480 |
+| 5 | `fix/dependency-security-and-action-runtime` | PENDING | #483 |
+| 6 | FDD engine edge integration audit | PENDING | docs only |
+| 7 | `feat/edge-fdd-engine-api` | PENDING | #481 prereq |
+| 8 | `feat/react-fdd-phase-b` | PENDING | #481 |
+| 9 | `feat/datafusion-canonical-50-rules` | PENDING | #482 |
+| 10 | Full E2E validation report | PENDING | — |
+| 11 | Issue/docs hygiene closeout | PENDING | — |
+
+## Merge gate rule
+
+Do not start a dependent phase until its blocking PR is merged and checks are green, except independent work (branch audit, security triage) which may proceed in parallel after Phase 1.


### PR DESCRIPTION
## Summary
- Replace `docker/metadata-action` with explicit bash-computed `nightly` / `sha-*` / `nightly-YYYYMMDD` tags to fix schedule and workflow_dispatch publish crashes (`Cannot read properties of undefined (reading 'hash')` from invalid Handlebars `{{date format=...}}`).
- Remove GHCR pruning from the critical publish job (dedicated `ghcr-prune.yml` remains); publish success is build + multi-arch push + tag inspect only.
- Harden Docker smoke (trap cleanup, `reports/generated`, React asset check, isolated workspace) and document recovery register + failure analysis.

## Test plan
- [ ] actionlint / YAML parse on `rust-ghcr.yml`
- [ ] PR checks green (Rust Edge CI, AppSec, etc.)
- [ ] After merge: `gh workflow run rust-ghcr.yml --ref master`
- [ ] Confirm `docker buildx imagetools inspect` for `nightly`, `sha-*`, and dated nightly
- [ ] Update/close #486 with run evidence

Closes: related to #486 (publish path; stuck-run closure after validation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release validation with stronger formatting, linting, test, build, and container health checks.
  - Enhanced verification of dashboard loading, compiled assets, and runtime isolation.
  - Made container image tagging and publishing more reliable and predictable.

- **Documentation**
  - Added maintenance records covering recent publishing failures, recovery status, and remediation steps.
  - Added a phased project recovery checklist with merge-gate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->