### PR TITLE
fix: CodeRabbit follow-ups for fieldbus paths and BACnet stop

### DIFF
--- a/scripts/fieldbus/bench_lib.sh
+++ b/scripts/fieldbus/bench_lib.sh
@@ -4,13 +4,14 @@
 # Sidecar startup (docker/.env): OPENFDD_FIELDBUS_BIND, API key, HAYSTACK_* for Niagara.
 # Per-request targets (Modbus host/port, BACnet device/point): exported here and passed in JSON bodies.
 #
-# Override via environment or copy scripts/bench.env.example → scripts/bench.env.local
+# Override via environment or copy scripts/fieldbus/bench.env.example → scripts/fieldbus/bench.env.local
 bench_load_env() {
-  local root="${1:?root}"
-  if [[ -f "$root/scripts/bench.env.local" ]]; then
+  local root="${1:?repo root}"
+  local env_file="$root/scripts/fieldbus/bench.env.local"
+  if [[ -f "$env_file" ]]; then
     set -a
     # shellcheck source=/dev/null
-    source "$root/scripts/bench.env.local"
+    source "$env_file"
     set +a
   fi
 }

--- a/scripts/fieldbus/bench_test.sh
+++ b/scripts/fieldbus/bench_test.sh
@@ -15,9 +15,10 @@
 #   HAYSTACK_USER=open_fdd HAYSTACK_PASS=... HAYSTACK_AUTH_MODE=basic
 set -uo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# shellcheck source=scripts/bench_lib.sh
-source "$ROOT/scripts/bench_lib.sh"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/fieldbus/bench_lib.sh
+source "$SCRIPT_DIR/bench_lib.sh"
 
 bench_load_env "$ROOT"
 bench_require_tools
@@ -220,7 +221,7 @@ validate_cycle_pcap() {
     PCAP_MIN_READ="${PCAP_MIN_READ:-2}" \
     PCAP_MIN_RPM="${PCAP_MIN_RPM:-1}" \
     PCAP_MIN_WRITE="${PCAP_MIN_WRITE:-2}" \
-    "$ROOT/scripts/pcap_validate_docker.sh"; then
+    "$SCRIPT_DIR/pcap_validate_docker.sh"; then
     PCAP_FAIL=$((PCAP_FAIL+1))
     bad "pcap cycle $cycle APDU validation failed"
   else
@@ -245,7 +246,7 @@ validate_key_pcaps() {
       PCAP_MIN_READ=1 \
       PCAP_MIN_RPM=1 \
       PCAP_MIN_WRITE=0 \
-      "$ROOT/scripts/pcap_validate_docker.sh"; then
+      "$SCRIPT_DIR/pcap_validate_docker.sh"; then
       ok "pcap validate:$phase APDU gate passed"
     else
       PCAP_FAIL=$((PCAP_FAIL+1))

--- a/scripts/fieldbus/openfdd_bench_gate.sh
+++ b/scripts/fieldbus/openfdd_bench_gate.sh
@@ -10,9 +10,10 @@
 #   BENCH_MINUTES=30 scripts/openfdd_bench_gate.sh   # half-hour soak inside bench_test
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# shellcheck source=scripts/bench_lib.sh
-source "$ROOT/scripts/bench_lib.sh"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/fieldbus/bench_lib.sh
+source "$SCRIPT_DIR/bench_lib.sh"
 
 bench_load_env "$ROOT"
 bench_require_tools
@@ -22,13 +23,13 @@ echo "base=$BENCH_BASE artifacts=${BENCH_ARTIFACTS:-$ROOT/artifacts}"
 
 echo
 echo "== Phase 1: smoke_test.sh =="
-"$ROOT/scripts/smoke_test.sh"
+"$SCRIPT_DIR/smoke_test.sh"
 
 echo
 echo "== Phase 2: bench_test.sh (BACnet PCAP + Modbus + Haystack) =="
 export BENCH_PCAP="${BENCH_PCAP:-1}"
 export BENCH_MINUTES="${BENCH_MINUTES:-0}"
-"$ROOT/scripts/bench_test.sh"
+"$SCRIPT_DIR/bench_test.sh"
 
 echo
 echo "== BENCH GATE PASSED =="

--- a/scripts/fieldbus/pcap_validate.sh
+++ b/scripts/fieldbus/pcap_validate.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PCAP="${1:-${PCAP_FILE:-${ROOT}/artifacts/bacnet_capture.pcap}}"
 
 if [[ ! -f "$PCAP" ]]; then

--- a/scripts/fieldbus/pcap_validate_docker.sh
+++ b/scripts/fieldbus/pcap_validate_docker.sh
@@ -6,7 +6,8 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PCAP="${1:-${PCAP_FILE:-${ROOT}/artifacts/bacnet_capture.pcap}}"
 IMAGE="${PCAP_VALIDATE_IMAGE:-diy-bacnet-server:rust}"
 
@@ -21,7 +22,7 @@ PCAP_BASE="$(basename "$PCAP_ABS")"
 
 docker run --rm \
   -v "${PCAP_DIR}:/pcap:ro" \
-  -v "${ROOT}/scripts/pcap_validate.sh:/app/scripts/pcap_validate.sh:ro" \
+  -v "${SCRIPT_DIR}/pcap_validate.sh:/app/scripts/pcap_validate.sh:ro" \
   -e PCAP_MIN_IAM="${PCAP_MIN_IAM:-0}" \
   -e PCAP_MIN_WHOIS="${PCAP_MIN_WHOIS:-0}" \
   -e PCAP_MIN_READ="${PCAP_MIN_READ:-0}" \

--- a/scripts/fieldbus/soak_test.sh
+++ b/scripts/fieldbus/soak_test.sh
@@ -21,9 +21,10 @@
 #   SOAK_MINUTES=30 scripts/fieldbus/soak_test.sh
 set -uo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# shellcheck source=scripts/bench_lib.sh
-source "$ROOT/scripts/bench_lib.sh"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/fieldbus/bench_lib.sh
+source "$SCRIPT_DIR/bench_lib.sh"
 bench_load_env "$ROOT"
 
 BASE="${SMOKE_BASE:-$BENCH_BASE}"

--- a/scripts/gates/openapi_central_present.sh
+++ b/scripts/gates/openapi_central_present.sh
@@ -14,7 +14,7 @@ fi
 
 cargo check -p openfdd-central
 
-if ! grep -nE '"/openapi\.json"|/openapi\.json' services/central/src >/dev/null; then
+if ! grep -rnE '"/openapi\.json"|/openapi\.json' services/central/src >/dev/null; then
   echo "FAIL: /openapi.json route not found under services/central/src" >&2
   exit 1
 fi

--- a/services/fieldbus/src/openapi_paths.rs
+++ b/services/fieldbus/src/openapi_paths.rs
@@ -11,7 +11,7 @@ use crate::models::*;
     tag = "Root",
     responses((status = 200, description = "Service metadata"))
 )]
-fn doc_root() {}
+pub(crate) fn doc_root() {}
 
 /// Liveness probe.
 #[utoipa::path(
@@ -20,7 +20,7 @@ fn doc_root() {}
     tag = "Root",
     responses((status = 200, description = "OK"))
 )]
-fn doc_health() {}
+pub(crate) fn doc_health() {}
 
 /// Open-FDD health shape (`service`, `version`, `git_sha`, `poll_running`).
 #[utoipa::path(
@@ -29,7 +29,7 @@ fn doc_health() {}
     tag = "Open-FDD",
     responses((status = 200, description = "Sidecar health"))
 )]
-fn doc_api_health() {}
+pub(crate) fn doc_api_health() {}
 
 /// ReadProperty on a field device (bench/low-level).
 #[utoipa::path(
@@ -43,7 +43,7 @@ fn doc_api_health() {}
         (status = 502, description = "BACnet error")
     )
 )]
-fn doc_bacnet_read() {}
+pub(crate) fn doc_bacnet_read() {}
 
 /// WriteProperty with optional dry-run when `approved` is false.
 #[utoipa::path(
@@ -58,7 +58,7 @@ fn doc_bacnet_read() {}
         (status = 502, description = "BACnet error")
     )
 )]
-fn doc_bacnet_write() {}
+pub(crate) fn doc_bacnet_write() {}
 
 /// Validate and encode a write without touching the BACnet bus.
 #[utoipa::path(
@@ -69,7 +69,7 @@ fn doc_bacnet_write() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Dry-run result"))
 )]
-fn doc_bacnet_write_dry_run() {}
+pub(crate) fn doc_bacnet_write_dry_run() {}
 
 /// ReadPropertyMultiple batch read.
 #[utoipa::path(
@@ -80,7 +80,7 @@ fn doc_bacnet_write_dry_run() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "RPM results"))
 )]
-fn doc_bacnet_rpm() {}
+pub(crate) fn doc_bacnet_rpm() {}
 
 /// Who-Is device discovery — send `{}` to scan all instances (0–4194303); set `low`/`high` to narrow.
 #[utoipa::path(
@@ -91,7 +91,7 @@ fn doc_bacnet_rpm() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Discovered devices"))
 )]
-fn doc_bacnet_whois() {}
+pub(crate) fn doc_bacnet_whois() {}
 
 /// Who-Is router-to-network — discovers MS/TP routers on the BACnet/IP segment (no request body).
 #[utoipa::path(
@@ -101,7 +101,7 @@ fn doc_bacnet_whois() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Router list"))
 )]
-fn doc_bacnet_whois_router() {}
+pub(crate) fn doc_bacnet_whois_router() {}
 
 /// Point discovery — walks object-list, reads object names, flags commandable points.
 #[utoipa::path(
@@ -112,7 +112,7 @@ fn doc_bacnet_whois_router() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Discovered objects with names"))
 )]
-fn doc_api_point_discovery() {}
+pub(crate) fn doc_api_point_discovery() {}
 
 /// Read all 16 priority-array slots for one object.
 #[utoipa::path(
@@ -123,7 +123,7 @@ fn doc_api_point_discovery() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Priority array slots"))
 )]
-fn doc_bacnet_priority_array() {}
+pub(crate) fn doc_bacnet_priority_array() {}
 
 /// Supervisory override audit — scans commandable points and reports active priority overrides.
 #[utoipa::path(
@@ -134,7 +134,7 @@ fn doc_bacnet_priority_array() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Override audit with points_with_overrides"))
 )]
-fn doc_bacnet_supervisory() {}
+pub(crate) fn doc_bacnet_supervisory() {}
 
 /// Open-FDD supervisory override audit (preferred path) — same as `/bacnet/supervisory`.
 #[utoipa::path(
@@ -145,7 +145,7 @@ fn doc_bacnet_supervisory() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Override audit with points_with_overrides"))
 )]
-fn doc_api_supervisory() {}
+pub(crate) fn doc_api_supervisory() {}
 
 /// Background poll engine status and last values.
 #[utoipa::path(
@@ -155,7 +155,7 @@ fn doc_api_supervisory() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Poll status"))
 )]
-fn doc_bacnet_poll_status() {}
+pub(crate) fn doc_bacnet_poll_status() {}
 
 /// Run one poll cycle immediately.
 #[utoipa::path(
@@ -165,7 +165,7 @@ fn doc_bacnet_poll_status() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Poll cycle result"))
 )]
-fn doc_bacnet_poll_once() {}
+pub(crate) fn doc_bacnet_poll_once() {}
 
 /// List all hosted server objects (device 599999).
 #[utoipa::path(
@@ -175,7 +175,7 @@ fn doc_bacnet_poll_once() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Server object list"))
 )]
-fn doc_bacnet_server_objects() {}
+pub(crate) fn doc_bacnet_server_objects() {}
 
 /// Open-FDD alias for `/bacnet/server/objects`.
 #[utoipa::path(
@@ -185,7 +185,7 @@ fn doc_bacnet_server_objects() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Server object list"))
 )]
-fn doc_api_server_points() {}
+pub(crate) fn doc_api_server_points() {}
 
 /// Commandable points on the hosted server (BACnet-writable, REST read-only).
 #[utoipa::path(
@@ -195,7 +195,7 @@ fn doc_api_server_points() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Commandable server points"))
 )]
-fn doc_bacnet_server_commandable() {}
+pub(crate) fn doc_bacnet_server_commandable() {}
 
 /// Update server-owned points via REST (rejects commandable points).
 #[utoipa::path(
@@ -206,7 +206,7 @@ fn doc_bacnet_server_commandable() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Update result"))
 )]
-fn doc_bacnet_server_update() {}
+pub(crate) fn doc_bacnet_server_update() {}
 
 /// Cached Open-Meteo weather for the hosted server.
 #[utoipa::path(
@@ -216,7 +216,7 @@ fn doc_bacnet_server_update() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Weather cache", body = WeatherResponse))
 )]
-fn doc_weather() {}
+pub(crate) fn doc_weather() {}
 
 /// Force refresh weather from Open-Meteo.
 #[utoipa::path(
@@ -226,7 +226,7 @@ fn doc_weather() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Refreshed weather"))
 )]
-fn doc_weather_refresh() {}
+pub(crate) fn doc_weather_refresh() {}
 
 /// Modbus TCP read (registers specified in body).
 #[utoipa::path(
@@ -237,7 +237,7 @@ fn doc_weather_refresh() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Register values"))
 )]
-fn doc_modbus_read() {}
+pub(crate) fn doc_modbus_read() {}
 
 /// Haystack server metadata.
 #[utoipa::path(
@@ -247,7 +247,7 @@ fn doc_modbus_read() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Haystack about"))
 )]
-fn doc_haystack_about() {}
+pub(crate) fn doc_haystack_about() {}
 
 /// Haystack read by filter.
 #[utoipa::path(
@@ -258,7 +258,7 @@ fn doc_haystack_about() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Haystack grid"))
 )]
-fn doc_haystack_read() {}
+pub(crate) fn doc_haystack_read() {}
 
 /// Haystack nav tree.
 #[utoipa::path(
@@ -269,7 +269,7 @@ fn doc_haystack_read() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "Nav nodes"))
 )]
-fn doc_haystack_nav() {}
+pub(crate) fn doc_haystack_nav() {}
 
 /// Haystack history read.
 #[utoipa::path(
@@ -280,4 +280,4 @@ fn doc_haystack_nav() {}
     security(("BearerAuth" = [])),
     responses((status = 200, description = "History grid"))
 )]
-fn doc_haystack_his_read() {}
+pub(crate) fn doc_haystack_his_read() {}

--- a/services/fieldbus/src/services/bacnet_client.rs
+++ b/services/fieldbus/src/services/bacnet_client.rs
@@ -99,6 +99,21 @@ impl BacnetClientService {
             .map_err(|e| e.to_string())
     }
 
+    /// Always `stop()` the client, preserving the primary operation error when both fail.
+    async fn finish_client<T>(
+        mut client: BACnetClient<bacnet_transport::bip::BipTransport>,
+        result: Result<T, String>,
+    ) -> Result<T, String> {
+        let stop = client.stop().await.map_err(|e| e.to_string());
+        match result {
+            Ok(v) => stop.map(|()| v),
+            Err(e) => {
+                let _ = stop;
+                Err(e)
+            }
+        }
+    }
+
     async fn seed_field_device(
         &self,
         client: &BACnetClient<bacnet_transport::bip::BipTransport>,
@@ -191,38 +206,41 @@ impl BacnetClientService {
         let pid = parse_property_id(property_id);
         let bind_port = self.bind_port(device);
 
-        let mut client = self.new_client(device).await?;
-        self.prepare(&client, device, device_instance).await?;
+        let client = self.new_client(device).await?;
+        let result = async {
+            self.prepare(&client, device, device_instance).await?;
 
-        let ack = match client
-            .read_property_from_device(device_instance, oid, pid, None)
-            .await
-        {
-            Ok(a) => a,
-            Err(_) if device.is_some() => {
-                let d = device.unwrap();
-                let ip: Ipv4Addr = d.host.parse().map_err(|e| format!("bad host: {e}"))?;
-                let mac = encode_bip_mac(ip.octets(), d.port);
-                client
-                    .read_property(&mac, oid, pid, None)
-                    .await
-                    .map_err(|e| e.to_string())?
-            }
-            Err(e) => return Err(e.to_string()),
-        };
-        client.stop().await.map_err(|e| e.to_string())?;
+            let ack = match client
+                .read_property_from_device(device_instance, oid, pid, None)
+                .await
+            {
+                Ok(a) => a,
+                Err(_) if device.is_some() => {
+                    let d = device.unwrap();
+                    let ip: Ipv4Addr = d.host.parse().map_err(|e| format!("bad host: {e}"))?;
+                    let mac = encode_bip_mac(ip.octets(), d.port);
+                    client
+                        .read_property(&mac, oid, pid, None)
+                        .await
+                        .map_err(|e| e.to_string())?
+                }
+                Err(e) => return Err(e.to_string()),
+            };
 
-        let (pv, _) =
-            decode_application_value(&ack.property_value, 0).map_err(|e| e.to_string())?;
-        Ok(json!({
-            "device_instance": device_instance,
-            "object_type": object_type,
-            "object_instance": object_instance,
-            "property_id": property_id,
-            "tag": property_value_tag(&pv),
-            "value": property_value_to_json(&pv),
-            "client_bind_port": bind_port,
-        }))
+            let (pv, _) =
+                decode_application_value(&ack.property_value, 0).map_err(|e| e.to_string())?;
+            Ok(json!({
+                "device_instance": device_instance,
+                "object_type": object_type,
+                "object_instance": object_instance,
+                "property_id": property_id,
+                "tag": property_value_tag(&pv),
+                "value": property_value_to_json(&pv),
+                "client_bind_port": bind_port,
+            }))
+        }
+        .await;
+        Self::finish_client(client, result).await
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -287,42 +305,45 @@ impl BacnetClientService {
         let mut buf = BytesMut::new();
         encode_property_value(&mut buf, &pv).map_err(|e| e.to_string())?;
 
-        let mut client = self.new_client(device).await?;
-        self.prepare(&client, device, device_instance).await?;
+        let client = self.new_client(device).await?;
+        let result = async {
+            self.prepare(&client, device, device_instance).await?;
 
-        if let Err(_e) = client
-            .write_property_to_device(
-                device_instance,
-                oid,
-                pid,
-                None,
-                buf.to_vec(),
-                write_priority,
-            )
-            .await
-        {
-            if let Some(d) = device {
-                let ip: Ipv4Addr = d.host.parse().map_err(|e| format!("bad host: {e}"))?;
-                let mac = encode_bip_mac(ip.octets(), d.port);
-                client
-                    .write_property(&mac, oid, pid, None, buf.to_vec(), write_priority)
-                    .await
-                    .map_err(|e| e.to_string())?;
-            } else {
-                return Err("write failed".into());
+            if let Err(_e) = client
+                .write_property_to_device(
+                    device_instance,
+                    oid,
+                    pid,
+                    None,
+                    buf.to_vec(),
+                    write_priority,
+                )
+                .await
+            {
+                if let Some(d) = device {
+                    let ip: Ipv4Addr = d.host.parse().map_err(|e| format!("bad host: {e}"))?;
+                    let mac = encode_bip_mac(ip.octets(), d.port);
+                    client
+                        .write_property(&mac, oid, pid, None, buf.to_vec(), write_priority)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                } else {
+                    return Err("write failed".into());
+                }
             }
-        }
-        client.stop().await.map_err(|e| e.to_string())?;
 
-        Ok(json!({
-            "status": "success",
-            "device_instance": device_instance,
-            "object_type": object_type,
-            "object_instance": object_instance,
-            "property_id": property_id,
-            "released": is_release,
-            "priority": write_priority,
-        }))
+            Ok(json!({
+                "status": "success",
+                "device_instance": device_instance,
+                "object_type": object_type,
+                "object_instance": object_instance,
+                "property_id": property_id,
+                "released": is_release,
+                "priority": write_priority,
+            }))
+        }
+        .await;
+        Self::finish_client(client, result).await
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -403,19 +424,21 @@ impl BacnetClientService {
             });
         }
         let bind_port = self.bind_port(device);
-        let mut client = self.new_client(device).await?;
-        self.prepare(&client, device, device_instance).await?;
-        let rpm = client
-            .read_property_multiple_from_device(device_instance, specs)
-            .await
-            .map_err(|e| e.to_string())?;
-        client.stop().await.map_err(|e| e.to_string())?;
-
-        Ok(json!({
-            "device_instance": device_instance,
-            "results": serialize_rpm(&rpm),
-            "client_bind_port": bind_port,
-        }))
+        let client = self.new_client(device).await?;
+        let result = async {
+            self.prepare(&client, device, device_instance).await?;
+            let rpm = client
+                .read_property_multiple_from_device(device_instance, specs)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(json!({
+                "device_instance": device_instance,
+                "results": serialize_rpm(&rpm),
+                "client_bind_port": bind_port,
+            }))
+        }
+        .await;
+        Self::finish_client(client, result).await
     }
 
     pub async fn poll_points(&self) -> Result<Vec<Value>, String> {
@@ -495,46 +518,53 @@ impl BacnetClientService {
         device: &FieldDevice,
         specs: &[ReadAccessSpecification],
     ) -> Result<HashMap<String, (Option<Value>, Option<String>)>, String> {
-        let mut client = self.new_client(Some(device)).await?;
-        self.prepare(&client, Some(device), device.device_instance)
-            .await?;
-        let rpm = client
-            .read_property_multiple_from_device(device.device_instance, specs.to_vec())
-            .await
-            .map_err(|e| e.to_string())?;
-        client.stop().await.map_err(|e| e.to_string())?;
+        let client = self.new_client(Some(device)).await?;
+        let result = async {
+            self.prepare(&client, Some(device), device.device_instance)
+                .await?;
+            let rpm = client
+                .read_property_multiple_from_device(device.device_instance, specs.to_vec())
+                .await
+                .map_err(|e| e.to_string())?;
 
-        let mut map = HashMap::new();
-        for obj in rpm.list_of_read_access_results {
-            let oid_str = normalize_oid(&obj.object_identifier);
-            for r in obj.list_of_results {
-                if let Some((class, code)) = r.error {
-                    map.insert(
-                        oid_str.clone(),
-                        (None, Some(format!("Error: class={class:?} code={code:?}"))),
-                    );
-                } else if let Some(bytes) = r.property_value {
-                    let (pv, _) = decode_application_value(&bytes, 0).map_err(|e| e.to_string())?;
-                    map.insert(oid_str.clone(), (Some(property_value_to_json(&pv)), None));
+            let mut map = HashMap::new();
+            for obj in rpm.list_of_read_access_results {
+                let oid_str = normalize_oid(&obj.object_identifier);
+                for r in obj.list_of_results {
+                    if let Some((class, code)) = r.error {
+                        map.insert(
+                            oid_str.clone(),
+                            (None, Some(format!("Error: class={class:?} code={code:?}"))),
+                        );
+                    } else if let Some(bytes) = r.property_value {
+                        let (pv, _) =
+                            decode_application_value(&bytes, 0).map_err(|e| e.to_string())?;
+                        map.insert(oid_str.clone(), (Some(property_value_to_json(&pv)), None));
+                    }
                 }
             }
+            Ok(map)
         }
-        Ok(map)
+        .await;
+        Self::finish_client(client, result).await
     }
 
     pub async fn who_is(&self, low: Option<u32>, high: Option<u32>) -> Result<Vec<Value>, String> {
         let _guard = self.bus_lock.lock().await;
         let cfg = &self.settings.bacnet_client;
-        let mut client = self.new_client(None).await?;
-        self.seed_configured_field_devices(&client).await?;
-        client.who_is(low, high).await.map_err(|e| e.to_string())?;
-        tokio::time::sleep(Duration::from_secs_f64(cfg.whois_timeout_secs)).await;
-        // Re-seed so configured bench devices appear even when broadcast I-Am is not
-        // received on the client's ephemeral UDP port (hosted server owns :47808).
-        self.seed_configured_field_devices(&client).await?;
-        let devices = client.discovered_devices().await;
-        client.stop().await.map_err(|e| e.to_string())?;
-        Ok(devices.iter().map(device_summary).collect())
+        let client = self.new_client(None).await?;
+        let result = async {
+            self.seed_configured_field_devices(&client).await?;
+            client.who_is(low, high).await.map_err(|e| e.to_string())?;
+            tokio::time::sleep(Duration::from_secs_f64(cfg.whois_timeout_secs)).await;
+            // Re-seed so configured bench devices appear even when broadcast I-Am is not
+            // received on the client's ephemeral UDP port (hosted server owns :47808).
+            self.seed_configured_field_devices(&client).await?;
+            let devices = client.discovered_devices().await;
+            Ok(devices.iter().map(device_summary).collect())
+        }
+        .await;
+        Self::finish_client(client, result).await
     }
 
     pub async fn who_is_router_to_network(&self) -> Result<Vec<Value>, String> {
@@ -566,70 +596,73 @@ impl BacnetClientService {
 
     async fn point_discovery_impl(&self, device_instance: u32) -> Result<Value, String> {
         let device = self.find_device(device_instance);
-        let mut client = self.new_client(device).await?;
-        self.prepare(&client, device, device_instance).await?;
-        let addr = self.resolve_address(&client, device, device_instance).await;
+        let client = self.new_client(device).await?;
+        let result = async {
+            self.prepare(&client, device, device_instance).await?;
+            let addr = self.resolve_address(&client, device, device_instance).await;
 
-        let raw_oids = self.read_object_list(&client, device_instance).await?;
-        let oids: Vec<_> = raw_oids
-            .into_iter()
-            .filter(|o| object_type_name(o.object_type()) != "device")
-            .collect();
-
-        let name_map = self
-            .read_object_names(&client, device_instance, &oids)
-            .await?;
-
-        let mut commandable = HashSet::new();
-        let candidates: Vec<_> = oids
-            .iter()
-            .filter(|o| COMMANDABLE_TYPES.contains(&object_type_name(o.object_type()).as_str()))
-            .copied()
-            .collect();
-        for chunk in candidates.chunks(15) {
-            let specs: Vec<_> = chunk
-                .iter()
-                .map(|o| ReadAccessSpecification {
-                    object_identifier: *o,
-                    list_of_property_references: vec![PropertyReference {
-                        property_identifier: PropertyIdentifier::PRIORITY_ARRAY,
-                        property_array_index: Some(0),
-                    }],
-                })
+            let raw_oids = self.read_object_list(&client, device_instance).await?;
+            let oids: Vec<_> = raw_oids
+                .into_iter()
+                .filter(|o| object_type_name(o.object_type()) != "device")
                 .collect();
-            if let Ok(res) = client
-                .read_property_multiple_from_device(device_instance, specs)
-                .await
-            {
-                for obj in res.list_of_read_access_results {
-                    let oid_str = normalize_oid(&obj.object_identifier);
-                    for r in obj.list_of_results {
-                        if r.error.is_none() && r.property_value.is_some() {
-                            commandable.insert(oid_str.clone());
+
+            let name_map = self
+                .read_object_names(&client, device_instance, &oids)
+                .await?;
+
+            let mut commandable = HashSet::new();
+            let candidates: Vec<_> = oids
+                .iter()
+                .filter(|o| COMMANDABLE_TYPES.contains(&object_type_name(o.object_type()).as_str()))
+                .copied()
+                .collect();
+            for chunk in candidates.chunks(15) {
+                let specs: Vec<_> = chunk
+                    .iter()
+                    .map(|o| ReadAccessSpecification {
+                        object_identifier: *o,
+                        list_of_property_references: vec![PropertyReference {
+                            property_identifier: PropertyIdentifier::PRIORITY_ARRAY,
+                            property_array_index: Some(0),
+                        }],
+                    })
+                    .collect();
+                if let Ok(res) = client
+                    .read_property_multiple_from_device(device_instance, specs)
+                    .await
+                {
+                    for obj in res.list_of_read_access_results {
+                        let oid_str = normalize_oid(&obj.object_identifier);
+                        for r in obj.list_of_results {
+                            if r.error.is_none() && r.property_value.is_some() {
+                                commandable.insert(oid_str.clone());
+                            }
                         }
                     }
                 }
             }
-        }
-        client.stop().await.map_err(|e| e.to_string())?;
 
-        let objects: Vec<_> = oids
-            .iter()
-            .map(|o| {
-                let oid_str = normalize_oid(o);
-                json!({
-                    "object_identifier": oid_str,
-                    "name": name_map.get(&oid_str).cloned().unwrap_or_else(|| json!("?")),
-                    "commandable": commandable.contains(&oid_str),
+            let objects: Vec<_> = oids
+                .iter()
+                .map(|o| {
+                    let oid_str = normalize_oid(o);
+                    json!({
+                        "object_identifier": oid_str,
+                        "name": name_map.get(&oid_str).cloned().unwrap_or_else(|| json!("?")),
+                        "commandable": commandable.contains(&oid_str),
+                    })
                 })
-            })
-            .collect();
+                .collect();
 
-        Ok(json!({
-            "device_address": addr,
-            "device_instance": device_instance,
-            "objects": objects,
-        }))
+            Ok(json!({
+                "device_address": addr,
+                "device_instance": device_instance,
+                "objects": objects,
+            }))
+        }
+        .await;
+        Self::finish_client(client, result).await
     }
 
     async fn read_object_list(
@@ -720,17 +753,20 @@ impl BacnetClientService {
         let device = self.find_device(device_instance);
         let ot = parse_object_type(object_type)?;
         let oid = ObjectIdentifier::new(ot, object_instance).map_err(|e| e.to_string())?;
-        let mut client = self.new_client(device).await?;
-        self.prepare(&client, device, device_instance).await?;
-        let slots = self
-            .read_priority_slots(&client, device_instance, oid)
-            .await?;
-        client.stop().await.map_err(|e| e.to_string())?;
-        Ok(json!({
-            "device_instance": device_instance,
-            "object_identifier": normalize_oid(&oid),
-            "priority_array": slots,
-        }))
+        let client = self.new_client(device).await?;
+        let result = async {
+            self.prepare(&client, device, device_instance).await?;
+            let slots = self
+                .read_priority_slots(&client, device_instance, oid)
+                .await?;
+            Ok(json!({
+                "device_instance": device_instance,
+                "object_identifier": normalize_oid(&oid),
+                "priority_array": slots,
+            }))
+        }
+        .await;
+        Self::finish_client(client, result).await
     }
 
     async fn read_priority_slots(
@@ -931,86 +967,89 @@ impl BacnetClientService {
             .collect();
 
         let device = self.find_device(device_instance);
-        let mut client = self.new_client(device).await?;
-        self.prepare(&client, device, device_instance).await?;
+        let client = self.new_client(device).await?;
+        let result = async {
+            self.prepare(&client, device, device_instance).await?;
 
-        let mut points = Vec::new();
-        let mut overrides_by_oid: HashMap<String, Vec<Value>> = HashMap::new();
-        let mut with_pa = 0usize;
+            let mut points = Vec::new();
+            let mut overrides_by_oid: HashMap<String, Vec<Value>> = HashMap::new();
+            let mut with_pa = 0usize;
 
-        for o in &commandable {
-            let oid_str = o["object_identifier"].as_str().unwrap_or("");
-            let mut parts = oid_str.split(',');
-            let type_name = parts.next().unwrap_or("");
-            let inst: u32 = parts.next().unwrap_or("0").parse().unwrap_or(0);
-            let ot = parse_object_type(type_name)?;
-            let oid = ObjectIdentifier::new(ot, inst).map_err(|e| e.to_string())?;
-            let slots = self
-                .read_priority_slots(&client, device_instance, oid)
-                .await?;
-            let active: Vec<_> = slots
-                .iter()
-                .filter(|s| {
-                    s["type"]
-                        .as_str()
-                        .map(|t| t != "null" && t != "error")
-                        .unwrap_or(false)
-                })
-                .cloned()
-                .collect();
-            if !slots.is_empty() {
-                with_pa += 1;
-            }
-            for s in active {
-                let rec = json!({
-                    "priority_level": s["priority_level"],
-                    "object_identifier": oid_str,
-                    "object_name": o["name"],
-                    "type": s["type"],
-                    "value": s["value"],
-                });
-                points.push(rec.clone());
-                overrides_by_oid
-                    .entry(oid_str.to_string())
-                    .or_default()
-                    .push(json!({
+            for o in &commandable {
+                let oid_str = o["object_identifier"].as_str().unwrap_or("");
+                let mut parts = oid_str.split(',');
+                let type_name = parts.next().unwrap_or("");
+                let inst: u32 = parts.next().unwrap_or("0").parse().unwrap_or(0);
+                let ot = parse_object_type(type_name)?;
+                let oid = ObjectIdentifier::new(ot, inst).map_err(|e| e.to_string())?;
+                let slots = self
+                    .read_priority_slots(&client, device_instance, oid)
+                    .await?;
+                let active: Vec<_> = slots
+                    .iter()
+                    .filter(|s| {
+                        s["type"]
+                            .as_str()
+                            .map(|t| t != "null" && t != "error")
+                            .unwrap_or(false)
+                    })
+                    .cloned()
+                    .collect();
+                if !slots.is_empty() {
+                    with_pa += 1;
+                }
+                for s in active {
+                    let rec = json!({
                         "priority_level": s["priority_level"],
+                        "object_identifier": oid_str,
+                        "object_name": o["name"],
                         "type": s["type"],
                         "value": s["value"],
-                    }));
+                    });
+                    points.push(rec.clone());
+                    overrides_by_oid
+                        .entry(oid_str.to_string())
+                        .or_default()
+                        .push(json!({
+                            "priority_level": s["priority_level"],
+                            "type": s["type"],
+                            "value": s["value"],
+                        }));
+                }
             }
-        }
-        client.stop().await.map_err(|e| e.to_string())?;
 
-        let points_with_overrides: Vec<_> = overrides_by_oid
-            .into_iter()
-            .map(|(oid_str, slots)| {
-                let levels: Vec<_> = slots
-                    .iter()
-                    .filter_map(|s| s["priority_level"].as_u64())
-                    .collect();
-                json!({
-                    "object_identifier": oid_str,
-                    "object_name": name_by_oid.get(&oid_str).cloned().unwrap_or(json!("")),
-                    "override_priority_levels": levels,
-                    "has_multiple_overrides": levels.len() > 1,
-                    "overrides": slots,
+            let points_with_overrides: Vec<_> = overrides_by_oid
+                .into_iter()
+                .map(|(oid_str, slots)| {
+                    let levels: Vec<_> = slots
+                        .iter()
+                        .filter_map(|s| s["priority_level"].as_u64())
+                        .collect();
+                    json!({
+                        "object_identifier": oid_str,
+                        "object_name": name_by_oid.get(&oid_str).cloned().unwrap_or(json!("")),
+                        "override_priority_levels": levels,
+                        "has_multiple_overrides": levels.len() > 1,
+                        "overrides": slots,
+                    })
                 })
-            })
-            .collect();
+                .collect();
 
-        Ok(json!({
-            "device_id": device_instance,
-            "address": device_address,
-            "points": points,
-            "points_with_overrides": points_with_overrides,
-            "summary": {
-                "total_points": objects.len(),
-                "with_priority_array": with_pa,
-                "without_priority_array": objects.len().saturating_sub(with_pa),
-                "points_with_override_count": points_with_overrides.len(),
-            }
-        }))
+            Ok(json!({
+                "device_id": device_instance,
+                "address": device_address,
+                "points": points,
+                "points_with_overrides": points_with_overrides,
+                "summary": {
+                    "total_points": objects.len(),
+                    "with_priority_array": with_pa,
+                    "without_priority_array": objects.len().saturating_sub(with_pa),
+                    "points_with_override_count": points_with_overrides.len(),
+                }
+            }))
+        }
+        .await;
+        Self::finish_client(client, result).await
     }
 
     async fn resolve_address(


### PR DESCRIPTION
## Summary
- Fix `scripts/fieldbus/*` ROOT / sibling path resolution so bench/smoke/pcap scripts actually source `bench_lib.sh` and call sibling tools
- Fix `openapi_central_present` gate (`grep -rn` on `services/central/src`)
- Always `stop()` BACnet clients via `finish_client` on success and failure paths
- Mark OpenAPI `doc_*` stubs `pub(crate)` for explicit sibling visibility

Follow-up to #495 CodeRabbit critical review threads.

## Test plan
- [x] `cargo check -p openfdd-fieldbus`
- [x] `cargo clippy -p openfdd-fieldbus -- -D warnings`
- [x] `scripts/gates/openapi_central_present.sh`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BACnet operation reliability by ensuring client sessions close correctly after successful or failed requests.
  * Preserved the original operation error when cleanup also encounters an error.
  * Improved BACnet discovery, reads, writes, priority-array, and supervisory operations.

* **Maintenance**
  * Improved fieldbus benchmarking and PCAP validation scripts when run from different repository locations.
  * Strengthened OpenAPI route validation to search the complete service source tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->