### PR TITLE
fix(ci): unblock openfdd-ui GHCR nightly (VITE_OUT_DIR=dist)

### DIFF
--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -57,6 +57,8 @@ jobs:
         run: cargo test -p openfdd-central -p openfdd-fieldbus -p openfdd_mqtt
 
       - name: Dashboard production build
+        env:
+          VITE_OUT_DIR: dist
         run: |
           cd workspace/dashboard
           npm ci
@@ -134,6 +136,7 @@ jobs:
             ${{ env.UI_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
             ${{ env.UI_IMAGE }}:${{ steps.vars.outputs.version }}
           build-args: |
+            VITE_OUT_DIR=dist
             VITE_API_BASE=
           labels: |
             org.opencontainers.image.title=Open-FDD UI

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -77,6 +77,14 @@ jobs:
           VITE_OUT_DIR: ../../frontend
         run: npm run build
 
+      - name: Split UI image artifact (dist)
+        working-directory: workspace/dashboard
+        env:
+          VITE_OUT_DIR: dist
+        run: |
+          npm run build
+          test -f dist/index.html
+
       - name: Built UI guards
         run: |
           test -f frontend/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ workspace/overrides/
 workspace/bacnet/
 workspace/fixtures/ahu_data/*.csv
 workspace/dashboard/node_modules/
+workspace/dashboard/dist/
 frontend/assets/
 frontend/index.html
 **/*.db

--- a/workspace/dashboard/Dockerfile
+++ b/workspace/dashboard/Dockerfile
@@ -4,9 +4,12 @@ WORKDIR /src
 COPY workspace/dashboard/package.json workspace/dashboard/package-lock.json ./
 RUN npm ci
 COPY workspace/dashboard ./
+# Split UI image uses /src/dist (legacy monolith still embeds ../../frontend via vite default).
+ARG VITE_OUT_DIR=dist
+ENV VITE_OUT_DIR=$VITE_OUT_DIR
 ARG VITE_API_BASE=
 ENV VITE_API_BASE=$VITE_API_BASE
-RUN npm run build
+RUN npm run build && test -f dist/index.html
 
 FROM caddy:2-alpine
 COPY --from=build /src/dist /srv


### PR DESCRIPTION
## Summary
- Stack GHCR `Dashboard production build` failed: Vite wrote `frontend/`, CI asserted `dist/index.html`
- UI Dockerfile copies `/src/dist` but build never produced it by default
- Fix: set `VITE_OUT_DIR=dist` for split UI Dockerfile + `ghcr-openfdd-stack.yml`; preserve legacy `../../frontend` for rust-ci / monolithic embeds
- PR CI now also verifies the `dist` artifact contract

Unblocks `ghcr.io/bbartling/openfdd-{central,ui,fieldbus,mqtt}:nightly`.

## Test plan
- [x] `VITE_OUT_DIR=dist npm run build` → `dist/index.html`
- [ ] Rust Edge CI TypeScript job green (frontend + dist)
- [ ] After merge: Publish Open-FDD stack to GHCR succeeds and tags all four `:nightly`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend build reliability by standardizing production output in the `dist` directory.
  * Added validation to confirm the built dashboard includes the expected entry page.
  * Enhanced Docker-based builds with configurable frontend output and API settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->