### PR TITLE
feat(lab): live Streamlit workflow + MCP accuracy tools

### DIFF
--- a/crates/fdd_rules/src/lib.rs
+++ b/crates/fdd_rules/src/lib.rs
@@ -7,7 +7,7 @@ pub mod tuning;
 
 pub use params::{poll_params, read_poll_from_cache, rule_params, substitute_sql};
 pub use registry::{load_registry, RuleParameterDef, RuleRegistry, RuleSpec};
-pub use runner::{run_all_rules, RuleRunReport};
+pub use runner::{run_all_rules, run_all_rules_with_overrides, RuleRunReport};
 pub use tuning::{effective_param_strings, load_tuning_profiles};
 
 #[cfg(test)]

--- a/crates/fdd_rules/src/runner.rs
+++ b/crates/fdd_rules/src/runner.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::Result;
@@ -33,6 +34,20 @@ pub async fn run_all_rules(
     parquet_root: &Path,
     registry: &RuleRegistry,
     out_dir: &Path,
+) -> Result<RuleRunReport> {
+    run_all_rules_with_overrides(parquet_root, registry, out_dir, &HashMap::new(), None).await
+}
+
+/// Run registry rules with request/session parameter overrides.
+///
+/// Keys are canonical rule IDs and registry parameter names. This keeps the
+/// HTTP layer typed: arbitrary SQL is never accepted from the dashboard.
+pub async fn run_all_rules_with_overrides(
+    parquet_root: &Path,
+    registry: &RuleRegistry,
+    out_dir: &Path,
+    overrides: &HashMap<String, HashMap<String, f64>>,
+    equipment_filter: Option<&str>,
 ) -> Result<RuleRunReport> {
     let started = std::time::Instant::now();
     std::fs::create_dir_all(out_dir)?;
@@ -78,7 +93,8 @@ pub async fn run_all_rules(
         }
         let confirm_secs = rule.confirm_seconds;
         let mut params = rule_params(poll_seconds, confirm_secs);
-        if let Ok(tuned) = effective_param_strings(rule, &tuning, None, None, None) {
+        let session_override = overrides.get(&rule.rule_id);
+        if let Ok(tuned) = effective_param_strings(rule, &tuning, None, None, session_override) {
             for (k, v) in tuned {
                 params.insert(k, v);
             }
@@ -90,7 +106,15 @@ pub async fn run_all_rules(
                 params.insert("CONFIRM_ROWS".into(), rows.to_string());
             }
         }
-        let sql = substitute_sql(&raw_sql, &params);
+        let mut sql = substitute_sql(&raw_sql, &params);
+        if let Some(equipment_id) = equipment_filter {
+            let escaped = equipment_id.replace('\'', "''");
+            sql = format!(
+                "SELECT * FROM ({}) filtered_rule WHERE equipment_id = '{}'",
+                sql.trim().trim_end_matches(';'),
+                escaped
+            );
+        }
         match run_sql(&ctx, &sql).await {
             Ok(result) => {
                 std::fs::write(

--- a/docs/agent/linux-edge-tester-stack-recipes-prompt.md
+++ b/docs/agent/linux-edge-tester-stack-recipes-prompt.md
@@ -35,11 +35,13 @@ Charter:
 - GHCR `:nightly` (or pinned `sha-*`) only — no local product builds, no product code PRs.
 - Test, document, file/comment GitHub issues. The WSL product agent owns closing/keeping issues after your report.
 - Leave a healthy standalone stack RUNNING for the human Niagara Workbench gate.
+- MCP is its OWN container/image (`ghcr.io/bbartling/openfdd-mcp`). A healthy MCP process alone is NOT a pass — answers must match direct central API truth.
 
 Goal:
 1. Pull fresh GHCR images (central, ui, fieldbus, mqtt, mcp). Record image digests + git revision
    label from `docker inspect` / image labels. On Pi: `docker pull --platform linux/amd64 …`
    and assert bench↔Pi digests match (or FAIL with NEEDS PRODUCT FIX on #530).
+   Assert MCP digest/revision aligns with the same tip as central/ui (same OPENFDD_IMAGE_TAG).
 2. Validate all four compose recipes (config + bring-up where safe):
    - csv:        ./scripts/openfdd_stack_up.sh csv
    - central:    ./scripts/openfdd_stack_up.sh central   (needs MQTT certs)
@@ -53,11 +55,12 @@ Goal:
    - plain wide CSV WITHOUT equipment_id column must still preflight verdict=pass (#536)
    - assert parquet_ingest.ok
    - column literally named fan_cmd must survive into parquet / FC1 schema
-   - POST /api/fdd/run mode=registry rule_ids=["FC1"] (also try "FC13" alias)
+   - POST /api/fdd/run mode=registry rule_ids=["FC1"] (also try "FC13" alias → FC13-SAT-HIGH)
    - assert rules_succeeded≥1; note poll_seconds / grid_minutes for 1-min fixtures
-5. openfdd_package_v1 ZIP (if #514 shipped on this nightly):
-   - upload a minimal package zip via POST /api/csv/import/package
-   - assert equipment roles + parquet; edit roles via /api/csv/import/package/roles
+   - assert response includes results[] rows with rule_id / equipment_id / status (not aggregates-only)
+5. openfdd_package_v1 ZIP:
+   - prefer IN-LAB upload on /lab (sidebar) OR POST /api/csv/import/package
+   - assert equipment roles + parquet; edit roles via package roles API
    - session_config.json inside the zip should seed GET /api/fdd/session-config (#515)
 6. Weather + FD soak (gate 08 — critical after #535):
    - Sample fieldbus container FD count at t=0 and t≈30 min (`ls /proc/<pid>/fd | wc -l`
@@ -77,9 +80,45 @@ Goal:
    - Assert GET point decode + scale, JSONPath miss → structured error, bearer/API-key auth,
      write 403 when disabled, write clamp, circuit-breaker on sim kill,
      FD-count stability across ≥500 polls (no #535-style leak on reqwest).
-10. Optional cloud-sim / multi-site if LAN allows (Pi remote edge) — attach evidence to #519 / #530.
-11. Leave standalone healthy and RUNNING. Do not docker compose down. Do not prune volumes.
-12. Human gate: Niagara Workbench discovery + trend of 599999 (Madison) and 600000 (Chicago if Pi).
+10. Lab UX IA gate (Streamlit parity — FAIL if any miss):
+   - UI http://<bench-ip>:3000/lab is a FULL-BLEED lab shell — NOT wrapped in product
+     Integrations/Ops nav. Theme toggle + logout OK; no DashboardStream 15s polls to missing APIs.
+   - Exactly **8** horizontal sections (no Energy Model):
+     Overview → Data Model → Run Rules → Results by Category → FDD Plots → RCx Plots → Metering → Export
+   - Left rail: package ZIP + session save/load + display/site + rule family/sliders + Reset/Rerun cat.
+   - Center: equipment select + section radio.
+   - Results by Category groups by **equipment_type** (not parity_status); PASS/FAULT/SKIPPED metrics.
+   - FDD Plots: live series via /api/fdd/series (or honest empty). RCx/Metering: NO fake sine waves.
+   - Run Rules: explicit Run; sliders do not refetch until Run / Rerun cat.
+11. #549 central dashboard API matrix (product shell — not Lab):
+   - GET each must NOT 404: /api/health/stack, /api/building/snapshot, /api/faults/status,
+     /api/export/meta, /api/data-management/summary, /api/host/stats, /api/fdd-schema/tables,
+     /api/fdd-rules, /api/reports, /api/reports/templates, /api/capabilities
+   - GET /api/capabilities: reports/export/host_stats/faults/health_stack/data_management true
+   - Report Builder: must NOT auto-POST /api/reports/draft on page load (create only on user action)
+   - Product nav items with requiredCapability disable/hide when capability false
+12. #550 parity honesty (docs + behavior — do NOT claim full cookbook parity):
+   - Docs/registry story: ~18 proven_building_100, ~44 ported_from_cookbook, FC7 skipped.
+     “ported ≠ oracle.” FAIL the soak narrative if UI/docs still say “54 full parity”.
+   - Spot-check: SCHED-1 can consume string occ_mode (unoccupied/occupied) after package/CSV ingest.
+   - Note remaining oracle backlog (SV-*, PID-HUNT-1, FC4/6/14/15, TRIM-*, …) as KEEP OPEN on #550.
+13. Standalone MCP accuracy gate (OWN container — required):
+   - Pull/run `ghcr.io/bbartling/openfdd-mcp:${OPENFDD_IMAGE_TAG}` separately (compose profile `mcp`
+     or `docker run -i`). Do NOT accept MCP embedded inside central/ui.
+   - Record MCP image digest + org.opencontainers.image.revision; must match tip with central.
+   - initialize + tools/list must include at least:
+     openfdd_health, openfdd_fdd_registry, openfdd_fdd_equipment, openfdd_fdd_results,
+     openfdd_fdd_series, openfdd_fdd_accuracy_snapshot, openfdd_capabilities (or equiv)
+   - Accuracy: for the same JWT/base URL, MCP tool payloads must EQUAL direct curl to
+     /api/fdd/rules, /api/fdd/equipment, /api/fdd/results (rule_id lists, equipment ids/types,
+     result status/fault_hours). Prefer tools/call openfdd_fdd_accuracy_snapshot → ok=true.
+   - Negative cases (structured errors, not plausible fakes):
+     unknown equipment_id / rule_id on series; central stopped / bad token; raw SQL rejected on run.
+   - Optional local: scripts/release/smoke_mcp_central.sh against the pulled images if docker build
+     is unavailable — still require MCP↔central equality evidence in the report.
+14. Optional cloud-sim / multi-site if LAN allows (Pi remote edge) — attach evidence to #519 / #530.
+15. Leave standalone healthy and RUNNING. Do not docker compose down. Do not prune volumes.
+16. Human gate: Niagara Workbench discovery + trend of 599999 (Madison) and 600000 (Chicago if Pi).
     Prepare evidence only; only a human records OT PASS.
 
 Never:
@@ -90,6 +129,8 @@ Never:
 - Close or reopen GitHub issues yourself (product agent manages GH from your triage table)
 - Weaken tests or invent product workarounds as “PASS”
 - Silently accept a stale local image when GHCR pull fails on arm64
+- Treat MCP “process up” as accuracy PASS
+- Claim SQL↔Pandas full parity for ported_from_cookbook rules
 
 GitHub issue workflow (required):
 1. Before testing: `gh issue list --state open --limit 40` and note numbers that apply to this soak.
@@ -112,36 +153,44 @@ KEEP OPEN / retest:
 - #530 No arm64 GHCR fieldbus image — RAISE PRIORITY (silent stale-image caused device-ID collision)
 - #519 Multi-site MQTT subscribe / ACL / site_id on /api/edges
 - #520 Feather→parquet live compaction
-- #514–#518 Streamlit parity (CLOSE any that this nightly proves shipped: ZIP #514, session #515, UI)
+- #516 Occupancy calendar / ops gates UI+SQL
+- #517 Live Open-Meteo psychrometrics in Lab charts
+- #518 DOCX / WattLab RCx Word export
+- #550 SQL↔Pandas oracle parity (phase 1 docs/harness may land; full rewrite NOT done)
 
-Expect CLOSED on tip nightlies after #541/#542 (confirm still green; do not reopen if PASS):
+CLOSE candidates when this nightly proves them (comment evidence first):
+- #549 Central missing edge dashboard APIs (routes 200 + capabilities + no eager report draft)
+- Lab UX regressions previously filed as F+ theme-only (if gates 10 all PASS — cite PR tip)
+
+Expect CLOSED on tip nightlies after prior soaks (confirm still green; do not reopen if PASS):
+- #514 package ZIP, #515 session_config
 - #535 BACnet client UDP FD leak (P0) — verify FD flat over soak
 - #536 EQUIPMENT_ID_MISSING no longer fail-closes strict execute
 - #537 I-Am vendor_id 999
 - #539 /bacnet/whois honors low/high range
+- #540 REST/JSON edge driver — re-run gate 09
 - #531 OPENFDD_BACNET_DEVICE_INSTANCE env (verified; crash-loop remainder only if still seen)
-
-In flight / verify if merged:
-- #540 REST/JSON edge driver (draft→merge) — run gate 09 when image contains /rest/*
 
 Evidence to collect:
 - docker images ls | grep openfdd
-- digests + org.opencontainers.image.revision (bench AND Pi)
+- digests + org.opencontainers.image.revision for central, ui, fieldbus, mqtt, **mcp** (bench AND Pi)
 - docker compose -f docker/compose.standalone.yml ps
 - curl -fsS http://127.0.0.1:8080/api/health
+- curl capabilities + #549 route matrix status codes
 - ingest/stats + edges JSON (redact secrets)
 - csv execute including parquet_ingest + wide CSV without equipment_id → verdict pass
-- package zip upload (if shipped) + role edit
-- fdd/run response (rules_succeeded, poll_seconds)
+- package zip (in-lab and/or API) + role edit + session-config
+- fdd/run response (rules_succeeded, poll_seconds, results[])
+- Lab screenshots or DOM notes: 8 sections, no product nav, Results by equipment_type
+- MCP tools/list + accuracy_snapshot + MCP vs curl equality snippets
 - Who-Is range filter result; I-Am vendor_id hex/APDU
 - fieldbus FD count t=0 vs t≈30m
 - weather before/after + Open-Meteo MATCH
 - REST gate 09 results (if shipped)
-- UI http://<bench-ip>:3000 — Lab looks Streamlit-like (sidebar rule tuning, 9 sections, red accent)
 
 Final report structure (paste back to product agent):
-1. Images under test (tag, digest, revision) — bench + Pi
-2. Gate matrix (00–09) PASS/FAIL
+1. Images under test (tag, digest, revision) — bench + Pi — include MCP
+2. Gate matrix (00–13) PASS/FAIL including Lab IA, #549, #550 honesty, MCP accuracy
 3. Issue triage table (CLOSE / KEEP OPEN / NEEDS PRODUCT FIX) — required
 4. New issues filed (numbers + titles) or “none”
 5. Leave-running confirmation (nofile ulimit note if still elevated)
@@ -156,6 +205,13 @@ See [Build recipes](../operations/build-recipes.md). Helper scripts:
 export OPENFDD_IMAGE_TAG=nightly
 # pin when bisecting: e.g. OPENFDD_IMAGE_TAG=sha-<rev>
 ./scripts/openfdd_stack_pull.sh all
+./scripts/openfdd_stack_pull.sh mcp
 ./scripts/openfdd_stack_up.sh csv
 ./scripts/openfdd_stack_up.sh standalone
+```
+
+MCP accuracy helper (optional when images are local/CI-tagged):
+
+```bash
+./scripts/release/smoke_mcp_central.sh
 ```

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use fdd_rules::{
-    effective_param_strings, load_registry, load_tuning_profiles, rule_params, run_all_rules,
-    substitute_sql, RuleRegistry, RuleSpec,
+    effective_param_strings, load_registry, load_tuning_profiles, rule_params,
+    run_all_rules_with_overrides, substitute_sql, RuleRegistry, RuleSpec,
 };
+use fdd_sql::{register_parquet_tree, run_sql};
 use serde_json::{json, Value};
 
 fn sql_rules_dir() -> PathBuf {
@@ -198,6 +199,181 @@ fn walkdir_count(root: &Path, ext: &str) -> usize {
         .count()
 }
 
+fn infer_equipment_type(equipment_id: &str) -> &'static str {
+    let id = equipment_id.to_ascii_uppercase();
+    if id.contains("VAV") || id.contains("ZONE") {
+        "VAV"
+    } else if id.contains("AHU") || id.contains("RTU") || id.contains("MAU") {
+        "AHU"
+    } else if id.contains("CHILL")
+        || id.contains("BOILER")
+        || id.contains("PUMP")
+        || id.contains("TOWER")
+    {
+        "PLANT"
+    } else if id.contains("HP") || id.contains("HEAT_PUMP") {
+        "HEAT_PUMP"
+    } else if id.contains("METER") {
+        "METER"
+    } else {
+        "GENERAL"
+    }
+}
+
+/// `GET /api/fdd/equipment` — equipment present in the parquet cache.
+pub fn equipment_response() -> Value {
+    let root = parquet_root();
+    let mut ids = Vec::new();
+    if root.is_dir() {
+        for entry in walkdir::WalkDir::new(&root)
+            .min_depth(1)
+            .max_depth(3)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_dir())
+        {
+            if let Some(id) = entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.strip_prefix("equipment="))
+            {
+                ids.push(id.to_string());
+            }
+        }
+    }
+    ids.sort();
+    ids.dedup();
+    let equipment: Vec<Value> = ids
+        .iter()
+        .map(|id| {
+            json!({
+                "equipment_id": id,
+                "equipment_type": infer_equipment_type(id),
+            })
+        })
+        .collect();
+    json!({"ok": true, "count": equipment.len(), "equipment": equipment})
+}
+
+/// `GET /api/fdd/results` — normalized rows from the most recent registry run.
+pub fn results_response() -> Value {
+    let dir = results_dir();
+    let reg = load_reg().ok();
+    let mut metadata = HashMap::new();
+    if let Some(reg) = &reg {
+        for rule in &reg.rules {
+            metadata.insert(rule.rule_id.clone(), rule.description.clone());
+        }
+    }
+    let mut rows = Vec::new();
+    if dir.is_dir() {
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("json"))
+            .collect();
+        files.sort();
+        for path in files {
+            let Some(rule_id) = path.file_stem().and_then(|x| x.to_str()) else {
+                continue;
+            };
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(body) = serde_json::from_str::<Value>(&text) else {
+                continue;
+            };
+            for row in body
+                .get("rows")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let equipment_id = row
+                    .get("equipment_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                let fault_hours = row
+                    .get("fault_hours")
+                    .and_then(Value::as_f64)
+                    .unwrap_or(0.0);
+                rows.push(json!({
+                    "rule_id": rule_id,
+                    "title": metadata.get(rule_id).cloned().unwrap_or_default(),
+                    "equipment_id": equipment_id,
+                    "equipment_type": infer_equipment_type(equipment_id),
+                    "status": if fault_hours > 0.0 { "FAULT" } else { "PASS" },
+                    "fault_hours": fault_hours,
+                    "fault_pct": row.get("fault_pct").and_then(Value::as_f64),
+                    "missing_roles": [],
+                    "notes": row.get("notes").cloned().unwrap_or(Value::Null),
+                }));
+            }
+        }
+    }
+    json!({"ok": true, "count": rows.len(), "results": rows})
+}
+
+/// Downsampled history series for one equipment/rule. Rule math continues to
+/// use full-resolution parquet; only this display response is capped.
+pub fn series_response(equipment_id: &str, rule_id: &str) -> Value {
+    let reg = match load_reg() {
+        Ok(r) => r,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let Some(rule) = reg
+        .rules
+        .iter()
+        .find(|r| r.rule_id == rule_id || r.aliases.iter().any(|a| a == rule_id))
+    else {
+        return json!({"ok": false, "error": format!("unknown rule_id {rule_id}")});
+    };
+    let columns: Vec<&str> = rule
+        .required_roles
+        .iter()
+        .map(String::as_str)
+        .filter(|name| name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
+        .collect();
+    if columns.is_empty() {
+        return json!({"ok": true, "equipment_id": equipment_id, "rule_id": rule.rule_id, "rows": []});
+    }
+    let escaped_equipment = equipment_id.replace('\'', "''");
+    let sql = format!(
+        "SELECT timestamp_utc, equipment_id, {} FROM history WHERE equipment_id = '{}' ORDER BY timestamp_utc LIMIT 5000",
+        columns.join(", "),
+        escaped_equipment
+    );
+    let root = parquet_root();
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => return json!({"ok": false, "error": format!("runtime: {e}")}),
+    };
+    rt.block_on(async {
+        let ctx = datafusion::prelude::SessionContext::new();
+        if let Err(e) = register_parquet_tree(&ctx, &root).await {
+            return json!({"ok": false, "error": e.to_string()});
+        }
+        match run_sql(&ctx, &sql).await {
+            Ok(result) => json!({
+                "ok": true,
+                "equipment_id": equipment_id,
+                "equipment_type": infer_equipment_type(equipment_id),
+                "rule_id": rule.rule_id,
+                "roles": columns,
+                "rows": result.rows,
+                "downsampled": result.row_count >= 5000,
+                "max_points": 5000,
+            }),
+            Err(e) => json!({"ok": false, "error": e.to_string()}),
+        }
+    })
+}
+
 /// `GET /api/fdd/roles` — role map file if present.
 pub fn roles_response() -> Value {
     let candidates = [
@@ -281,21 +457,40 @@ pub fn run_registry(payload: &Value) -> Value {
         return json!({"ok": false, "error": "no matching rules to run"});
     }
 
-    // Apply request overrides into a temp tuning overlay via env is overkill;
-    // runner uses registry defaults + rule_tuning/. Request params are applied
-    // by rewriting confirm_seconds on a per-rule clone when provided.
+    // Normalize aliases and pass typed request overrides into the runner.
     let mut effective = filtered.clone();
+    let mut session_overrides: HashMap<String, HashMap<String, f64>> = HashMap::new();
     if let Some(params_by_rule) = payload.get("params").and_then(|v| v.as_object()) {
         for rule in &mut effective.rules {
-            if let Some(p) = params_by_rule
-                .get(&rule.rule_id)
-                .and_then(|v| v.as_object())
-            {
+            let supplied = params_by_rule.get(&rule.rule_id).or_else(|| {
+                rule.aliases
+                    .iter()
+                    .find_map(|alias| params_by_rule.get(alias))
+            });
+            if let Some(p) = supplied.and_then(|v| v.as_object()) {
                 if let Some(cm) = p.get("confirm_min").and_then(|v| v.as_f64()) {
                     rule.confirm_seconds = (cm * 60.0).round() as u32;
                 }
                 if let Some(cs) = p.get("confirm_seconds").and_then(|v| v.as_f64()) {
                     rule.confirm_seconds = cs.round() as u32;
+                }
+                let mut typed = HashMap::new();
+                for (key, value) in p {
+                    let Some(number) = value.as_f64() else {
+                        continue;
+                    };
+                    if rule.parameters.contains_key(key) {
+                        typed.insert(key.clone(), number);
+                    } else if let Some((param_key, _)) = rule
+                        .parameters
+                        .iter()
+                        .find(|(_, def)| def.sql_placeholder == *key)
+                    {
+                        typed.insert(param_key.clone(), number);
+                    }
+                }
+                if !typed.is_empty() {
+                    session_overrides.insert(rule.rule_id.clone(), typed);
                 }
             }
         }
@@ -309,19 +504,29 @@ pub fn run_registry(payload: &Value) -> Value {
         Ok(r) => r,
         Err(e) => return json!({"ok": false, "error": format!("runtime: {e}")}),
     };
-    match rt.block_on(run_all_rules(&pq, &effective, &out)) {
-        Ok(report) => json!({
-            "ok": true,
-            "engine": "fdd_rules+DataFusion",
-            "mode": "registry",
-            "rules_run": report.rules_run,
-            "rules_succeeded": report.rules_succeeded,
-            "rules_failed": report.rules_failed,
-            "poll_seconds": report.poll_seconds,
-            "total_ms": report.total_ms,
-            "timings": report.timings,
-            "results_dir": out.display().to_string(),
-        }),
+    match rt.block_on(run_all_rules_with_overrides(
+        &pq,
+        &effective,
+        &out,
+        &session_overrides,
+        payload.get("equipment_id").and_then(Value::as_str),
+    )) {
+        Ok(report) => {
+            let normalized = results_response();
+            json!({
+                "ok": true,
+                "engine": "fdd_rules+DataFusion",
+                "mode": "registry",
+                "rules_run": report.rules_run,
+                "rules_succeeded": report.rules_succeeded,
+                "rules_failed": report.rules_failed,
+                "poll_seconds": report.poll_seconds,
+                "total_ms": report.total_ms,
+                "timings": report.timings,
+                "results_dir": out.display().to_string(),
+                "results": normalized.get("results").cloned().unwrap_or_else(|| json!([])),
+            })
+        }
         Err(e) => json!({"ok": false, "error": e.to_string()}),
     }
 }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -109,9 +109,15 @@ docker run -i --rm --network host \
 | `openfdd_csv_fusion_preview` | Merged grid preview |
 | `openfdd_csv_import_execute` | Save to Arrow (write gate) |
 | `openfdd_historian_query` | Historian pivot query |
-| `openfdd_fdd_rules_list` | FDD rule catalog |
+| `openfdd_fdd_rules_list` | Legacy wire/SQL FDD rule catalog |
+| `openfdd_fdd_registry` | Production DataFusion registry |
+| `openfdd_fdd_equipment` | Loaded equipment IDs/types |
+| `openfdd_fdd_results` | Latest per-equipment rule outcomes |
+| `openfdd_fdd_series` | Mapped live display series |
+| `openfdd_fdd_session_config` | Active units / role map / tuning |
+| `openfdd_fdd_accuracy_snapshot` | MCP vs central count parity check |
 | `openfdd_fdd_rule_test_sql` | Test rule SQL |
-| `openfdd_fdd_run` | Run ad-hoc FDD SQL (write gate) |
+| `openfdd_fdd_run` | Run typed registry FDD rules (write gate) |
 | `openfdd_model_assignments_save` | Save assignments (write gate) |
 | `openfdd_reports_draft` / `patch` / `render_pdf` | Report → PDF pipeline (write gate) |
 

--- a/mcp/src/bridge.rs
+++ b/mcp/src/bridge.rs
@@ -67,11 +67,15 @@ impl BridgeClient {
     }
 
     fn request(&self, req: reqwest::blocking::RequestBuilder) -> Result<Value, String> {
-        self.auth(req)
-            .send()
-            .map_err(|e| e.to_string())?
-            .json()
-            .map_err(|e| e.to_string())
+        let response = self.auth(req).send().map_err(|e| e.to_string())?;
+        let status = response.status();
+        let text = response.text().map_err(|e| e.to_string())?;
+        let body: Value = serde_json::from_str(&text)
+            .map_err(|e| format!("HTTP {status}: invalid JSON response ({e}): {text}"))?;
+        if !status.is_success() {
+            return Err(format!("HTTP {status}: {body}"));
+        }
+        Ok(body)
     }
 
     pub fn csv_import_preview(&self, args: &Value) -> Result<Value, String> {
@@ -361,6 +365,81 @@ impl BridgeClient {
         self.get("/api/fdd-rules")
     }
 
+    pub fn fdd_series(&self, equipment_id: &str, rule_id: &str) -> Result<Value, String> {
+        let mut url =
+            reqwest::Url::parse(&self.url("/api/fdd/series")).map_err(|e| e.to_string())?;
+        url.query_pairs_mut()
+            .append_pair("equipment_id", equipment_id)
+            .append_pair("rule_id", rule_id);
+        self.request(self.http.get(url))
+    }
+
+    /// Fetch the same central truth surfaces exposed as individual MCP tools
+    /// and verify their count fields against the arrays actually returned.
+    pub fn fdd_accuracy_snapshot(&self) -> Result<Value, String> {
+        let registry = self.get("/api/fdd/rules")?;
+        let equipment = self.get("/api/fdd/equipment")?;
+        let results = self.get("/api/fdd/results")?;
+        let capabilities = self.get("/api/capabilities").unwrap_or_else(|error| {
+            json!({
+                "ok": false,
+                "optional": true,
+                "error": error,
+                "hint": "capabilities will be required after #549 lands"
+            })
+        });
+
+        let checks = [
+            (
+                "registry_count",
+                registry.get("count").and_then(Value::as_u64),
+                registry
+                    .get("rules")
+                    .and_then(Value::as_array)
+                    .map(|rows| rows.len() as u64),
+            ),
+            (
+                "equipment_count",
+                equipment.get("count").and_then(Value::as_u64),
+                equipment
+                    .get("equipment")
+                    .and_then(Value::as_array)
+                    .map(|rows| rows.len() as u64),
+            ),
+            (
+                "results_count",
+                results.get("count").and_then(Value::as_u64),
+                results
+                    .get("results")
+                    .and_then(Value::as_array)
+                    .map(|rows| rows.len() as u64),
+            ),
+        ];
+        let check_rows: Vec<Value> = checks
+            .into_iter()
+            .map(|(name, declared, actual)| {
+                json!({
+                    "name": name,
+                    "ok": declared.is_some() && declared == actual,
+                    "declared": declared,
+                    "actual": actual,
+                })
+            })
+            .collect();
+        let ok = check_rows
+            .iter()
+            .all(|row| row.get("ok").and_then(Value::as_bool) == Some(true));
+
+        Ok(json!({
+            "ok": ok,
+            "checks": check_rows,
+            "registry": registry,
+            "equipment": equipment,
+            "results": results,
+            "capabilities": capabilities,
+        }))
+    }
+
     pub fn fdd_rule_test_sql(&self, args: &Value) -> Result<Value, String> {
         let rule_id = args
             .get("rule_id")
@@ -374,9 +453,17 @@ impl BridgeClient {
     }
 
     pub fn fdd_run(&self, args: &Value) -> Result<Value, String> {
+        if args
+            .get("sql")
+            .and_then(Value::as_str)
+            .is_some_and(|s| !s.trim().is_empty())
+        {
+            return Err("raw SQL rejected — use mode=registry with typed rule_ids/params".into());
+        }
         let mut body = args.clone();
         if let Some(obj) = body.as_object_mut() {
             obj.remove("confirm");
+            obj.insert("mode".into(), json!("registry"));
         }
         self.post("/api/fdd/run", &body)
     }

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -63,7 +63,10 @@ impl Server {
             tool("openfdd_bench_topology", "Bench NIC, API bases, driver endpoints (from OPENFDD_BENCH_TOPOLOGY_FILE or doc pointer)", json!({})),
             tool("openfdd_driver_status", "Poll bridge driver status endpoints", json!({})),
             tool("openfdd_health", "GET /api/health (public liveness)", json!({})),
+            tool("openfdd_capabilities", "GET /api/capabilities — central feature contract", json!({})),
             tool("openfdd_stack_status", "GET /api/health/stack — data plane strip (JWT)", json!({})),
+            tool("openfdd_faults_status", "GET /api/faults/status — live fault subsystem status", json!({})),
+            tool("openfdd_export_meta", "GET /api/export/meta — available export contract", json!({})),
             tool("openfdd_haystack_status", "GET /api/haystack/status", json!({})),
             tool("openfdd_haystack_test", "POST /api/haystack/test", json!({})),
             tool("openfdd_haystack_read", "POST /api/haystack/read", json!({"filter": {"type": "string"}})),
@@ -132,17 +135,26 @@ impl Server {
                 "equipment_id": {"type": "string"}
             })),
             tool("openfdd_fdd_rules_list", "GET /api/fdd-rules — list wire/SQL fault rules", json!({})),
+            tool("openfdd_fdd_registry", "GET /api/fdd/rules — production DataFusion registry", json!({})),
+            tool("openfdd_fdd_equipment", "GET /api/fdd/equipment — loaded equipment IDs and types", json!({})),
+            tool("openfdd_fdd_results", "GET /api/fdd/results — latest per-equipment rule outcomes", json!({})),
+            tool("openfdd_fdd_series", "GET /api/fdd/series — mapped live display series (max 5000 points)", json!({
+                "equipment_id": {"type": "string"},
+                "rule_id": {"type": "string"}
+            })),
+            tool("openfdd_fdd_session_config", "GET /api/fdd/session-config — active units, role map, and typed tuning", json!({})),
+            tool("openfdd_fdd_accuracy_snapshot", "Cross-check registry/equipment/result counts against central truth without inventing defaults", json!({})),
             tool("openfdd_fdd_rule_test_sql", "POST /api/fdd-rules/{id}/test-sql — dry-run rule SQL on sample/historian data", json!({
                 "rule_id": {"type": "string"},
                 "sql": {"type": "string"},
                 "params": {"type": "object"},
                 "confirmation_seconds": {"type": "integer"}
             })),
-            tool("openfdd_fdd_run", "POST /api/fdd/run — execute ad-hoc DataFusion SQL FDD (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
+            tool("openfdd_fdd_run", "POST /api/fdd/run — execute production registry rules with typed params (write gate)", json!({
                 "confirm": {"type": "boolean", "description": "Must be true"},
-                "sql": {"type": "string"},
-                "params": {"type": "object"},
-                "confirmation_seconds": {"type": "integer"}
+                "rule_ids": {"type": "array", "items": {"type": "string"}},
+                "equipment_id": {"type": "string"},
+                "params": {"type": "object", "description": "rule_id → typed parameter overrides"}
             })),
             tool("openfdd_model_assignments_save", "POST /api/model/assignments/save — persist Haystack assignments (write: confirm:true + OPENFDD_MCP_ALLOW_WRITES=1)", json!({
                 "confirm": {"type": "boolean"},
@@ -218,7 +230,10 @@ impl Server {
             "openfdd_bench_topology" => Ok(self.bridge.bench_topology()),
             "openfdd_driver_status" => Ok(self.bridge.driver_status()),
             "openfdd_health" => self.bridge.get("/api/health"),
+            "openfdd_capabilities" => self.bridge.get("/api/capabilities"),
             "openfdd_stack_status" => self.bridge.get("/api/health/stack"),
+            "openfdd_faults_status" => self.bridge.get("/api/faults/status"),
+            "openfdd_export_meta" => self.bridge.get("/api/export/meta"),
             "openfdd_haystack_status" => self.bridge.get("/api/haystack/status"),
             "openfdd_haystack_test" => self.bridge.post("/api/haystack/test", &json!({})),
             "openfdd_haystack_read" => self.bridge.haystack_read(args),
@@ -285,6 +300,22 @@ impl Server {
             }
             "openfdd_historian_query" => self.bridge.historian_query(args),
             "openfdd_fdd_rules_list" => self.bridge.fdd_rules_list(),
+            "openfdd_fdd_registry" => self.bridge.get("/api/fdd/rules"),
+            "openfdd_fdd_equipment" => self.bridge.get("/api/fdd/equipment"),
+            "openfdd_fdd_results" => self.bridge.get("/api/fdd/results"),
+            "openfdd_fdd_series" => {
+                let equipment_id = args
+                    .get("equipment_id")
+                    .and_then(Value::as_str)
+                    .ok_or("equipment_id required")?;
+                let rule_id = args
+                    .get("rule_id")
+                    .and_then(Value::as_str)
+                    .ok_or("rule_id required")?;
+                self.bridge.fdd_series(equipment_id, rule_id)
+            }
+            "openfdd_fdd_session_config" => self.bridge.get("/api/fdd/session-config"),
+            "openfdd_fdd_accuracy_snapshot" => self.bridge.fdd_accuracy_snapshot(),
             "openfdd_fdd_rule_test_sql" => self.bridge.fdd_rule_test_sql(args),
             "openfdd_fdd_run" => {
                 require_write_confirm(args, "openfdd_fdd_run")?;
@@ -396,4 +427,30 @@ fn tool(name: &str, description: &str, schema: Value) -> Value {
             "additionalProperties": false
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lists_production_fdd_accuracy_tools() {
+        let server = Server::new(BridgeClient::from_env());
+        let tools = server.tools_list();
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+            .collect();
+        for expected in [
+            "openfdd_capabilities",
+            "openfdd_fdd_registry",
+            "openfdd_fdd_equipment",
+            "openfdd_fdd_results",
+            "openfdd_fdd_series",
+            "openfdd_fdd_session_config",
+            "openfdd_fdd_accuracy_snapshot",
+        ] {
+            assert!(names.contains(&expected), "missing MCP tool {expected}");
+        }
+    }
 }

--- a/scripts/release/smoke_mcp_central.sh
+++ b/scripts/release/smoke_mcp_central.sh
@@ -46,10 +46,40 @@ echo "OK central health"
 MCP_OUT="$(printf '%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
   '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"openfdd_health","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}' \
+  '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"openfdd_fdd_registry","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"openfdd_fdd_equipment","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"openfdd_fdd_results","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"openfdd_fdd_accuracy_snapshot","arguments":{}}}' \
   | docker run -i --rm --network "$NETWORK" \
       -e OPENFDD_API_BASE="http://${CENTRAL_NAME}:8080" \
       "$MCP_IMAGE")"
 
 echo "$MCP_OUT" | jq -s '.[] | select(.id == 2) | .result.content[0].text | fromjson | .service == "openfdd-central"' | grep -q true
 echo "OK MCP openfdd_health → central"
+echo "$MCP_OUT" | jq -se '
+  (map(select(.id == 3))[0].result.tools | map(.name)) as $tools
+  | ["openfdd_fdd_registry","openfdd_fdd_equipment","openfdd_fdd_results",
+     "openfdd_fdd_series","openfdd_fdd_accuracy_snapshot"]
+  | all(. as $name | $tools | index($name) != null)
+' | grep -q true
+echo "OK MCP production FDD tools listed"
+
+DIRECT_RULES="$(curl -fsS http://127.0.0.1:18080/api/fdd/rules | jq -c .)"
+DIRECT_EQUIPMENT="$(curl -fsS http://127.0.0.1:18080/api/fdd/equipment | jq -c .)"
+DIRECT_RESULTS="$(curl -fsS http://127.0.0.1:18080/api/fdd/results | jq -c .)"
+MCP_RULES="$(echo "$MCP_OUT" | jq -rs '.[] | select(.id == 4) | .result.content[0].text | fromjson')"
+MCP_EQUIPMENT="$(echo "$MCP_OUT" | jq -rs '.[] | select(.id == 5) | .result.content[0].text | fromjson')"
+MCP_RESULTS="$(echo "$MCP_OUT" | jq -rs '.[] | select(.id == 6) | .result.content[0].text | fromjson')"
+jq -ne --argjson direct "$DIRECT_RULES" --argjson mcp "$MCP_RULES" \
+  '$direct.count == $mcp.count and ($direct.rules | map(.rule_id)) == ($mcp.rules | map(.rule_id))' | grep -q true
+jq -ne --argjson direct "$DIRECT_EQUIPMENT" --argjson mcp "$MCP_EQUIPMENT" \
+  '$direct.equipment == $mcp.equipment' | grep -q true
+jq -ne --argjson direct "$DIRECT_RESULTS" --argjson mcp "$MCP_RESULTS" \
+  '$direct.results == $mcp.results' | grep -q true
+echo "OK MCP FDD answers exactly match direct central API"
+
+echo "$MCP_OUT" | jq -rse \
+  '.[] | select(.id == 7) | .result.content[0].text | fromjson | .ok' | grep -q true
+echo "OK MCP accuracy snapshot"
 echo "PASS: MCP central smoke"

--- a/services/central/src/models.rs
+++ b/services/central/src/models.rs
@@ -126,6 +126,12 @@ pub struct EdgePayloadResponse {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct FddRunRequest {
+    #[serde(default = "default_registry_mode")]
+    pub mode: String,
+    #[serde(default)]
+    pub rule_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub equipment_id: Option<String>,
     #[serde(default)]
     #[schema(value_type = Object)]
     pub params: Value,
@@ -133,6 +139,10 @@ pub struct FddRunRequest {
     pub confirmation_seconds: Option<i64>,
     #[serde(default)]
     pub sql: Option<String>,
+}
+
+fn default_registry_mode() -> String {
+    "registry".into()
 }
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -27,6 +27,7 @@ pub fn router(state: Arc<AppState>) -> Router {
     let public = Router::new()
         .route("/api/health", get(health))
         .route("/health", get(health))
+        .route("/api/capabilities", get(capabilities))
         .route("/api/auth/status", get(auth_status))
         .route("/api/auth/me", get(auth_me))
         .route("/api/auth/login", post(auth_login));
@@ -76,6 +77,9 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/fdd/rules", get(fdd_registry_rules))
         .route("/api/fdd/rules/{rule_id}/params", get(fdd_rule_params))
         .route("/api/fdd/cache/status", get(fdd_cache_status))
+        .route("/api/fdd/equipment", get(fdd_equipment))
+        .route("/api/fdd/results", get(fdd_results))
+        .route("/api/fdd/series", get(fdd_series))
         .route("/api/fdd/roles", get(fdd_roles))
         .route(
             "/api/fdd/session-config",
@@ -111,6 +115,30 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Json<OkHealthResponse
         ingest_dup: *state.ingest_dup.lock().unwrap(),
         ingest_reject: *state.ingest_reject.lock().unwrap(),
     })
+}
+
+/// Feature advertisement for UI capability gates and MCP accuracy checks.
+pub async fn capabilities() -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "capabilities": {
+            "lab": true,
+            "fdd_registry": true,
+            "fdd_equipment": true,
+            "fdd_results": true,
+            "fdd_series": true,
+            "session_config": true,
+            "csv_package": true,
+            "reports": false,
+            "export": false,
+            "data_management": false,
+            "host_stats": false,
+            "faults": false,
+            "health_stack": false,
+            "fdd_rules_authoring": false,
+            "fdd_schema": false
+        }
+    }))
 }
 
 #[utoipa::path(
@@ -617,8 +645,9 @@ pub async fn fdd_run(Json(body): Json<FddRunRequest>) -> Json<Value> {
     let payload = json!({
         "confirmation_seconds": body.confirmation_seconds,
         "params": body.params,
-        "mode": body.params.get("mode").cloned().unwrap_or(json!("registry")),
-        "rule_ids": body.params.get("rule_ids").cloned(),
+        "mode": body.mode,
+        "rule_ids": body.rule_ids,
+        "equipment_id": body.equipment_id,
     });
     let result = tokio::task::spawn_blocking(move || {
         open_fdd_edge_prototype::fdd::registry_api::run_registry(&payload)
@@ -638,6 +667,32 @@ pub async fn fdd_rule_params(Path(rule_id): Path<String>) -> Json<Value> {
 
 pub async fn fdd_cache_status() -> Json<Value> {
     Json(open_fdd_edge_prototype::fdd::registry_api::cache_status())
+}
+
+pub async fn fdd_equipment() -> Json<Value> {
+    Json(open_fdd_edge_prototype::fdd::registry_api::equipment_response())
+}
+
+pub async fn fdd_results() -> Json<Value> {
+    Json(open_fdd_edge_prototype::fdd::registry_api::results_response())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FddSeriesQuery {
+    equipment_id: String,
+    rule_id: String,
+}
+
+pub async fn fdd_series(Query(query): Query<FddSeriesQuery>) -> Json<Value> {
+    let result = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::fdd::registry_api::series_response(
+            &query.equipment_id,
+            &query.rule_id,
+        )
+    })
+    .await
+    .unwrap_or_else(|e| json!({"ok": false, "error": format!("series task failed: {e}")}));
+    Json(result)
 }
 
 pub async fn fdd_roles() -> Json<Value> {

--- a/workspace/dashboard/src/pages/Vibe19LabPage.tsx
+++ b/workspace/dashboard/src/pages/Vibe19LabPage.tsx
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
+import PackageImportPanel from "../components/PackageImportPanel";
 import { apiFetch } from "../lib/api";
+import {
+  uploadPackageZip,
+  type PackageImportResponse,
+} from "../lib/csvPackageImport";
 import { formatApiError } from "../lib/formatApiError";
 import {
   buildSessionConfig,
@@ -13,17 +18,11 @@ import {
 } from "../lib/sessionConfig";
 import {
   barChart,
-  basVsWebOatOverlay,
-  meteringBarScatter,
-  multiEquipmentBox,
-  oatScatter,
   plotlyConfig,
   ruleResultChart,
-  vavComfortDonut,
 } from "../vibe19/charts";
 import {
   type RegistryRule,
-  type RcxPresetMeta,
   type RuleParamDef,
   type Vibe19Section,
   RCX_PRESETS,
@@ -50,6 +49,29 @@ type CacheStatus = {
   rule_file_count?: number;
   result_file_count?: number;
 };
+type Equipment = { equipment_id: string; equipment_type: string };
+type EquipmentResponse = { ok: boolean; count: number; equipment: Equipment[]; error?: string };
+type ResultRow = {
+  rule_id: string;
+  title?: string;
+  equipment_id: string;
+  equipment_type: string;
+  status: string;
+  fault_hours: number;
+  fault_pct?: number | null;
+  missing_roles?: string[];
+  notes?: unknown;
+};
+type ResultsResponse = { ok: boolean; count: number; results: ResultRow[]; error?: string };
+type SeriesResponse = {
+  ok: boolean;
+  equipment_id: string;
+  equipment_type?: string;
+  rule_id: string;
+  roles?: string[];
+  rows?: Record<string, unknown>[];
+  error?: string;
+};
 
 async function fetchRules() {
   return apiFetch<RulesResponse>("/api/fdd/rules");
@@ -60,6 +82,16 @@ async function fetchParams(ruleId: string) {
 async function fetchCache() {
   return apiFetch<CacheStatus>("/api/fdd/cache/status");
 }
+async function fetchEquipment() {
+  return apiFetch<EquipmentResponse>("/api/fdd/equipment");
+}
+async function fetchResults() {
+  return apiFetch<ResultsResponse>("/api/fdd/results");
+}
+async function fetchSeries(equipmentId: string, ruleId: string) {
+  const query = new URLSearchParams({ equipment_id: equipmentId, rule_id: ruleId });
+  return apiFetch<SeriesResponse>(`/api/fdd/series?${query}`);
+}
 async function runRegistry(body: Record<string, unknown>) {
   return apiFetch<Record<string, unknown>>("/api/fdd/run", {
     method: "POST",
@@ -67,8 +99,17 @@ async function runRegistry(body: Record<string, unknown>) {
   });
 }
 
-function OverviewSection({ cache, rules }: { cache?: CacheStatus; rules?: RegistryRule[] }) {
-  const donut = vavComfortDonut({ title: "Zone comfort (demo)", inComfort: 82, outComfort: 18 });
+function OverviewSection({
+  cache,
+  rules,
+  equipment,
+  results,
+}: {
+  cache?: CacheStatus;
+  rules?: RegistryRule[];
+  equipment?: Equipment[];
+  results?: ResultRow[];
+}) {
   const bars = barChart({
     title: "Rules by wiring status",
     labels: ["wired", "not wired"],
@@ -100,40 +141,58 @@ function OverviewSection({ cache, rules }: { cache?: CacheStatus; rules?: Regist
         then tune rules below without a full page reload.
       </p>
       <div className="vibe19-metric">
-        <div className="label">Result files</div>
-        <div className="value">{cache?.result_file_count ?? 0}</div>
+        <div className="label">Equipment</div>
+        <div className="value">{equipment?.length ?? 0}</div>
       </div>
-      <div className="vibe19-card wide">
-        <PlotHost data={donut.data} layout={donut.layout} config={plotlyConfig()} height={280} />
+      <div className="vibe19-metric">
+        <div className="label">Fault results</div>
+        <div className="value">{results?.filter((r) => r.status === "FAULT").length ?? 0}</div>
       </div>
       <div className="vibe19-card wide">
         <PlotHost data={bars.data} layout={bars.layout} config={plotlyConfig()} height={280} />
       </div>
-      <OverviewExtras />
+      <div className="vibe19-card wide">
+        <h3>Building analytics</h3>
+        <p className="muted">
+          Motor runtime, mechanical-cooling OAT, comfort, and BAS-vs-web weather charts appear
+          only when their mapped history is available. Demo series are intentionally not shown.
+        </p>
+      </div>
     </div>
   );
 }
 
-function DataModelSection({ rules }: { rules?: RegistryRule[] }) {
+function DataModelSection({
+  rules,
+  packageResult,
+}: {
+  rules?: RegistryRule[];
+  packageResult?: PackageImportResponse | null;
+}) {
   const roles = useMemo(() => {
     const s = new Set<string>();
     for (const r of rules ?? []) for (const role of r.required_roles ?? []) s.add(role);
     return [...s].sort();
   }, [rules]);
   return (
-    <div className="vibe19-card">
-      <h3>Role catalog (from registry required_roles)</h3>
-      <p className="muted">
-        Equipment → cookbook role → column mapping is data-model driven. Roles referenced by loaded
-        rules:
-      </p>
-      <ul className="vibe19-role-list">
-        {roles.map((r) => (
-          <li key={r}>
-            <code>{r}</code>
-          </li>
-        ))}
-      </ul>
+    <div className="vibe19-grid">
+      {packageResult ? <PackageImportPanel result={packageResult} /> : null}
+      <div className="vibe19-card wide">
+        <h3>Points by equipment</h3>
+        <p className="muted">
+          Import a package in the left rail to inspect and edit equipment role mappings here.
+        </p>
+        <details>
+          <summary>Cookbook role catalog ({roles.length})</summary>
+          <ul className="vibe19-role-list">
+            {roles.map((r) => (
+              <li key={r}>
+                <code>{r}</code>
+              </li>
+            ))}
+          </ul>
+        </details>
+      </div>
     </div>
   );
 }
@@ -318,12 +377,17 @@ function RuleTuningSidebar({
   rules,
   paramOverrides,
   setParamOverrides,
+  onRerunCategory,
+  rerunning,
 }: {
   rules: RegistryRule[];
   paramOverrides: ParamOverrides;
   setParamOverrides: React.Dispatch<React.SetStateAction<ParamOverrides>>;
+  onRerunCategory: (ruleIds: string[]) => void;
+  rerunning: boolean;
 }) {
   const [category, setCategory] = useState("(all)");
+  const [requireOperationalProof, setRequireOperationalProof] = useState(true);
   const grouped = useMemo(
     () => groupRulesByFamily(rules.map((r) => r.rule_id)),
     [rules],
@@ -336,6 +400,17 @@ function RuleTuningSidebar({
   return (
     <div className="vibe19-sidebar-block">
       <h3>Rule tuning</h3>
+      <p className="muted">
+        Sliders only change thresholds. Rules update when you click Run or Rerun cat.
+      </p>
+      <label className="vibe19-checkbox">
+        <input
+          type="checkbox"
+          checked={requireOperationalProof}
+          onChange={(e) => setRequireOperationalProof(e.target.checked)}
+        />
+        Require operational proof (fan/pump status)
+      </label>
       <label>
         Category
         <select value={category} onChange={(e) => setCategory(e.target.value)}>
@@ -353,7 +428,16 @@ function RuleTuningSidebar({
       </p>
       <div className="vibe19-sidebar-actions">
         <button type="button" onClick={() => setParamOverrides({})}>
-          Reset all tuning
+          Reset
+        </button>
+        <button
+          type="button"
+          disabled={rerunning}
+          onClick={() =>
+            onRerunCategory(shown.flatMap(([, ids]) => ids))
+          }
+        >
+          {rerunning ? "Running…" : "Rerun cat."}
         </button>
       </div>
       <div className="vibe19-tuning">
@@ -394,6 +478,9 @@ function LabSidebar({
   setUnitSystem,
   baseConfig,
   setBaseConfig,
+  onPackageImported,
+  onRerunCategory,
+  rerunning,
 }: {
   cache?: CacheStatus;
   rules: RegistryRule[];
@@ -403,7 +490,33 @@ function LabSidebar({
   setUnitSystem: (u: SessionConfig["unit_system"]) => void;
   baseConfig: SessionConfig | null;
   setBaseConfig: (c: SessionConfig) => void;
+  onPackageImported: (result: PackageImportResponse) => void;
+  onRerunCategory: (ruleIds: string[]) => void;
+  rerunning: boolean;
 }) {
+  const packageRef = useRef<HTMLInputElement>(null);
+  const [packageBusy, setPackageBusy] = useState(false);
+  const [packageNote, setPackageNote] = useState("");
+  const [packageError, setPackageError] = useState("");
+
+  async function importPackage(file: File) {
+    setPackageBusy(true);
+    setPackageNote("");
+    setPackageError("");
+    try {
+      const result = await uploadPackageZip(file);
+      if (!result.ok) throw new Error(result.error ?? "package import failed");
+      onPackageImported(result);
+      setPackageNote(
+        `Loaded ${result.equipment_written ?? result.equipment?.length ?? 0} equipment · ${result.total_rows?.toLocaleString() ?? "?"} rows`,
+      );
+    } catch (error) {
+      setPackageError(formatApiError(error));
+    } finally {
+      setPackageBusy(false);
+    }
+  }
+
   return (
     <aside className="vibe19-lab-sidebar">
       <div className="vibe19-sidebar-block">
@@ -413,10 +526,27 @@ function LabSidebar({
             ? `Parquet cache ready (${cache.parquet_file_count} files).`
             : "No building data loaded yet."}
         </p>
+        {packageNote ? <p className="ok">{packageNote}</p> : null}
+        {packageError ? <p className="error">{packageError}</p> : null}
         <div className="vibe19-sidebar-actions">
-          <a href="/csv">
-            <button type="button">Load CSV / package zip…</button>
-          </a>
+          <button
+            type="button"
+            disabled={packageBusy}
+            onClick={() => packageRef.current?.click()}
+          >
+            {packageBusy ? "Loading…" : "Building package zip(s)…"}
+          </button>
+          <input
+            ref={packageRef}
+            type="file"
+            accept=".zip,application/zip"
+            hidden
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void importPackage(file);
+              e.target.value = "";
+            }}
+          />
         </div>
       </div>
       <hr />
@@ -439,8 +569,42 @@ function LabSidebar({
           >
             <option value="imperial">imperial</option>
             <option value="metric">metric</option>
-            <option value="si">si</option>
           </select>
+        </label>
+        <label className="vibe19-checkbox">
+          <input
+            type="checkbox"
+            checked={baseConfig?.prefer_web_oat ?? true}
+            onChange={(e) =>
+              setBaseConfig({
+                ...(baseConfig ?? buildSessionConfig(paramOverrides, unitSystem)),
+                prefer_web_oat: e.target.checked,
+              })
+            }
+          />
+          Prefer web OAT (Open-Meteo)
+        </label>
+        <label>
+          CHW leave proof max {unitSystem === "metric" ? "°C" : "°F"}
+          <input
+            type="range"
+            min={unitSystem === "metric" ? 1.7 : 35}
+            max={unitSystem === "metric" ? 10 : 50}
+            step={0.5}
+            value={
+              unitSystem === "metric"
+                ? (((baseConfig?.chw_leave_max_f ?? 48) - 32) * 5) / 9
+                : (baseConfig?.chw_leave_max_f ?? 48)
+            }
+            onChange={(e) => {
+              const displayed = Number(e.target.value);
+              setBaseConfig({
+                ...(baseConfig ?? buildSessionConfig(paramOverrides, unitSystem)),
+                chw_leave_max_f:
+                  unitSystem === "metric" ? (displayed * 9) / 5 + 32 : displayed,
+              });
+            }}
+          />
         </label>
       </div>
       <hr />
@@ -448,6 +612,8 @@ function LabSidebar({
         rules={rules}
         paramOverrides={paramOverrides}
         setParamOverrides={setParamOverrides}
+        onRerunCategory={onRerunCategory}
+        rerunning={rerunning}
       />
     </aside>
   );
@@ -456,12 +622,15 @@ function LabSidebar({
 function RunRulesSection({
   rules,
   paramOverrides,
+  selectedEquipment,
 }: {
   rules?: RegistryRule[];
   paramOverrides: ParamOverrides;
+  selectedEquipment?: string;
 }) {
   const qc = useQueryClient();
   const [selected, setSelected] = useState<string[]>([]);
+  const [equipmentScope, setEquipmentScope] = useState<"selected" | "all">("all");
 
   const runMut = useMutation({
     mutationFn: () =>
@@ -469,9 +638,11 @@ function RunRulesSection({
         mode: "registry",
         rule_ids: selected.length ? selected : undefined,
         params: paramOverrides,
+        equipment_id: equipmentScope === "selected" ? selectedEquipment : undefined,
       }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["fdd-cache"] });
+      void qc.invalidateQueries({ queryKey: ["fdd-results"] });
     },
   });
 
@@ -538,6 +709,26 @@ function RunRulesSection({
           Thresholds come from <strong>Rule tuning</strong> in the left sidebar — slider changes
           stay local until you press Run (no Streamlit-style rerun).
         </p>
+        <fieldset className="vibe19-inline-radio">
+          <legend>Equipment scope</legend>
+          <label>
+            <input
+              type="radio"
+              checked={equipmentScope === "selected"}
+              disabled={!selectedEquipment}
+              onChange={() => setEquipmentScope("selected")}
+            />
+            selected equipment{selectedEquipment ? ` (${selectedEquipment})` : ""}
+          </label>
+          <label>
+            <input
+              type="radio"
+              checked={equipmentScope === "all"}
+              onChange={() => setEquipmentScope("all")}
+            />
+            all equipment
+          </label>
+        </fieldset>
         {modifiedIds.length ? (
           <p>
             Tuned rules applied on run:{" "}
@@ -558,76 +749,133 @@ function RunRulesSection({
   );
 }
 
-function ResultsSection({ rules }: { rules?: RegistryRule[] }) {
-  const byStatus = useMemo(() => {
-    const m = new Map<string, RegistryRule[]>();
-    for (const r of rules ?? []) {
-      const k = r.parity_status || "unknown";
-      const arr = m.get(k) ?? [];
-      arr.push(r);
-      m.set(k, arr);
+function ResultsSection({ results }: { results?: ResultRow[] }) {
+  const [hideNa, setHideNa] = useState(true);
+  const byEquipmentType = useMemo(() => {
+    const grouped = new Map<string, Map<string, ResultRow[]>>();
+    for (const row of results ?? []) {
+      if (hideNa && row.status === "NOT_APPLICABLE_EQUIPMENT_TYPE") continue;
+      const byDevice = grouped.get(row.equipment_type) ?? new Map<string, ResultRow[]>();
+      const deviceRows = byDevice.get(row.equipment_id) ?? [];
+      deviceRows.push(row);
+      byDevice.set(row.equipment_id, deviceRows);
+      grouped.set(row.equipment_type, byDevice);
     }
-    return [...m.entries()];
-  }, [rules]);
+    return [...grouped.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, [hideNa, results]);
+  const statuses = ["PASS", "FAULT", "SKIPPED_MISSING_ROLES", "SKIPPED_EQUIPMENT_OFF", "NOT_APPLICABLE_EQUIPMENT_TYPE", "ERROR"];
   return (
-    <div className="vibe19-card">
-      <h3>Results by category (registry metadata)</h3>
+    <div>
+      <h3>Results by equipment type</h3>
       <p className="muted">
-        After a registry run, fault hours land in <code>.cache/rule_results</code>. Below is the
-        catalog grouped by parity status until live results are loaded.
+        Organized by mechanical device type, then device. Run rules to refresh these live rows.
       </p>
-      {byStatus.map(([status, list]) => (
-        <div key={status}>
-          <h4>{status}</h4>
-          <table className="vibe19-table">
-            <thead>
-              <tr>
-                <th>Rule</th>
-                <th>Confirm (s)</th>
-                <th>Roles</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.map((r) => (
-                <tr key={r.rule_id}>
-                  <td>{r.rule_id}</td>
-                  <td>{r.confirm_seconds}</td>
-                  <td>{(r.required_roles ?? []).join(", ")}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+      <div className="vibe19-status-metrics">
+        {statuses.map((status) => (
+          <div className="vibe19-metric" key={status}>
+            <div className="label">{status.replaceAll("_", " ")}</div>
+            <div className="value">{results?.filter((r) => r.status === status).length ?? 0}</div>
+          </div>
+        ))}
+      </div>
+      <label className="vibe19-checkbox">
+        <input type="checkbox" checked={hideNa} onChange={(e) => setHideNa(e.target.checked)} />
+        Hide N/A rows (NOT_APPLICABLE_EQUIPMENT_TYPE)
+      </label>
+      {byEquipmentType.length === 0 ? (
+        <div className="vibe19-card"><p className="muted">No live rule results yet.</p></div>
+      ) : null}
+      {byEquipmentType.map(([equipmentType, devices]) => (
+        <section key={equipmentType}>
+          <h3>{equipmentType} · {devices.size} device(s)</h3>
+          {[...devices.entries()].map(([equipmentId, rows]) => (
+            <details className="vibe19-result-device" key={equipmentId}>
+              <summary>
+                {equipmentId} · FAULT {rows.filter((r) => r.status === "FAULT").length} · PASS{" "}
+                {rows.filter((r) => r.status === "PASS").length}
+              </summary>
+              <table className="vibe19-table">
+                <thead>
+                  <tr><th>Rule</th><th>Status</th><th>Fault hours</th><th>Fault %</th></tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr key={`${equipmentId}-${row.rule_id}`}>
+                      <td title={row.title}>{row.rule_id}</td>
+                      <td>{row.status}</td>
+                      <td>{row.fault_hours.toFixed(3)}</td>
+                      <td>{row.fault_pct == null ? "—" : row.fault_pct.toFixed(1)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </details>
+          ))}
+        </section>
       ))}
     </div>
   );
 }
 
-function FddPlotsSection({ rules }: { rules?: RegistryRule[] }) {
+function FddPlotsSection({
+  rules,
+  equipment,
+  selectedEquipment,
+  onEquipment,
+  results,
+}: {
+  rules?: RegistryRule[];
+  equipment?: Equipment[];
+  selectedEquipment: string;
+  onEquipment: (equipmentId: string) => void;
+  results?: ResultRow[];
+}) {
   const [focus, setFocus] = useState<string>("");
   const wired = useMemo(
-    () => (rules ?? []).filter((r) => r.dashboard_wired).slice(0, 12),
+    () => (rules ?? []).filter((r) => r.dashboard_wired),
     [rules],
   );
-  const active = focus || wired[0]?.rule_id || "DEMO";
-  const demo = ruleResultChart({
-    title: `${active} — rule card (demo series)`,
-    series: [
-      {
-        name: "sat",
-        points: Array.from({ length: 48 }, (_, i) => ({
-          t: i,
-          y: 55 + Math.sin(i / 5) * 3,
-        })),
-      },
-    ],
-    confirmed: Array.from({ length: 48 }, (_, i) => ({ t: i, fault: i > 30 && i < 40 })),
+  const active = focus || wired[0]?.rule_id || "";
+  const seriesQ = useQuery({
+    queryKey: ["fdd-series", selectedEquipment, active],
+    queryFn: () => fetchSeries(selectedEquipment, active),
+    enabled: Boolean(selectedEquipment && active),
   });
+  const figure = useMemo(() => {
+    const rows = seriesQ.data?.rows ?? [];
+    const roles = seriesQ.data?.roles ?? [];
+    if (!rows.length) return null;
+    return ruleResultChart({
+      title: `${active} — ${selectedEquipment}`,
+      series: roles.map((role) => ({
+        name: role,
+        points: rows
+          .map((row, index) => ({
+            t: (row.timestamp_utc as string | number | undefined) ?? index,
+            y: typeof row[role] === "number" ? (row[role] as number) : null,
+          }))
+          .filter((point) => point.y != null),
+      })),
+      confirmed: [],
+    });
+  }, [active, selectedEquipment, seriesQ.data]);
+  const activeResults = (results ?? []).filter(
+    (row) => row.equipment_id === selectedEquipment,
+  );
   return (
     <div className="vibe19-run">
       <aside className="vibe19-sidebar">
-        <h3>Rule cards</h3>
-        <p className="muted">Auto-list applicable (dashboard_wired) rules.</p>
+        <h3>FDD plot picker</h3>
+        <label>
+          Device
+          <select value={selectedEquipment} onChange={(e) => onEquipment(e.target.value)}>
+            {(equipment ?? []).map((item) => (
+              <option key={item.equipment_id} value={item.equipment_id}>
+                {item.equipment_type} · {item.equipment_id}
+              </option>
+            ))}
+          </select>
+        </label>
         <ul>
           {wired.map((r) => (
             <li key={r.rule_id}>
@@ -641,32 +889,44 @@ function FddPlotsSection({ rules }: { rules?: RegistryRule[] }) {
       <div className="vibe19-card grow">
         <h3>FDD Plots — {active}</h3>
         <p className="muted">
-          Cards use <code>rule_result_chart</code> (multi-y + confirmed-fault swim lane). Display
-          downsample ≤5k points; rule math stays full-resolution.
+          Live mapped history from the parquet cache. Display is capped at 5,000 points; rule math
+          stays full-resolution.
         </p>
-        <PlotHost data={demo.data} layout={demo.layout} config={plotlyConfig()} height={360} />
+        {seriesQ.isLoading ? <p>Loading series…</p> : null}
+        {seriesQ.data && !seriesQ.data.ok ? <p className="error">{seriesQ.data.error}</p> : null}
+        {figure ? (
+          <PlotHost data={figure.data} layout={figure.layout} config={plotlyConfig()} height={420} />
+        ) : !seriesQ.isLoading ? (
+          <p className="muted">No mapped live series are available for this device/rule.</p>
+        ) : null}
+        <h3>Rule cards</h3>
+        {wired.map((rule) => {
+          const result = activeResults.find((row) => row.rule_id === rule.rule_id);
+          return (
+            <details key={rule.rule_id} open={rule.rule_id === active}>
+              <summary>
+                {rule.rule_id} — {rule.description} · {result?.status ?? "Not run"}
+              </summary>
+              <p>{rule.description}</p>
+              <p className="muted">
+                Roles: {(rule.required_roles ?? []).join(", ") || "none"} · Confirm{" "}
+                {rule.confirm_seconds}s
+              </p>
+            </details>
+          );
+        })}
       </div>
     </div>
   );
 }
 
-function demoSeries(seed: number) {
-  return Array.from({ length: 60 }, (_, i) => ({
-    t: i,
-    y: 50 + seed * 3 + Math.sin((i + seed) / 6) * 4,
-  }));
-}
-
 function RcxPlotsSection() {
   const [presetId, setPresetId] = useState(RCX_PRESETS[0].id);
   const preset = RCX_PRESETS.find((p) => p.id === presetId) ?? RCX_PRESETS[0];
-  const fig = useMemo(() => buildRcxDemo(preset), [preset]);
   const families = useMemo(() => {
-    const m = new Map<string, RcxPresetMeta[]>();
+    const m = new Map<string, typeof RCX_PRESETS>();
     for (const p of RCX_PRESETS) {
-      const arr = m.get(p.family) ?? [];
-      arr.push(p);
-      m.set(p.family, arr);
+      m.set(p.family, [...(m.get(p.family) ?? []), p]);
     }
     return [...m.entries()];
   }, []);
@@ -705,116 +965,53 @@ function RcxPlotsSection() {
             ({preset.weatherAxis === "none" ? "no weather axis" : preset.weatherAxis})
           </span>
         </h3>
-        <PlotHost data={fig.data} layout={fig.layout} config={plotlyConfig()} height={380} />
+        <p className="muted">
+          No mapped live series currently satisfies this preset. Synthetic fallback charts have
+          been removed; import the required package roles and rerun rules.
+        </p>
       </div>
     </div>
   );
-}
-
-function buildRcxDemo(preset: RcxPresetMeta) {
-  if (preset.chart === "donut") {
-    return vavComfortDonut({ title: preset.label, inComfort: 72, outComfort: 28 });
-  }
-  if (preset.chart === "box") {
-    return multiEquipmentBox({
-      title: preset.label,
-      series: [
-        { name: "AHU-1", values: [1.1, 1.2, 1.15, 1.3, 0.9] },
-        { name: "AHU-2", values: [0.8, 0.85, 0.9, 1.0, 0.75] },
-      ],
-    });
-  }
-  if (preset.chart === "scatter") {
-    const axis =
-      preset.weatherAxis === "wet_bulb" ? "Web wet-bulb °F" : "Web dry-bulb °F";
-    return oatScatter({
-      title: preset.label,
-      x: Array.from({ length: 80 }, (_, i) => 40 + (i % 40)),
-      y: Array.from({ length: 80 }, (_, i) => 55 + Math.sin(i / 7) * 8),
-      xTitle: axis,
-      yTitle: "Leave / SAT °F",
-    });
-  }
-  if (preset.chart === "metering") {
-    return meteringBarScatter({
-      title: preset.label,
-      months: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
-      usage: [120, 110, 95, 80, 70, 90],
-      degreeDays: [900, 750, 500, 200, 50, 100],
-      usageName: preset.id.includes("gas") ? "gas" : "kWh",
-      ddName: preset.id.includes("gas") ? "HDD" : "CDD",
-    });
-  }
-  const s1 = demoSeries(1);
-  const s2 = demoSeries(2);
-  return {
-    data: [
-      {
-        type: "scatter",
-        mode: "lines",
-        name: "eq-1",
-        x: s1.map((p) => p.t),
-        y: s1.map((p) => p.y),
-      },
-      {
-        type: "scatter",
-        mode: "lines",
-        name: "eq-2",
-        x: s2.map((p) => p.t),
-        y: s2.map((p) => p.y),
-      },
-    ],
-    layout: { title: { text: preset.label }, margin: { t: 48, r: 24, b: 40, l: 48 } },
-  };
 }
 
 function MeteringSection() {
-  const elec = meteringBarScatter({
-    title: "Electric kWh vs CDD",
-    months: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
-    usage: [140, 120, 100, 85, 95, 110],
-    degreeDays: [50, 80, 200, 350, 450, 500],
-    usageName: "kWh",
-    ddName: "CDD",
-  });
-  const gas = meteringBarScatter({
-    title: "Gas vs HDD",
-    months: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
-    usage: [300, 260, 180, 90, 40, 20],
-    degreeDays: [900, 750, 500, 200, 50, 10],
-    usageName: "therms",
-    ddName: "HDD",
-  });
-  return (
-    <div className="vibe19-grid">
-      <div className="vibe19-card wide">
-        <PlotHost data={elec.data} layout={elec.layout} config={plotlyConfig()} height={320} />
-      </div>
-      <div className="vibe19-card wide">
-        <PlotHost data={gas.data} layout={gas.layout} config={plotlyConfig()} height={320} />
-      </div>
-    </div>
-  );
-}
-
-function OverviewExtras() {
-  const overlay = basVsWebOatOverlay({
-    title: "BAS vs web OAT",
-    bas: demoSeries(0).map((p) => ({ ...p, y: (p.y ?? 0) + 20 })),
-    web: demoSeries(1).map((p) => ({ ...p, y: (p.y ?? 0) + 18 })),
-  });
-  return (
-    <div className="vibe19-card wide">
-      <PlotHost data={overlay.data} layout={overlay.layout} config={plotlyConfig()} height={280} />
-    </div>
-  );
-}
-
-function Placeholder({ title, blurb }: { title: string; blurb: string }) {
   return (
     <div className="vibe19-card">
-      <h3>{title}</h3>
-      <p className="muted">{blurb}</p>
+      <h3>Metering</h3>
+      <p className="muted">
+        Electric kWh/CDD and gas/HDD charts require mapped meter and weather series. No synthetic
+        monthly values are displayed.
+      </p>
+    </div>
+  );
+}
+
+function ExportSection({ results }: { results?: ResultRow[] }) {
+  function downloadResults() {
+    const headers = ["rule_id", "equipment_id", "equipment_type", "status", "fault_hours", "fault_pct"];
+    const lines = [
+      headers.join(","),
+      ...(results ?? []).map((row) =>
+        headers
+          .map((key) => JSON.stringify(row[key as keyof ResultRow] ?? ""))
+          .join(","),
+      ),
+    ];
+    const url = URL.createObjectURL(new Blob([lines.join("\n")], { type: "text/csv" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "fdd_results_by_equipment.csv";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+  return (
+    <div className="vibe19-card">
+      <h3>Export</h3>
+      <p>Current live result rows and session configuration can leave the Lab without a route hop.</p>
+      <button type="button" disabled={!results?.length} onClick={downloadResults}>
+        Download full results CSV
+      </button>
+      <p className="muted">WattLab dump and Generic RCx DOCX remain tracked in #518.</p>
     </div>
   );
 }
@@ -824,8 +1021,30 @@ export default function Vibe19LabPage() {
   const [paramOverrides, setParamOverrides] = useState<ParamOverrides>({});
   const [unitSystem, setUnitSystem] = useState<SessionConfig["unit_system"]>("imperial");
   const [baseConfig, setBaseConfig] = useState<SessionConfig | null>(null);
+  const [packageResult, setPackageResult] = useState<PackageImportResponse | null>(null);
+  const [selectedEquipment, setSelectedEquipment] = useState("");
   const rulesQ = useQuery({ queryKey: ["fdd-rules"], queryFn: fetchRules });
   const cacheQ = useQuery({ queryKey: ["fdd-cache"], queryFn: fetchCache });
+  const equipmentQ = useQuery({ queryKey: ["fdd-equipment"], queryFn: fetchEquipment });
+  const resultsQ = useQuery({ queryKey: ["fdd-results"], queryFn: fetchResults });
+  const queryClient = useQueryClient();
+  const rerunMutation = useMutation({
+    mutationFn: (ruleIds: string[]) =>
+      runRegistry({
+        mode: "registry",
+        rule_ids: ruleIds.length ? ruleIds : undefined,
+        params: paramOverrides,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["fdd-results"] });
+      void queryClient.invalidateQueries({ queryKey: ["fdd-cache"] });
+    },
+  });
+
+  useEffect(() => {
+    const first = equipmentQ.data?.equipment?.[0]?.equipment_id;
+    if (!selectedEquipment && first) setSelectedEquipment(first);
+  }, [equipmentQ.data, selectedEquipment]);
 
   return (
     <div className="vibe19-shell">
@@ -838,6 +1057,19 @@ export default function Vibe19LabPage() {
         setUnitSystem={setUnitSystem}
         baseConfig={baseConfig}
         setBaseConfig={setBaseConfig}
+        onPackageImported={(result) => {
+          setPackageResult(result);
+          void queryClient.invalidateQueries({ queryKey: ["fdd-cache"] });
+          void queryClient.invalidateQueries({ queryKey: ["fdd-equipment"] });
+          void fetchSessionConfig().then((response) => {
+            if (!response.config) return;
+            setBaseConfig(response.config);
+            setUnitSystem(response.config.unit_system);
+            setParamOverrides(sessionConfigToParamOverrides(response.config));
+          });
+        }}
+        onRerunCategory={(ruleIds) => rerunMutation.mutate(ruleIds)}
+        rerunning={rerunMutation.isPending}
       />
 
       <div className="vibe19-content">
@@ -845,9 +1077,10 @@ export default function Vibe19LabPage() {
           <div>
             <h1>Open FDD Vibe Coder</h1>
             <p className="muted">
-              Streamlit-parity lab — tune rules in the left sidebar, run on demand, browse
-              sections below. Units: {unitSystem}.
+              Educational React + DataFusion lab for the Open-FDD cookbook. Building data stays
+              as-is — map columns to roles, tune thresholds, then run on demand.
             </p>
+            <p><strong>How it works:</strong> Data package → Data model → Run Rules → FDD / RCx plots.</p>
           </div>
           <div className="vibe19-hero-meta">
             {rulesQ.data?.ok ? (
@@ -857,6 +1090,20 @@ export default function Vibe19LabPage() {
             )}
           </div>
         </header>
+
+        <label className="vibe19-equipment-picker">
+          Equipment
+          <select
+            value={selectedEquipment}
+            onChange={(event) => setSelectedEquipment(event.target.value)}
+          >
+            {(equipmentQ.data?.equipment ?? []).map((item) => (
+              <option key={item.equipment_id} value={item.equipment_id}>
+                {item.equipment_id}
+              </option>
+            ))}
+          </select>
+        </label>
 
         <nav className="vibe19-nav" aria-label="Lab sections">
           {VIBE19_SECTIONS.map((s) => (
@@ -873,21 +1120,38 @@ export default function Vibe19LabPage() {
 
         <main className="vibe19-main">
           {section === "Overview" ? (
-            <OverviewSection cache={cacheQ.data} rules={rulesQ.data?.rules} />
+            <OverviewSection
+              cache={cacheQ.data}
+              rules={rulesQ.data?.rules}
+              equipment={equipmentQ.data?.equipment}
+              results={resultsQ.data?.results}
+            />
           ) : null}
-          {section === "Data Model" ? <DataModelSection rules={rulesQ.data?.rules} /> : null}
+          {section === "Data Model" ? (
+            <DataModelSection rules={rulesQ.data?.rules} packageResult={packageResult} />
+          ) : null}
           {section === "Run Rules" ? (
-            <RunRulesSection rules={rulesQ.data?.rules} paramOverrides={paramOverrides} />
+            <RunRulesSection
+              rules={rulesQ.data?.rules}
+              paramOverrides={paramOverrides}
+              selectedEquipment={selectedEquipment}
+            />
           ) : null}
           {section === "Results by Category" ? (
-            <ResultsSection rules={rulesQ.data?.rules} />
+            <ResultsSection results={resultsQ.data?.results} />
           ) : null}
-          {section === "FDD Plots" ? <FddPlotsSection rules={rulesQ.data?.rules} /> : null}
+          {section === "FDD Plots" ? (
+            <FddPlotsSection
+              rules={rulesQ.data?.rules}
+              equipment={equipmentQ.data?.equipment}
+              selectedEquipment={selectedEquipment}
+              onEquipment={setSelectedEquipment}
+              results={resultsQ.data?.results}
+            />
+          ) : null}
           {section === "RCx Plots" ? <RcxPlotsSection /> : null}
           {section === "Metering" ? <MeteringSection /> : null}
-          {section === "Export" ? (
-            <Placeholder title="Export" blurb="CSV / session / health / data-model exports." />
-          ) : null}
+          {section === "Export" ? <ExportSection results={resultsQ.data?.results} /> : null}
         </main>
       </div>
     </div>

--- a/workspace/dashboard/src/pages/vibe19.css
+++ b/workspace/dashboard/src/pages/vibe19.css
@@ -118,6 +118,57 @@
   font-size: 0.82rem;
 }
 
+.vibe19-checkbox {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0.45rem !important;
+}
+
+.vibe19-equipment-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-width: 32rem;
+  font-weight: 600;
+}
+
+.vibe19-equipment-picker select,
+.vibe19-sidebar select {
+  background: var(--input-bg, #fff);
+  color: var(--input-text, inherit);
+  border: 1px solid var(--border, #e3e6ee);
+  border-radius: 0.35rem;
+  padding: 0.45rem 0.6rem;
+}
+
+.vibe19-status-metrics {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(7rem, 1fr));
+  gap: 0.55rem;
+  margin-bottom: 0.8rem;
+}
+
+.vibe19-result-device {
+  border: 1px solid var(--border, #e3e6ee);
+  border-radius: 0.4rem;
+  padding: 0.5rem 0.7rem;
+  margin-bottom: 0.5rem;
+  background: var(--panel, #fff);
+}
+
+.vibe19-result-device summary {
+  cursor: pointer;
+  font-weight: 650;
+}
+
+.vibe19-inline-radio {
+  border: 1px solid var(--border, #e3e6ee);
+  border-radius: 0.4rem;
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
 .vibe19-sidebar-block select,
 .vibe19-sidebar-block input[type="text"] {
   background: var(--input-bg, #fff);
@@ -325,5 +376,8 @@
   }
   .vibe19-role-list {
     columns: 1;
+  }
+  .vibe19-status-metrics {
+    grid-template-columns: repeat(2, minmax(7rem, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
Replacement for auto-closed #552 after #551 merged and deleted the stacked base branch.

- Adds `/api/fdd/equipment`, `/api/fdd/results`, `/api/fdd/series`, and typed full-param registry runs.
- Lab: in-rail package ZIP, equipment picker, Results by equipment type, live FDD series, honest empty states.
- Standalone `openfdd-mcp` accuracy tools + MCP↔central parity smoke.

## Test plan
- [x] dashboard vitest + build
- [x] `cargo test -p fdd_rules --lib`
- [x] `cargo test -p openfdd-mcp`
- [ ] CI green

Made with [Cursor](https://cursor.com)