### PR TITLE
fix(ci): raise GHCR multi-arch publish timeouts

### DIFF
--- a/.github/workflows/rust-ghcr.yml
+++ b/.github/workflows/rust-ghcr.yml
@@ -114,7 +114,8 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    # arm64-via-QEMU cold builds can take >4h; keep step under job budget.
+    timeout-minutes: 420
     steps:
       - uses: actions/checkout@v5
 
@@ -141,7 +142,7 @@ jobs:
 
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v6
-        timeout-minutes: 240
+        timeout-minutes: 390
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
## Summary
- Edge nightly publish failed with step timeout at 240m during QEMU arm64 cargo compile ([run 29279982546](https://github.com/bbartling/open-fdd/actions/runs/29279982546)).
- Raise publish job timeout 300→420 and build-push step 240→390 so cold multi-arch can complete; GHA cache should speed later runs.

## Test plan
- [ ] Merge, then `gh workflow run "Publish Rust edge to GHCR" --ref master`
- [ ] Confirm `:nightly` inspects for amd64+arm64

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased build time limits for nightly container image publishing.
  * Improved support for slower multi-architecture image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->