### PR TITLE
feat(ui): Streamlit-parity Lab redesign — vibe19 theme, sidebar rule tuning, 9 sections

### DIFF
--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -9,52 +9,52 @@ type HealthInfo = { version?: string; image_tag?: string };
 type NavItem = {
   to: string;
   end?: boolean;
-  icon: string;
   label: string;
   protected?: boolean;
   disabled?: boolean;
   disabledHint?: string;
 };
 
+/* Streamlit-parity nav: plain text labels, no emoji icons. */
 const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   {
     title: "Overview",
-    items: [{ to: "/", end: true, icon: "🏠", label: "Dashboard" }],
+    items: [{ to: "/", end: true, label: "Dashboard" }],
   },
   {
     title: "Integrations",
     items: [
-      { to: "/edge-fleet", icon: "🛰️", label: "Edge fleet", protected: true },
-      { to: "/bacnet", icon: "📡", label: "BACnet (legacy)", protected: true },
-      { to: "/haystack", icon: "🌿", label: "Haystack (legacy)", protected: true },
-      { to: "/modbus", icon: "🔌", label: "Modbus (legacy)", protected: true },
-      { to: "/json-api", icon: "🌐", label: "JSON API", protected: true },
+      { to: "/edge-fleet", label: "Edge fleet", protected: true },
+      { to: "/bacnet", label: "BACnet (legacy)", protected: true },
+      { to: "/haystack", label: "Haystack (legacy)", protected: true },
+      { to: "/modbus", label: "Modbus (legacy)", protected: true },
+      { to: "/json-api", label: "JSON API", protected: true },
     ],
   },
   {
     title: "Model & rules",
     items: [
-      { to: "/lab", icon: "🧪", label: "Open-FDD Lab (vibe19)", protected: true },
-      { to: "/csv", icon: "📥", label: "CSV job upload", protected: true },
-      { to: "/model", icon: "📐", label: "Model & FDD assignments", protected: true },
-      { to: "/sql-fdd", icon: "⚡", label: "SQL FDD lab (integrator)", protected: true },
-      { to: "/plot", icon: "📈", label: "Plots", protected: true },
-      { to: "/reports", icon: "📄", label: "Reports", protected: true },
+      { to: "/lab", label: "Open-FDD Lab (vibe19)", protected: true },
+      { to: "/csv", label: "CSV job upload", protected: true },
+      { to: "/model", label: "Model & FDD assignments", protected: true },
+      { to: "/sql-fdd", label: "SQL FDD lab (integrator)", protected: true },
+      { to: "/plot", label: "Plots", protected: true },
+      { to: "/reports", label: "Reports", protected: true },
     ],
   },
   {
     title: "Data & ops",
     items: [
-      { to: "/exports", icon: "⬇️", label: "Data export", protected: true },
-      { to: "/data-management", icon: "🗄️", label: "Historian storage", protected: true },
-      { to: "/host", icon: "📊", label: "Host stats", protected: true },
-      { to: "/algorithms", icon: "⚙️", label: "Algorithms", protected: true },
+      { to: "/exports", label: "Data export", protected: true },
+      { to: "/data-management", label: "Historian storage", protected: true },
+      { to: "/host", label: "Host stats", protected: true },
+      { to: "/algorithms", label: "Algorithms", protected: true },
     ],
   },
   {
     title: "Settings",
     items: [
-      { to: "/agent", icon: "🔌", label: "External agents", protected: true },
+      { to: "/agent", label: "External agents", protected: true },
     ],
   },
 ];
@@ -149,7 +149,6 @@ export default function AppLayout() {
                     title={item.disabledHint ?? "Coming soon"}
                     aria-disabled="true"
                   >
-                    <span className="nav-icon">{item.icon}</span>
                     {item.label}
                     <span className="nav-soon">Soon</span>
                   </span>
@@ -160,7 +159,6 @@ export default function AppLayout() {
                     end={item.end}
                     className={({ isActive }) => `nav-item${isActive ? " active" : ""}`}
                   >
-                    <span className="nav-icon">{item.icon}</span>
                     {item.label}
                   </NavLink>
                 ),

--- a/workspace/dashboard/src/lib/csvPackageImport.test.ts
+++ b/workspace/dashboard/src/lib/csvPackageImport.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { COOKBOOK_ROLES } from "./csvPackageImport";
+
+/** Guard the hardcoded frontend role vocabulary against registry drift. */
+describe("COOKBOOK_ROLES", () => {
+  it("covers every required_roles entry in sql_rules/registry.yaml", () => {
+    const registryPath = resolve(__dirname, "../../../../sql_rules/registry.yaml");
+    const text = readFileSync(registryPath, "utf-8");
+    const roles = new Set<string>();
+    for (const m of text.matchAll(/required_roles:\s*\[([^\]]*)\]/g)) {
+      for (const role of m[1].split(",")) {
+        const r = role.trim();
+        if (r) roles.add(r);
+      }
+    }
+    expect(roles.size).toBeGreaterThan(10);
+    const missing = [...roles].filter((r) => !COOKBOOK_ROLES.includes(r));
+    expect(missing).toEqual([]);
+  });
+
+  it("starts with the empty (unassigned) option and has no duplicates", () => {
+    expect(COOKBOOK_ROLES[0]).toBe("");
+    expect(new Set(COOKBOOK_ROLES).size).toBe(COOKBOOK_ROLES.length);
+  });
+});

--- a/workspace/dashboard/src/pages/Vibe19LabPage.tsx
+++ b/workspace/dashboard/src/pages/Vibe19LabPage.tsx
@@ -29,8 +29,11 @@ import {
   RCX_PRESETS,
   VIBE19_SECTIONS,
 } from "../vibe19/contract";
+import { groupRulesByFamily } from "../vibe19/families";
 import { PlotHost } from "../vibe19/PlotHost";
 import "./vibe19.css";
+
+type ParamOverrides = Record<string, Record<string, number>>;
 
 type RulesResponse = { ok: boolean; count: number; rules: RegistryRule[]; error?: string };
 type ParamsResponse = {
@@ -138,16 +141,19 @@ function DataModelSection({ rules }: { rules?: RegistryRule[] }) {
 /** Save / load openfdd_session_v1 fault settings (#515) wired to the rule sliders. */
 function SessionConfigPanel({
   paramOverrides,
+  unitSystem,
+  baseConfig,
+  onBaseConfig,
+  onUnitSystem,
   onLoaded,
 }: {
-  paramOverrides: Record<string, Record<string, number>>;
-  onLoaded: (
-    overrides: Record<string, Record<string, number>>,
-    config: SessionConfig,
-  ) => void;
+  paramOverrides: ParamOverrides;
+  unitSystem: SessionConfig["unit_system"];
+  baseConfig: SessionConfig | null;
+  onBaseConfig: (config: SessionConfig) => void;
+  onUnitSystem: (unit: SessionConfig["unit_system"]) => void;
+  onLoaded: (overrides: ParamOverrides, config: SessionConfig) => void;
 }) {
-  const [unitSystem, setUnitSystem] = useState<SessionConfig["unit_system"]>("imperial");
-  const [baseConfig, setBaseConfig] = useState<SessionConfig | null>(null);
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState("");
   const [error, setError] = useState("");
@@ -160,8 +166,8 @@ function SessionConfigPanel({
     void fetchSessionConfig()
       .then((res) => {
         if (!res.ok || !res.config) return;
-        setBaseConfig(res.config);
-        setUnitSystem(res.config.unit_system ?? "imperial");
+        onBaseConfig(res.config);
+        onUnitSystem(res.config.unit_system ?? "imperial");
         if (res.persisted) {
           onLoaded(sessionConfigToParamOverrides(res.config), res.config);
           setNote("Loaded persisted session config (sliders seeded).");
@@ -170,7 +176,7 @@ function SessionConfigPanel({
       .catch(() => {
         /* offline / unauthenticated — keep defaults */
       });
-  }, [onLoaded]);
+  }, [onBaseConfig, onLoaded, onUnitSystem]);
 
   async function save() {
     setBusy(true);
@@ -180,7 +186,7 @@ function SessionConfigPanel({
       const cfg = buildSessionConfig(paramOverrides, unitSystem, baseConfig);
       const out = await saveSessionConfig(cfg);
       if (!out.ok) throw new Error(out.error ?? "save failed");
-      setBaseConfig(out.config ?? cfg);
+      onBaseConfig(out.config ?? cfg);
       const warn = out.warnings?.length ? ` · ${out.warnings.length} warning(s)` : "";
       setNote(`Session saved to server${warn}.`);
     } catch (e) {
@@ -199,8 +205,8 @@ function SessionConfigPanel({
       const out = await saveSessionConfig(cfg);
       if (!out.ok) throw new Error(out.error ?? "load failed");
       const effective = out.config ?? cfg;
-      setBaseConfig(effective);
-      setUnitSystem(effective.unit_system ?? "imperial");
+      onBaseConfig(effective);
+      onUnitSystem(effective.unit_system ?? "imperial");
       onLoaded(sessionConfigToParamOverrides(effective), effective);
       const warn = out.warnings?.length ? ` · ${out.warnings.join("; ")}` : "";
       setNote(`Session loaded — sliders updated${warn}.`);
@@ -212,41 +218,23 @@ function SessionConfigPanel({
   }
 
   return (
-    <div className="vibe19-card">
-      <h3>Session / fault settings (openfdd_session_v1)</h3>
+    <div className="vibe19-sidebar-block">
+      <h3>Session restore</h3>
       {error ? <p className="error">{error}</p> : null}
       {note ? <p className="ok">{note}</p> : null}
-      <div className="toolbar toolbar-spaced">
-        <label>
-          Units{" "}
-          <select
-            value={unitSystem}
-            disabled={busy}
-            onChange={(e) => setUnitSystem(e.target.value as SessionConfig["unit_system"])}
-          >
-            <option value="imperial">imperial</option>
-            <option value="metric">metric</option>
-            <option value="si">si</option>
-          </select>
-        </label>
-        <button type="button" className="secondary-btn" disabled={busy} onClick={() => void save()}>
+      <div className="vibe19-sidebar-actions">
+        <button type="button" disabled={busy} onClick={() => void save()}>
           {busy ? "Working…" : "Save session"}
         </button>
         <button
           type="button"
-          className="secondary-btn"
           disabled={busy}
           onClick={() => downloadSessionConfig(buildSessionConfig(paramOverrides, unitSystem, baseConfig))}
         >
-          Download JSON
+          Download session config
         </button>
-        <button
-          type="button"
-          className="secondary-btn"
-          disabled={busy}
-          onClick={() => fileRef.current?.click()}
-        >
-          Load JSON…
+        <button type="button" disabled={busy} onClick={() => fileRef.current?.click()}>
+          Load session JSON…
         </button>
         <input
           ref={fileRef}
@@ -261,24 +249,219 @@ function SessionConfigPanel({
         />
       </div>
       <p className="muted">
-        Saves slider overrides + unit system to the server and seeds them on reload. The same
-        JSON travels inside <code>openfdd_package_v1</code> zips as <code>session_config.json</code>.
+        openfdd_session_v1 — slider overrides + units persist on the server and travel inside
+        package zips as <code>session_config.json</code>.
       </p>
     </div>
   );
 }
 
-function RunRulesSection({ rules }: { rules?: RegistryRule[] }) {
+/** Per-rule tuning expander — params fetched lazily on first open (no full-app rerun). */
+function RuleTuningExpander({
+  rule,
+  overrides,
+  onChange,
+}: {
+  rule: RegistryRule;
+  overrides: Record<string, number> | undefined;
+  onChange: (key: string, value: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const paramsQ = useQuery({
+    queryKey: ["fdd-params", rule.rule_id],
+    queryFn: () => fetchParams(rule.rule_id),
+    enabled: open,
+  });
+  const modified = Boolean(overrides && Object.keys(overrides).length);
+  const title = rule.description
+    ? `${rule.rule_id} — ${rule.description.slice(0, 36)}`
+    : rule.rule_id;
+  return (
+    <details onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}>
+      <summary>
+        {title}
+        {modified ? <span className="modified"> · modified</span> : null}
+      </summary>
+      {!open ? null : paramsQ.isLoading ? (
+        <p className="muted">Loading params…</p>
+      ) : (
+        <div className="vibe19-sliders">
+          {Object.values(paramsQ.data?.params ?? {}).map((p) => {
+            const val = overrides?.[p.key] ?? overrides?.[p.sql_placeholder] ?? p.default;
+            return (
+              <label key={p.key} className="vibe19-slider">
+                <span>
+                  {p.label} ({p.unit}) — <strong>{val}</strong>
+                </span>
+                <input
+                  type="range"
+                  min={p.min}
+                  max={p.max}
+                  step={p.step}
+                  value={val}
+                  onChange={(e) => onChange(p.key, Number(e.target.value))}
+                />
+              </label>
+            );
+          })}
+          {Object.keys(paramsQ.data?.params ?? {}).length === 0 ? (
+            <p className="muted">No tunable params.</p>
+          ) : null}
+        </div>
+      )}
+    </details>
+  );
+}
+
+/** Sidebar rule tuning — vibe19 category selectbox + per-rule expanders. */
+function RuleTuningSidebar({
+  rules,
+  paramOverrides,
+  setParamOverrides,
+}: {
+  rules: RegistryRule[];
+  paramOverrides: ParamOverrides;
+  setParamOverrides: React.Dispatch<React.SetStateAction<ParamOverrides>>;
+}) {
+  const [category, setCategory] = useState("(all)");
+  const grouped = useMemo(
+    () => groupRulesByFamily(rules.map((r) => r.rule_id)),
+    [rules],
+  );
+  const byId = useMemo(() => new Map(rules.map((r) => [r.rule_id, r])), [rules]);
+  const shown = grouped.filter(([label]) => category === "(all)" || label === category);
+  const modifiedCount = Object.keys(paramOverrides).filter(
+    (id) => Object.keys(paramOverrides[id] ?? {}).length,
+  ).length;
+  return (
+    <div className="vibe19-sidebar-block">
+      <h3>Rule tuning</h3>
+      <label>
+        Category
+        <select value={category} onChange={(e) => setCategory(e.target.value)}>
+          <option value="(all)">(all)</option>
+          {grouped.map(([label]) => (
+            <option key={label} value={label}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="muted">
+        Sliders update local state only — run rules to apply.{" "}
+        {modifiedCount ? `${modifiedCount} rule(s) modified.` : ""}
+      </p>
+      <div className="vibe19-sidebar-actions">
+        <button type="button" onClick={() => setParamOverrides({})}>
+          Reset all tuning
+        </button>
+      </div>
+      <div className="vibe19-tuning">
+        {shown.map(([label, ids]) => (
+          <div key={label}>
+            <p className="vibe19-tuning-family">{label}</p>
+            {ids.map((id) => {
+              const rule = byId.get(id);
+              if (!rule) return null;
+              return (
+                <RuleTuningExpander
+                  key={id}
+                  rule={rule}
+                  overrides={paramOverrides[id]}
+                  onChange={(key, value) =>
+                    setParamOverrides((prev) => ({
+                      ...prev,
+                      [id]: { ...(prev[id] ?? {}), [key]: value },
+                    }))
+                  }
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Streamlit-parity page sidebar: data load → session restore → display & site → rule tuning. */
+function LabSidebar({
+  cache,
+  rules,
+  paramOverrides,
+  setParamOverrides,
+  unitSystem,
+  setUnitSystem,
+  baseConfig,
+  setBaseConfig,
+}: {
+  cache?: CacheStatus;
+  rules: RegistryRule[];
+  paramOverrides: ParamOverrides;
+  setParamOverrides: React.Dispatch<React.SetStateAction<ParamOverrides>>;
+  unitSystem: SessionConfig["unit_system"];
+  setUnitSystem: (u: SessionConfig["unit_system"]) => void;
+  baseConfig: SessionConfig | null;
+  setBaseConfig: (c: SessionConfig) => void;
+}) {
+  return (
+    <aside className="vibe19-lab-sidebar">
+      <div className="vibe19-sidebar-block">
+        <h3>Building data</h3>
+        <p className="muted">
+          {cache?.parquet_exists
+            ? `Parquet cache ready (${cache.parquet_file_count} files).`
+            : "No building data loaded yet."}
+        </p>
+        <div className="vibe19-sidebar-actions">
+          <a href="/csv">
+            <button type="button">Load CSV / package zip…</button>
+          </a>
+        </div>
+      </div>
+      <hr />
+      <SessionConfigPanel
+        paramOverrides={paramOverrides}
+        unitSystem={unitSystem}
+        baseConfig={baseConfig}
+        onBaseConfig={setBaseConfig}
+        onUnitSystem={setUnitSystem}
+        onLoaded={(overrides) => setParamOverrides(overrides)}
+      />
+      <hr />
+      <div className="vibe19-sidebar-block">
+        <h3>Display &amp; site</h3>
+        <label>
+          Units
+          <select
+            value={unitSystem}
+            onChange={(e) => setUnitSystem(e.target.value as SessionConfig["unit_system"])}
+          >
+            <option value="imperial">imperial</option>
+            <option value="metric">metric</option>
+            <option value="si">si</option>
+          </select>
+        </label>
+      </div>
+      <hr />
+      <RuleTuningSidebar
+        rules={rules}
+        paramOverrides={paramOverrides}
+        setParamOverrides={setParamOverrides}
+      />
+    </aside>
+  );
+}
+
+function RunRulesSection({
+  rules,
+  paramOverrides,
+}: {
+  rules?: RegistryRule[];
+  paramOverrides: ParamOverrides;
+}) {
   const qc = useQueryClient();
   const [selected, setSelected] = useState<string[]>([]);
-  const [activeRule, setActiveRule] = useState<string>("");
-  const [paramOverrides, setParamOverrides] = useState<Record<string, Record<string, number>>>({});
-
-  const paramsQ = useQuery({
-    queryKey: ["fdd-params", activeRule],
-    queryFn: () => fetchParams(activeRule),
-    enabled: Boolean(activeRule),
-  });
 
   const runMut = useMutation({
     mutationFn: () =>
@@ -293,22 +476,25 @@ function RunRulesSection({ rules }: { rules?: RegistryRule[] }) {
   });
 
   const families = useMemo(() => {
-    const m = new Map<string, RegistryRule[]>();
-    for (const r of rules ?? []) {
-      const fam = r.rule_id.split("-")[0] || "OTHER";
-      const arr = m.get(fam) ?? [];
-      arr.push(r);
-      m.set(fam, arr);
-    }
-    return [...m.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+    const byId = new Map((rules ?? []).map((r) => [r.rule_id, r]));
+    return groupRulesByFamily([...byId.keys()]).map(
+      ([label, ids]) =>
+        [label, ids.map((id) => byId.get(id)!).filter(Boolean)] as [string, RegistryRule[]],
+    );
   }, [rules]);
+  const modifiedIds = Object.keys(paramOverrides).filter(
+    (id) => Object.keys(paramOverrides[id] ?? {}).length,
+  );
 
   return (
     <div className="vibe19-run">
       <aside className="vibe19-sidebar">
-        <h3>Rule families</h3>
+        <h3>Scope</h3>
+        <p className="muted">
+          {selected.length ? `${selected.length} rule(s) selected` : "All rules (no selection)"}
+        </p>
         {families.map(([fam, list]) => (
-          <details key={fam} open={fam === "FC" || fam === "VAV" || fam === "SV"}>
+          <details key={fam}>
             <summary>
               {fam} ({list.length})
             </summary>
@@ -325,7 +511,6 @@ function RunRulesSection({ rules }: { rules?: RegistryRule[] }) {
                             ? [...prev, r.rule_id]
                             : prev.filter((id) => id !== r.rule_id),
                         );
-                        setActiveRule(r.rule_id);
                       }}
                     />{" "}
                     {r.rule_id}
@@ -341,56 +526,33 @@ function RunRulesSection({ rules }: { rules?: RegistryRule[] }) {
           disabled={runMut.isPending}
           onClick={() => runMut.mutate()}
         >
-          {runMut.isPending ? "Running…" : "Run selected (registry)"}
+          {runMut.isPending ? "Running…" : selected.length ? "Run selected" : "Run all rules"}
         </button>
         {runMut.isError ? (
           <p className="error">{(runMut.error as Error).message}</p>
         ) : null}
+      </aside>
+      <div className="vibe19-card grow">
+        <h3>Run rules</h3>
+        <p className="muted">
+          Thresholds come from <strong>Rule tuning</strong> in the left sidebar — slider changes
+          stay local until you press Run (no Streamlit-style rerun).
+        </p>
+        {modifiedIds.length ? (
+          <p>
+            Tuned rules applied on run:{" "}
+            {modifiedIds.map((id) => (
+              <code key={id} style={{ marginRight: "0.4rem" }}>
+                {id}
+              </code>
+            ))}
+          </p>
+        ) : (
+          <p className="muted">No slider overrides yet — registry defaults will be used.</p>
+        )}
         {runMut.data ? (
           <pre className="vibe19-pre">{JSON.stringify(runMut.data, null, 2)}</pre>
         ) : null}
-      </aside>
-      <div className="vibe19-card grow">
-        <h3>Sliders — {activeRule || "select a rule"}</h3>
-        {!activeRule ? (
-          <p className="muted">Select a rule to tune confirm_min and thresholds (no raw SQL).</p>
-        ) : paramsQ.isLoading ? (
-          <p className="muted">Loading params…</p>
-        ) : (
-          <div className="vibe19-sliders">
-            {Object.values(paramsQ.data?.params ?? {}).map((p) => {
-              const val =
-                paramOverrides[activeRule]?.[p.key] ??
-                paramOverrides[activeRule]?.[p.sql_placeholder] ??
-                p.default;
-              return (
-                <label key={p.key} className="vibe19-slider">
-                  <span>
-                    {p.label} ({p.unit}) — <strong>{val}</strong>
-                  </span>
-                  <input
-                    type="range"
-                    min={p.min}
-                    max={p.max}
-                    step={p.step}
-                    value={val}
-                    onChange={(e) => {
-                      const n = Number(e.target.value);
-                      setParamOverrides((prev) => ({
-                        ...prev,
-                        [activeRule]: { ...(prev[activeRule] ?? {}), [p.key]: n },
-                      }));
-                    }}
-                  />
-                </label>
-              );
-            })}
-          </div>
-        )}
-        <SessionConfigPanel
-          paramOverrides={paramOverrides}
-          onLoaded={(overrides) => setParamOverrides(overrides)}
-        />
       </div>
     </div>
   );
@@ -659,57 +821,81 @@ function Placeholder({ title, blurb }: { title: string; blurb: string }) {
 
 export default function Vibe19LabPage() {
   const [section, setSection] = useState<Vibe19Section>("Overview");
+  const [paramOverrides, setParamOverrides] = useState<ParamOverrides>({});
+  const [unitSystem, setUnitSystem] = useState<SessionConfig["unit_system"]>("imperial");
+  const [baseConfig, setBaseConfig] = useState<SessionConfig | null>(null);
   const rulesQ = useQuery({ queryKey: ["fdd-rules"], queryFn: fetchRules });
   const cacheQ = useQuery({ queryKey: ["fdd-cache"], queryFn: fetchCache });
 
   return (
     <div className="vibe19-shell">
-      <header className="vibe19-hero">
-        <div>
-          <h1>Open-FDD Lab</h1>
-          <p className="muted">
-            vibe19 look &amp; feel — data-model driven, registry sliders, Plotly charts (no Streamlit
-            reruns).
-          </p>
-        </div>
-        <div className="vibe19-hero-meta">
-          {rulesQ.data?.ok ? (
-            <span>{rulesQ.data.count} rules</span>
-          ) : (
-            <span className="error">{rulesQ.data?.error ?? (rulesQ.isError ? "API error" : "…")}</span>
-          )}
-        </div>
-      </header>
+      <LabSidebar
+        cache={cacheQ.data}
+        rules={rulesQ.data?.rules ?? []}
+        paramOverrides={paramOverrides}
+        setParamOverrides={setParamOverrides}
+        unitSystem={unitSystem}
+        setUnitSystem={setUnitSystem}
+        baseConfig={baseConfig}
+        setBaseConfig={setBaseConfig}
+      />
 
-      <nav className="vibe19-nav" aria-label="Lab sections">
-        {VIBE19_SECTIONS.map((s) => (
-          <button
-            key={s}
-            type="button"
-            className={s === section ? "active" : ""}
-            onClick={() => setSection(s)}
-          >
-            {s}
-          </button>
-        ))}
-      </nav>
+      <div className="vibe19-content">
+        <header className="vibe19-hero">
+          <div>
+            <h1>Open FDD Vibe Coder</h1>
+            <p className="muted">
+              Streamlit-parity lab — tune rules in the left sidebar, run on demand, browse
+              sections below. Units: {unitSystem}.
+            </p>
+          </div>
+          <div className="vibe19-hero-meta">
+            {rulesQ.data?.ok ? (
+              <span>{rulesQ.data.count} rules</span>
+            ) : (
+              <span className="error">{rulesQ.data?.error ?? (rulesQ.isError ? "API error" : "…")}</span>
+            )}
+          </div>
+        </header>
 
-      <main className="vibe19-main">
-        {section === "Overview" ? (
-          <OverviewSection cache={cacheQ.data} rules={rulesQ.data?.rules} />
-        ) : null}
-        {section === "Data Model" ? <DataModelSection rules={rulesQ.data?.rules} /> : null}
-        {section === "Run Rules" ? <RunRulesSection rules={rulesQ.data?.rules} /> : null}
-        {section === "Results by Category" ? (
-          <ResultsSection rules={rulesQ.data?.rules} />
-        ) : null}
-        {section === "FDD Plots" ? <FddPlotsSection rules={rulesQ.data?.rules} /> : null}
-        {section === "RCx Plots" ? <RcxPlotsSection /> : null}
-        {section === "Metering" ? <MeteringSection /> : null}
-        {section === "Export" ? (
-          <Placeholder title="Export" blurb="CSV / session / health / data-model exports." />
-        ) : null}
-      </main>
+        <nav className="vibe19-nav" aria-label="Lab sections">
+          {VIBE19_SECTIONS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              className={s === section ? "active" : ""}
+              onClick={() => setSection(s)}
+            >
+              {s}
+            </button>
+          ))}
+        </nav>
+
+        <main className="vibe19-main">
+          {section === "Overview" ? (
+            <OverviewSection cache={cacheQ.data} rules={rulesQ.data?.rules} />
+          ) : null}
+          {section === "Data Model" ? <DataModelSection rules={rulesQ.data?.rules} /> : null}
+          {section === "Run Rules" ? (
+            <RunRulesSection rules={rulesQ.data?.rules} paramOverrides={paramOverrides} />
+          ) : null}
+          {section === "Results by Category" ? (
+            <ResultsSection rules={rulesQ.data?.rules} />
+          ) : null}
+          {section === "FDD Plots" ? <FddPlotsSection rules={rulesQ.data?.rules} /> : null}
+          {section === "RCx Plots" ? <RcxPlotsSection /> : null}
+          {section === "Metering" ? <MeteringSection /> : null}
+          {section === "Energy Model" ? (
+            <Placeholder
+              title="Energy Model"
+              blurb="WattLab energy model wizard port is tracked separately — section reserved for parity with the vibe19 dashboard contract."
+            />
+          ) : null}
+          {section === "Export" ? (
+            <Placeholder title="Export" blurb="CSV / session / health / data-model exports." />
+          ) : null}
+        </main>
+      </div>
     </div>
   );
 }

--- a/workspace/dashboard/src/pages/vibe19.css
+++ b/workspace/dashboard/src/pages/vibe19.css
@@ -1,8 +1,23 @@
+/* Streamlit-parity Lab layout: persistent left tuning sidebar + lazy sections. */
 .vibe19-shell {
+  display: grid;
+  grid-template-columns: minmax(280px, 320px) 1fr;
+  gap: 1.25rem;
+  padding: 0.5rem 0 2rem;
+  align-items: start;
+}
+
+.vibe19-content {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 0.5rem 0 2rem;
+  min-width: 0;
+}
+
+.vibe19-hero h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.7rem;
+  font-weight: 700;
 }
 
 .vibe19-hero {
@@ -12,32 +27,140 @@
   gap: 1rem;
 }
 
-.vibe19-hero h1 {
-  margin: 0 0 0.25rem;
-  font-size: 1.6rem;
-}
-
+/* Section picker — Streamlit horizontal radio look. */
 .vibe19-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
-  border-bottom: 1px solid var(--border, #2a3344);
-  padding-bottom: 0.5rem;
+  gap: 0.25rem 0.9rem;
+  border-bottom: 1px solid var(--border, #e3e6ee);
+  padding-bottom: 0.4rem;
 }
 
 .vibe19-nav button {
-  border: 1px solid transparent;
+  border: none;
   background: transparent;
   color: inherit;
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
+  padding: 0.35rem 0.15rem;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.92rem;
+}
+
+.vibe19-nav button:hover {
+  color: var(--primary, #ff4b4b);
 }
 
 .vibe19-nav button.active {
-  background: #1f6feb33;
-  border-color: #1f6feb;
+  color: var(--primary, #ff4b4b);
+  border-bottom-color: var(--primary, #ff4b4b);
+  font-weight: 600;
+}
+
+/* Streamlit-style page sidebar (secondary background, full height). */
+.vibe19-lab-sidebar {
+  background: var(--panel-soft, #f0f2f6);
+  border: 1px solid var(--border, #e3e6ee);
+  border-radius: 10px;
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: sticky;
+  top: 0.5rem;
+  max-height: calc(100vh - 1rem);
+  overflow: auto;
+}
+
+.vibe19-lab-sidebar h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+}
+
+.vibe19-lab-sidebar hr {
+  border: none;
+  border-top: 1px solid var(--border, #e3e6ee);
+  margin: 0;
+  width: 100%;
+}
+
+.vibe19-sidebar-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.88rem;
+}
+
+.vibe19-sidebar-block label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.82rem;
+}
+
+.vibe19-sidebar-block select,
+.vibe19-sidebar-block input[type="text"] {
+  background: var(--input-bg, #fff);
+  color: var(--input-text, inherit);
+  border: 1px solid var(--border, #e3e6ee);
+  border-radius: 6px;
+  padding: 0.3rem 0.4rem;
+  font-size: 0.85rem;
+}
+
+.vibe19-sidebar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.vibe19-sidebar-actions button {
+  border: 1px solid var(--border, #e3e6ee);
+  background: var(--panel, #fff);
+  color: inherit;
+  border-radius: 6px;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.vibe19-sidebar-actions button:hover {
+  border-color: var(--primary, #ff4b4b);
+  color: var(--primary, #ff4b4b);
+}
+
+/* Rule tuning expanders (one per rule, collapsed by default). */
+.vibe19-tuning {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.vibe19-tuning details {
+  border: 1px solid var(--border, #e3e6ee);
+  border-radius: 8px;
+  background: var(--panel, #fff);
+  padding: 0.35rem 0.55rem;
+}
+
+.vibe19-tuning summary {
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 600;
+  list-style-position: inside;
+}
+
+.vibe19-tuning summary .modified {
+  color: var(--primary, #ff4b4b);
+  font-weight: 700;
+}
+
+.vibe19-tuning-family {
+  margin: 0.35rem 0 0.1rem;
+  font-size: 0.78rem;
+  text-transform: none;
+  color: var(--muted, #808495);
+  font-weight: 700;
 }
 
 .vibe19-grid {
@@ -48,8 +171,8 @@
 
 .vibe19-metric,
 .vibe19-card {
-  background: var(--panel, #121821);
-  border: 1px solid var(--border, #2a3344);
+  background: var(--panel, #fff);
+  border: 1px solid var(--border, #e3e6ee);
   border-radius: 10px;
   padding: 0.9rem 1rem;
 }
@@ -76,8 +199,8 @@
 }
 
 .vibe19-sidebar {
-  background: var(--panel, #121821);
-  border: 1px solid var(--border, #2a3344);
+  background: var(--panel, #fff);
+  border: 1px solid var(--border, #e3e6ee);
   border-radius: 10px;
   padding: 0.75rem;
   max-height: 70vh;
@@ -102,7 +225,8 @@
 }
 
 .vibe19-sidebar button.active {
-  background: #1f6feb33;
+  background: color-mix(in srgb, var(--primary, #ff4b4b) 14%, transparent);
+  color: var(--primary, #ff4b4b);
   font-weight: 600;
 }
 
@@ -123,6 +247,11 @@
   gap: 0.35rem;
 }
 
+.vibe19-slider input[type="range"],
+.vibe19-tuning input[type="range"] {
+  accent-color: var(--primary, #ff4b4b);
+}
+
 .vibe19-table {
   width: 100%;
   border-collapse: collapse;
@@ -132,7 +261,7 @@
 
 .vibe19-table th,
 .vibe19-table td {
-  border-bottom: 1px solid var(--border, #2a3344);
+  border-bottom: 1px solid var(--border, #e3e6ee);
   text-align: left;
   padding: 0.35rem 0.4rem;
 }
@@ -141,7 +270,7 @@
   font-size: 0.75rem;
   max-height: 240px;
   overflow: auto;
-  background: #0b1018;
+  background: var(--panel-soft, #f0f2f6);
   padding: 0.5rem;
   border-radius: 6px;
 }
@@ -153,6 +282,16 @@
 
 .vibe19-card.grow {
   min-height: 320px;
+}
+
+@media (max-width: 1100px) {
+  .vibe19-shell {
+    grid-template-columns: 1fr;
+  }
+  .vibe19-lab-sidebar {
+    position: static;
+    max-height: none;
+  }
 }
 
 @media (max-width: 900px) {

--- a/workspace/dashboard/src/styles.css
+++ b/workspace/dashboard/src/styles.css
@@ -11,52 +11,55 @@
   border: 0;
 }
 
+/* Streamlit default palette parity (vibe19 ships no custom theme):
+   light = white content / #f0f2f6 sidebar / #ff4b4b primary / #31333f text,
+   dark  = #0e1117 content / #262730 sidebar / #fafafa text. */
 :root {
   color-scheme: light;
-  --bg: #f4f6fb;
+  --bg: #ffffff;
   --panel: #ffffff;
-  --panel-soft: #eef2f8;
-  --text: #1a2332;
-  --muted: #5c6b82;
-  --primary: #3b6de0;
-  --primary-strong: #2f5fcc;
-  --border: #d8e0ec;
-  --sidebar-bg: #ffffff;
-  --nav-hover-bg: #eef2f8;
-  --nav-active-bg: #e3ebfa;
-  --nav-active-text: #1a3f8f;
+  --panel-soft: #f0f2f6;
+  --text: #31333f;
+  --muted: #808495;
+  --primary: #ff4b4b;
+  --primary-strong: #e03c3c;
+  --border: #e3e6ee;
+  --sidebar-bg: #f0f2f6;
+  --nav-hover-bg: #e4e7ee;
+  --nav-active-bg: rgba(255, 75, 75, 0.12);
+  --nav-active-text: #d33030;
   --input-bg: #ffffff;
-  --input-text: #1a2332;
-  --danger: #c53d3d;
-  --ok: #2d9a52;
-  --warning: #c9870a;
+  --input-text: #31333f;
+  --danger: #ff2b2b;
+  --ok: #21a353;
+  --warning: #d9a207;
   --accent: var(--primary);
-  --traffic-housing-bg: #e8edf4;
-  --traffic-lamp-off: #c5cedb;
+  --traffic-housing-bg: #e8ebf2;
+  --traffic-lamp-off: #c9cfda;
 }
 
 [data-theme="dark"] {
   color-scheme: dark;
-  --bg: #0f1218;
-  --panel: #161b24;
-  --panel-soft: #1b2230;
-  --text: #e8edf6;
-  --muted: #97a3b8;
-  --primary: #4f78e8;
-  --primary-strong: #5b82ef;
-  --border: #273043;
-  --sidebar-bg: #131923;
-  --nav-hover-bg: #1f2735;
-  --nav-active-bg: #293855;
-  --nav-active-text: #f6f9ff;
-  --input-bg: #121824;
-  --input-text: #e8edf6;
-  --danger: #d45555;
-  --ok: #7fd992;
+  --bg: #0e1117;
+  --panel: #14181f;
+  --panel-soft: #262730;
+  --text: #fafafa;
+  --muted: #a3a8b8;
+  --primary: #ff4b4b;
+  --primary-strong: #ff6c6c;
+  --border: #31333f;
+  --sidebar-bg: #262730;
+  --nav-hover-bg: #31333f;
+  --nav-active-bg: rgba(255, 75, 75, 0.22);
+  --nav-active-text: #ff8383;
+  --input-bg: #14181f;
+  --input-text: #fafafa;
+  --danger: #ff6c6c;
+  --ok: #5fd38d;
   --warning: #fbbf24;
   --accent: var(--primary);
-  --traffic-housing-bg: #11151c;
-  --traffic-lamp-off: #2a313f;
+  --traffic-housing-bg: #171b23;
+  --traffic-lamp-off: #333846;
 }
 
 * {
@@ -68,7 +71,7 @@ body {
   min-height: 100vh;
   background: var(--bg);
   color: var(--text);
-  font-family: "SF Pro Display", Inter, "Segoe UI", system-ui, sans-serif;
+  font-family: "Source Sans Pro", "Source Sans 3", "Segoe UI", system-ui, sans-serif;
   line-height: 1.45;
 }
 
@@ -290,11 +293,6 @@ a {
 .nav-item.active {
   background: var(--nav-active-bg);
   color: var(--nav-active-text);
-}
-
-.nav-icon {
-  width: 18px;
-  text-align: center;
 }
 
 .app-main {

--- a/workspace/dashboard/src/vibe19/charts.test.ts
+++ b/workspace/dashboard/src/vibe19/charts.test.ts
@@ -18,11 +18,18 @@ import {
 } from "./contract";
 
 describe("vibe19 contract", () => {
-  it("keeps frozen main sections", () => {
-    expect(VIBE19_SECTIONS).toContain("Overview");
-    expect(VIBE19_SECTIONS).toContain("Run Rules");
-    expect(VIBE19_SECTIONS).toContain("FDD Plots");
-    expect(VIBE19_SECTIONS).toContain("RCx Plots");
+  it("keeps frozen main sections (all nine, vibe19 order)", () => {
+    expect([...VIBE19_SECTIONS]).toEqual([
+      "Overview",
+      "Data Model",
+      "Run Rules",
+      "Results by Category",
+      "FDD Plots",
+      "RCx Plots",
+      "Metering",
+      "Energy Model",
+      "Export",
+    ]);
   });
 
   it("lists required chart APIs", () => {

--- a/workspace/dashboard/src/vibe19/contract.ts
+++ b/workspace/dashboard/src/vibe19/contract.ts
@@ -8,6 +8,7 @@ export const VIBE19_SECTIONS = [
   "FDD Plots",
   "RCx Plots",
   "Metering",
+  "Energy Model",
   "Export",
 ] as const;
 

--- a/workspace/dashboard/src/vibe19/families.test.ts
+++ b/workspace/dashboard/src/vibe19/families.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { FAMILY_LABELS, groupRulesByFamily, ruleFamily } from "./families";
+
+describe("ruleFamily", () => {
+  it("matches the vibe19 cookbook catalog families", () => {
+    expect(ruleFamily("FC1")).toBe("ahu");
+    expect(ruleFamily("ECON-3")).toBe("ahu");
+    expect(ruleFamily("OAT-METEO")).toBe("ahu");
+    expect(ruleFamily("SV-RATE")).toBe("sensor");
+    expect(ruleFamily("SV-SLEW")).toBe("sensor");
+    expect(ruleFamily("PID-HUNT-1")).toBe("control");
+    expect(ruleFamily("VAV-REHEAT")).toBe("vav");
+    expect(ruleFamily("CHW-2")).toBe("plant");
+    expect(ruleFamily("CW-FAN-1")).toBe("plant");
+    expect(ruleFamily("HP-1")).toBe("heatpump");
+    expect(ruleFamily("WX-1")).toBe("weather");
+    expect(ruleFamily("TRIM-3")).toBe("trim");
+    expect(ruleFamily("SCHED-247")).toBe("schedule");
+    expect(ruleFamily("MYSTERY-9")).toBe("other");
+  });
+});
+
+describe("groupRulesByFamily", () => {
+  it("orders buckets by family and uses numbered vibe19 labels", () => {
+    const grouped = groupRulesByFamily(["CHW-1", "FC1", "SV-RANGE", "SCHED-1"]);
+    expect(grouped.map(([label]) => label)).toEqual([
+      FAMILY_LABELS.sensor,
+      FAMILY_LABELS.ahu,
+      FAMILY_LABELS.plant,
+      FAMILY_LABELS.schedule,
+    ]);
+    expect(grouped[0][1]).toEqual(["SV-RANGE"]);
+  });
+});

--- a/workspace/dashboard/src/vibe19/families.ts
+++ b/workspace/dashboard/src/vibe19/families.ts
@@ -1,0 +1,92 @@
+/** Mechanical families for rule-tuning grouping — mirrors vibe19
+ * `app/column_map_json.py` FAMILY_LABELS and the cookbook catalog family field. */
+
+export const FAMILY_ORDER = [
+  "sensor",
+  "control",
+  "ahu",
+  "vav",
+  "plant",
+  "heatpump",
+  "weather",
+  "trim",
+  "schedule",
+  "other",
+] as const;
+
+export type RuleFamily = (typeof FAMILY_ORDER)[number];
+
+export const FAMILY_LABELS: Record<RuleFamily, string> = {
+  sensor: "1 · Sensor validation",
+  control: "2 · Control loops",
+  ahu: "3 · AHU / air handling",
+  vav: "4 · VAV / terminal",
+  plant: "5 · Central plant",
+  heatpump: "6 · Heat pump",
+  weather: "7 · Weather / OAT",
+  trim: "8 · Trim & respond",
+  schedule: "9 · Schedule / runtime",
+  other: "10 · Other",
+};
+
+/** Explicit rule_id → family from the vibe19 cookbook catalog (source of truth). */
+const RULE_FAMILY: Record<string, RuleFamily> = {
+  "SV-RANGE": "sensor",
+  "SV-FLATLINE": "sensor",
+  "SV-SPIKE": "sensor",
+  "SV-STALE": "sensor",
+  "SV-RATE": "sensor",
+  "SV-SLEW": "sensor",
+  "PID-HUNT-1": "control",
+  "AHU-SATDEV": "ahu",
+  "AHU-DUCTHI": "ahu",
+  "AHU-SIMUL": "ahu",
+  "OAT-METEO": "ahu",
+  "MECH-OAT-1": "ahu",
+  "CMD-1": "ahu",
+  "OA-1": "ahu",
+  "DMP-1": "ahu",
+  "VLV-1": "ahu",
+  "CHW-NOLOAD-1": "plant",
+  "CW-OPT-1": "plant",
+  "CW-APR-1": "plant",
+  "CW-FAN-1": "plant",
+  "VAV-REHEAT": "vav",
+  "VAV-AHU-LEAVE": "vav",
+  "HP-1": "heatpump",
+  "WX-1": "weather",
+  "SCHED-247": "schedule",
+};
+
+/** Family for a rule id: explicit catalog map first, then prefix inference. */
+export function ruleFamily(ruleId: string): RuleFamily {
+  const id = ruleId.trim().toUpperCase();
+  const explicit = RULE_FAMILY[id];
+  if (explicit) return explicit;
+  const prefix = id.split("-")[0] ?? "";
+  if (prefix === "SV") return "sensor";
+  if (prefix === "PID") return "control";
+  if (/^FC\d+/.test(id) || prefix === "ECON" || prefix === "AHU" || prefix === "OAT") return "ahu";
+  if (prefix === "VAV") return "vav";
+  if (prefix === "CHW" || prefix === "CW" || prefix === "HW") return "plant";
+  if (prefix === "HP") return "heatpump";
+  if (prefix === "WX") return "weather";
+  if (prefix === "TRIM") return "trim";
+  if (prefix === "SCHED") return "schedule";
+  return "other";
+}
+
+/** Group rule ids into ordered [family label, rule ids] buckets (empty families dropped). */
+export function groupRulesByFamily(ruleIds: string[]): [string, string[]][] {
+  const buckets = new Map<RuleFamily, string[]>();
+  for (const id of ruleIds) {
+    const fam = ruleFamily(id);
+    const arr = buckets.get(fam) ?? [];
+    arr.push(id);
+    buckets.set(fam, arr);
+  }
+  return FAMILY_ORDER.filter((f) => buckets.has(f)).map((f) => [
+    FAMILY_LABELS[f],
+    buckets.get(f)!,
+  ]);
+}


### PR DESCRIPTION
## Summary
Stacked on #545 (session config). Radical Lab UX redo so vibe19 users recognize the React app:
- App-wide Streamlit-default palette (`#ff4b4b` accent, `#f0f2f6` / `#0e1117` surfaces, Source Sans); emoji nav icons removed.
- Lab left sidebar: building data → session restore → units → category-filtered per-rule slider expanders (lazy param fetch, local state, explicit Run — no Streamlit rerun wonkiness).
- All **9** frozen sections including **Energy Model**; mechanical family labels from vibe19 catalog.
- `families.ts` + COOKBOOK_ROLES drift guard tests.

## Test plan
- [x] Dashboard vitest (incl. section contract + families + COOKBOOK_ROLES)
- [x] `vite build`
- [ ] CI green
- [ ] Visual: Lab sidebar + section radio feels like vibe19; units switch does not remount analytics

Made with [Cursor](https://cursor.com)