### PR TITLE
fix(docker): libclang for central/fieldbus stack GHCR builds

### DIFF
--- a/services/central/Dockerfile
+++ b/services/central/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM rust:1.95-bookworm AS builder
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends clang libclang-dev build-essential pkg-config libssl-dev \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates

--- a/services/fieldbus/Dockerfile
+++ b/services/fieldbus/Dockerfile
@@ -2,6 +2,9 @@
 # Open-FDD fieldbus — sole BACnet/Modbus/Haystack wire owner.
 
 FROM rust:1.95-bookworm AS builder
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends clang libclang-dev build-essential pkg-config libssl-dev \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates


### PR DESCRIPTION
## Summary
- Stack GHCR **test** job is green after #498 (`VITE_OUT_DIR=dist`)
- **publish** failed building `openfdd-central`: bindgen/oxrocksdb missing libclang
- Mirror root `Dockerfile` builder deps (`clang`, `libclang-dev`, etc.) into central + fieldbus Dockerfiles

## Test plan
- [ ] Publish Open-FDD stack to GHCR succeeds on merge
- [ ] `ghcr.io/bbartling/openfdd-{central,ui,fieldbus,mqtt}:nightly` all updated

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build environments for central and fieldbus services by adding required system tooling and libraries.
  * Reduced leftover package metadata during image creation to help keep build artifacts smaller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->