### PR TITLE
fix(fdd): #550 phase-1 parity honesty + oracle harness

### DIFF
--- a/crates/fdd_rules/src/lib.rs
+++ b/crates/fdd_rules/src/lib.rs
@@ -13,4 +13,8 @@ pub use tuning::{effective_param_strings, load_tuning_profiles};
 #[cfg(test)]
 mod econ4_confirm_test;
 #[cfg(test)]
+mod oracle_harness;
+#[cfg(test)]
+mod oracle_parity_test;
+#[cfg(test)]
 mod poll_test;

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -1,0 +1,131 @@
+//! Shared helpers for SQL ↔ pandas-equivalent oracle fixtures (#550 phase 1).
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use fdd_sql::{register_parquet_tree, run_sql};
+use fdd_store::ingest_building;
+
+use crate::params::{rule_params, substitute_sql};
+
+pub struct RoleCol {
+    pub csv_col: &'static str,
+    pub role: &'static str,
+}
+
+/// Minimal building layout: one equipment folder with `columns.csv` + `history_wide.csv`.
+pub fn write_equipment_fixture(
+    building_root: &Path,
+    equipment_id: &str,
+    grid_minutes: u32,
+    roles: &[RoleCol],
+    header_and_rows: &str,
+) {
+    std::fs::write(
+        building_root.join("manifest.json"),
+        format!(r#"{{"grid_minutes": {grid_minutes}}}"#),
+    )
+    .unwrap();
+    let eq = building_root.join(equipment_id);
+    std::fs::create_dir_all(&eq).unwrap();
+    let mut cols = String::from("col,point_role\n");
+    for r in roles {
+        cols.push_str(&format!("{},{}\n", r.csv_col, r.role));
+    }
+    std::fs::write(eq.join("columns.csv"), cols).unwrap();
+    let mut f = std::fs::File::create(eq.join("history_wide.csv")).unwrap();
+    write!(f, "{header_and_rows}").unwrap();
+}
+
+pub async fn run_rule_fault_hours(
+    building_root: &Path,
+    sql_file: &str,
+    poll_seconds: f64,
+    confirm_seconds: u32,
+    extra_params: &[(&str, &str)],
+) -> f64 {
+    let tmp_parquet = building_root
+        .parent()
+        .unwrap()
+        .join(format!("parquet-{}", sql_file.replace('.', "-")));
+    let _ = std::fs::remove_dir_all(&tmp_parquet);
+    let data_root = building_root.parent().unwrap();
+    let building_id = building_root
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    ingest_building(data_root, &building_id, &tmp_parquet).unwrap();
+
+    let ctx = datafusion::prelude::SessionContext::new();
+    register_parquet_tree(&ctx, &tmp_parquet).await.unwrap();
+
+    let sql_path = repo_sql_rules().join(sql_file);
+    let raw_sql = std::fs::read_to_string(&sql_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", sql_path.display()));
+    let mut params = rule_params(poll_seconds, confirm_seconds);
+    for (k, v) in extra_params {
+        params.insert((*k).into(), (*v).into());
+    }
+    let sql = substitute_sql(&raw_sql, &params);
+    let result = run_sql(&ctx, &sql).await.unwrap();
+    if result.row_count == 0 {
+        return 0.0;
+    }
+    result.rows[0]
+        .get("fault_hours")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0)
+}
+
+/// Pandas `confirm_fault` equivalent: confirm after `confirm_rows` consecutive true samples
+/// in a streak (group on raw != raw.shift()).
+pub fn pandas_confirm_fault_hours(raw: &[bool], poll_seconds: f64, confirm_rows: usize) -> f64 {
+    let mut confirmed = 0usize;
+    let mut streak = 0usize;
+    let mut prev: Option<bool> = None;
+    for &r in raw {
+        if prev != Some(r) {
+            streak = 0;
+        }
+        if r {
+            streak += 1;
+            if streak >= confirm_rows {
+                confirmed += 1;
+            }
+        } else {
+            streak = 0;
+        }
+        prev = Some(r);
+    }
+    confirmed as f64 * poll_seconds / 3600.0
+}
+
+pub fn assert_hours_close(got: f64, expected: f64, label: &str) {
+    assert!(
+        (got - expected).abs() < 1e-6,
+        "{label}: expected {expected}h, got {got}h"
+    );
+}
+
+fn repo_sql_rules() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("sql_rules")
+}
+
+/// Convenience: build params map for debugging.
+#[allow(dead_code)]
+pub fn merge_params(
+    poll_seconds: f64,
+    confirm_seconds: u32,
+    extra: &[(&str, &str)],
+) -> HashMap<String, String> {
+    let mut m = rule_params(poll_seconds, confirm_seconds);
+    for (k, v) in extra {
+        m.insert((*k).into(), (*v).into());
+    }
+    m
+}

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1,0 +1,202 @@
+//! Mask-level SQL oracle fixtures for #550 phase 1.
+//!
+//! These compare shipped SQL `fault_hours` against a pandas-equivalent
+//! `confirm_fault` reference on synthetic role-mapped history.
+
+#[cfg(test)]
+mod tests {
+    use crate::oracle_harness::{
+        assert_hours_close, pandas_confirm_fault_hours, run_rule_fault_hours,
+        write_equipment_fixture, RoleCol,
+    };
+
+    #[tokio::test]
+    async fn sched1_confirm_matches_pandas_reference() {
+        // poll=300s, confirm=600s -> CONFIRM_ROWS=2 (narrower than registry default so the
+        // synthetic series stays short; still exercises the same streak math).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SCHED1");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // occ unoccupied + fan on => raw 1. Sequence: 0,0,1,1,1,0,1,1
+        let rows = "\
+timestamp_utc,occ_col,fan_col
+2026-01-01T00:00:00Z,occupied,1
+2026-01-01T00:05:00Z,occupied,1
+2026-01-01T00:10:00Z,unoccupied,1
+2026-01-01T00:15:00Z,unoccupied,1
+2026-01-01T00:20:00Z,unoccupied,1
+2026-01-01T00:25:00Z,occupied,0
+2026-01-01T00:30:00Z,unoccupied,1
+2026-01-01T00:35:00Z,unoccupied,1
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "occ_col",
+                    role: "occ_mode",
+                },
+                RoleCol {
+                    csv_col: "fan_col",
+                    role: "fan_status",
+                },
+            ],
+            rows,
+        );
+
+        let got =
+            run_rule_fault_hours(&building, "sched1_unoccupied_runtime.sql", 300.0, 600, &[]).await;
+
+        let raw = [false, false, true, true, true, false, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        // indices 3,4,7 confirm => 3 * 300/3600 = 0.25h
+        assert_hours_close(expected, 0.25, "pandas reference");
+        assert_hours_close(got, expected, "SCHED-1 SQL");
+    }
+
+    #[tokio::test]
+    async fn vav7_underflow_confirm_matches_pandas_reference() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_VAV7");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // under min_flow_sp: flow 100 vs sp 200 => raw 1. Sequence length 6 with confirm_rows=2.
+        let rows = "\
+timestamp_utc,flow_col,min_col
+2026-01-01T00:00:00Z,250,200
+2026-01-01T00:05:00Z,250,200
+2026-01-01T00:10:00Z,100,200
+2026-01-01T00:15:00Z,100,200
+2026-01-01T00:20:00Z,100,200
+2026-01-01T00:25:00Z,250,200
+";
+        write_equipment_fixture(
+            &building,
+            "VAV_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "flow_col",
+                    role: "zone_flow",
+                },
+                RoleCol {
+                    csv_col: "min_col",
+                    role: "min_flow_sp",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "vav7_min_airflow.sql",
+            300.0,
+            600,
+            &[("HIGH_MIN_FLOW_SP", "2000")], // keep high-min branch inactive
+        )
+        .await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "VAV-7 under-flow SQL");
+    }
+
+    #[tokio::test]
+    async fn sv_rate_screening_confirm_streak() {
+        // Documents SV-RATE as a screening SQL (hard-coded 5°F Δ), not full pandas context.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SVRATE");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // Jump >5°F within persistence window on consecutive samples.
+        let rows = "\
+timestamp_utc,oat_col
+2026-01-01T00:00:00Z,70
+2026-01-01T00:05:00Z,70
+2026-01-01T00:10:00Z,80
+2026-01-01T00:15:00Z,90
+2026-01-01T00:20:00Z,100
+2026-01-01T00:25:00Z,100
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[RoleCol {
+                csv_col: "oat_col",
+                role: "oa_t",
+            }],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "sv_rate.sql",
+            300.0,
+            600,
+            &[("PERSISTENCE_MIN", "10")],
+        )
+        .await;
+
+        // raw: row0 no prev=0; 70->70=0; 70->80=1; 80->90=1; 90->100=1; 100->100=0
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "SV-RATE screening SQL");
+    }
+
+    #[tokio::test]
+    async fn chw_noload_confirm_matches_screening_reference() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_CHW");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // pump on + supply within band of SP => fault. sat_band default-like 1.5°F
+        let rows = "\
+timestamp_utc,t_col,sp_col,pump_col
+2026-01-01T00:00:00Z,44,44,0
+2026-01-01T00:05:00Z,44,44,0
+2026-01-01T00:10:00Z,44,44,50
+2026-01-01T00:15:00Z,44,44,50
+2026-01-01T00:20:00Z,44,44,50
+2026-01-01T00:25:00Z,50,44,50
+";
+        write_equipment_fixture(
+            &building,
+            "CHILLER_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "t_col",
+                    role: "chw_supply_t",
+                },
+                RoleCol {
+                    csv_col: "sp_col",
+                    role: "chw_supply_sp",
+                },
+                RoleCol {
+                    csv_col: "pump_col",
+                    role: "chw_pump_cmd",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "chw_noload_1.sql",
+            300.0,
+            600,
+            &[("SAT_BAND_F", "1.5")],
+        )
+        .await;
+
+        // pump>0.05 and |t-sp|<=1.5: rows 2,3,4 fault; 5 has |50-44|=6 => 0
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "CHW-NOLOAD-1 screening SQL");
+    }
+}

--- a/crates/fdd_store/src/ingest.rs
+++ b/crates/fdd_store/src/ingest.rs
@@ -149,7 +149,22 @@ fn read_csv_batch(path: &Path, columns_path: &Path) -> Result<(RecordBatch, u64)
         included.push((idx, role));
     }
     included.sort_by_key(|(idx, _)| *idx);
-    let mut num_cols: Vec<Vec<Option<f64>>> = vec![Vec::new(); included.len()];
+    // Most FDD roles are numeric; a few categorical schedule/mode roles must stay Utf8
+    // so SQL like LOWER(occ_mode)='unoccupied' works (#550 / SCHED-*).
+    let mut num_cols: Vec<Vec<Option<f64>>> = Vec::new();
+    let mut str_cols: Vec<Vec<Option<String>>> = Vec::new();
+    let mut col_kind: Vec<bool> = Vec::new(); // true => Utf8
+    for (_, role) in &included {
+        if is_utf8_role(role) {
+            col_kind.push(true);
+            str_cols.push(Vec::new());
+            num_cols.push(Vec::new());
+        } else {
+            col_kind.push(false);
+            str_cols.push(Vec::new());
+            num_cols.push(Vec::new());
+        }
+    }
     let mut rows = 0u64;
 
     for rec in rdr.records() {
@@ -165,8 +180,16 @@ fn read_csv_batch(path: &Path, columns_path: &Path) -> Result<(RecordBatch, u64)
             .unwrap_or(0);
         ts_vals.push(ts);
         for (j, (i, _)) in included.iter().enumerate() {
-            let v = rec.get(*i).and_then(|s| s.parse::<f64>().ok());
-            num_cols[j].push(v);
+            let cell = rec.get(*i).unwrap_or("").trim();
+            if col_kind[j] {
+                if cell.is_empty() {
+                    str_cols[j].push(None);
+                } else {
+                    str_cols[j].push(Some(cell.to_string()));
+                }
+            } else {
+                num_cols[j].push(cell.parse::<f64>().ok());
+            }
         }
     }
 
@@ -179,9 +202,15 @@ fn read_csv_batch(path: &Path, columns_path: &Path) -> Result<(RecordBatch, u64)
         vec![std::sync::Arc::new(TimestampNanosecondArray::from(ts_vals)) as _];
 
     for (j, (_, role)) in included.iter().enumerate() {
-        fields.push(Field::new(role, DataType::Float64, true));
-        let arr = Float64Array::from(num_cols[j].clone());
-        arrays.push(std::sync::Arc::new(arr) as _);
+        if col_kind[j] {
+            fields.push(Field::new(role, DataType::Utf8, true));
+            let arr = StringArray::from(str_cols[j].clone());
+            arrays.push(std::sync::Arc::new(arr) as _);
+        } else {
+            fields.push(Field::new(role, DataType::Float64, true));
+            let arr = Float64Array::from(num_cols[j].clone());
+            arrays.push(std::sync::Arc::new(arr) as _);
+        }
     }
 
     // equipment_id column for SQL joins
@@ -197,6 +226,13 @@ fn read_csv_batch(path: &Path, columns_path: &Path) -> Result<(RecordBatch, u64)
     let schema = Schema::new(fields);
     let batch = RecordBatch::try_new(std::sync::Arc::new(schema), arrays)?;
     Ok((batch, rows))
+}
+
+fn is_utf8_role(role: &str) -> bool {
+    matches!(
+        role,
+        "occ_mode" | "occupancy" | "schedule" | "mode" | "equip_mode"
+    )
 }
 
 /// When multiple CSV columns map to the same role, pick the oracle-preferred column.
@@ -355,6 +391,47 @@ mod tests {
         let min = col.iter().flatten().fold(f64::INFINITY, f64::min);
         let max = col.iter().flatten().fold(f64::NEG_INFINITY, f64::max);
         assert!(min > 60.0 && max < 90.0, "zone_t range {min}..{max}");
+    }
+
+    #[test]
+    fn occ_mode_ingested_as_utf8() {
+        let tmp = TempDir::new().unwrap();
+        let data = tmp.path().join("BUILDING_100");
+        std::fs::create_dir_all(&data).unwrap();
+        std::fs::write(data.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let ahu = data.join("AHU_1");
+        std::fs::create_dir_all(&ahu).unwrap();
+        std::fs::write(
+            ahu.join("columns.csv"),
+            "col,point_role\nocc_col,occ_mode\nfan_col,fan_status\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,occ_col,fan_col").unwrap();
+        writeln!(f, "2026-01-01T00:00:00Z,unoccupied,1").unwrap();
+
+        let out = tmp.path().join("parquet");
+        ingest_building(tmp.path(), "BUILDING_100", &out).unwrap();
+        let pq = out.join("building=BUILDING_100/equipment=AHU_1/history.parquet");
+        let file = std::fs::File::open(&pq).unwrap();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let batch = reader.into_iter().next().unwrap().unwrap();
+        let occ = batch
+            .schema()
+            .fields()
+            .iter()
+            .position(|f| f.name() == "occ_mode")
+            .expect("occ_mode");
+        assert_eq!(batch.schema().field(occ).data_type(), &DataType::Utf8);
+        let arr = batch
+            .column(occ)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(arr.value(0), "unoccupied");
     }
 
     #[test]

--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -6,35 +6,58 @@ nav_order: 6
 
 # SQL ↔ Pandas parity matrix
 
-**Audit date:** 2026-07-16 · **Validated catalog:** 59 vibe19 rules · **Target:** zero silent drift
+**Audit date:** 2026-07-19 · **Registry source:** `sql_rules/registry.yaml` · **Target:** zero silent drift
 
-## Summary
+## Honesty first
 
-| Status | Count |
-|--------|------:|
-| Full parity (SQL + Pandas, same ID) | 54 |
-| Pandas-complete / SQL simplified | 5 |
-| Documented but not in validated catalog | 13 |
+`parity_status` in the registry is the only machine-readable claim. Cookbook prose must not outrun it.
 
-**SQL-simplified (intentional):** `SV-RATE`, `PID-HUNT-1`, `FC4`, `SV-SPIKE`, `SV-FLATLINE` — rolling / multi-sensor logic is fully validated in Pandas; SQL ships a screening variant with an explicit caveat in the SQL cookbook.
+| `parity_status` | Count (registry) | Meaning |
+|-----------------|-----------------:|---------|
+| `proven_building_100` | 18 | Exercised against BUILDING_100-style fixtures / production soak with matching fault-hour intent |
+| `ported_from_cookbook` | 44 | SQL exists and compiles; **ported ≠ oracle-proven**. Mask / confirm / rolling behavior may still diverge from Pandas |
+| `skipped_missing_roles` | 1 | `FC7` — skipped until required roles are modeled |
+
+**Do not claim “54 full parity.”** That figure was aspirational catalog coverage, not mask-level SQL↔Pandas agreement.
+
+Oracle harness (phase 1, #550): `crates/fdd_rules` mask/fault-hour fixtures patterned on `econ4_confirm_test.rs`. A rule may only move to `proven_building_100` after a passing oracle (or documented BUILDING_100 soak) — never by docs alone.
 
 ---
 
-## Family coverage
+## Proven vs ported (high level)
 
-| Family | Validated IDs | SQL | Pandas |
-|--------|---------------|:---:|:------:|
-| sensor | SV-RANGE, SV-FLATLINE, SV-SPIKE, SV-STALE, SV-RATE | ✅* | ✅ |
-| control | PID-HUNT-1 | ✅* | ✅ |
-| ahu | FC1–FC15, AHU-*, ECON-1–7, OAT-METEO, MECH-OAT-1, CMD-1, OA-1, VLV-1, DMP-1 | ✅ | ✅ |
-| vav | VAV-1, VAV-3–5, VAV-7, VAV-REHEAT, VAV-AHU-LEAVE | ✅ | ✅ |
-| plant | CHW-1–4, CHW-NOLOAD-1, CW-APR-1, CW-FAN-1, CW-OPT-1 | ✅ | ✅ |
-| heatpump | HP-1 | ✅ | ✅ |
-| weather | WX-1 | ✅ | ✅ |
-| trim | TRIM-1, TRIM-3, TRIM-4 | ✅ | ✅ |
-| schedule | SCHED-1, SCHED-247 | ✅ | ✅ |
+### `proven_building_100` (18)
 
-\* simplified SQL variant
+`AVG-ZONE-TEMP`, `ECON-1`, `ECON-2`, `ECON-4`, `FAN-RUNTIME-HOURS`, `FAULT-ELAPSED-HOURS`, `FC1`, `FC2`, `FC3`, `FC8`, `FC9`, `FC10`, `FC11`, `FC12`, `FC13-SAT-HIGH`, `OAT-METEO`, `VAV-1`, `ZONE-COMFORT-PCT`
+
+### Representative `ported_from_cookbook` risk set (phase-1 oracle focus)
+
+These are the mismatch classes called out in #550 — SQL is present; treat results as screening until fixtures pass:
+
+| Family | Rule IDs | Typical drift |
+|--------|----------|---------------|
+| sensor | `SV-RANGE`, `SV-FLATLINE`, `SV-SPIKE`, `SV-STALE`, `SV-RATE` | Rolling / multi-sensor / rate context simplified in SQL |
+| control | `PID-HUNT-1`, `FC4` | Hunting metrics screening vs full TV/reversal |
+| ahu | `FC6`, `FC14`, `FC15`, `MECH-OAT-1`, … | Mix / coil / mech enable gates |
+| vav | `VAV-4`, `VAV-7`, … | Rolling “fixed high” / high-min SP incomplete in SQL |
+| plant | `CHW-NOLOAD-1`, … | Load proxies simplified |
+| trim / schedule | `TRIM-*`, `SCHED-1`, `SCHED-247` | Confirm + occupancy semantics |
+
+---
+
+## Family coverage (catalog presence, not oracle)
+
+| Family | IDs in registry | SQL file | Pandas cookbook | Oracle-proven? |
+|--------|-----------------|:--------:|:---------------:|:--------------:|
+| sensor | SV-* | ✅ | ✅ | mostly **ported** |
+| control | PID-HUNT-1 | ✅* | ✅ | **ported** |
+| ahu | FC*, AHU-*, ECON-*, OAT-METEO, MECH-OAT-1, … | ✅ | ✅ | mixed |
+| vav | VAV-1, VAV-3–5, VAV-7, VAV-REHEAT, VAV-AHU-LEAVE | ✅ | ✅ | mixed (`VAV-1` proven) |
+| plant | CHW-*, CW-*, … | ✅ | ✅ | **ported** |
+| trim | TRIM-1/3/4 | ✅ | ✅ | **ported** |
+| schedule | SCHED-1, SCHED-247 | ✅ | ✅ | **ported** (confirm fixtures landing) |
+
+\* SQL often ships a **screening** variant; see per-rule caveats in the SQL cookbook.
 
 ---
 
@@ -43,17 +66,18 @@ nav_order: 6
 | Topic | DataFusion SQL | Pandas |
 |-------|----------------|--------|
 | Window / rolling | `LAG()`, limited `OVER` | `.shift()`, `.rolling()`, multi-sensor sweeps |
-| Confirmation | API `confirmation_seconds` | `confirm_fault()` |
-| Sensor sweeps | Per-column CASE examples | Catalog `sensor_sweep=True` across all roles |
+| Confirmation | `CONFIRM_ROWS` streak (pandas-equivalent grouping) | `confirm_fault()` |
+| Sensor sweeps | Per-column CASE examples | Catalog `sensor_sweep=True` across roles |
 | Control hunting | Screening thresholds | Full TV / reversal / cycle metrics (`PID-HUNT-1`) |
 
 ---
 
 ## Parity test procedure
 
-1. Export `telemetry_pivot` window from edge historian
-2. Run SQL via `POST /api/fdd-rules/{id}/test-sql`
-3. Run matching Pandas mask offline (vibe19 catalog compute)
-4. Run fixture suite: `scripts/cookbook_parity_check.py --all`
+1. Prefer Rust oracle fixtures in `crates/fdd_rules` (mask / `fault_hours` vs pandas-equivalent reference).
+2. Export `telemetry_pivot` window from edge historian when debugging site data.
+3. Run SQL via registry runner / `POST /api/fdd/run` (typed params only).
+4. Run Pandas mask offline from vibe19 / cookbook compute.
+5. Optional docs integrity: `scripts/cookbook_parity_check.py --all` (pandas “any fault” smoke — **not** a full SQL oracle).
 
 See [benchmark strategy](benchmark-strategy.html).

--- a/sql_rules/vav7_min_airflow.sql
+++ b/sql_rules/vav7_min_airflow.sql
@@ -1,4 +1,8 @@
 -- vav7_min_airflow.sql — Min airflow / fixed high flow
+-- Phase-1 (#550): SQL screens the under-min-flow branch only.
+-- Pandas also faults on rolling "fixed high" flow and high min-flow SP while air is on
+-- (params flow_on_min / fixed_flow_* / high_min_flow_sp). Those windows are not ported yet;
+-- {{HIGH_MIN_FLOW_SP}} is accepted so registry substitution stays valid but is unused here.
 WITH base AS (
   SELECT
     equipment_id,
@@ -6,7 +10,6 @@ WITH base AS (
     CAST(CASE
       WHEN zone_flow IS NULL OR min_flow_sp IS NULL THEN 0
       WHEN zone_flow < min_flow_sp THEN 1
-      WHEN min_flow_sp > {{HIGH_MIN_FLOW_SP}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
   FROM history


### PR DESCRIPTION
## Summary
- **Docs:** `parity-matrix.md` now matches `registry.yaml` (18 `proven_building_100`, 44 `ported_from_cookbook`, 1 skipped). Stops claiming “54 full parity”; ported ≠ oracle.
- **Oracle harness:** `oracle_harness` + fixtures for SCHED-1, VAV-7 under-flow, SV-RATE screening, CHW-NOLOAD-1 (pandas-equivalent confirm streaks).
- **Fixes this cycle:** ingest keeps `occ_mode` (and related mode roles) as Utf8; VAV-7 SQL no longer over-fires bare `high_min` without rolling windows.
- **Not done:** remaining ~40 ported rules / PID-HUNT / FC4 rolling rewrites — stay `ported_from_cookbook` (next cycle).

Closes nothing — comments on #550 after merge.

## Test plan
- [x] `cargo test -p fdd_rules oracle_`
- [x] `cargo test -p fdd_store --lib`
- [ ] CI green

Made with [Cursor](https://cursor.com)