### PR TITLE
feat(fieldbus): generic REST/JSON edge driver — 4th OT protocol (#540)

### DIFF
--- a/config/fieldbus/gateway.toml
+++ b/config/fieldbus/gateway.toml
@@ -36,3 +36,12 @@ base_url = "http://127.0.0.1:8081"
 username = "admin"
 # Local demo credentials only — override via env in real deployments (never use defaults OT-side).
 password = "changeme"
+
+# Generic REST/JSON driver (#540). Device catalog lives in rest_devices.toml.
+# Writes fail closed: allow_write here AND the per-binding enabled flag must
+# both be true before POST /rest/write does anything.
+[rest]
+default_timeout_secs = 10
+default_tls_verify = true
+default_poll_interval_secs = 60
+allow_write = false

--- a/config/fieldbus/rest_devices.toml
+++ b/config/fieldbus/rest_devices.toml
@@ -1,0 +1,46 @@
+# REST/JSON device catalog for the fieldbus edge (#540).
+#
+# Rules (enforced at startup — the service refuses to boot on violations):
+#   * Secrets are env-indirect only: `token_env` names an environment variable;
+#     an enabled device whose env var is missing/empty aborts startup.
+#   * `auth` is one of: bearer | api_key_header | basic | none.
+#     - bearer:          token_env holds the bearer token
+#     - api_key_header:  token_env holds the key, sent in `api_key_header`
+#                        (default header name "X-API-Key")
+#     - basic:           `basic_username` (non-secret) + token_env as password
+#   * Point/write paths are relative to base_url only — absolute URLs, `//`,
+#     schemes, and `..` traversal are rejected (SSRF guard). The HTTP API takes
+#     device/point/binding names only, never free-form URLs.
+#   * TLS verification defaults on (`[rest] default_tls_verify` in gateway.toml).
+#   * Writes fail closed: `[rest] allow_write` in gateway.toml AND the
+#     per-binding `enabled` flag must both be true. Every write attempt is
+#     audit-logged (target = rest_audit).
+#
+# Devices default to enabled = false; flip deliberately per site.
+
+[[devices]]
+name = "example-disabled"
+enabled = false
+base_url = "https://127.0.0.1:8443/api"
+auth = "bearer" # bearer | api_key_header | basic | none
+token_env = "OPENFDD_REST_TOKEN_EXAMPLE"
+tls_verify = true
+timeout_secs = 10
+# poll_interval_secs = 60   # per-device override of [rest] default
+
+  [[devices.points]]
+  point_name = "CHW-ST"
+  method = "GET"
+  path = "/points/chw_supply_temp"
+  select = "$.value" # minimal JSONPath: $.key.sub[0].leaf
+  units = "°F"
+  scale = 1.0
+
+  [[devices.writes]]
+  name = "chw_setpoint"
+  enabled = false # fail closed — enable per binding, per site
+  method = "POST"
+  path = "/points/chw_setpoint"
+  body_template = '{"value": {{value}}, "priority": 8}'
+  value_min = 40.0
+  value_max = 55.0

--- a/crates/openfdd_contracts/src/envelope.rs
+++ b/crates/openfdd_contracts/src/envelope.rs
@@ -13,6 +13,7 @@ pub enum Protocol {
     Bacnet,
     Modbus,
     Haystack,
+    Rest,
     JsonApi,
     Weather,
     Mixed,

--- a/crates/openfdd_contracts/src/topics.rs
+++ b/crates/openfdd_contracts/src/topics.rs
@@ -88,6 +88,7 @@ fn protocol_slug(p: Protocol) -> &'static str {
         Protocol::Bacnet => "bacnet",
         Protocol::Modbus => "modbus",
         Protocol::Haystack => "haystack",
+        Protocol::Rest => "rest",
         Protocol::JsonApi => "json_api",
         Protocol::Weather => "weather",
         Protocol::Mixed => "mixed",

--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -93,6 +93,124 @@ impl Default for ModbusSettings {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct RestSettings {
+    pub default_timeout_secs: u64,
+    pub default_tls_verify: bool,
+    pub default_poll_interval_secs: u64,
+    pub allow_write: bool,
+}
+
+impl Default for RestSettings {
+    fn default() -> Self {
+        Self {
+            default_timeout_secs: 10,
+            default_tls_verify: true,
+            default_poll_interval_secs: 60,
+            allow_write: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestAuth {
+    None,
+    Bearer,
+    ApiKeyHeader,
+    Basic,
+}
+
+impl RestAuth {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RestAuth::None => "none",
+            RestAuth::Bearer => "bearer",
+            RestAuth::ApiKeyHeader => "api_key_header",
+            RestAuth::Basic => "basic",
+        }
+    }
+}
+
+fn parse_rest_auth(raw: &str) -> Result<RestAuth, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "none" => Ok(RestAuth::None),
+        "bearer" => Ok(RestAuth::Bearer),
+        "api_key_header" => Ok(RestAuth::ApiKeyHeader),
+        "basic" => Ok(RestAuth::Basic),
+        other => Err(format!(
+            "invalid rest auth '{other}' (expected bearer | api_key_header | basic | none)"
+        )),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RestPoint {
+    pub point_name: String,
+    /// Validated to GET at load time; retained for catalog parity.
+    #[allow(dead_code)]
+    pub method: String,
+    pub path: String,
+    pub select: String,
+    pub units: String,
+    pub scale: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RestWriteBinding {
+    pub name: String,
+    pub enabled: bool,
+    pub method: String,
+    pub path: String,
+    pub body_template: String,
+    pub value_min: Option<f64>,
+    pub value_max: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RestDevice {
+    pub name: String,
+    pub enabled: bool,
+    pub base_url: String,
+    pub auth: RestAuth,
+    pub token_env: Option<String>,
+    pub api_key_header: String,
+    pub basic_username: Option<String>,
+    pub tls_verify: bool,
+    pub timeout_secs: u64,
+    pub poll_interval_secs: u64,
+    pub points: Vec<RestPoint>,
+    pub writes: Vec<RestWriteBinding>,
+}
+
+/// Reject anything that is not a plain relative path joined below `base_url`
+/// (SSRF guard: no absolute URLs, schemes, authority tricks, or traversal).
+pub fn validate_rest_path(path: &str) -> Result<(), String> {
+    let p = path.trim();
+    if p.is_empty() {
+        return Err("path must be non-empty".into());
+    }
+    if !p.starts_with('/') {
+        return Err(format!(
+            "path '{p}' must start with '/' (relative to base_url)"
+        ));
+    }
+    if p.starts_with("//") {
+        return Err(format!("path '{p}' must not start with '//'"));
+    }
+    if p.contains("://") || p.contains('\\') {
+        return Err(format!(
+            "path '{p}' must be relative (no scheme or backslashes)"
+        ));
+    }
+    if p.split('/').any(|seg| seg == "..") {
+        return Err(format!("path '{p}' must not contain '..' segments"));
+    }
+    if p.contains(char::is_whitespace) {
+        return Err(format!("path '{p}' must not contain whitespace"));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HaystackAuthMode {
     Scram,
@@ -188,6 +306,7 @@ pub struct Settings {
     pub weather: WeatherSettings,
     pub modbus: ModbusSettings,
     pub haystack: HaystackSettings,
+    pub rest: RestSettings,
     pub poll: PollSettings,
     pub http_host: String,
     pub http_port: u16,
@@ -206,6 +325,7 @@ impl Default for Settings {
             weather: WeatherSettings::default(),
             modbus: ModbusSettings::default(),
             haystack: HaystackSettings::default(),
+            rest: RestSettings::default(),
             poll: PollSettings::default(),
             http_host: "0.0.0.0".into(),
             http_port: 8080,
@@ -224,7 +344,16 @@ struct GatewayToml {
     weather: Option<WeatherToml>,
     modbus: Option<ModbusToml>,
     haystack: Option<HaystackToml>,
+    rest: Option<RestToml>,
     poll: Option<PollToml>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestToml {
+    default_timeout_secs: Option<u64>,
+    default_tls_verify: Option<bool>,
+    default_poll_interval_secs: Option<u64>,
+    allow_write: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -305,6 +434,49 @@ struct FieldPointToml {
     object_instance: u32,
     point_name: Option<String>,
     units: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RestDevicesToml {
+    #[serde(default)]
+    devices: Vec<RestDeviceToml>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestDeviceToml {
+    name: String,
+    enabled: Option<bool>,
+    base_url: String,
+    auth: Option<String>,
+    token_env: Option<String>,
+    api_key_header: Option<String>,
+    basic_username: Option<String>,
+    tls_verify: Option<bool>,
+    timeout_secs: Option<u64>,
+    poll_interval_secs: Option<u64>,
+    points: Option<Vec<RestPointToml>>,
+    writes: Option<Vec<RestWriteToml>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestPointToml {
+    point_name: String,
+    method: Option<String>,
+    path: String,
+    select: Option<String>,
+    units: Option<String>,
+    scale: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestWriteToml {
+    name: String,
+    enabled: Option<bool>,
+    method: Option<String>,
+    path: String,
+    body_template: String,
+    value_min: Option<f64>,
+    value_max: Option<f64>,
 }
 
 pub fn config_dir() -> PathBuf {
@@ -461,6 +633,20 @@ pub fn load_settings() -> Settings {
         }
         if let Some(v) = h.tls_verify {
             s.haystack.tls_verify = v;
+        }
+    }
+    if let Some(r) = raw.rest {
+        if let Some(v) = r.default_timeout_secs {
+            s.rest.default_timeout_secs = v;
+        }
+        if let Some(v) = r.default_tls_verify {
+            s.rest.default_tls_verify = v;
+        }
+        if let Some(v) = r.default_poll_interval_secs {
+            s.rest.default_poll_interval_secs = v;
+        }
+        if let Some(v) = r.allow_write {
+            s.rest.allow_write = v;
         }
     }
     if let Some(p) = raw.poll {
@@ -623,6 +809,102 @@ pub fn load_field_devices(path: Option<&Path>) -> Result<Vec<FieldDevice>, Strin
         .collect())
 }
 
+/// Load the REST/JSON device catalog. A missing file means "no REST devices"
+/// (the driver is optional); a malformed file or invalid entry is a hard error.
+pub fn load_rest_devices(
+    path: Option<&Path>,
+    defaults: &RestSettings,
+) -> Result<Vec<RestDevice>, String> {
+    let toml_path = path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| config_dir().join("rest_devices.toml"));
+    if !toml_path.exists() {
+        return Ok(Vec::new());
+    }
+    let text = std::fs::read_to_string(&toml_path)
+        .map_err(|e| format!("failed to read {}: {e}", toml_path.display()))?;
+    let data: RestDevicesToml =
+        toml::from_str(&text).map_err(|e| format!("{}: {e}", toml_path.display()))?;
+
+    let mut devices = Vec::new();
+    for d in data.devices {
+        let auth = parse_rest_auth(d.auth.as_deref().unwrap_or("none"))
+            .map_err(|e| format!("rest device '{}': {e}", d.name))?;
+        let base = d.base_url.trim();
+        if !(base.starts_with("http://") || base.starts_with("https://")) {
+            return Err(format!(
+                "rest device '{}': base_url must be http(s), got '{base}'",
+                d.name
+            ));
+        }
+        let mut points = Vec::new();
+        for p in d.points.unwrap_or_default() {
+            validate_rest_path(&p.path)
+                .map_err(|e| format!("rest device '{}' point '{}': {e}", d.name, p.point_name))?;
+            let method = p.method.unwrap_or_else(|| "GET".into()).to_uppercase();
+            if method != "GET" {
+                return Err(format!(
+                    "rest device '{}' point '{}': only GET reads are supported",
+                    d.name, p.point_name
+                ));
+            }
+            points.push(RestPoint {
+                point_name: p.point_name,
+                method,
+                path: p.path,
+                select: p.select.unwrap_or_default(),
+                units: p.units.unwrap_or_default(),
+                scale: p.scale.unwrap_or(1.0),
+            });
+        }
+        let mut writes = Vec::new();
+        for w in d.writes.unwrap_or_default() {
+            validate_rest_path(&w.path)
+                .map_err(|e| format!("rest device '{}' write '{}': {e}", d.name, w.name))?;
+            let method = w.method.unwrap_or_else(|| "POST".into()).to_uppercase();
+            if !matches!(method.as_str(), "POST" | "PUT" | "PATCH") {
+                return Err(format!(
+                    "rest device '{}' write '{}': method must be POST, PUT, or PATCH",
+                    d.name, w.name
+                ));
+            }
+            writes.push(RestWriteBinding {
+                name: w.name,
+                // Writes fail closed: bindings are disabled unless explicitly enabled.
+                enabled: w.enabled.unwrap_or(false),
+                method,
+                path: w.path,
+                body_template: w.body_template,
+                value_min: w.value_min,
+                value_max: w.value_max,
+            });
+        }
+        devices.push(RestDevice {
+            name: d.name,
+            enabled: d.enabled.unwrap_or(false),
+            base_url: base.trim_end_matches('/').to_string(),
+            auth,
+            token_env: d.token_env,
+            api_key_header: d.api_key_header.unwrap_or_else(|| "X-API-Key".into()),
+            basic_username: d.basic_username,
+            tls_verify: d.tls_verify.unwrap_or(defaults.default_tls_verify),
+            timeout_secs: d.timeout_secs.unwrap_or(defaults.default_timeout_secs),
+            poll_interval_secs: d
+                .poll_interval_secs
+                .unwrap_or(defaults.default_poll_interval_secs),
+            points,
+            writes,
+        });
+    }
+    let mut names: Vec<&str> = devices.iter().map(|d| d.name.as_str()).collect();
+    names.sort_unstable();
+    names.dedup();
+    if names.len() != devices.len() {
+        return Err("rest_devices.toml: device names must be unique".into());
+    }
+    Ok(devices)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -750,6 +1032,72 @@ mod tests {
         assert_eq!(parse_haystack_auth_mode("basic"), HaystackAuthMode::Basic);
         assert_eq!(parse_haystack_auth_mode("niagara"), HaystackAuthMode::Basic);
         assert_eq!(parse_haystack_auth_mode("scram"), HaystackAuthMode::Scram);
+    }
+
+    #[test]
+    fn rest_settings_defaults_fail_closed() {
+        let s = RestSettings::default();
+        assert_eq!(s.default_timeout_secs, 10);
+        assert!(s.default_tls_verify);
+        assert_eq!(s.default_poll_interval_secs, 60);
+        assert!(!s.allow_write);
+    }
+
+    #[test]
+    fn load_rest_devices_repo_example() {
+        std::env::set_var("OPENFDD_FIELDBUS_CONFIG_DIR", repo_config_dir());
+        let devices = load_rest_devices(None, &RestSettings::default()).expect("rest_devices");
+        assert_eq!(devices.len(), 1);
+        let d = &devices[0];
+        assert_eq!(d.name, "example-disabled");
+        assert!(!d.enabled, "shipped example must stay disabled");
+        assert_eq!(d.auth, RestAuth::Bearer);
+        assert_eq!(d.token_env.as_deref(), Some("OPENFDD_REST_TOKEN_EXAMPLE"));
+        assert!(d.tls_verify);
+        assert_eq!(d.points.len(), 1);
+        assert_eq!(d.points[0].point_name, "CHW-ST");
+        assert_eq!(d.points[0].select, "$.value");
+        assert_eq!(d.writes.len(), 1);
+        assert!(
+            !d.writes[0].enabled,
+            "shipped write binding must stay disabled"
+        );
+        assert_eq!(d.writes[0].value_min, Some(40.0));
+        assert_eq!(d.writes[0].value_max, Some(55.0));
+    }
+
+    #[test]
+    fn load_rest_devices_missing_file_is_empty() {
+        let devices = load_rest_devices(
+            Some(Path::new("/nonexistent/rest_devices.toml")),
+            &RestSettings::default(),
+        )
+        .unwrap();
+        assert!(devices.is_empty());
+    }
+
+    #[test]
+    fn rest_path_must_be_relative() {
+        assert!(validate_rest_path("/points/chw_supply_temp").is_ok());
+        assert!(validate_rest_path("/a/b?x=1").is_ok());
+        assert!(validate_rest_path("").is_err());
+        assert!(validate_rest_path("points/x").is_err());
+        assert!(validate_rest_path("https://evil.example/x").is_err());
+        assert!(validate_rest_path("//evil.example/x").is_err());
+        assert!(validate_rest_path("/a/../secrets").is_err());
+        assert!(validate_rest_path("/a b").is_err());
+    }
+
+    #[test]
+    fn rest_auth_parsing() {
+        assert_eq!(parse_rest_auth("bearer").unwrap(), RestAuth::Bearer);
+        assert_eq!(
+            parse_rest_auth("api_key_header").unwrap(),
+            RestAuth::ApiKeyHeader
+        );
+        assert_eq!(parse_rest_auth("basic").unwrap(), RestAuth::Basic);
+        assert_eq!(parse_rest_auth("none").unwrap(), RestAuth::None);
+        assert!(parse_rest_auth("oauth-dance").is_err());
     }
 
     #[test]

--- a/services/fieldbus/src/main.rs
+++ b/services/fieldbus/src/main.rs
@@ -18,7 +18,7 @@ use axum::middleware;
 use config::load_settings;
 use services::{
     bacnet_client::BacnetClientService, bacnet_server::BacnetServerManager,
-    haystack::HaystackService, poll::PollEngine, weather::WeatherService,
+    haystack::HaystackService, poll::PollEngine, rest::RestClientService, weather::WeatherService,
 };
 use state::AppState;
 use tower_http::trace::TraceLayer;
@@ -61,10 +61,21 @@ async fn run(
 
     let haystack = Arc::new(HaystackService::new(settings.haystack.clone()));
 
+    // REST/JSON driver (#540): startup fails loudly when an enabled device
+    // references a missing secret env var.
+    let rest_devices =
+        config::load_rest_devices(None, &settings.rest).map_err(std::io::Error::other)?;
+    let rest = Arc::new(
+        RestClientService::from_config(settings.rest.clone(), rest_devices)
+            .map_err(std::io::Error::other)?,
+    );
+    rest.start().await;
+
     mqtt_bridge::spawn_if_configured(
         Arc::clone(&settings),
         Arc::clone(&poll_engine),
         Arc::clone(&bacnet_client),
+        Arc::clone(&rest),
     )
     .await;
 
@@ -84,6 +95,7 @@ async fn run(
         poll_engine,
         weather,
         haystack,
+        rest,
     };
 
     info!(
@@ -112,6 +124,7 @@ async fn run(
             state.poll_engine.clone(),
             state.bacnet_server.clone(),
             state.haystack.clone(),
+            state.rest.clone(),
         ))
         .await?;
 
@@ -123,10 +136,12 @@ async fn shutdown_signal(
     poll_engine: Arc<PollEngine>,
     bacnet_server: Arc<BacnetServerManager>,
     haystack: Arc<HaystackService>,
+    rest: Arc<RestClientService>,
 ) {
     let _ = tokio::signal::ctrl_c().await;
     info!("Shutting down...");
     haystack.close().await;
+    rest.stop().await;
     poll_engine.stop().await;
     weather.stop().await;
     let _ = bacnet_server.stop().await;
@@ -160,6 +175,9 @@ mod tests {
             Arc::clone(&bacnet_server),
         ));
         let haystack = Arc::new(HaystackService::new(settings.haystack.clone()));
+        let rest_devices = config::load_rest_devices(None, &settings.rest).unwrap();
+        let rest =
+            Arc::new(RestClientService::from_config(settings.rest.clone(), rest_devices).unwrap());
         AppState {
             settings,
             api_key: None,
@@ -168,6 +186,7 @@ mod tests {
             poll_engine,
             weather,
             haystack,
+            rest,
         }
     }
 

--- a/services/fieldbus/src/models.rs
+++ b/services/fieldbus/src/models.rs
@@ -192,6 +192,38 @@ pub struct HaystackHisReadRequest {
     pub range_end: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Validate)]
+pub struct RestReadRequest {
+    /// Configured device name from `rest_devices.toml` (no free-form URLs).
+    #[validate(length(min = 1, max = 128))]
+    pub device: String,
+    /// Configured point name on that device.
+    #[validate(length(min = 1, max = 256))]
+    pub point: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Validate)]
+pub struct RestGetRequest {
+    /// Configured device name from `rest_devices.toml` (no free-form URLs).
+    #[validate(length(min = 1, max = 128))]
+    pub device: String,
+    /// Relative path joined below the device base_url (absolute URLs rejected).
+    #[validate(length(min = 1, max = 2048))]
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Validate)]
+pub struct RestWriteRequest {
+    /// Configured device name from `rest_devices.toml`.
+    #[validate(length(min = 1, max = 128))]
+    pub device: String,
+    /// Allowlisted write binding name on that device.
+    #[validate(length(min = 1, max = 256))]
+    pub name: String,
+    /// Numeric value substituted into the binding's body_template.
+    pub value: f64,
+}
+
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct WeatherResponse {
     pub temp_f: f64,

--- a/services/fieldbus/src/mqtt_bridge.rs
+++ b/services/fieldbus/src/mqtt_bridge.rs
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 use crate::config::Settings;
 use crate::services::bacnet_client::BacnetClientService;
 use crate::services::poll::PollEngine;
+use crate::services::rest::RestClientService;
 
 const MAX_SEEN_COMMANDS: usize = 10_000;
 
@@ -322,10 +323,41 @@ async fn connect_mqtt_session(
     })
 }
 
+/// Map REST poll rows into telemetry points (`rest:<device>:<point>` ids).
+fn rest_telemetry_points(rows: &[serde_json::Value]) -> Vec<TelemetryPoint> {
+    rows.iter()
+        .filter_map(|v| {
+            let device = v.get("device")?.as_str()?;
+            let point = v.get("point")?.as_str()?;
+            Some(TelemetryPoint {
+                id: format!("rest:{device}:{point}"),
+                display_name: Some(point.to_string()),
+                kind: Some(ValueKind::Number),
+                value: v.get("value").cloned().unwrap_or(serde_json::Value::Null),
+                unit: v
+                    .get("units")
+                    .and_then(|x| x.as_str())
+                    .filter(|u| !u.is_empty())
+                    .map(str::to_string),
+                quality: if v.get("error").map(|e| e.is_null()).unwrap_or(true) {
+                    Quality::Good
+                } else {
+                    Quality::Bad
+                },
+                tags: serde_json::json!({"rest": true, "device": device})
+                    .as_object()
+                    .cloned()
+                    .unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
 pub async fn spawn_if_configured(
     settings: Arc<Settings>,
     poll: Arc<PollEngine>,
     bacnet_client: Arc<BacnetClientService>,
+    rest: Arc<RestClientService>,
 ) {
     if !mqtt_enabled() {
         info!("MQTT bridge disabled (set OPENFDD_MQTT_ENABLED=1 to enable)");
@@ -373,9 +405,6 @@ pub async fn spawn_if_configured(
                 .and_then(|v| v.as_array())
                 .cloned()
                 .unwrap_or_default();
-            if last_values.is_empty() {
-                continue;
-            }
             let points: Vec<TelemetryPoint> = last_values
                 .into_iter()
                 .filter_map(|v| {
@@ -406,14 +435,26 @@ pub async fn spawn_if_configured(
                     })
                 })
                 .collect();
-            if points.is_empty() {
+            let rest_rows = rest.last_values().await;
+            let rest_points = rest_telemetry_points(&rest_rows);
+            if points.is_empty() && rest_points.is_empty() {
                 continue;
             }
-            let env = TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Bacnet, seq, points);
-            let topic = topics.topic(TopicKind::Telemetry, Some(Protocol::Bacnet));
-            if let Err(err) = spool.enqueue(&topic, env).await {
-                warn!(%err, "spool enqueue failed");
-                continue;
+            if !points.is_empty() {
+                let env = TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Bacnet, seq, points);
+                let topic = topics.topic(TopicKind::Telemetry, Some(Protocol::Bacnet));
+                if let Err(err) = spool.enqueue(&topic, env).await {
+                    warn!(%err, "spool enqueue failed");
+                    continue;
+                }
+            }
+            if !rest_points.is_empty() {
+                let env =
+                    TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Rest, seq, rest_points);
+                let topic = topics.topic(TopicKind::Telemetry, Some(Protocol::Rest));
+                if let Err(err) = spool.enqueue(&topic, env).await {
+                    warn!(%err, "rest spool enqueue failed");
+                }
             }
 
             if mqtt.is_none() {
@@ -479,6 +520,27 @@ mod tests {
         assert_eq!(telemetry_point_value(&legacy), serde_json::json!(70.25));
         let missing = serde_json::json!({"point_name": "OA-T"});
         assert_eq!(telemetry_point_value(&missing), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn rest_rows_map_to_rest_telemetry_points() {
+        let rows = vec![
+            serde_json::json!({
+                "device": "chiller-api", "point": "CHW-ST",
+                "value": 44.2, "units": "°F", "error": null
+            }),
+            serde_json::json!({
+                "device": "chiller-api", "point": "CHW-RT",
+                "value": null, "units": "", "error": "circuit open"
+            }),
+        ];
+        let points = rest_telemetry_points(&rows);
+        assert_eq!(points.len(), 2);
+        assert_eq!(points[0].id, "rest:chiller-api:CHW-ST");
+        assert_eq!(points[0].quality, Quality::Good);
+        assert_eq!(points[0].unit.as_deref(), Some("°F"));
+        assert_eq!(points[1].quality, Quality::Bad);
+        assert_eq!(points[1].unit, None);
     }
 
     #[test]

--- a/services/fieldbus/src/openapi.rs
+++ b/services/fieldbus/src/openapi.rs
@@ -46,6 +46,10 @@ use crate::openapi_paths::*;
         doc_haystack_read,
         doc_haystack_nav,
         doc_haystack_his_read,
+        doc_rest_devices,
+        doc_rest_read,
+        doc_rest_get,
+        doc_rest_write,
     ),
     components(schemas(
         BacnetReadRequest,
@@ -62,6 +66,9 @@ use crate::openapi_paths::*;
         HaystackReadRequest,
         HaystackNavRequest,
         HaystackHisReadRequest,
+        RestReadRequest,
+        RestGetRequest,
+        RestWriteRequest,
         WeatherResponse,
         OkResponse,
     )),
@@ -74,6 +81,7 @@ use crate::openapi_paths::*;
         (name = "Weather", description = "Open-Meteo weather cache"),
         (name = "Modbus", description = "Modbus TCP reads"),
         (name = "Haystack", description = "Read-only Haystack client"),
+        (name = "REST/JSON", description = "Generic REST/JSON driver — catalog devices only, fail-closed writes"),
         (name = "Open-FDD compat", description = "Open-FDD /api aliases"),
     )
 )]

--- a/services/fieldbus/src/openapi_paths.rs
+++ b/services/fieldbus/src/openapi_paths.rs
@@ -281,3 +281,57 @@ pub(crate) fn doc_haystack_nav() {}
     responses((status = 200, description = "History grid"))
 )]
 pub(crate) fn doc_haystack_his_read() {}
+
+/// List configured REST/JSON devices with per-device health.
+#[utoipa::path(
+    get,
+    path = "/rest/devices",
+    tag = "REST/JSON",
+    security(("BearerAuth" = [])),
+    responses((status = 200, description = "Device catalog + circuit-breaker health"))
+)]
+pub(crate) fn doc_rest_devices() {}
+
+/// Live read of one configured point (select + scale applied).
+#[utoipa::path(
+    post,
+    path = "/rest/read",
+    tag = "REST/JSON",
+    request_body = RestReadRequest,
+    security(("BearerAuth" = [])),
+    responses(
+        (status = 200, description = "Point value"),
+        (status = 404, description = "Unknown device or point"),
+        (status = 502, description = "Upstream error or circuit open")
+    )
+)]
+pub(crate) fn doc_rest_read() {}
+
+/// Raw passthrough GET below the device base_url (relative path only).
+#[utoipa::path(
+    post,
+    path = "/rest/get",
+    tag = "REST/JSON",
+    request_body = RestGetRequest,
+    security(("BearerAuth" = [])),
+    responses(
+        (status = 200, description = "Raw upstream response"),
+        (status = 400, description = "Path must be relative")
+    )
+)]
+pub(crate) fn doc_rest_get() {}
+
+/// Allowlisted write — 403 unless rest.allow_write AND the binding are enabled.
+#[utoipa::path(
+    post,
+    path = "/rest/write",
+    tag = "REST/JSON",
+    request_body = RestWriteRequest,
+    security(("BearerAuth" = [])),
+    responses(
+        (status = 200, description = "Write executed"),
+        (status = 403, description = "Writes disabled (fail closed)"),
+        (status = 404, description = "Unknown device or write binding")
+    )
+)]
+pub(crate) fn doc_rest_write() {}

--- a/services/fieldbus/src/routes/mod.rs
+++ b/services/fieldbus/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod bacnet;
 pub mod compat;
 pub mod haystack;
 pub mod modbus;
+pub mod rest;
 pub mod root;
 pub mod weather;
 
@@ -17,6 +18,7 @@ pub fn api_routes(state: AppState) -> Router {
         .merge(weather::router())
         .merge(modbus::router())
         .merge(haystack::router())
+        .merge(rest::router())
         .merge(compat::router())
         .nest("/api", {
             Router::new()
@@ -24,6 +26,7 @@ pub fn api_routes(state: AppState) -> Router {
                 .merge(weather::router())
                 .merge(modbus::router())
                 .merge(haystack::router())
+                .merge(rest::router())
         })
         .with_state(state)
 }

--- a/services/fieldbus/src/routes/rest.rs
+++ b/services/fieldbus/src/routes/rest.rs
@@ -1,0 +1,74 @@
+//! Generic REST/JSON driver routes (#540). Devices and write bindings are
+//! referenced by catalog name only — no free-form URLs cross this API.
+
+use axum::{
+    extract::State,
+    routing::{get, post},
+    Json, Router,
+};
+use serde_json::Value;
+
+use crate::error::{validate, ApiError, ApiResult};
+use crate::models::{RestGetRequest, RestReadRequest, RestWriteRequest};
+use crate::services::rest::RestError;
+use crate::state::AppState;
+
+fn map_err(e: RestError) -> ApiError {
+    match e {
+        RestError::BadRequest(m) => ApiError::BadRequest(m),
+        RestError::Forbidden(m) => ApiError::Forbidden(m),
+        RestError::NotFound(m) => ApiError::NotFound(m),
+        RestError::Upstream(m) => ApiError::Upstream(m),
+    }
+}
+
+async fn rest_devices(State(state): State<AppState>) -> ApiResult<Json<Value>> {
+    Ok(Json(state.rest.list_devices().await))
+}
+
+async fn rest_read(
+    State(state): State<AppState>,
+    Json(body): Json<RestReadRequest>,
+) -> ApiResult<Json<Value>> {
+    validate(&body)?;
+    let result = state
+        .rest
+        .read_point(&body.device, &body.point)
+        .await
+        .map_err(map_err)?;
+    Ok(Json(result))
+}
+
+async fn rest_get(
+    State(state): State<AppState>,
+    Json(body): Json<RestGetRequest>,
+) -> ApiResult<Json<Value>> {
+    validate(&body)?;
+    let result = state
+        .rest
+        .raw_get(&body.device, &body.path)
+        .await
+        .map_err(map_err)?;
+    Ok(Json(result))
+}
+
+async fn rest_write(
+    State(state): State<AppState>,
+    Json(body): Json<RestWriteRequest>,
+) -> ApiResult<Json<Value>> {
+    validate(&body)?;
+    let result = state
+        .rest
+        .write(&body.device, &body.name, body.value)
+        .await
+        .map_err(map_err)?;
+    Ok(Json(result))
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/rest/devices", get(rest_devices))
+        .route("/rest/read", post(rest_read))
+        .route("/rest/get", post(rest_get))
+        .route("/rest/write", post(rest_write))
+}

--- a/services/fieldbus/src/services/mod.rs
+++ b/services/fieldbus/src/services/mod.rs
@@ -3,4 +3,5 @@ pub mod bacnet_server;
 pub mod haystack;
 pub mod modbus;
 pub mod poll;
+pub mod rest;
 pub mod weather;

--- a/services/fieldbus/src/services/rest.rs
+++ b/services/fieldbus/src/services/rest.rs
@@ -1,0 +1,798 @@
+//! Generic REST/JSON edge driver (#540).
+//!
+//! One pooled `reqwest::Client` per configured device (never per operation —
+//! see the #535 fd-leak regression), per-device auth via env indirection,
+//! consecutive-failure circuit breaker, and an allowlisted fail-closed write
+//! path with structured audit logging.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+use crate::config::{RestAuth, RestDevice, RestSettings, RestWriteBinding};
+
+const BREAKER_THRESHOLD: u32 = 3;
+const BREAKER_MAX_BACKOFF_SECS: u64 = 300;
+
+#[derive(Debug)]
+pub enum RestError {
+    BadRequest(String),
+    Forbidden(String),
+    NotFound(String),
+    Upstream(String),
+}
+
+impl std::fmt::Display for RestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RestError::BadRequest(m)
+            | RestError::Forbidden(m)
+            | RestError::NotFound(m)
+            | RestError::Upstream(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for RestError {}
+
+/// Resolved (non-secret-logging) auth material for one device.
+#[derive(Clone)]
+enum ResolvedAuth {
+    None,
+    Bearer(String),
+    ApiKeyHeader { header: String, key: String },
+    Basic { username: String, password: String },
+}
+
+/// Exponential backoff once the consecutive-failure threshold is crossed.
+fn backoff_secs(consecutive_failures: u32) -> u64 {
+    if consecutive_failures < BREAKER_THRESHOLD {
+        return 0;
+    }
+    let exp = (consecutive_failures - BREAKER_THRESHOLD).min(16);
+    (5u64 << exp).min(BREAKER_MAX_BACKOFF_SECS)
+}
+
+#[derive(Debug, Default)]
+struct CircuitBreaker {
+    consecutive_failures: u32,
+    open_until: Option<Instant>,
+    last_error: Option<String>,
+    last_ok_ts: Option<f64>,
+}
+
+impl CircuitBreaker {
+    fn is_open(&self, now: Instant) -> bool {
+        self.open_until.is_some_and(|t| now < t)
+    }
+
+    fn record_success(&mut self) {
+        self.consecutive_failures = 0;
+        self.open_until = None;
+        self.last_error = None;
+        self.last_ok_ts = Some(unix_ts());
+    }
+
+    fn record_failure(&mut self, now: Instant, err: &str) {
+        self.consecutive_failures += 1;
+        self.last_error = Some(err.to_string());
+        let secs = backoff_secs(self.consecutive_failures);
+        if secs > 0 {
+            self.open_until = Some(now + Duration::from_secs(secs));
+        }
+    }
+}
+
+fn unix_ts() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+struct DeviceRuntime {
+    config: RestDevice,
+    client: reqwest::Client,
+    auth: ResolvedAuth,
+    breaker: Mutex<CircuitBreaker>,
+    last_values: Mutex<HashMap<String, Value>>,
+}
+
+pub struct RestClientService {
+    settings: RestSettings,
+    devices: Vec<Arc<DeviceRuntime>>,
+    tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
+}
+
+fn require_env(device: &str, var: Option<&str>) -> Result<String, String> {
+    let name = var
+        .filter(|v| !v.trim().is_empty())
+        .ok_or_else(|| format!("rest device '{device}': token_env is required for this auth"))?;
+    match std::env::var(name) {
+        Ok(v) if !v.trim().is_empty() => Ok(v.trim().to_string()),
+        _ => Err(format!(
+            "rest device '{device}': required env '{name}' is missing or empty (secrets are env-indirect only)"
+        )),
+    }
+}
+
+fn resolve_auth(device: &RestDevice) -> Result<ResolvedAuth, String> {
+    match device.auth {
+        RestAuth::None => Ok(ResolvedAuth::None),
+        RestAuth::Bearer => Ok(ResolvedAuth::Bearer(require_env(
+            &device.name,
+            device.token_env.as_deref(),
+        )?)),
+        RestAuth::ApiKeyHeader => Ok(ResolvedAuth::ApiKeyHeader {
+            header: device.api_key_header.clone(),
+            key: require_env(&device.name, device.token_env.as_deref())?,
+        }),
+        RestAuth::Basic => {
+            let username = device
+                .basic_username
+                .clone()
+                .filter(|u| !u.trim().is_empty())
+                .ok_or_else(|| {
+                    format!(
+                        "rest device '{}': basic auth requires basic_username",
+                        device.name
+                    )
+                })?;
+            Ok(ResolvedAuth::Basic {
+                username,
+                password: require_env(&device.name, device.token_env.as_deref())?,
+            })
+        }
+    }
+}
+
+/// Minimal JSONPath-style selector: `$.a.b[0].c` (dot keys + numeric indexes).
+pub fn select_json(body: &Value, select: &str) -> Result<Value, String> {
+    let s = select.trim();
+    let s = s.strip_prefix('$').unwrap_or(s);
+    let mut current = body;
+    let mut rest = s;
+    while !rest.is_empty() {
+        rest = rest.strip_prefix('.').unwrap_or(rest);
+        if rest.is_empty() {
+            break;
+        }
+        if let Some(idx_body) = rest.strip_prefix('[') {
+            let end = idx_body
+                .find(']')
+                .ok_or_else(|| format!("select '{select}': unterminated '['"))?;
+            let idx: usize = idx_body[..end]
+                .parse()
+                .map_err(|_| format!("select '{select}': bad array index"))?;
+            current = current
+                .get(idx)
+                .ok_or_else(|| format!("select '{select}': index {idx} not found"))?;
+            rest = &idx_body[end + 1..];
+        } else {
+            let end = rest.find(['.', '[']).unwrap_or(rest.len());
+            let key = &rest[..end];
+            current = current
+                .get(key)
+                .ok_or_else(|| format!("select '{select}': key '{key}' not found"))?;
+            rest = &rest[end..];
+        }
+    }
+    Ok(current.clone())
+}
+
+/// Coerce a selected JSON value to f64 (numbers, bools, numeric strings).
+pub fn value_as_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Number(n) => n.as_f64(),
+        Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+        Value::String(s) => s.trim().parse().ok(),
+        _ => None,
+    }
+}
+
+/// Render `{{value}}` into a write body template.
+pub fn render_body_template(template: &str, value: f64) -> String {
+    let rendered = if value.fract() == 0.0 && value.abs() < 1e15 {
+        format!("{}", value as i64)
+    } else {
+        format!("{value}")
+    };
+    template
+        .replace("{{ value }}", &rendered)
+        .replace("{{value}}", &rendered)
+}
+
+fn check_write_allowed(
+    allow_write_global: bool,
+    binding: &RestWriteBinding,
+    value: f64,
+) -> Result<(), RestError> {
+    if !allow_write_global {
+        return Err(RestError::Forbidden(
+            "REST writes are disabled globally (rest.allow_write = false)".into(),
+        ));
+    }
+    if !binding.enabled {
+        return Err(RestError::Forbidden(format!(
+            "write binding '{}' is disabled",
+            binding.name
+        )));
+    }
+    if let Some(min) = binding.value_min {
+        if value < min {
+            return Err(RestError::BadRequest(format!(
+                "value {value} below value_min {min}"
+            )));
+        }
+    }
+    if let Some(max) = binding.value_max {
+        if value > max {
+            return Err(RestError::BadRequest(format!(
+                "value {value} above value_max {max}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+impl RestClientService {
+    /// Build the service from settings + catalog. Fails loudly (startup abort)
+    /// when an enabled device references a missing secret env var.
+    pub fn from_config(settings: RestSettings, devices: Vec<RestDevice>) -> Result<Self, String> {
+        let mut runtimes = Vec::new();
+        for device in devices {
+            if !device.enabled {
+                // Disabled devices are listed but never built (no secrets needed).
+                runtimes.push(Arc::new(DeviceRuntime {
+                    client: reqwest::Client::new(),
+                    auth: ResolvedAuth::None,
+                    breaker: Mutex::new(CircuitBreaker::default()),
+                    last_values: Mutex::new(HashMap::new()),
+                    config: device,
+                }));
+                continue;
+            }
+            let auth = resolve_auth(&device)?;
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(device.timeout_secs.max(1)))
+                .danger_accept_invalid_certs(!device.tls_verify)
+                .build()
+                .map_err(|e| format!("rest device '{}': client build failed: {e}", device.name))?;
+            if !device.tls_verify {
+                warn!(device = %device.name, "REST device has tls_verify=false (certificate checks disabled)");
+            }
+            runtimes.push(Arc::new(DeviceRuntime {
+                client,
+                auth,
+                breaker: Mutex::new(CircuitBreaker::default()),
+                last_values: Mutex::new(HashMap::new()),
+                config: device,
+            }));
+        }
+        Ok(Self {
+            settings,
+            devices: runtimes,
+            tasks: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn find_device(&self, name: &str) -> Result<&Arc<DeviceRuntime>, RestError> {
+        self.devices
+            .iter()
+            .find(|d| d.config.name == name)
+            .ok_or_else(|| RestError::NotFound(format!("unknown rest device '{name}'")))
+    }
+
+    fn find_enabled(&self, name: &str) -> Result<&Arc<DeviceRuntime>, RestError> {
+        let d = self.find_device(name)?;
+        if !d.config.enabled {
+            return Err(RestError::Forbidden(format!(
+                "rest device '{name}' is disabled"
+            )));
+        }
+        Ok(d)
+    }
+
+    pub async fn list_devices(&self) -> Value {
+        let mut out = Vec::new();
+        for d in &self.devices {
+            let breaker = d.breaker.lock().await;
+            out.push(json!({
+                "name": d.config.name,
+                "enabled": d.config.enabled,
+                "base_url": d.config.base_url,
+                "auth": d.config.auth.as_str(),
+                "tls_verify": d.config.tls_verify,
+                "timeout_secs": d.config.timeout_secs,
+                "poll_interval_secs": d.config.poll_interval_secs,
+                "points": d.config.points.iter().map(|p| &p.point_name).collect::<Vec<_>>(),
+                "writes": d.config.writes.iter().map(|w| json!({
+                    "name": w.name,
+                    "enabled": w.enabled,
+                })).collect::<Vec<_>>(),
+                "health": {
+                    "consecutive_failures": breaker.consecutive_failures,
+                    "circuit_open": breaker.is_open(Instant::now()),
+                    "last_error": breaker.last_error,
+                    "last_ok_ts": breaker.last_ok_ts,
+                },
+            }));
+        }
+        json!({ "ok": true, "allow_write": self.settings.allow_write, "devices": out })
+    }
+
+    async fn guard_breaker(&self, d: &DeviceRuntime) -> Result<(), RestError> {
+        let breaker = d.breaker.lock().await;
+        if breaker.is_open(Instant::now()) {
+            return Err(RestError::Upstream(format!(
+                "rest device '{}': circuit open after {} consecutive failures (last error: {})",
+                d.config.name,
+                breaker.consecutive_failures,
+                breaker.last_error.as_deref().unwrap_or("unknown"),
+            )));
+        }
+        Ok(())
+    }
+
+    fn apply_auth(
+        &self,
+        d: &DeviceRuntime,
+        req: reqwest::RequestBuilder,
+    ) -> reqwest::RequestBuilder {
+        match &d.auth {
+            ResolvedAuth::None => req,
+            ResolvedAuth::Bearer(token) => req.bearer_auth(token),
+            ResolvedAuth::ApiKeyHeader { header, key } => req.header(header.as_str(), key.as_str()),
+            ResolvedAuth::Basic { username, password } => req.basic_auth(username, Some(password)),
+        }
+    }
+
+    /// Execute a GET against a device-relative path, breaker-gated.
+    async fn device_get(&self, d: &DeviceRuntime, path: &str) -> Result<(u16, Value), RestError> {
+        crate::config::validate_rest_path(path).map_err(RestError::BadRequest)?;
+        self.guard_breaker(d).await?;
+        let url = format!("{}{}", d.config.base_url, path);
+        let req = self.apply_auth(d, d.client.get(&url));
+        let result = async {
+            let resp = req.send().await.map_err(|e| e.to_string())?;
+            let status = resp.status();
+            let text = resp.text().await.map_err(|e| e.to_string())?;
+            if status.is_server_error() {
+                return Err(format!("HTTP {status}: {}", truncate(&text, 200)));
+            }
+            let body = serde_json::from_str(&text)
+                .unwrap_or_else(|_| json!({ "raw": truncate(&text, 2000) }));
+            Ok((status.as_u16(), body))
+        }
+        .await;
+        let mut breaker = d.breaker.lock().await;
+        match result {
+            Ok(ok) => {
+                breaker.record_success();
+                Ok(ok)
+            }
+            Err(e) => {
+                breaker.record_failure(Instant::now(), &e);
+                Err(RestError::Upstream(format!(
+                    "rest device '{}' GET {path}: {e}",
+                    d.config.name
+                )))
+            }
+        }
+    }
+
+    /// Live read of one configured point (select + scale applied).
+    pub async fn read_point(&self, device: &str, point: &str) -> Result<Value, RestError> {
+        let d = self.find_enabled(device)?;
+        let p = d
+            .config
+            .points
+            .iter()
+            .find(|p| p.point_name == point)
+            .ok_or_else(|| {
+                RestError::NotFound(format!("unknown point '{point}' on device '{device}'"))
+            })?
+            .clone();
+        let (status, body) = self.device_get(d, &p.path).await?;
+        let selected = if p.select.trim().is_empty() {
+            body.clone()
+        } else {
+            select_json(&body, &p.select).map_err(RestError::Upstream)?
+        };
+        let value = value_as_f64(&selected).map(|v| v * p.scale);
+        Ok(json!({
+            "ok": true,
+            "device": device,
+            "point": p.point_name,
+            "status": status,
+            "value": value,
+            "raw": selected,
+            "units": p.units,
+            "ts": unix_ts(),
+        }))
+    }
+
+    /// Raw passthrough GET — path is relative-only, joined below base_url.
+    pub async fn raw_get(&self, device: &str, path: &str) -> Result<Value, RestError> {
+        let d = self.find_enabled(device)?;
+        let (status, body) = self.device_get(d, path).await?;
+        Ok(json!({
+            "ok": true,
+            "device": device,
+            "path": path,
+            "status": status,
+            "body": body,
+        }))
+    }
+
+    /// Allowlisted write. Fails closed unless BOTH rest.allow_write and the
+    /// binding's enabled flag are true. Every attempt is audit-logged.
+    pub async fn write(&self, device: &str, name: &str, value: f64) -> Result<Value, RestError> {
+        let audit = |outcome: &str, detail: &str| {
+            info!(
+                target: "rest_audit",
+                device,
+                write = name,
+                value,
+                outcome,
+                detail,
+                "rest write audit"
+            );
+        };
+        let d = match self.find_enabled(device) {
+            Ok(d) => d,
+            Err(e) => {
+                audit("rejected", &e.to_string());
+                return Err(e);
+            }
+        };
+        let binding = match d.config.writes.iter().find(|w| w.name == name) {
+            Some(b) => b.clone(),
+            None => {
+                let e = RestError::NotFound(format!(
+                    "unknown write binding '{name}' on device '{device}'"
+                ));
+                audit("rejected", &e.to_string());
+                return Err(e);
+            }
+        };
+        if let Err(e) = check_write_allowed(self.settings.allow_write, &binding, value) {
+            audit("rejected", &e.to_string());
+            return Err(e);
+        }
+        if let Err(e) = self.guard_breaker(d).await {
+            audit("rejected", &e.to_string());
+            return Err(e);
+        }
+
+        let url = format!("{}{}", d.config.base_url, binding.path);
+        let body = render_body_template(&binding.body_template, value);
+        let req = match binding.method.as_str() {
+            "PUT" => d.client.put(&url),
+            "PATCH" => d.client.patch(&url),
+            _ => d.client.post(&url),
+        };
+        let req = self
+            .apply_auth(d, req)
+            .header("content-type", "application/json")
+            .body(body);
+        let result = async {
+            let resp = req.send().await.map_err(|e| e.to_string())?;
+            let status = resp.status();
+            let text = resp.text().await.map_err(|e| e.to_string())?;
+            if !status.is_success() {
+                return Err(format!("HTTP {status}: {}", truncate(&text, 200)));
+            }
+            Ok(status.as_u16())
+        }
+        .await;
+
+        let mut breaker = d.breaker.lock().await;
+        match result {
+            Ok(status) => {
+                breaker.record_success();
+                audit("executed", &format!("HTTP {status}"));
+                Ok(json!({
+                    "ok": true,
+                    "device": device,
+                    "write": name,
+                    "value": value,
+                    "status": status,
+                }))
+            }
+            Err(e) => {
+                breaker.record_failure(Instant::now(), &e);
+                audit("failed", &e);
+                Err(RestError::Upstream(format!(
+                    "rest device '{device}' write '{name}': {e}"
+                )))
+            }
+        }
+    }
+
+    /// Spawn one poll task per enabled device with configured points.
+    pub async fn start(self: &Arc<Self>) {
+        let mut tasks = self.tasks.lock().await;
+        if !tasks.is_empty() {
+            return;
+        }
+        for d in &self.devices {
+            if !d.config.enabled || d.config.points.is_empty() {
+                continue;
+            }
+            let this = Arc::clone(self);
+            let device = Arc::clone(d);
+            let interval = device.config.poll_interval_secs.max(1);
+            info!(
+                device = %device.config.name,
+                interval_secs = interval,
+                points = device.config.points.len(),
+                "rest poll task started"
+            );
+            tasks.push(tokio::spawn(async move {
+                loop {
+                    this.poll_device(&device).await;
+                    tokio::time::sleep(Duration::from_secs(interval)).await;
+                }
+            }));
+        }
+    }
+
+    pub async fn stop(&self) {
+        for handle in self.tasks.lock().await.drain(..) {
+            handle.abort();
+        }
+    }
+
+    async fn poll_device(self: &Arc<Self>, d: &Arc<DeviceRuntime>) {
+        let names: Vec<String> = d
+            .config
+            .points
+            .iter()
+            .map(|p| p.point_name.clone())
+            .collect();
+        for point in names {
+            let row = match self.read_point(&d.config.name, &point).await {
+                Ok(mut row) => {
+                    row["error"] = Value::Null;
+                    row
+                }
+                Err(e) => json!({
+                    "device": d.config.name,
+                    "point": point,
+                    "value": Value::Null,
+                    "ts": unix_ts(),
+                    "error": e.to_string(),
+                }),
+            };
+            d.last_values.lock().await.insert(point, row);
+        }
+    }
+
+    /// Last polled rows across all devices (consumed by the MQTT bridge).
+    pub async fn last_values(&self) -> Vec<Value> {
+        let mut out = Vec::new();
+        for d in &self.devices {
+            out.extend(d.last_values.lock().await.values().cloned());
+        }
+        out
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &s[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding(enabled: bool) -> RestWriteBinding {
+        RestWriteBinding {
+            name: "chw_setpoint".into(),
+            enabled,
+            method: "POST".into(),
+            path: "/points/chw_setpoint".into(),
+            body_template: r#"{"value": {{value}}, "priority": 8}"#.into(),
+            value_min: Some(40.0),
+            value_max: Some(55.0),
+        }
+    }
+
+    #[test]
+    fn select_json_dotted_path() {
+        let body = json!({"value": 54.2, "meta": {"units": "°F"}, "items": [{"v": 7}]});
+        assert_eq!(select_json(&body, "$.value").unwrap(), json!(54.2));
+        assert_eq!(select_json(&body, "$.meta.units").unwrap(), json!("°F"));
+        assert_eq!(select_json(&body, "$.items[0].v").unwrap(), json!(7));
+        assert_eq!(select_json(&body, "$").unwrap(), body);
+        assert!(select_json(&body, "$.missing").is_err());
+        assert!(select_json(&body, "$.items[9].v").is_err());
+    }
+
+    #[test]
+    fn value_coercion_and_scale_types() {
+        assert_eq!(value_as_f64(&json!(1.5)), Some(1.5));
+        assert_eq!(value_as_f64(&json!(true)), Some(1.0));
+        assert_eq!(value_as_f64(&json!("42.5")), Some(42.5));
+        assert_eq!(value_as_f64(&json!({"nested": 1})), None);
+    }
+
+    #[test]
+    fn body_template_renders_value() {
+        let b = binding(true);
+        assert_eq!(
+            render_body_template(&b.body_template, 44.0),
+            r#"{"value": 44, "priority": 8}"#
+        );
+        assert_eq!(
+            render_body_template(&b.body_template, 44.5),
+            r#"{"value": 44.5, "priority": 8}"#
+        );
+    }
+
+    #[test]
+    fn write_fails_closed_globally() {
+        let err = check_write_allowed(false, &binding(true), 45.0).unwrap_err();
+        assert!(matches!(err, RestError::Forbidden(_)));
+    }
+
+    #[test]
+    fn write_fails_closed_per_binding() {
+        let err = check_write_allowed(true, &binding(false), 45.0).unwrap_err();
+        assert!(matches!(err, RestError::Forbidden(_)));
+    }
+
+    #[test]
+    fn write_bounds_enforced() {
+        assert!(check_write_allowed(true, &binding(true), 45.0).is_ok());
+        assert!(matches!(
+            check_write_allowed(true, &binding(true), 39.0).unwrap_err(),
+            RestError::BadRequest(_)
+        ));
+        assert!(matches!(
+            check_write_allowed(true, &binding(true), 56.0).unwrap_err(),
+            RestError::BadRequest(_)
+        ));
+    }
+
+    #[test]
+    fn breaker_opens_after_consecutive_failures() {
+        let mut b = CircuitBreaker::default();
+        let now = Instant::now();
+        b.record_failure(now, "timeout");
+        b.record_failure(now, "timeout");
+        assert!(!b.is_open(now));
+        b.record_failure(now, "timeout");
+        assert!(b.is_open(now));
+        // Half-open after the backoff window elapses.
+        assert!(!b.is_open(now + Duration::from_secs(6)));
+        // Success resets everything.
+        b.record_success();
+        assert_eq!(b.consecutive_failures, 0);
+        assert!(!b.is_open(now));
+    }
+
+    #[test]
+    fn breaker_backoff_grows_and_caps() {
+        assert_eq!(backoff_secs(0), 0);
+        assert_eq!(backoff_secs(2), 0);
+        assert_eq!(backoff_secs(3), 5);
+        assert_eq!(backoff_secs(4), 10);
+        assert_eq!(backoff_secs(5), 20);
+        assert_eq!(backoff_secs(60), BREAKER_MAX_BACKOFF_SECS);
+    }
+
+    #[test]
+    fn missing_env_fails_loudly_for_enabled_device() {
+        std::env::remove_var("OPENFDD_REST_TOKEN_TEST_MISSING");
+        let device = RestDevice {
+            name: "unit-test".into(),
+            enabled: true,
+            base_url: "https://127.0.0.1:8443/api".into(),
+            auth: RestAuth::Bearer,
+            token_env: Some("OPENFDD_REST_TOKEN_TEST_MISSING".into()),
+            api_key_header: "X-API-Key".into(),
+            basic_username: None,
+            tls_verify: true,
+            timeout_secs: 10,
+            poll_interval_secs: 60,
+            points: vec![],
+            writes: vec![],
+        };
+        let err = RestClientService::from_config(RestSettings::default(), vec![device.clone()])
+            .err()
+            .expect("must fail loudly");
+        assert!(err.contains("OPENFDD_REST_TOKEN_TEST_MISSING"), "{err}");
+
+        // The same device disabled must not require the secret.
+        let disabled = RestDevice {
+            enabled: false,
+            ..device
+        };
+        assert!(RestClientService::from_config(RestSettings::default(), vec![disabled]).is_ok());
+    }
+
+    #[tokio::test]
+    async fn write_403_when_disabled() {
+        std::env::set_var("OPENFDD_REST_TOKEN_UNIT_WRITE", "secret");
+        let device = RestDevice {
+            name: "unit-write".into(),
+            enabled: true,
+            base_url: "https://127.0.0.1:9".into(),
+            auth: RestAuth::Bearer,
+            token_env: Some("OPENFDD_REST_TOKEN_UNIT_WRITE".into()),
+            api_key_header: "X-API-Key".into(),
+            basic_username: None,
+            tls_verify: true,
+            timeout_secs: 1,
+            poll_interval_secs: 60,
+            points: vec![],
+            writes: vec![binding(false)],
+        };
+        // allow_write=false globally → Forbidden even before binding check.
+        let svc =
+            RestClientService::from_config(RestSettings::default(), vec![device.clone()]).unwrap();
+        let err = svc
+            .write("unit-write", "chw_setpoint", 45.0)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RestError::Forbidden(_)), "{err}");
+
+        // allow_write=true but binding disabled → still Forbidden (fail closed).
+        let settings = RestSettings {
+            allow_write: true,
+            ..RestSettings::default()
+        };
+        let svc = RestClientService::from_config(settings, vec![device]).unwrap();
+        let err = svc
+            .write("unit-write", "chw_setpoint", 45.0)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RestError::Forbidden(_)), "{err}");
+    }
+
+    #[tokio::test]
+    async fn raw_get_rejects_absolute_and_traversal_paths() {
+        std::env::set_var("OPENFDD_REST_TOKEN_UNIT_PATHS", "secret");
+        let device = RestDevice {
+            name: "unit-paths".into(),
+            enabled: true,
+            base_url: "https://127.0.0.1:9".into(),
+            auth: RestAuth::Bearer,
+            token_env: Some("OPENFDD_REST_TOKEN_UNIT_PATHS".into()),
+            api_key_header: "X-API-Key".into(),
+            basic_username: None,
+            tls_verify: true,
+            timeout_secs: 1,
+            poll_interval_secs: 60,
+            points: vec![],
+            writes: vec![],
+        };
+        let svc = RestClientService::from_config(RestSettings::default(), vec![device]).unwrap();
+        for bad in [
+            "https://evil.example/steal",
+            "//evil.example/steal",
+            "points/no-leading-slash",
+            "/points/../../admin",
+            "",
+        ] {
+            let err = svc.raw_get("unit-paths", bad).await.unwrap_err();
+            assert!(
+                matches!(err, RestError::BadRequest(_)),
+                "path {bad:?}: {err}"
+            );
+        }
+    }
+}

--- a/services/fieldbus/src/state.rs
+++ b/services/fieldbus/src/state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::config::Settings;
 use crate::services::{
     bacnet_client::BacnetClientService, bacnet_server::BacnetServerManager,
-    haystack::HaystackService, poll::PollEngine, weather::WeatherService,
+    haystack::HaystackService, poll::PollEngine, rest::RestClientService, weather::WeatherService,
 };
 
 #[derive(Clone)]
@@ -17,4 +17,5 @@ pub struct AppState {
     pub poll_engine: Arc<PollEngine>,
     pub weather: Arc<WeatherService>,
     pub haystack: Arc<HaystackService>,
+    pub rest: Arc<RestClientService>,
 }


### PR DESCRIPTION
## Summary

First cut of the 4th OT protocol driver (`rest`) for the fieldbus container, per the OT bench spec in #540. Mirrors the BACnet/Modbus/Haystack layering: declarative TOML catalog → client service → routes behind existing bearer auth → poll → MQTT telemetry.

- **Config**: `[rest]` block in `gateway.toml` (`default_timeout_secs`, `default_tls_verify`, `default_poll_interval_secs`, `allow_write = false`) + device catalog `config/fieldbus/rest_devices.toml` (disabled example shipped, rules documented in the file header). Missing catalog file = no REST devices; malformed entries are hard errors.
- **Service** (`services/rest.rs`): one pooled `reqwest::Client` per device — never per operation (#535 regression guard). Per-device auth `bearer | api_key_header | basic | none` with secrets via env indirection only; startup fails loudly if an enabled device's env var is missing. TLS verify on by default; per-device timeout; consecutive-failure circuit breaker (opens at 3 failures, capped exponential backoff to 300s).
- **Routes** (behind existing `Authorization: Bearer`):
  | Route | Verb | Purpose |
  |---|---|---|
  | `/rest/devices` | GET | list devices + circuit-breaker health |
  | `/rest/read` | POST | `{"device","point"}` live GET (select + scale) |
  | `/rest/get` | POST | `{"device","path"}` raw passthrough, relative path only |
  | `/rest/write` | POST | allowlisted write; 403 unless global `allow_write` AND binding `enabled` |

  Devices/bindings by name only — no free-form URL crosses the API (SSRF kill). Absolute URLs, `//`, schemes, and `..` traversal rejected in all paths. Also mirrored under `/api/*` and documented in Swagger.
- **Writes fail closed** with min/max bounds and a structured audit log (`target = rest_audit`) on every attempt (rejected, executed, failed).
- **Telemetry**: `Protocol::Rest` added to `openfdd_contracts` (envelope enum + `rest` topic slug). Per-device poll tasks feed the MQTT bridge, which publishes the same `TelemetryEnvelope` shape as BACnet with ids `rest:<device>:<point>` on `.../telemetry/rest`. Central ingest handles the new protocol generically (no changes needed).

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy -p openfdd-fieldbus --all-targets` — no warnings from new code (remaining warnings are pre-existing `vendor/bacnet-client` doc lints)
- [x] `cargo test -p openfdd-fieldbus` — 59 passed + fd-leak integration test
- [x] `cargo test -p openfdd_contracts` / `-p openfdd-central` — green (envelope change is additive)
- [x] Unit tests cover: JSONPath-style select decode, write 403 when disabled (global and per-binding), value bounds, relative-path enforcement (absolute/`//`/traversal rejected), missing env fails startup for enabled devices only, circuit-breaker threshold + backoff growth/cap, catalog load of the shipped example, REST→telemetry point mapping
- [ ] Bench: point at a live JSON API, verify `/rest/read` and `telemetry/rest` MQTT envelopes end-to-end
- [ ] Bench: enable `allow_write` + one binding and verify audit log + upstream write

## Not included (first cut)

- Reads are GET-only (catalog rejects other read methods)
- No write path via MQTT `CommandEnvelope` for `Protocol::Rest` (HTTP route only)
- JSONPath support is the minimal `$.key.sub[0].leaf` subset — no filters/wildcards

Closes #540

Made with [Cursor](https://cursor.com)