### PR TITLE
fix(readme): restore docs + FDD Rule Cookbook links, guard them in CI

### DIFF
--- a/.github/workflows/cookbook-parity.yml
+++ b/.github/workflows/cookbook-parity.yml
@@ -9,12 +9,14 @@ on:
       - "docs/rules/cookbook/**"
       - "scripts/cookbook_parity_check.py"
       - ".github/workflows/cookbook-parity.yml"
+      - "README.md"
   pull_request:
     branches: [master, main]
     paths:
       - "docs/rules/cookbook/**"
       - "scripts/cookbook_parity_check.py"
       - ".github/workflows/cookbook-parity.yml"
+      - "README.md"
 
 jobs:
   fixtures:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Architecture / MQTT cutover gates
         run: bash scripts/gates/run_all_gates.sh --quick
 
+      - name: Cookbook + README docs integrity (59-rule floor, cookbook link)
+        run: python3 scripts/cookbook_parity_check.py --docs-only
+
       - name: Anti-hardcoding audit
         run: bash -n scripts/audit_no_private_bench_hardcoding.sh && ./scripts/audit_no_private_bench_hardcoding.sh
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@
   <img src="https://raw.githubusercontent.com/bbartling/open-fdd/master/image_new_chiller.png" alt="Open-FDD logo" width="440">
 </p>
 
+<p align="center">
+  <a href="https://bbartling.github.io/open-fdd/">
+    <img src="https://img.shields.io/badge/Docs-online-2563EB?style=for-the-badge" alt="Online docs">
+  </a>
+  <a href="https://bbartling.github.io/open-fdd/rules/cookbook/">
+    <img src="https://img.shields.io/badge/FDD%20Rule%20Cookbook-59%20rules%20SQL%20%2B%20Pandas-DC2626?style=for-the-badge" alt="FDD Rule Cookbook — DataFusion SQL + Pandas">
+  </a>
+  <a href="https://bbartling.github.io/open-fdd/quick-start/docker-ghcr.html">
+    <img src="https://img.shields.io/badge/Quick%20Start-GHCR%20stack-059669?style=for-the-badge" alt="Quick start">
+  </a>
+  <a href="https://arrow.apache.org/">
+    <img src="https://img.shields.io/badge/Apache%20Arrow-columnar%20data-0B7285?style=for-the-badge" alt="Apache Arrow">
+  </a>
+  <a href="https://datafusion.apache.org/">
+    <img src="https://img.shields.io/badge/DataFusion-SQL%20engine-6D28D9?style=for-the-badge" alt="Apache DataFusion">
+  </a>
+</p>
+
 
 > **Open-source semantic building analytics and HVAC supervisory fault detection. Local-first. On-premises. Vendor-neutral. Free to run at the edge or offline.**
 
@@ -48,6 +66,17 @@ Open-FDD supports flexible deployment recipes:
 ### CSV-only
 
 `central` + `ui` — bulk CSV jobs and FDD without pulling mqtt or fieldbus images.
+
+---
+
+## FDD Rule Cookbook (the heart of the project)
+
+The **[HVAC FDD Rule Cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/)** is the validated catalog of **59 fault-detection rules**, published in two parity-matched flavors:
+
+- **[DataFusion SQL cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/datafusion-sql-cookbook.html)** — copy-paste SQL that runs on the edge/central Arrow historian
+- **[Pandas cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html)** — the same rules for notebooks, CSV exports, and RCx studies
+
+Rules use generic Haystack semantic roles, so they are portable across any modeled site. CI enforces a minimum of 59 rule headings in both cookbooks (`scripts/cookbook_parity_check.py`) — the catalog can never shrink.
 
 ---
 

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -43,7 +43,7 @@ See [examples/external-agents.md](../examples/external-agents.md).
 | [bench-vs-source.md](bench-vs-source.md) | Bench vs product source trees *(paste-only — not on Pages)* |
 | [vibe19-parity-nightly-monster-prompt.md](vibe19-parity-nightly-monster-prompt.md) | **Product agent** — vibe19 look/feel + 59 rules + security PR train *(paste-only)* |
 | [vibe16-bacnet-feather-port-agent-prompt.md](vibe16-bacnet-feather-port-agent-prompt.md) | **Product agent** — vibe16 BACnet/Feather port cycle *(paste-only)* |
-| [linux-edge-tester-stack-recipes-prompt.md](linux-edge-tester-stack-recipes-prompt.md) | **Second bench** — all 4 recipes, 5007, leave-running + human Workbench *(paste-only)* |
+| [linux-edge-tester-stack-recipes-prompt.md](linux-edge-tester-stack-recipes-prompt.md) | **Second bench** — living daily prompt (overwrite in place, never date) — 4 recipes, 5007, leave-running + human Workbench *(paste-only)* |
 | [linux-edge-tester-stack-nightly-prompt.md](linux-edge-tester-stack-nightly-prompt.md) | **Linux edge tester** — standalone stack nightly (central/ui/fieldbus/mqtt) *(paste-only)* |
 | [linux-edge-tester-second-bench-ghcr-soak-prompt.md](linux-edge-tester-second-bench-ghcr-soak-prompt.md) | **Second bench** — rigorous GHCR soak (superseded by stack-recipes prompt) *(paste-only)* |
 | [linux-edge-tester-prompt.md](linux-edge-tester-prompt.md) | **Linux edge tester** — turnkey copy-paste validation *(paste-only)* |

--- a/docs/agent/linux-edge-tester-stack-recipes-prompt.md
+++ b/docs/agent/linux-edge-tester-stack-recipes-prompt.md
@@ -6,6 +6,10 @@ nav_order: 12
 
 # Linux edge tester — stack recipes GHCR soak
 
+**Living daily prompt.** Rewrite this file in place each day (or whenever nightlies
+change). Do **not** create dated copies (`*-2026-07-17.md`, `bench-NNN-*`, etc.).
+One path forever: `docs/agent/linux-edge-tester-stack-recipes-prompt.md`.
+
 Copy-paste prompt for a **second OT bench**. Pulls GHCR nightlies, exercises all four
 compose build recipes, validates BACnet device **5007** via fieldbus, then **leaves
 the standalone stack running** for human Niagara Workbench validation of hosted

--- a/scripts/cookbook_parity_check.py
+++ b/scripts/cookbook_parity_check.py
@@ -130,6 +130,17 @@ def run_docs_integrity() -> None:
     if missing:
         raise AssertionError(f"missing cookbook pages: {missing}")
 
+    # The README must always link the cookbook — it is the heart of the project
+    # and must never be vibe-coded out of the front page again.
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    for required_link in (
+        "https://bbartling.github.io/open-fdd/rules/cookbook/",
+        "https://bbartling.github.io/open-fdd/",
+    ):
+        if required_link not in readme:
+            raise AssertionError(f"README.md missing required docs link: {required_link}")
+    print("PASS README cookbook + docs links present")
+
     for name in ("pandas-cookbook.md", "datafusion-sql-cookbook.md"):
         text = (COOKBOOK / name).read_text(encoding="utf-8")
         n = len(RULE_HEADING_RE.findall(text))


### PR DESCRIPTION
## Summary
- Restore the README badge row lost in #513, now with a dedicated **FDD Rule Cookbook** badge, plus a prominent cookbook section linking the [DataFusion SQL](https://bbartling.github.io/open-fdd/rules/cookbook/datafusion-sql-cookbook.html) and [Pandas](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html) cookbooks
- Guard: `cookbook_parity_check.py` now fails if README loses the docs/cookbook links; runs docs-only check on every `Rust Stack CI` push and `cookbook-parity.yml` now triggers on README changes
- Mark `linux-edge-tester-stack-recipes-prompt.md` as a living daily prompt (rewrite in place, never dated copies)

## Test plan
- [x] `python3 scripts/cookbook_parity_check.py --docs-only` (59 headings both cookbooks, README links present)
- [x] Cookbook pages verified live on GitHub Pages
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prominent links and badges for documentation, Quick Start, the FDD Rule Cookbook, Apache Arrow, and DataFusion.
  * Clarified the 59-rule cookbook, including links to its DataFusion SQL and Pandas versions.
  * Updated agent guidance to keep the daily prompt current and avoid dated copies.

* **Quality Improvements**
  * Documentation checks now verify required cookbook links and ensure the cookbook catalog does not shrink.
  * Documentation changes automatically trigger relevant parity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->