### PR TITLE
docs(agent): rewrite linux edge tester soak prompt (post OT-bench round 2)

### DIFF
--- a/docs/agent/linux-edge-tester-stack-recipes-prompt.md
+++ b/docs/agent/linux-edge-tester-stack-recipes-prompt.md
@@ -11,9 +11,9 @@ change). Do **not** create dated copies (`*-2026-07-17.md`, `bench-NNN-*`, etc.)
 One path forever: `docs/agent/linux-edge-tester-stack-recipes-prompt.md`.
 
 Copy-paste prompt for a **second OT bench**. Pulls GHCR nightlies, exercises all four
-compose build recipes, validates BACnet device **5007** via fieldbus, then **leaves
-the standalone stack running** for human Niagara Workbench validation of hosted
-device **599999**.
+compose build recipes, validates BACnet / Modbus / Haystack / (new) REST drivers, then
+**leaves the standalone stack running** for human Niagara Workbench validation of hosted
+devices **599999** (bench) and **600000** (Pi edge, if present).
 
 Do **not** tear down a healthy stack after tests. Only a human records OT PASS for Workbench.
 
@@ -21,8 +21,10 @@ Do **not** tear down a healthy stack after tests. Only a human records OT PASS f
 
 - Docker + `gh` CLI authenticated for GHCR (`gh auth token` → `docker login ghcr.io`)
 - Repo checkout or compose files available
-- OT LAN reachability to device instance **5007**
+- OT LAN reachability to device instance **5007** (and Pi edge if cloud-sim)
 - Env: `OPENFDD_JWT_SECRET`, `OPENFDD_ADMIN_PASSWORD` (and MQTT kits for standalone/central)
+- On arm64 Pi: pull with `--platform linux/amd64` explicitly; **fail loud** on digest drift
+  vs the bench (do not silently reuse a stale local image — that caused duplicate 599999)
 
 ## Prompt
 
@@ -35,22 +37,50 @@ Charter:
 - Leave a healthy standalone stack RUNNING for the human Niagara Workbench gate.
 
 Goal:
-1. Pull fresh GHCR images (central, ui, fieldbus, mqtt, mcp). Record image digests + git revision label from `docker inspect` / image labels.
+1. Pull fresh GHCR images (central, ui, fieldbus, mqtt, mcp). Record image digests + git revision
+   label from `docker inspect` / image labels. On Pi: `docker pull --platform linux/amd64 …`
+   and assert bench↔Pi digests match (or FAIL with NEEDS PRODUCT FIX on #530).
 2. Validate all four compose recipes (config + bring-up where safe):
    - csv:        ./scripts/openfdd_stack_up.sh csv
    - central:    ./scripts/openfdd_stack_up.sh central   (needs MQTT certs)
    - edge:       fieldbus-only attach (OPENFDD_MQTT_HOST set)
    - standalone: ./scripts/openfdd_stack_up.sh standalone
-3. On standalone: BACnet device 5007 end-to-end via fieldbus (Who-Is / poll / MQTTS telemetry on central /api/edges + /api/ingest/stats). Confirm hosted instance 599999 answers directed ReadProperty.
+3. On standalone: BACnet device 5007 end-to-end via fieldbus (Who-Is / poll / MQTTS telemetry
+   on central /api/edges + /api/ingest/stats). Confirm hosted instance 599999 answers directed
+   ReadProperty. If Pi edge is up: 600000 only on the Pi, 599999 only on the bench — no collision.
 4. CSV → FDD (strict defaults — do NOT set OPENFDD_CSV_STRICT=0 unless documenting a new regression):
    - preview → plan → preflight → execute
+   - plain wide CSV WITHOUT equipment_id column must still preflight verdict=pass (#536)
    - assert parquet_ingest.ok
    - column literally named fan_cmd must survive into parquet / FC1 schema
    - POST /api/fdd/run mode=registry rule_ids=["FC1"] (also try "FC13" alias)
    - assert rules_succeeded≥1; note poll_seconds / grid_minutes for 1-min fixtures
-5. Optional cloud-sim / multi-site if LAN allows (Pi remote edge) — attach evidence to #519 / #530.
-6. Leave standalone healthy and RUNNING. Do not docker compose down. Do not prune volumes.
-7. Human gate: Niagara Workbench discovery of hosted BACnet 599999. Prepare evidence only; only a human records OT PASS.
+5. openfdd_package_v1 ZIP (if #514 shipped on this nightly):
+   - upload a minimal package zip via POST /api/csv/import/package
+   - assert equipment roles + parquet; edit roles via /api/csv/import/package/roles
+   - session_config.json inside the zip should seed GET /api/fdd/session-config (#515)
+6. Weather + FD soak (gate 08 — critical after #535):
+   - Sample fieldbus container FD count at t=0 and t≈30 min (`ls /proc/<pid>/fd | wc -l`
+     or `docker exec … ls /proc/1/fd | wc -l`). Growth must be ≈flat (not +~180/h).
+   - Weather AV:9101/9102 timestamps must advance; values must match live Open-Meteo
+     for the configured city (not pinned 70.0/50.0).
+   - On a forced transient fetch error, last-known-good should hold (stale / app-fault BV)
+     instead of dropping to canned fallback.
+7. BACnet discovery / I-Am:
+   - POST /bacnet/whois with a tight low/high range must NOT return out-of-range seeded devices (#539)
+   - I-Am / device object vendor_id must be 999, not 0 (#537)
+   - #526: hosted devices still may be invisible to product whois (ephemeral bind); Workbench
+     binding :47808 is the human discovery gate — prepare evidence only.
+8. Modbus OT (bench sim) + Haystack API surface — keep green; note any new fails.
+9. REST/JSON driver (#540) if present on this nightly — gate 09:
+   - Stand up a tiny JSON sim (or use the disabled example flipped on with a test token env).
+   - Assert GET point decode + scale, JSONPath miss → structured error, bearer/API-key auth,
+     write 403 when disabled, write clamp, circuit-breaker on sim kill,
+     FD-count stability across ≥500 polls (no #535-style leak on reqwest).
+10. Optional cloud-sim / multi-site if LAN allows (Pi remote edge) — attach evidence to #519 / #530.
+11. Leave standalone healthy and RUNNING. Do not docker compose down. Do not prune volumes.
+12. Human gate: Niagara Workbench discovery + trend of 599999 (Madison) and 600000 (Chicago if Pi).
+    Prepare evidence only; only a human records OT PASS.
 
 Never:
 - Claim Workbench OT PASS yourself
@@ -59,11 +89,12 @@ Never:
 - Pull or document any monolith / openfdd-edge-rust image (removed)
 - Close or reopen GitHub issues yourself (product agent manages GH from your triage table)
 - Weaken tests or invent product workarounds as “PASS”
+- Silently accept a stale local image when GHCR pull fails on arm64
 
 GitHub issue workflow (required):
-1. Before testing: `gh issue list --state open --limit 30` and note numbers that apply to this soak.
+1. Before testing: `gh issue list --state open --limit 40` and note numbers that apply to this soak.
 2. For each open issue you touch: comment with PASS/FAIL evidence (command + redacted JSON snippet + image digest/sha).
-3. File NEW issues only for new reproducible product defects (title + rev + repro + expected). Do not duplicate #514–#520 Streamlit-parity backlog.
+3. File NEW issues only for new reproducible product defects (title + rev + repro + expected).
 4. End your report with an **Issue triage table** the product agent will execute:
 
 | Issue | Recommendation | Evidence one-liner |
@@ -76,37 +107,45 @@ Recommendations mean:
 - NEEDS PRODUCT FIX — new or still-broken P0/P1; product agent patches next nightly.
 
 Current known board (update if gh list differs):
-- #526 Hosted BACnet Who-Is / I-Am (Workbench blocker) — retest hard
-- #530 No arm64 fieldbus image (Pi/qemu)
-- #531 field_devices.toml crash-loop remainder (FC13 alias + DEVICE_INSTANCE env shipped in #532 — verify those two; keep open only if crash-loop remains)
-- #519 Multi-site MQTT subscribe / ACL / broker SAN / site attribution on /api/edges
+KEEP OPEN / retest:
+- #526 Hosted BACnet Who-Is / I-Am (client ephemeral bind vs broadcast I-Am) — Workbench human gate
+- #530 No arm64 GHCR fieldbus image — RAISE PRIORITY (silent stale-image caused device-ID collision)
+- #519 Multi-site MQTT subscribe / ACL / site_id on /api/edges
 - #520 Feather→parquet live compaction
-- #514–#518 Streamlit parity (KEEP OPEN unless you prove shipped)
+- #514–#518 Streamlit parity (CLOSE any that this nightly proves shipped: ZIP #514, session #515, UI)
 
-Already closed after #532 (confirm still green; do not reopen if PASS):
-- #525 fan_cmd column drop
-- #527 OPENFDD_PARQUET_ROOT standalone
-- #528 grid_minutes hardcoded 5
-- #529 strict preflight metadata COLUMN_UNKNOWN
+Expect CLOSED on tip nightlies after #541/#542 (confirm still green; do not reopen if PASS):
+- #535 BACnet client UDP FD leak (P0) — verify FD flat over soak
+- #536 EQUIPMENT_ID_MISSING no longer fail-closes strict execute
+- #537 I-Am vendor_id 999
+- #539 /bacnet/whois honors low/high range
+- #531 OPENFDD_BACNET_DEVICE_INSTANCE env (verified; crash-loop remainder only if still seen)
+
+In flight / verify if merged:
+- #540 REST/JSON edge driver (draft→merge) — run gate 09 when image contains /rest/*
 
 Evidence to collect:
 - docker images ls | grep openfdd
-- digests + org.opencontainers.image.revision
+- digests + org.opencontainers.image.revision (bench AND Pi)
 - docker compose -f docker/compose.standalone.yml ps
 - curl -fsS http://127.0.0.1:8080/api/health
 - ingest/stats + edges JSON (redact secrets)
-- csv execute including parquet_ingest + columns present
+- csv execute including parquet_ingest + wide CSV without equipment_id → verdict pass
+- package zip upload (if shipped) + role edit
 - fdd/run response (rules_succeeded, poll_seconds)
-- Who-Is results for 5007 vs 599999 (broadcast + unicast if testing #526)
-- UI http://<bench-ip>:3000 reachable
+- Who-Is range filter result; I-Am vendor_id hex/APDU
+- fieldbus FD count t=0 vs t≈30m
+- weather before/after + Open-Meteo MATCH
+- REST gate 09 results (if shipped)
+- UI http://<bench-ip>:3000 — Lab looks Streamlit-like (sidebar rule tuning, 9 sections, red accent)
 
 Final report structure (paste back to product agent):
-1. Images under test (tag, digest, revision)
-2. Gate matrix (00–07 or equivalent) PASS/FAIL
+1. Images under test (tag, digest, revision) — bench + Pi
+2. Gate matrix (00–09) PASS/FAIL
 3. Issue triage table (CLOSE / KEEP OPEN / NEEDS PRODUCT FIX) — required
 4. New issues filed (numbers + titles) or “none”
-5. Leave-running confirmation
-6. Human Workbench gate status (blocked by #526 or ready for human)
+5. Leave-running confirmation (nofile ulimit note if still elevated)
+6. Human Workbench gate status (ready / blocked — with device addresses)
 ```
 
 ## Recipes reference
@@ -115,7 +154,7 @@ See [Build recipes](../operations/build-recipes.md). Helper scripts:
 
 ```bash
 export OPENFDD_IMAGE_TAG=nightly
-# after #532 publish: prefer tip sha if you need a pin, e.g. sha-aeee5cf
+# pin when bisecting: e.g. OPENFDD_IMAGE_TAG=sha-<rev>
 ./scripts/openfdd_stack_pull.sh all
 ./scripts/openfdd_stack_up.sh csv
 ./scripts/openfdd_stack_up.sh standalone


### PR DESCRIPTION
## Summary
- Rewrites the living `linux-edge-tester-stack-recipes-prompt.md` for the next GHCR nightly after #541/#542 and the REST driver work.
- Adds gates: FD soak (#535), whois range (#539), vendor_id (#537), wide CSV without equipment_id (#536), package zip/session, REST gate 09 (#540), arm64 digest-drift hard fail (#530).
- Refreshes triage board (closed vs keep-open) for the product agent.

## Test plan
- [x] Prompt is still a single living file (no dated copy)
- [ ] Hand to linux edge testers after nightly publish

Made with [Cursor](https://cursor.com)