### PR TITLE
fix(fieldbus): BACnet fd leak (P0 #535), vendor_id in I-Am (#537), whois range filter (#539), weather stale-hold

### DIFF
--- a/services/fieldbus/src/services/bacnet_client.rs
+++ b/services/fieldbus/src/services/bacnet_client.rs
@@ -567,7 +567,16 @@ impl BacnetClientService {
             // received on the client's ephemeral UDP port (hosted server owns :47808).
             self.seed_configured_field_devices(&client).await?;
             let devices = client.discovered_devices().await;
-            Ok(devices.iter().map(device_summary).collect())
+            // #539: discovered_devices() is a full device-table snapshot (incl.
+            // seeded devices); honor the caller's requested instance range.
+            Ok(devices
+                .iter()
+                .filter(|d| {
+                    let instance = d.object_identifier.instance_number();
+                    low.is_none_or(|lo| instance >= lo) && high.is_none_or(|hi| instance <= hi)
+                })
+                .map(device_summary)
+                .collect())
         }
         .await;
         Self::finish_client(client, result).await

--- a/services/fieldbus/src/services/bacnet_server.rs
+++ b/services/fieldbus/src/services/bacnet_server.rs
@@ -91,11 +91,14 @@ impl BacnetServerManager {
         let rows = load_objects_csv(Some(&self.settings.objects_csv))?;
         let db = build_database(cfg.device_instance, &cfg.device_name, &rows)?;
 
-        let server = BACnetServer::bip_builder()
-            .interface(cfg.interface)
-            .port(cfg.port)
-            .broadcast_address(cfg.broadcast)
+        // Use the generic builder: only it exposes vendor_id, and the default
+        // (0, ASHRAE reserved) leaks into I-Am responses (#537).
+        let transport =
+            bacnet_transport::bip::BipTransport::new(cfg.interface, cfg.port, cfg.broadcast);
+        let server = BACnetServer::generic_builder()
+            .vendor_id(OPENFDD_VENDOR_ID)
             .database(db)
+            .transport(transport)
             .build()
             .await
             .map_err(|e| e.to_string())?;

--- a/services/fieldbus/src/services/weather.rs
+++ b/services/fieldbus/src/services/weather.rs
@@ -124,7 +124,25 @@ impl WeatherService {
                 }
                 Err(e) => {
                     warn!("weather poll failed: {e}");
-                    let fb = self.fallback(&e);
+                    // Hold last-known-good on a transient fetch error (marked
+                    // stale via from_api=false → app-fault BV active) instead
+                    // of dropping BACnet consumers to the canned fallback.
+                    let degraded = {
+                        let cache = self.cache.lock().await;
+                        match cache.as_ref() {
+                            Some(prev) if prev.from_api => Some(WeatherReading {
+                                from_api: false,
+                                reason: format!("stale (last good held): {e}"),
+                                location: prev.location.clone(),
+                                ..prev.clone()
+                            }),
+                            Some(prev) if prev.reason.starts_with("stale") => {
+                                Some(prev.clone())
+                            }
+                            _ => None,
+                        }
+                    };
+                    let fb = degraded.unwrap_or_else(|| self.fallback(&e));
                     *self.cache.lock().await = Some(fb.clone());
                     let _ = self.mirror_to_bacnet(&fb).await;
                 }

--- a/services/fieldbus/src/services/weather.rs
+++ b/services/fieldbus/src/services/weather.rs
@@ -136,9 +136,7 @@ impl WeatherService {
                                 location: prev.location.clone(),
                                 ..prev.clone()
                             }),
-                            Some(prev) if prev.reason.starts_with("stale") => {
-                                Some(prev.clone())
-                            }
+                            Some(prev) if prev.reason.starts_with("stale") => Some(prev.clone()),
                             _ => None,
                         }
                     };

--- a/services/fieldbus/tests/bacnet_fd_leak.rs
+++ b/services/fieldbus/tests/bacnet_fd_leak.rs
@@ -1,0 +1,50 @@
+//! Regression test for #535: `BACnetClient::stop()` must stop the transport so
+//! the UDP socket fd is released. Before the vendored fix, every short-lived
+//! client (one per poll/read operation) leaked one socket until EMFILE killed
+//! HTTP and weather after a few hours of uptime.
+
+#![cfg(target_os = "linux")]
+
+use std::net::Ipv4Addr;
+
+use bacnet_client::client::BACnetClient;
+
+fn open_fd_count() -> usize {
+    std::fs::read_dir("/proc/self/fd")
+        .expect("read /proc/self/fd")
+        .count()
+}
+
+#[tokio::test]
+async fn client_stop_closes_transport_socket() {
+    // Warm up runtime / lazy fds so the baseline is stable.
+    for _ in 0..3 {
+        let mut client = BACnetClient::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .broadcast_address(Ipv4Addr::BROADCAST)
+            .build()
+            .await
+            .expect("start client");
+        client.stop().await.expect("stop client");
+    }
+
+    let baseline = open_fd_count();
+    const ITERATIONS: usize = 50;
+    for _ in 0..ITERATIONS {
+        let mut client = BACnetClient::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .broadcast_address(Ipv4Addr::BROADCAST)
+            .build()
+            .await
+            .expect("start client");
+        client.stop().await.expect("stop client");
+    }
+    let after = open_fd_count();
+
+    assert!(
+        after <= baseline + 3,
+        "fd leak: baseline {baseline} -> {after} after {ITERATIONS} client start/stop cycles"
+    );
+}

--- a/vendor/bacnet-client/src/client/lifecycle.rs
+++ b/vendor/bacnet-client/src/client/lifecycle.rs
@@ -117,12 +117,33 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     pub fn local_mac(&self) -> &[u8] {
         &self.local_mac
     }
-    /// Stop the client, aborting the dispatch task.
+    /// Stop the client: abort the dispatch task, then stop the network layer
+    /// and its transport so the underlying socket is actually closed.
+    ///
+    /// Without the transport shutdown every short-lived client leaked one UDP
+    /// socket (the transport recv task owns an `Arc<UdpSocket>` that outlives
+    /// the dropped client), exhausting the process fd limit under a
+    /// one-client-per-operation usage pattern.
     pub async fn stop(&mut self) -> Result<(), Error> {
         if let Some(task) = self.dispatch_task.take() {
             task.abort();
             let _ = task.await;
         }
-        Ok(())
+        // The dispatch task held the only long-lived clone of `network`; other
+        // clones are transient within in-flight operations. Yield a few times
+        // to let those drop, then reclaim exclusive access and stop the
+        // transport (which aborts its recv task and drops the socket).
+        for _ in 0..64 {
+            if Arc::get_mut(&mut self.network).is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        match Arc::get_mut(&mut self.network) {
+            Some(network) => network.stop().await,
+            None => Err(Error::Encoding(
+                "cannot stop transport: network layer still shared".into(),
+            )),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **#535 (P0)**: `BACnetClient::stop()` in the vendored client now stops the network layer + transport so the UDP socket fd is actually released. Previously every per-operation client leaked one socket (~180 fds/h measured on the OT bench), hitting EMFILE at ~5 h uptime — HTTP/health died and weather fell back permanently ("frozen fallback weather" in Workbench). Regression test asserts stable `/proc/self/fd` count across 50 client start/stop cycles.
- **Weather stale-hold**: on a transient fetch error the service now holds the last good reading (marked stale, `app-fault` BV active) instead of replacing the cache with the canned 70.0/50.0 fallback.
- **#537**: hosted server is built via the generic builder so `vendor_id 999` reaches I-Am responses (BIP builder has no `vendor_id` setter; default 0 is ASHRAE reserved).
- **#539**: `/bacnet/whois` filters the device-table snapshot by the requested `low`/`high` instance range instead of returning all seeded/out-of-range devices.

Evidence: nightly OT bench report 2026-07-18 round 2 (§3 fd instrumentation 52→142 fds/30 min; §4 I-Am hex `…2100`; §10 #539 whois snapshot).

## Test plan
- [x] `cargo test -p openfdd-fieldbus` (42 unit + new fd-leak regression test)
- [x] `cargo clippy -p openfdd-fieldbus --all-targets` clean
- [x] `cargo fmt --all --check`
- [ ] Edge bench re-run: FD count stable over soak, I-Am vendor_id 999, whois range respected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BACnet device discovery now correctly respects requested instance ranges.
  * Weather readings retain the last known values during temporary provider errors, clearly marking stale data instead of immediately switching to defaults.
  * BACnet client shutdown now properly releases network resources, improving repeated start/stop reliability.
* **Improvements**
  * BACnet server startup now uses updated transport configuration for more consistent connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->