### PR TITLE
feat(central): #549 mount dashboard APIs + capabilities

### DIFF
--- a/mcp/src/bridge.rs
+++ b/mcp/src/bridge.rs
@@ -385,7 +385,7 @@ impl BridgeClient {
                 "ok": false,
                 "optional": true,
                 "error": error,
-                "hint": "capabilities will be required after #549 lands"
+                "hint": "capabilities endpoint unavailable"
             })
         });
 

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -87,6 +87,30 @@ pub fn router(state: Arc<AppState>) -> Router {
         )
         .route("/api/fdd/run", post(fdd_run))
         .route("/api/fdd/status", get(fdd_status))
+        .route("/api/health/stack", get(health_stack))
+        .route("/api/building/snapshot", get(building_snapshot))
+        .route("/api/faults/status", get(faults_status))
+        .route("/api/faults/summary", get(faults_summary))
+        .route("/api/export/meta", get(export_meta))
+        .route("/api/data-management/summary", get(data_management_summary))
+        .route("/api/host/stats", get(host_stats))
+        .route("/api/fdd-schema/tables", get(fdd_schema_tables))
+        .route("/api/fdd-rules", get(fdd_rules_list))
+        .route("/api/reports", get(reports_list))
+        .route("/api/reports/templates", get(reports_templates))
+        .route("/api/reports/draft", post(reports_draft))
+        .route(
+            "/api/reports/{report_id}",
+            get(reports_get).patch(reports_patch).delete(reports_delete),
+        )
+        .route(
+            "/api/reports/{report_id}/render/pdf",
+            post(reports_render_pdf),
+        )
+        .route(
+            "/api/reports/{report_id}/download.pdf",
+            get(reports_download_pdf),
+        )
         .merge(csv)
         .layer(middleware::from_fn_with_state(
             Arc::clone(&state),
@@ -129,14 +153,14 @@ pub async fn capabilities() -> Json<Value> {
             "fdd_series": true,
             "session_config": true,
             "csv_package": true,
-            "reports": false,
-            "export": false,
-            "data_management": false,
-            "host_stats": false,
-            "faults": false,
-            "health_stack": false,
-            "fdd_rules_authoring": false,
-            "fdd_schema": false
+            "reports": true,
+            "export": true,
+            "data_management": true,
+            "host_stats": true,
+            "faults": true,
+            "health_stack": true,
+            "fdd_rules_authoring": true,
+            "fdd_schema": true
         }
     }))
 }
@@ -896,4 +920,120 @@ pub async fn csv_preview_dataset(
         q.offset.unwrap_or(0) as u64,
         q.limit.unwrap_or(100) as u64,
     ))
+}
+
+pub async fn health_stack() -> Json<Value> {
+    Json(open_fdd_edge_prototype::dashboard::stack_health())
+}
+
+pub async fn building_snapshot() -> Json<Value> {
+    Json(open_fdd_edge_prototype::dashboard::building_snapshot())
+}
+
+pub async fn faults_status() -> Json<Value> {
+    Json(open_fdd_edge_prototype::faults::status_json())
+}
+
+pub async fn faults_summary() -> Json<Value> {
+    Json(open_fdd_edge_prototype::faults::summary_json())
+}
+
+pub async fn export_meta() -> Json<Value> {
+    Json(open_fdd_edge_prototype::export::meta_json())
+}
+
+pub async fn data_management_summary() -> Json<Value> {
+    Json(open_fdd_edge_prototype::data_management::storage_summary())
+}
+
+pub async fn host_stats() -> Json<Value> {
+    Json(open_fdd_edge_prototype::ops::host_stats::stats_json())
+}
+
+pub async fn fdd_schema_tables() -> Json<Value> {
+    match serde_json::from_str(&open_fdd_edge_prototype::fdd::wires::api::schema_tables_json()) {
+        Ok(v) => Json(v),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+pub async fn fdd_rules_list() -> Json<Value> {
+    match serde_json::from_str(&open_fdd_edge_prototype::fdd::wires::api::list_rules_json()) {
+        Ok(v) => Json(v),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+pub async fn reports_list() -> Json<Value> {
+    Json(open_fdd_edge_prototype::reports::list_reports())
+}
+
+pub async fn reports_templates() -> Json<Value> {
+    Json(open_fdd_edge_prototype::reports::templates())
+}
+
+pub async fn reports_draft(Json(body): Json<Value>) -> Json<Value> {
+    let result =
+        tokio::task::spawn_blocking(move || open_fdd_edge_prototype::reports::create_draft(&body))
+            .await
+            .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports draft task: {e}")}));
+    Json(result)
+}
+
+pub async fn reports_get(Path(report_id): Path<String>) -> Json<Value> {
+    Json(open_fdd_edge_prototype::reports::get_report(&report_id))
+}
+
+pub async fn reports_patch(Path(report_id): Path<String>, Json(body): Json<Value>) -> Json<Value> {
+    let result = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::reports::patch_report(&report_id, &body)
+    })
+    .await
+    .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports patch task: {e}")}));
+    Json(result)
+}
+
+pub async fn reports_delete(Path(report_id): Path<String>) -> Json<Value> {
+    let result = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::reports::delete_report(&report_id)
+    })
+    .await
+    .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports delete task: {e}")}));
+    Json(result)
+}
+
+pub async fn reports_render_pdf(Path(report_id): Path<String>) -> Json<Value> {
+    let result = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::reports::render_pdf_bundle(&report_id)
+    })
+    .await
+    .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports render task: {e}")}));
+    Json(result)
+}
+
+pub async fn reports_download_pdf(
+    Path(report_id): Path<String>,
+) -> Result<(StatusCode, HeaderMap, Vec<u8>), (StatusCode, Json<Value>)> {
+    let path =
+        open_fdd_edge_prototype::reports::download_path(&report_id, "pdf").ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({"ok": false, "error": "pdf not found — render first"})),
+            )
+        })?;
+    let bytes = std::fs::read(&path).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"ok": false, "error": e.to_string()})),
+        )
+    })?;
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, "application/pdf".parse().unwrap());
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        format!("attachment; filename=\"report-{report_id}.pdf\"")
+            .parse()
+            .unwrap(),
+    );
+    Ok((StatusCode::OK, headers, bytes))
 }

--- a/services/central/tests/dashboard_api_smoke.rs
+++ b/services/central/tests/dashboard_api_smoke.rs
@@ -1,0 +1,141 @@
+//! Central must expose the legacy edge dashboard families used by the UI shell (#549).
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::Duration;
+
+struct Server {
+    child: Child,
+    port: u16,
+    workspace: PathBuf,
+}
+
+impl Server {
+    fn start() -> Self {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral")
+            .local_addr()
+            .expect("port")
+            .port();
+        let workspace =
+            std::env::temp_dir().join(format!("openfdd-central-dash-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&workspace);
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = manifest_dir.join("../..");
+        let sql_rules = repo_root.join("sql_rules");
+        let bin = env!("CARGO_BIN_EXE_openfdd-central");
+        let mut child = Command::new(bin)
+            .env("OPENFDD_CENTRAL_HOST", "127.0.0.1")
+            .env("OPENFDD_CENTRAL_PORT", port.to_string())
+            .env("OPENFDD_MQTT_ENABLED", "0")
+            .env("OPENFDD_WORKSPACE", &workspace)
+            .env("OPENFDD_PARQUET_ROOT", workspace.join(".cache/parquet"))
+            .env("OPENFDD_SQL_RULES_DIR", &sql_rules)
+            .spawn()
+            .expect("start openfdd-central");
+
+        for _ in 0..80 {
+            let (status, body) = http("GET", port, "/api/health", None);
+            if status == 200 && body.contains("\"openfdd-central\"") {
+                return Self {
+                    child,
+                    port,
+                    workspace,
+                };
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("central did not become ready on port {port}");
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.workspace);
+    }
+}
+
+fn http(method: &str, port: u16, path: &str, body: Option<&str>) -> (u16, String) {
+    let host_port = format!("127.0.0.1:{port}");
+    let mut stream = match TcpStream::connect(&host_port) {
+        Ok(s) => s,
+        Err(_) => return (0, String::new()),
+    };
+    stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host_port}\r\nConnection: close\r\n")
+        .into_bytes();
+    if let Some(b) = body {
+        req.extend_from_slice(b"Content-Type: application/json\r\n");
+        req.extend_from_slice(format!("Content-Length: {}\r\n\r\n", b.len()).as_bytes());
+        req.extend_from_slice(b.as_bytes());
+    } else {
+        req.extend_from_slice(b"\r\n");
+    }
+    stream.write_all(&req).unwrap();
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(50));
+                continue;
+            }
+            Err(e) => panic!("HTTP read failed: {e}"),
+        }
+    }
+    let resp = String::from_utf8_lossy(&buf);
+    let status = resp
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let body = resp.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
+    (status, body)
+}
+
+#[test]
+fn dashboard_shell_routes_are_not_404() {
+    let server = Server::start();
+    let paths = [
+        "/api/capabilities",
+        "/api/health/stack",
+        "/api/building/snapshot",
+        "/api/faults/status",
+        "/api/faults/summary",
+        "/api/export/meta",
+        "/api/data-management/summary",
+        "/api/host/stats",
+        "/api/fdd-schema/tables",
+        "/api/fdd-rules",
+        "/api/reports",
+        "/api/reports/templates",
+    ];
+    for path in paths {
+        let (status, body) = http("GET", server.port, path, None);
+        assert_ne!(status, 404, "{path} returned 404: {body}");
+        assert!(
+            (200..500).contains(&status),
+            "{path} unexpected status {status}: {body}"
+        );
+    }
+
+    let (status, body) = http(
+        "POST",
+        server.port,
+        "/api/reports/draft",
+        Some(r#"{"title":"smoke draft","template_id":"blank"}"#),
+    );
+    assert_ne!(status, 404, "POST /api/reports/draft returned 404: {body}");
+}

--- a/workspace/dashboard/src/components/AppLayout.tsx
+++ b/workspace/dashboard/src/components/AppLayout.tsx
@@ -13,6 +13,12 @@ type NavItem = {
   protected?: boolean;
   disabled?: boolean;
   disabledHint?: string;
+  requiredCapability?: string;
+};
+
+type CapabilitiesResponse = {
+  ok?: boolean;
+  capabilities?: Record<string, boolean>;
 };
 
 /* Streamlit-parity nav: plain text labels, no emoji icons. */
@@ -37,17 +43,42 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
       { to: "/lab", label: "Open-FDD Lab (vibe19)", protected: true },
       { to: "/csv", label: "CSV job upload", protected: true },
       { to: "/model", label: "Model & FDD assignments", protected: true },
-      { to: "/sql-fdd", label: "SQL FDD lab (integrator)", protected: true },
+      {
+        to: "/sql-fdd",
+        label: "SQL FDD lab (integrator)",
+        protected: true,
+        requiredCapability: "fdd_rules_authoring",
+      },
       { to: "/plot", label: "Plots", protected: true },
-      { to: "/reports", label: "Reports", protected: true },
+      {
+        to: "/reports",
+        label: "Reports",
+        protected: true,
+        requiredCapability: "reports",
+      },
     ],
   },
   {
     title: "Data & ops",
     items: [
-      { to: "/exports", label: "Data export", protected: true },
-      { to: "/data-management", label: "Historian storage", protected: true },
-      { to: "/host", label: "Host stats", protected: true },
+      {
+        to: "/exports",
+        label: "Data export",
+        protected: true,
+        requiredCapability: "export",
+      },
+      {
+        to: "/data-management",
+        label: "Historian storage",
+        protected: true,
+        requiredCapability: "data_management",
+      },
+      {
+        to: "/host",
+        label: "Host stats",
+        protected: true,
+        requiredCapability: "host_stats",
+      },
       { to: "/algorithms", label: "Algorithms", protected: true },
     ],
   },
@@ -67,6 +98,7 @@ export default function AppLayout() {
   const [sessionRole, setSessionRole] = useState<string | null>(null);
   const [sessionUser, setSessionUser] = useState<string | null>(null);
   const [edgeVersion, setEdgeVersion] = useState<string | null>(null);
+  const [capabilities, setCapabilities] = useState<Record<string, boolean> | null>(null);
 
   useEffect(() => {
     const base = getBridgeBase();
@@ -74,6 +106,12 @@ export default function AppLayout() {
       .then((r) => r.json())
       .then((h: HealthInfo) => setEdgeVersion(h.version || h.image_tag || null))
       .catch(() => setEdgeVersion(null));
+    fetch(`${base}/api/capabilities`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body: CapabilitiesResponse | null) => {
+        setCapabilities(body?.capabilities ?? null);
+      })
+      .catch(() => setCapabilities(null));
   }, []);
 
   useEffect(() => {
@@ -141,12 +179,22 @@ export default function AppLayout() {
           {NAV_SECTIONS.map((section) => (
             <div key={section.title} className="nav-section">
               <div className="nav-section-title">{section.title}</div>
-              {section.items.map((item) =>
-                item.disabled ? (
+              {section.items.map((item) => {
+                const capabilityMissing =
+                  Boolean(item.requiredCapability) &&
+                  capabilities != null &&
+                  capabilities[item.requiredCapability!] !== true;
+                const disabled = Boolean(item.disabled || capabilityMissing);
+                return disabled ? (
                   <span
                     key={item.to}
                     className="nav-item nav-item-disabled"
-                    title={item.disabledHint ?? "Coming soon"}
+                    title={
+                      item.disabledHint ??
+                      (capabilityMissing
+                        ? `Unavailable — central missing ${item.requiredCapability}`
+                        : "Coming soon")
+                    }
                     aria-disabled="true"
                   >
                     {item.label}
@@ -161,8 +209,8 @@ export default function AppLayout() {
                   >
                     {item.label}
                   </NavLink>
-                ),
-              )}
+                );
+              })}
             </div>
           ))}
         </nav>

--- a/workspace/dashboard/src/pages/ReportBuilderPage.tsx
+++ b/workspace/dashboard/src/pages/ReportBuilderPage.tsx
@@ -132,10 +132,10 @@ export default function ReportBuilderPage() {
     const id = searchParams.get("id");
     if (id) {
       void loadReportById(id);
-    } else {
-      void createDraft();
     }
-  }, [searchParams]);
+    // Do not auto-create a draft on mount — wait for an explicit user action
+    // so product shells stay quiet when reports APIs are unavailable.
+  }, [searchParams, loadReportById, loadReports]);
 
   async function deleteReport(reportId: string) {
     setBusy(true);


### PR DESCRIPTION
## Summary
- Mounts the edge dashboard API families on central so the product shell stops 404ing (#549): health/stack, building snapshot, faults, export meta, data-management, host stats, fdd-schema/tables, fdd-rules list, and reports CRUD/render/download.
- Advertises those families via `GET /api/capabilities`; AppLayout disables nav items when a capability is false/missing.
- Report Builder no longer auto-POSTs `/api/reports/draft` on mount.
- Adds `services/central/tests/dashboard_api_smoke.rs` asserting newly mounted paths are not 404.

Replaces auto-closed #554 after #553 base branch deletion; rebased onto current master.

## Test plan
- [x] `cargo test -p openfdd-central --test dashboard_api_smoke`
- [ ] CI green
- [ ] Manual: product nav Reports/Export/Host no longer 404; Report Builder stays idle until Create draft

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard APIs for health, building status, faults, exports, data management, host statistics, and FDD configuration.
  * Added report management capabilities, including listing, drafting, editing, deleting, PDF rendering, and downloading.
  * Added capability-aware navigation that clearly indicates unavailable sections.
* **Bug Fixes**
  * Updated capability availability messaging when the endpoint cannot be reached.
  * Report drafts are no longer created automatically when opening the report builder; users can generate them explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->