### PR TITLE
feat(ui): vibe19 lab shell + Plotly chart parity (#481)

### DIFF
--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -13,6 +13,7 @@ import HostStatsPage from "./pages/HostStatsPage";
 import LoginPage from "./pages/LoginPage";
 import PlotPage from "./pages/PlotPage";
 import SqlFddRulesPage from "./pages/SqlFddRulesPage";
+import Vibe19LabPage from "./pages/Vibe19LabPage";
 import LiveFddValidationPage from "./pages/LiveFddValidationPage";
 import DataManagementPage from "./pages/DataManagementPage";
 import ReportBuilderPage from "./pages/ReportBuilderPage";
@@ -31,10 +32,11 @@ export default function App() {
           <Route index element={<HomePage />} />
           <Route path="faults" element={<Navigate to="/" replace />} />
           <Route element={<RequireAuth />}>
+            <Route path="lab" element={<TabErrorBoundary tab="lab"><Vibe19LabPage /></TabErrorBoundary>} />
             <Route path="live-fdd-validation" element={<TabErrorBoundary tab="live-fdd-validation"><LiveFddValidationPage /></TabErrorBoundary>} />
             <Route path="bench-5007" element={<Navigate to="/live-fdd-validation" replace />} />
             <Route path="sql-fdd" element={<TabErrorBoundary tab="sql-fdd"><SqlFddRulesPage /></TabErrorBoundary>} />
-            <Route path="rule-lab" element={<Navigate to="/sql-fdd" replace />} />
+            <Route path="rule-lab" element={<Navigate to="/lab" replace />} />
             <Route path="model" element={<TabErrorBoundary tab="model"><DataModelPage /></TabErrorBoundary>} />
             <Route path="algorithms" element={<TabErrorBoundary tab="algorithms"><AlgorithmsPage /></TabErrorBoundary>} />
             <Route path="data-model" element={<Navigate to="/model" replace />} />
@@ -55,7 +57,7 @@ export default function App() {
             <Route path="reports" element={<TabErrorBoundary tab="reports"><ReportBuilderPage /></TabErrorBoundary>} />
             <Route path="agent" element={<TabErrorBoundary tab="agent"><AgentPage /></TabErrorBoundary>} />
             <Route path="host" element={<TabErrorBoundary tab="host"><HostStatsPage /></TabErrorBoundary>} />
-            <Route path="fdd" element={<Navigate to="/sql-fdd" replace />} />
+            <Route path="fdd" element={<Navigate to="/lab" replace />} />
             <Route path="fdd-wires" element={<Navigate to="/model" replace />} />
             <Route path="rules" element={<Navigate to="/model" replace />} />
           </Route>

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -34,8 +34,9 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   {
     title: "Model & rules",
     items: [
+      { to: "/lab", icon: "🧪", label: "Open-FDD Lab (vibe19)", protected: true },
       { to: "/model", icon: "📐", label: "Model & FDD assignments", protected: true },
-      { to: "/sql-fdd", icon: "⚡", label: "SQL FDD Rules", protected: true },
+      { to: "/sql-fdd", icon: "⚡", label: "SQL FDD lab (integrator)", protected: true },
       { to: "/plot", icon: "📈", label: "Plots", protected: true },
       { to: "/reports", icon: "📄", label: "Reports", protected: true },
     ],

--- a/workspace/dashboard/src/pages/Vibe19LabPage.tsx
+++ b/workspace/dashboard/src/pages/Vibe19LabPage.tsx
@@ -1,11 +1,22 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { apiFetch } from "../lib/api";
-import { barChart, plotlyConfig, ruleResultChart, vavComfortDonut } from "../vibe19/charts";
+import {
+  barChart,
+  basVsWebOatOverlay,
+  meteringBarScatter,
+  multiEquipmentBox,
+  oatScatter,
+  plotlyConfig,
+  ruleResultChart,
+  vavComfortDonut,
+} from "../vibe19/charts";
 import {
   type RegistryRule,
+  type RcxPresetMeta,
   type RuleParamDef,
   type Vibe19Section,
+  RCX_PRESETS,
   VIBE19_SECTIONS,
 } from "../vibe19/contract";
 import { PlotHost } from "../vibe19/PlotHost";
@@ -79,6 +90,7 @@ function OverviewSection({ cache, rules }: { cache?: CacheStatus; rules?: Regist
       <div className="vibe19-card wide">
         <PlotHost data={bars.data} layout={bars.layout} config={plotlyConfig()} height={280} />
       </div>
+      <OverviewExtras />
     </div>
   );
 }
@@ -276,9 +288,15 @@ function ResultsSection({ rules }: { rules?: RegistryRule[] }) {
   );
 }
 
-function FddPlotsSection() {
+function FddPlotsSection({ rules }: { rules?: RegistryRule[] }) {
+  const [focus, setFocus] = useState<string>("");
+  const wired = useMemo(
+    () => (rules ?? []).filter((r) => r.dashboard_wired).slice(0, 12),
+    [rules],
+  );
+  const active = focus || wired[0]?.rule_id || "DEMO";
   const demo = ruleResultChart({
-    title: "Example rule card chart (SAT + confirmed fault)",
+    title: `${active} — rule card (demo series)`,
     series: [
       {
         name: "sat",
@@ -291,13 +309,188 @@ function FddPlotsSection() {
     confirmed: Array.from({ length: 48 }, (_, i) => ({ t: i, fault: i > 30 && i < 40 })),
   });
   return (
-    <div className="vibe19-card">
-      <h3>FDD Plots</h3>
-      <p className="muted">
-        Rule cards use <code>rule_result_chart</code> — multi-y traces with a confirmed-fault swim
-        lane. Live series wire to registry run outputs next.
-      </p>
-      <PlotHost data={demo.data} layout={demo.layout} config={plotlyConfig()} height={360} />
+    <div className="vibe19-run">
+      <aside className="vibe19-sidebar">
+        <h3>Rule cards</h3>
+        <p className="muted">Auto-list applicable (dashboard_wired) rules.</p>
+        <ul>
+          {wired.map((r) => (
+            <li key={r.rule_id}>
+              <button type="button" className={r.rule_id === active ? "active" : ""} onClick={() => setFocus(r.rule_id)}>
+                {r.rule_id}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <div className="vibe19-card grow">
+        <h3>FDD Plots — {active}</h3>
+        <p className="muted">
+          Cards use <code>rule_result_chart</code> (multi-y + confirmed-fault swim lane). Display
+          downsample ≤5k points; rule math stays full-resolution.
+        </p>
+        <PlotHost data={demo.data} layout={demo.layout} config={plotlyConfig()} height={360} />
+      </div>
+    </div>
+  );
+}
+
+function demoSeries(seed: number) {
+  return Array.from({ length: 60 }, (_, i) => ({
+    t: i,
+    y: 50 + seed * 3 + Math.sin((i + seed) / 6) * 4,
+  }));
+}
+
+function RcxPlotsSection() {
+  const [presetId, setPresetId] = useState(RCX_PRESETS[0].id);
+  const preset = RCX_PRESETS.find((p) => p.id === presetId) ?? RCX_PRESETS[0];
+  const fig = useMemo(() => buildRcxDemo(preset), [preset]);
+  const families = useMemo(() => {
+    const m = new Map<string, RcxPresetMeta[]>();
+    for (const p of RCX_PRESETS) {
+      const arr = m.get(p.family) ?? [];
+      arr.push(p);
+      m.set(p.family, arr);
+    }
+    return [...m.entries()];
+  }, []);
+  return (
+    <div className="vibe19-run">
+      <aside className="vibe19-sidebar">
+        <h3>RCx presets</h3>
+        <p className="muted">
+          Weather: dry-bulb for SAT/HW/CHW resets; wet-bulb for CW/tower.
+        </p>
+        {families.map(([fam, list]) => (
+          <details key={fam} open>
+            <summary>
+              {fam} ({list.length})
+            </summary>
+            <ul>
+              {list.map((p) => (
+                <li key={p.id}>
+                  <button
+                    type="button"
+                    className={p.id === presetId ? "active" : ""}
+                    onClick={() => setPresetId(p.id)}
+                  >
+                    {p.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </details>
+        ))}
+      </aside>
+      <div className="vibe19-card grow">
+        <h3>
+          {preset.label}{" "}
+          <span className="muted">
+            ({preset.weatherAxis === "none" ? "no weather axis" : preset.weatherAxis})
+          </span>
+        </h3>
+        <PlotHost data={fig.data} layout={fig.layout} config={plotlyConfig()} height={380} />
+      </div>
+    </div>
+  );
+}
+
+function buildRcxDemo(preset: RcxPresetMeta) {
+  if (preset.chart === "donut") {
+    return vavComfortDonut({ title: preset.label, inComfort: 72, outComfort: 28 });
+  }
+  if (preset.chart === "box") {
+    return multiEquipmentBox({
+      title: preset.label,
+      series: [
+        { name: "AHU-1", values: [1.1, 1.2, 1.15, 1.3, 0.9] },
+        { name: "AHU-2", values: [0.8, 0.85, 0.9, 1.0, 0.75] },
+      ],
+    });
+  }
+  if (preset.chart === "scatter") {
+    const axis =
+      preset.weatherAxis === "wet_bulb" ? "Web wet-bulb °F" : "Web dry-bulb °F";
+    return oatScatter({
+      title: preset.label,
+      x: Array.from({ length: 80 }, (_, i) => 40 + (i % 40)),
+      y: Array.from({ length: 80 }, (_, i) => 55 + Math.sin(i / 7) * 8),
+      xTitle: axis,
+      yTitle: "Leave / SAT °F",
+    });
+  }
+  if (preset.chart === "metering") {
+    return meteringBarScatter({
+      title: preset.label,
+      months: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+      usage: [120, 110, 95, 80, 70, 90],
+      degreeDays: [900, 750, 500, 200, 50, 100],
+      usageName: preset.id.includes("gas") ? "gas" : "kWh",
+      ddName: preset.id.includes("gas") ? "HDD" : "CDD",
+    });
+  }
+  const s1 = demoSeries(1);
+  const s2 = demoSeries(2);
+  return {
+    data: [
+      {
+        type: "scatter",
+        mode: "lines",
+        name: "eq-1",
+        x: s1.map((p) => p.t),
+        y: s1.map((p) => p.y),
+      },
+      {
+        type: "scatter",
+        mode: "lines",
+        name: "eq-2",
+        x: s2.map((p) => p.t),
+        y: s2.map((p) => p.y),
+      },
+    ],
+    layout: { title: { text: preset.label }, margin: { t: 48, r: 24, b: 40, l: 48 } },
+  };
+}
+
+function MeteringSection() {
+  const elec = meteringBarScatter({
+    title: "Electric kWh vs CDD",
+    months: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    usage: [140, 120, 100, 85, 95, 110],
+    degreeDays: [50, 80, 200, 350, 450, 500],
+    usageName: "kWh",
+    ddName: "CDD",
+  });
+  const gas = meteringBarScatter({
+    title: "Gas vs HDD",
+    months: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    usage: [300, 260, 180, 90, 40, 20],
+    degreeDays: [900, 750, 500, 200, 50, 10],
+    usageName: "therms",
+    ddName: "HDD",
+  });
+  return (
+    <div className="vibe19-grid">
+      <div className="vibe19-card wide">
+        <PlotHost data={elec.data} layout={elec.layout} config={plotlyConfig()} height={320} />
+      </div>
+      <div className="vibe19-card wide">
+        <PlotHost data={gas.data} layout={gas.layout} config={plotlyConfig()} height={320} />
+      </div>
+    </div>
+  );
+}
+
+function OverviewExtras() {
+  const overlay = basVsWebOatOverlay({
+    title: "BAS vs web OAT",
+    bas: demoSeries(0).map((p) => ({ ...p, y: (p.y ?? 0) + 20 })),
+    web: demoSeries(1).map((p) => ({ ...p, y: (p.y ?? 0) + 18 })),
+  });
+  return (
+    <div className="vibe19-card wide">
+      <PlotHost data={overlay.data} layout={overlay.layout} config={plotlyConfig()} height={280} />
     </div>
   );
 }
@@ -357,16 +550,9 @@ export default function Vibe19LabPage() {
         {section === "Results by Category" ? (
           <ResultsSection rules={rulesQ.data?.rules} />
         ) : null}
-        {section === "FDD Plots" ? <FddPlotsSection /> : null}
-        {section === "RCx Plots" ? (
-          <Placeholder
-            title="RCx Plots"
-            blurb="Frozen RCx presets (zone comfort, AHU resets, OA scatters) — chart builders landed; preset picker next."
-          />
-        ) : null}
-        {section === "Metering" ? (
-          <Placeholder title="Metering" blurb="Electric/gas monthly + degree-day charts." />
-        ) : null}
+        {section === "FDD Plots" ? <FddPlotsSection rules={rulesQ.data?.rules} /> : null}
+        {section === "RCx Plots" ? <RcxPlotsSection /> : null}
+        {section === "Metering" ? <MeteringSection /> : null}
         {section === "Export" ? (
           <Placeholder title="Export" blurb="CSV / session / health / data-model exports." />
         ) : null}

--- a/workspace/dashboard/src/pages/Vibe19LabPage.tsx
+++ b/workspace/dashboard/src/pages/Vibe19LabPage.tsx
@@ -1,0 +1,376 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { apiFetch } from "../lib/api";
+import { barChart, plotlyConfig, ruleResultChart, vavComfortDonut } from "../vibe19/charts";
+import {
+  type RegistryRule,
+  type RuleParamDef,
+  type Vibe19Section,
+  VIBE19_SECTIONS,
+} from "../vibe19/contract";
+import { PlotHost } from "../vibe19/PlotHost";
+import "./vibe19.css";
+
+type RulesResponse = { ok: boolean; count: number; rules: RegistryRule[]; error?: string };
+type ParamsResponse = {
+  ok: boolean;
+  rule_id: string;
+  params: Record<string, RuleParamDef>;
+  error?: string;
+};
+type CacheStatus = {
+  ok: boolean;
+  parquet_exists: boolean;
+  parquet_file_count: number;
+  sql_rules_present: boolean;
+  rule_file_count?: number;
+  result_file_count?: number;
+};
+
+async function fetchRules() {
+  return apiFetch<RulesResponse>("/api/fdd/rules");
+}
+async function fetchParams(ruleId: string) {
+  return apiFetch<ParamsResponse>(`/api/fdd/rules/${encodeURIComponent(ruleId)}/params`);
+}
+async function fetchCache() {
+  return apiFetch<CacheStatus>("/api/fdd/cache/status");
+}
+async function runRegistry(body: Record<string, unknown>) {
+  return apiFetch<Record<string, unknown>>("/api/fdd/run", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function OverviewSection({ cache, rules }: { cache?: CacheStatus; rules?: RegistryRule[] }) {
+  const donut = vavComfortDonut({ title: "Zone comfort (demo)", inComfort: 82, outComfort: 18 });
+  const bars = barChart({
+    title: "Rules by wiring status",
+    labels: ["wired", "not wired"],
+    values: [
+      rules?.filter((r) => r.dashboard_wired).length ?? 0,
+      rules?.filter((r) => !r.dashboard_wired).length ?? 0,
+    ],
+  });
+  return (
+    <div className="vibe19-grid">
+      <div className="vibe19-metric">
+        <div className="label">Registry rules</div>
+        <div className="value">{rules?.length ?? "—"}</div>
+      </div>
+      <div className="vibe19-metric">
+        <div className="label">SQL rules present</div>
+        <div className="value">{cache?.sql_rules_present ? "yes" : "no"}</div>
+      </div>
+      <div className="vibe19-metric">
+        <div className="label">Parquet cache</div>
+        <div className="value">
+          {cache?.parquet_exists ? `${cache.parquet_file_count} files` : "missing"}
+        </div>
+      </div>
+      <div className="vibe19-metric">
+        <div className="label">Result files</div>
+        <div className="value">{cache?.result_file_count ?? 0}</div>
+      </div>
+      <div className="vibe19-card wide">
+        <PlotHost data={donut.data} layout={donut.layout} config={plotlyConfig()} height={280} />
+      </div>
+      <div className="vibe19-card wide">
+        <PlotHost data={bars.data} layout={bars.layout} config={plotlyConfig()} height={280} />
+      </div>
+    </div>
+  );
+}
+
+function DataModelSection({ rules }: { rules?: RegistryRule[] }) {
+  const roles = useMemo(() => {
+    const s = new Set<string>();
+    for (const r of rules ?? []) for (const role of r.required_roles ?? []) s.add(role);
+    return [...s].sort();
+  }, [rules]);
+  return (
+    <div className="vibe19-card">
+      <h3>Role catalog (from registry required_roles)</h3>
+      <p className="muted">
+        Equipment → cookbook role → column mapping is data-model driven. Roles referenced by loaded
+        rules:
+      </p>
+      <ul className="vibe19-role-list">
+        {roles.map((r) => (
+          <li key={r}>
+            <code>{r}</code>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RunRulesSection({ rules }: { rules?: RegistryRule[] }) {
+  const qc = useQueryClient();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [activeRule, setActiveRule] = useState<string>("");
+  const [paramOverrides, setParamOverrides] = useState<Record<string, Record<string, number>>>({});
+
+  const paramsQ = useQuery({
+    queryKey: ["fdd-params", activeRule],
+    queryFn: () => fetchParams(activeRule),
+    enabled: Boolean(activeRule),
+  });
+
+  const runMut = useMutation({
+    mutationFn: () =>
+      runRegistry({
+        mode: "registry",
+        rule_ids: selected.length ? selected : undefined,
+        params: paramOverrides,
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["fdd-cache"] });
+    },
+  });
+
+  const families = useMemo(() => {
+    const m = new Map<string, RegistryRule[]>();
+    for (const r of rules ?? []) {
+      const fam = r.rule_id.split("-")[0] || "OTHER";
+      const arr = m.get(fam) ?? [];
+      arr.push(r);
+      m.set(fam, arr);
+    }
+    return [...m.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [rules]);
+
+  return (
+    <div className="vibe19-run">
+      <aside className="vibe19-sidebar">
+        <h3>Rule families</h3>
+        {families.map(([fam, list]) => (
+          <details key={fam} open={fam === "FC" || fam === "VAV" || fam === "SV"}>
+            <summary>
+              {fam} ({list.length})
+            </summary>
+            <ul>
+              {list.map((r) => (
+                <li key={r.rule_id}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(r.rule_id)}
+                      onChange={(e) => {
+                        setSelected((prev) =>
+                          e.target.checked
+                            ? [...prev, r.rule_id]
+                            : prev.filter((id) => id !== r.rule_id),
+                        );
+                        setActiveRule(r.rule_id);
+                      }}
+                    />{" "}
+                    {r.rule_id}
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </details>
+        ))}
+        <button
+          type="button"
+          className="primary-btn"
+          disabled={runMut.isPending}
+          onClick={() => runMut.mutate()}
+        >
+          {runMut.isPending ? "Running…" : "Run selected (registry)"}
+        </button>
+        {runMut.isError ? (
+          <p className="error">{(runMut.error as Error).message}</p>
+        ) : null}
+        {runMut.data ? (
+          <pre className="vibe19-pre">{JSON.stringify(runMut.data, null, 2)}</pre>
+        ) : null}
+      </aside>
+      <div className="vibe19-card grow">
+        <h3>Sliders — {activeRule || "select a rule"}</h3>
+        {!activeRule ? (
+          <p className="muted">Select a rule to tune confirm_min and thresholds (no raw SQL).</p>
+        ) : paramsQ.isLoading ? (
+          <p className="muted">Loading params…</p>
+        ) : (
+          <div className="vibe19-sliders">
+            {Object.values(paramsQ.data?.params ?? {}).map((p) => {
+              const val =
+                paramOverrides[activeRule]?.[p.key] ??
+                paramOverrides[activeRule]?.[p.sql_placeholder] ??
+                p.default;
+              return (
+                <label key={p.key} className="vibe19-slider">
+                  <span>
+                    {p.label} ({p.unit}) — <strong>{val}</strong>
+                  </span>
+                  <input
+                    type="range"
+                    min={p.min}
+                    max={p.max}
+                    step={p.step}
+                    value={val}
+                    onChange={(e) => {
+                      const n = Number(e.target.value);
+                      setParamOverrides((prev) => ({
+                        ...prev,
+                        [activeRule]: { ...(prev[activeRule] ?? {}), [p.key]: n },
+                      }));
+                    }}
+                  />
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ResultsSection({ rules }: { rules?: RegistryRule[] }) {
+  const byStatus = useMemo(() => {
+    const m = new Map<string, RegistryRule[]>();
+    for (const r of rules ?? []) {
+      const k = r.parity_status || "unknown";
+      const arr = m.get(k) ?? [];
+      arr.push(r);
+      m.set(k, arr);
+    }
+    return [...m.entries()];
+  }, [rules]);
+  return (
+    <div className="vibe19-card">
+      <h3>Results by category (registry metadata)</h3>
+      <p className="muted">
+        After a registry run, fault hours land in <code>.cache/rule_results</code>. Below is the
+        catalog grouped by parity status until live results are loaded.
+      </p>
+      {byStatus.map(([status, list]) => (
+        <div key={status}>
+          <h4>{status}</h4>
+          <table className="vibe19-table">
+            <thead>
+              <tr>
+                <th>Rule</th>
+                <th>Confirm (s)</th>
+                <th>Roles</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map((r) => (
+                <tr key={r.rule_id}>
+                  <td>{r.rule_id}</td>
+                  <td>{r.confirm_seconds}</td>
+                  <td>{(r.required_roles ?? []).join(", ")}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FddPlotsSection() {
+  const demo = ruleResultChart({
+    title: "Example rule card chart (SAT + confirmed fault)",
+    series: [
+      {
+        name: "sat",
+        points: Array.from({ length: 48 }, (_, i) => ({
+          t: i,
+          y: 55 + Math.sin(i / 5) * 3,
+        })),
+      },
+    ],
+    confirmed: Array.from({ length: 48 }, (_, i) => ({ t: i, fault: i > 30 && i < 40 })),
+  });
+  return (
+    <div className="vibe19-card">
+      <h3>FDD Plots</h3>
+      <p className="muted">
+        Rule cards use <code>rule_result_chart</code> — multi-y traces with a confirmed-fault swim
+        lane. Live series wire to registry run outputs next.
+      </p>
+      <PlotHost data={demo.data} layout={demo.layout} config={plotlyConfig()} height={360} />
+    </div>
+  );
+}
+
+function Placeholder({ title, blurb }: { title: string; blurb: string }) {
+  return (
+    <div className="vibe19-card">
+      <h3>{title}</h3>
+      <p className="muted">{blurb}</p>
+    </div>
+  );
+}
+
+export default function Vibe19LabPage() {
+  const [section, setSection] = useState<Vibe19Section>("Overview");
+  const rulesQ = useQuery({ queryKey: ["fdd-rules"], queryFn: fetchRules });
+  const cacheQ = useQuery({ queryKey: ["fdd-cache"], queryFn: fetchCache });
+
+  return (
+    <div className="vibe19-shell">
+      <header className="vibe19-hero">
+        <div>
+          <h1>Open-FDD Lab</h1>
+          <p className="muted">
+            vibe19 look &amp; feel — data-model driven, registry sliders, Plotly charts (no Streamlit
+            reruns).
+          </p>
+        </div>
+        <div className="vibe19-hero-meta">
+          {rulesQ.data?.ok ? (
+            <span>{rulesQ.data.count} rules</span>
+          ) : (
+            <span className="error">{rulesQ.data?.error ?? (rulesQ.isError ? "API error" : "…")}</span>
+          )}
+        </div>
+      </header>
+
+      <nav className="vibe19-nav" aria-label="Lab sections">
+        {VIBE19_SECTIONS.map((s) => (
+          <button
+            key={s}
+            type="button"
+            className={s === section ? "active" : ""}
+            onClick={() => setSection(s)}
+          >
+            {s}
+          </button>
+        ))}
+      </nav>
+
+      <main className="vibe19-main">
+        {section === "Overview" ? (
+          <OverviewSection cache={cacheQ.data} rules={rulesQ.data?.rules} />
+        ) : null}
+        {section === "Data Model" ? <DataModelSection rules={rulesQ.data?.rules} /> : null}
+        {section === "Run Rules" ? <RunRulesSection rules={rulesQ.data?.rules} /> : null}
+        {section === "Results by Category" ? (
+          <ResultsSection rules={rulesQ.data?.rules} />
+        ) : null}
+        {section === "FDD Plots" ? <FddPlotsSection /> : null}
+        {section === "RCx Plots" ? (
+          <Placeholder
+            title="RCx Plots"
+            blurb="Frozen RCx presets (zone comfort, AHU resets, OA scatters) — chart builders landed; preset picker next."
+          />
+        ) : null}
+        {section === "Metering" ? (
+          <Placeholder title="Metering" blurb="Electric/gas monthly + degree-day charts." />
+        ) : null}
+        {section === "Export" ? (
+          <Placeholder title="Export" blurb="CSV / session / health / data-model exports." />
+        ) : null}
+      </main>
+    </div>
+  );
+}

--- a/workspace/dashboard/src/pages/vibe19.css
+++ b/workspace/dashboard/src/pages/vibe19.css
@@ -90,6 +90,22 @@
   margin: 0.35rem 0 0.75rem;
 }
 
+.vibe19-sidebar button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  padding: 0.15rem 0.25rem;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.vibe19-sidebar button.active {
+  background: #1f6feb33;
+  font-weight: 600;
+}
+
 .vibe19-sidebar details summary {
   cursor: pointer;
   font-weight: 600;

--- a/workspace/dashboard/src/pages/vibe19.css
+++ b/workspace/dashboard/src/pages/vibe19.css
@@ -1,0 +1,149 @@
+.vibe19-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.5rem 0 2rem;
+}
+
+.vibe19-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.vibe19-hero h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.6rem;
+}
+
+.vibe19-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  border-bottom: 1px solid var(--border, #2a3344);
+  padding-bottom: 0.5rem;
+}
+
+.vibe19-nav button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.vibe19-nav button.active {
+  background: #1f6feb33;
+  border-color: #1f6feb;
+}
+
+.vibe19-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.vibe19-metric,
+.vibe19-card {
+  background: var(--panel, #121821);
+  border: 1px solid var(--border, #2a3344);
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+}
+
+.vibe19-metric .label {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.vibe19-metric .value {
+  font-size: 1.4rem;
+  font-weight: 650;
+  margin-top: 0.25rem;
+}
+
+.vibe19-card.wide {
+  grid-column: 1 / -1;
+}
+
+.vibe19-run {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 0.75rem;
+}
+
+.vibe19-sidebar {
+  background: var(--panel, #121821);
+  border: 1px solid var(--border, #2a3344);
+  border-radius: 10px;
+  padding: 0.75rem;
+  max-height: 70vh;
+  overflow: auto;
+}
+
+.vibe19-sidebar ul {
+  list-style: none;
+  padding-left: 0.5rem;
+  margin: 0.35rem 0 0.75rem;
+}
+
+.vibe19-sidebar details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.vibe19-sliders {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.vibe19-slider {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.vibe19-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.vibe19-table th,
+.vibe19-table td {
+  border-bottom: 1px solid var(--border, #2a3344);
+  text-align: left;
+  padding: 0.35rem 0.4rem;
+}
+
+.vibe19-pre {
+  font-size: 0.75rem;
+  max-height: 240px;
+  overflow: auto;
+  background: #0b1018;
+  padding: 0.5rem;
+  border-radius: 6px;
+}
+
+.vibe19-role-list {
+  columns: 2;
+  gap: 1rem;
+}
+
+.vibe19-card.grow {
+  min-height: 320px;
+}
+
+@media (max-width: 900px) {
+  .vibe19-run {
+    grid-template-columns: 1fr;
+  }
+  .vibe19-role-list {
+    columns: 1;
+  }
+}

--- a/workspace/dashboard/src/vibe19/PlotHost.tsx
+++ b/workspace/dashboard/src/vibe19/PlotHost.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+import Plotly from "plotly.js-dist-min";
+
+export function PlotHost({
+  data,
+  layout,
+  config,
+  height = 320,
+}: {
+  data: object[];
+  layout: object;
+  config?: object;
+  height?: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    void (Plotly as any).react(el, data, { ...layout, autosize: true, height }, {
+      displaylogo: false,
+      responsive: true,
+      ...config,
+    });
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      void (Plotly as any).purge(el);
+    };
+  }, [data, layout, config, height]);
+
+  return <div ref={ref} style={{ width: "100%", minHeight: height }} />;
+}

--- a/workspace/dashboard/src/vibe19/charts.test.ts
+++ b/workspace/dashboard/src/vibe19/charts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { downsample, ruleResultChart, vavComfortDonut } from "./charts";
+import { REQUIRED_CHART_APIS, VIBE19_SECTIONS } from "./contract";
+
+describe("vibe19 contract", () => {
+  it("keeps frozen main sections", () => {
+    expect(VIBE19_SECTIONS).toContain("Overview");
+    expect(VIBE19_SECTIONS).toContain("Run Rules");
+    expect(VIBE19_SECTIONS).toContain("FDD Plots");
+  });
+
+  it("lists required chart APIs", () => {
+    expect(REQUIRED_CHART_APIS).toContain("rule_result_chart");
+    expect(REQUIRED_CHART_APIS.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe("vibe19 charts", () => {
+  it("downsamples for display only", () => {
+    const xs = Array.from({ length: 10000 }, (_, i) => i);
+    expect(downsample(xs, 5000).length).toBeLessThanOrEqual(5000);
+  });
+
+  it("builds rule_result_chart with fault lane", () => {
+    const fig = ruleResultChart({
+      title: "t",
+      series: [{ name: "sat", points: [{ t: 0, y: 55 }, { t: 1, y: 56 }] }],
+      confirmed: [
+        { t: 0, fault: false },
+        { t: 1, fault: true },
+      ],
+    });
+    expect(fig.data.length).toBe(2);
+    expect(fig.data[1].name).toBe("confirmed_fault");
+  });
+
+  it("builds comfort donut", () => {
+    const fig = vavComfortDonut({ title: "c", inComfort: 9, outComfort: 1 });
+    expect(fig.data[0].type).toBe("pie");
+  });
+});

--- a/workspace/dashboard/src/vibe19/charts.test.ts
+++ b/workspace/dashboard/src/vibe19/charts.test.ts
@@ -1,17 +1,47 @@
 import { describe, expect, it } from "vitest";
-import { downsample, ruleResultChart, vavComfortDonut } from "./charts";
-import { REQUIRED_CHART_APIS, VIBE19_SECTIONS } from "./contract";
+import {
+  basVsWebOatOverlay,
+  downsample,
+  meteringBarScatter,
+  motorWeeklyRuntimeChart,
+  multiEquipmentBox,
+  oatScatter,
+  ruleResultChart,
+  sensorFaultChart,
+  vavComfortDonut,
+} from "./charts";
+import {
+  RCX_PRESETS,
+  REQUIRED_CHART_APIS,
+  REQUIRED_RCX_PRESET_IDS,
+  VIBE19_SECTIONS,
+} from "./contract";
 
 describe("vibe19 contract", () => {
   it("keeps frozen main sections", () => {
     expect(VIBE19_SECTIONS).toContain("Overview");
     expect(VIBE19_SECTIONS).toContain("Run Rules");
     expect(VIBE19_SECTIONS).toContain("FDD Plots");
+    expect(VIBE19_SECTIONS).toContain("RCx Plots");
   });
 
   it("lists required chart APIs", () => {
     expect(REQUIRED_CHART_APIS).toContain("rule_result_chart");
+    expect(REQUIRED_CHART_APIS).toContain("multi_equipment_box");
+    expect(REQUIRED_CHART_APIS).toContain("sensor_fault_chart");
     expect(REQUIRED_CHART_APIS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("freezes RCx presets with weather policy", () => {
+    expect(REQUIRED_RCX_PRESET_IDS.length).toBeGreaterThanOrEqual(12);
+    const ids = new Set(RCX_PRESETS.map((p) => p.id));
+    for (const id of REQUIRED_RCX_PRESET_IDS) {
+      expect(ids.has(id)).toBe(true);
+    }
+    const cw = RCX_PRESETS.find((p) => p.id === "cw_reset_scatter");
+    expect(cw?.weatherAxis).toBe("wet_bulb");
+    const hw = RCX_PRESETS.find((p) => p.id === "hw_reset_scatter");
+    expect(hw?.weatherAxis).toBe("dry_bulb");
   });
 });
 
@@ -24,7 +54,15 @@ describe("vibe19 charts", () => {
   it("builds rule_result_chart with fault lane", () => {
     const fig = ruleResultChart({
       title: "t",
-      series: [{ name: "sat", points: [{ t: 0, y: 55 }, { t: 1, y: 56 }] }],
+      series: [
+        {
+          name: "sat",
+          points: [
+            { t: 0, y: 55 },
+            { t: 1, y: 56 },
+          ],
+        },
+      ],
       confirmed: [
         { t: 0, fault: false },
         { t: 1, fault: true },
@@ -37,5 +75,38 @@ describe("vibe19 charts", () => {
   it("builds comfort donut", () => {
     const fig = vavComfortDonut({ title: "c", inComfort: 9, outComfort: 1 });
     expect(fig.data[0].type).toBe("pie");
+  });
+
+  it("builds box / scatter / runtime / overlay / sensor / metering", () => {
+    expect(multiEquipmentBox({ title: "b", series: [{ name: "a", values: [1, 2, 3] }] }).data[0].type).toBe(
+      "box",
+    );
+    expect(oatScatter({ title: "s", x: [1, 2], y: [3, 4] }).data[0].mode).toBe("markers");
+    expect(
+      motorWeeklyRuntimeChart({ title: "m", weeks: ["W1"], hours: [10] }).data[0].type,
+    ).toBe("bar");
+    expect(
+      basVsWebOatOverlay({
+        title: "o",
+        bas: [{ t: 0, y: 70 }],
+        web: [{ t: 0, y: 68 }],
+      }).data.length,
+    ).toBe(2);
+    expect(
+      sensorFaultChart({
+        title: "sf",
+        sensors: ["sat"],
+        days: ["d1"],
+        z: [[0.2]],
+      }).data[0].type,
+    ).toBe("heatmap");
+    expect(
+      meteringBarScatter({
+        title: "met",
+        months: ["Jan"],
+        usage: [100],
+        degreeDays: [200],
+      }).data.length,
+    ).toBe(2);
   });
 });

--- a/workspace/dashboard/src/vibe19/charts.ts
+++ b/workspace/dashboard/src/vibe19/charts.ts
@@ -56,7 +56,13 @@ export function ruleResultChart(opts: {
       title: { text: opts.title },
       margin: { t: 48, r: 48, b: 40, l: 48 },
       legend: { orientation: "h" },
-      yaxis2: { overlaying: "y", side: "right", range: [0, 1.2], showgrid: false, title: { text: "fault" } },
+      yaxis2: {
+        overlaying: "y",
+        side: "right",
+        range: [0, 1.2],
+        showgrid: false,
+        title: { text: "fault" },
+      },
     },
   };
 }
@@ -76,7 +82,30 @@ export function multiEquipmentTimeseries(opts: {
         y: pts.map((p) => p.y),
       };
     }),
-    layout: { title: { text: opts.title }, margin: { t: 48, r: 24, b: 40, l: 48 }, legend: { orientation: "h" } },
+    layout: {
+      title: { text: opts.title },
+      margin: { t: 48, r: 24, b: 40, l: 48 },
+      legend: { orientation: "h" },
+    },
+  };
+}
+
+export function multiEquipmentBox(opts: {
+  title: string;
+  series: { name: string; values: number[] }[];
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: opts.series.map((s) => ({
+      type: "box",
+      name: s.name,
+      y: downsample(s.values),
+      boxpoints: false,
+    })),
+    layout: {
+      title: { text: opts.title },
+      margin: { t: 48, r: 24, b: 40, l: 48 },
+      showlegend: false,
+    },
   };
 }
 
@@ -85,6 +114,8 @@ export function oatScatter(opts: {
   x: number[];
   y: number[];
   name?: string;
+  xTitle?: string;
+  yTitle?: string;
 }): { data: Data[]; layout: Partial<Layout> } {
   const n = Math.min(opts.x.length, opts.y.length);
   const idx = downsample([...Array(n).keys()]);
@@ -101,9 +132,149 @@ export function oatScatter(opts: {
     ],
     layout: {
       title: { text: opts.title },
-      xaxis: { title: { text: "OAT °F" } },
-      yaxis: { title: { text: "Value" } },
+      xaxis: { title: { text: opts.xTitle ?? "OAT °F" } },
+      yaxis: { title: { text: opts.yTitle ?? "Value" } },
       margin: { t: 48, r: 24, b: 48, l: 48 },
+    },
+  };
+}
+
+export function motorWeeklyRuntimeChart(opts: {
+  title: string;
+  weeks: string[];
+  hours: number[];
+  name?: string;
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: [
+      {
+        type: "bar",
+        name: opts.name ?? "runtime_h",
+        x: opts.weeks,
+        y: opts.hours,
+      },
+    ],
+    layout: {
+      title: { text: opts.title },
+      xaxis: { title: { text: "Week" } },
+      yaxis: { title: { text: "Hours" } },
+      margin: { t: 48, r: 24, b: 48, l: 48 },
+    },
+  };
+}
+
+function histogram(opts: {
+  title: string;
+  values: number[];
+  name?: string;
+  xTitle?: string;
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: [
+      {
+        type: "histogram",
+        name: opts.name ?? "samples",
+        x: downsample(opts.values),
+        nbinsx: 40,
+      },
+    ],
+    layout: {
+      title: { text: opts.title },
+      xaxis: { title: { text: opts.xTitle ?? "°F" } },
+      yaxis: { title: { text: "Count" } },
+      margin: { t: 48, r: 24, b: 48, l: 48 },
+      bargap: 0.05,
+    },
+  };
+}
+
+export function mechCoolingOatHistogram(opts: {
+  title: string;
+  oatValues: number[];
+}): { data: Data[]; layout: Partial<Layout> } {
+  return histogram({
+    title: opts.title,
+    values: opts.oatValues,
+    name: "mech_cooling_oat",
+    xTitle: "OAT °F (mechanical cooling)",
+  });
+}
+
+export function basVsWebOatHistogram(opts: {
+  title: string;
+  deltaValues: number[];
+}): { data: Data[]; layout: Partial<Layout> } {
+  return histogram({
+    title: opts.title,
+    values: opts.deltaValues,
+    name: "bas_minus_web",
+    xTitle: "BAS − web OAT °F",
+  });
+}
+
+export function basVsWebOatOverlay(opts: {
+  title: string;
+  bas: SeriesPoint[];
+  web: SeriesPoint[];
+}): { data: Data[]; layout: Partial<Layout> } {
+  const bas = downsample(opts.bas);
+  const web = downsample(opts.web);
+  return {
+    data: [
+      {
+        type: "scatter",
+        mode: "lines",
+        name: "BAS OAT",
+        x: bas.map((p) => p.t),
+        y: bas.map((p) => p.y),
+      },
+      {
+        type: "scatter",
+        mode: "lines",
+        name: "Web OAT",
+        x: web.map((p) => p.t),
+        y: web.map((p) => p.y),
+      },
+    ],
+    layout: {
+      title: { text: opts.title },
+      yaxis: { title: { text: "°F" } },
+      margin: { t: 48, r: 24, b: 40, l: 48 },
+      legend: { orientation: "h" },
+    },
+  };
+}
+
+/** Stacked/overlaid lines for equipment inspection. */
+export function equipmentInspectionChart(opts: {
+  title: string;
+  series: { name: string; points: SeriesPoint[] }[];
+}): { data: Data[]; layout: Partial<Layout> } {
+  return multiEquipmentTimeseries(opts);
+}
+
+/** Sensor-health matrix — rows = sensors, columns = days, z = fault fraction. */
+export function sensorFaultChart(opts: {
+  title: string;
+  sensors: string[];
+  days: string[];
+  z: number[][];
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: [
+      {
+        type: "heatmap",
+        z: opts.z,
+        x: opts.days,
+        y: opts.sensors,
+        colorscale: "YlOrRd",
+        zmin: 0,
+        zmax: 1,
+      },
+    ],
+    layout: {
+      title: { text: opts.title },
+      margin: { t: 48, r: 24, b: 48, l: 96 },
     },
   };
 }
@@ -135,5 +306,41 @@ export function barChart(opts: {
   return {
     data: [{ type: "bar", name: opts.name ?? "value", x: opts.labels, y: opts.values }],
     layout: { title: { text: opts.title }, margin: { t: 48, r: 24, b: 48, l: 48 } },
+  };
+}
+
+/** Metering: monthly bars + degree-day scatter companion. */
+export function meteringBarScatter(opts: {
+  title: string;
+  months: string[];
+  usage: number[];
+  degreeDays: number[];
+  usageName?: string;
+  ddName?: string;
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: [
+      {
+        type: "bar",
+        name: opts.usageName ?? "usage",
+        x: opts.months,
+        y: opts.usage,
+        yaxis: "y",
+      },
+      {
+        type: "scatter",
+        mode: "markers+lines",
+        name: opts.ddName ?? "degree_days",
+        x: opts.months,
+        y: opts.degreeDays,
+        yaxis: "y2",
+      },
+    ],
+    layout: {
+      title: { text: opts.title },
+      margin: { t: 48, r: 48, b: 48, l: 48 },
+      legend: { orientation: "h" },
+      yaxis2: { overlaying: "y", side: "right", title: { text: "DD" } },
+    },
   };
 }

--- a/workspace/dashboard/src/vibe19/charts.ts
+++ b/workspace/dashboard/src/vibe19/charts.ts
@@ -1,0 +1,139 @@
+import { MAX_PLOT_POINTS } from "./contract";
+
+// plotly.js-dist-min does not export TS Data/Layout types reliably — keep loose.
+type Data = Record<string, unknown>;
+type Layout = Record<string, unknown>;
+type Config = Record<string, unknown>;
+
+export function plotlyConfig(): Partial<Config> {
+  return {
+    displaylogo: false,
+    responsive: true,
+    toImageButtonOptions: { format: "png", filename: "openfdd-chart" },
+  };
+}
+
+/** Display-only downsample — never use for rule math. */
+export function downsample<T>(xs: T[], max = MAX_PLOT_POINTS): T[] {
+  if (xs.length <= max) return xs;
+  const step = Math.ceil(xs.length / max);
+  return xs.filter((_, i) => i % step === 0);
+}
+
+export type SeriesPoint = { t: string | number; y: number | null };
+
+/** Multi-y traces + confirmed-fault swim lane (vibe19 rule_result_chart). */
+export function ruleResultChart(opts: {
+  title: string;
+  series: { name: string; points: SeriesPoint[]; yaxis?: string }[];
+  confirmed: { t: string | number; fault: boolean }[];
+}): { data: Data[]; layout: Partial<Layout> } {
+  const data: Data[] = opts.series.map((s, i) => {
+    const pts = downsample(s.points);
+    return {
+      type: "scatter",
+      mode: "lines",
+      name: s.name,
+      x: pts.map((p) => p.t),
+      y: pts.map((p) => p.y),
+      yaxis: s.yaxis ?? (i === 0 ? "y" : `y${i + 1}`),
+    };
+  });
+  const conf = downsample(opts.confirmed);
+  data.push({
+    type: "scatter",
+    mode: "lines",
+    name: "confirmed_fault",
+    x: conf.map((p) => p.t),
+    y: conf.map((p) => (p.fault ? 1 : 0)),
+    yaxis: "y2",
+    line: { shape: "hv", width: 1 },
+    fill: "tozeroy",
+  });
+  return {
+    data,
+    layout: {
+      title: { text: opts.title },
+      margin: { t: 48, r: 48, b: 40, l: 48 },
+      legend: { orientation: "h" },
+      yaxis2: { overlaying: "y", side: "right", range: [0, 1.2], showgrid: false, title: { text: "fault" } },
+    },
+  };
+}
+
+export function multiEquipmentTimeseries(opts: {
+  title: string;
+  series: { name: string; points: SeriesPoint[] }[];
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: opts.series.map((s) => {
+      const pts = downsample(s.points);
+      return {
+        type: "scatter",
+        mode: "lines",
+        name: s.name,
+        x: pts.map((p) => p.t),
+        y: pts.map((p) => p.y),
+      };
+    }),
+    layout: { title: { text: opts.title }, margin: { t: 48, r: 24, b: 40, l: 48 }, legend: { orientation: "h" } },
+  };
+}
+
+export function oatScatter(opts: {
+  title: string;
+  x: number[];
+  y: number[];
+  name?: string;
+}): { data: Data[]; layout: Partial<Layout> } {
+  const n = Math.min(opts.x.length, opts.y.length);
+  const idx = downsample([...Array(n).keys()]);
+  return {
+    data: [
+      {
+        type: "scatter",
+        mode: "markers",
+        name: opts.name ?? "samples",
+        x: idx.map((i) => opts.x[i]),
+        y: idx.map((i) => opts.y[i]),
+        marker: { size: 5, opacity: 0.6 },
+      },
+    ],
+    layout: {
+      title: { text: opts.title },
+      xaxis: { title: { text: "OAT °F" } },
+      yaxis: { title: { text: "Value" } },
+      margin: { t: 48, r: 24, b: 48, l: 48 },
+    },
+  };
+}
+
+export function vavComfortDonut(opts: {
+  title: string;
+  inComfort: number;
+  outComfort: number;
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: [
+      {
+        type: "pie",
+        hole: 0.55,
+        labels: ["In comfort", "Out of comfort"],
+        values: [opts.inComfort, opts.outComfort],
+      },
+    ],
+    layout: { title: { text: opts.title }, margin: { t: 48, r: 24, b: 24, l: 24 } },
+  };
+}
+
+export function barChart(opts: {
+  title: string;
+  labels: string[];
+  values: number[];
+  name?: string;
+}): { data: Data[]; layout: Partial<Layout> } {
+  return {
+    data: [{ type: "bar", name: opts.name ?? "value", x: opts.labels, y: opts.values }],
+    layout: { title: { text: opts.title }, margin: { t: 48, r: 24, b: 48, l: 48 } },
+  };
+}

--- a/workspace/dashboard/src/vibe19/contract.ts
+++ b/workspace/dashboard/src/vibe19/contract.ts
@@ -1,0 +1,54 @@
+/** Frozen vibe19 dashboard sections — mirror app/dashboard_contract.py */
+
+export const VIBE19_SECTIONS = [
+  "Overview",
+  "Data Model",
+  "Run Rules",
+  "Results by Category",
+  "FDD Plots",
+  "RCx Plots",
+  "Metering",
+  "Export",
+] as const;
+
+export type Vibe19Section = (typeof VIBE19_SECTIONS)[number];
+
+/** Chart APIs required for Plotly parity with vibe19. */
+export const REQUIRED_CHART_APIS = [
+  "rule_result_chart",
+  "multi_equipment_timeseries",
+  "multi_equipment_box",
+  "oat_scatter",
+  "motor_weekly_runtime_chart",
+  "mech_cooling_oat_histogram",
+  "bas_vs_web_oat_histogram",
+  "bas_vs_web_oat_overlay",
+  "equipment_inspection_chart",
+  "sensor_fault_chart",
+  "vav_comfort_donut",
+] as const;
+
+export const MAX_PLOT_POINTS = 5000;
+
+export type RegistryRule = {
+  rule_id: string;
+  description: string;
+  confirm_seconds: number;
+  confirm_min?: number;
+  required_roles: string[];
+  parameter_count: number;
+  parity_status?: string;
+  dashboard_wired?: boolean;
+};
+
+export type RuleParamDef = {
+  key: string;
+  label: string;
+  default: number;
+  min: number;
+  max: number;
+  step: number;
+  unit: string;
+  control: string;
+  sql_placeholder: string;
+};

--- a/workspace/dashboard/src/vibe19/contract.ts
+++ b/workspace/dashboard/src/vibe19/contract.ts
@@ -26,7 +26,150 @@ export const REQUIRED_CHART_APIS = [
   "equipment_inspection_chart",
   "sensor_fault_chart",
   "vav_comfort_donut",
+  "metering_bar_scatter",
 ] as const;
+
+/**
+ * Frozen RCx preset ids from vibe19 `REQUIRED_RCX_PRESET_IDS`.
+ * Weather policy: dry-bulb (web OAT) for SAT/HW/CHW resets; wet-bulb for CW/tower.
+ */
+export const REQUIRED_RCX_PRESET_IDS = [
+  "zone_comfort_rank",
+  "zone_temps",
+  "ahu_dats",
+  "ahu_mats",
+  "ahu_rats",
+  "ahu_dampers",
+  "duct_static_box",
+  "ahu_sat_reset_scatter",
+  "hw_reset_scatter",
+  "chw_reset_scatter",
+  "cw_reset_scatter",
+  "vav_flows",
+  "fan_speeds",
+  "meter_elec_cdd",
+  "meter_gas_hdd",
+] as const;
+
+export type RcxPresetId = (typeof REQUIRED_RCX_PRESET_IDS)[number];
+
+export type RcxWeatherAxis = "dry_bulb" | "wet_bulb" | "none";
+
+export type RcxPresetMeta = {
+  id: RcxPresetId;
+  label: string;
+  family: string;
+  chart: "timeseries" | "box" | "scatter" | "donut" | "metering";
+  weatherAxis: RcxWeatherAxis;
+};
+
+export const RCX_PRESETS: RcxPresetMeta[] = [
+  {
+    id: "zone_comfort_rank",
+    label: "Zone comfort rank",
+    family: "Zone",
+    chart: "donut",
+    weatherAxis: "none",
+  },
+  {
+    id: "zone_temps",
+    label: "Zone temperatures",
+    family: "Zone",
+    chart: "timeseries",
+    weatherAxis: "none",
+  },
+  {
+    id: "ahu_dats",
+    label: "AHU discharge air temps",
+    family: "AHU",
+    chart: "timeseries",
+    weatherAxis: "none",
+  },
+  {
+    id: "ahu_mats",
+    label: "AHU mixed air temps",
+    family: "AHU",
+    chart: "timeseries",
+    weatherAxis: "none",
+  },
+  {
+    id: "ahu_rats",
+    label: "AHU return air temps",
+    family: "AHU",
+    chart: "timeseries",
+    weatherAxis: "none",
+  },
+  {
+    id: "ahu_dampers",
+    label: "AHU OA dampers",
+    family: "AHU",
+    chart: "timeseries",
+    weatherAxis: "none",
+  },
+  {
+    id: "duct_static_box",
+    label: "Duct static (fan-on box)",
+    family: "AHU",
+    chart: "box",
+    weatherAxis: "none",
+  },
+  {
+    id: "ahu_sat_reset_scatter",
+    label: "AHU SAT reset vs web dry-bulb",
+    family: "AHU",
+    chart: "scatter",
+    weatherAxis: "dry_bulb",
+  },
+  {
+    id: "hw_reset_scatter",
+    label: "HW leave reset vs web dry-bulb",
+    family: "Plant",
+    chart: "scatter",
+    weatherAxis: "dry_bulb",
+  },
+  {
+    id: "chw_reset_scatter",
+    label: "CHW leave reset vs web dry-bulb",
+    family: "Plant",
+    chart: "scatter",
+    weatherAxis: "dry_bulb",
+  },
+  {
+    id: "cw_reset_scatter",
+    label: "CW / tower vs wet-bulb",
+    family: "Plant",
+    chart: "scatter",
+    weatherAxis: "wet_bulb",
+  },
+  {
+    id: "vav_flows",
+    label: "VAV airflow",
+    family: "VAV",
+    chart: "timeseries",
+    weatherAxis: "none",
+  },
+  {
+    id: "fan_speeds",
+    label: "Fan speeds",
+    family: "AHU",
+    chart: "timeseries",
+    weatherAxis: "none",
+  },
+  {
+    id: "meter_elec_cdd",
+    label: "Electric vs CDD",
+    family: "Metering",
+    chart: "metering",
+    weatherAxis: "none",
+  },
+  {
+    id: "meter_gas_hdd",
+    label: "Gas vs HDD",
+    family: "Metering",
+    chart: "metering",
+    weatherAxis: "none",
+  },
+];
 
 export const MAX_PLOT_POINTS = 5000;
 


### PR DESCRIPTION
## Summary
- React lab at `/lab` with vibe19 sections (Overview, Data Model, Run Rules, Results, FDD Plots, RCx Plots, Metering, Export).
- Registry-driven family checkboxes + param sliders (no raw SQL on operator surface).
- Typed Plotly chart library over `plotly.js-dist-min` covering `REQUIRED_CHART_APIS` + frozen `REQUIRED_RCX_PRESET_IDS` (dry-bulb for SAT/HW/CHW, wet-bulb for CW).
- Vitest coverage for chart-spec builders.

Closes #481.

## Test plan
- [x] `npm test -- --run src/vibe19` (7 passed)
- [ ] rust-ci TypeScript dashboard build green
- [ ] CodeRabbit triage
- [ ] Squash-merge after green

Depends on #505 (merged). Prefer merge after #506 (sql rules) so registry count matches lab UI.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Open-FDD Lab with overview metrics, data model details, rule execution, results, metering, export placeholders, and interactive visualizations.
  - Added new Lab, Live FDD Validation, and SQL FDD navigation routes.
  - Added interactive charts for trends, faults, equipment, comfort, runtime, and energy metering.
  - Updated navigation labels and redirects to reflect the new lab experience.

- **Tests**
  - Added coverage for dashboard sections, chart configurations, presets, and chart output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->