### PR TITLE
fix: CodeRabbit follow-ups from #556/#557

### DIFF
--- a/docs/agent/linux-edge-tester-stack-recipes-prompt.md
+++ b/docs/agent/linux-edge-tester-stack-recipes-prompt.md
@@ -38,8 +38,8 @@ You are the Open-FDD second-bench soak agent on the OT / edge tester machine.
 
 Charter:
 - GHCR tip for this soak: prefer `OPENFDD_IMAGE_TAG=sha-ef2b85e` (or `:nightly` with
-  matching org.opencontainers.image.revision=ef2b85e07e6e… on central + mcp). No local
-  product builds, no product code PRs.
+  matching `org.opencontainers.image.revision=ef2b85e07e6e…` on **every** stack image —
+  central, ui, fieldbus, mqtt, and mcp). No local product builds, no product code PRs.
 - Test, document, file/comment GitHub issues. The WSL product agent owns closing/keeping issues after your report.
 - Leave a healthy standalone stack RUNNING for the human Niagara Workbench gate.
 - MCP is its OWN container/image (`ghcr.io/bbartling/openfdd-mcp`). A healthy MCP process alone is NOT a pass — answers must match direct central API truth.

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -64,7 +64,7 @@ impl Server {
             tool("openfdd_driver_status", "Poll bridge driver status endpoints", json!({})),
             tool("openfdd_health", "GET /api/health (public liveness)", json!({})),
             tool("openfdd_capabilities", "GET /api/capabilities — central feature contract", json!({})),
-            tool("openfdd_stack_status", "GET /api/health/stack — data plane strip (JWT)", json!({})),
+            tool("openfdd_stack_status", "GET /api/health/stack — data plane strip (public)", json!({})),
             tool("openfdd_faults_status", "GET /api/faults/status — live fault subsystem status", json!({})),
             tool("openfdd_export_meta", "GET /api/export/meta — available export contract", json!({})),
             tool("openfdd_haystack_status", "GET /api/haystack/status", json!({})),

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -30,7 +30,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/capabilities", get(capabilities))
         .route("/api/auth/status", get(auth_status))
         .route("/api/auth/me", get(auth_me))
-        .route("/api/auth/login", post(auth_login));
+        .route("/api/auth/login", post(auth_login))
+        // Shell strip + building summary are intentionally public (UI before login).
+        .route("/api/health/stack", get(health_stack))
+        .route("/api/building/snapshot", get(building_snapshot));
 
     let csv = Router::new()
         .route("/api/csv/import/preview", post(csv_preview))
@@ -87,8 +90,6 @@ pub fn router(state: Arc<AppState>) -> Router {
         )
         .route("/api/fdd/run", post(fdd_run))
         .route("/api/fdd/status", get(fdd_status))
-        .route("/api/health/stack", get(health_stack))
-        .route("/api/building/snapshot", get(building_snapshot))
         .route("/api/faults/status", get(faults_status))
         .route("/api/faults/summary", get(faults_summary))
         .route("/api/export/meta", get(export_meta))
@@ -1014,6 +1015,22 @@ pub async fn reports_render_pdf(Path(report_id): Path<String>) -> Json<Value> {
 pub async fn reports_download_pdf(
     Path(report_id): Path<String>,
 ) -> Result<(StatusCode, HeaderMap, Vec<u8>), (StatusCode, Json<Value>)> {
+    let safe_id: String = report_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if safe_id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "invalid report_id"})),
+        ));
+    }
     let path =
         open_fdd_edge_prototype::reports::download_path(&report_id, "pdf").ok_or_else(|| {
             (
@@ -1021,19 +1038,29 @@ pub async fn reports_download_pdf(
                 Json(json!({"ok": false, "error": "pdf not found — render first"})),
             )
         })?;
-    let bytes = std::fs::read(&path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"ok": false, "error": e.to_string()})),
-        )
-    })?;
+    let bytes = tokio::task::spawn_blocking(move || std::fs::read(path))
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"ok": false, "error": format!("reports download task: {e}")})),
+            )
+        })?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"ok": false, "error": e.to_string()})),
+            )
+        })?;
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, "application/pdf".parse().unwrap());
-    headers.insert(
-        header::CONTENT_DISPOSITION,
-        format!("attachment; filename=\"report-{report_id}.pdf\"")
-            .parse()
-            .unwrap(),
-    );
+    let disposition = format!("attachment; filename=\"report-{safe_id}.pdf\"");
+    let disposition_value = disposition.parse().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "invalid report_id for Content-Disposition"})),
+        )
+    })?;
+    headers.insert(header::CONTENT_DISPOSITION, disposition_value);
     Ok((StatusCode::OK, headers, bytes))
 }

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1031,27 +1031,27 @@ pub async fn reports_download_pdf(
             Json(json!({"ok": false, "error": "invalid report_id"})),
         ));
     }
-    let path =
-        open_fdd_edge_prototype::reports::download_path(&report_id, "pdf").ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(json!({"ok": false, "error": "pdf not found — render first"})),
-            )
-        })?;
-    let bytes = tokio::task::spawn_blocking(move || std::fs::read(path))
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"ok": false, "error": format!("reports download task: {e}")})),
-            )
-        })?
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"ok": false, "error": e.to_string()})),
-            )
-        })?;
+    let report_id_for_io = report_id.clone();
+    let bytes = tokio::task::spawn_blocking(move || {
+        let path = open_fdd_edge_prototype::reports::download_path(&report_id_for_io, "pdf")
+            .ok_or_else(|| "pdf not found — render first".to_string())?;
+        std::fs::read(path).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"ok": false, "error": format!("reports download task: {e}")})),
+        )
+    })?
+    .map_err(|e| {
+        let status = if e.contains("not found") {
+            StatusCode::NOT_FOUND
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
+        (status, Json(json!({"ok": false, "error": e})))
+    })?;
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, "application/pdf".parse().unwrap());
     let disposition = format!("attachment; filename=\"report-{safe_id}.pdf\"");

--- a/workspace/dashboard/src/pages/ReportBuilderPage.tsx
+++ b/workspace/dashboard/src/pages/ReportBuilderPage.tsx
@@ -82,7 +82,7 @@ export default function ReportBuilderPage() {
     } catch (e) {
       setError(formatApiError(e));
     }
-  }, [templateId, includeBranding]);
+  }, []);
 
   const sections = useMemo(
     () => [...(report?.sections ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
@@ -112,7 +112,7 @@ export default function ReportBuilderPage() {
     } finally {
       setBusy(false);
     }
-  }, [templateId]);
+  }, [templateId, includeBranding]);
 
   const loadReportById = useCallback(async (reportId: string) => {
     setBusy(true);
@@ -127,15 +127,16 @@ export default function ReportBuilderPage() {
     }
   }, []);
 
+  const reportIdFromQuery = searchParams.get("id");
+
   useEffect(() => {
     void loadReports();
-    const id = searchParams.get("id");
-    if (id) {
-      void loadReportById(id);
+    if (reportIdFromQuery) {
+      void loadReportById(reportIdFromQuery);
     }
     // Do not auto-create a draft on mount — wait for an explicit user action
     // so product shells stay quiet when reports APIs are unavailable.
-  }, [searchParams, loadReportById, loadReports]);
+  }, [reportIdFromQuery, loadReportById, loadReports]);
 
   async function deleteReport(reportId: string) {
     setBusy(true);


### PR DESCRIPTION
## Summary
- Require GHCR tip `org.opencontainers.image.revision` match on **all** stack images (central, ui, fieldbus, mqtt, mcp) in the edge-tester soak prompt (#557).
- Move `/api/health/stack` and `/api/building/snapshot` to the public router so the pre-login shell strip works when JWT auth is enabled (#556).
- Harden `reports_download_pdf`: sanitize filename, fallible `Content-Disposition`, `spawn_blocking` for disk I/O (#556).
- Stabilize `ReportBuilderPage` effect/callback deps (`id` only; `createDraft` includes branding) (#556).

## Test plan
- [x] `cargo test -p openfdd-central --test dashboard_api_smoke`
- [ ] CI green on this PR (Rust Stack CI, AppSec, Docs, Stack Security Guards)
- [ ] With `OPENFDD_JWT_SECRET` set: unauthenticated `GET /api/health/stack` and `/api/building/snapshot` return 200; other dashboard routes still 401


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved report PDF downloads with sanitized filenames and more defensive error handling.
  - Fixed report builder behavior so branding toggle changes are reflected when creating drafts.
  - Improved report loading driven by URL parameters (more reliable query handling).

- **Improvements**
  - Made dashboard health and building snapshot endpoints available without login.
  - Clarified stack status “public” data-plane strip description in status metadata/documentation.
  - Expanded pinned image revision verification to require matching across all stack images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->