### PR TITLE
feat(fdd): unify registry engine APIs + ship sql_rules (#481 prelude)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,8 @@ dependencies = [
  "csv",
  "datafusion",
  "encoding_rs",
+ "fdd_rules",
+ "fdd_sql",
  "hex",
  "hmac",
  "once_cell",
@@ -2837,6 +2839,7 @@ dependencies = [
  "subtle",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "walkdir",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ COPY edge ./edge
 COPY mcp ./mcp
 COPY crates ./crates
 COPY services ./services
+COPY sql_rules ./sql_rules
+COPY rule_tuning ./rule_tuning
 RUN echo "==> release build jobs=${CARGO_BUILD_JOBS}" \
     && cargo build --release -p open_fdd_edge_prototype -p openfdd-mcp -j "${CARGO_BUILD_JOBS}"
 
@@ -38,6 +40,9 @@ COPY --from=builder /app/target/release/open_fdd_edge_prototype /usr/local/bin/o
 COPY --from=builder /app/target/release/openfdd-edge /usr/local/bin/openfdd-edge
 COPY --from=builder /app/target/release/openfdd-mcp /usr/local/bin/openfdd-mcp
 COPY --from=dashboard /app/frontend ./frontend
+COPY sql_rules /app/sql_rules
+COPY rule_tuning /app/rule_tuning
+ENV OPENFDD_SQL_RULES_DIR=/app/sql_rules
 
 ENV FRONTEND_DIR=/app/frontend \
     PORT=8080 \

--- a/docs/frontend/API_CONTRACT.md
+++ b/docs/frontend/API_CONTRACT.md
@@ -1,6 +1,6 @@
 # Frontend API contract
 
-Dashboard calls the Rust edge HTTP API on the same origin in production (`/` + `/api/*`).
+Dashboard calls the Rust edge/central HTTP API on the same origin in production (`/` + `/api/*`).
 
 ## Dev proxy
 
@@ -10,30 +10,38 @@ Vite (`workspace/dashboard/vite.config.ts`) proxies:
 - `/health` → edge
 - `/openfdd-agent` → edge
 
-## Core endpoints (existing edge)
+Standalone stack UI (Caddy) reverse-proxies `/api*` → `central:8080`.
+
+## Core endpoints (existing)
 
 | Method | Path | Purpose |
 | --- | --- | --- |
 | GET | `/api/health` | Liveness JSON |
 | POST | `/api/auth/login` | Operator session |
+| GET | `/api/auth/status` | Whether auth is required |
 | GET | `/api/bacnet/driver/tree` | Driver tree (auth) |
 
-Full edge API surface is defined in edge route modules; extend this doc as FDD endpoints are added.
-
-## Planned FDD endpoints (Rust engine integration)
+## FDD registry endpoints (Rust engine)
 
 | Method | Path | Purpose |
 | --- | --- | --- |
 | GET | `/api/fdd/rules` | Registry from `sql_rules/registry.yaml` |
 | GET | `/api/fdd/rules/{id}/params` | Tuning schema (`control` field per parameter) |
-| POST | `/api/fdd/run` | Execute rules against Parquet cache |
-| GET | `/api/fdd/cache/status` | Ingest / Parquet sidecar status |
+| POST | `/api/fdd/run` | Execute rules — prefer `{ "mode": "registry", "rule_ids": [...] }` (typed params). Raw SQL only for integrator lab. |
+| GET | `/api/fdd/cache/status` | Parquet ingest / results status |
 | GET | `/api/fdd/roles` | Column role mappings |
+| GET | `/api/fdd/status` | Registry count + rules dir |
 
-See `docs/migration/vibe19/API_CONTRACT.md` for parameter schema (`control`, not `frontend_control`).
+Env:
+
+- `OPENFDD_SQL_RULES_DIR` (default `/app/sql_rules` in images)
+- `OPENFDD_PARQUET_ROOT` (default `.cache/parquet`)
+- `OPENFDD_RULE_RESULTS_DIR` (default `.cache/rule_results`)
+
+See `docs/migration/vibe19/SQL_RULE_TUNING_CONTRACT.md` for parameter schema (`control`, not only `frontend_control`).
 
 ## Rules for UI
 
 - No raw SQL editing in operator dashboard.
 - Parameter types come from registry + tuning contract.
-- Auth required when `OFDD_AUTH_REQUIRED=true`.
+- Auth required when JWT secret / `OFDD_AUTH_REQUIRED` is set.

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -40,3 +40,6 @@ reqwest = { version = "0.13.4", default-features = false, features = ["blocking"
 rusty-modbus-client = { git = "https://github.com/jscott3201/rusty-modbus", version = "0.1.0" }
 rusty-modbus-types = { git = "https://github.com/jscott3201/rusty-modbus", version = "0.1.0" }
 oxigraph = "0.5"
+fdd_rules = { path = "../crates/fdd_rules" }
+fdd_sql = { path = "../crates/fdd_sql" }
+walkdir = "2"

--- a/edge/src/fdd/mod.rs
+++ b/edge/src/fdd/mod.rs
@@ -3,6 +3,7 @@
 pub mod confirmation;
 pub mod datafusion_sql;
 pub mod execution;
+pub mod registry_api;
 pub mod rules;
 pub mod sql_safety;
 pub mod wires;

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -1,0 +1,382 @@
+//! Registry-backed FDD API — loads `sql_rules/registry.yaml` via `fdd_rules`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use fdd_rules::{
+    effective_param_strings, load_registry, load_tuning_profiles, rule_params, run_all_rules,
+    substitute_sql, RuleRegistry, RuleSpec,
+};
+use serde_json::{json, Value};
+
+fn sql_rules_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("OPENFDD_SQL_RULES_DIR") {
+        return PathBuf::from(p);
+    }
+    for c in [
+        PathBuf::from("sql_rules"),
+        PathBuf::from("/app/sql_rules"),
+        PathBuf::from("../sql_rules"),
+    ] {
+        if c.join("registry.yaml").is_file() {
+            return c;
+        }
+    }
+    PathBuf::from("sql_rules")
+}
+
+fn parquet_root() -> PathBuf {
+    if let Ok(p) = std::env::var("OPENFDD_PARQUET_ROOT") {
+        return PathBuf::from(p);
+    }
+    for c in [
+        PathBuf::from(".cache/parquet"),
+        PathBuf::from("/var/openfdd/workspace/.cache/parquet"),
+        PathBuf::from("workspace/.cache/parquet"),
+    ] {
+        if c.is_dir() {
+            return c;
+        }
+    }
+    PathBuf::from(".cache/parquet")
+}
+
+fn results_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("OPENFDD_RULE_RESULTS_DIR") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(".cache/rule_results")
+}
+
+fn load_reg() -> Result<RuleRegistry, String> {
+    let dir = sql_rules_dir();
+    load_registry(&dir).map_err(|e| format!("load registry {}: {e}", dir.display()))
+}
+
+fn param_to_json(rule: &RuleSpec) -> Value {
+    let mut params = serde_json::Map::new();
+    for (key, def) in &rule.parameters {
+        params.insert(
+            key.clone(),
+            json!({
+                "key": key,
+                "label": def.label,
+                "default": def.default,
+                "min": def.min,
+                "max": def.max,
+                "step": def.step,
+                "unit": def.unit,
+                "control": def.frontend_control,
+                "sql_placeholder": def.sql_placeholder,
+            }),
+        );
+    }
+    // Always expose confirm as confirm_min (minutes) for vibe19 UI parity.
+    if !params.contains_key("confirm_min") && !params.contains_key("confirm_seconds") {
+        params.insert(
+            "confirm_min".into(),
+            json!({
+                "key": "confirm_min",
+                "label": "Fault confirm delay",
+                "default": (rule.confirm_seconds as f64) / 60.0,
+                "min": 0.0,
+                "max": 120.0,
+                "step": 1.0,
+                "unit": "min",
+                "control": "slider",
+                "sql_placeholder": "CONFIRM_SECONDS",
+            }),
+        );
+    }
+    Value::Object(params)
+}
+
+fn rule_summary(rule: &RuleSpec) -> Value {
+    json!({
+        "rule_id": rule.rule_id,
+        "sql_file": rule.sql_file,
+        "description": rule.description,
+        "required_roles": rule.required_roles,
+        "output_columns": rule.output_columns,
+        "confirm_seconds": rule.confirm_seconds,
+        "confirm_min": (rule.confirm_seconds as f64) / 60.0,
+        "parity_status": rule.parity_status,
+        "dashboard_wired": rule.dashboard_wired,
+        "parameter_count": rule.parameters.len(),
+    })
+}
+
+/// `GET /api/fdd/rules` — full registry catalog.
+pub fn list_registry_rules() -> Value {
+    match load_reg() {
+        Ok(reg) => {
+            let rules: Vec<Value> = reg.rules.iter().map(rule_summary).collect();
+            json!({
+                "ok": true,
+                "rules_dir": reg.rules_dir,
+                "count": rules.len(),
+                "rules": rules,
+            })
+        }
+        Err(e) => json!({"ok": false, "error": e, "count": 0, "rules": []}),
+    }
+}
+
+/// `GET /api/fdd/rules/{id}/params` — tuning schema for one rule.
+pub fn rule_params_response(rule_id: &str) -> Value {
+    match load_reg() {
+        Ok(reg) => match reg.rules.iter().find(|r| r.rule_id == rule_id) {
+            Some(rule) => json!({
+                "ok": true,
+                "rule_id": rule.rule_id,
+                "confirm_seconds": rule.confirm_seconds,
+                "required_roles": rule.required_roles,
+                "params": param_to_json(rule),
+            }),
+            None => json!({"ok": false, "error": format!("unknown rule_id {rule_id}")}),
+        },
+        Err(e) => json!({"ok": false, "error": e}),
+    }
+}
+
+/// `GET /api/fdd/cache/status` — parquet ingest / results status.
+pub fn cache_status() -> Value {
+    let pq = parquet_root();
+    let results = results_dir();
+    let history = pq.join("history");
+    let parquet_files = walkdir_count(&pq, "parquet");
+    let result_files = walkdir_count(&results, "json");
+    json!({
+        "ok": true,
+        "parquet_root": pq.display().to_string(),
+        "parquet_exists": pq.is_dir(),
+        "history_exists": history.is_dir(),
+        "parquet_file_count": parquet_files,
+        "results_dir": results.display().to_string(),
+        "result_file_count": result_files,
+        "sql_rules_dir": sql_rules_dir().display().to_string(),
+        "sql_rules_present": sql_rules_dir().join("registry.yaml").is_file(),
+    })
+}
+
+fn walkdir_count(root: &Path, ext: &str) -> usize {
+    if !root.is_dir() {
+        return 0;
+    }
+    walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().is_file()
+                && e.path()
+                    .extension()
+                    .and_then(|x| x.to_str())
+                    .is_some_and(|x| x.eq_ignore_ascii_case(ext))
+        })
+        .count()
+}
+
+/// `GET /api/fdd/roles` — role map file if present.
+pub fn roles_response() -> Value {
+    let candidates = [
+        PathBuf::from("configs/role_map.json"),
+        PathBuf::from("workspace/data/role_map.json"),
+        PathBuf::from("/app/configs/role_map.json"),
+    ];
+    for c in candidates {
+        if c.is_file() {
+            match std::fs::read_to_string(&c) {
+                Ok(text) => match serde_json::from_str::<Value>(&text) {
+                    Ok(v) => {
+                        return json!({
+                            "ok": true,
+                            "path": c.display().to_string(),
+                            "roles": v,
+                        })
+                    }
+                    Err(e) => {
+                        return json!({
+                            "ok": false,
+                            "error": format!("parse {}: {e}", c.display()),
+                        })
+                    }
+                },
+                Err(e) => {
+                    return json!({"ok": false, "error": e.to_string()});
+                }
+            }
+        }
+    }
+    json!({
+        "ok": true,
+        "path": null,
+        "roles": {},
+        "hint": "no role_map.json found; place under configs/ or workspace/data/"
+    })
+}
+
+/// `POST /api/fdd/run` body for registry engine (typed params only — no raw SQL).
+///
+/// ```json
+/// { "mode": "registry", "rule_ids": ["FC1","VAV-1"], "params": { "FC1": { "confirm_min": 5 } } }
+/// ```
+/// Omit `rule_ids` to run all. Without parquet cache, returns a clear error.
+pub fn run_registry(payload: &Value) -> Value {
+    let pq = parquet_root();
+    if !pq.is_dir() {
+        return json!({
+            "ok": false,
+            "error": format!(
+                "parquet cache missing at {} — set OPENFDD_PARQUET_ROOT or ingest a building package first",
+                pq.display()
+            ),
+            "cache": cache_status(),
+        });
+    }
+    let reg = match load_reg() {
+        Ok(r) => r,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+
+    let filter: Option<Vec<String>> = payload.get("rule_ids").and_then(|v| v.as_array()).map(|a| {
+        a.iter()
+            .filter_map(|x| x.as_str().map(str::to_string))
+            .collect()
+    });
+
+    let filtered = if let Some(ids) = filter {
+        let mut clone = reg.clone();
+        clone
+            .rules
+            .retain(|r| ids.iter().any(|id| id == &r.rule_id));
+        clone
+    } else {
+        reg
+    };
+
+    if filtered.rules.is_empty() {
+        return json!({"ok": false, "error": "no matching rules to run"});
+    }
+
+    // Apply request overrides into a temp tuning overlay via env is overkill;
+    // runner uses registry defaults + rule_tuning/. Request params are applied
+    // by rewriting confirm_seconds on a per-rule clone when provided.
+    let mut effective = filtered.clone();
+    if let Some(params_by_rule) = payload.get("params").and_then(|v| v.as_object()) {
+        for rule in &mut effective.rules {
+            if let Some(p) = params_by_rule
+                .get(&rule.rule_id)
+                .and_then(|v| v.as_object())
+            {
+                if let Some(cm) = p.get("confirm_min").and_then(|v| v.as_f64()) {
+                    rule.confirm_seconds = (cm * 60.0).round() as u32;
+                }
+                if let Some(cs) = p.get("confirm_seconds").and_then(|v| v.as_f64()) {
+                    rule.confirm_seconds = cs.round() as u32;
+                }
+            }
+        }
+    }
+
+    let out = results_dir();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build();
+    let rt = match rt {
+        Ok(r) => r,
+        Err(e) => return json!({"ok": false, "error": format!("runtime: {e}")}),
+    };
+    match rt.block_on(run_all_rules(&pq, &effective, &out)) {
+        Ok(report) => json!({
+            "ok": true,
+            "engine": "fdd_rules+DataFusion",
+            "mode": "registry",
+            "rules_run": report.rules_run,
+            "rules_succeeded": report.rules_succeeded,
+            "rules_failed": report.rules_failed,
+            "poll_seconds": report.poll_seconds,
+            "total_ms": report.total_ms,
+            "timings": report.timings,
+            "results_dir": out.display().to_string(),
+        }),
+        Err(e) => json!({"ok": false, "error": e.to_string()}),
+    }
+}
+
+/// Preview substituted SQL for a rule (integrator lab only — not operator UI).
+pub fn preview_sql(rule_id: &str, overrides: &Value) -> Value {
+    let reg = match load_reg() {
+        Ok(r) => r,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let Some(rule) = reg.rules.iter().find(|r| r.rule_id == rule_id) else {
+        return json!({"ok": false, "error": format!("unknown rule_id {rule_id}")});
+    };
+    let sql_path = Path::new(&reg.rules_dir).join(&rule.sql_file);
+    let raw = match std::fs::read_to_string(&sql_path) {
+        Ok(s) => s,
+        Err(e) => return json!({"ok": false, "error": e.to_string()}),
+    };
+    let poll = overrides
+        .get("poll_seconds")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(300.0);
+    let mut confirm = rule.confirm_seconds;
+    if let Some(cm) = overrides.get("confirm_min").and_then(|v| v.as_f64()) {
+        confirm = (cm * 60.0).round() as u32;
+    }
+    if let Some(cs) = overrides.get("confirm_seconds").and_then(|v| v.as_u64()) {
+        confirm = cs as u32;
+    }
+    let mut params = rule_params(poll, confirm);
+    if let Ok(tuning) = load_tuning_profiles(Path::new(&reg.rules_dir)) {
+        if let Ok(tuned) = effective_param_strings(rule, &tuning, None, None, None) {
+            for (k, v) in tuned {
+                params.insert(k, v);
+            }
+        }
+    }
+    if let Some(obj) = overrides.as_object() {
+        for (k, v) in obj {
+            if let Some(n) = v.as_f64() {
+                // Map param keys to SQL placeholders when present on the rule.
+                if let Some(def) = rule.parameters.get(k) {
+                    params.insert(def.sql_placeholder.clone(), n.to_string());
+                }
+            }
+        }
+    }
+    let sql = substitute_sql(&raw, &params);
+    json!({
+        "ok": true,
+        "rule_id": rule_id,
+        "params": params.into_iter().collect::<HashMap<_,_>>(),
+        "sql": sql,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_rules_loads_repo_registry() {
+        let v = list_registry_rules();
+        assert_eq!(v["ok"], true, "{v}");
+        assert!(v["count"].as_u64().unwrap_or(0) >= 19, "{v}");
+    }
+
+    #[test]
+    fn vav1_params_include_sliders() {
+        let v = rule_params_response("VAV-1");
+        assert_eq!(v["ok"], true, "{v}");
+        assert!(v["params"]["zone_t_lo"]["control"].as_str().is_some());
+    }
+
+    #[test]
+    fn cache_status_ok_shape() {
+        let v = cache_status();
+        assert_eq!(v["ok"], true);
+        assert!(v.get("parquet_root").is_some());
+    }
+}

--- a/edge/src/server.rs
+++ b/edge/src/server.rs
@@ -729,13 +729,41 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             &mut stream,
             model::sparql::execute(&parse_json_body_or_empty(&body)),
         ),
+        ("GET", "/api/fdd/rules") => {
+            json_response(&mut stream, fdd::registry_api::list_registry_rules())
+        }
+        ("GET", "/api/fdd/cache/status") => {
+            json_response(&mut stream, fdd::registry_api::cache_status())
+        }
+        ("GET", "/api/fdd/roles") => {
+            json_response(&mut stream, fdd::registry_api::roles_response())
+        }
         ("POST", "/api/fdd/run") => match parse_json_body(&body) {
-            Ok(payload) => require_role(
-                &mut stream,
-                &principal,
-                &["integrator", "agent"],
-                fdd::datafusion_sql::run_fdd_response(&payload),
-            ),
+            Ok(payload) => {
+                let mode = payload.get("mode").and_then(|v| v.as_str()).unwrap_or("");
+                let resp = if mode == "registry"
+                    || payload.get("rule_ids").is_some()
+                    || payload
+                        .get("sql")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .is_empty()
+                        && payload.get("mode").is_some()
+                {
+                    fdd::registry_api::run_registry(&payload)
+                } else if payload
+                    .get("sql")
+                    .and_then(|v| v.as_str())
+                    .map(|s| !s.trim().is_empty())
+                    .unwrap_or(false)
+                {
+                    fdd::datafusion_sql::run_fdd_response(&payload)
+                } else {
+                    // Default: registry batch when no raw SQL
+                    fdd::registry_api::run_registry(&payload)
+                };
+                require_role(&mut stream, &principal, &["integrator", "agent"], resp)
+            }
             Err(err) => json_response(&mut stream, json!({"ok": false, "error": err})),
         },
         ("GET", "/api/rules") => {
@@ -1205,6 +1233,19 @@ fn handle(mut stream: TcpStream, frontend: &Path) -> std::io::Result<()> {
             if method == "GET" && route_path.starts_with("/api/bacnet/jobs/") {
                 let job_id = route_path.trim_start_matches("/api/bacnet/jobs/");
                 return json_response(&mut stream, drivers::bacnet::job_status_json(job_id));
+            }
+            if method == "GET" {
+                if let Some(rule_id) = route_path
+                    .strip_prefix("/api/fdd/rules/")
+                    .and_then(|rest| rest.strip_suffix("/params"))
+                {
+                    if !rule_id.is_empty() && !rule_id.contains('/') {
+                        return json_response(
+                            &mut stream,
+                            fdd::registry_api::rule_params_response(rule_id),
+                        );
+                    }
+                }
             }
             if let Some(resp) = handle_fdd_wires_dynamic(
                 &mut stream,

--- a/services/central/Dockerfile
+++ b/services/central/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=builder /src/target/release/openfdd-provision /usr/local/bin/openfdd
 COPY sql_rules /app/sql_rules
 COPY rule_tuning /app/rule_tuning
 ENV OPENFDD_CENTRAL_HOST=0.0.0.0
+ENV OPENFDD_SQL_RULES_DIR=/app/sql_rules
 ENV OPENFDD_CENTRAL_PORT=8080
 EXPOSE 8080
 HEALTHCHECK CMD curl -fsS http://127.0.0.1:8080/api/health || exit 1

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -37,6 +37,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/commands", post(issue_command))
         .route("/api/commands/{command_id}/ack", get(get_ack))
         .route("/api/agent/tools", get(agent_tools))
+        .route("/api/fdd/rules", get(fdd_registry_rules))
+        .route("/api/fdd/rules/{rule_id}/params", get(fdd_rule_params))
+        .route("/api/fdd/cache/status", get(fdd_cache_status))
+        .route("/api/fdd/roles", get(fdd_roles))
         .route("/api/fdd/run", post(fdd_run))
         .route("/api/fdd/status", get(fdd_status))
         .layer(middleware::from_fn_with_state(
@@ -544,20 +548,39 @@ pub async fn agent_tools() -> Json<AgentToolsResponse> {
     tag = "central",
     security(("bearerAuth" = [])),
     request_body = FddRunRequest,
-    responses((status = 200, description = "FDD batch or ad-hoc SQL run result", body = Object))
+    responses((status = 200, description = "FDD registry or ad-hoc SQL run result", body = Object))
 )]
 pub async fn fdd_run(Json(body): Json<FddRunRequest>) -> Json<Value> {
     let payload = json!({
         "sql": body.sql,
         "confirmation_seconds": body.confirmation_seconds,
         "params": body.params,
+        "mode": body.params.get("mode").cloned().unwrap_or(json!("registry")),
+        "rule_ids": body.params.get("rule_ids").cloned(),
     });
-    let result = if body.sql.as_ref().is_some_and(|s| !s.trim().is_empty()) {
+    let has_sql = body.sql.as_ref().is_some_and(|s| !s.trim().is_empty());
+    let result = if has_sql {
         open_fdd_edge_prototype::fdd::datafusion_sql::run_fdd_response(&payload)
     } else {
-        open_fdd_edge_prototype::fdd::datafusion_sql::batch_run_response()
+        open_fdd_edge_prototype::fdd::registry_api::run_registry(&payload)
     };
     Json(result)
+}
+
+pub async fn fdd_registry_rules() -> Json<Value> {
+    Json(open_fdd_edge_prototype::fdd::registry_api::list_registry_rules())
+}
+
+pub async fn fdd_rule_params(Path(rule_id): Path<String>) -> Json<Value> {
+    Json(open_fdd_edge_prototype::fdd::registry_api::rule_params_response(&rule_id))
+}
+
+pub async fn fdd_cache_status() -> Json<Value> {
+    Json(open_fdd_edge_prototype::fdd::registry_api::cache_status())
+}
+
+pub async fn fdd_roles() -> Json<Value> {
+    Json(open_fdd_edge_prototype::fdd::registry_api::roles_response())
 }
 
 #[utoipa::path(
@@ -568,26 +591,25 @@ pub async fn fdd_run(Json(body): Json<FddRunRequest>) -> Json<Value> {
     responses((status = 200, description = "FDD rules workspace status", body = FddStatusResponse))
 )]
 pub async fn fdd_status() -> Json<FddStatusResponse> {
-    let rules_body = open_fdd_edge_prototype::fdd::rules::list_rules();
-    let count = rules_body
-        .get("count")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
-    let workspace = std::env::var("OPENFDD_WORKSPACE").unwrap_or_else(|_| "workspace".into());
-    let rules_dir = format!("{workspace}/data/fdd_wires/rules");
-    let rules_dir_exists = std::path::Path::new(&rules_dir).exists();
+    let reg = open_fdd_edge_prototype::fdd::registry_api::list_registry_rules();
+    let count = reg.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let rules_dir = reg
+        .get("rules_dir")
+        .and_then(|v| v.as_str())
+        .unwrap_or("sql_rules")
+        .to_string();
+    let rules_dir_exists = std::path::Path::new(&rules_dir)
+        .join("registry.yaml")
+        .exists();
     Json(FddStatusResponse {
         ok: true,
-        rules_dir,
+        rules_dir: rules_dir.clone(),
         rules_dir_exists,
         rule_count: count,
         hint: if count == 0 {
-            Some(
-                "activate rules in workspace/data/fdd_wires/rules or POST /api/fdd/run with sql"
-                    .into(),
-            )
+            Some("set OPENFDD_SQL_RULES_DIR or ship sql_rules/ in the image".into())
         } else {
-            None
+            Some("POST /api/fdd/run with mode=registry (typed params; no raw SQL)".into())
         },
     })
 }


### PR DESCRIPTION
## Summary
PR-1 of the vibe19 parity train:

- Edge depends on `fdd_rules` / `fdd_sql`
- New registry HTTP surface: `/api/fdd/rules`, `/api/fdd/rules/{id}/params`, `/api/fdd/cache/status`, `/api/fdd/roles`, registry-mode `/api/fdd/run`
- Central exposes the same routes (UI same-origin via Caddy)
- Docker images ship `sql_rules/` + `rule_tuning/` + `OPENFDD_SQL_RULES_DIR`

## Test plan
- [x] `cargo test -p open_fdd_edge_prototype --lib registry_api`
- [x] `cargo check -p openfdd-central`
- [ ] CI green + CodeRabbit triage


Made with [Cursor](https://cursor.com)