### PR TITLE
fix(edge): strict preflight EQUIPMENT_ID_MISSING info severity + explicit equipment_id_column mapping (#536)

### DIFF
--- a/edge/src/csv_ingest/plan.rs
+++ b/edge/src/csv_ingest/plan.rs
@@ -48,6 +48,11 @@ pub struct FileMapping {
     pub timestamp_column: String,
     pub timezone: String,
     pub value_columns: Vec<String>,
+    /// Optional explicit equipment-id column for wide CSVs whose id column is
+    /// not literally named `equipment_id` (#536). Values are copied into the
+    /// output rows under the `equipment_id` key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub equipment_id_column: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -120,6 +125,11 @@ pub fn parse_file_to_rows(
                 .map(|i| (vc.clone(), i))
         })
         .collect();
+    let equip_idx: Option<usize> = mapping
+        .equipment_id_column
+        .as_deref()
+        .filter(|c| !c.is_empty())
+        .and_then(|col| profile.headers.iter().position(|h| h == col));
 
     let mut rdr = csv::ReaderBuilder::new()
         .delimiter(delimiter as u8)
@@ -137,6 +147,12 @@ pub fn parse_file_to_rows(
                 crate::csv_ingest::parse::sanitize_header(name),
                 rec.get(*idx).unwrap_or("").to_string(),
             );
+        }
+        if let Some(ei) = equip_idx {
+            let equip = rec.get(ei).unwrap_or("").trim().to_string();
+            if !equip.is_empty() {
+                values.insert("equipment_id".into(), equip);
+            }
         }
         let pt = crate::csv_ingest::timestamp::parse_row_timestamp(&raw_ts, tz, ambiguous_policy);
         rows.push(OutputRow {
@@ -566,6 +582,7 @@ pub fn auto_detect_mapping(filename: &str, headers: &[String]) -> FileMapping {
         timestamp_column: ts_candidates,
         timezone: "America/Chicago".into(),
         value_columns,
+        equipment_id_column: None,
     }
 }
 

--- a/edge/src/ingest/validate.rs
+++ b/edge/src/ingest/validate.rs
@@ -116,6 +116,18 @@ pub fn evaluate_csv_session(input: ValidationInput<'_>) -> Value {
             ));
         }
 
+        // Columns explicitly mapped as equipment ids are identifiers, not values.
+        let mapped_equip_cols: Vec<String> = input
+            .plan
+            .map(|plan| {
+                plan.files
+                    .iter()
+                    .filter_map(|f| f.equipment_id_column.clone())
+                    .filter(|c| !c.is_empty())
+                    .map(|c| c.to_ascii_lowercase())
+                    .collect()
+            })
+            .unwrap_or_default();
         let numeric_cols: Vec<String> = p
             .column_names
             .iter()
@@ -126,6 +138,7 @@ pub fn evaluate_csv_session(input: ValidationInput<'_>) -> Value {
                     && lc != "timestamp_utc"
                     && lc != "equipment_id"
                     && lc != "site_id"
+                    && !mapped_equip_cols.contains(&lc)
             })
             .cloned()
             .collect();
@@ -163,14 +176,18 @@ pub fn evaluate_csv_session(input: ValidationInput<'_>) -> Value {
             .column_names
             .iter()
             .any(|c| c.eq_ignore_ascii_case("equipment_id"));
-        if !has_equip_col {
+        // An explicit per-file equipment_id_column mapping counts as present.
+        if !has_equip_col && mapped_equip_cols.is_empty() {
             if let Some(plan) = input.plan {
                 if plan.mode == crate::csv_ingest::plan::OperationMode::Single
                     && plan.files.len() == 1
                 {
+                    // Severity "info": this documents a defined fallback
+                    // (filename-derived equip id) and must not fail-close a
+                    // strict execute (#536).
                     checks.push(check(
                         "EQUIPMENT_ID_MISSING",
-                        "warn",
+                        "info",
                         "Wide CSV has no equipment_id column — historian will use filename-derived equip id",
                         0,
                         vec![],
@@ -389,6 +406,80 @@ mod tests {
             validation_report: None,
         });
         assert_eq!(out["verdict"], "pass");
+    }
+
+    #[test]
+    fn equipment_id_missing_is_informational_not_blocking() {
+        // #536: a plain wide CSV without an equipment_id column must still
+        // reach verdict "pass" under strict defaults; the check documents a
+        // defined fallback (filename-derived equip id).
+        let preview = PlanPreview {
+            row_count: 100,
+            column_names: vec!["timestamp".into(), "oa_t".into(), "fan_cmd".into()],
+            sample_rows: vec![],
+            timestamp_analysis: TimestampAnalysis::default(),
+            warnings: vec![],
+            time_range: None,
+        };
+        let plan = ImportPlan {
+            mode: crate::csv_ingest::plan::OperationMode::Single,
+            files: vec![crate::csv_ingest::plan::FileMapping {
+                filename: "wide.csv".into(),
+                timestamp_column: "timestamp".into(),
+                timezone: "UTC".into(),
+                value_columns: vec!["oa_t".into(), "fan_cmd".into()],
+                equipment_id_column: None,
+            }],
+            ..Default::default()
+        };
+        let out = evaluate_csv_session(ValidationInput {
+            session_files: &[],
+            plan: Some(&plan),
+            preview: Some(&preview),
+            validation_report: None,
+        });
+        assert_eq!(out["verdict"], "pass", "{out}");
+        let checks = out["checks"].as_array().unwrap();
+        let equip = checks
+            .iter()
+            .find(|c| c["code"] == "EQUIPMENT_ID_MISSING")
+            .expect("informational check still surfaces");
+        assert_eq!(equip["severity"], "info");
+    }
+
+    #[test]
+    fn explicit_equipment_id_mapping_suppresses_check() {
+        let preview = PlanPreview {
+            row_count: 100,
+            column_names: vec!["timestamp".into(), "ahu_name".into(), "oa_t".into()],
+            sample_rows: vec![],
+            timestamp_analysis: TimestampAnalysis::default(),
+            warnings: vec![],
+            time_range: None,
+        };
+        let plan = ImportPlan {
+            mode: crate::csv_ingest::plan::OperationMode::Single,
+            files: vec![crate::csv_ingest::plan::FileMapping {
+                filename: "wide.csv".into(),
+                timestamp_column: "timestamp".into(),
+                timezone: "UTC".into(),
+                value_columns: vec!["oa_t".into()],
+                equipment_id_column: Some("ahu_name".into()),
+            }],
+            ..Default::default()
+        };
+        let out = evaluate_csv_session(ValidationInput {
+            session_files: &[],
+            plan: Some(&plan),
+            preview: Some(&preview),
+            validation_report: None,
+        });
+        assert_eq!(out["verdict"], "pass", "{out}");
+        let checks = out["checks"].as_array().unwrap();
+        assert!(
+            !checks.iter().any(|c| c["code"] == "EQUIPMENT_ID_MISSING"),
+            "{out}"
+        );
     }
 
     #[test]

--- a/edge/tests/csv_ingest_tests.rs
+++ b/edge/tests/csv_ingest_tests.rs
@@ -55,6 +55,7 @@ fn append_school_samples() {
         timestamp_column: "Date".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["kW".into()],
+        equipment_id_column: None,
     };
     let rows_a = parse_file_to_rows(csv, &mapping, ',', "first").unwrap();
     let rows_b = parse_file_to_rows(csv, &mapping, ',', "first").unwrap();
@@ -71,12 +72,14 @@ fn join_weather_floor_hour() {
         timestamp_column: "Date".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["kW".into()],
+        equipment_id_column: None,
     };
     let wx_map = FileMapping {
         filename: "wx.csv".into(),
         timestamp_column: "time_local".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["temp_f".into(), "humidity".into()],
+        equipment_id_column: None,
     };
     let left = parse_file_to_rows(kw_csv, &kw_map, ',', "first").unwrap();
     let right = parse_file_to_rows(wx_csv, &wx_map, ',', "first").unwrap();
@@ -106,6 +109,24 @@ fn dataset_save_and_list() {
 }
 
 #[test]
+fn equipment_id_column_mapping_copies_ids_into_rows() {
+    // #536: an explicitly mapped equipment-id column lands in row values
+    // under the canonical `equipment_id` key.
+    let csv = "Date,kW,ahu_name\n6/19/2013 0:15,1,AHU-1\n6/19/2013 0:30,2,AHU-2\n";
+    let mapping = FileMapping {
+        filename: "wide.csv".into(),
+        timestamp_column: "Date".into(),
+        timezone: "America/Chicago".into(),
+        value_columns: vec!["kW".into()],
+        equipment_id_column: Some("ahu_name".into()),
+    };
+    let rows = parse_file_to_rows(csv, &mapping, ',', "first").unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values.get("equipment_id").unwrap(), "AHU-1");
+    assert_eq!(rows[1].values.get("equipment_id").unwrap(), "AHU-2");
+}
+
+#[test]
 fn path_traversal_filename_rejected() {
     assert!(sanitize_filename("../evil.csv").is_err());
 }
@@ -126,6 +147,7 @@ fn resample_kw_hourly_averages() {
         timestamp_column: "Date".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["kW".into()],
+        equipment_id_column: None,
     };
     let left = parse_file_to_rows(kw_csv, &kw_map, ',', "first").unwrap();
     assert_eq!(left.len(), 3);
@@ -160,18 +182,21 @@ fn join_schools_then_weather() {
         timestamp_column: "Date".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["kW".into()],
+        equipment_id_column: None,
     };
     let kw_map_b = FileMapping {
         filename: "school_b.csv".into(),
         timestamp_column: "Date".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["kW".into()],
+        equipment_id_column: None,
     };
     let wx_map = FileMapping {
         filename: "open_meteo_weather.csv".into(),
         timestamp_column: "time_local".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["temp_f".into(), "humidity".into()],
+        equipment_id_column: None,
     };
     let left_a = parse_file_to_rows(kw_csv, &kw_map, ',', "first").unwrap();
     let left_b = parse_file_to_rows(kw_csv, &kw_map_b, ',', "first").unwrap();

--- a/edge/tests/csv_lake_geneva_integration.rs
+++ b/edge/tests/csv_lake_geneva_integration.rs
@@ -33,6 +33,7 @@ fn lake_geneva_append_four_school_files() {
             timestamp_column: "Date".into(),
             timezone: "America/Chicago".into(),
             value_columns: vec!["kW".into()],
+            equipment_id_column: None,
         };
         let rows = parse_file_to_rows(&text, &mapping, profile.delimiter, "first").unwrap();
         assert!(rows.len() > 1000, "{name} should have substantial rows");
@@ -57,6 +58,7 @@ fn lake_geneva_join_weather_to_kw() {
         timestamp_column: "Date".into(),
         timezone: "America/Chicago".into(),
         value_columns: vec!["kW".into()],
+        equipment_id_column: None,
     };
     let wx_map = FileMapping {
         filename: "weather.csv".into(),
@@ -69,6 +71,7 @@ fn lake_geneva_join_weather_to_kw() {
             .take(5)
             .cloned()
             .collect(),
+        equipment_id_column: None,
     };
     let left = parse_file_to_rows(&kw_text, &kw_map, kw_profile.delimiter, "first").unwrap();
     let right = parse_file_to_rows(&wx_text, &wx_map, wx_profile.delimiter, "first").unwrap();


### PR DESCRIPTION
## Summary
- `EQUIPMENT_ID_MISSING` downgraded from `warn` to new `info` severity — it documents a defined fallback (filename-derived equip id) and no longer flips the preflight verdict to `warn`, so a plain wide CSV executes under strict defaults (bench gate 06 blocker).
- `FileMapping.equipment_id_column: Option<String>` lets a UI/agent explicitly map an id column that is not literally named `equipment_id`; values land in output rows under the canonical `equipment_id` key (picked up by historian sync), and the mapped column is excluded from `COLUMN_UNKNOWN`.

Evidence: nightly OT bench 2026-07-18 round 2 §2 gate 06 + §5 (strict fail-closed on informational warn; FileMapping had no explicit mapping).

## Test plan
- [x] `cargo test -p open_fdd_edge_prototype` (145 lib + integration suites green; new tests for info severity, suppression with mapping, row copy)
- [x] `cargo clippy` / `cargo fmt` clean
- [ ] Bench re-run gate 06 with plain wide CSV (no equipment_id column) under strict defaults

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV imports can now map equipment identifiers from columns with custom names.
  * Mapped identifiers are automatically standardized for downstream processing.

* **Bug Fixes**
  * Prevented valid custom equipment-ID columns from triggering incorrect validation warnings.
  * Improved handling of wide CSV files without a literal `equipment_id` column.

* **Tests**
  * Added coverage for custom equipment-ID mappings and validation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->