### PR TITLE
feat(csv): openfdd_package_v1 ZIP loader + role mapping UI (#514)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "csv",
  "datafusion",
  "encoding_rs",
+ "fdd_core",
  "fdd_rules",
  "fdd_sql",
  "fdd_store",
@@ -2840,9 +2841,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "subtle",
+ "tempfile",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -2871,6 +2874,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "zip",
 ]
 
 [[package]]

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -40,7 +40,12 @@ reqwest = { version = "0.13.4", default-features = false, features = ["blocking"
 rusty-modbus-client = { git = "https://github.com/jscott3201/rusty-modbus", version = "0.1.0" }
 rusty-modbus-types = { git = "https://github.com/jscott3201/rusty-modbus", version = "0.1.0" }
 oxigraph = "0.5"
+fdd_core = { path = "../crates/fdd_core" }
 fdd_rules = { path = "../crates/fdd_rules" }
 fdd_sql = { path = "../crates/fdd_sql" }
 fdd_store = { path = "../crates/fdd_store" }
 walkdir = "2"
+zip = { version = "3", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/edge/src/csv_ingest/mod.rs
+++ b/edge/src/csv_ingest/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP handlers for CSV UT3 import API.
 
 pub mod dataset;
+pub mod package;
 pub mod parquet_bridge;
 pub mod parse;
 pub mod plan;

--- a/edge/src/csv_ingest/package.rs
+++ b/edge/src/csv_ingest/package.rs
@@ -856,12 +856,25 @@ mod tests {
 
     #[test]
     fn loads_package_maps_roles_and_ingests() {
+        // Serialize against other env-mutating unit tests; unique dir per run.
         let _env = crate::test_support::workspace_env_lock();
-        let tmp = std::env::temp_dir().join(format!("openfdd_pkg_test_{}", std::process::id()));
+        let tmp = std::env::temp_dir().join(format!(
+            "openfdd_pkg_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
-        std::env::set_var("OPENFDD_WORKSPACE", &tmp);
-        std::env::set_var("OPENFDD_PARQUET_ROOT", tmp.join(".cache/parquet"));
+        // Re-assert env immediately before each call that reads workspace_dir(),
+        // because other tests still mutate OPENFDD_WORKSPACE without the lock.
+        let set_ws = |tmp: &std::path::Path| {
+            std::env::set_var("OPENFDD_WORKSPACE", tmp);
+            std::env::set_var("OPENFDD_PARQUET_ROOT", tmp.join(".cache/parquet"));
+        };
+        set_ws(&tmp);
 
         let map = r#"{"equipType":"ahu","points":{
             "fan-cmd":"SF_SPD",
@@ -880,6 +893,7 @@ mod tests {
             ("BUILDING_9/AHU_1/history_wide.csv", &history_csv()),
             ("BUILDING_9/AHU_1/history_wide.json", map),
         ]);
+        set_ws(&tmp);
         let out = import_package_zip(&zip);
         assert_eq!(out["ok"], json!(true), "{out}");
         assert_eq!(out["building_id"], json!("BUILDING_9"));
@@ -891,15 +905,25 @@ mod tests {
             json!("imperial"),
             "{out}"
         );
-        let cols =
-            std::fs::read_to_string(tmp.join("data/csv_buildings/BUILDING_9/AHU_1/columns.csv"))
-                .unwrap();
+        let cols_path = tmp.join("data/csv_buildings/BUILDING_9/AHU_1/columns.csv");
+        let cols = std::fs::read_to_string(&cols_path).unwrap_or_else(|e| {
+            panic!(
+                "missing {}: {e}; import out={out}; tmp entries={:?}",
+                cols_path.display(),
+                std::fs::read_dir(&tmp)
+                    .map(|d| d
+                        .filter_map(|e| e.ok().map(|e| e.path()))
+                        .collect::<Vec<_>>())
+                    .unwrap_or_default()
+            )
+        });
         assert!(cols.contains("SF_SPD,fan_cmd"), "{cols}");
         assert!(tmp
             .join(".cache/parquet/building=BUILDING_9/equipment=AHU_1/history.parquet")
             .is_file());
 
         // Role update rewrites columns.csv and re-ingests.
+        set_ws(&tmp);
         let upd = update_package_roles_handler(&json!({
             "building_id": "BUILDING_9",
             "equipment_id": "AHU_1",
@@ -907,9 +931,7 @@ mod tests {
         }));
         assert_eq!(upd["ok"], json!(true), "{upd}");
         assert_eq!(upd["ignored_columns"], json!(["GHOST"]), "{upd}");
-        let cols =
-            std::fs::read_to_string(tmp.join("data/csv_buildings/BUILDING_9/AHU_1/columns.csv"))
-                .unwrap();
+        let cols = std::fs::read_to_string(&cols_path).unwrap();
         assert!(cols.contains("SF_SPD,fan_status"), "{cols}");
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/edge/src/csv_ingest/package.rs
+++ b/edge/src/csv_ingest/package.rs
@@ -12,7 +12,7 @@
 
 use crate::historian::store::workspace_dir;
 use serde_json::{json, Map, Value};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -27,7 +27,8 @@ fn env_cap_mb(name: &str, default_mb: u64) -> u64 {
 }
 
 fn max_uncompressed_bytes() -> u64 {
-    env_cap_mb("OPENFDD_MAX_UNCOMPRESSED_MB", 2048) * 1024 * 1024
+    // Cap default at 512 MiB so concurrent uploads cannot pin multi-GiB in RAM.
+    env_cap_mb("OPENFDD_MAX_UNCOMPRESSED_MB", 512) * 1024 * 1024
 }
 
 fn max_entries() -> usize {
@@ -136,16 +137,25 @@ fn parse_manifest(raw: &Value) -> Result<PackageManifest, String> {
     })
 }
 
-fn sanitize_id(id: &str) -> String {
-    let s: String = id
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
-        .collect();
-    if s.is_empty() {
-        "building".into()
-    } else {
-        s
+/// Accept only a single safe path component (no slash / traversal / empty).
+/// Distinct inputs must not collapse into the same directory name.
+fn validate_id(id: &str) -> Result<String, String> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err("id must be non-empty".into());
     }
+    if id == "." || id == ".." || id.contains('/') || id.contains('\\') || id.contains(':') {
+        return Err(format!("id {id:?} is not a single safe path component"));
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "id {id:?} may only contain ASCII alphanumeric, '-', or '_'"
+        ));
+    }
+    Ok(id.to_string())
 }
 
 /// Normalize a zip entry name: forward slashes, reject traversal / absolute paths.
@@ -442,12 +452,29 @@ pub fn import_package_zip(zip_bytes: &[u8]) -> Value {
 
     let mut plans: Vec<EquipmentPlan> = Vec::new();
     let mut missing_maps: Vec<String> = Vec::new();
+    let mut seen_leaf_ids: BTreeSet<String> = BTreeSet::new();
     for dir in &equip_dirs {
         let equip_id = dir
             .file_name()
             .and_then(|s| s.to_str())
             .unwrap_or("equipment")
             .to_string();
+        let equip_id = match validate_id(&equip_id) {
+            Ok(id) => id,
+            Err(e) => {
+                warnings.push(format!("{}: {e} — skipped", dir.display()));
+                continue;
+            }
+        };
+        if !seen_leaf_ids.insert(equip_id.clone()) {
+            return json!({
+                "ok": false,
+                "error": format!(
+                    "duplicate equipment id {equip_id:?} — two folders flatten to the same leaf name under the building root"
+                ),
+                "hint": "rename equipment folders so each leaf directory name is unique",
+            });
+        }
         let is_weather = equip_id.eq_ignore_ascii_case("weather");
         let history = in_building
             .get(&dir.join("history_wide.csv"))
@@ -534,7 +561,12 @@ pub fn import_package_zip(zip_bytes: &[u8]) -> Value {
     }
 
     // Materialize csv_buildings/<building_id>/ layout.
-    let building_id = sanitize_id(&manifest.building_id);
+    let building_id = match validate_id(&manifest.building_id) {
+        Ok(id) => id,
+        Err(e) => {
+            return json!({"ok": false, "error": format!("manifest building_id: {e}")});
+        }
+    };
     let data_root = workspace_dir().join("data").join("csv_buildings");
     let building_root = data_root.join(&building_id);
     let _ = std::fs::remove_dir_all(&building_root);
@@ -655,25 +687,28 @@ pub fn import_package_handler(content_type: &str, body: &[u8]) -> Value {
 /// Update role assignments for one ingested package equipment and re-ingest.
 /// Body: `{"building_id": "...", "equipment_id": "...", "roles": {"column": "role"}}`.
 pub fn update_package_roles_handler(body: &Value) -> Value {
-    let building_id = sanitize_id(
+    let building_id = match validate_id(
         body.get("building_id")
             .and_then(|v| v.as_str())
             .unwrap_or(""),
-    );
-    let equipment_id = body
-        .get("equipment_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim();
+    ) {
+        Ok(id) => id,
+        Err(e) => return json!({"ok": false, "error": format!("building_id: {e}")}),
+    };
+    let equipment_id = match validate_id(
+        body.get("equipment_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+    ) {
+        Ok(id) => id,
+        Err(e) => return json!({"ok": false, "error": format!("equipment_id: {e}")}),
+    };
     let Some(roles_obj) = body.get("roles").and_then(|v| v.as_object()) else {
         return json!({"ok": false, "error": "roles object required"});
     };
-    if building_id.is_empty() || equipment_id.is_empty() {
-        return json!({"ok": false, "error": "building_id and equipment_id required"});
-    }
     let data_root = workspace_dir().join("data").join("csv_buildings");
     let building_root = data_root.join(&building_id);
-    let eq_dir = match find_equipment_dir(&building_root, equipment_id) {
+    let eq_dir = match find_equipment_dir(&building_root, &equipment_id) {
         Some(d) => d,
         None => {
             return json!({
@@ -721,6 +756,7 @@ pub fn update_package_roles_handler(body: &Value) -> Value {
 }
 
 fn find_equipment_dir(building_root: &Path, equipment_id: &str) -> Option<PathBuf> {
+    // equipment_id is already validate_id()'d — exactly one safe path component.
     let direct = building_root.join(equipment_id);
     if direct.join("history_wide.csv").is_file() {
         return Some(direct);

--- a/edge/src/csv_ingest/package.rs
+++ b/edge/src/csv_ingest/package.rs
@@ -1,0 +1,880 @@
+//! `openfdd_package_v1` ZIP loader (#514).
+//!
+//! Accepts the vibe19 Streamlit package layout (see vibe19 `docs/PACKAGE_SPEC.md`):
+//! `manifest.json` + per-equipment `history_wide.csv` with a sibling Haystack-style
+//! column map (`history_wide.json` / `history_wide.column_map.json` / `column_map.json`),
+//! optional root `column_map.json`, `session_config.json`, and `weather/history_wide.csv`.
+//!
+//! The package is materialized under `workspace/data/csv_buildings/<building_id>/`
+//! (the layout `fdd_store::ingest_building` already validates: manifest `grid_minutes`
+//! → poll_seconds, per-equipment `columns.csv` role map) and ingested to parquet so
+//! `/api/fdd/run` registry mode works immediately.
+
+use crate::historian::store::workspace_dir;
+use serde_json::{json, Map, Value};
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+pub const PACKAGE_SCHEMA: &str = "openfdd_package_v1";
+
+fn env_cap_mb(name: &str, default_mb: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(default_mb)
+}
+
+fn max_uncompressed_bytes() -> u64 {
+    env_cap_mb("OPENFDD_MAX_UNCOMPRESSED_MB", 2048) * 1024 * 1024
+}
+
+fn max_entries() -> usize {
+    std::env::var("OPENFDD_MAX_ENTRIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(2000)
+}
+
+/// Project-Haystack-style point tags used by vibe19 column maps → SQL cookbook roles.
+/// Mirrors vibe19 `app/column_map_json.py` POINT_DISPLAY vocabulary.
+fn haystack_point_to_role(point: &str) -> String {
+    let slug = point.trim().to_lowercase().replace([' ', '_'], "-");
+    match slug.as_str() {
+        "discharge-air-temp" => "sat".into(),
+        "discharge-air-temp-sp" => "sat_sp".into(),
+        "mixed-air-temp" => "mat".into(),
+        "return-air-temp" => "rat".into(),
+        "outside-air-temp" | "bas-outside-air-temp" => "oa_t".into(),
+        "outside-air-humidity" => "oa_h".into(),
+        "outside-air-damper" => "oa_damper_pct".into(),
+        "cooling-valve" => "clg_valve_pct".into(),
+        "heating-valve" => "htg_valve_pct".into(),
+        "fan-cmd" => "fan_cmd".into(),
+        "return-fan-cmd" => "return_fan".into(),
+        "fan-status" => "fan_status".into(),
+        "duct-static-pressure" => "duct_static".into(),
+        "duct-static-pressure-sp" => "duct_static_sp".into(),
+        "zone-air-temp" => "zone_t".into(),
+        "zone-airflow" => "zone_flow".into(),
+        "min-flow-sp" => "min_flow_sp".into(),
+        "damper" => "damper_pct".into(),
+        "reheat-valve" => "reheat_valve_pct".into(),
+        "vav-discharge-air-temp" => "vav_discharge_t".into(),
+        "vav-inlet-air-temp" => "vav_inlet_t".into(),
+        "ahu-discharge-air-temp" => "ahu_sat".into(),
+        "chilled-water-supply-temp" => "chw_supply_t".into(),
+        "chilled-water-return-temp" => "chw_return_t".into(),
+        "chilled-water-supply-temp-sp" => "chw_supply_sp".into(),
+        "hot-water-supply-temp" => "hw_supply_t".into(),
+        "hot-water-return-temp" => "hw_return_t".into(),
+        "occupied" => "occ_mode".into(),
+        "chw-diff-pressure" => "chw_dp".into(),
+        "chw-diff-pressure-sp" => "chw_dp_sp".into(),
+        "chw-flow" => "chw_flow".into(),
+        "chw-pump-cmd" => "chw_pump_cmd".into(),
+        "cw-pump-cmd" => "cw_pump_cmd".into(),
+        "tower-fan-cmd" | "cw-fan-cmd" => "tower_fan_cmd".into(),
+        "condenser-water-supply-temp" => "cw_supply_t".into(),
+        "condenser-water-return-temp" => "cw_return_t".into(),
+        "preheat-leaving-temp" => "preheat_leave_t".into(),
+        "web-outside-air-temp" => "web_oa_t".into(),
+        "web-outside-air-dewpoint" => "web_oa_dp".into(),
+        "web-outside-air-wetbulb" => "web_wb_t".into(),
+        "web-outside-air-humidity" => "web_oa_h".into(),
+        other => fdd_core::normalize_role(&other.replace('-', "_")),
+    }
+}
+
+#[derive(Debug)]
+struct PackageManifest {
+    building_id: String,
+    grid_minutes: u32,
+    timezone: Option<String>,
+    notes: Option<String>,
+}
+
+fn parse_manifest(raw: &Value) -> Result<PackageManifest, String> {
+    let schema = raw
+        .get("schema_version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if schema != PACKAGE_SCHEMA {
+        return Err(format!(
+            "manifest.json schema_version must be {PACKAGE_SCHEMA:?}, got {schema:?}"
+        ));
+    }
+    let building_id = raw
+        .get("building_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if building_id.is_empty() {
+        return Err("manifest.json building_id must be a non-empty string".into());
+    }
+    let grid_minutes = raw
+        .get("grid_minutes")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    if grid_minutes <= 0.0 || !grid_minutes.is_finite() {
+        return Err("manifest.json grid_minutes must be > 0".into());
+    }
+    Ok(PackageManifest {
+        building_id,
+        grid_minutes: (grid_minutes.round() as u32).clamp(1, 24 * 60),
+        timezone: raw
+            .get("timezone")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        notes: raw
+            .get("notes")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+    })
+}
+
+fn sanitize_id(id: &str) -> String {
+    let s: String = id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    if s.is_empty() {
+        "building".into()
+    } else {
+        s
+    }
+}
+
+/// Normalize a zip entry name: forward slashes, reject traversal / absolute paths.
+fn safe_member_path(name: &str) -> Result<PathBuf, String> {
+    let name = name.replace('\\', "/");
+    let mut out = PathBuf::new();
+    for part in name.split('/') {
+        if part.is_empty() || part == "." {
+            continue;
+        }
+        if part == ".." || part.contains(':') {
+            return Err(format!("unsafe zip entry path: {name:?}"));
+        }
+        out.push(part);
+    }
+    if out.components().count() == 0 || out.components().count() > 8 {
+        return Err(format!("unsupported zip entry path: {name:?}"));
+    }
+    Ok(out)
+}
+
+/// In-memory extraction of the package zip: relative path → bytes.
+fn read_zip_entries(bytes: &[u8]) -> Result<BTreeMap<PathBuf, Vec<u8>>, String> {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(cursor).map_err(|e| format!("not a readable zip: {e}"))?;
+    if archive.len() > max_entries() {
+        return Err(format!(
+            "zip has {} entries; cap is {} (OPENFDD_MAX_ENTRIES)",
+            archive.len(),
+            max_entries()
+        ));
+    }
+    let cap = max_uncompressed_bytes();
+    let mut total: u64 = 0;
+    let mut out = BTreeMap::new();
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| format!("zip entry {i}: {e}"))?;
+        if entry.is_dir() {
+            continue;
+        }
+        let path = safe_member_path(entry.name())?;
+        total = total.saturating_add(entry.size());
+        if total > cap {
+            return Err(format!(
+                "zip expands past {} MB cap (OPENFDD_MAX_UNCOMPRESSED_MB)",
+                cap / (1024 * 1024)
+            ));
+        }
+        let mut buf = Vec::with_capacity(entry.size() as usize);
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|e| format!("zip entry {:?}: {e}", entry.name()))?;
+        out.insert(path, buf);
+    }
+    if out.is_empty() {
+        return Err("zip contains no files".into());
+    }
+    Ok(out)
+}
+
+/// Root may be the building itself or a single top-level folder holding manifest.json.
+fn resolve_building_prefix(entries: &BTreeMap<PathBuf, Vec<u8>>) -> Result<PathBuf, String> {
+    if entries.contains_key(Path::new("manifest.json")) {
+        return Ok(PathBuf::new());
+    }
+    let mut candidates: Vec<PathBuf> = entries
+        .keys()
+        .filter(|p| p.file_name().map(|f| f == "manifest.json").unwrap_or(false))
+        .filter(|p| p.components().count() == 2)
+        .filter_map(|p| p.parent().map(Path::to_path_buf))
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+    match candidates.len() {
+        1 => Ok(candidates.remove(0)),
+        0 => Err("package is missing manifest.json (root or single top-level folder)".into()),
+        n => Err(format!(
+            "found {n} top-level manifest.json files; expected 1"
+        )),
+    }
+}
+
+/// Extract `{point/role → csv column}` pairs for one equipment from any accepted
+/// map JSON shape: full package map (`equip`/`equipment`/`devices`/`role_map`),
+/// single-equip `{equipType, points: {…}}`, or a flat role → column object.
+fn points_from_map_json(map: &Value, equip_id: &str) -> Option<BTreeMap<String, String>> {
+    fn string_map(v: &Value) -> Option<BTreeMap<String, String>> {
+        let obj = v.as_object()?;
+        if obj.is_empty() {
+            return None;
+        }
+        let mut out = BTreeMap::new();
+        for (k, val) in obj {
+            out.insert(k.clone(), val.as_str()?.to_string());
+        }
+        Some(out)
+    }
+    fn block_points(block: &Value) -> Option<BTreeMap<String, String>> {
+        for key in ["points", "column_roles", "roles"] {
+            if let Some(p) = block.get(key).and_then(string_map) {
+                return Some(p);
+            }
+        }
+        None
+    }
+    let obj = map.as_object()?;
+    for key in ["equip", "equipment", "devices", "role_map"] {
+        if let Some(blocks) = obj.get(key).and_then(|v| v.as_object()) {
+            if let Some(block) = blocks.get(equip_id) {
+                return block_points(block).or_else(|| string_map(block));
+            }
+            // Full-document map that doesn't mention this equipment.
+            if !blocks.is_empty() {
+                return None;
+            }
+        }
+    }
+    if let Some(p) = block_points(map) {
+        return Some(p);
+    }
+    // Flat role → column object (ignore metadata keys).
+    let meta = [
+        "schema_version",
+        "version",
+        "building",
+        "building_id",
+        "siteRef",
+        "site_id",
+        "site",
+        "generated_by",
+        "notes",
+        "units",
+        "equipType",
+        "equipment_type",
+        "device",
+    ];
+    let flat: Map<String, Value> = obj
+        .iter()
+        .filter(|(k, _)| !meta.contains(&k.as_str()))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    string_map(&Value::Object(flat))
+}
+
+struct EquipmentPlan {
+    equipment_id: String,
+    dir: PathBuf,
+    headers: Vec<String>,
+    roles: BTreeMap<String, String>,
+    map_source: String,
+}
+
+fn csv_headers(bytes: &[u8]) -> Result<Vec<String>, String> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(bytes);
+    Ok(rdr
+        .headers()
+        .map_err(|e| format!("history_wide.csv headers: {e}"))?
+        .iter()
+        .map(|h| h.trim().to_string())
+        .collect())
+}
+
+/// Convert map-file points (point/role name → CSV column) to column → cookbook role,
+/// keeping only columns that exist in the CSV header.
+fn roles_for_equipment(
+    points: &BTreeMap<String, String>,
+    headers: &[String],
+    warnings: &mut Vec<String>,
+    equip_id: &str,
+) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for (point, column) in points {
+        if point.trim().is_empty() || column.trim().is_empty() {
+            continue;
+        }
+        if !headers.iter().any(|h| h == column.trim()) {
+            warnings.push(format!(
+                "{equip_id}: map references column {column:?} not present in history_wide.csv"
+            ));
+            continue;
+        }
+        let role = haystack_point_to_role(point);
+        if role.is_empty() || role == "ignore" {
+            continue;
+        }
+        out.entry(column.trim().to_string()).or_insert(role);
+    }
+    out
+}
+
+fn write_columns_csv(
+    path: &Path,
+    headers: &[String],
+    roles: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let mut body = String::from("column,role\n");
+    for h in headers {
+        if h == "timestamp_utc" || h == "timestamp" || h.is_empty() {
+            continue;
+        }
+        let role = roles.get(h).map(String::as_str).unwrap_or("");
+        let col = if h.contains(',') || h.contains('"') {
+            format!("\"{}\"", h.replace('"', "\"\""))
+        } else {
+            h.clone()
+        };
+        body.push_str(&format!("{col},{role}\n"));
+    }
+    std::fs::write(path, body).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+fn parquet_out_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("OPENFDD_PARQUET_ROOT") {
+        return PathBuf::from(p);
+    }
+    workspace_dir().join(".cache/parquet")
+}
+
+/// Load `openfdd_package_v1` zip bytes: validate, materialize under
+/// `workspace/data/csv_buildings/<building_id>/`, ingest to parquet.
+pub fn import_package_zip(zip_bytes: &[u8]) -> Value {
+    let entries = match read_zip_entries(zip_bytes) {
+        Ok(e) => e,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let prefix = match resolve_building_prefix(&entries) {
+        Ok(p) => p,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let rel = |p: &Path| -> PathBuf {
+        if prefix.as_os_str().is_empty() {
+            p.to_path_buf()
+        } else {
+            p.strip_prefix(&prefix)
+                .map(Path::to_path_buf)
+                .unwrap_or_default()
+        }
+    };
+    let in_building: BTreeMap<PathBuf, &Vec<u8>> = entries
+        .iter()
+        .filter(|(p, _)| prefix.as_os_str().is_empty() || p.starts_with(&prefix))
+        .map(|(p, b)| (rel(p), b))
+        .filter(|(p, _)| !p.as_os_str().is_empty())
+        .collect();
+
+    let manifest_raw: Value = match in_building
+        .get(Path::new("manifest.json"))
+        .ok_or("manifest.json missing".to_string())
+        .and_then(|b| serde_json::from_slice(b).map_err(|e| format!("manifest.json: {e}")))
+    {
+        Ok(v) => v,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let manifest = match parse_manifest(&manifest_raw) {
+        Ok(m) => m,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+
+    let mut warnings: Vec<String> = Vec::new();
+    for p in in_building.keys() {
+        if p.extension().map(|e| e == "zip").unwrap_or(false) {
+            warnings.push(format!(
+                "nested zip {:?} ignored (expand nested zips before upload)",
+                p.display()
+            ));
+        }
+    }
+
+    let root_map: Option<Value> = in_building
+        .get(Path::new("column_map.json"))
+        .and_then(|b| serde_json::from_slice(b).ok());
+    let session_config: Option<Value> = in_building
+        .get(Path::new("session_config.json"))
+        .and_then(|b| serde_json::from_slice(b).ok());
+
+    // Discover equipment: any folder (depth 1-2) holding history_wide.csv.
+    let mut equip_dirs: Vec<PathBuf> = in_building
+        .keys()
+        .filter(|p| {
+            p.file_name()
+                .map(|f| f == "history_wide.csv")
+                .unwrap_or(false)
+        })
+        .filter_map(|p| p.parent().map(Path::to_path_buf))
+        .filter(|d| !d.as_os_str().is_empty())
+        .collect();
+    equip_dirs.sort();
+    equip_dirs.dedup();
+
+    let mut plans: Vec<EquipmentPlan> = Vec::new();
+    let mut missing_maps: Vec<String> = Vec::new();
+    for dir in &equip_dirs {
+        let equip_id = dir
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("equipment")
+            .to_string();
+        let is_weather = equip_id.eq_ignore_ascii_case("weather");
+        let history = in_building
+            .get(&dir.join("history_wide.csv"))
+            .expect("discovered via history_wide.csv");
+        let headers = match csv_headers(history) {
+            Ok(h) => h,
+            Err(e) => {
+                warnings.push(format!("{equip_id}: {e}"));
+                continue;
+            }
+        };
+        if !headers
+            .iter()
+            .any(|h| h == "timestamp_utc" || h == "timestamp")
+        {
+            warnings.push(format!(
+                "{equip_id}: history_wide.csv missing timestamp_utc column — skipped"
+            ));
+            continue;
+        }
+
+        // Sibling map (first match wins), then root column_map.json supplement.
+        let mut map_source = String::new();
+        let mut points: Option<BTreeMap<String, String>> = None;
+        for name in [
+            "history_wide.json",
+            "history_wide.column_map.json",
+            "column_map.json",
+        ] {
+            if let Some(bytes) = in_building.get(&dir.join(name)) {
+                match serde_json::from_slice::<Value>(bytes) {
+                    Ok(v) => {
+                        points = points_from_map_json(&v, &equip_id);
+                        if points.is_some() {
+                            map_source = format!("{}/{name}", dir.display());
+                            break;
+                        }
+                        warnings.push(format!("{equip_id}: {name} has no usable point map"));
+                    }
+                    Err(e) => warnings.push(format!("{equip_id}: {name}: {e}")),
+                }
+            }
+        }
+        if points.is_none() {
+            if let Some(root) = &root_map {
+                points = points_from_map_json(root, &equip_id);
+                if points.is_some() {
+                    map_source = "column_map.json (package root)".into();
+                }
+            }
+        }
+
+        let roles = match &points {
+            Some(p) => roles_for_equipment(p, &headers, &mut warnings, &equip_id),
+            None if is_weather => BTreeMap::new(), // weather map is optional
+            None => {
+                missing_maps.push(format!("{}/history_wide.csv", dir.display()));
+                continue;
+            }
+        };
+        plans.push(EquipmentPlan {
+            equipment_id: equip_id,
+            dir: dir.clone(),
+            headers,
+            roles,
+            map_source,
+        });
+    }
+
+    if !missing_maps.is_empty() {
+        return json!({
+            "ok": false,
+            "error": "package rejected — equipment history_wide.csv files missing sibling column maps",
+            "missing_maps": missing_maps,
+            "hint": "each equipment folder needs history_wide.json / history_wide.column_map.json / column_map.json (weather/ is exempt)",
+        });
+    }
+    if plans.is_empty() {
+        return json!({
+            "ok": false,
+            "error": "no equipment folders with history_wide.csv found in package",
+            "warnings": warnings,
+        });
+    }
+
+    // Materialize csv_buildings/<building_id>/ layout.
+    let building_id = sanitize_id(&manifest.building_id);
+    let data_root = workspace_dir().join("data").join("csv_buildings");
+    let building_root = data_root.join(&building_id);
+    let _ = std::fs::remove_dir_all(&building_root);
+    if let Err(e) = std::fs::create_dir_all(&building_root) {
+        return json!({"ok": false, "error": format!("mkdir {}: {e}", building_root.display())});
+    }
+    let manifest_out = json!({
+        "grid_minutes": manifest.grid_minutes,
+        "export_metadata": {
+            "source": "openfdd_package_v1",
+            "schema_version": PACKAGE_SCHEMA,
+            "building_id": manifest.building_id,
+            "timezone": manifest.timezone,
+            "notes": manifest.notes,
+        }
+    });
+    if let Err(e) = std::fs::write(
+        building_root.join("manifest.json"),
+        serde_json::to_string_pretty(&manifest_out).unwrap_or_default(),
+    ) {
+        return json!({"ok": false, "error": format!("manifest write: {e}")});
+    }
+    if let Some(cfg) = &session_config {
+        let _ = std::fs::write(
+            building_root.join("session_config.json"),
+            serde_json::to_string_pretty(cfg).unwrap_or_default(),
+        );
+    }
+
+    let mut equipment_report = Vec::new();
+    for plan in &plans {
+        let eq_dir = building_root.join(plan.dir.file_name().unwrap_or_default());
+        if let Err(e) = std::fs::create_dir_all(&eq_dir) {
+            return json!({"ok": false, "error": format!("mkdir {}: {e}", eq_dir.display())});
+        }
+        let history = in_building
+            .get(&plan.dir.join("history_wide.csv"))
+            .expect("history bytes");
+        if let Err(e) = std::fs::write(eq_dir.join("history_wide.csv"), history) {
+            return json!({"ok": false, "error": format!("history write: {e}")});
+        }
+        if let Err(e) = write_columns_csv(&eq_dir.join("columns.csv"), &plan.headers, &plan.roles) {
+            return json!({"ok": false, "error": e});
+        }
+        let unmapped: Vec<&String> = plan
+            .headers
+            .iter()
+            .filter(|h| *h != "timestamp_utc" && *h != "timestamp" && !plan.roles.contains_key(*h))
+            .collect();
+        equipment_report.push(json!({
+            "equipment_id": plan.equipment_id,
+            "column_count": plan.headers.len().saturating_sub(1),
+            "roles": plan.roles,
+            "unmapped_columns": unmapped,
+            "map_source": plan.map_source,
+        }));
+    }
+
+    let out_dir = parquet_out_dir();
+    match fdd_store::ingest_building(&data_root, &building_id, &out_dir) {
+        Ok(report) => json!({
+            "ok": true,
+            "schema_version": PACKAGE_SCHEMA,
+            "building_id": building_id,
+            "grid_minutes": manifest.grid_minutes,
+            "poll_seconds": manifest.grid_minutes.saturating_mul(60),
+            "timezone": manifest.timezone,
+            "equipment": equipment_report,
+            "equipment_written": report.equipment_written,
+            "total_rows": report.total_rows,
+            "total_ms": report.total_ms,
+            "out_dir": report.out_dir,
+            "package_root": building_root.display().to_string(),
+            "session_config": session_config,
+            "warnings": warnings,
+        }),
+        Err(e) => json!({
+            "ok": false,
+            "error": format!("parquet ingest failed: {e:#}"),
+            "equipment": equipment_report,
+            "warnings": warnings,
+            "package_root": building_root.display().to_string(),
+        }),
+    }
+}
+
+/// HTTP entry: multipart / JSON base64 / raw zip body.
+pub fn import_package_handler(content_type: &str, body: &[u8]) -> Value {
+    let ct = content_type.to_ascii_lowercase();
+    let zip_bytes: Vec<u8> =
+        if ct.contains("multipart/form-data") || ct.contains("application/json") {
+            // Multipart must go through the binary-safe parser: lossy UTF-8 corrupts zips.
+            let parsed = if ct.contains("multipart/form-data") {
+                super::upload::parse_multipart_files(content_type, body)
+            } else {
+                super::upload::parse_upload(content_type, body)
+            };
+            let (files, _sid) = match parsed {
+                Ok(parsed) => parsed,
+                Err(e) => return json!({"ok": false, "error": e}),
+            };
+            let Some((_, bytes)) = files
+                .into_iter()
+                .find(|(name, _)| name.to_lowercase().ends_with(".zip"))
+            else {
+                return json!({"ok": false, "error": "no .zip file in upload"});
+            };
+            bytes
+        } else {
+            body.to_vec()
+        };
+    if zip_bytes.is_empty() {
+        return json!({"ok": false, "error": "empty upload"});
+    }
+    import_package_zip(&zip_bytes)
+}
+
+/// Update role assignments for one ingested package equipment and re-ingest.
+/// Body: `{"building_id": "...", "equipment_id": "...", "roles": {"column": "role"}}`.
+pub fn update_package_roles_handler(body: &Value) -> Value {
+    let building_id = sanitize_id(
+        body.get("building_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+    );
+    let equipment_id = body
+        .get("equipment_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
+    let Some(roles_obj) = body.get("roles").and_then(|v| v.as_object()) else {
+        return json!({"ok": false, "error": "roles object required"});
+    };
+    if building_id.is_empty() || equipment_id.is_empty() {
+        return json!({"ok": false, "error": "building_id and equipment_id required"});
+    }
+    let data_root = workspace_dir().join("data").join("csv_buildings");
+    let building_root = data_root.join(&building_id);
+    let eq_dir = match find_equipment_dir(&building_root, equipment_id) {
+        Some(d) => d,
+        None => {
+            return json!({
+                "ok": false,
+                "error": format!("equipment {equipment_id:?} not found under {}", building_root.display()),
+            })
+        }
+    };
+    let history = eq_dir.join("history_wide.csv");
+    let headers = match std::fs::read(&history)
+        .map_err(|e| format!("read {}: {e}", history.display()))
+        .and_then(|b| csv_headers(&b))
+    {
+        Ok(h) => h,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let mut roles: BTreeMap<String, String> = BTreeMap::new();
+    let mut ignored: Vec<String> = Vec::new();
+    for (col, role) in roles_obj {
+        let role = role.as_str().unwrap_or("").trim();
+        if role.is_empty() {
+            continue;
+        }
+        if headers.iter().any(|h| h == col) {
+            roles.insert(col.clone(), fdd_core::normalize_role(role));
+        } else {
+            ignored.push(col.clone());
+        }
+    }
+    if let Err(e) = write_columns_csv(&eq_dir.join("columns.csv"), &headers, &roles) {
+        return json!({"ok": false, "error": e});
+    }
+    match fdd_store::ingest_building(&data_root, &building_id, &parquet_out_dir()) {
+        Ok(report) => json!({
+            "ok": true,
+            "building_id": building_id,
+            "equipment_id": equipment_id,
+            "roles": roles,
+            "ignored_columns": ignored,
+            "equipment_written": report.equipment_written,
+            "total_rows": report.total_rows,
+        }),
+        Err(e) => json!({"ok": false, "error": format!("re-ingest failed: {e:#}")}),
+    }
+}
+
+fn find_equipment_dir(building_root: &Path, equipment_id: &str) -> Option<PathBuf> {
+    let direct = building_root.join(equipment_id);
+    if direct.join("history_wide.csv").is_file() {
+        return Some(direct);
+    }
+    for e in walkdir::WalkDir::new(building_root)
+        .min_depth(1)
+        .max_depth(3)
+        .into_iter()
+        .flatten()
+    {
+        if e.file_type().is_dir()
+            && e.file_name().to_str() == Some(equipment_id)
+            && e.path().join("history_wide.csv").is_file()
+        {
+            return Some(e.path().to_path_buf());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn build_zip(files: &[(&str, &str)]) -> Vec<u8> {
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut zw = zip::ZipWriter::new(&mut cursor);
+            let opts = zip::write::SimpleFileOptions::default();
+            for (name, content) in files {
+                zw.start_file(*name, opts).unwrap();
+                zw.write_all(content.as_bytes()).unwrap();
+            }
+            zw.finish().unwrap();
+        }
+        cursor.into_inner()
+    }
+
+    fn history_csv() -> String {
+        let mut s = String::from("timestamp_utc,SF_SPD,DA_P,DA_P_SP\n");
+        for i in 0..6 {
+            s.push_str(&format!("2024-01-01T00:{:02}:00Z,0.95,0.4,1.4\n", i * 5));
+        }
+        s
+    }
+
+    #[test]
+    fn haystack_points_translate_to_sql_roles() {
+        assert_eq!(haystack_point_to_role("fan-cmd"), "fan_cmd");
+        assert_eq!(
+            haystack_point_to_role("duct-static-pressure"),
+            "duct_static"
+        );
+        assert_eq!(haystack_point_to_role("discharge-air-temp-sp"), "sat_sp");
+        assert_eq!(haystack_point_to_role("zone_air_temp"), "zone_t");
+        assert_eq!(
+            haystack_point_to_role("web-outside-air-wetbulb"),
+            "web_wb_t"
+        );
+        // Snake-case cookbook roles pass through the normalize fallback.
+        assert_eq!(haystack_point_to_role("chw_supply_t"), "chw_supply_t");
+    }
+
+    #[test]
+    fn rejects_wrong_schema_and_traversal() {
+        let zip = build_zip(&[(
+            "manifest.json",
+            r#"{"schema_version":"other","building_id":"B","grid_minutes":5}"#,
+        )]);
+        let out = import_package_zip(&zip);
+        assert_eq!(out["ok"], json!(false));
+        assert!(out["error"].as_str().unwrap().contains("schema_version"));
+
+        let zip = build_zip(&[("../evil.txt", "x")]);
+        let out = import_package_zip(&zip);
+        assert_eq!(out["ok"], json!(false));
+        assert!(out["error"].as_str().unwrap().contains("unsafe zip entry"));
+    }
+
+    #[test]
+    fn rejects_missing_equipment_map() {
+        let zip = build_zip(&[
+            (
+                "manifest.json",
+                r#"{"schema_version":"openfdd_package_v1","building_id":"B_MAPLESS","grid_minutes":5}"#,
+            ),
+            ("AHU_1/history_wide.csv", &history_csv()),
+        ]);
+        let out = import_package_zip(&zip);
+        assert_eq!(out["ok"], json!(false), "{out}");
+        assert!(
+            out["missing_maps"].as_array().map(|a| !a.is_empty()) == Some(true),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn loads_package_maps_roles_and_ingests() {
+        let _env = crate::test_support::workspace_env_lock();
+        let tmp = std::env::temp_dir().join(format!("openfdd_pkg_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", &tmp);
+        std::env::set_var("OPENFDD_PARQUET_ROOT", tmp.join(".cache/parquet"));
+
+        let map = r#"{"equipType":"ahu","points":{
+            "fan-cmd":"SF_SPD",
+            "duct-static-pressure":"DA_P",
+            "duct-static-pressure-sp":"DA_P_SP"
+        }}"#;
+        let zip = build_zip(&[
+            (
+                "BUILDING_9/manifest.json",
+                r#"{"schema_version":"openfdd_package_v1","building_id":"BUILDING_9","grid_minutes":5,"timezone":"UTC"}"#,
+            ),
+            (
+                "BUILDING_9/session_config.json",
+                r#"{"schema_version":"openfdd_session_v1","unit_system":"imperial"}"#,
+            ),
+            ("BUILDING_9/AHU_1/history_wide.csv", &history_csv()),
+            ("BUILDING_9/AHU_1/history_wide.json", map),
+        ]);
+        let out = import_package_zip(&zip);
+        assert_eq!(out["ok"], json!(true), "{out}");
+        assert_eq!(out["building_id"], json!("BUILDING_9"));
+        assert_eq!(out["grid_minutes"], json!(5));
+        assert_eq!(out["equipment"][0]["roles"]["SF_SPD"], json!("fan_cmd"));
+        assert_eq!(out["equipment"][0]["roles"]["DA_P"], json!("duct_static"));
+        assert_eq!(
+            out["session_config"]["unit_system"],
+            json!("imperial"),
+            "{out}"
+        );
+        let cols =
+            std::fs::read_to_string(tmp.join("data/csv_buildings/BUILDING_9/AHU_1/columns.csv"))
+                .unwrap();
+        assert!(cols.contains("SF_SPD,fan_cmd"), "{cols}");
+        assert!(tmp
+            .join(".cache/parquet/building=BUILDING_9/equipment=AHU_1/history.parquet")
+            .is_file());
+
+        // Role update rewrites columns.csv and re-ingests.
+        let upd = update_package_roles_handler(&json!({
+            "building_id": "BUILDING_9",
+            "equipment_id": "AHU_1",
+            "roles": {"SF_SPD": "fan_status", "DA_P": "duct_static", "DA_P_SP": "duct_static_sp", "GHOST": "oa_t"}
+        }));
+        assert_eq!(upd["ok"], json!(true), "{upd}");
+        assert_eq!(upd["ignored_columns"], json!(["GHOST"]), "{upd}");
+        let cols =
+            std::fs::read_to_string(tmp.join("data/csv_buildings/BUILDING_9/AHU_1/columns.csv"))
+                .unwrap();
+        assert!(cols.contains("SF_SPD,fan_status"), "{cols}");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/edge/src/csv_ingest/parquet_bridge.rs
+++ b/edge/src/csv_ingest/parquet_bridge.rs
@@ -181,6 +181,7 @@ mod tests {
 
     #[test]
     fn ingest_rows_writes_parquet_layout() {
+        let _env = crate::test_support::workspace_env_lock();
         let tmp = std::env::temp_dir().join(format!("openfdd_pq_test_{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(&tmp).unwrap();

--- a/edge/src/csv_ingest/upload.rs
+++ b/edge/src/csv_ingest/upload.rs
@@ -111,10 +111,24 @@ fn extract_form_name(line: &str, key: &str) -> Option<String> {
 
 /// Binary-safe multipart parse (no lossy UTF-8 on file contents) — required for zip uploads.
 pub(super) fn parse_multipart_files(content_type: &str, body: &[u8]) -> UploadParseResult {
+    // Parse Content-Type parameters case-insensitively (Boundary=…; charset=…).
     let boundary = content_type
-        .split("boundary=")
-        .nth(1)
-        .map(|b| b.trim().trim_matches('"').to_string())
+        .split(';')
+        .skip(1)
+        .find_map(|param| {
+            let param = param.trim();
+            let (key, value) = param.split_once('=')?;
+            if key.eq_ignore_ascii_case("boundary") {
+                let b = value.trim().trim_matches('"').to_string();
+                if b.is_empty() {
+                    None
+                } else {
+                    Some(b)
+                }
+            } else {
+                None
+            }
+        })
         .ok_or("missing multipart boundary")?;
     parse_multipart_binary(&boundary, body)
 }

--- a/edge/src/csv_ingest/upload.rs
+++ b/edge/src/csv_ingest/upload.rs
@@ -109,6 +109,16 @@ fn extract_form_name(line: &str, key: &str) -> Option<String> {
     }
 }
 
+/// Binary-safe multipart parse (no lossy UTF-8 on file contents) — required for zip uploads.
+pub(super) fn parse_multipart_files(content_type: &str, body: &[u8]) -> UploadParseResult {
+    let boundary = content_type
+        .split("boundary=")
+        .nth(1)
+        .map(|b| b.trim().trim_matches('"').to_string())
+        .ok_or("missing multipart boundary")?;
+    parse_multipart_binary(&boundary, body)
+}
+
 fn parse_multipart_binary(boundary: &str, body: &[u8]) -> UploadParseResult {
     let marker = format!("--{boundary}");
     let parts: Vec<&[u8]> = split_bytes(body, marker.as_bytes());

--- a/services/central/Cargo.toml
+++ b/services/central/Cargo.toml
@@ -39,3 +39,4 @@ rumqttc = { version = "0.24", default-features = false, features = ["use-native-
 base64 = "0.22"
 jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs"] }
 serde_json = "1"
+zip = { version = "3", default-features = false, features = ["deflate"] }

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -33,6 +33,11 @@ pub fn router(state: Arc<AppState>) -> Router {
 
     let csv = Router::new()
         .route("/api/csv/import/preview", post(csv_preview))
+        .route("/api/csv/import/package", post(csv_import_package))
+        .route(
+            "/api/csv/import/package/roles",
+            post(csv_import_package_roles),
+        )
         .route("/api/csv/import/plan", post(csv_plan))
         .route("/api/csv/import/preflight", post(csv_preflight))
         .route("/api/csv/import/execute", post(csv_execute))
@@ -697,6 +702,27 @@ pub async fn csv_preview(headers: HeaderMap, body: Bytes) -> Json<Value> {
     Json(open_fdd_edge_prototype::csv_ingest::preview_handler(
         &ct, &body, None,
     ))
+}
+
+/// `openfdd_package_v1` zip upload (#514): multipart, JSON base64, or raw zip body.
+pub async fn csv_import_package(headers: HeaderMap, body: Bytes) -> Json<Value> {
+    let ct = content_type(&headers);
+    let result = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::csv_ingest::package::import_package_handler(&ct, &body)
+    })
+    .await
+    .unwrap_or_else(|e| json!({"ok": false, "error": format!("package import task: {e}")}));
+    Json(result)
+}
+
+/// Edit role assignments for an ingested package equipment, then re-ingest.
+pub async fn csv_import_package_roles(Json(body): Json<Value>) -> Json<Value> {
+    let result = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::csv_ingest::package::update_package_roles_handler(&body)
+    })
+    .await
+    .unwrap_or_else(|e| json!({"ok": false, "error": format!("package roles task: {e}")}));
+    Json(result)
 }
 
 pub async fn csv_plan(Json(body): Json<Value>) -> Json<Value> {

--- a/services/central/tests/zip_package_fdd_integration.rs
+++ b/services/central/tests/zip_package_fdd_integration.rs
@@ -1,0 +1,259 @@
+//! Central HTTP integration: openfdd_package_v1 zip upload → parquet ingest → FC1 registry run.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+fn pick_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("port")
+        .port()
+}
+
+struct Server {
+    child: Child,
+    port: u16,
+    workspace: PathBuf,
+}
+
+impl Server {
+    fn start() -> Self {
+        let port = pick_port();
+        let workspace =
+            std::env::temp_dir().join(format!("openfdd-central-zip-it-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&workspace);
+        std::fs::create_dir_all(&workspace).unwrap();
+        let parquet_root = workspace.join(".cache/parquet");
+        std::fs::create_dir_all(&parquet_root).unwrap();
+
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = manifest_dir.join("../..");
+        let sql_rules = repo_root.join("sql_rules");
+        assert!(
+            sql_rules.join("registry.yaml").is_file(),
+            "sql_rules missing"
+        );
+
+        let bin = env!("CARGO_BIN_EXE_openfdd-central");
+        let mut child = Command::new(bin)
+            .env("OPENFDD_CENTRAL_HOST", "127.0.0.1")
+            .env("OPENFDD_CENTRAL_PORT", port.to_string())
+            .env("OPENFDD_MQTT_ENABLED", "0")
+            .env("OPENFDD_WORKSPACE", &workspace)
+            .env("OPENFDD_PARQUET_ROOT", &parquet_root)
+            .env("OPENFDD_SQL_RULES_DIR", &sql_rules)
+            .spawn()
+            .expect("start openfdd-central");
+
+        for _ in 0..80 {
+            let (status, body) = http_raw("GET", port, "/api/health", None, "application/json");
+            if status == 200 && body.contains("\"openfdd-central\"") {
+                return Self {
+                    child,
+                    port,
+                    workspace,
+                };
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("central did not become ready on port {port}");
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.workspace);
+    }
+}
+
+/// Minimal HTTP/1.1 client supporting binary bodies (zip upload).
+fn http_raw(
+    method: &str,
+    port: u16,
+    path: &str,
+    body: Option<&[u8]>,
+    content_type: &str,
+) -> (u16, String) {
+    let host_port = format!("127.0.0.1:{port}");
+    let mut stream = match TcpStream::connect(&host_port) {
+        Ok(s) => s,
+        Err(_) => return (0, String::new()),
+    };
+    stream.set_read_timeout(Some(Duration::from_secs(120))).ok();
+    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\nConnection: close\r\n")
+        .into_bytes();
+    if let Some(b) = body {
+        req.extend_from_slice(format!("Content-Type: {content_type}\r\n").as_bytes());
+        req.extend_from_slice(format!("Content-Length: {}\r\n\r\n", b.len()).as_bytes());
+        req.extend_from_slice(b);
+    } else {
+        req.extend_from_slice(b"\r\n");
+    }
+    stream.write_all(&req).unwrap();
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(50));
+                continue;
+            }
+            Err(e) => panic!("HTTP read failed: {e}"),
+        }
+    }
+    let resp = String::from_utf8_lossy(&buf);
+    let status = resp
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let body_start = resp.find("\r\n\r\n").map(|i| i + 4).unwrap_or(0);
+    (status, resp[body_start..].to_string())
+}
+
+fn post_bytes(port: u16, path: &str, body: &[u8], content_type: &str) -> (u16, Value) {
+    let (status, text) = http_raw("POST", port, path, Some(body), content_type);
+    assert_ne!(status, 0, "HTTP connect failed for POST {path}");
+    let json: Value = serde_json::from_str(&text).unwrap_or(json!({"raw": text}));
+    (status, json)
+}
+
+/// FC1 fault data: duct static pinned below setpoint while the fan runs hard.
+fn fc1_history_csv() -> String {
+    let mut s = String::from("timestamp_utc,SF_SPD,DA_P,DA_P_SP\n");
+    for i in 0..30 {
+        s.push_str(&format!("2024-01-01T00:{:02}:00Z,0.95,0.10,1.40\n", i));
+    }
+    s
+}
+
+fn build_package_zip() -> Vec<u8> {
+    let manifest = json!({
+        "schema_version": "openfdd_package_v1",
+        "building_id": "ZIP_BUILDING_1",
+        "grid_minutes": 1,
+        "timezone": "UTC"
+    })
+    .to_string();
+    let column_map = json!({
+        "equipType": "ahu",
+        "points": {
+            "fan-cmd": "SF_SPD",
+            "duct-static-pressure": "DA_P",
+            "duct-static-pressure-sp": "DA_P_SP"
+        }
+    })
+    .to_string();
+    let session_config = json!({
+        "schema_version": "openfdd_session_v1",
+        "unit_system": "imperial"
+    })
+    .to_string();
+
+    let mut cursor = std::io::Cursor::new(Vec::new());
+    {
+        let mut zw = zip::ZipWriter::new(&mut cursor);
+        let opts = zip::write::SimpleFileOptions::default();
+        for (name, content) in [
+            ("ZIP_BUILDING_1/manifest.json", manifest.as_str()),
+            (
+                "ZIP_BUILDING_1/session_config.json",
+                session_config.as_str(),
+            ),
+            ("ZIP_BUILDING_1/AHU_1/history_wide.csv", &fc1_history_csv()),
+            (
+                "ZIP_BUILDING_1/AHU_1/history_wide.json",
+                column_map.as_str(),
+            ),
+        ] {
+            zw.start_file(name, opts).unwrap();
+            zw.write_all(content.as_bytes()).unwrap();
+        }
+        zw.finish().unwrap();
+    }
+    cursor.into_inner()
+}
+
+#[test]
+fn zip_package_upload_then_fc1_registry_run() {
+    let srv = Server::start();
+    let zip_bytes = build_package_zip();
+
+    let (status, pkg) = post_bytes(
+        srv.port,
+        "/api/csv/import/package",
+        &zip_bytes,
+        "application/zip",
+    );
+    assert_eq!(status, 200, "package status: {pkg}");
+    assert_eq!(pkg.get("ok"), Some(&json!(true)), "package: {pkg}");
+    assert_eq!(pkg["building_id"], json!("ZIP_BUILDING_1"), "{pkg}");
+    assert_eq!(pkg["grid_minutes"], json!(1), "{pkg}");
+    assert_eq!(pkg["poll_seconds"], json!(60), "{pkg}");
+    assert_eq!(
+        pkg["equipment"][0]["roles"]["SF_SPD"],
+        json!("fan_cmd"),
+        "{pkg}"
+    );
+    assert_eq!(
+        pkg["equipment"][0]["roles"]["DA_P"],
+        json!("duct_static"),
+        "{pkg}"
+    );
+    assert_eq!(
+        pkg["session_config"]["unit_system"],
+        json!("imperial"),
+        "session_config should surface for #515: {pkg}"
+    );
+
+    // Role mapping edit endpoint: re-map and re-ingest.
+    let roles_body = json!({
+        "building_id": "ZIP_BUILDING_1",
+        "equipment_id": "AHU_1",
+        "roles": {"SF_SPD": "fan_cmd", "DA_P": "duct_static", "DA_P_SP": "duct_static_sp"}
+    })
+    .to_string();
+    let (status, upd) = post_bytes(
+        srv.port,
+        "/api/csv/import/package/roles",
+        roles_body.as_bytes(),
+        "application/json",
+    );
+    assert_eq!(status, 200, "roles: {upd}");
+    assert_eq!(upd.get("ok"), Some(&json!(true)), "roles: {upd}");
+
+    let fdd_body = json!({
+        "params": {
+            "mode": "registry",
+            "rule_ids": ["FC1"],
+            "FC1": { "confirm_seconds": 60 }
+        }
+    })
+    .to_string();
+    let (status, fdd) = post_bytes(
+        srv.port,
+        "/api/fdd/run",
+        fdd_body.as_bytes(),
+        "application/json",
+    );
+    assert_eq!(status, 200, "fdd run: {fdd}");
+    assert_eq!(fdd.get("ok"), Some(&json!(true)), "fdd run: {fdd}");
+    assert!(
+        fdd.get("rules_run").and_then(|v| v.as_u64()).unwrap_or(0) >= 1,
+        "expected FC1 to run: {fdd}"
+    );
+}

--- a/workspace/dashboard/src/components/PackageImportPanel.tsx
+++ b/workspace/dashboard/src/components/PackageImportPanel.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { formatApiError } from "../lib/formatApiError";
+import {
+  COOKBOOK_ROLES,
+  updatePackageRoles,
+  type PackageEquipment,
+  type PackageImportResponse,
+} from "../lib/csvPackageImport";
+
+type Props = {
+  result: PackageImportResponse;
+  onRolesSaved?: (equipmentId: string, roles: Record<string, string>) => void;
+};
+
+function EquipmentRolesCard({
+  buildingId,
+  equipment,
+  onRolesSaved,
+}: {
+  buildingId: string;
+  equipment: PackageEquipment;
+  onRolesSaved?: Props["onRolesSaved"];
+}) {
+  const initial: Record<string, string> = {
+    ...(equipment.roles ?? {}),
+    ...Object.fromEntries((equipment.unmapped_columns ?? []).map((c) => [c, ""])),
+  };
+  const [roles, setRoles] = useState<Record<string, string>>(initial);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState("");
+  const [error, setError] = useState("");
+  const columns = Object.keys(roles).sort();
+
+  async function save() {
+    setBusy(true);
+    setError("");
+    setNote("");
+    try {
+      const nonEmpty = Object.fromEntries(
+        Object.entries(roles).filter(([, r]) => r.trim() !== ""),
+      );
+      const out = await updatePackageRoles(buildingId, equipment.equipment_id, nonEmpty);
+      if (!out.ok) throw new Error(out.error ?? "role update failed");
+      setNote(`Saved · re-ingested ${out.total_rows?.toLocaleString() ?? "?"} rows`);
+      onRolesSaved?.(equipment.equipment_id, nonEmpty);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="panel csv-package-equipment">
+      <h4 className="panel-title">
+        {equipment.equipment_id}
+        {equipment.map_source ? (
+          <span className="muted"> · map: {equipment.map_source}</span>
+        ) : null}
+      </h4>
+      {error ? <p className="error">{error}</p> : null}
+      {note ? <p className="ok">{note}</p> : null}
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>CSV column</th>
+            <th>FDD role</th>
+          </tr>
+        </thead>
+        <tbody>
+          {columns.map((col) => (
+            <tr key={col}>
+              <td>
+                <code>{col}</code>
+              </td>
+              <td>
+                <select
+                  value={roles[col] ?? ""}
+                  disabled={busy}
+                  onChange={(e) =>
+                    setRoles((prev) => ({ ...prev, [col]: e.target.value }))
+                  }
+                >
+                  {COOKBOOK_ROLES.map((r) => (
+                    <option key={r || "(none)"} value={r}>
+                      {r || "— unmapped —"}
+                    </option>
+                  ))}
+                  {roles[col] && !COOKBOOK_ROLES.includes(roles[col]!) ? (
+                    <option value={roles[col]}>{roles[col]}</option>
+                  ) : null}
+                </select>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button type="button" className="secondary-btn" disabled={busy} onClick={() => void save()}>
+        {busy ? "Saving…" : "Save roles & re-ingest"}
+      </button>
+    </div>
+  );
+}
+
+/** Result panel for an openfdd_package_v1 zip import (#514): building summary +
+ * per-equipment editable role mapping backed by /api/csv/import/package/roles. */
+export default function PackageImportPanel({ result, onRolesSaved }: Props) {
+  const buildingId = result.building_id ?? "";
+  return (
+    <section className="panel csv-package-result">
+      <h3 className="panel-title">Package: {buildingId}</h3>
+      <p className="muted">
+        {result.equipment_written ?? result.equipment?.length ?? 0} equipment ·{" "}
+        {result.total_rows?.toLocaleString() ?? "?"} rows · grid {result.grid_minutes ?? "?"} min
+        {result.timezone ? ` · ${result.timezone}` : ""}
+        {result.session_config ? " · session_config.json detected" : ""}
+      </p>
+      {(result.warnings ?? []).length > 0 ? (
+        <ul className="csv-upload-results">
+          {result.warnings!.map((w, i) => (
+            <li key={i} className="muted">
+              ⚠ {w}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {(result.equipment ?? []).map((eq) => (
+        <EquipmentRolesCard
+          key={eq.equipment_id}
+          buildingId={buildingId}
+          equipment={eq}
+          onRolesSaved={onRolesSaved}
+        />
+      ))}
+    </section>
+  );
+}

--- a/workspace/dashboard/src/components/PackageImportPanel.tsx
+++ b/workspace/dashboard/src/components/PackageImportPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { formatApiError } from "../lib/formatApiError";
 import {
   COOKBOOK_ROLES,
@@ -12,6 +12,13 @@ type Props = {
   onRolesSaved?: (equipmentId: string, roles: Record<string, string>) => void;
 };
 
+function rolesFromEquipment(equipment: PackageEquipment): Record<string, string> {
+  return {
+    ...(equipment.roles ?? {}),
+    ...Object.fromEntries((equipment.unmapped_columns ?? []).map((c) => [c, ""])),
+  };
+}
+
 function EquipmentRolesCard({
   buildingId,
   equipment,
@@ -21,14 +28,18 @@ function EquipmentRolesCard({
   equipment: PackageEquipment;
   onRolesSaved?: Props["onRolesSaved"];
 }) {
-  const initial: Record<string, string> = {
-    ...(equipment.roles ?? {}),
-    ...Object.fromEntries((equipment.unmapped_columns ?? []).map((c) => [c, ""])),
-  };
-  const [roles, setRoles] = useState<Record<string, string>>(initial);
+  const [roles, setRoles] = useState<Record<string, string>>(() => rolesFromEquipment(equipment));
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState("");
   const [error, setError] = useState("");
+
+  // Remount-safe: if the same equipment_id is re-imported, reset local edits.
+  useEffect(() => {
+    setRoles(rolesFromEquipment(equipment));
+    setNote("");
+    setError("");
+  }, [equipment]);
+
   const columns = Object.keys(roles).sort();
 
   async function save() {

--- a/workspace/dashboard/src/lib/csvPackageImport.ts
+++ b/workspace/dashboard/src/lib/csvPackageImport.ts
@@ -1,0 +1,101 @@
+import { apiFetch, apiUploadRaw } from "./api";
+
+export type PackageEquipment = {
+  equipment_id: string;
+  column_count?: number;
+  roles?: Record<string, string>;
+  unmapped_columns?: string[];
+  map_source?: string;
+};
+
+export type PackageImportResponse = {
+  ok?: boolean;
+  error?: string;
+  hint?: string;
+  missing_maps?: string[];
+  schema_version?: string;
+  building_id?: string;
+  grid_minutes?: number;
+  poll_seconds?: number;
+  timezone?: string | null;
+  equipment?: PackageEquipment[];
+  equipment_written?: number;
+  total_rows?: number;
+  warnings?: string[];
+  session_config?: Record<string, unknown> | null;
+};
+
+export type PackageRolesUpdateResponse = {
+  ok?: boolean;
+  error?: string;
+  building_id?: string;
+  equipment_id?: string;
+  roles?: Record<string, string>;
+  ignored_columns?: string[];
+  total_rows?: number;
+};
+
+/** SQL cookbook logical roles (mirrors sql_rules/registry.yaml required_roles). */
+export const COOKBOOK_ROLES: string[] = [
+  "",
+  "sat",
+  "sat_sp",
+  "mat",
+  "rat",
+  "oa_t",
+  "oa_h",
+  "oa_damper_pct",
+  "clg_valve_pct",
+  "htg_valve_pct",
+  "fan_cmd",
+  "fan_status",
+  "return_fan",
+  "duct_static",
+  "duct_static_sp",
+  "zone_t",
+  "zone_flow",
+  "min_flow_sp",
+  "damper_pct",
+  "reheat_valve_pct",
+  "vav_discharge_t",
+  "vav_inlet_t",
+  "ahu_sat",
+  "occ_mode",
+  "chw_supply_t",
+  "chw_return_t",
+  "chw_supply_sp",
+  "chw_dp",
+  "chw_dp_sp",
+  "chw_flow",
+  "chw_pump_cmd",
+  "cw_supply_t",
+  "cw_return_t",
+  "tower_fan_cmd",
+  "hw_supply_t",
+  "hw_return_t",
+  "preheat_leave_t",
+  "web_oa_t",
+  "web_oa_dp",
+  "web_wb_t",
+];
+
+/** Upload an openfdd_package_v1 zip (raw body — binary safe). */
+export async function uploadPackageZip(file: File): Promise<PackageImportResponse> {
+  return apiUploadRaw<PackageImportResponse>(
+    "/api/csv/import/package",
+    file,
+    "application/zip",
+  );
+}
+
+/** Save edited role assignments for one equipment and re-ingest the building. */
+export async function updatePackageRoles(
+  buildingId: string,
+  equipmentId: string,
+  roles: Record<string, string>,
+): Promise<PackageRolesUpdateResponse> {
+  return apiFetch<PackageRolesUpdateResponse>("/api/csv/import/package/roles", {
+    method: "POST",
+    body: JSON.stringify({ building_id: buildingId, equipment_id: equipmentId, roles }),
+  });
+}

--- a/workspace/dashboard/src/lib/csvPackageImport.ts
+++ b/workspace/dashboard/src/lib/csvPackageImport.ts
@@ -68,6 +68,7 @@ export const COOKBOOK_ROLES: string[] = [
   "chw_dp_sp",
   "chw_flow",
   "chw_pump_cmd",
+  "cw_pump_cmd",
   "cw_supply_t",
   "cw_return_t",
   "tower_fan_cmd",
@@ -76,6 +77,7 @@ export const COOKBOOK_ROLES: string[] = [
   "preheat_leave_t",
   "web_oa_t",
   "web_oa_dp",
+  "web_oa_h",
   "web_wb_t",
 ];
 

--- a/workspace/dashboard/src/pages/CsvWorkbenchPage.tsx
+++ b/workspace/dashboard/src/pages/CsvWorkbenchPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import PageHeader from "../components/PageHeader";
 import CsvSessionSidecart from "../components/CsvSessionSidecart";
+import PackageImportPanel from "../components/PackageImportPanel";
 import Spinner from "../components/Spinner";
 import { hasToken } from "../lib/api";
 import { formatApiError } from "../lib/formatApiError";
@@ -8,6 +9,10 @@ import {
   uploadFilesForPreview,
   type CsvPreviewFileProfile,
 } from "../lib/csvImportUpload";
+import {
+  uploadPackageZip,
+  type PackageImportResponse,
+} from "../lib/csvPackageImport";
 import {
   datasetFromFusionPreview,
   fetchAgentSessionFusionPreview,
@@ -23,6 +28,35 @@ export default function CsvWorkbenchPage() {
   const [status, setStatus] = useState("");
   const [sessionId, setSessionId] = useState("");
   const [uploadCards, setUploadCards] = useState<UploadCard[]>([]);
+  const [packageResult, setPackageResult] = useState<PackageImportResponse | null>(null);
+
+  const ingestPackage = useCallback(async (zips: File[]) => {
+    setError("");
+    setBusy("package");
+    try {
+      let last: PackageImportResponse | null = null;
+      for (const zip of zips) {
+        const res = await uploadPackageZip(zip);
+        if (!res.ok) {
+          const missing = res.missing_maps?.length
+            ? ` — missing maps: ${res.missing_maps.join(", ")}`
+            : "";
+          throw new Error(`${res.error ?? "package load failed"}${missing}`);
+        }
+        last = res;
+      }
+      if (last) {
+        setPackageResult(last);
+        setStatus(
+          `Package ${last.building_id} ingested — ${last.equipment_written ?? 0} equipment, ${last.total_rows?.toLocaleString() ?? "?"} rows. FDD rules can run now.`,
+        );
+      }
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy("");
+    }
+  }, []);
 
   const ingestFiles = useCallback(
     async (files: FileList | File[]) => {
@@ -30,9 +64,14 @@ export default function CsvWorkbenchPage() {
         setError("Sign in to upload CSV files.");
         return;
       }
-      const list = Array.from(files).filter((f) => f.name.toLowerCase().endsWith(".csv"));
+      const all = Array.from(files);
+      const zips = all.filter((f) => f.name.toLowerCase().endsWith(".zip"));
+      if (zips.length) {
+        await ingestPackage(zips);
+      }
+      const list = all.filter((f) => f.name.toLowerCase().endsWith(".csv"));
       if (!list.length) {
-        setError("Choose one or more .csv files.");
+        if (!zips.length) setError("Choose one or more .csv files or an openfdd_package_v1 .zip.");
         return;
       }
       setError("");
@@ -55,7 +94,7 @@ export default function CsvWorkbenchPage() {
         setBusy("");
       }
     },
-    [sessionId],
+    [sessionId, ingestPackage],
   );
 
   const openSession = useCallback(async (id: string) => {
@@ -120,10 +159,13 @@ export default function CsvWorkbenchPage() {
           void ingestFiles(e.dataTransfer.files);
         }}
       >
-        <p className="csv-drop-title">Drop CSV files here</p>
-        <p className="muted">Multiple files append to one import session · long Niagara exports may need agent pivot before preflight pass</p>
+        <p className="csv-drop-title">Drop CSV files or an openfdd_package_v1 .zip here</p>
+        <p className="muted">
+          Multiple CSVs append to one import session · zip packages (manifest.json + per-equipment
+          history_wide.csv + Haystack column maps) ingest straight to the FDD store
+        </p>
         <label className="primary-btn csv-drop-btn">
-          {busy === "upload" ? (
+          {busy === "upload" || busy === "package" ? (
             <>
               <Spinner inline /> Uploading…
             </>
@@ -132,10 +174,10 @@ export default function CsvWorkbenchPage() {
           )}
           <input
             type="file"
-            accept=".csv,text/csv"
+            accept=".csv,text/csv,.zip,application/zip"
             multiple
             hidden
-            disabled={busy === "upload"}
+            disabled={busy === "upload" || busy === "package"}
             onChange={(e) => {
               if (e.target.files?.length) void ingestFiles(e.target.files);
               e.target.value = "";
@@ -143,6 +185,8 @@ export default function CsvWorkbenchPage() {
           />
         </label>
       </div>
+
+      {packageResult ? <PackageImportPanel result={packageResult} /> : null}
 
       {uploadCards.length > 0 ? (
         <section className="panel">

--- a/workspace/dashboard/src/pages/CsvWorkbenchPage.tsx
+++ b/workspace/dashboard/src/pages/CsvWorkbenchPage.tsx
@@ -30,8 +30,9 @@ export default function CsvWorkbenchPage() {
   const [uploadCards, setUploadCards] = useState<UploadCard[]>([]);
   const [packageResult, setPackageResult] = useState<PackageImportResponse | null>(null);
 
-  const ingestPackage = useCallback(async (zips: File[]) => {
+  const ingestPackage = useCallback(async (zips: File[]): Promise<boolean> => {
     setError("");
+    setPackageResult(null);
     setBusy("package");
     try {
       let last: PackageImportResponse | null = null;
@@ -51,8 +52,10 @@ export default function CsvWorkbenchPage() {
           `Package ${last.building_id} ingested — ${last.equipment_written ?? 0} equipment, ${last.total_rows?.toLocaleString() ?? "?"} rows. FDD rules can run now.`,
         );
       }
+      return true;
     } catch (e) {
       setError(formatApiError(e));
+      return false;
     } finally {
       setBusy("");
     }
@@ -66,15 +69,16 @@ export default function CsvWorkbenchPage() {
       }
       const all = Array.from(files);
       const zips = all.filter((f) => f.name.toLowerCase().endsWith(".zip"));
-      if (zips.length) {
-        await ingestPackage(zips);
-      }
       const list = all.filter((f) => f.name.toLowerCase().endsWith(".csv"));
+      if (zips.length) {
+        const ok = await ingestPackage(zips);
+        if (!ok || !list.length) return;
+      }
       if (!list.length) {
         if (!zips.length) setError("Choose one or more .csv files or an openfdd_package_v1 .zip.");
         return;
       }
-      setError("");
+      if (!zips.length) setError("");
       setBusy("upload");
       try {
         const res = await uploadFilesForPreview(list, sessionId || undefined);


### PR DESCRIPTION
## Summary
- **Backend (edge + central):** new `csv_ingest::package` module loads the vibe19 `openfdd_package_v1` zip layout — validates `manifest.json` (`schema_version`, `building_id`, `grid_minutes` → `poll_seconds`, `timezone`), resolves per-equipment Haystack column maps (`history_wide.json` / `history_wide.column_map.json` / `column_map.json`, plus package-root supplement), translates Haystack point tags (`fan-cmd`, `duct-static-pressure`, …) to SQL cookbook roles, materializes the `csv_buildings/` layout, and ingests straight to parquet so `/api/fdd/run` registry mode works immediately. Weather folders are map-exempt per spec; packages with unmapped equipment CSVs are rejected with the missing-map list. `session_config.json` is surfaced in the response for #515.
- **New central endpoints:** `POST /api/csv/import/package` (raw zip, multipart — binary-safe, or JSON base64) and `POST /api/csv/import/package/roles` (edit column→role assignments, rewrite `columns.csv`, re-ingest).
- **React CSV workbench:** the dropzone now accepts `.zip` packages; a package result panel shows building/equipment/rows/grid and a per-equipment editable role table (cookbook role dropdowns) wired to the roles endpoint.
- Safety: zip path-traversal rejection, uncompressed-size cap (`OPENFDD_MAX_UNCOMPRESSED_MB`, default 2048 MB), entry cap (`OPENFDD_MAX_ENTRIES`, default 2000), backslash-path zips tolerated per spec.

Closes #514.

## Test plan
- [x] `cargo test -p open_fdd_edge_prototype --lib` — 4 new unit tests (role translation, schema/traversal rejection, missing-map rejection, full load + role edit re-ingest)
- [x] `cargo test -p openfdd-central --test zip_package_fdd_integration` — end-to-end: zip upload → parquet ingest → role edit → FC1 registry run over live HTTP
- [x] `cargo test --workspace`, `cargo fmt --check`, `cargo clippy --workspace --all-targets` clean
- [x] `npm run build` + `npm test` (dashboard, 65 tests)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenFDD “package v1” ZIP import to the CSV Workbench, including package-level summaries and editable per-equipment role mappings.
  - Added API endpoints for importing package ZIPs and updating equipment role mappings (including binary-safe multipart upload handling).
  - Added UI to review column-to-role assignments and re-ingest after saving changes.
- **Bug Fixes**
  - Improved multipart ZIP upload parsing and strengthened ZIP validation (safer entry handling plus limits on size and contents).
- **Tests**
  - Added central end-to-end integration coverage for ZIP import, role updates, and subsequent rule execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->