### PR TITLE
fix: preserve BACnet result when stop() fails

### DIFF
--- a/services/fieldbus/src/services/bacnet_client.rs
+++ b/services/fieldbus/src/services/bacnet_client.rs
@@ -99,19 +99,15 @@ impl BacnetClientService {
             .map_err(|e| e.to_string())
     }
 
-    /// Always `stop()` the client, preserving the primary operation error when both fail.
+    /// Always `stop()` the client; preserve the primary operation result and log stop failures.
     async fn finish_client<T>(
         mut client: BACnetClient<bacnet_transport::bip::BipTransport>,
         result: Result<T, String>,
     ) -> Result<T, String> {
-        let stop = client.stop().await.map_err(|e| e.to_string());
-        match result {
-            Ok(v) => stop.map(|()| v),
-            Err(e) => {
-                let _ = stop;
-                Err(e)
-            }
+        if let Err(e) = client.stop().await {
+            warn!("failed to stop BACnet client: {e}");
         }
+        result
     }
 
     async fn seed_field_device(


### PR DESCRIPTION
## Summary
- `finish_client` always returns the primary operation result
- Log `stop()` failures with `warn!` instead of discarding successful field ops

Addresses CodeRabbit follow-up on #496.

## Test plan
- [x] `cargo check -p openfdd-fieldbus`
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so the original operation result is preserved.
  * Shutdown failures are now recorded as warnings instead of replacing the primary error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->