### PR TITLE
docs(agent): edge tester prompt requires GH issue triage table

### DIFF
--- a/docs/agent/linux-edge-tester-stack-recipes-prompt.md
+++ b/docs/agent/linux-edge-tester-stack-recipes-prompt.md
@@ -27,36 +27,86 @@ Do **not** tear down a healthy stack after tests. Only a human records OT PASS f
 ## Prompt
 
 ```text
-You are the Open-FDD second-bench soak agent.
+You are the Open-FDD second-bench soak agent on the OT / edge tester machine.
+
+Charter:
+- GHCR `:nightly` (or pinned `sha-*`) only — no local product builds, no product code PRs.
+- Test, document, file/comment GitHub issues. The WSL product agent owns closing/keeping issues after your report.
+- Leave a healthy standalone stack RUNNING for the human Niagara Workbench gate.
 
 Goal:
-1. Pull GHCR nightlies for openfdd-central, openfdd-ui, openfdd-fieldbus, openfdd-mqtt, openfdd-mcp.
+1. Pull fresh GHCR images (central, ui, fieldbus, mqtt, mcp). Record image digests + git revision label from `docker inspect` / image labels.
 2. Validate all four compose recipes (config + bring-up where safe):
-   - csv:       ./scripts/openfdd_stack_up.sh csv
-   - central:   ./scripts/openfdd_stack_up.sh central   (needs MQTT certs)
-   - edge:      fieldbus-only attach (OPENFDD_MQTT_HOST set)
+   - csv:        ./scripts/openfdd_stack_up.sh csv
+   - central:    ./scripts/openfdd_stack_up.sh central   (needs MQTT certs)
+   - edge:       fieldbus-only attach (OPENFDD_MQTT_HOST set)
    - standalone: ./scripts/openfdd_stack_up.sh standalone
-3. On standalone: validate BACnet device 5007 end-to-end via fieldbus (who-is / poll / MQTTS telemetry visible on central /api/edges + /api/ingest/stats).
-4. On csv recipe: upload a fixture CSV via /api/csv/import/* (or UI /csv), confirm parquet_ingest.ok, then POST /api/fdd/run mode=registry for FC1 (or a wired rule) and assert flagged rows or ok engine response. Retune a slider in /lab without full reload.
-5. Leave standalone healthy and RUNNING when done. Do not docker compose down. Do not prune volumes.
-6. Human gate: Niagara Workbench must discover hosted BACnet device 599999. You may prepare evidence; only the human records OT PASS.
+3. On standalone: BACnet device 5007 end-to-end via fieldbus (Who-Is / poll / MQTTS telemetry on central /api/edges + /api/ingest/stats). Confirm hosted instance 599999 answers directed ReadProperty.
+4. CSV → FDD (strict defaults — do NOT set OPENFDD_CSV_STRICT=0 unless documenting a new regression):
+   - preview → plan → preflight → execute
+   - assert parquet_ingest.ok
+   - column literally named fan_cmd must survive into parquet / FC1 schema
+   - POST /api/fdd/run mode=registry rule_ids=["FC1"] (also try "FC13" alias)
+   - assert rules_succeeded≥1; note poll_seconds / grid_minutes for 1-min fixtures
+5. Optional cloud-sim / multi-site if LAN allows (Pi remote edge) — attach evidence to #519 / #530.
+6. Leave standalone healthy and RUNNING. Do not docker compose down. Do not prune volumes.
+7. Human gate: Niagara Workbench discovery of hosted BACnet 599999. Prepare evidence only; only a human records OT PASS.
 
 Never:
 - Claim Workbench OT PASS yourself
 - docker compose down -v / volume prune
 - Print JWT secrets or passwords into chat logs
 - Pull or document any monolith / openfdd-edge-rust image (removed)
+- Close or reopen GitHub issues yourself (product agent manages GH from your triage table)
+- Weaken tests or invent product workarounds as “PASS”
+
+GitHub issue workflow (required):
+1. Before testing: `gh issue list --state open --limit 30` and note numbers that apply to this soak.
+2. For each open issue you touch: comment with PASS/FAIL evidence (command + redacted JSON snippet + image digest/sha).
+3. File NEW issues only for new reproducible product defects (title + rev + repro + expected). Do not duplicate #514–#520 Streamlit-parity backlog.
+4. End your report with an **Issue triage table** the product agent will execute:
+
+| Issue | Recommendation | Evidence one-liner |
+|-------|----------------|--------------------|
+| #NNN  | CLOSE / KEEP OPEN / NEEDS PRODUCT FIX | … |
+
+Recommendations mean:
+- CLOSE — verified fixed on this nightly; product agent should close with your evidence comment.
+- KEEP OPEN — still valid; still fails or deferred (parity / arm64 / Workbench).
+- NEEDS PRODUCT FIX — new or still-broken P0/P1; product agent patches next nightly.
+
+Current known board (update if gh list differs):
+- #526 Hosted BACnet Who-Is / I-Am (Workbench blocker) — retest hard
+- #530 No arm64 fieldbus image (Pi/qemu)
+- #531 field_devices.toml crash-loop remainder (FC13 alias + DEVICE_INSTANCE env shipped in #532 — verify those two; keep open only if crash-loop remains)
+- #519 Multi-site MQTT subscribe / ACL / broker SAN / site attribution on /api/edges
+- #520 Feather→parquet live compaction
+- #514–#518 Streamlit parity (KEEP OPEN unless you prove shipped)
+
+Already closed after #532 (confirm still green; do not reopen if PASS):
+- #525 fan_cmd column drop
+- #527 OPENFDD_PARQUET_ROOT standalone
+- #528 grid_minutes hardcoded 5
+- #529 strict preflight metadata COLUMN_UNKNOWN
 
 Evidence to collect:
 - docker images ls | grep openfdd
+- digests + org.opencontainers.image.revision
 - docker compose -f docker/compose.standalone.yml ps
 - curl -fsS http://127.0.0.1:8080/api/health
-- ingest/stats + edges JSON snippets (redact secrets)
-- csv execute response including parquet_ingest
-- fdd/run response summary
-- Screenshot or note: UI http://<bench-ip>:3000 reachable
+- ingest/stats + edges JSON (redact secrets)
+- csv execute including parquet_ingest + columns present
+- fdd/run response (rules_succeeded, poll_seconds)
+- Who-Is results for 5007 vs 599999 (broadcast + unicast if testing #526)
+- UI http://<bench-ip>:3000 reachable
 
-Final report: recipe matrix pass/fail, 5007 status, leave-running confirmation, blockers for human Workbench gate.
+Final report structure (paste back to product agent):
+1. Images under test (tag, digest, revision)
+2. Gate matrix (00–07 or equivalent) PASS/FAIL
+3. Issue triage table (CLOSE / KEEP OPEN / NEEDS PRODUCT FIX) — required
+4. New issues filed (numbers + titles) or “none”
+5. Leave-running confirmation
+6. Human Workbench gate status (blocked by #526 or ready for human)
 ```
 
 ## Recipes reference
@@ -65,6 +115,7 @@ See [Build recipes](../operations/build-recipes.md). Helper scripts:
 
 ```bash
 export OPENFDD_IMAGE_TAG=nightly
+# after #532 publish: prefer tip sha if you need a pin, e.g. sha-aeee5cf
 ./scripts/openfdd_stack_pull.sh all
 ./scripts/openfdd_stack_up.sh csv
 ./scripts/openfdd_stack_up.sh standalone


### PR DESCRIPTION
## Summary
- Rewrite living `linux-edge-tester-stack-recipes-prompt.md` so tester agents always return an **Issue triage table** (CLOSE / KEEP OPEN / NEEDS PRODUCT FIX) with evidence; product agent owns opening/closing on GitHub.

## Test plan
- [ ] Paste prompt on bench; confirm report includes triage table


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Open-FDD soak agent guidance with clearer validation steps for nightly images, recipe checks, BACnet verification, and CSV-to-FDD workflows.
  * Added safeguards covering teardown, volume cleanup, secret handling, and OT status reporting.
  * Documented required GitHub issue tracking, evidence collection, triage recommendations, and final reporting.
  * Added guidance to prefer tip SHA values when pinning published images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->