### PR TITLE
docs(docker): finalize vibe19 nightly verification

### DIFF
--- a/docker/VERSION_MANIFEST.md
+++ b/docker/VERSION_MANIFEST.md
@@ -44,20 +44,20 @@ Bump all three together when cutting a coordinated stack release.
 
 ## Latest verified nightlies (vibe19 parity train)
 
-Recorded after monster PR train `#504`→`#509` on `master` tip **`9e44f1cb`** (`9e44f1c`).
+Recorded after monster PR train `#504`→`#509` on `master` tip **`c87a0ae8`** (`c87a0ae`).
 
 | Channel | Git SHA | GHCR workflow run |
 |---------|---------|-------------------|
-| Stack (`openfdd-{central,ui,fieldbus,mqtt}:nightly`) | `9e44f1cb` / `sha-9e44f1c` | [29543750678](https://github.com/bbartling/open-fdd/actions/runs/29543750678) — **success** |
-| Legacy edge (`openfdd-edge-rust:nightly`) | `9e44f1cb` | [29543751569](https://github.com/bbartling/open-fdd/actions/runs/29543751569) — publish in flight / verify before claiming |
+| Stack (`openfdd-{central,ui,fieldbus,mqtt}:nightly`) | `c87a0ae8` / `sha-c87a0ae` | [29549666487](https://github.com/bbartling/open-fdd/actions/runs/29549666487) — **success** |
+| Legacy edge (`openfdd-edge-rust:nightly`) | `c87a0ae8` | [29549652669](https://github.com/bbartling/open-fdd/actions/runs/29549652669) — **success** |
 
 Pin compose to immutable tags for bench retest:
 
 ```bash
-export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-9e44f1c
-export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-9e44f1c
-export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-9e44f1c
-export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-9e44f1c
+export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-c87a0ae
+export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-c87a0ae
+export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-c87a0ae
+export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-c87a0ae
 # or floating:
 # export OPENFDD_*_IMAGE=ghcr.io/bbartling/openfdd-*:nightly
 ```


### PR DESCRIPTION
## Summary
- record successful stack and legacy edge GHCR publishes for `c87a0ae8`
- update immutable image pins for the bench handoff

## Verification
- Stack: https://github.com/bbartling/open-fdd/actions/runs/29549666487
- Edge: https://github.com/bbartling/open-fdd/actions/runs/29549652669

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the verified nightly build references.
  * Refreshed nightly workflow links and statuses.
  * Updated container image examples to use the latest immutable tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->