### PR TITLE
docs(docker): pin verified nightlies to sha-db15994

### DIFF
--- a/docker/VERSION_MANIFEST.md
+++ b/docker/VERSION_MANIFEST.md
@@ -46,22 +46,23 @@ Bump all three together when cutting a coordinated stack release.
 
 ## Latest verified nightlies
 
-Published successfully from stack-only `master` tip **`1eb82b98`**:
+Published successfully from stack-only `master` tip **`db159949`**:
 
 | Images | Immutable tag | Workflow |
 |--------|---------------|----------|
-| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-1eb82b9` | [29585092421](https://github.com/bbartling/open-fdd/actions/runs/29585092421) — success |
-| `openfdd-mcp` | `sha-1eb82b9` | [29585091221](https://github.com/bbartling/open-fdd/actions/runs/29585091221) — success |
+| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-db15994` | [29591686722](https://github.com/bbartling/open-fdd/actions/runs/29591686722) — success |
+| `openfdd-mcp` | `sha-db15994` | [29591686920](https://github.com/bbartling/open-fdd/actions/runs/29591686920) — success |
 
 ```bash
-export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-1eb82b9
-export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-1eb82b9
-export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-1eb82b9
-export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-1eb82b9
-export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-1eb82b9
+export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-db15994
+export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-db15994
+export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-db15994
+export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-db15994
+export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-db15994
 ```
 
-The workflows verified build/push metadata and manifests. Pull/run verification is
+The workflows verified build/push metadata, manifests, MCP↔central smoke, and
+csv-recipe boot + `/api/health`. Pull/run verification of all four recipes is
 the next bench gate because Docker is unavailable in the current WSL environment.
 Run `docs/agent/linux-edge-tester-stack-recipes-prompt.md`; leave standalone
 running for the human Niagara check.


### PR DESCRIPTION
## Summary
- Update `docker/VERSION_MANIFEST.md` to tip `db159949` / `sha-db15994` with green publish run links (stack [29591686722](https://github.com/bbartling/open-fdd/actions/runs/29591686722), MCP [29591686920](https://github.com/bbartling/open-fdd/actions/runs/29591686920)).

## Test plan
- [x] Stack + MCP GHCR publish success on `db159949`
- [ ] Docs Pages re-dispatch after prior flake (multiple github-pages artifacts)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the latest verified nightly container references.
  * Refreshed documented image tags and workflow links.
  * Expanded verification guidance to include MCP-to-central smoke testing, recipe startup health checks, and pull/run verification across all recipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->