### PR TITLE
fix(ci): amd64 stack GHCR nightlies (avoid QEMU timeout)

### DIFF
--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -103,11 +103,12 @@ jobs:
 
       - name: Build and push openfdd-central
         uses: docker/build-push-action@v6
-        timeout-minutes: 120
+        # RocksDB via oxrocksdb + QEMU arm64 exceeds 2h; ship amd64 nightly first for local MQTTS tests.
+        timeout-minutes: 240
         with:
           context: .
           file: services/central/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.CENTRAL_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
@@ -130,7 +131,7 @@ jobs:
         with:
           context: .
           file: workspace/dashboard/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.UI_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
@@ -152,11 +153,11 @@ jobs:
 
       - name: Build and push openfdd-fieldbus
         uses: docker/build-push-action@v6
-        timeout-minutes: 180
+        timeout-minutes: 240
         with:
           context: .
           file: services/fieldbus/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.FIELDBUS_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
@@ -179,7 +180,7 @@ jobs:
         with:
           context: services/mqtt
           file: services/mqtt/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.MQTT_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}

--- a/docker/VERSION_MANIFEST.md
+++ b/docker/VERSION_MANIFEST.md
@@ -19,6 +19,8 @@ All four container images in the MQTT stack share a **coordinated release** tied
 | `<workspace.version>` | Every publish | Semver from `Cargo.toml` (e.g. `3.3.0`) |
 | `nightly` | `master` branch only | Floating integration channel |
 
+Current stack publish builds **linux/amd64** only so RocksDB-heavy central/fieldbus images finish within GH Actions time budgets (QEMU arm64 previously timed out at 2h). Re-enable multi-arch when a native arm64 runner or longer budget is available.
+
 Only advance `nightly` after `scripts/release/smoke_standalone_mqtts.sh` passes on the candidate SHA.
 
 ## Compose alignment


### PR DESCRIPTION
## Summary
- Previous master stack publish failed: `Build and push openfdd-central` timed out at 120m during multi-arch RocksDB compile
- Scope stack images to `linux/amd64` and raise central/fieldbus step timeouts to 240m
- Document in `VERSION_MANIFEST.md` (arm64 multi-arch deferred)

Unblocks `*:nightly` for local MQTTS FE/central/edge testing on amd64/WSL.

## Test plan
- [ ] After merge: Publish Open-FDD stack to GHCR succeeds
- [ ] All four `ghcr.io/bbartling/openfdd-*:nightly` tags exist for amd64

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated stack image publishing to use `linux/amd64` builds, improving build reliability and completion times.
  * Increased build time limits for longer-running image builds.
* **Documentation**
  * Documented the current amd64-only publishing configuration and the conditions for restoring multi-architecture builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->