### PR TITLE
feat(sql_rules): vibe19 catalog 19→63 rules (#482)

### DIFF
--- a/.github/workflows/fdd-engine-ci.yml
+++ b/.github/workflows/fdd-engine-ci.yml
@@ -51,7 +51,11 @@ jobs:
           if missing:
               print("Missing SQL files:", missing)
               sys.exit(1)
-          print(f"OK: {len(reg['rules'])} rules")
+          n = len(reg.get("rules", []))
+          if n < 59:
+              print(f"Expected >= 59 registry rules (vibe19 catalog), got {n}")
+              sys.exit(1)
+          print(f"OK: {n} rules")
           PY
       - name: fixture validate
         run: cargo run -p fdd_cli --release -- validate --data-root examples/sample_data --building BUILDING_FIXTURE

--- a/docs/rules/cookbook/fixtures/fc2_obvious_fault.jsonl
+++ b/docs/rules/cookbook/fixtures/fc2_obvious_fault.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-07-01T14:00:00Z","equipment_id":"equip:test-ahu","mat":45.0,"rat":72.0,"oat":30.0,"oa_damper":0.05,"fan_cmd":0.9}
+{"timestamp":"2026-07-01T14:01:00Z","equipment_id":"equip:test-ahu","mat":44.5,"rat":72.0,"oat":29.5,"oa_damper":0.04,"fan_cmd":0.91}
+{"timestamp":"2026-07-01T14:02:00Z","equipment_id":"equip:test-ahu","mat":44.0,"rat":71.5,"oat":29.0,"oa_damper":0.03,"fan_cmd":0.92}

--- a/docs/rules/cookbook/fixtures/sched247_obvious_fault.jsonl
+++ b/docs/rules/cookbook/fixtures/sched247_obvious_fault.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-07-01T03:00:00Z","equipment_id":"equip:test-ahu","fan_status":true,"occ_mode":"unoccupied"}
+{"timestamp":"2026-07-01T03:15:00Z","equipment_id":"equip:test-ahu","fan_status":true,"occ_mode":"unoccupied"}
+{"timestamp":"2026-07-01T03:30:00Z","equipment_id":"equip:test-ahu","fan_status":true,"occ_mode":"unoccupied"}

--- a/docs/rules/cookbook/fixtures/vav1_obvious_fault.jsonl
+++ b/docs/rules/cookbook/fixtures/vav1_obvious_fault.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-07-01T14:00:00Z","equipment_id":"equip:test-vav","zone_t":82.0,"occ_mode":"occupied"}
+{"timestamp":"2026-07-01T14:05:00Z","equipment_id":"equip:test-vav","zone_t":82.5,"occ_mode":"occupied"}
+{"timestamp":"2026-07-01T14:10:00Z","equipment_id":"equip:test-vav","zone_t":83.0,"occ_mode":"occupied"}
+{"timestamp":"2026-07-01T14:15:00Z","equipment_id":"equip:test-vav","zone_t":83.2,"occ_mode":"occupied"}

--- a/scripts/cookbook_parity_check.py
+++ b/scripts/cookbook_parity_check.py
@@ -91,13 +91,37 @@ def rule_vav7(df):
     )
 
 
+def rule_vav1(df):
+    return df["zone_t"].notna() & ((df["zone_t"] < 68.0) | (df["zone_t"] > 76.0))
+
+
+def rule_fc2(df):
+    """MAT too cold vs RAT/OAT mix when OA damper nearly closed (screening oracle)."""
+    fan = norm_cmd(df["fan_cmd"])
+    return (
+        df["mat"].notna()
+        & df["rat"].notna()
+        & (df["oa_damper"] <= 0.1)
+        & (df["mat"] < df["rat"] - 8.0)
+        & (fan >= 0.5)
+    )
+
+
+def rule_sched247(df):
+    """After-hours fan run while unoccupied (aligned with SCHED-1 / SCHED-247 family)."""
+    return df["occ_mode"].eq("unoccupied") & df["fan_status"].astype(bool)
+
+
 CHECKS = {
     "reset1_obvious_fault.jsonl": (rule_reset1, True),
     "reset1_normal.jsonl": (rule_reset1, False),
     "sched1_obvious_fault.jsonl": (rule_sched1, True),
     "fc1_obvious_fault.jsonl": (rule_fc1, True),
+    "fc2_obvious_fault.jsonl": (rule_fc2, True),
+    "vav1_obvious_fault.jsonl": (rule_vav1, True),
     "vav6_obvious_fault.jsonl": (rule_vav6, True),
     "vav7_obvious_fault.jsonl": (rule_vav7, True),
+    "sched247_obvious_fault.jsonl": (rule_sched247, True),
 }
 
 

--- a/sql_rules/ahu_ducthi.sql
+++ b/sql_rules/ahu_ducthi.sql
@@ -1,0 +1,54 @@
+-- ahu_ducthi.sql — Duct static pressure high
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    duct_static, duct_static_sp,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN duct_static IS NULL OR duct_static_sp IS NULL THEN 0
+      WHEN (fan IS NOT NULL AND fan >= 0.05 OR duct_static > {{PRESSURE_ON_MIN}})
+       AND duct_static > duct_static_sp + {{DUCT_HIGH_MARGIN}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/ahu_satdev.sql
+++ b/sql_rules/ahu_satdev.sql
@@ -1,0 +1,45 @@
+-- ahu_satdev.sql — SAT deviation from setpoint
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN sat IS NULL OR sat_sp IS NULL THEN 0
+      WHEN ABS(sat - sat_sp) > {{SAT_DEV_ERR}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/ahu_simul.sql
+++ b/sql_rules/ahu_simul.sql
@@ -1,0 +1,53 @@
+-- ahu_simul.sql — Heating and cooling simultaneous
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CASE WHEN htg_valve_pct IS NULL THEN NULL WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg,
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN htg IS NULL OR clg IS NULL THEN 0
+      WHEN htg > {{VALVE_OPEN_PCT}} AND clg > {{VALVE_OPEN_PCT}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/chw1_low_dt.sql
+++ b/sql_rules/chw1_low_dt.sql
@@ -1,0 +1,54 @@
+-- chw1_low_dt.sql — Low chilled-water ΔT
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    chw_supply_t, chw_return_t,
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN chw_supply_t IS NULL OR chw_return_t IS NULL THEN 0
+      WHEN pump IS NOT NULL AND pump <= 0.05 THEN 0
+      WHEN (chw_return_t - chw_supply_t) < {{MIN_DT}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/chw2_dp_low.sql
+++ b/sql_rules/chw2_dp_low.sql
@@ -1,0 +1,53 @@
+-- chw2_dp_low.sql — DP below SP at max pump speed
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    chw_dp, chw_dp_sp,
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN chw_dp IS NULL OR chw_dp_sp IS NULL OR pump IS NULL THEN 0
+      WHEN pump >= 0.87 AND chw_dp < chw_dp_sp - {{DP_MARGIN}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/chw3_supply_band.sql
+++ b/sql_rules/chw3_supply_band.sql
@@ -1,0 +1,54 @@
+-- chw3_supply_band.sql — Plant supply temp outside deadband
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    chw_supply_t, chw_supply_sp,
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN chw_supply_t IS NULL OR chw_supply_sp IS NULL THEN 0
+      WHEN pump IS NOT NULL AND pump <= 0.05 THEN 0
+      WHEN ABS(chw_supply_t - chw_supply_sp) > {{SP_BAND}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/chw4_flow_high.sql
+++ b/sql_rules/chw4_flow_high.sql
@@ -1,0 +1,53 @@
+-- chw4_flow_high.sql — Flow high at max pump
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    chw_flow,
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN chw_flow IS NULL OR pump IS NULL THEN 0
+      WHEN pump >= 0.87 AND chw_flow > {{FLOW_HI}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/chw_noload_1.sql
+++ b/sql_rules/chw_noload_1.sql
@@ -1,0 +1,54 @@
+-- chw_noload_1.sql — Chiller running with no building load
+-- Simplified: chiller/pump on while CHWS within sat_band of SP (plant-local).
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    chw_supply_t, chw_supply_sp,
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN chw_supply_t IS NULL OR chw_supply_sp IS NULL OR pump IS NULL THEN 0
+      WHEN pump > 0.05 AND ABS(chw_supply_t - chw_supply_sp) <= {{SAT_BAND_F}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/cmd1_fan_mismatch.sql
+++ b/sql_rules/cmd1_fan_mismatch.sql
@@ -1,0 +1,53 @@
+-- cmd1_fan_mismatch.sql — Fan cmd/status mismatch
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    fan_status
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+        CAST(CASE
+          WHEN fan IS NULL OR fan_status IS NULL THEN 0
+          WHEN (fan >= 0.05) <> (fan_status > 0.5) THEN 1
+          ELSE 0
+        END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/cw_apr_1.sql
+++ b/sql_rules/cw_apr_1.sql
@@ -1,0 +1,54 @@
+-- cw_apr_1.sql — High CW approach at full tower fan
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    cw_supply_t, web_wb_t,
+    CASE WHEN tower_fan_cmd IS NULL THEN NULL WHEN tower_fan_cmd > 1.0 THEN tower_fan_cmd / 100.0 ELSE tower_fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN cw_supply_t IS NULL OR web_wb_t IS NULL OR fan IS NULL THEN 0
+      WHEN fan >= {{TOWER_FAN_HI}}
+       AND (cw_supply_t - web_wb_t) > {{APPROACH_MAX_F}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/cw_fan_1.sql
+++ b/sql_rules/cw_fan_1.sql
@@ -1,0 +1,54 @@
+-- cw_fan_1.sql — Excess tower fan energy vs wet-bulb limit
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    cw_supply_t, web_wb_t,
+    CASE WHEN tower_fan_cmd IS NULL THEN NULL WHEN tower_fan_cmd > 1.0 THEN tower_fan_cmd / 100.0 ELSE tower_fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN cw_supply_t IS NULL OR web_wb_t IS NULL OR fan IS NULL THEN 0
+      WHEN fan >= {{TOWER_FAN_HI}}
+       AND cw_supply_t > web_wb_t + {{CW_APPROACH}} + {{EXCESS_BEYOND_APPROACH_F}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/cw_opt_1.sql
+++ b/sql_rules/cw_opt_1.sql
@@ -1,0 +1,45 @@
+-- cw_opt_1.sql — Condenser water not optimized vs wet-bulb
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN cw_supply_t IS NULL OR web_wb_t IS NULL THEN 0
+      WHEN cw_supply_t < web_wb_t + {{CW_APPROACH}} - {{CW_SLACK}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/dmp1_oa_damper_leak.sql
+++ b/sql_rules/dmp1_oa_damper_leak.sql
@@ -1,0 +1,53 @@
+-- dmp1_oa_damper_leak.sql — OA damper leakage
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    oa_t, mat,
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN oa_d IS NULL OR oa_t IS NULL OR mat IS NULL THEN 0
+      WHEN oa_d <= 0.05 AND ABS(mat - oa_t) < {{LEAK_DELTA}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/econ3_mech_without_econ.sql
+++ b/sql_rules/econ3_mech_without_econ.sql
@@ -1,0 +1,55 @@
+-- econ3_mech_without_econ.sql — Mech cooling without integrated economizer
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    web_oa_t, web_oa_dp,
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN web_oa_t IS NULL OR web_oa_dp IS NULL OR oa_d IS NULL OR clg IS NULL THEN 0
+      WHEN web_oa_t >= {{ECON3_DB_MIN}} AND web_oa_t < {{ECON3_DB_MAX}} AND web_oa_dp < {{ECON3_DP_MAX}}
+       AND clg > 0.01 AND oa_d < {{ECON3_DAMPER_HI}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/econ5_preheat_over.sql
+++ b/sql_rules/econ5_preheat_over.sql
@@ -1,0 +1,53 @@
+-- econ5_preheat_over.sql — Preheat over-conditioning
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    preheat_leave_t, sat_sp,
+    CASE WHEN htg_valve_pct IS NULL THEN 0.0 WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN preheat_leave_t IS NULL OR sat_sp IS NULL THEN 0
+      WHEN htg > 0.01 AND preheat_leave_t > sat_sp + {{PREHEAT_OVER_F}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/econ6_econ_freezing.sql
+++ b/sql_rules/econ6_econ_freezing.sql
@@ -1,0 +1,53 @@
+-- econ6_econ_freezing.sql — Economizing in freezing weather
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    web_oa_t,
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN web_oa_t IS NULL OR oa_d IS NULL THEN 0
+      WHEN web_oa_t < {{ECON6_OAT_MAX_F}} AND oa_d > {{ECON6_DAMPER_MAX}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/econ7_ok_not_economizing.sql
+++ b/sql_rules/econ7_ok_not_economizing.sql
@@ -1,0 +1,55 @@
+-- econ7_ok_not_economizing.sql — Economizer OK but not economizing
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    web_oa_t, web_oa_dp,
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN web_oa_t IS NULL OR web_oa_dp IS NULL OR oa_d IS NULL OR clg IS NULL THEN 0
+      WHEN web_oa_t >= {{ECON7_DB_MIN}} AND web_oa_t < {{ECON7_DB_MAX}} AND web_oa_dp < {{ECON7_DP_MAX}}
+       AND clg > 0.01 AND oa_d < {{ECON7_DAMPER_MIN}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/fc14_chw_coil_dt_inactive.sql
+++ b/sql_rules/fc14_chw_coil_dt_inactive.sql
@@ -1,0 +1,58 @@
+-- fc14_chw_coil_dt_inactive.sql — CHW coil ΔT when inactive (GL36 L)
+-- Simplified: uses MAT/SAT as coil enter/leave proxy when dedicated coil temps absent.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    mat, sat,
+    CASE WHEN clg_valve_pct IS NULL THEN 0.0 WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
+    CASE WHEN oa_damper_pct IS NULL THEN 0.0 WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
+    CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN mat IS NULL OR sat IS NULL THEN 0
+      WHEN fan < 0.05 THEN 0
+      WHEN clg > 0.01 THEN 0
+      WHEN ABS(mat - sat) >= SQRT(2.0 * {{MIX_TOL}} * {{MIX_TOL}}) + 0.55 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/fc15_hw_coil_dt_inactive.sql
+++ b/sql_rules/fc15_hw_coil_dt_inactive.sql
@@ -1,0 +1,57 @@
+-- fc15_hw_coil_dt_inactive.sql — HW coil ΔT when inactive (GL36 M)
+-- Simplified: uses MAT/SAT proxy when dedicated HW coil temps absent.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    mat, sat,
+    CASE WHEN htg_valve_pct IS NULL THEN 0.0 WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg,
+    CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN mat IS NULL OR sat IS NULL THEN 0
+      WHEN fan < 0.05 THEN 0
+      WHEN htg > 0.01 THEN 0
+      WHEN ABS(sat - mat) >= SQRT(2.0 * {{MIX_TOL}} * {{MIX_TOL}}) + 0.55 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/fc4_os_hunting.sql
+++ b/sql_rules/fc4_os_hunting.sql
@@ -1,0 +1,67 @@
+-- fc4_pid_hunting.sql — PID hunting / OS oscillation
+-- Simplified SQL variant. Full operating-state transition counting validated in Pandas.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+modes AS (
+  SELECT
+    *,
+    CASE
+      WHEN fan IS NULL OR fan < 0.05 THEN 0
+      WHEN clg IS NOT NULL AND clg > 0.1 THEN 3
+      WHEN oa_d IS NOT NULL AND oa_d > 0.5 THEN 2
+      ELSE 1
+    END AS op_mode
+  FROM h
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN op_mode = 0 THEN 0
+      WHEN LAG(op_mode) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) IS NULL THEN 0
+      WHEN op_mode <> LAG(op_mode) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM modes
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/fc5_sat_cold_heating.sql
+++ b/sql_rules/fc5_sat_cold_heating.sql
@@ -1,0 +1,55 @@
+-- fc5_sat_cold_heating.sql — SAT cold when heating commanded (GL36 D)
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    sat, mat,
+    CASE WHEN htg_valve_pct IS NULL THEN NULL WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN sat IS NULL OR mat IS NULL OR htg IS NULL OR fan IS NULL THEN 0
+      WHEN fan >= 0.05 AND htg > 0.01
+       AND (sat + {{MIX_TOL}}) <= (mat - {{MIX_TOL}} + 0.55) THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/fc6_oa_frac_mismatch.sql
+++ b/sql_rules/fc6_oa_frac_mismatch.sql
@@ -1,0 +1,56 @@
+-- fc6_oa_frac_mismatch.sql — Estimated OA fraction mismatch
+-- Simplified SQL variant. Full design-min OA% mode gating validated in Pandas.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    mat, rat, oa_t,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN mat IS NULL OR rat IS NULL OR oa_t IS NULL OR fan IS NULL THEN 0
+      WHEN fan < 0.05 THEN 0
+      WHEN ABS(rat - oa_t) < 5.0 THEN 0
+      WHEN ABS((mat - rat) / NULLIF(oa_t - rat, 0) - 0.20) > {{AIRFLOW_ERR}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/hp1_discharge_cold.sql
+++ b/sql_rules/hp1_discharge_cold.sql
@@ -1,0 +1,53 @@
+-- hp1_discharge_cold.sql — Discharge cold when heating
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    sat, zone_t,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN sat IS NULL OR zone_t IS NULL OR fan IS NULL THEN 0
+      WHEN fan >= 0.05 AND zone_t < {{ZONE_COLD}} AND sat < {{MIN_SAT}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/mech_oat_1.sql
+++ b/sql_rules/mech_oat_1.sql
@@ -1,0 +1,54 @@
+-- mech_oat_1.sql — Mechanical cooling below 60°F web OAT
+-- Uses clg_valve as proxy when compressor/chiller proof roles absent.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    web_oa_t,
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN web_oa_t IS NULL OR clg IS NULL THEN 0
+      WHEN web_oa_t < {{MECH_OAT_MAX_F}} AND clg > 0.05 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/oa1_low_oa_frac.sql
+++ b/sql_rules/oa1_low_oa_frac.sql
@@ -1,0 +1,55 @@
+-- oa1_low_oa_frac.sql — Low OA fraction
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    mat, rat, oa_t,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN mat IS NULL OR rat IS NULL OR oa_t IS NULL THEN 0
+      WHEN ABS(rat - oa_t) <= {{OAT_RAT_GUARD}} THEN 0
+      WHEN (mat - rat) / NULLIF(oa_t - rat, 0) < {{MIN_OA_FRAC}}
+       AND fan IS NOT NULL AND fan >= 0.05 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/pid_hunt_1.sql
+++ b/sql_rules/pid_hunt_1.sql
@@ -1,0 +1,61 @@
+-- pid_hunt_1.sql — Suspected control-output hunting
+-- Simplified SQL variant. Full rolling TV/cycle/reversal logic validated in Pandas.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CASE WHEN clg_valve_pct IS NULL THEN NULL
+         WHEN clg_valve_pct > 1.0 THEN clg_valve_pct
+         ELSE clg_valve_pct * 100.0 END AS out_pct,
+    LAG(CASE WHEN clg_valve_pct IS NULL THEN NULL
+             WHEN clg_valve_pct > 1.0 THEN clg_valve_pct
+             ELSE clg_valve_pct * 100.0 END)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_out
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN out_pct IS NULL OR prev_out IS NULL THEN 0
+      WHEN ABS(out_pct - prev_out) > {{CHANGE_DEADBAND_PCT}}
+       AND ABS(out_pct - prev_out) >= {{MINIMUM_SPAN_PCT}} / 10.0
+      THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -380,3 +380,1549 @@ rules:
     dashboard_wired: true
     delete_python_candidate: false
     confirm_seconds: 600
+
+# --- Ported from datafusion-sql-cookbook (feat/sql-rules-59) ---
+
+  - rule_id: SV-RANGE
+    sql_file: sv_range.sql
+    pandas_function: null
+    description: Sensor out of hard range
+    required_roles: [oa_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      range_scale_temperature:
+        label: Temp range scale
+        default: 1.0
+        min: 0.5
+        max: 2.0
+        step: 0.25
+        unit: x
+        frontend_control: slider
+        sql_placeholder: RANGE_SCALE_TEMPERATURE
+
+  - rule_id: SV-FLATLINE
+    sql_file: sv_flatline.sql
+    pandas_function: null
+    description: Sensor flatline (stuck)
+    required_roles: [oa_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      flatline_tol:
+        label: Flatline tolerance
+        default: 0.1
+        min: 0.02
+        max: 1.0
+        step: 0.01
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: FLATLINE_TOL
+
+  - rule_id: SV-SPIKE
+    sql_file: sv_spike.sql
+    pandas_function: null
+    description: Sensor rate-of-change spike
+    required_roles: [oa_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      spike_scale:
+        label: Spike limit scale (global)
+        default: 1.0
+        min: 0.25
+        max: 3.0
+        step: 0.25
+        unit: x
+        frontend_control: slider
+        sql_placeholder: SPIKE_SCALE
+
+  - rule_id: SV-STALE
+    sql_file: sv_stale.sql
+    pandas_function: null
+    description: Stale data (no fresh samples)
+    required_roles: []
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      stale_hours:
+        label: Stale window
+        default: 2.0
+        min: 0.5
+        max: 12.0
+        step: 0.5
+        unit: h
+        frontend_control: slider
+        sql_placeholder: STALE_HOURS
+
+  - rule_id: SV-RATE
+    sql_file: sv_rate.sql
+    pandas_function: null
+    description: Context-aware sensor rate of change
+    required_roles: [oa_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      persistence_min:
+        label: Fault persistence
+        default: 10.0
+        min: 5.0
+        max: 60.0
+        step: 1.0
+        unit: min
+        frontend_control: slider
+        sql_placeholder: PERSISTENCE_MIN
+
+  - rule_id: PID-HUNT-1
+    sql_file: pid_hunt_1.sql
+    pandas_function: null
+    description: Suspected control-output hunting
+    required_roles: [clg_valve_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      change_deadband_pct:
+        label: Ignore changes below
+        default: 1.0
+        min: 0.0
+        max: 10.0
+        step: 0.5
+        unit: pct
+        frontend_control: slider
+        sql_placeholder: CHANGE_DEADBAND_PCT
+      minimum_span_pct:
+        label: Minimum observed span
+        default: 20.0
+        min: 5.0
+        max: 100.0
+        step: 1.0
+        unit: pct
+        frontend_control: slider
+        sql_placeholder: MINIMUM_SPAN_PCT
+
+  - rule_id: FC4
+    sql_file: fc4_os_hunting.sql
+    pandas_function: null
+    description: PID hunting (operating-state oscillation)
+    required_roles: [oa_damper_pct, clg_valve_pct, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 3600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 3600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+
+  - rule_id: FC5
+    sql_file: fc5_sat_cold_heating.sql
+    pandas_function: null
+    description: SAT cold when heating commanded (GL36 D)
+    required_roles: [sat, mat, htg_valve_pct, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      mix_tol:
+        label: Mixing tolerance
+        default: 1.15
+        min: 0.5
+        max: 3.0
+        step: 0.25
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MIX_TOL
+
+  - rule_id: FC6
+    sql_file: fc6_oa_frac_mismatch.sql
+    pandas_function: null
+    description: Estimated OA fraction mismatch
+    required_roles: [mat, rat, oa_t, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      airflow_err:
+        label: OA fraction error
+        default: 0.15
+        min: 0.05
+        max: 0.5
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: AIRFLOW_ERR
+
+  - rule_id: FC14
+    sql_file: fc14_chw_coil_dt_inactive.sql
+    pandas_function: null
+    description: CHW coil ΔT when inactive (GL36 L)
+    required_roles: [mat, sat, clg_valve_pct, oa_damper_pct, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      mix_tol:
+        label: Mixing tolerance
+        default: 1.15
+        min: 0.25
+        max: 3.0
+        step: 0.25
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MIX_TOL
+
+  - rule_id: FC15
+    sql_file: fc15_hw_coil_dt_inactive.sql
+    pandas_function: null
+    description: HW coil ΔT when inactive (GL36 M)
+    required_roles: [mat, sat, htg_valve_pct, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      mix_tol:
+        label: Mixing tolerance
+        default: 1.15
+        min: 0.25
+        max: 3.0
+        step: 0.25
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MIX_TOL
+
+  - rule_id: AHU-SATDEV
+    sql_file: ahu_satdev.sql
+    pandas_function: null
+    description: SAT deviation from setpoint
+    required_roles: [sat, sat_sp]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      sat_dev_err:
+        label: SAT deviation
+        default: 5.0
+        min: 1.0
+        max: 15.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: SAT_DEV_ERR
+
+  - rule_id: AHU-DUCTHI
+    sql_file: ahu_ducthi.sql
+    pandas_function: null
+    description: Duct static pressure high
+    required_roles: [duct_static, duct_static_sp, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      duct_high_margin:
+        label: High margin
+        default: 0.25
+        min: 0.05
+        max: 1.0
+        step: 0.01
+        unit: in_wc
+        frontend_control: slider
+        sql_placeholder: DUCT_HIGH_MARGIN
+      pressure_on_min:
+        label: Pressure-on evidence
+        default: 0.2
+        min: 0.05
+        max: 1.0
+        step: 0.01
+        unit: in_wc
+        frontend_control: slider
+        sql_placeholder: PRESSURE_ON_MIN
+
+  - rule_id: AHU-SIMUL
+    sql_file: ahu_simul.sql
+    pandas_function: null
+    description: Heating and cooling simultaneous
+    required_roles: [htg_valve_pct, clg_valve_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      valve_open_pct:
+        label: Valve open threshold
+        default: 0.1
+        min: 0.05
+        max: 0.5
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: VALVE_OPEN_PCT
+
+  - rule_id: ECON-3
+    sql_file: econ3_mech_without_econ.sql
+    pandas_function: null
+    description: Mech cooling without integrated economizer
+    required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      econ3_db_min:
+        label: Free-cool OA dry-bulb min
+        default: 60.0
+        min: 50.0
+        max: 68.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON3_DB_MIN
+      econ3_db_max:
+        label: Free-cool OA dry-bulb max
+        default: 72.0
+        min: 65.0
+        max: 80.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON3_DB_MAX
+      econ3_dp_max:
+        label: Free-cool OA dew point max
+        default: 60.0
+        min: 45.0
+        max: 68.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON3_DP_MAX
+      econ3_damper_hi:
+        label: Integrated economizer damper
+        default: 0.9
+        min: 0.5
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: ECON3_DAMPER_HI
+
+  - rule_id: ECON-5
+    sql_file: econ5_preheat_over.sql
+    pandas_function: null
+    description: Preheat over-conditioning
+    required_roles: [preheat_leave_t, sat_sp, htg_valve_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      preheat_over_f:
+        label: Preheat over ΔT
+        default: 2.2
+        min: 0.5
+        max: 8.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: PREHEAT_OVER_F
+
+  - rule_id: ECON-6
+    sql_file: econ6_econ_freezing.sql
+    pandas_function: null
+    description: Economizing in freezing weather
+    required_roles: [web_oa_t, oa_damper_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      econ6_oat_max_f:
+        label: Winter OAT ceiling
+        default: 25.0
+        min: 15.0
+        max: 40.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON6_OAT_MAX_F
+      econ6_damper_max:
+        label: Winter min-OA damper
+        default: 0.25
+        min: 0.05
+        max: 0.5
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: ECON6_DAMPER_MAX
+
+  - rule_id: ECON-7
+    sql_file: econ7_ok_not_economizing.sql
+    pandas_function: null
+    description: Economizer OK but not economizing
+    required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      econ7_db_min:
+        label: Econ-OK dry-bulb floor (freeze guard)
+        default: 35.0
+        min: 20.0
+        max: 50.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON7_DB_MIN
+      econ7_db_max:
+        label: Econ-OK dry-bulb max
+        default: 72.0
+        min: 65.0
+        max: 80.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON7_DB_MAX
+      econ7_dp_max:
+        label: Econ-OK dew point max
+        default: 60.0
+        min: 45.0
+        max: 68.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON7_DP_MAX
+      econ7_damper_min:
+        label: Economizing damper threshold
+        default: 0.5
+        min: 0.2
+        max: 0.9
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: ECON7_DAMPER_MIN
+
+  - rule_id: MECH-OAT-1
+    sql_file: mech_oat_1.sql
+    pandas_function: null
+    description: Mechanical cooling below 60°F web OAT
+    required_roles: [web_oa_t, clg_valve_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      mech_oat_max_f:
+        label: Mech-cool OAT ceiling
+        default: 60.0
+        min: 45.0
+        max: 65.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MECH_OAT_MAX_F
+
+  - rule_id: CMD-1
+    sql_file: cmd1_fan_mismatch.sql
+    pandas_function: null
+    description: Fan cmd/status mismatch
+    required_roles: [fan_cmd, fan_status]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+
+  - rule_id: OA-1
+    sql_file: oa1_low_oa_frac.sql
+    pandas_function: null
+    description: Low OA fraction
+    required_roles: [mat, rat, oa_t, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      min_oa_frac:
+        label: Min OA fraction
+        default: 0.15
+        min: 0.05
+        max: 0.4
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: MIN_OA_FRAC
+      oat_rat_guard:
+        label: Oat Rat Guard
+        default: 1.0
+        min: 0.0
+        max: 100.0
+        step: 0.5
+        unit: eng
+        frontend_control: slider
+        sql_placeholder: OAT_RAT_GUARD
+
+  - rule_id: DMP-1
+    sql_file: dmp1_oa_damper_leak.sql
+    pandas_function: null
+    description: OA damper leakage
+    required_roles: [oa_damper_pct, oa_t, mat]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      leak_delta:
+        label: Leak ΔT
+        default: 2.0
+        min: 0.5
+        max: 6.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: LEAK_DELTA
+
+  - rule_id: VLV-1
+    sql_file: vlv1_clg_valve_leak.sql
+    pandas_function: null
+    description: Cooling valve leakage
+    required_roles: [clg_valve_pct, sat, sat_sp, mat]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      sat_err:
+        label: SAT vs SP leak ΔT
+        default: 2.0
+        min: 0.5
+        max: 8.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: SAT_ERR
+      mat_leak_delta:
+        label: SAT vs MAT leak ΔT
+        default: 2.0
+        min: 0.5
+        max: 12.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MAT_LEAK_DELTA
+
+  - rule_id: VAV-3
+    sql_file: vav3_excessive_reheat.sql
+    pandas_function: null
+    description: Excessive reheat during warm weather
+    required_roles: [oa_t, reheat_valve_pct, zone_flow]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      reheat_oat:
+        label: Warm OAT
+        default: 78.0
+        min: 65.0
+        max: 90.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: REHEAT_OAT
+      reheat_pct:
+        label: Reheat frac
+        default: 0.52
+        min: 0.1
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: REHEAT_PCT
+      flow_on_min:
+        label: Airflow-on min
+        default: 25.0
+        min: 0.0
+        max: 200.0
+        step: 10.0
+        unit: cfm
+        frontend_control: slider
+        sql_placeholder: FLOW_ON_MIN
+
+  - rule_id: VAV-4
+    sql_file: vav4_damper_full_open.sql
+    pandas_function: null
+    description: Damper stuck at full open
+    required_roles: [damper_pct, zone_flow]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      full_open_pct:
+        label: Full open frac
+        default: 0.975
+        min: 0.8
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: FULL_OPEN_PCT
+      flow_on_min:
+        label: Airflow-on min
+        default: 25.0
+        min: 0.0
+        max: 200.0
+        step: 10.0
+        unit: cfm
+        frontend_control: slider
+        sql_placeholder: FLOW_ON_MIN
+
+  - rule_id: VAV-5
+    sql_file: vav5_airflow_bias.sql
+    pandas_function: null
+    description: Airflow sensor bias
+    required_roles: [zone_flow, damper_pct]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+
+  - rule_id: VAV-REHEAT
+    sql_file: vav_reheat.sql
+    pandas_function: null
+    description: Reheat valve stuck / no temp rise
+    required_roles: [reheat_valve_pct, vav_discharge_t, vav_inlet_t, zone_flow]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      reheat_cmd:
+        label: Reheat open frac
+        default: 0.3
+        min: 0.1
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: REHEAT_CMD
+      min_rise:
+        label: Min temp rise
+        default: 3.0
+        min: 0.5
+        max: 15.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MIN_RISE
+      flow_on_min:
+        label: Airflow-on min
+        default: 25.0
+        min: 0.0
+        max: 200.0
+        step: 10.0
+        unit: cfm
+        frontend_control: slider
+        sql_placeholder: FLOW_ON_MIN
+
+  - rule_id: VAV-AHU-LEAVE
+    sql_file: vav_ahu_leave.sql
+    pandas_function: null
+    description: VAV leave vs parent AHU SAT (fedBy)
+    required_roles: [vav_discharge_t, ahu_sat, zone_flow]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      delta_f:
+        label: Leave Δ vs AHU SAT
+        default: 8.0
+        min: 2.0
+        max: 25.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: DELTA_F
+      flow_on_min:
+        label: Airflow-on min
+        default: 25.0
+        min: 0.0
+        max: 200.0
+        step: 10.0
+        unit: cfm
+        frontend_control: slider
+        sql_placeholder: FLOW_ON_MIN
+
+  - rule_id: VAV-7
+    sql_file: vav7_min_airflow.sql
+    pandas_function: null
+    description: Min airflow / fixed high flow
+    required_roles: [zone_flow, min_flow_sp]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      high_min_flow_sp:
+        label: High min-flow SP
+        default: 250.0
+        min: 50.0
+        max: 2000.0
+        step: 50.0
+        unit: cfm
+        frontend_control: slider
+        sql_placeholder: HIGH_MIN_FLOW_SP
+
+  - rule_id: CHW-NOLOAD-1
+    sql_file: chw_noload_1.sql
+    pandas_function: null
+    description: Chiller running with no building load
+    required_roles: [chw_supply_t, chw_supply_sp, chw_pump_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 1800
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 1800.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      sat_band_f:
+        label: AHU SAT≈SP band
+        default: 2.0
+        min: 0.5
+        max: 6.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: SAT_BAND_F
+
+  - rule_id: CHW-1
+    sql_file: chw1_low_dt.sql
+    pandas_function: null
+    description: Low chilled-water ΔT
+    required_roles: [chw_supply_t, chw_return_t, chw_pump_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      min_dt:
+        label: Minimum delta-T
+        default: 4.0
+        min: 2.0
+        max: 12.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MIN_DT
+
+  - rule_id: CHW-2
+    sql_file: chw2_dp_low.sql
+    pandas_function: null
+    description: DP below SP at max pump speed
+    required_roles: [chw_dp, chw_dp_sp, chw_pump_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      dp_margin:
+        label: DP margin
+        default: 2.2
+        min: 0.5
+        max: 6.0
+        step: 0.5
+        unit: psi
+        frontend_control: slider
+        sql_placeholder: DP_MARGIN
+
+  - rule_id: CHW-3
+    sql_file: chw3_supply_band.sql
+    pandas_function: null
+    description: Plant supply temp outside deadband
+    required_roles: [chw_supply_t, chw_supply_sp, chw_pump_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      sp_band:
+        label: SP band
+        default: 2.2
+        min: 0.5
+        max: 6.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: SP_BAND
+
+  - rule_id: CHW-4
+    sql_file: chw4_flow_high.sql
+    pandas_function: null
+    description: Flow high at max pump
+    required_roles: [chw_flow, chw_pump_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      flow_hi:
+        label: Flow high
+        default: 1100.0
+        min: 200.0
+        max: 3000.0
+        step: 50.0
+        unit: gpm
+        frontend_control: slider
+        sql_placeholder: FLOW_HI
+
+  - rule_id: CW-OPT-1
+    sql_file: cw_opt_1.sql
+    pandas_function: null
+    description: Condenser water not optimized vs wet-bulb
+    required_roles: [cw_supply_t, web_wb_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      cw_approach:
+        label: Design approach
+        default: 7.0
+        min: 3.0
+        max: 15.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: CW_APPROACH
+      cw_slack:
+        label: Slack below target
+        default: 2.0
+        min: 0.5
+        max: 6.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: CW_SLACK
+
+  - rule_id: CW-APR-1
+    sql_file: cw_apr_1.sql
+    pandas_function: null
+    description: High CW approach at full tower fan
+    required_roles: [cw_supply_t, web_wb_t, tower_fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      approach_max_f:
+        label: Max approach at full fan
+        default: 8.0
+        min: 5.0
+        max: 15.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: APPROACH_MAX_F
+      tower_fan_hi:
+        label: Tower fan full-speed threshold
+        default: 0.95
+        min: 0.8
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: TOWER_FAN_HI
+
+  - rule_id: CW-FAN-1
+    sql_file: cw_fan_1.sql
+    pandas_function: null
+    description: Excess tower fan energy vs wet-bulb limit
+    required_roles: [cw_supply_t, web_wb_t, tower_fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 900
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 900.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      cw_approach:
+        label: Design approach
+        default: 7.0
+        min: 3.0
+        max: 15.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: CW_APPROACH
+      excess_beyond_approach_f:
+        label: Excess beyond approach
+        default: 5.0
+        min: 2.0
+        max: 20.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: EXCESS_BEYOND_APPROACH_F
+      tower_fan_hi:
+        label: Tower fan full-speed threshold
+        default: 0.95
+        min: 0.8
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: TOWER_FAN_HI
+
+  - rule_id: HP-1
+    sql_file: hp1_discharge_cold.sql
+    pandas_function: null
+    description: Discharge cold when heating
+    required_roles: [sat, zone_t, fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      min_sat:
+        label: Min discharge SAT
+        default: 85.0
+        min: 70.0
+        max: 110.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: MIN_SAT
+      zone_cold:
+        label: Zone cold threshold
+        default: 69.0
+        min: 60.0
+        max: 75.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ZONE_COLD
+
+  - rule_id: WX-1
+    sql_file: wx1_oa_spike.sql
+    pandas_function: null
+    description: OA temperature spike
+    required_roles: [oa_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 300
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 300.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      spike_limit:
+        label: Spike limit
+        default: 16.0
+        min: 5.0
+        max: 30.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: SPIKE_LIMIT
+
+  - rule_id: TRIM-1
+    sql_file: trim1_duct_static.sql
+    pandas_function: null
+    description: Duct static trim advisory
+    required_roles: [duct_static_sp]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 1800
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 1800.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      duct_hi:
+        label: Duct static high
+        default: 1.35
+        min: 0.5
+        max: 3.0
+        step: 0.25
+        unit: in_wc
+        frontend_control: slider
+        sql_placeholder: DUCT_HI
+      request_lo:
+        label: Request sum low
+        default: 1.0
+        min: 0.0
+        max: 10.0
+        step: 0.5
+        unit: count
+        frontend_control: slider
+        sql_placeholder: REQUEST_LO
+
+  - rule_id: TRIM-3
+    sql_file: trim3_hwst.sql
+    pandas_function: null
+    description: HWST trim advisory
+    required_roles: [hw_supply_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 1800
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 1800.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      hwst_hi:
+        label: HWST high
+        default: 160.0
+        min: 120.0
+        max: 200.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: HWST_HI
+      request_lo:
+        label: Request sum low
+        default: 1.0
+        min: 0.0
+        max: 10.0
+        step: 0.5
+        unit: count
+        frontend_control: slider
+        sql_placeholder: REQUEST_LO
+
+  - rule_id: TRIM-4
+    sql_file: trim4_chw_reset.sql
+    pandas_function: null
+    description: CHW plant reset advisory
+    required_roles: [chw_supply_t]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 1800
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 1800.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+      chw_lo:
+        label: CHWS low
+        default: 45.0
+        min: 35.0
+        max: 55.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: CHW_LO
+      request_lo:
+        label: Request sum low
+        default: 1.0
+        min: 0.0
+        max: 10.0
+        step: 0.5
+        unit: count
+        frontend_control: slider
+        sql_placeholder: REQUEST_LO
+
+  - rule_id: SCHED-1
+    sql_file: sched1_unoccupied_runtime.sql
+    pandas_function: null
+    description: Unoccupied runtime
+    required_roles: [occ_mode, fan_status]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 1800
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 1800.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
+
+  - rule_id: SCHED-247
+    sql_file: sched247_always_on.sql
+    pandas_function: null
+    description: Always-on fan or pump runtime
+    required_roles: [fan_cmd]
+    output_columns: [equipment_id, fault_hours]
+    priority: P0
+    parity_status: ported_from_cookbook
+    dashboard_wired: false
+    delete_python_candidate: false
+    confirm_seconds: 3600
+    parameters:
+      confirm_seconds:
+        label: Confirm time
+        default: 3600.0
+        min: 0.0
+        max: 3600.0
+        step: 300.0
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS

--- a/sql_rules/sched1_unoccupied_runtime.sql
+++ b/sql_rules/sched1_unoccupied_runtime.sql
@@ -1,0 +1,45 @@
+-- sched1_unoccupied_runtime.sql — Unoccupied runtime
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+        CAST(CASE
+          WHEN occ_mode IS NULL OR fan_status IS NULL THEN 0
+          WHEN LOWER(occ_mode) = 'unoccupied' AND fan_status > 0.5 THEN 1
+          ELSE 0
+        END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/sched247_always_on.sql
+++ b/sql_rules/sched247_always_on.sql
@@ -1,0 +1,52 @@
+-- sched247_always_on.sql — Always-on fan or pump runtime
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN fan IS NULL THEN 0
+      WHEN fan >= 0.05 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/sv_flatline.sql
+++ b/sql_rules/sv_flatline.sql
@@ -1,0 +1,54 @@
+-- sv_flatline.sql — Sensor flatline (stuck)
+-- Simplified SQL variant. Full rolling / multi-sensor logic validated in Pandas.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    oa_t,
+    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN oa_t IS NULL OR prev_oa_t IS NULL THEN 0
+      WHEN ABS(oa_t - prev_oa_t) <= {{FLATLINE_TOL}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/sv_range.sql
+++ b/sql_rules/sv_range.sql
@@ -1,0 +1,45 @@
+-- sv_range.sql — Sensor out of hard range (OAT example; extend per sensor type)
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN oa_t IS NULL THEN 0
+      WHEN oa_t < -60.0 * {{RANGE_SCALE_TEMPERATURE}} OR oa_t > 130.0 * {{RANGE_SCALE_TEMPERATURE}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/sv_rate.sql
+++ b/sql_rules/sv_rate.sql
@@ -1,0 +1,59 @@
+-- sv_rate.sql — Context-aware sensor rate of change
+-- Simplified SQL variant. Full context-aware rate logic validated in Pandas.
+-- Screening placeholder: does not latch until site-tuned profiles are coded.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    oa_t,
+    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t,
+    LAG(timestamp_utc) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_ts
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      -- Simplified screen: sustained |ΔT| > 5°F/min between samples (tune via params unused here)
+      WHEN oa_t IS NULL OR prev_oa_t IS NULL OR prev_ts IS NULL THEN 0
+      WHEN ABS(oa_t - prev_oa_t) > 5.0
+       AND CAST(EXTRACT(EPOCH FROM (timestamp_utc - prev_ts)) AS DOUBLE) <= {{PERSISTENCE_MIN}} * 60.0
+      THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/sv_spike.sql
+++ b/sql_rules/sv_spike.sql
@@ -1,0 +1,54 @@
+-- sv_spike.sql — Sensor rate-of-change spike
+-- Simplified SQL variant. Full multi-sensor spike matrix validated in Pandas.
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    oa_t,
+    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN oa_t IS NULL OR prev_oa_t IS NULL THEN 0
+      WHEN ABS(oa_t - prev_oa_t) > 16.0 * {{SPIKE_SCALE}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/sv_stale.sql
+++ b/sql_rules/sv_stale.sql
@@ -1,0 +1,49 @@
+-- sv_stale.sql — Stale data (no fresh samples)
+WITH mx AS (
+  SELECT MAX(timestamp_utc) AS max_ts FROM history
+),
+base AS (
+  SELECT
+    h.equipment_id,
+    h.timestamp_utc,
+    CAST(CASE
+      WHEN CAST(EXTRACT(EPOCH FROM (mx.max_ts - h.timestamp_utc)) AS DOUBLE)
+           > {{STALE_HOURS}} * 3600.0 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history h
+  CROSS JOIN mx
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/trim1_duct_static.sql
+++ b/sql_rules/trim1_duct_static.sql
@@ -1,0 +1,46 @@
+-- trim1_duct_static.sql — Duct static trim advisory
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN duct_static_sp IS NULL THEN 0
+      WHEN duct_static_sp > {{DUCT_HI}}
+       AND COALESCE(static_reset_request, 0) <= {{REQUEST_LO}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/trim3_hwst.sql
+++ b/sql_rules/trim3_hwst.sql
@@ -1,0 +1,46 @@
+-- trim3_hwst.sql — HWST trim advisory
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN hw_supply_t IS NULL THEN 0
+      WHEN hw_supply_t > {{HWST_HI}}
+       AND COALESCE(hw_reset_request_sum, 0) <= {{REQUEST_LO}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/trim4_chw_reset.sql
+++ b/sql_rules/trim4_chw_reset.sql
@@ -1,0 +1,46 @@
+-- trim4_chw_reset.sql — CHW plant reset advisory
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN chw_supply_t IS NULL THEN 0
+      WHEN chw_supply_t < {{CHW_LO}}
+       AND COALESCE(chw_reset_request_sum, 0) <= {{REQUEST_LO}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/vav3_excessive_reheat.sql
+++ b/sql_rules/vav3_excessive_reheat.sql
@@ -1,0 +1,54 @@
+-- vav3_excessive_reheat.sql — Excessive reheat during warm weather
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    oa_t, zone_flow,
+    CASE WHEN reheat_valve_pct IS NULL THEN NULL WHEN reheat_valve_pct > 1.0 THEN reheat_valve_pct / 100.0 ELSE reheat_valve_pct END AS rh
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN oa_t IS NULL OR rh IS NULL THEN 0
+      WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}}
+       AND oa_t > {{REHEAT_OAT}} AND rh > {{REHEAT_PCT}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/vav4_damper_full_open.sql
+++ b/sql_rules/vav4_damper_full_open.sql
@@ -1,0 +1,53 @@
+-- vav4_damper_full_open.sql — Damper stuck at full open
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    zone_flow,
+    CASE WHEN damper_pct IS NULL THEN NULL WHEN damper_pct > 1.0 THEN damper_pct / 100.0 ELSE damper_pct END AS dmp
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN dmp IS NULL THEN 0
+      WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}} AND dmp > {{FULL_OPEN_PCT}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/vav5_airflow_bias.sql
+++ b/sql_rules/vav5_airflow_bias.sql
@@ -1,0 +1,53 @@
+-- vav5_airflow_bias.sql — Airflow sensor bias
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    zone_flow,
+    CASE WHEN damper_pct IS NULL THEN NULL WHEN damper_pct > 1.0 THEN damper_pct / 100.0 ELSE damper_pct END AS dmp
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN zone_flow IS NULL OR dmp IS NULL THEN 0
+      WHEN zone_flow > 50.0 AND dmp < 0.10 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/vav7_min_airflow.sql
+++ b/sql_rules/vav7_min_airflow.sql
@@ -1,0 +1,46 @@
+-- vav7_min_airflow.sql — Min airflow / fixed high flow
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN zone_flow IS NULL OR min_flow_sp IS NULL THEN 0
+      WHEN zone_flow < min_flow_sp THEN 1
+      WHEN min_flow_sp > {{HIGH_MIN_FLOW_SP}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/vav_ahu_leave.sql
+++ b/sql_rules/vav_ahu_leave.sql
@@ -1,0 +1,46 @@
+-- vav_ahu_leave.sql — VAV leave vs parent AHU SAT (fedBy)
+WITH base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN vav_discharge_t IS NULL OR ahu_sat IS NULL THEN 0
+      WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}}
+       AND ABS(vav_discharge_t - ahu_sat) > {{DELTA_F}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM history
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/vav_reheat.sql
+++ b/sql_rules/vav_reheat.sql
@@ -1,0 +1,55 @@
+-- vav_reheat.sql — Reheat valve stuck / no temp rise
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    vav_discharge_t, vav_inlet_t, zone_flow,
+    CASE WHEN reheat_valve_pct IS NULL THEN NULL WHEN reheat_valve_pct > 1.0 THEN reheat_valve_pct / 100.0 ELSE reheat_valve_pct END AS rh
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN rh IS NULL OR vav_discharge_t IS NULL OR vav_inlet_t IS NULL THEN 0
+      WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}}
+       AND rh > {{REHEAT_CMD}}
+       AND (vav_discharge_t - vav_inlet_t) < {{MIN_RISE}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/vlv1_clg_valve_leak.sql
+++ b/sql_rules/vlv1_clg_valve_leak.sql
@@ -1,0 +1,56 @@
+-- vlv1_clg_valve_leak.sql — Cooling valve leakage
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    sat, sat_sp, mat,
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN clg IS NULL OR sat IS NULL THEN 0
+      WHEN clg <= 0.05 AND (
+        (sat_sp IS NOT NULL AND sat < sat_sp - {{SAT_ERR}})
+        OR (mat IS NOT NULL AND sat < mat - {{MAT_LEAK_DELTA}})
+      ) THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;

--- a/sql_rules/wx1_oa_spike.sql
+++ b/sql_rules/wx1_oa_spike.sql
@@ -1,0 +1,53 @@
+-- wx1_oa_spike.sql — OA temperature spike
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    oa_t,
+    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t
+  FROM history
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN oa_t IS NULL OR prev_oa_t IS NULL THEN 0
+      WHEN ABS(oa_t - prev_oa_t) > {{SPIKE_LIMIT}} THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM h
+),
+lagged AS (
+  SELECT
+    *,
+    CASE
+      WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
+      THEN 0 ELSE 1
+    END AS is_new_streak
+  FROM base
+),
+grp AS (
+  SELECT
+    *,
+    SUM(is_new_streak)
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc ROWS UNBOUNDED PRECEDING) AS streak_id
+  FROM lagged
+),
+ranked AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY equipment_id, streak_id ORDER BY timestamp_utc) AS streak_len
+  FROM grp
+),
+final AS (
+  SELECT
+    equipment_id,
+    CASE WHEN raw_fault = 1 AND streak_len >= {{CONFIRM_ROWS}} THEN 1 ELSE 0 END AS confirmed
+  FROM ranked
+)
+SELECT
+  equipment_id,
+  SUM(confirmed) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
+FROM final
+GROUP BY equipment_id;


### PR DESCRIPTION
## Summary
- Port remaining cookbook DataFusion SQL rules into `sql_rules/` + `registry.yaml` (63 total; vibe19 target ≥59).
- SV-RATE / PID-HUNT-1 ship as documented simplified screening variants.
- Extend cookbook fixtures/oracles (FC2, VAV-1, SCHED-247) and enforce `>=59` rules in `fdd-engine-ci`.

Closes #482.

## Test plan
- [x] Local registry validate: 63 rules, no missing SQL files
- [x] `python3 scripts/cookbook_parity_check.py --all` (docs integrity)
- [ ] `fdd-engine-ci` green (fixture ingest + run-rules)
- [ ] CodeRabbit triage
- [ ] Squash-merge after green

Depends on #505 (merged).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a broad catalog of HVAC fault and advisory detections covering sensors, AHUs, VAVs, chilled/condenser water, economizers, valves, scheduling, and outdoor-air conditions.
  * Faults now support configurable thresholds, persistence confirmation, and equipment-level fault-hour reporting.
* **Tests**
  * Added representative fixtures and parity checks for additional VAV, fan-coil, and scheduling scenarios.
* **Chores**
  * Strengthened validation to require the expected minimum catalog rule count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->