### PR TITLE
Cherry-pick deep-sleep / GHCR-only edge tester prompt updates

### DIFF
--- a/docs/agent/linux-edge-tester-gh-actions-watch-prompt.md
+++ b/docs/agent/linux-edge-tester-gh-actions-watch-prompt.md
@@ -12,10 +12,27 @@ You are the Open-FDD Linux edge tester on /home/ben/open-fdd.
 Charter: TEST, DOCUMENT, REPORT — no Rust/TS edits, no git push, no upstream PR.
 Your job NOW: watch GitHub Actions until :nightly is green, then deploy and re-run gates.
 
+Bench has insufficient RAM for Rust/Docker builds — **GHCR pull only** (`docker pull` / site update).
+Never run `docker build`, `cargo build`, or compile the edge image locally. Product fixes ship via CI → GHCR.
+
 Acknowledged. Bench /home/ben/open-fdd. Channel: nightly. Gate: #429.
 Will watch GH Actions, post on #429/#433, proceed only when nightly is published.
-No git push. No product code edits on bench.
+No git push. No product code edits on bench. No local image builds.
 ```
+
+---
+
+## Bench constraint — GHCR only (not enough RAM to build)
+
+This host **cannot** build the edge stack locally. Do not attempt `docker compose build`, `docker build`, or `cargo build` for Open-FDD edge/MCP images — OOM or multi-hour hangs are expected.
+
+| Allowed | Forbidden |
+|---------|-----------|
+| `docker pull ghcr.io/bbartling/openfdd-edge-rust:nightly` | `docker build` / `compose build` |
+| `./scripts/openfdd_rust_site_update.sh` (pull + recreate) | `cargo build --release` in `edge/` |
+| `./scripts/openfdd_bench_pull_ghcr.sh` | Rebuilding to “pick up” a WSL patch without GHCR |
+
+If a fix is not in GHCR yet, **wait** for product merge + green **`Publish Rust edge to GHCR`**, then pull. See [bench-vs-source.md](./bench-vs-source.md).
 
 ---
 
@@ -103,6 +120,8 @@ docker pull "$IMAGE" 2>&1 | tail -3
 ---
 
 ## Step 3 — Preflight + deploy (mandatory every iteration)
+
+**Pull-only deploy** — scripts below fetch from GHCR; they do not build images on bench.
 
 ```bash
 cd /home/ben/open-fdd
@@ -259,8 +278,9 @@ NEW_TAG=nightly \
 
 ## Rules
 
-- **You** watch Actions and test; **WSL product** merges fixes.
-- Never deploy a failed CI build.
+- **You** watch Actions and test; **WSL product** merges fixes and CI publishes GHCR.
+- **GHCR pull only** — bench RAM is too small to build containers; never local-build the edge image.
+- Never deploy a failed CI build or an image that was not published by GH Actions.
 - Never skip vibe16 `bacnet_app` preflight.
 - Never close #429 yourself.
 - Update `LAST_TESTED_SHA` after every full gate run.

--- a/docs/agent/wsl-product-gh-actions-deep-sleep-prompt.md
+++ b/docs/agent/wsl-product-gh-actions-deep-sleep-prompt.md
@@ -1,14 +1,77 @@
 # WSL product agent — GH Actions deep sleep (paste prompt)
 
-**Repo-only**. Paste on **`/home/ben/src/open-fdd`** to monitor CI, fix failures, ship nightly.
+**Repo-only** (not on GitHub Pages). Paste into Cursor on **`/home/ben/src/open-fdd`** when you want the product agent to monitor CI and fix failures without chatter until green.
+
+Edge tester counterpart: [linux-edge-tester-gh-actions-watch-prompt.md](./linux-edge-tester-gh-actions-watch-prompt.md)
 
 ---
 
 ```
-Deep sleep: check master GH Actions every 30m. Fix red CI immediately. Go silent when all green.
-Acknowledged. Product WSL. Channel: master → GHCR :nightly.
+You are the Open-FDD WSL product agent on /home/ben/src/open-fdd.
+
+Deep sleep mode: check GitHub Actions on master every 30 minutes.
+Fix failures immediately (code PR, re-dispatch, cancel stuck GHCR publish).
+Redeploy Docs/Pages or verify GHCR when a fix lands.
+Go SILENT when all critical workflows are success on master HEAD — no status spam.
+
+Acknowledged. Product tree /home/ben/src/open-fdd. Channel: master CI → GHCR :nightly.
+Critical workflows: Rust Edge CI, Publish Rust edge to GHCR, Security Guards, AppSec, Docs.
+Will wake only on failure or stuck publish (>2h in_progress).
 ```
 
+---
+
+## Watch command (one shot)
+
 ```bash
-./scripts/openfdd_product_gh_actions_watch.sh   # 0=green 1=fail 2=pending
+./scripts/openfdd_product_gh_actions_watch.sh
+echo $?   # 0=all green, 1=failure (fix now), 2=pending (silent wait)
 ```
+
+## Background loop (30 min, wake agent only on failure)
+
+```bash
+cd /home/ben/src/open-fdd
+while true; do
+  sleep 1800
+  ./scripts/openfdd_product_gh_actions_watch.sh || true
+done
+```
+
+The script prints `AGENT_LOOP_WAKE_GH_ACTIONS` only when a workflow **failed** on the current `master` HEAD.
+
+---
+
+## On wake (failure)
+
+1. Identify run: `gh run list --repo bbartling/open-fdd --branch master --limit 10`
+2. Logs: `gh run view <id> --log-failed`
+3. Fix in WSL → PR → merge (or `workflow_dispatch` / cancel stuck GHCR if transient)
+4. Wait for green on new HEAD; **do not** message until failure or user asks
+
+### Stuck GHCR publish (>2 h `in_progress`)
+
+```bash
+gh run list --repo bbartling/open-fdd --workflow "Publish Rust edge to GHCR" --limit 3
+gh run cancel <run_id>   # if hung
+gh workflow run rust-ghcr.yml --ref master   # if workflow supports dispatch
+```
+
+---
+
+## Green lit (stay silent)
+
+When `./scripts/openfdd_product_gh_actions_watch.sh` exits **0** with no output:
+
+- Rust CI + GHCR publish + guards + AppSec + Pages all **success** on `master` HEAD
+- `:nightly` is published for edge to pull
+- No comment on #429 unless edge is waiting for explicit handoff
+
+---
+
+## Division of labor
+
+| Agent | Host | CI role |
+|-------|------|---------|
+| **Product (you)** | WSL | Build via GH Actions, fix red CI, publish GHCR |
+| **Edge tester** | `/home/ben/open-fdd` | Pull GHCR only (no local build — insufficient RAM), re-gate #429 |

--- a/scripts/openfdd_product_gh_actions_watch.sh
+++ b/scripts/openfdd_product_gh_actions_watch.sh
@@ -7,6 +7,7 @@ BRANCH="${OPENFDD_GH_BRANCH:-master}"
 
 HEAD="$(gh api "repos/${REPO}/commits/${BRANCH}" --jq '.sha' | tr -d '"')"
 HEAD7="${HEAD:0:7}"
+MSG="$(gh api "repos/${REPO}/commits/${BRANCH}" --jq '.commit.message' | head -1 | tr -d '"' | cut -c1-72)"
 
 WORKFLOWS=(
   "rust-ci.yml"
@@ -22,7 +23,7 @@ pending=()
 check_workflow() {
   local wf="$1"
   gh run list --repo "$REPO" --workflow "$wf" --branch "$BRANCH" --limit 15 \
-    --json conclusion,status,headSha,url \
+    --json conclusion,status,headSha,url,databaseId,createdAt,updatedAt \
     -q "[.[] | select(.headSha == \"${HEAD}\")][0]"
 }
 
@@ -45,14 +46,16 @@ for wf in "${WORKFLOWS[@]}"; do
 done
 
 if ((${#failures[@]} > 0)); then
-  echo "GH_ACTIONS_FAIL master@${HEAD7}"
+  echo "GH_ACTIONS_FAIL master@${HEAD7} ${MSG}"
   printf '  FAIL %s\n' "${failures[@]}"
-  echo 'AGENT_LOOP_WAKE_GH_ACTIONS {"prompt":"GH Actions failure on bbartling/open-fdd master. Fix and merge."}'
+  echo 'AGENT_LOOP_WAKE_GH_ACTIONS {"prompt":"GH Actions failure on bbartling/open-fdd master. Inspect failing workflow logs with gh run view, fix code or re-dispatch, merge if needed. Redeploy Pages/GHCR when fixed. Stay silent when all workflows success on HEAD."}'
   exit 1
 fi
 
 if ((${#pending[@]} > 0)); then
+  # Pending — no wake; product stays silent until next tick or failure.
   exit 2
 fi
 
+# All green on HEAD — silent success (no sentinel).
 exit 0


### PR DESCRIPTION
## Summary
- Port unique remaining content from ``chore/product-gh-actions-deep-sleep`` (held in #480 audit): GHCR-only bench constraint, expanded deep-sleep paste prompt, richer ``openfdd_product_gh_actions_watch.sh`` wake payload.
- After merge, delete ``origin/chore/product-gh-actions-deep-sleep`` and close #480.

## Test plan
- [ ] Diff review of the three files
- [ ] ``bash -n scripts/openfdd_product_gh_actions_watch.sh``
