### PR TITLE
Rule param/slider parity with validated vibe19 catalog

### DIFF
--- a/crates/fdd_rules/src/econ4_confirm_test.rs
+++ b/crates/fdd_rules/src/econ4_confirm_test.rs
@@ -74,7 +74,9 @@ mod tests {
             .unwrap_or_else(|e| panic!("read {}: {e}", sql_path.display()));
 
         // registry.yaml: ECON-4 confirm_seconds = 600 -> CONFIRM_ROWS = ceil(600/300) = 2.
-        let params = rule_params(300.0, 600);
+        let mut params = rule_params(300.0, 600);
+        // Registry default for the ECON-4 tunable (min OA fraction, percent).
+        params.insert("OA_MIN_PCT".into(), "21".into());
         let sql = substitute_sql(&raw_sql, &params);
         let result = run_sql(&ctx, &sql).await.unwrap();
 

--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -256,7 +256,7 @@ WHERE equipment_id = 'equip:your-id'
 ### PID-HUNT-1 — Suspected control-output hunting
 **Family:** `control` · **Equipment:** `ahu`, `vav`, `chiller`, `boiler`, `heatpump`  
 **Equation:** Rolling 1h total variation of any 0–100% control output (dampers, valves, fan speeds, heat/cool cmds) with span ≥20%, TV ≥500 %·pts, ≥2.5 equivalent cycles, ≥4 reversals — suspected loop hunting (not proof of bad PID alone).  
-**Default confirmation:** 300 s
+**Default confirmation:** 0 s (rolling 1h window is its own persistence)
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
@@ -271,7 +271,7 @@ WHERE equipment_id = 'equip:your-id'
 {: .important }
 **Simplified SQL variant.** Full rolling / multi-sensor logic for `PID-HUNT-1` is validated in Pandas. Use SQL for screening; use Pandas for parity and RCx studies.
 ```sql
--- confirmation_seconds: 300
+-- confirmation_seconds: 0  (rolling 1h window is its own persistence)
 -- rule: PID-HUNT-1 — Suspected control-output hunting
 -- equation: Rolling 1h total variation of any 0–100% control output (dampers, valves, fan speeds, heat/cool cmds) with span ≥20%, TV ≥500 %·pts, ≥2.5 equivalent cycles, ≥4 reversals — suspected loop hunting (not proof of bad PID alone).
 
@@ -294,17 +294,20 @@ Includes GL36 FC1–FC15, AHU auxiliaries, economizer/ventilation, leakage, and 
 
 ### FC1 — Duct static below SP at full fan (GL36 A)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan ≥ 87% AND duct static < static SP − 0.12 in.w.c.  
+**Equation:** DSP < DSPSP − εDSP AND VFDSPD ≥ 100% − εVFDSPD.  
 **Default confirmation:** 300 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `duct_static_err` | Duct static error | in. w.c. | 0.12 | 0.02–0.5 |
-| `fan_hi` | Fan high threshold | frac | 0.87 | 0.5–1.0 |
+| `eps_dsp` | Duct-static error εDSP (GL36 default 0.1 in.w.c.) | in. w.c. | 0.12 | 0.0–0.5 |
+| `eps_vfd_spd` | VFD speed error εVFDSPD (GL36 default 5%) | frac | 0.13 | 0.0–0.5 |
+| `duct_static_err` | Legacy duct-static error (sets εDSP) | in. w.c. | 0.12 | 0.0–0.5 |
+| `fan_hi` | Legacy fan-high threshold (sets εVFDSPD) | frac | 0.87 | 0.5–1.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 300
--- param: duct_static_err = 0.12 ; fan_hi = 0.87
+-- param: eps_dsp = 0.12 ; eps_vfd_spd = 0.13  (fan high = 1.0 − eps_vfd_spd = 0.87)
 SELECT
   timestamp, equipment_id, duct_static, duct_static_sp, fan_cmd,
   CASE
@@ -319,12 +322,17 @@ WHERE equipment_id = 'equip:your-ahu'
 
 ### FC2 — MAT below OAT/RAT envelope (GL36 B)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND MAT below min(OAT, RAT) envelope (default mix_tol = 1.15°F ⇒ 2.3°F).  
+**Equation:** MATavg + εMAT < min(RATavg − εRAT, OATavg − εOAT).  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.5–3.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_rat` | RAT sensor error εRAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -344,12 +352,17 @@ WHERE equipment_id = 'equip:your-ahu'
 
 ### FC3 — MAT above OAT/RAT envelope (GL36 C)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND MAT above max(OAT, RAT) envelope (default mix_tol = 1.15°F ⇒ 2.3°F).  
+**Equation:** MATavg − εMAT > max(RATavg + εRAT, OATavg + εOAT).  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.5–3.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_rat` | RAT sensor error εRAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -368,12 +381,13 @@ WHERE equipment_id = 'equip:your-ahu'
 
 ### FC4 — PID hunting (operating-state oscillation)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** More than 5 operating-mode entry transitions in any hour (heating/econ/mech modes).  
+**Equation:** ΔOS > ΔOSmax during the prior 60-minute moving window.  
 **Default confirmation:** 3600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `delta_os_max` | Max mode changes/hr | count | 5 | 2–20 |
+| `delta_os_max` | Max mode changes/hr ΔOSmax (GL36 default 7) | count | 5 | 1–30 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 
 {: .important }
@@ -401,12 +415,18 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC5 — SAT cold when heating commanded (GL36 D)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND heating > 1% AND SAT + mix_tol ≤ MAT − mix_tol + 0.55°F (default mix_tol = 1.15°F).  
+**Equation:** SATavg + εSAT ≤ MATavg − εMAT + ΔTSF while heating is commanded.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.5–3.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `htg_on_min` | Heating-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -427,13 +447,18 @@ WHERE equipment_id = 'equip:your-ahu'
 
 ### FC6 — Estimated OA fraction mismatch
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** |RAT−OAT| ≥ 5°F AND |estimated OA% − design min OA%| > 15% in heating/mech-only modes.  
+**Equation:** |RATavg−OATavg| ≥ ΔTmin AND |estimated OA% − design min OA%| > εF.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `airflow_err` | OA fraction error | frac | 0.15 | 0.05–0.5 |
+| `eps_airflow` | Airflow error εF (GL36 default 30%) | frac | 0.15 | 0.05–1.0 |
+| `delta_t_min` | Minimum |OAT−RAT| ΔTmin (GL36 default 10°F) | °F | 5.0 | 0.0–30.0 |
+| `airflow_err` | Legacy OA-fraction error (sets εF) | frac | 0.15 | 0.05–1.0 |
+| `oat_rat_delta_min` | Legacy OAT/RAT guard (sets ΔTmin) | °F | 5.0 | 0.0–30.0 |
 | `min_cfm_design` | Design min OA CFM | cfm | 5000 | 500–20000 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -459,12 +484,16 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC7 — SAT low with full heating (GL36 E)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND heating > 90% AND SAT < SAT SP − 1.0°F.  
+**Equation:** SATavg < SATSP − εSAT AND HC ≥ full-heating threshold.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `sat_err` | SAT error | °F | 1.0 | 0.25–5.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.0 | 0.0–10.0 |
+| `sat_err` | Legacy SAT error (sets εSAT) | °F | 1.0 | 0.0–10.0 |
+| `htg_full_min` | Full-heating threshold (GL36 99%) | frac | 0.9 | 0.5–1.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -490,13 +519,19 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC8 — SAT/MAT mismatch in economizer (GL36 F)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Economizer open, CHW < 10%, |SAT − 0.55°F − MAT| > √(supply_tol²+mix_tol²).  
+**Equation:** |SATavg − ΔTSF − MATavg| > √(εSAT² + εMAT²) in OS#2.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
-| `supply_tol` | Supply tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `supply_tol` | Legacy SAT tolerance master (sets εSAT) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -522,12 +557,18 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC9 — OAT too warm for free cooling (GL36 G)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Economizer open, CHW < 10%, OAT − mix_tol > SAT SP − 0.55°F + mix_tol.  
+**Equation:** OATavg − εOAT > SATSP − ΔTSF + εSAT in OS#2.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -553,12 +594,17 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC10 — OAT/MAT mismatch + mech cooling (GL36 H)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, economizer > 90%, |MAT − OAT| > √(mix_tol²+mix_tol²).  
+**Equation:** |MATavg − OATavg| > √(εMAT² + εOAT²) in OS#3.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -584,12 +630,18 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC11 — OAT/MAT mismatch economizer-only (GL36 I)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, economizer > 90%, OAT + mix_tol < SAT SP − 0.55°F − mix_tol.  
+**Equation:** OATavg + εOAT < SATSP − ΔTSF − εSAT in OS#3.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -615,13 +667,20 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC12 — SAT above blend in cooling (GL36 J)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, SAT − supply_tol − 0.55°F > MAT + mix_tol at min or full economizer.  
+**Equation:** SATavg − εSAT − ΔTSF ≥ MATavg + εMAT in OS#3/OS#4.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
-| `supply_tol` | Supply tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `supply_tol` | Legacy SAT tolerance master (sets εSAT) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -647,12 +706,17 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC13 — SAT above SP at full cooling (GL36 K)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, SAT > SAT SP + 1.0°F at min or full economizer.  
+**Equation:** SATavg > SATSP + εSAT AND CC ≥ full-cooling threshold in OS#3/OS#4.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `sat_err` | SAT error | °F | 1.0 | 0.25–5.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.0 | 0.0–10.0 |
+| `sat_err` | Legacy SAT error (sets εSAT) | °F | 1.0 | 0.0–10.0 |
+| `clg_full_min` | Full-cooling threshold (GL36 99%) | frac | 0.01 | 0.5–1.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -678,12 +742,19 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC14 — CHW coil ΔT when inactive (GL36 L)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Cooling coil ΔT ≥ √(mix_tol²+mix_tol²)+0.55°F while coil should be inactive.  
+**Equation:** Cooling-coil ΔT ≥ √(εCCET² + εCCLT²) + ΔTSF while coil should be inactive.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_ccet` | Cooling-coil entering sensor error εCCET | °F | 1.15 | 0.0–10.0 |
+| `eps_cclt` | Cooling-coil leaving sensor error εCCLT | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `htg_on_min` | Heating-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -709,12 +780,20 @@ WHERE equipment_id = 'equip:your-id'
 
 ### FC15 — HW coil ΔT when inactive (GL36 M)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Heating coil ΔT ≥ √(mix_tol²+mix_tol²)+0.55°F while coil should be inactive.  
+**Equation:** Heating-coil ΔT ≥ √(εHCET² + εHCLT²) + ΔTSF while coil should be inactive.  
 **Default confirmation:** 600 s
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_hcet` | Heating-coil entering sensor error εHCET | °F | 1.15 | 0.0–10.0 |
+| `eps_hclt` | Heating-coil leaving sensor error εHCLT | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -833,7 +912,7 @@ WHERE equipment_id = 'equip:your-id'
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `oat_err` | OAT vs meteo error | °F | 5.0 | 2.0–15.0 |
+| `oat_err` | Max OAT disagreement | °F | 5.0 | 2.0–20.0 |
 
 ```sql
 -- confirmation_seconds: 900
@@ -1391,7 +1470,6 @@ WHERE equipment_id = 'equip:your-vav'
 | `comfort_low_f` | Comfort low | °F | 70.0 | 60.0–78.0 |
 | `comfort_high_f` | Comfort high | °F | 75.0 | 68.0–85.0 |
 | `sat_band_f` | AHU SAT≈SP band | °F | 2.0 | 0.5–6.0 |
-| `confirm_min` | Fault confirm delay | min | 30.0 | 0.0–60.0 |
 
 ```sql
 -- confirmation_seconds: 1800
@@ -1418,7 +1496,7 @@ WHERE equipment_id = 'equip:your-id'
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `min_dt` | Minimum delta-T | °F | 4.0 | 2.0–12.0 |
+| `min_dt` | Min ΔT | °F | 4.0 | 1.0–12.0 |
 
 ```sql
 -- confirmation_seconds: 900
@@ -1445,6 +1523,7 @@ WHERE equipment_id = 'equip:your-chw-plant'
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
 | `dp_margin` | DP margin | psi | 2.2 | 0.5–6.0 |
+| `pump_hi` | Pump high-speed threshold | frac | 0.87 | 0.5–1.0 |
 
 ```sql
 -- confirmation_seconds: 300
@@ -1505,6 +1584,7 @@ WHERE equipment_id = 'equip:your-id'
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
 | `flow_hi` | Flow high | gpm | 1100 | 200–3000 |
+| `pump_hi` | Pump high-speed threshold | frac | 0.87 | 0.5–1.0 |
 
 ```sql
 -- confirmation_seconds: 300
@@ -1623,8 +1703,8 @@ WHERE equipment_id = 'equip:your-id'
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `min_sat` | Min discharge SAT | °F | 85.0 | 70.0–110.0 |
-| `zone_cold` | Zone cold threshold | °F | 69.0 | 60.0–75.0 |
+| `min_sat` | Min heating SAT | °F | 85.0 | 70.0–110.0 |
+| `zone_cold` | Zone cold | °F | 69.0 | 60.0–72.0 |
 
 ```sql
 -- confirmation_seconds: 600
@@ -1650,7 +1730,7 @@ WHERE equipment_id = 'equip:your-heatpump'
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `spike_limit` | Spike limit | °F | 16.0 | 5.0–30.0 |
+| `spike_limit` | Spike limit | °F | 16.0 | 4.0–40.0 |
 
 ```sql
 -- confirmation_seconds: 300

--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -453,7 +453,7 @@ WHERE equipment_id = 'equip:your-ahu'
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
 | `eps_airflow` | Airflow error εF (GL36 default 30%) | frac | 0.15 | 0.05–1.0 |
-| `delta_t_min` | Minimum |OAT−RAT| ΔTmin (GL36 default 10°F) | °F | 5.0 | 0.0–30.0 |
+| `delta_t_min` | Minimum \|OAT−RAT\| ΔTmin (GL36 default 10°F) | °F | 5.0 | 0.0–30.0 |
 | `airflow_err` | Legacy OA-fraction error (sets εF) | frac | 0.15 | 0.05–1.0 |
 | `oat_rat_delta_min` | Legacy OAT/RAT guard (sets ΔTmin) | °F | 5.0 | 0.0–30.0 |
 | `min_cfm_design` | Design min OA CFM | cfm | 5000 | 500–20000 |

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -614,7 +614,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
 | `eps_airflow` | Airflow error εF (GL36 default 30%) | frac | 0.15 | 0.05–1.0 |
-| `delta_t_min` | Minimum |OAT−RAT| ΔTmin (GL36 default 10°F) | °F | 5.0 | 0.0–30.0 |
+| `delta_t_min` | Minimum \|OAT−RAT\| ΔTmin (GL36 default 10°F) | °F | 5.0 | 0.0–30.0 |
 | `airflow_err` | Legacy OA-fraction error (sets εF) | frac | 0.15 | 0.05–1.0 |
 | `oat_rat_delta_min` | Legacy OAT/RAT guard (sets ΔTmin) | °F | 5.0 | 0.0–30.0 |
 | `min_cfm_design` | Design min OA CFM | cfm | 5000 | 500–20000 |

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -277,7 +277,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 **Family:** `control` · **Equipment:** `ahu`, `vav`, `chiller`, `boiler`, `heatpump`  
 **Mode:** control-output sweep (dampers, valves, speeds, heat/cool cmds)  
 **Equation:** Rolling 1h total variation of any 0–100% control output (dampers, valves, fan speeds, heat/cool cmds) with span ≥20%, TV ≥500 %·pts, ≥2.5 equivalent cycles, ≥4 reversals — suspected loop hunting (not proof of bad PID alone).  
-**Default confirmation:** 300 s
+**Default confirmation:** 0 s (rolling 1h window is its own persistence)
 
 **Optional roles:** `loop-enabled`
 
@@ -293,7 +293,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 | `minimum_coverage_pct` | Minimum data coverage | % | 80.0 | 25.0–100.0 |
 
 ```python
-FAULT_CONFIRM_SECONDS = 300
+FAULT_CONFIRM_SECONDS = 0  # rolling 1h window supplies persistence
 
 def _pid_hunt_1(d: pd.DataFrame, p: dict, poll: float) -> pd.Series:
     """Suspected control-output hunting across any present 0–100% analog roles."""
@@ -328,9 +328,76 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 Includes GL36 FC1–FC15, AHU auxiliaries, economizer/ventilation, leakage, and outdoor-air screens.
 
+### GL36 shared helpers
+
+The FC rules read canonical GL36 epsilon variables (`eps_*`) with legacy session-param
+fallbacks (`mix_tol`, `duct_static_err`, …), and suspend faulting for `mode_delay_min`
+minutes after an AHU operating-state change:
+
+```python
+MIX_TOL = 1.15
+SUPPLY_TOL = 1.15
+AHU_MIN_OA_DPR = 0.05
+DELTA_SUPPLY_FAN = 0.55
+FAN_ON_MIN = 0.01
+
+def _f(p: dict, key: str, default: float) -> float:
+    try:
+        v = p.get(key, default)
+        return float(v) if v is not None else float(default)
+    except (TypeError, ValueError):
+        return float(default)
+
+def _false(index) -> pd.Series:
+    return pd.Series(False, index=index)
+
+def _fan(d: pd.DataFrame) -> pd.Series:
+    if "fan-cmd" in d.columns:
+        return norm_cmd(d["fan-cmd"]).fillna(0)
+    if "fan-status" in d.columns:
+        return as_bool(d["fan-status"]).astype(float)
+    return pd.Series(1.0, index=d.index)
+
+def _gl36_value(p: dict, key: str, legacy_key: str | None, default: float) -> float:
+    """Read a canonical GL36 variable, retaining old session-param compatibility."""
+    if key in p:
+        return float(p[key])
+    if legacy_key and legacy_key in p:
+        return float(p[legacy_key])
+    return float(default)
+
+def _gl36_mode_stable(d: pd.DataFrame, p: dict, poll: float) -> pd.Series:
+    """False during GL36 ModeDelay after an AHU operating-state change."""
+    delay_min = _f(p, "mode_delay_min", 0.0)
+    if delay_min <= 0 or d.empty:
+        return pd.Series(True, index=d.index)
+    htg = norm_cmd(d["heating-valve"]).fillna(0) if "heating-valve" in d else pd.Series(0.0, index=d.index)
+    clg = norm_cmd(d["cooling-valve"]).fillna(0) if "cooling-valve" in d else pd.Series(0.0, index=d.index)
+    econ = norm_cmd(d["outside-air-damper"]).fillna(0) if "outside-air-damper" in d else pd.Series(0.0, index=d.index)
+    fan = _fan(d)
+    fan_on = _gl36_value(p, "fan_on_min", None, FAN_ON_MIN)
+    econ_min = _gl36_value(p, "econ_min_pos", None, AHU_MIN_OA_DPR)
+    clg_on = _gl36_value(p, "clg_on_min", None, 0.01)
+    htg_on = _gl36_value(p, "htg_on_min", None, 0.01)
+    state = pd.Series(0, index=d.index, dtype=int)
+    state[(fan > fan_on) & (htg > htg_on) & (clg <= clg_on)] = 1
+    state[(fan > fan_on) & (htg <= htg_on) & (clg <= clg_on) & (econ > econ_min)] = 2
+    state[(fan > fan_on) & (htg <= htg_on) & (clg > clg_on) & (econ > econ_min)] = 3
+    state[(fan > fan_on) & (htg <= htg_on) & (clg > clg_on) & (econ <= econ_min)] = 4
+    changed = state.ne(state.shift()).fillna(False)
+    if len(changed):
+        changed.iloc[0] = False
+    samples = max(1, int(np.ceil(delay_min * 60.0 / max(float(poll), 1.0))))
+    recent_change = changed.astype(int).rolling(samples, min_periods=1).max().astype(bool)
+    return ~recent_change
+
+def _gl36_fault(raw: pd.Series, d: pd.DataFrame, p: dict, poll: float) -> pd.Series:
+    return raw.fillna(False) & _gl36_mode_stable(d, p, poll)
+```
+
 ### FC1 — Duct static below SP at full fan (GL36 A)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan ≥ 87% AND duct static < static SP − 0.12 in.w.c.  
+**Equation:** DSP < DSPSP − εDSP AND VFDSPD ≥ 100% − εVFDSPD.  
 **Default confirmation:** 300 s
 
 **Required roles:** `duct-static-pressure`, `duct-static-pressure-sp`, `fan-cmd`
@@ -339,21 +406,26 @@ Includes GL36 FC1–FC15, AHU auxiliaries, economizer/ventilation, leakage, and 
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `duct_static_err` | Duct static error | in. w.c. | 0.12 | 0.02–0.5 |
-| `fan_hi` | Fan high threshold | frac | 0.87 | 0.5–1.0 |
+| `eps_dsp` | Duct-static error εDSP (GL36 default 0.1 in.w.c.) | in. w.c. | 0.12 | 0.0–0.5 |
+| `eps_vfd_spd` | VFD speed error εVFDSPD (GL36 default 5%) | frac | 0.13 | 0.0–0.5 |
+| `duct_static_err` | Legacy duct-static error (sets εDSP) | in. w.c. | 0.12 | 0.0–0.5 |
+| `fan_hi` | Legacy fan-high threshold (sets εVFDSPD) | frac | 0.87 | 0.5–1.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 300
 
 def fc1(d, p, poll):
-    err = _f(p, "duct_static_err", 0.12)
-    fan_hi = _f(p, "fan_hi", 0.87)
+    err = _gl36_value(p, "eps_dsp", "duct_static_err", 0.12)
+    speed_err = _gl36_value(p, "eps_vfd_spd", None, 0.13)
+    fan_hi = _gl36_value(p, "fan_hi", None, 1.0 - speed_err)
     fan = _fan(d)
-    return (
+    raw = (
         d["duct-static-pressure"].notna() & d["duct-static-pressure-sp"].notna()
         & (d["duct-static-pressure"] < d["duct-static-pressure-sp"] - err)
         & (fan >= fan_hi)
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc1(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -361,7 +433,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC2 — MAT below OAT/RAT envelope (GL36 B)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND MAT + mix_tol < min(RAT − mix_tol, OAT − mix_tol) (≡ MAT < min(RAT, OAT) − 2·mix_tol; default mix_tol = 1.15°F).  
+**Equation:** MATavg + εMAT < min(RATavg − εRAT, OATavg − εOAT).  
 **Default confirmation:** 600 s
 
 **Required roles:** `mixed-air-temp`, `outside-air-temp`, `return-air-temp`, `fan-cmd`
@@ -370,7 +442,12 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_rat` | RAT sensor error εRAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
@@ -382,13 +459,17 @@ def fc2(d, p, poll):
     ``mat + tol < min(rat - tol, oat - tol)`` ≡ ``mat < min(rat, oat) - 2·tol``.
     Never subtract the same tol from both sides of the inequality (that cancels).
     """
-    tol = _f(p, "mix_tol", MIX_TOL)
+    eps_mat = _gl36_value(p, "eps_mat", "mix_tol", MIX_TOL)
+    eps_rat = _gl36_value(p, "eps_rat", "mix_tol", MIX_TOL)
+    eps_oat = _gl36_value(p, "eps_oat", "mix_tol", MIX_TOL)
+    fan_on = _gl36_value(p, "fan_on_min", None, FAN_ON_MIN)
     fan = _fan(d)
-    return (
-        (fan > FAN_ON_MIN)
+    raw = (
+        (fan > fan_on)
         & d["mixed-air-temp"].notna() & d["outside-air-temp"].notna() & d["return-air-temp"].notna()
-        & ((d["mixed-air-temp"] + tol) < np.minimum(d["return-air-temp"] - tol, d["outside-air-temp"] - tol))
+        & ((d["mixed-air-temp"] + eps_mat) < np.minimum(d["return-air-temp"] - eps_rat, d["outside-air-temp"] - eps_oat))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc2(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -396,7 +477,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC3 — MAT above OAT/RAT envelope (GL36 C)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND MAT − mix_tol > max(RAT + mix_tol, OAT + mix_tol) (≡ MAT > max(RAT, OAT) + 2·mix_tol; default mix_tol = 1.15°F).  
+**Equation:** MATavg − εMAT > max(RATavg + εRAT, OATavg + εOAT).  
 **Default confirmation:** 600 s
 
 **Required roles:** `mixed-air-temp`, `outside-air-temp`, `return-air-temp`, `fan-cmd`
@@ -405,19 +486,28 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_rat` | RAT sensor error εRAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc3(d, p, poll):
-    tol = _f(p, "mix_tol", MIX_TOL)
+    eps_mat = _gl36_value(p, "eps_mat", "mix_tol", MIX_TOL)
+    eps_rat = _gl36_value(p, "eps_rat", "mix_tol", MIX_TOL)
+    eps_oat = _gl36_value(p, "eps_oat", "mix_tol", MIX_TOL)
+    fan_on = _gl36_value(p, "fan_on_min", None, FAN_ON_MIN)
     fan = _fan(d)
-    return (
-        (fan > FAN_ON_MIN)
+    raw = (
+        (fan > fan_on)
         & d["mixed-air-temp"].notna() & d["outside-air-temp"].notna() & d["return-air-temp"].notna()
-        & ((d["mixed-air-temp"] - tol) > np.maximum(d["return-air-temp"] + tol, d["outside-air-temp"] + tol))
+        & ((d["mixed-air-temp"] - eps_mat) > np.maximum(d["return-air-temp"] + eps_rat, d["outside-air-temp"] + eps_oat))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc3(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -425,7 +515,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC4 — PID hunting (operating-state oscillation)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** More than 5 operating-mode entry transitions in any hour (heating/econ/mech modes).  
+**Equation:** ΔOS > ΔOSmax during the prior 60-minute moving window.  
 **Default confirmation:** 3600 s
 
 **Required roles:** `outside-air-damper`, `cooling-valve`, `fan-cmd`
@@ -434,7 +524,8 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `delta_os_max` | Max mode changes/hr | count | 5 | 2–20 |
+| `delta_os_max` | Max mode changes/hr ΔOSmax (GL36 default 7) | count | 5 | 1–30 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 3600
@@ -471,7 +562,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC5 — SAT cold when heating commanded (GL36 D)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND heating > 1% AND SAT + mix_tol ≤ MAT − mix_tol + 0.55°F (default mix_tol = 1.15°F).  
+**Equation:** SATavg + εSAT ≤ MATavg − εMAT + ΔTSF while heating is commanded.  
 **Default confirmation:** 600 s
 
 **Required roles:** `discharge-air-temp`, `mixed-air-temp`, `fan-cmd`, `heating-valve`
@@ -480,21 +571,32 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `htg_on_min` | Heating-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc5(d, p, poll):
     """SAT cold when heating commanded (GL36 D). ``mix_tol`` applies to both SAT and MAT."""
-    tol = _f(p, "mix_tol", MIX_TOL)
+    eps_sat = _gl36_value(p, "eps_sat", "mix_tol", MIX_TOL)
+    eps_mat = _gl36_value(p, "eps_mat", "mix_tol", MIX_TOL)
+    delta_tsf = _f(p, "delta_supply_fan", DELTA_SUPPLY_FAN)
+    fan_on = _gl36_value(p, "fan_on_min", None, FAN_ON_MIN)
+    htg_on = _f(p, "htg_on_min", 0.01)
     fan = _fan(d)
     htg = norm_cmd(d["heating-valve"]).fillna(0)
-    return (
+    raw = (
         d["discharge-air-temp"].notna() & d["mixed-air-temp"].notna()
-        & (fan > FAN_ON_MIN) & (htg > 0.01)
-        & ((d["discharge-air-temp"] + tol) <= (d["mixed-air-temp"] - tol + DELTA_SUPPLY_FAN))
+        & (fan > fan_on) & (htg > htg_on)
+        & ((d["discharge-air-temp"] + eps_sat) <= (d["mixed-air-temp"] - eps_mat + delta_tsf))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc5(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -502,7 +604,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC6 — Estimated OA fraction mismatch
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** abs(RAT−OAT) ≥ 5°F AND abs(estimated OA% − design min OA%) > 15% in heating/mech-only modes.  
+**Equation:** |RATavg−OATavg| ≥ ΔTmin AND |estimated OA% − design min OA%| > εF.  
 **Default confirmation:** 600 s
 
 **Required roles:** `mixed-air-temp`, `outside-air-temp`, `return-air-temp`, `vav-total-airflow`
@@ -511,25 +613,32 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `airflow_err` | OA fraction error | frac | 0.15 | 0.05–0.5 |
+| `eps_airflow` | Airflow error εF (GL36 default 30%) | frac | 0.15 | 0.05–1.0 |
+| `delta_t_min` | Minimum |OAT−RAT| ΔTmin (GL36 default 10°F) | °F | 5.0 | 0.0–30.0 |
+| `airflow_err` | Legacy OA-fraction error (sets εF) | frac | 0.15 | 0.05–1.0 |
+| `oat_rat_delta_min` | Legacy OAT/RAT guard (sets ΔTmin) | °F | 5.0 | 0.0–30.0 |
 | `min_cfm_design` | Design min OA CFM | cfm | 5000 | 500–20000 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc6(d, p, poll):
-    airflow_err = _f(p, "airflow_err", 0.15)
-    oat_rat_min = _f(p, "oat_rat_delta_min", 5.0)
+    airflow_err = _gl36_value(p, "eps_airflow", "airflow_err", 0.15)
+    oat_rat_min = _gl36_value(p, "delta_t_min", "oat_rat_delta_min", 5.0)
     design_cfm = _f(p, "min_cfm_design", 5000.0)
+    fan_on = _gl36_value(p, "fan_on_min", None, FAN_ON_MIN)
     fan = _fan(d)
     rat_minus_oat = (d["return-air-temp"] - d["outside-air-temp"]).abs()
     pct_oa = ((d["mixed-air-temp"] - d["return-air-temp"]) / (d["outside-air-temp"] - d["return-air-temp"]).replace(0, np.nan)).clip(lower=0)
     perc_oamin = design_cfm / d["vav-total-airflow"].replace(0, np.nan)
     oa_err = (pct_oa - perc_oamin).abs()
-    return (
+    raw = (
         d["mixed-air-temp"].notna() & d["outside-air-temp"].notna() & d["return-air-temp"].notna() & d["vav-total-airflow"].notna()
-        & (rat_minus_oat >= oat_rat_min) & (oa_err > airflow_err) & (fan > FAN_ON_MIN)
+        & (rat_minus_oat >= oat_rat_min) & (oa_err > airflow_err) & (fan > fan_on)
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc6(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -537,7 +646,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC7 — SAT low with full heating (GL36 E)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Fan on AND heating > 90% AND SAT < SAT SP − 1.0°F.  
+**Equation:** SATavg < SATSP − εSAT AND HC ≥ full-heating threshold.  
 **Default confirmation:** 600 s
 
 **Required roles:** `discharge-air-temp`, `discharge-air-temp-sp`, `fan-cmd`, `heating-valve`
@@ -546,19 +655,26 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `sat_err` | SAT error | °F | 1.0 | 0.25–5.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.0 | 0.0–10.0 |
+| `sat_err` | Legacy SAT error (sets εSAT) | °F | 1.0 | 0.0–10.0 |
+| `htg_full_min` | Full-heating threshold (GL36 99%) | frac | 0.9 | 0.5–1.0 |
+| `fan_on_min` | Fan-on command threshold | frac | 0.01 | 0.0–0.25 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc7(d, p, poll):
-    sat_err = _f(p, "sat_err", 1.0)
+    sat_err = _gl36_value(p, "eps_sat", "sat_err", 1.0)
+    fan_on = _gl36_value(p, "fan_on_min", None, FAN_ON_MIN)
+    htg_full = _f(p, "htg_full_min", 0.9)
     fan = _fan(d)
     htg = norm_cmd(d["heating-valve"]).fillna(0)
-    return (
+    raw = (
         d["discharge-air-temp"].notna() & d["discharge-air-temp-sp"].notna()
-        & (fan > FAN_ON_MIN) & (d["discharge-air-temp"] < d["discharge-air-temp-sp"] - sat_err) & (htg > 0.9)
+        & (fan > fan_on) & (d["discharge-air-temp"] < d["discharge-air-temp-sp"] - sat_err) & (htg >= htg_full)
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc7(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -566,7 +682,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC8 — SAT/MAT mismatch in economizer (GL36 F)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Economizer open, CHW < 10%, |SAT − 0.55°F − MAT| > √(supply_tol²+mix_tol²).  
+**Equation:** |SATavg − ΔTSF − MATavg| > √(εSAT² + εMAT²) in OS#2.  
 **Default confirmation:** 600 s
 
 **Required roles:** `discharge-air-temp`, `mixed-air-temp`, `outside-air-damper`, `cooling-valve`
@@ -575,23 +691,33 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
-| `supply_tol` | Supply tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `supply_tol` | Legacy SAT tolerance master (sets εSAT) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc8(d, p, poll):
-    mix_tol = _f(p, "mix_tol", MIX_TOL)
-    supply_tol = _f(p, "supply_tol", SUPPLY_TOL)
+    eps_mat = _gl36_value(p, "eps_mat", "mix_tol", MIX_TOL)
+    eps_sat = _gl36_value(p, "eps_sat", "supply_tol", SUPPLY_TOL)
+    delta_tsf = _f(p, "delta_supply_fan", DELTA_SUPPLY_FAN)
+    econ_min = _f(p, "econ_min_pos", AHU_MIN_OA_DPR)
+    clg_inactive = _f(p, "clg_inactive_max", 0.1)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
-    sat_mat_err = (d["discharge-air-temp"] - DELTA_SUPPLY_FAN - d["mixed-air-temp"]).abs()
-    sqrt_tol = float(np.sqrt(supply_tol**2 + mix_tol**2))
-    return (
+    sat_mat_err = (d["discharge-air-temp"] - delta_tsf - d["mixed-air-temp"]).abs()
+    sqrt_tol = float(np.sqrt(eps_sat**2 + eps_mat**2))
+    raw = (
         d["discharge-air-temp"].notna() & d["mixed-air-temp"].notna()
-        & (econ > AHU_MIN_OA_DPR) & (clg < 0.1) & (sat_mat_err > sqrt_tol)
+        & (econ > econ_min) & (clg < clg_inactive) & (sat_mat_err > sqrt_tol)
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc8(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -599,7 +725,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC9 — OAT too warm for free cooling (GL36 G)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Economizer open, CHW < 10%, OAT − mix_tol > SAT SP − 0.55°F + mix_tol.  
+**Equation:** OATavg − εOAT > SATSP − ΔTSF + εSAT in OS#2.  
 **Default confirmation:** 600 s
 
 **Required roles:** `outside-air-temp`, `discharge-air-temp-sp`, `outside-air-damper`, `cooling-valve`
@@ -608,20 +734,31 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc9(d, p, poll):
-    mix_tol = _f(p, "mix_tol", MIX_TOL)
+    eps_oat = _gl36_value(p, "eps_oat", "mix_tol", MIX_TOL)
+    eps_sat = _gl36_value(p, "eps_sat", "mix_tol", MIX_TOL)
+    delta_tsf = _f(p, "delta_supply_fan", DELTA_SUPPLY_FAN)
+    econ_min = _f(p, "econ_min_pos", AHU_MIN_OA_DPR)
+    clg_inactive = _f(p, "clg_inactive_max", 0.1)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
-    return (
+    raw = (
         d["outside-air-temp"].notna() & d["discharge-air-temp-sp"].notna()
-        & (econ > AHU_MIN_OA_DPR) & (clg < 0.1)
-        & ((d["outside-air-temp"] - mix_tol) > (d["discharge-air-temp-sp"] - DELTA_SUPPLY_FAN + mix_tol))
+        & (econ > econ_min) & (clg < clg_inactive)
+        & ((d["outside-air-temp"] - eps_oat) > (d["discharge-air-temp-sp"] - delta_tsf + eps_sat))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc9(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -629,7 +766,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC10 — OAT/MAT mismatch + mech cooling (GL36 H)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, economizer > 90%, |MAT − OAT| > √(mix_tol²+mix_tol²).  
+**Equation:** |MATavg − OATavg| > √(εMAT² + εOAT²) in OS#3.  
 **Default confirmation:** 600 s
 
 **Required roles:** `mixed-air-temp`, `outside-air-temp`, `outside-air-damper`, `cooling-valve`
@@ -638,18 +775,27 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc10(d, p, poll):
-    mix_tol = _f(p, "mix_tol", MIX_TOL)
+    eps_mat = _gl36_value(p, "eps_mat", "mix_tol", MIX_TOL)
+    eps_oat = _gl36_value(p, "eps_oat", "mix_tol", MIX_TOL)
+    econ_full = _f(p, "econ_full_open", 0.9)
+    clg_on = _f(p, "clg_on_min", 0.01)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
     abs_mat_oat = (d["mixed-air-temp"] - d["outside-air-temp"]).abs()
-    sqrt_tol = float(np.sqrt(mix_tol**2 + mix_tol**2))
-    return d["mixed-air-temp"].notna() & d["outside-air-temp"].notna() & (clg > 0.01) & (econ > 0.9) & (abs_mat_oat > sqrt_tol)
+    sqrt_tol = float(np.sqrt(eps_mat**2 + eps_oat**2))
+    raw = d["mixed-air-temp"].notna() & d["outside-air-temp"].notna() & (clg > clg_on) & (econ > econ_full) & (abs_mat_oat > sqrt_tol)
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc10(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -657,7 +803,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC11 — OAT/MAT mismatch economizer-only (GL36 I)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, economizer > 90%, OAT + mix_tol < SAT SP − 0.55°F − mix_tol.  
+**Equation:** OATavg + εOAT < SATSP − ΔTSF − εSAT in OS#3.  
 **Default confirmation:** 600 s
 
 **Required roles:** `outside-air-temp`, `discharge-air-temp-sp`, `outside-air-damper`, `cooling-valve`
@@ -666,19 +812,30 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_oat` | OAT sensor error εOAT (GL36 default 2°F local / 5°F global) | °F | 1.15 | 0.0–10.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc11(d, p, poll):
-    mix_tol = _f(p, "mix_tol", MIX_TOL)
+    eps_oat = _gl36_value(p, "eps_oat", "mix_tol", MIX_TOL)
+    eps_sat = _gl36_value(p, "eps_sat", "mix_tol", MIX_TOL)
+    delta_tsf = _f(p, "delta_supply_fan", DELTA_SUPPLY_FAN)
+    econ_full = _f(p, "econ_full_open", 0.9)
+    clg_on = _f(p, "clg_on_min", 0.01)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
-    return (
-        d["outside-air-temp"].notna() & d["discharge-air-temp-sp"].notna() & (clg > 0.01) & (econ > 0.9)
-        & ((d["outside-air-temp"] + mix_tol) < (d["discharge-air-temp-sp"] - DELTA_SUPPLY_FAN - mix_tol))
+    raw = (
+        d["outside-air-temp"].notna() & d["discharge-air-temp-sp"].notna() & (clg > clg_on) & (econ > econ_full)
+        & ((d["outside-air-temp"] + eps_oat) < (d["discharge-air-temp-sp"] - delta_tsf - eps_sat))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc11(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -686,7 +843,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC12 — SAT above blend in cooling (GL36 J)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, SAT − supply_tol − 0.55°F > MAT + mix_tol at min or full economizer.  
+**Equation:** SATavg − εSAT − ΔTSF ≥ MATavg + εMAT in OS#3/OS#4.  
 **Default confirmation:** 600 s
 
 **Required roles:** `discharge-air-temp`, `mixed-air-temp`, `outside-air-damper`, `cooling-valve`
@@ -695,23 +852,35 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
-| `supply_tol` | Supply tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.15 | 0.0–10.0 |
+| `eps_mat` | MAT sensor error εMAT (GL36 default 5°F) | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `supply_tol` | Legacy SAT tolerance master (sets εSAT) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc12(d, p, poll):
-    mix_tol = _f(p, "mix_tol", MIX_TOL)
-    supply_tol = _f(p, "supply_tol", SUPPLY_TOL)
+    eps_mat = _gl36_value(p, "eps_mat", "mix_tol", MIX_TOL)
+    eps_sat = _gl36_value(p, "eps_sat", "supply_tol", SUPPLY_TOL)
+    delta_tsf = _f(p, "delta_supply_fan", DELTA_SUPPLY_FAN)
+    econ_min = _f(p, "econ_min_pos", AHU_MIN_OA_DPR)
+    econ_full = _f(p, "econ_full_open", 0.9)
+    clg_on = _f(p, "clg_on_min", 0.01)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
-    sat_check = d["discharge-air-temp"] - supply_tol - DELTA_SUPPLY_FAN
-    mat_check = d["mixed-air-temp"] + mix_tol
-    return (
-        d["discharge-air-temp"].notna() & d["mixed-air-temp"].notna() & (clg > 0.01)
-        & (sat_check > mat_check) & ((econ <= AHU_MIN_OA_DPR) | (econ > 0.9))
+    sat_check = d["discharge-air-temp"] - eps_sat - delta_tsf
+    mat_check = d["mixed-air-temp"] + eps_mat
+    raw = (
+        d["discharge-air-temp"].notna() & d["mixed-air-temp"].notna() & (clg > clg_on)
+        & (sat_check > mat_check) & ((econ <= econ_min) | (econ > econ_full))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc12(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -719,7 +888,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC13 — SAT above SP at full cooling (GL36 K)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** CHW > 1%, SAT > SAT SP + 1.0°F at min or full economizer.  
+**Equation:** SATavg > SATSP + εSAT AND CC ≥ full-cooling threshold in OS#3/OS#4.  
 **Default confirmation:** 600 s
 
 **Required roles:** `discharge-air-temp`, `discharge-air-temp-sp`, `outside-air-damper`, `cooling-valve`
@@ -728,19 +897,28 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `sat_err` | SAT error | °F | 1.0 | 0.25–5.0 |
+| `eps_sat` | SAT sensor error εSAT (GL36 default 2°F) | °F | 1.0 | 0.0–10.0 |
+| `sat_err` | Legacy SAT error (sets εSAT) | °F | 1.0 | 0.0–10.0 |
+| `clg_full_min` | Full-cooling threshold (GL36 99%) | frac | 0.01 | 0.5–1.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc13(d, p, poll):
-    sat_err = _f(p, "sat_err", 1.0)
+    sat_err = _gl36_value(p, "eps_sat", "sat_err", 1.0)
+    econ_min = _f(p, "econ_min_pos", AHU_MIN_OA_DPR)
+    econ_full = _f(p, "econ_full_open", 0.9)
+    clg_full = _f(p, "clg_full_min", 0.01)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
-    return (
-        d["discharge-air-temp"].notna() & d["discharge-air-temp-sp"].notna() & (clg > 0.01)
-        & (d["discharge-air-temp"] > d["discharge-air-temp-sp"] + sat_err) & ((econ <= AHU_MIN_OA_DPR) | (econ > 0.9))
+    raw = (
+        d["discharge-air-temp"].notna() & d["discharge-air-temp-sp"].notna() & (clg >= clg_full)
+        & (d["discharge-air-temp"] > d["discharge-air-temp-sp"] + sat_err) & ((econ <= econ_min) | (econ > econ_full))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc13(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -748,7 +926,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC14 — CHW coil ΔT when inactive (GL36 L)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Cooling coil ΔT ≥ √(mix_tol²+mix_tol²)+0.55°F while coil should be inactive.  
+**Equation:** Cooling-coil ΔT ≥ √(εCCET² + εCCLT²) + ΔTSF while coil should be inactive.  
 **Default confirmation:** 600 s
 
 **Required roles:** `cooling-coil-entering-temp`, `cooling-coil-leaving-temp`, `outside-air-damper`, `cooling-valve`
@@ -757,24 +935,37 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_ccet` | Cooling-coil entering sensor error εCCET | °F | 1.15 | 0.0–10.0 |
+| `eps_cclt` | Cooling-coil leaving sensor error εCCLT | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `htg_on_min` | Heating-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc14(d, p, poll):
-    mix_tol = _f(p, "mix_tol", MIX_TOL)
+    eps_ccet = _gl36_value(p, "eps_ccet", "mix_tol", MIX_TOL)
+    eps_cclt = _gl36_value(p, "eps_cclt", "mix_tol", MIX_TOL)
+    delta_tsf = _f(p, "delta_supply_fan", DELTA_SUPPLY_FAN)
+    econ_min = _f(p, "econ_min_pos", AHU_MIN_OA_DPR)
+    clg_inactive = _f(p, "clg_inactive_max", 0.1)
+    htg_on = _f(p, "htg_on_min", 0.01)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
     htg = norm_cmd(d["heating-valve"]).fillna(0) if "heating-valve" in d else pd.Series(0.0, index=d.index)
     fan = _fan(d)
     delta = d["cooling-coil-entering-temp"] - d["cooling-coil-leaving-temp"]
-    tol = float(np.sqrt(mix_tol**2 + mix_tol**2)) + DELTA_SUPPLY_FAN
-    return (
+    tol = float(np.sqrt(eps_ccet**2 + eps_cclt**2)) + delta_tsf
+    raw = (
         d["cooling-coil-entering-temp"].notna() & d["cooling-coil-leaving-temp"].notna()
         & (delta >= tol)
-        & (((econ > AHU_MIN_OA_DPR) & (clg < 0.1)) | ((htg > 0) & (fan > 0)))
+        & (((econ > econ_min) & (clg < clg_inactive)) | ((htg > htg_on) & (fan > 0)))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc14(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -782,7 +973,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 ### FC15 — HW coil ΔT when inactive (GL36 M)
 **Family:** `ahu` · **Equipment:** `ahu`  
-**Equation:** Heating coil ΔT ≥ √(mix_tol²+mix_tol²)+0.55°F while coil should be inactive.  
+**Equation:** Heating-coil ΔT ≥ √(εHCET² + εHCLT²) + ΔTSF while coil should be inactive.  
 **Default confirmation:** 600 s
 
 **Required roles:** `heating-coil-entering-temp`, `heating-coil-leaving-temp`, `outside-air-damper`, `cooling-valve`
@@ -791,22 +982,37 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
-| `mix_tol` | Mixing tolerance | °F | 1.15 | 0.25–3.0 |
+| `eps_hcet` | Heating-coil entering sensor error εHCET | °F | 1.15 | 0.0–10.0 |
+| `eps_hclt` | Heating-coil leaving sensor error εHCLT | °F | 1.15 | 0.0–10.0 |
+| `delta_supply_fan` | Supply-fan heat rise ΔTSF (GL36 default 2°F) | °F | 0.55 | 0.0–5.0 |
+| `econ_min_pos` | Economizer minimum-position threshold | frac | 0.05 | 0.0–0.5 |
+| `econ_full_open` | Economizer full-open threshold | frac | 0.9 | 0.5–1.0 |
+| `clg_inactive_max` | Cooling-command inactive ceiling | frac | 0.1 | 0.0–0.5 |
+| `clg_on_min` | Cooling-command ON threshold | frac | 0.01 | 0.0–0.25 |
+| `mix_tol` | Legacy master sensor tolerance (sets all ε values) | °F | 1.15 | 0.0–10.0 |
+| `mode_delay_min` | Mode-change suspension (GL36 default 30) | min | 0.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 600
 
 def fc15(d, p, poll):
-    mix_tol = _f(p, "mix_tol", MIX_TOL)
+    eps_hcet = _gl36_value(p, "eps_hcet", "mix_tol", MIX_TOL)
+    eps_hclt = _gl36_value(p, "eps_hclt", "mix_tol", MIX_TOL)
+    delta_tsf = _f(p, "delta_supply_fan", DELTA_SUPPLY_FAN)
+    econ_min = _f(p, "econ_min_pos", AHU_MIN_OA_DPR)
+    econ_full = _f(p, "econ_full_open", 0.9)
+    clg_inactive = _f(p, "clg_inactive_max", 0.1)
+    clg_on = _f(p, "clg_on_min", 0.01)
     econ = norm_cmd(d["outside-air-damper"]).fillna(0)
     clg = norm_cmd(d["cooling-valve"]).fillna(0)
     delta = d["heating-coil-entering-temp"] - d["heating-coil-leaving-temp"]
-    tol = float(np.sqrt(mix_tol**2 + mix_tol**2)) + DELTA_SUPPLY_FAN
-    return (
+    tol = float(np.sqrt(eps_hcet**2 + eps_hclt**2)) + delta_tsf
+    raw = (
         d["heating-coil-entering-temp"].notna() & d["heating-coil-leaving-temp"].notna()
         & (delta >= tol)
-        & (((econ > AHU_MIN_OA_DPR) & (clg < 0.1)) | ((clg > 0.01) & (econ <= AHU_MIN_OA_DPR)) | ((clg > 0.01) & (econ > 0.9)))
+        & (((econ > econ_min) & (clg < clg_inactive)) | ((clg > clg_on) & (econ <= econ_min)) | ((clg > clg_on) & (econ > econ_full)))
     )
+    return _gl36_fault(raw, d, p, poll)
 
 d = apply_fault(d, fc15(d, params, POLL_SECONDS))
 d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFIRM_SECONDS // POLL_SECONDS))
@@ -1600,7 +1806,6 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 | `comfort_low_f` | Comfort low | °F | 70.0 | 60.0–78.0 |
 | `comfort_high_f` | Comfort high | °F | 75.0 | 68.0–85.0 |
 | `sat_band_f` | AHU SAT≈SP band | °F | 2.0 | 0.5–6.0 |
-| `confirm_min` | Fault confirm delay | min | 30.0 | 0.0–60.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 1800
@@ -1679,6 +1884,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
 | `dp_margin` | DP margin | psi | 2.2 | 0.5–6.0 |
+| `pump_hi` | Pump high-speed threshold | frac | 0.87 | 0.5–1.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 300
@@ -1736,6 +1942,7 @@ d["fault_confirmed"] = confirm_fault(d["fault_raw"], min_rows=max(1, FAULT_CONFI
 | Param | Label | Unit | Default | Range |
 |-------|-------|------|--------:|-------|
 | `flow_hi` | Flow high | gpm | 1100 | 200–3000 |
+| `pump_hi` | Pump high-speed threshold | frac | 0.87 | 0.5–1.0 |
 
 ```python
 FAULT_CONFIRM_SECONDS = 300

--- a/sql_rules/chw2_dp_low.sql
+++ b/sql_rules/chw2_dp_low.sql
@@ -13,7 +13,7 @@ base AS (
     timestamp_utc,
     CAST(CASE
       WHEN chw_dp IS NULL OR chw_dp_sp IS NULL OR pump IS NULL THEN 0
-      WHEN pump >= 0.87 AND chw_dp < chw_dp_sp - {{DP_MARGIN}} THEN 1
+      WHEN pump >= {{PUMP_HI}} AND chw_dp < chw_dp_sp - {{DP_MARGIN}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
   FROM h

--- a/sql_rules/chw4_flow_high.sql
+++ b/sql_rules/chw4_flow_high.sql
@@ -13,7 +13,7 @@ base AS (
     timestamp_utc,
     CAST(CASE
       WHEN chw_flow IS NULL OR pump IS NULL THEN 0
-      WHEN pump >= 0.87 AND chw_flow > {{FLOW_HI}} THEN 1
+      WHEN pump >= {{PUMP_HI}} AND chw_flow > {{FLOW_HI}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
   FROM h

--- a/sql_rules/econ1_stuck_closed.sql
+++ b/sql_rules/econ1_stuck_closed.sql
@@ -11,7 +11,7 @@ SELECT
   equipment_id,
   SUM(CASE
     WHEN fan_cmd > 0.01 AND oa_damper_pct IS NOT NULL AND oa_t IS NOT NULL
-     AND oa_damper_pct < 0.05 AND oa_t > 55.0
+     AND oa_damper_pct < 0.05 AND oa_t > {{ECON1_OAT_MIN}}
     THEN 1 ELSE 0 END) * {{POLL_SECONDS}} / 3600.0 AS fault_hours
 FROM h
 GROUP BY equipment_id;

--- a/sql_rules/econ4_low_oa_frac.sql
+++ b/sql_rules/econ4_low_oa_frac.sql
@@ -16,7 +16,7 @@ base AS (
     CAST(CASE
       WHEN fan > 0.01 AND mat IS NOT NULL AND rat IS NOT NULL AND oa_t IS NOT NULL
        AND ABS(rat - oa_t) > 2.2
-       AND ((mat - rat) / NULLIF(oa_t - rat, 0)) * 100.0 < 21.0
+       AND ((mat - rat) / NULLIF(oa_t - rat, 0)) * 100.0 < {{OA_MIN_PCT}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
   FROM h
 ),

--- a/sql_rules/economizer_fault.sql
+++ b/sql_rules/economizer_fault.sql
@@ -1,4 +1,4 @@
--- economizer_fault.sql — ECON-2 cookbook defaults (OAT > 63°F, damper > 42%) + confirm
+-- economizer_fault.sql — ECON-2 economizing when outdoor unfavorable + confirm
 WITH h AS (
   SELECT
     equipment_id,
@@ -13,7 +13,7 @@ base AS (
     timestamp_utc,
     CAST(CASE
       WHEN oa_t IS NOT NULL AND oa_damper_pct IS NOT NULL
-       AND oa_t > 63.0 AND oa_damper_pct > 0.42
+       AND oa_t > {{ECON2_OAT_HI}} AND oa_damper_pct > {{ECON2_DAMPER}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
   FROM h
 ),

--- a/sql_rules/fc1_duct_static_low.sql
+++ b/sql_rules/fc1_duct_static_low.sql
@@ -14,8 +14,8 @@ base AS (
     timestamp_utc,
     CAST(CASE
       WHEN duct_static IS NOT NULL AND duct_static_sp IS NOT NULL
-       AND duct_static < duct_static_sp - 0.12
-       AND fan_cmd >= 0.87
+       AND duct_static < duct_static_sp - {{EPS_DSP}}
+       AND fan_cmd >= 1.0 - {{EPS_VFD_SPD}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
   FROM h
 ),

--- a/sql_rules/fc5_sat_cold_heating.sql
+++ b/sql_rules/fc5_sat_cold_heating.sql
@@ -14,7 +14,7 @@ base AS (
     timestamp_utc,
     CAST(CASE
       WHEN sat IS NULL OR mat IS NULL OR htg IS NULL OR fan IS NULL THEN 0
-      WHEN fan >= 0.05 AND htg > 0.01
+      WHEN fan >= 0.05 AND htg > {{HTG_ON_MIN}}
        AND (sat + {{MIX_TOL}}) <= (mat - {{MIX_TOL}} + 0.55) THEN 1
       ELSE 0
     END AS INT) AS raw_fault

--- a/sql_rules/fc6_oa_frac_mismatch.sql
+++ b/sql_rules/fc6_oa_frac_mismatch.sql
@@ -15,7 +15,7 @@ base AS (
     CAST(CASE
       WHEN mat IS NULL OR rat IS NULL OR oa_t IS NULL OR fan IS NULL THEN 0
       WHEN fan < 0.05 THEN 0
-      WHEN ABS(rat - oa_t) < 5.0 THEN 0
+      WHEN ABS(rat - oa_t) < {{DELTA_T_MIN}} THEN 0
       WHEN ABS((mat - rat) / NULLIF(oa_t - rat, 0) - 0.20) > {{AIRFLOW_ERR}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault

--- a/sql_rules/fc7_sat_low_heating.sql
+++ b/sql_rules/fc7_sat_low_heating.sql
@@ -15,7 +15,7 @@ base AS (
     timestamp_utc,
     CAST(CASE
       WHEN sat IS NOT NULL AND sat_sp IS NOT NULL AND fan > 0.01
-       AND sat < sat_sp - 1.0 AND htg_valve_pct > 0.9
+       AND sat < sat_sp - {{SAT_ERR}} AND htg_valve_pct > {{HTG_FULL_MIN}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
   FROM h
 ),

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -27,17 +27,17 @@ rules:
     confirm_seconds: 900
     parameters:
       zone_t_lo:
-        label: Zone comfort low
-        default: 68.0
-        min: 60.0
+        label: Zone low
+        default: 70.0
+        min: 55.0
         max: 72.0
         step: 0.5
         unit: degF
         frontend_control: slider
         sql_placeholder: ZONE_T_LO
       zone_t_hi:
-        label: Zone comfort high
-        default: 76.0
+        label: Zone high
+        default: 75.0
         min: 72.0
         max: 85.0
         step: 0.5
@@ -162,8 +162,8 @@ rules:
       oat_err:
         label: OAT vs meteo tolerance
         default: 5.0
-        min: 1.0
-        max: 15.0
+        min: 2.0
+        max: 20.0
         step: 0.5
         unit: degF
         frontend_control: slider
@@ -194,8 +194,8 @@ rules:
       sat_err:
         label: SAT high error band
         default: 1.0
-        min: 0.25
-        max: 5.0
+        min: 0.0
+        max: 10.0
         step: 0.25
         unit: degF
         frontend_control: slider
@@ -248,6 +248,34 @@ rules:
     dashboard_wired: true
     delete_python_candidate: false
     confirm_seconds: 300
+    parameters:
+      econ2_oat_hi:
+        label: OAT high cutoff
+        default: 63.0
+        min: 55.0
+        max: 80.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON2_OAT_HI
+      econ2_damper:
+        label: Damper open frac
+        default: 0.42
+        min: 0.2
+        max: 0.9
+        step: 0.02
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: ECON2_DAMPER
+      confirm_seconds:
+        label: Confirm time
+        default: 300
+        min: 0
+        max: 3600
+        step: 300
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC1
     sql_file: fc1_duct_static_low.sql
@@ -260,6 +288,34 @@ rules:
     dashboard_wired: true
     delete_python_candidate: false
     confirm_seconds: 300
+    parameters:
+      eps_dsp:
+        label: Duct-static error epsDSP (GL36 default 0.1 in.w.c.)
+        default: 0.12
+        min: 0.0
+        max: 0.5
+        step: 0.01
+        unit: inwc
+        frontend_control: slider
+        sql_placeholder: EPS_DSP
+      eps_vfd_spd:
+        label: VFD speed error epsVFDSPD (GL36 default 5%)
+        default: 0.13
+        min: 0.0
+        max: 0.5
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: EPS_VFD_SPD
+      confirm_seconds:
+        label: Confirm time
+        default: 300
+        min: 0
+        max: 3600
+        step: 300
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC2
     sql_file: fc2_mat_low.sql
@@ -297,6 +353,34 @@ rules:
     delete_python_candidate: false
     blocker: "htg_valve_pct missing on some AHUs — Python and SQL both skip"
     confirm_seconds: 600
+    parameters:
+      sat_err:
+        label: Legacy SAT error (sets epsSAT)
+        default: 1.0
+        min: 0.0
+        max: 10.0
+        step: 0.25
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: SAT_ERR
+      htg_full_min:
+        label: Full-heating threshold (GL36 99%)
+        default: 0.9
+        min: 0.5
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: HTG_FULL_MIN
+      confirm_seconds:
+        label: Confirm time
+        default: 600
+        min: 0
+        max: 3600
+        step: 300
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC8
     sql_file: fc8_sat_mat_econ.sql
@@ -369,6 +453,16 @@ rules:
     dashboard_wired: true
     delete_python_candidate: false
     confirm_seconds: 600
+    parameters:
+      econ1_oat_min:
+        label: Favorable OAT
+        default: 55.0
+        min: 45.0
+        max: 70.0
+        step: 1.0
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: ECON1_OAT_MIN
 
   - rule_id: ECON-4
     sql_file: econ4_low_oa_frac.sql
@@ -381,6 +475,25 @@ rules:
     dashboard_wired: true
     delete_python_candidate: false
     confirm_seconds: 600
+    parameters:
+      oa_min_pct:
+        label: Min OA fraction
+        default: 21.0
+        min: 5.0
+        max: 40.0
+        step: 1.0
+        unit: pct
+        frontend_control: slider
+        sql_placeholder: OA_MIN_PCT
+      confirm_seconds:
+        label: Confirm time
+        default: 600
+        min: 0
+        max: 3600
+        step: 300
+        unit: sec
+        frontend_control: slider
+        sql_placeholder: CONFIRM_SECONDS
 
 # --- Ported from datafusion-sql-cookbook (feat/sql-rules-59) ---
 
@@ -410,7 +523,7 @@ rules:
         default: 1.0
         min: 0.5
         max: 2.0
-        step: 0.25
+        step: 0.1
         unit: x
         frontend_control: slider
         sql_placeholder: RANGE_SCALE_TEMPERATURE
@@ -441,7 +554,7 @@ rules:
         default: 0.1
         min: 0.02
         max: 1.0
-        step: 0.01
+        step: 0.02
         unit: degF
         frontend_control: slider
         sql_placeholder: FLATLINE_TOL
@@ -509,6 +622,7 @@ rules:
         sql_placeholder: STALE_HOURS
 
   - rule_id: SV-RATE
+    aliases: [SV-SLEW]
     sql_file: sv_rate.sql
     pandas_function: null
     description: Context-aware sensor rate of change
@@ -549,11 +663,11 @@ rules:
     parity_status: ported_from_cookbook
     dashboard_wired: false
     delete_python_candidate: false
-    confirm_seconds: 300
+    confirm_seconds: 0
     parameters:
       confirm_seconds:
         label: Confirm time
-        default: 300.0
+        default: 0.0
         min: 0.0
         max: 3600.0
         step: 300.0
@@ -574,7 +688,7 @@ rules:
         default: 20.0
         min: 5.0
         max: 100.0
-        step: 1.0
+        step: 5.0
         unit: pct
         frontend_control: slider
         sql_placeholder: MINIMUM_SPAN_PCT
@@ -623,14 +737,23 @@ rules:
         frontend_control: slider
         sql_placeholder: CONFIRM_SECONDS
       mix_tol:
-        label: Mixing tolerance
+        label: Legacy master sensor tolerance (sets all eps values)
         default: 1.15
-        min: 0.5
-        max: 3.0
+        min: 0.0
+        max: 10.0
         step: 0.25
         unit: degF
         frontend_control: slider
         sql_placeholder: MIX_TOL
+      htg_on_min:
+        label: Heating-command ON threshold
+        default: 0.01
+        min: 0.0
+        max: 0.25
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: HTG_ON_MIN
 
   - rule_id: FC6
     sql_file: fc6_oa_frac_mismatch.sql
@@ -654,14 +777,23 @@ rules:
         frontend_control: slider
         sql_placeholder: CONFIRM_SECONDS
       airflow_err:
-        label: OA fraction error
+        label: Airflow error epsF (GL36 default 30%)
         default: 0.15
         min: 0.05
-        max: 0.5
+        max: 1.0
         step: 0.01
         unit: frac
         frontend_control: slider
         sql_placeholder: AIRFLOW_ERR
+      delta_t_min:
+        label: Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)
+        default: 5.0
+        min: 0.0
+        max: 30.0
+        step: 0.5
+        unit: degF
+        frontend_control: slider
+        sql_placeholder: DELTA_T_MIN
 
   - rule_id: FC14
     sql_file: fc14_chw_coil_dt_inactive.sql
@@ -685,10 +817,10 @@ rules:
         frontend_control: slider
         sql_placeholder: CONFIRM_SECONDS
       mix_tol:
-        label: Mixing tolerance
+        label: Legacy master sensor tolerance (sets all eps values)
         default: 1.15
-        min: 0.25
-        max: 3.0
+        min: 0.0
+        max: 10.0
         step: 0.25
         unit: degF
         frontend_control: slider
@@ -716,10 +848,10 @@ rules:
         frontend_control: slider
         sql_placeholder: CONFIRM_SECONDS
       mix_tol:
-        label: Mixing tolerance
+        label: Legacy master sensor tolerance (sets all eps values)
         default: 1.15
-        min: 0.25
-        max: 3.0
+        min: 0.0
+        max: 10.0
         step: 0.25
         unit: degF
         frontend_control: slider
@@ -782,7 +914,7 @@ rules:
         default: 0.25
         min: 0.05
         max: 1.0
-        step: 0.01
+        step: 0.05
         unit: in_wc
         frontend_control: slider
         sql_placeholder: DUCT_HIGH_MARGIN
@@ -791,7 +923,7 @@ rules:
         default: 0.2
         min: 0.05
         max: 1.0
-        step: 0.01
+        step: 0.05
         unit: in_wc
         frontend_control: slider
         sql_placeholder: PRESSURE_ON_MIN
@@ -853,7 +985,7 @@ rules:
         default: 60.0
         min: 50.0
         max: 68.0
-        step: 0.5
+        step: 1.0
         unit: degF
         frontend_control: slider
         sql_placeholder: ECON3_DB_MIN
@@ -862,7 +994,7 @@ rules:
         default: 72.0
         min: 65.0
         max: 80.0
-        step: 0.5
+        step: 1.0
         unit: degF
         frontend_control: slider
         sql_placeholder: ECON3_DB_MAX
@@ -880,7 +1012,7 @@ rules:
         default: 0.9
         min: 0.5
         max: 1.0
-        step: 0.01
+        step: 0.02
         unit: frac
         frontend_control: slider
         sql_placeholder: ECON3_DAMPER_HI
@@ -911,7 +1043,7 @@ rules:
         default: 2.2
         min: 0.5
         max: 8.0
-        step: 0.5
+        step: 0.1
         unit: degF
         frontend_control: slider
         sql_placeholder: PREHEAT_OVER_F
@@ -991,7 +1123,7 @@ rules:
         default: 72.0
         min: 65.0
         max: 80.0
-        step: 0.5
+        step: 1.0
         unit: degF
         frontend_control: slider
         sql_placeholder: ECON7_DB_MAX
@@ -1009,7 +1141,7 @@ rules:
         default: 0.5
         min: 0.2
         max: 0.9
-        step: 0.01
+        step: 0.02
         unit: frac
         frontend_control: slider
         sql_placeholder: ECON7_DAMPER_MIN
@@ -1040,7 +1172,7 @@ rules:
         default: 60.0
         min: 45.0
         max: 65.0
-        step: 0.5
+        step: 1.0
         unit: degF
         frontend_control: slider
         sql_placeholder: MECH_OAT_MAX_F
@@ -1098,12 +1230,12 @@ rules:
         frontend_control: slider
         sql_placeholder: MIN_OA_FRAC
       oat_rat_guard:
-        label: Oat Rat Guard
-        default: 1.0
-        min: 0.0
-        max: 100.0
-        step: 0.5
-        unit: eng
+        label: OAT/RAT guard
+        default: 2.2
+        min: 0.5
+        max: 6.0
+        step: 0.1
+        unit: degF
         frontend_control: slider
         sql_placeholder: OAT_RAT_GUARD
 
@@ -1213,7 +1345,7 @@ rules:
         default: 0.52
         min: 0.1
         max: 1.0
-        step: 0.01
+        step: 0.02
         unit: frac
         frontend_control: slider
         sql_placeholder: REHEAT_PCT
@@ -1222,7 +1354,7 @@ rules:
         default: 25.0
         min: 0.0
         max: 200.0
-        step: 10.0
+        step: 5.0
         unit: cfm
         frontend_control: slider
         sql_placeholder: FLOW_ON_MIN
@@ -1253,7 +1385,7 @@ rules:
         default: 0.975
         min: 0.8
         max: 1.0
-        step: 0.01
+        step: 0.005
         unit: frac
         frontend_control: slider
         sql_placeholder: FULL_OPEN_PCT
@@ -1262,7 +1394,7 @@ rules:
         default: 25.0
         min: 0.0
         max: 200.0
-        step: 10.0
+        step: 5.0
         unit: cfm
         frontend_control: slider
         sql_placeholder: FLOW_ON_MIN
@@ -1315,7 +1447,7 @@ rules:
         default: 0.3
         min: 0.1
         max: 1.0
-        step: 0.01
+        step: 0.05
         unit: frac
         frontend_control: slider
         sql_placeholder: REHEAT_CMD
@@ -1333,7 +1465,7 @@ rules:
         default: 25.0
         min: 0.0
         max: 200.0
-        step: 10.0
+        step: 5.0
         unit: cfm
         frontend_control: slider
         sql_placeholder: FLOW_ON_MIN
@@ -1364,7 +1496,7 @@ rules:
         default: 8.0
         min: 2.0
         max: 25.0
-        step: 1.0
+        step: 0.5
         unit: degF
         frontend_control: slider
         sql_placeholder: DELTA_F
@@ -1373,7 +1505,7 @@ rules:
         default: 25.0
         min: 0.0
         max: 200.0
-        step: 10.0
+        step: 5.0
         unit: cfm
         frontend_control: slider
         sql_placeholder: FLOW_ON_MIN
@@ -1404,7 +1536,7 @@ rules:
         default: 250.0
         min: 50.0
         max: 2000.0
-        step: 50.0
+        step: 10.0
         unit: cfm
         frontend_control: slider
         sql_placeholder: HIGH_MIN_FLOW_SP
@@ -1464,7 +1596,7 @@ rules:
       min_dt:
         label: Minimum delta-T
         default: 4.0
-        min: 2.0
+        min: 1.0
         max: 12.0
         step: 0.5
         unit: degF
@@ -1497,10 +1629,19 @@ rules:
         default: 2.2
         min: 0.5
         max: 6.0
-        step: 0.5
+        step: 0.1
         unit: psi
         frontend_control: slider
         sql_placeholder: DP_MARGIN
+      pump_hi:
+        label: Pump high-speed threshold
+        default: 0.87
+        min: 0.5
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: PUMP_HI
 
   - rule_id: CHW-3
     sql_file: chw3_supply_band.sql
@@ -1528,7 +1669,7 @@ rules:
         default: 2.2
         min: 0.5
         max: 6.0
-        step: 0.5
+        step: 0.1
         unit: degF
         frontend_control: slider
         sql_placeholder: SP_BAND
@@ -1563,6 +1704,15 @@ rules:
         unit: gpm
         frontend_control: slider
         sql_placeholder: FLOW_HI
+      pump_hi:
+        label: Pump high-speed threshold
+        default: 0.87
+        min: 0.5
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: PUMP_HI
 
   - rule_id: CW-OPT-1
     sql_file: cw_opt_1.sql
@@ -1727,7 +1877,7 @@ rules:
         label: Zone cold threshold
         default: 69.0
         min: 60.0
-        max: 75.0
+        max: 72.0
         step: 0.5
         unit: degF
         frontend_control: slider
@@ -1757,8 +1907,8 @@ rules:
       spike_limit:
         label: Spike limit
         default: 16.0
-        min: 5.0
-        max: 30.0
+        min: 4.0
+        max: 40.0
         step: 1.0
         unit: degF
         frontend_control: slider
@@ -1790,7 +1940,7 @@ rules:
         default: 1.35
         min: 0.5
         max: 3.0
-        step: 0.25
+        step: 0.05
         unit: in_wc
         frontend_control: slider
         sql_placeholder: DUCT_HI


### PR DESCRIPTION
## Summary
- Field-by-field audit of `sql_rules/registry.yaml` against the Streamlit vibe19 `cookbook_catalog.py` (59-rule validated catalog): fixed default/range/step drift on 25+ slider params (VAV-1 zone band 70/75, OA-1 `oat_rat_guard` 2.2 with degF range, OAT-METEO/WX-1/HP-1/FC13 ranges, many step sizes).
- Added tunable params that the catalog exposes and wired them into the SQL (previously hardcoded constants): FC1 `eps_dsp`/`eps_vfd_spd`, FC5 `htg_on_min`, FC6 `delta_t_min`, FC7 `sat_err`/`htg_full_min`, ECON-1 `econ1_oat_min`, ECON-2 `econ2_oat_hi`/`econ2_damper`, ECON-4 `oa_min_pct`, CHW-2/CHW-4 `pump_hi`.
- `SV-SLEW` alias on SV-RATE; PID-HUNT-1 confirm 300 s -> 0 s (rolling 1h window is its own persistence, matching vibe19).
- Regenerated FC1–FC15 pandas-cookbook sections from the vibe19 GL36 refactor (canonical `eps_*` params, `mode_delay_min` gating, shared-helpers block) and aligned datafusion-sql-cookbook tables/equations. Both cookbooks now show **zero param drift** against the validated catalog (verified by an AST-based diff of the vibe19 source).

Deliberately not added: params the simplified SQL variants cannot honor (SV-RATE transition/gap set, PID-HUNT-1 TV/cycles/reversals, SCHED-247 `always_on_pct`, FC4 `delta_os_max`, comfort bands on SCHED-1/CHW-NOLOAD-1). Those stay pandas-cookbook-only until the SQL variants grow the logic; the docs keep the vibe19 tables so the tuning contract is visible.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace` green (fdd_rules ECON-4 confirm regression updated for the new `OA_MIN_PCT` placeholder)
- [x] `openfdd-central` `csv_fdd_integration` (CSV upload -> parquet -> FC1 registry run) green against the parameterized FC1 SQL
- [x] Placeholder audit: every `{{PLACEHOLDER}}` in all 63 rule SQL files resolves from registry defaults
- [x] `python3 scripts/cookbook_parity_check.py --docs-only` passes (59 headings both cookbooks, README links intact)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/expanded configurable tunables across economizer, AHU, and chilled-water/pump fault rules (including new pump high-speed gating).
  * Increased and refined parameter ranges and slider controls for improved customization in the rule registry.
* **Bug Fixes**
  * Corrected multiple fault-detection conditions to use configurable thresholds instead of fixed constants.
* **Documentation**
  * Updated the SQL and Pandas rule cookbooks with revised equations, epsilon-style parameterization, and operating-state/confirmation behavior.
  * Updated PID-HUNT-1 documentation to use a 0s confirmation delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->