### PR TITLE
feat(fdd): openfdd_session_v1 session/fault settings save-load (#515)

### DIFF
--- a/edge/src/csv_ingest/package.rs
+++ b/edge/src/csv_ingest/package.rs
@@ -594,6 +594,17 @@ pub fn import_package_zip(zip_bytes: &[u8]) -> Value {
             building_root.join("session_config.json"),
             serde_json::to_string_pretty(cfg).unwrap_or_default(),
         );
+        // Honor packaged session config (#515): persist workspace-wide so the
+        // Lab sliders pick it up. Invalid configs only warn — never block ingest.
+        match crate::fdd::session_config::normalize_session_config(cfg) {
+            Ok((normalized, mut cfg_warnings)) => {
+                if let Err(e) = crate::fdd::session_config::save_session_config(&normalized) {
+                    warnings.push(format!("session_config.json not persisted: {e}"));
+                }
+                warnings.append(&mut cfg_warnings);
+            }
+            Err(e) => warnings.push(format!("session_config.json invalid: {e}")),
+        }
     }
 
     let mut equipment_report = Vec::new();

--- a/edge/src/fdd/mod.rs
+++ b/edge/src/fdd/mod.rs
@@ -5,5 +5,6 @@ pub mod datafusion_sql;
 pub mod execution;
 pub mod registry_api;
 pub mod rules;
+pub mod session_config;
 pub mod sql_safety;
 pub mod wires;

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -61,6 +61,20 @@ fn load_reg() -> Result<RuleRegistry, String> {
     load_registry(&dir).map_err(|e| format!("load registry {}: {e}", dir.display()))
 }
 
+/// Registry rules keyed by rule_id and aliases (empty map when registry is unavailable).
+pub fn load_registry_rules_map() -> HashMap<String, RuleSpec> {
+    let mut out = HashMap::new();
+    if let Ok(reg) = load_reg() {
+        for rule in reg.rules {
+            for alias in &rule.aliases {
+                out.insert(alias.clone(), rule.clone());
+            }
+            out.insert(rule.rule_id.clone(), rule);
+        }
+    }
+    out
+}
+
 fn param_to_json(rule: &RuleSpec) -> Value {
     let mut params = serde_json::Map::new();
     for (key, def) in &rule.parameters {

--- a/edge/src/fdd/session_config.rs
+++ b/edge/src/fdd/session_config.rs
@@ -1,0 +1,330 @@
+//! `openfdd_session_v1` session / fault settings save-load (#515).
+//!
+//! Mirrors the vibe19 Streamlit `session_config.json` contract (vibe19
+//! `docs/PACKAGE_SPEC.md`): `unit_system`, `prefer_web_oat`, `chw_leave_max_f`,
+//! per-equipment `role_map`, per-rule `params`. Unknown keys are ignored with a
+//! warning; the deprecated `include_ahu_chw_valve` is always coerced off.
+//!
+//! The config persists at `workspace/data/session_config.json`, seeds the Lab
+//! rule sliders on load, and — when a `building_id` is supplied — applies the
+//! `role_map` to the ingested package via `columns.csv` rewrite + re-ingest.
+
+use crate::historian::store::workspace_dir;
+use serde_json::{json, Map, Value};
+use std::path::PathBuf;
+
+pub const SESSION_SCHEMA: &str = "openfdd_session_v1";
+
+fn session_config_path() -> PathBuf {
+    workspace_dir().join("data").join("session_config.json")
+}
+
+fn default_config() -> Value {
+    json!({
+        "schema_version": SESSION_SCHEMA,
+        "unit_system": "imperial",
+        "prefer_web_oat": true,
+        "role_map": {},
+        "params": {},
+    })
+}
+
+/// `GET /api/fdd/session-config` — persisted session config or defaults.
+pub fn get_session_config() -> Value {
+    let path = session_config_path();
+    let (config, persisted) = match std::fs::read_to_string(&path) {
+        Ok(text) => match serde_json::from_str::<Value>(&text) {
+            Ok(v) => (v, true),
+            Err(_) => (default_config(), false),
+        },
+        Err(_) => (default_config(), false),
+    };
+    json!({
+        "ok": true,
+        "persisted": persisted,
+        "path": path.display().to_string(),
+        "config": config,
+    })
+}
+
+/// Normalize an incoming session config: keep known keys, warn on unknown ones,
+/// coerce the deprecated `include_ahu_chw_valve` off, validate value shapes.
+pub fn normalize_session_config(raw: &Value) -> Result<(Value, Vec<String>), String> {
+    let obj = raw
+        .as_object()
+        .ok_or("session config must be a JSON object")?;
+    let schema = obj
+        .get("schema_version")
+        .and_then(|v| v.as_str())
+        .unwrap_or(SESSION_SCHEMA);
+    if schema != SESSION_SCHEMA {
+        return Err(format!(
+            "schema_version must be {SESSION_SCHEMA:?}, got {schema:?}"
+        ));
+    }
+
+    let mut warnings = Vec::new();
+    let mut out = Map::new();
+    out.insert("schema_version".into(), json!(SESSION_SCHEMA));
+
+    let unit = obj
+        .get("unit_system")
+        .and_then(|v| v.as_str())
+        .unwrap_or("imperial")
+        .to_lowercase();
+    if !matches!(unit.as_str(), "imperial" | "metric" | "si") {
+        return Err(format!(
+            "unit_system must be imperial|metric|si, got {unit:?}"
+        ));
+    }
+    out.insert("unit_system".into(), json!(unit));
+
+    if let Some(v) = obj.get("prefer_web_oat").and_then(|v| v.as_bool()) {
+        out.insert("prefer_web_oat".into(), json!(v));
+    }
+    if let Some(v) = obj.get("chw_leave_max_f").and_then(|v| v.as_f64()) {
+        out.insert("chw_leave_max_f".into(), json!(v));
+    }
+    if obj.get("include_ahu_chw_valve").and_then(|v| v.as_bool()) == Some(true) {
+        warnings.push(
+            "include_ahu_chw_valve is deprecated and always treated as false (coerced off)".into(),
+        );
+    }
+
+    // role_map: equipment_id -> role -> column (all strings).
+    let mut role_map = Map::new();
+    if let Some(rm) = obj.get("role_map").and_then(|v| v.as_object()) {
+        for (equip, roles) in rm {
+            let Some(roles) = roles.as_object() else {
+                warnings.push(format!("role_map.{equip}: not an object — skipped"));
+                continue;
+            };
+            let mut clean = Map::new();
+            for (role, col) in roles {
+                match col.as_str() {
+                    Some(c) if !c.trim().is_empty() => {
+                        clean.insert(role.clone(), json!(c.trim()));
+                    }
+                    _ => warnings.push(format!("role_map.{equip}.{role}: not a string — skipped")),
+                }
+            }
+            if !clean.is_empty() {
+                role_map.insert(equip.clone(), Value::Object(clean));
+            }
+        }
+    }
+    out.insert("role_map".into(), Value::Object(role_map));
+
+    // params: rule_id -> param key -> number. Clamp to registry slider ranges when known.
+    let registry = crate::fdd::registry_api::load_registry_rules_map();
+    let mut params = Map::new();
+    if let Some(pm) = obj.get("params").and_then(|v| v.as_object()) {
+        for (rule_id, rule_params) in pm {
+            let Some(rule_params) = rule_params.as_object() else {
+                warnings.push(format!("params.{rule_id}: not an object — skipped"));
+                continue;
+            };
+            let spec = registry.get(rule_id.as_str());
+            if spec.is_none() {
+                warnings.push(format!("params.{rule_id}: unknown rule id (kept as-is)"));
+            }
+            let mut clean = Map::new();
+            for (key, val) in rule_params {
+                let Some(n) = val.as_f64() else {
+                    warnings.push(format!("params.{rule_id}.{key}: not a number — skipped"));
+                    continue;
+                };
+                let n = match spec.and_then(|s| s.parameters.get(key)) {
+                    Some(def) if n < def.min || n > def.max => {
+                        let clamped = n.clamp(def.min, def.max);
+                        warnings.push(format!(
+                            "params.{rule_id}.{key}: {n} outside slider range {}..{} — clamped to {clamped}",
+                            def.min, def.max
+                        ));
+                        clamped
+                    }
+                    _ => n,
+                };
+                clean.insert(key.clone(), json!(n));
+            }
+            if !clean.is_empty() {
+                params.insert(rule_id.clone(), Value::Object(clean));
+            }
+        }
+    }
+    out.insert("params".into(), Value::Object(params));
+
+    let known = [
+        "schema_version",
+        "unit_system",
+        "prefer_web_oat",
+        "chw_leave_max_f",
+        "include_ahu_chw_valve",
+        "role_map",
+        "params",
+    ];
+    for key in obj.keys() {
+        if !known.contains(&key.as_str()) {
+            warnings.push(format!("unknown key {key:?} ignored"));
+        }
+    }
+
+    Ok((Value::Object(out), warnings))
+}
+
+/// Persist a normalized session config to the workspace. Returns warnings.
+pub fn save_session_config(config: &Value) -> Result<(), String> {
+    let path = session_config_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+    }
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(config).unwrap_or_default(),
+    )
+    .map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// `PUT /api/fdd/session-config` — validate, persist, optionally apply the
+/// role_map to an ingested building (`{"building_id": "...", "config": {…}}`
+/// or the config object directly).
+pub fn put_session_config(body: &Value) -> Value {
+    let (raw, building_id) = match body.get("config") {
+        Some(cfg) => (
+            cfg,
+            body.get("building_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        ),
+        None => (body, String::new()),
+    };
+    let (config, mut warnings) = match normalize_session_config(raw) {
+        Ok(v) => v,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    if let Err(e) = save_session_config(&config) {
+        return json!({"ok": false, "error": e});
+    }
+
+    let mut applied_role_map = Vec::new();
+    if !building_id.is_empty() {
+        if let Some(role_map) = config.get("role_map").and_then(|v| v.as_object()) {
+            for (equip, roles) in role_map {
+                // Session role_map is role -> column; the roles endpoint wants column -> role.
+                let mut column_roles = Map::new();
+                if let Some(roles) = roles.as_object() {
+                    for (role, col) in roles {
+                        if let Some(c) = col.as_str() {
+                            column_roles.insert(c.to_string(), json!(role));
+                        }
+                    }
+                }
+                if column_roles.is_empty() {
+                    continue;
+                }
+                let out = crate::csv_ingest::package::update_package_roles_handler(&json!({
+                    "building_id": building_id,
+                    "equipment_id": equip,
+                    "roles": Value::Object(column_roles),
+                }));
+                if out.get("ok") == Some(&json!(true)) {
+                    applied_role_map.push(json!({"equipment_id": equip, "ok": true}));
+                } else {
+                    warnings.push(format!(
+                        "role_map.{equip}: not applied — {}",
+                        out.get("error").and_then(|v| v.as_str()).unwrap_or("error")
+                    ));
+                    applied_role_map.push(json!({"equipment_id": equip, "ok": false}));
+                }
+            }
+        }
+    }
+
+    json!({
+        "ok": true,
+        "config": config,
+        "warnings": warnings,
+        "applied_role_map": applied_role_map,
+        "path": session_config_path().display().to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_wrong_schema_and_bad_units() {
+        let err = normalize_session_config(&json!({"schema_version": "v2"})).unwrap_err();
+        assert!(err.contains("schema_version"), "{err}");
+        let err = normalize_session_config(&json!({"unit_system": "cubits"})).unwrap_err();
+        assert!(err.contains("unit_system"), "{err}");
+    }
+
+    #[test]
+    fn coerces_deprecated_flag_and_warns_unknown_keys() {
+        let (cfg, warnings) = normalize_session_config(&json!({
+            "schema_version": SESSION_SCHEMA,
+            "unit_system": "imperial",
+            "include_ahu_chw_valve": true,
+            "mystery_key": 1,
+        }))
+        .unwrap();
+        assert!(cfg.get("include_ahu_chw_valve").is_none());
+        assert!(warnings.iter().any(|w| w.contains("include_ahu_chw_valve")));
+        assert!(warnings.iter().any(|w| w.contains("mystery_key")));
+    }
+
+    #[test]
+    fn keeps_role_map_and_numeric_params_only() {
+        let (cfg, warnings) = normalize_session_config(&json!({
+            "unit_system": "metric",
+            "role_map": {
+                "AHU_1": {"fan_status": "supply_fan_status", "bad": 7},
+            },
+            "params": {
+                "FC1": {"eps_dsp": 0.2, "junk": "nope"},
+                "NOT-A-RULE": {"x": 1.0},
+            },
+        }))
+        .unwrap();
+        assert_eq!(cfg["unit_system"], json!("metric"));
+        assert_eq!(
+            cfg["role_map"]["AHU_1"]["fan_status"],
+            json!("supply_fan_status")
+        );
+        assert!(cfg["role_map"]["AHU_1"].get("bad").is_none());
+        assert_eq!(cfg["params"]["FC1"]["eps_dsp"], json!(0.2));
+        assert!(cfg["params"]["FC1"].get("junk").is_none());
+        assert!(warnings.iter().any(|w| w.contains("NOT-A-RULE")));
+    }
+
+    #[test]
+    fn save_and_get_round_trip() {
+        let _env = crate::test_support::workspace_env_lock();
+        let tmp = std::env::temp_dir().join(format!("openfdd_session_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", &tmp);
+
+        let before = get_session_config();
+        assert_eq!(before["persisted"], json!(false));
+        assert_eq!(before["config"]["unit_system"], json!("imperial"));
+
+        let out = put_session_config(&json!({
+            "schema_version": SESSION_SCHEMA,
+            "unit_system": "metric",
+            "params": {"FC1": {"eps_dsp": 0.25}},
+        }));
+        assert_eq!(out["ok"], json!(true), "{out}");
+
+        let after = get_session_config();
+        assert_eq!(after["persisted"], json!(true));
+        assert_eq!(after["config"]["unit_system"], json!("metric"));
+        assert_eq!(after["config"]["params"]["FC1"]["eps_dsp"], json!(0.25));
+
+        std::env::remove_var("OPENFDD_WORKSPACE");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -77,6 +77,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/fdd/rules/{rule_id}/params", get(fdd_rule_params))
         .route("/api/fdd/cache/status", get(fdd_cache_status))
         .route("/api/fdd/roles", get(fdd_roles))
+        .route(
+            "/api/fdd/session-config",
+            get(fdd_session_config_get).put(fdd_session_config_put),
+        )
         .route("/api/fdd/run", post(fdd_run))
         .route("/api/fdd/status", get(fdd_status))
         .merge(csv)
@@ -638,6 +642,20 @@ pub async fn fdd_cache_status() -> Json<Value> {
 
 pub async fn fdd_roles() -> Json<Value> {
     Json(open_fdd_edge_prototype::fdd::registry_api::roles_response())
+}
+
+/// `openfdd_session_v1` session/fault settings (#515) — persisted per workspace.
+pub async fn fdd_session_config_get() -> Json<Value> {
+    Json(open_fdd_edge_prototype::fdd::session_config::get_session_config())
+}
+
+pub async fn fdd_session_config_put(Json(body): Json<Value>) -> Json<Value> {
+    let result = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::fdd::session_config::put_session_config(&body)
+    })
+    .await
+    .unwrap_or_else(|e| json!({"ok": false, "error": format!("session config task: {e}")}));
+    Json(result)
 }
 
 #[utoipa::path(

--- a/services/central/tests/zip_package_fdd_integration.rs
+++ b/services/central/tests/zip_package_fdd_integration.rs
@@ -236,6 +236,57 @@ fn zip_package_upload_then_fc1_registry_run() {
     assert_eq!(status, 200, "roles: {upd}");
     assert_eq!(upd.get("ok"), Some(&json!(true)), "roles: {upd}");
 
+    // #515: packaged session_config.json persists workspace-wide.
+    let (status, sess) = {
+        let (status, text) = http_raw(
+            "GET",
+            srv.port,
+            "/api/fdd/session-config",
+            None,
+            "application/json",
+        );
+        (
+            status,
+            serde_json::from_str::<Value>(&text).unwrap_or(json!({"raw": text})),
+        )
+    };
+    assert_eq!(status, 200, "session-config: {sess}");
+    assert_eq!(sess["persisted"], json!(true), "{sess}");
+    assert_eq!(sess["config"]["unit_system"], json!("imperial"), "{sess}");
+
+    // #515: PUT session config with rule params + role_map applied to the building.
+    let put_body = json!({
+        "building_id": "ZIP_BUILDING_1",
+        "config": {
+            "schema_version": "openfdd_session_v1",
+            "unit_system": "metric",
+            "params": {"FC1": {"eps_dsp": 0.2}},
+            "role_map": {"AHU_1": {"fan_cmd": "SF_SPD", "duct_static": "DA_P", "duct_static_sp": "DA_P_SP"}}
+        }
+    })
+    .to_string();
+    let (status, put) = {
+        let (status, text) = http_raw(
+            "PUT",
+            srv.port,
+            "/api/fdd/session-config",
+            Some(put_body.as_bytes()),
+            "application/json",
+        );
+        (
+            status,
+            serde_json::from_str::<Value>(&text).unwrap_or(json!({"raw": text})),
+        )
+    };
+    assert_eq!(status, 200, "session-config put: {put}");
+    assert_eq!(put.get("ok"), Some(&json!(true)), "put: {put}");
+    assert_eq!(put["config"]["unit_system"], json!("metric"), "{put}");
+    assert_eq!(
+        put["applied_role_map"][0]["ok"],
+        json!(true),
+        "role_map should apply to AHU_1: {put}"
+    );
+
     let fdd_body = json!({
         "params": {
             "mode": "registry",

--- a/workspace/dashboard/src/lib/sessionConfig.test.ts
+++ b/workspace/dashboard/src/lib/sessionConfig.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSessionConfig,
+  parseSessionConfigFile,
+  sessionConfigToParamOverrides,
+} from "./sessionConfig";
+
+describe("sessionConfigToParamOverrides", () => {
+  it("keeps only finite numeric params", () => {
+    const out = sessionConfigToParamOverrides({
+      schema_version: "openfdd_session_v1",
+      unit_system: "imperial",
+      params: {
+        FC1: { eps_dsp: 0.2, bad: NaN },
+        EMPTY: {},
+      },
+    });
+    expect(out).toEqual({ FC1: { eps_dsp: 0.2 } });
+  });
+
+  it("handles missing config", () => {
+    expect(sessionConfigToParamOverrides(null)).toEqual({});
+  });
+});
+
+describe("buildSessionConfig", () => {
+  it("exports slider state with unit system, dropping empty rules", () => {
+    const cfg = buildSessionConfig({ FC1: { eps_dsp: 0.15 }, FC2: {} }, "metric");
+    expect(cfg.schema_version).toBe("openfdd_session_v1");
+    expect(cfg.unit_system).toBe("metric");
+    expect(cfg.params).toEqual({ FC1: { eps_dsp: 0.15 } });
+  });
+
+  it("preserves base fields like role_map", () => {
+    const cfg = buildSessionConfig({}, "imperial", {
+      schema_version: "openfdd_session_v1",
+      unit_system: "imperial",
+      role_map: { AHU_1: { fan_status: "sf_status" } },
+    });
+    expect(cfg.role_map).toEqual({ AHU_1: { fan_status: "sf_status" } });
+  });
+});
+
+describe("parseSessionConfigFile", () => {
+  it("accepts valid config and fills defaults", () => {
+    const cfg = parseSessionConfigFile(
+      JSON.stringify({ unit_system: "metric", params: { FC1: { eps_dsp: 0.1 } } }),
+    );
+    expect(cfg.schema_version).toBe("openfdd_session_v1");
+    expect(cfg.unit_system).toBe("metric");
+  });
+
+  it("rejects wrong schema_version", () => {
+    expect(() =>
+      parseSessionConfigFile(JSON.stringify({ schema_version: "v2" })),
+    ).toThrow(/schema_version/);
+  });
+
+  it("rejects non-objects", () => {
+    expect(() => parseSessionConfigFile("42")).toThrow(/object/);
+  });
+});

--- a/workspace/dashboard/src/lib/sessionConfig.ts
+++ b/workspace/dashboard/src/lib/sessionConfig.ts
@@ -1,0 +1,103 @@
+import { apiFetch } from "./api";
+
+/** openfdd_session_v1 (#515) — mirrors vibe19 session_config.json. */
+export type SessionConfig = {
+  schema_version: "openfdd_session_v1";
+  unit_system: "imperial" | "metric" | "si";
+  prefer_web_oat?: boolean;
+  chw_leave_max_f?: number;
+  role_map?: Record<string, Record<string, string>>;
+  params?: Record<string, Record<string, number>>;
+};
+
+export type SessionConfigGetResponse = {
+  ok?: boolean;
+  error?: string;
+  persisted?: boolean;
+  config?: SessionConfig;
+};
+
+export type SessionConfigPutResponse = {
+  ok?: boolean;
+  error?: string;
+  config?: SessionConfig;
+  warnings?: string[];
+  applied_role_map?: { equipment_id: string; ok: boolean }[];
+};
+
+export function emptySessionConfig(): SessionConfig {
+  return {
+    schema_version: "openfdd_session_v1",
+    unit_system: "imperial",
+    prefer_web_oat: true,
+    role_map: {},
+    params: {},
+  };
+}
+
+/** Slider state (rule → param → value) from a loaded session config. */
+export function sessionConfigToParamOverrides(
+  config: SessionConfig | undefined | null,
+): Record<string, Record<string, number>> {
+  const out: Record<string, Record<string, number>> = {};
+  for (const [ruleId, params] of Object.entries(config?.params ?? {})) {
+    const clean: Record<string, number> = {};
+    for (const [key, value] of Object.entries(params ?? {})) {
+      if (typeof value === "number" && Number.isFinite(value)) clean[key] = value;
+    }
+    if (Object.keys(clean).length) out[ruleId] = clean;
+  }
+  return out;
+}
+
+/** Session config JSON from current slider state (export / save). */
+export function buildSessionConfig(
+  paramOverrides: Record<string, Record<string, number>>,
+  unitSystem: SessionConfig["unit_system"],
+  base?: SessionConfig | null,
+): SessionConfig {
+  return {
+    ...(base ?? emptySessionConfig()),
+    schema_version: "openfdd_session_v1",
+    unit_system: unitSystem,
+    params: Object.fromEntries(
+      Object.entries(paramOverrides).filter(([, p]) => Object.keys(p).length > 0),
+    ),
+  };
+}
+
+export function parseSessionConfigFile(text: string): SessionConfig {
+  const raw: unknown = JSON.parse(text);
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("session config must be a JSON object");
+  }
+  const cfg = raw as Partial<SessionConfig>;
+  if (cfg.schema_version && cfg.schema_version !== "openfdd_session_v1") {
+    throw new Error(`schema_version must be openfdd_session_v1, got ${cfg.schema_version}`);
+  }
+  return { ...emptySessionConfig(), ...cfg, schema_version: "openfdd_session_v1" };
+}
+
+export async function fetchSessionConfig(): Promise<SessionConfigGetResponse> {
+  return apiFetch<SessionConfigGetResponse>("/api/fdd/session-config");
+}
+
+export async function saveSessionConfig(
+  config: SessionConfig,
+  buildingId?: string,
+): Promise<SessionConfigPutResponse> {
+  return apiFetch<SessionConfigPutResponse>("/api/fdd/session-config", {
+    method: "PUT",
+    body: JSON.stringify(buildingId ? { building_id: buildingId, config } : config),
+  });
+}
+
+export function downloadSessionConfig(config: SessionConfig) {
+  const blob = new Blob([JSON.stringify(config, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "session_config.json";
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/workspace/dashboard/src/pages/Vibe19LabPage.tsx
+++ b/workspace/dashboard/src/pages/Vibe19LabPage.tsx
@@ -1,6 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch } from "../lib/api";
+import { formatApiError } from "../lib/formatApiError";
+import {
+  buildSessionConfig,
+  downloadSessionConfig,
+  fetchSessionConfig,
+  parseSessionConfigFile,
+  saveSessionConfig,
+  sessionConfigToParamOverrides,
+  type SessionConfig,
+} from "../lib/sessionConfig";
 import {
   barChart,
   basVsWebOatOverlay,
@@ -125,6 +135,139 @@ function DataModelSection({ rules }: { rules?: RegistryRule[] }) {
   );
 }
 
+/** Save / load openfdd_session_v1 fault settings (#515) wired to the rule sliders. */
+function SessionConfigPanel({
+  paramOverrides,
+  onLoaded,
+}: {
+  paramOverrides: Record<string, Record<string, number>>;
+  onLoaded: (
+    overrides: Record<string, Record<string, number>>,
+    config: SessionConfig,
+  ) => void;
+}) {
+  const [unitSystem, setUnitSystem] = useState<SessionConfig["unit_system"]>("imperial");
+  const [baseConfig, setBaseConfig] = useState<SessionConfig | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState("");
+  const [error, setError] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+  const seededRef = useRef(false);
+
+  useEffect(() => {
+    if (seededRef.current) return;
+    seededRef.current = true;
+    void fetchSessionConfig()
+      .then((res) => {
+        if (!res.ok || !res.config) return;
+        setBaseConfig(res.config);
+        setUnitSystem(res.config.unit_system ?? "imperial");
+        if (res.persisted) {
+          onLoaded(sessionConfigToParamOverrides(res.config), res.config);
+          setNote("Loaded persisted session config (sliders seeded).");
+        }
+      })
+      .catch(() => {
+        /* offline / unauthenticated — keep defaults */
+      });
+  }, [onLoaded]);
+
+  async function save() {
+    setBusy(true);
+    setError("");
+    setNote("");
+    try {
+      const cfg = buildSessionConfig(paramOverrides, unitSystem, baseConfig);
+      const out = await saveSessionConfig(cfg);
+      if (!out.ok) throw new Error(out.error ?? "save failed");
+      setBaseConfig(out.config ?? cfg);
+      const warn = out.warnings?.length ? ` · ${out.warnings.length} warning(s)` : "";
+      setNote(`Session saved to server${warn}.`);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function loadFile(file: File) {
+    setBusy(true);
+    setError("");
+    setNote("");
+    try {
+      const cfg = parseSessionConfigFile(await file.text());
+      const out = await saveSessionConfig(cfg);
+      if (!out.ok) throw new Error(out.error ?? "load failed");
+      const effective = out.config ?? cfg;
+      setBaseConfig(effective);
+      setUnitSystem(effective.unit_system ?? "imperial");
+      onLoaded(sessionConfigToParamOverrides(effective), effective);
+      const warn = out.warnings?.length ? ` · ${out.warnings.join("; ")}` : "";
+      setNote(`Session loaded — sliders updated${warn}.`);
+    } catch (e) {
+      setError(formatApiError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="vibe19-card">
+      <h3>Session / fault settings (openfdd_session_v1)</h3>
+      {error ? <p className="error">{error}</p> : null}
+      {note ? <p className="ok">{note}</p> : null}
+      <div className="toolbar toolbar-spaced">
+        <label>
+          Units{" "}
+          <select
+            value={unitSystem}
+            disabled={busy}
+            onChange={(e) => setUnitSystem(e.target.value as SessionConfig["unit_system"])}
+          >
+            <option value="imperial">imperial</option>
+            <option value="metric">metric</option>
+            <option value="si">si</option>
+          </select>
+        </label>
+        <button type="button" className="secondary-btn" disabled={busy} onClick={() => void save()}>
+          {busy ? "Working…" : "Save session"}
+        </button>
+        <button
+          type="button"
+          className="secondary-btn"
+          disabled={busy}
+          onClick={() => downloadSessionConfig(buildSessionConfig(paramOverrides, unitSystem, baseConfig))}
+        >
+          Download JSON
+        </button>
+        <button
+          type="button"
+          className="secondary-btn"
+          disabled={busy}
+          onClick={() => fileRef.current?.click()}
+        >
+          Load JSON…
+        </button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".json,application/json"
+          hidden
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) void loadFile(f);
+            e.target.value = "";
+          }}
+        />
+      </div>
+      <p className="muted">
+        Saves slider overrides + unit system to the server and seeds them on reload. The same
+        JSON travels inside <code>openfdd_package_v1</code> zips as <code>session_config.json</code>.
+      </p>
+    </div>
+  );
+}
+
 function RunRulesSection({ rules }: { rules?: RegistryRule[] }) {
   const qc = useQueryClient();
   const [selected, setSelected] = useState<string[]>([]);
@@ -244,6 +387,10 @@ function RunRulesSection({ rules }: { rules?: RegistryRule[] }) {
             })}
           </div>
         )}
+        <SessionConfigPanel
+          paramOverrides={paramOverrides}
+          onLoaded={(overrides) => setParamOverrides(overrides)}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Backend: `GET/PUT /api/fdd/session-config` for `openfdd_session_v1` (normalize, validate against registry, persist).
- Package zip may include `session_config.json` (seeded on import — depends on #538 already on master).
- Frontend: session save/load wired to Lab rule sliders (`sessionConfig.ts` + panel); unit tests included.
- Central integration coverage in zip package FDD test for session persistence.

Closes #515.

## Test plan
- [x] Session config unit tests (dashboard)
- [x] Central zip+session integration path
- [ ] CI green
- [ ] Lab: save session → reload → sliders restored; imperial/metric toggle persists

Made with [Cursor](https://cursor.com)