### PR TITLE
feat(ui): standalone Streamlit-parity FDD Lab shell

### DIFF
--- a/workspace/dashboard/src/App.tsx
+++ b/workspace/dashboard/src/App.tsx
@@ -22,19 +22,36 @@ import AlgorithmsPage from "./pages/AlgorithmsPage";
 import DataExportPage from "./pages/DataExportPage";
 import EdgeFleetPage from "./pages/EdgeFleet";
 import { TabErrorBoundary } from "./components/TabDebugPanel";
+import LabShell from "./components/LabShell";
 
 export default function App() {
   return (
-    <DashboardStreamProvider>
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route element={<RequireAuth />}>
+        <Route element={<LabShell />}>
+          <Route
+            path="lab"
+            element={
+              <TabErrorBoundary tab="lab">
+                <Vibe19LabPage />
+              </TabErrorBoundary>
+            }
+          />
+        </Route>
+      </Route>
+      <Route
+        element={
+          <DashboardStreamProvider>
+            <AppLayout />
+          </DashboardStreamProvider>
+        }
+      >
         {/* Public check-engine views — no sign-in required */}
-        <Route element={<AppLayout />}>
-          <Route index element={<HomePage />} />
-          <Route path="faults" element={<Navigate to="/" replace />} />
-          <Route element={<RequireAuth />}>
-            <Route path="lab" element={<TabErrorBoundary tab="lab"><Vibe19LabPage /></TabErrorBoundary>} />
-            <Route path="live-fdd-validation" element={<TabErrorBoundary tab="live-fdd-validation"><LiveFddValidationPage /></TabErrorBoundary>} />
+        <Route index element={<HomePage />} />
+        <Route path="faults" element={<Navigate to="/" replace />} />
+        <Route element={<RequireAuth />}>
+          <Route path="live-fdd-validation" element={<TabErrorBoundary tab="live-fdd-validation"><LiveFddValidationPage /></TabErrorBoundary>} />
             <Route path="bench-5007" element={<Navigate to="/live-fdd-validation" replace />} />
             <Route path="sql-fdd" element={<TabErrorBoundary tab="sql-fdd"><SqlFddRulesPage /></TabErrorBoundary>} />
             <Route path="rule-lab" element={<Navigate to="/lab" replace />} />
@@ -61,9 +78,8 @@ export default function App() {
             <Route path="fdd" element={<Navigate to="/lab" replace />} />
             <Route path="fdd-wires" element={<Navigate to="/model" replace />} />
             <Route path="rules" element={<Navigate to="/model" replace />} />
-          </Route>
         </Route>
-      </Routes>
-    </DashboardStreamProvider>
+      </Route>
+    </Routes>
   );
 }

--- a/workspace/dashboard/src/components/LabShell.tsx
+++ b/workspace/dashboard/src/components/LabShell.tsx
@@ -1,0 +1,39 @@
+import { Link, Outlet, useNavigate } from "react-router-dom";
+import { useTheme } from "../contexts/theme-context";
+import { clearToken, hasToken } from "../lib/api";
+
+/** Minimal chrome for the Streamlit-parity Lab.
+ *
+ * The product navigation intentionally does not wrap `/lab`: vibe19 is one
+ * focused workspace with one data/tuning rail, not two competing sidebars.
+ */
+export default function LabShell() {
+  const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <div className="lab-app-shell">
+      <div className="lab-app-controls" aria-label="Lab controls">
+        <Link to="/" className="lab-product-link">
+          Open-FDD product
+        </Link>
+        <button type="button" className="secondary-btn" onClick={toggleTheme}>
+          {theme === "dark" ? "Light UI" : "Dark UI"}
+        </button>
+        {hasToken() ? (
+          <button
+            type="button"
+            className="secondary-btn"
+            onClick={() => {
+              clearToken();
+              navigate("/login");
+            }}
+          >
+            Sign out
+          </button>
+        ) : null}
+      </div>
+      <Outlet />
+    </div>
+  );
+}

--- a/workspace/dashboard/src/pages/Vibe19LabPage.tsx
+++ b/workspace/dashboard/src/pages/Vibe19LabPage.tsx
@@ -885,12 +885,6 @@ export default function Vibe19LabPage() {
           {section === "FDD Plots" ? <FddPlotsSection rules={rulesQ.data?.rules} /> : null}
           {section === "RCx Plots" ? <RcxPlotsSection /> : null}
           {section === "Metering" ? <MeteringSection /> : null}
-          {section === "Energy Model" ? (
-            <Placeholder
-              title="Energy Model"
-              blurb="WattLab energy model wizard port is tracked separately — section reserved for parity with the vibe19 dashboard contract."
-            />
-          ) : null}
           {section === "Export" ? (
             <Placeholder title="Export" blurb="CSV / session / health / data-model exports." />
           ) : null}

--- a/workspace/dashboard/src/pages/vibe19.css
+++ b/workspace/dashboard/src/pages/vibe19.css
@@ -1,10 +1,28 @@
-/* Streamlit-parity Lab layout: persistent left tuning sidebar + lazy sections. */
+/* Standalone Streamlit-parity Lab: one utility strip and one data/tuning rail. */
+.lab-app-shell {
+  min-height: 100vh;
+  background: var(--bg, #fff);
+}
+
+.lab-app-controls {
+  min-height: 2.75rem;
+  padding: 0.4rem 1.5rem 0.4rem calc(21rem + 1.5rem);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--border, #e3e6ee);
+}
+
+.lab-product-link {
+  margin-right: auto;
+  font-size: 0.86rem;
+}
+
 .vibe19-shell {
   display: grid;
-  grid-template-columns: minmax(280px, 320px) 1fr;
-  gap: 1.25rem;
-  padding: 0.5rem 0 2rem;
-  align-items: start;
+  grid-template-columns: 21rem minmax(0, 1fr);
+  min-height: calc(100vh - 2.75rem);
 }
 
 .vibe19-content {
@@ -12,6 +30,7 @@
   flex-direction: column;
   gap: 1rem;
   min-width: 0;
+  padding: 1.5rem 2.25rem 3rem;
 }
 
 .vibe19-hero h1 {
@@ -59,16 +78,17 @@
 
 /* Streamlit-style page sidebar (secondary background, full height). */
 .vibe19-lab-sidebar {
-  background: var(--panel-soft, #f0f2f6);
-  border: 1px solid var(--border, #e3e6ee);
-  border-radius: 10px;
-  padding: 0.9rem;
+  background: var(--sidebar-bg, #f0f2f6);
+  border: 0;
+  border-right: 1px solid var(--border, #e3e6ee);
+  border-radius: 0;
+  padding: 1.5rem 1.25rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
   position: sticky;
-  top: 0.5rem;
-  max-height: calc(100vh - 1rem);
+  top: 0;
+  height: calc(100vh - 2.75rem);
   overflow: auto;
 }
 
@@ -285,12 +305,17 @@
 }
 
 @media (max-width: 1100px) {
+  .lab-app-controls {
+    padding-left: 1rem;
+  }
   .vibe19-shell {
     grid-template-columns: 1fr;
   }
   .vibe19-lab-sidebar {
     position: static;
-    max-height: none;
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--border, #e3e6ee);
   }
 }
 

--- a/workspace/dashboard/src/vibe19/charts.test.ts
+++ b/workspace/dashboard/src/vibe19/charts.test.ts
@@ -18,7 +18,7 @@ import {
 } from "./contract";
 
 describe("vibe19 contract", () => {
-  it("keeps frozen main sections (all nine, vibe19 order)", () => {
+  it("keeps the frozen eight sections and excludes Energy Model", () => {
     expect([...VIBE19_SECTIONS]).toEqual([
       "Overview",
       "Data Model",
@@ -27,9 +27,9 @@ describe("vibe19 contract", () => {
       "FDD Plots",
       "RCx Plots",
       "Metering",
-      "Energy Model",
       "Export",
     ]);
+    expect(VIBE19_SECTIONS).not.toContain("Energy Model");
   });
 
   it("lists required chart APIs", () => {

--- a/workspace/dashboard/src/vibe19/contract.ts
+++ b/workspace/dashboard/src/vibe19/contract.ts
@@ -8,7 +8,6 @@ export const VIBE19_SECTIONS = [
   "FDD Plots",
   "RCx Plots",
   "Metering",
-  "Energy Model",
   "Export",
 ] as const;
 


### PR DESCRIPTION
## Summary
- Moves `/lab` outside the full product navigation and dashboard polling provider so the Lab has one Streamlit-style rail.
- Restores the current vibe19 eight-section contract and removes the retired Energy Model section.
- Makes the Lab full-height/full-width with a minimal product/theme/sign-out strip.

## Test plan
- [x] `npm test -- --run` (76 tests)
- [x] `npm run build`
- [ ] Human compare `/lab` shell against vibe19 Streamlit

Part 1 of the Lab UX + #549 + #550 nightly cycle.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Lab layout with product navigation, theme controls, and sign-out access.
  * Improved Lab page structure and responsive behavior across screen sizes.
  * Added protected routing for Lab content.

* **Changes**
  * Removed the Energy Model section and its placeholder display from the Lab.
  * Preserved the remaining eight Lab sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->