### PR TITLE
fix(ui): Streamlit×SQL soak P0 — JWT, confirm_min, param aliases

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -74,14 +74,17 @@ jobs:
           test -f services/ui/streamlit_app.py
           test -f services/ui/requirements.txt
           test -f services/ui/app/central_client.py
-          python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py
+          python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py services/ui/app/agent_api.py
           grep -q "Rule tuning" services/ui/streamlit_app.py
           grep -q "Delete dataset" services/ui/streamlit_app.py
           grep -q "def _run_rule_list" services/ui/streamlit_app.py
           grep -q "DataFusion" services/ui/streamlit_app.py || grep -q "run_fdd" services/ui/app/central_client.py
+          grep -q "Authorization" services/ui/app/central_client.py
+          grep -q "confirm_seconds" services/ui/app/central_client.py
           ! test -d workspace/dashboard/src
           ! test -f workspace/dashboard/package.json
-
+          pip install -q pytest
+          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py -q)
       - name: BACnet NIC helper guards
         run: |
           test -x scripts/openfdd_bacnet_nic_setup.sh

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -83,7 +83,7 @@ jobs:
           grep -q "confirm_seconds" services/ui/app/central_client.py
           ! test -d workspace/dashboard/src
           ! test -f workspace/dashboard/package.json
-          pip install -q pytest
+          pip install -q pytest requests
           (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py -q)
       - name: BACnet NIC helper guards
         run: |

--- a/crates/fdd_rules/src/runner.rs
+++ b/crates/fdd_rules/src/runner.rs
@@ -96,15 +96,20 @@ pub async fn run_all_rules_with_overrides(
         let session_override = overrides.get(&rule.rule_id);
         if let Ok(tuned) = effective_param_strings(rule, &tuning, None, None, session_override) {
             for (k, v) in tuned {
+                // Do not let registry parameter defaults for CONFIRM_* wipe the
+                // confirm window already applied via rule.confirm_seconds /
+                // confirm_min (soak BUG-2). Session overrides for confirm_seconds
+                // are already merged into rule.confirm_seconds by the API layer.
+                if k == "CONFIRM_SECONDS" || k == "CONFIRM_ROWS" {
+                    continue;
+                }
                 params.insert(k, v);
             }
-            if let Some(cs) = params
-                .get("CONFIRM_SECONDS")
-                .and_then(|s| s.parse::<u32>().ok())
-            {
-                let rows = ((cs as f64 / poll_seconds.max(1.0)).ceil() as u32).max(1);
-                params.insert("CONFIRM_ROWS".into(), rows.to_string());
-            }
+        }
+        // Always re-assert confirm from the (possibly mutated) rule spec.
+        let confirm_params = rule_params(poll_seconds, rule.confirm_seconds);
+        for (k, v) in confirm_params {
+            params.insert(k, v);
         }
         let mut sql = substitute_sql(&raw_sql, &params);
         if let Some(equipment_id) = equipment_filter {

--- a/docker/VERSION_MANIFEST.md
+++ b/docker/VERSION_MANIFEST.md
@@ -46,25 +46,24 @@ Bump all three together when cutting a coordinated stack release.
 
 ## Latest verified nightlies
 
-Published successfully from stack-only `master` tip **`db159949`**:
+Published successfully from Streamlit UI + Feather/SQL tip **`f454792e`** (merge #559):
 
 | Images | Immutable tag | Workflow |
 |--------|---------------|----------|
-| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-db15994` | [29591686722](https://github.com/bbartling/open-fdd/actions/runs/29591686722) — success |
-| `openfdd-mcp` | `sha-db15994` | [29591686920](https://github.com/bbartling/open-fdd/actions/runs/29591686920) — success |
+| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-f454792` | [29751954018](https://github.com/bbartling/open-fdd/actions/runs/29751954018) — success |
+| `openfdd-mcp` | `sha-f454792` | [29751953969](https://github.com/bbartling/open-fdd/actions/runs/29751953969) — success |
 
 ```bash
-export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-db15994
-export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-db15994
-export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-db15994
-export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-db15994
-export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-db15994
+export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-f454792
+export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-f454792
+export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-f454792
+export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-f454792
+export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-f454792
 ```
 
-The workflows verified build/push metadata, manifests, MCP↔central smoke, and
-csv-recipe boot + `/api/health`. Pull/run verification of all four recipes is
-the next bench gate because Docker is unavailable in the current WSL environment.
-Run `docs/agent/linux-edge-tester-stack-recipes-prompt.md`; leave standalone
-running for the human Niagara check.
+UI is Streamlit (`services/ui`); FDD operator path is central DataFusion SQL.
+When `OPENFDD_JWT_SECRET` is set, also set `OPENFDD_ADMIN_PASSWORD` (or
+`OPENFDD_API_TOKEN`) on **both** central and ui so Run Rules / package ingest
+can authenticate.
 
 **Human Workbench gate** still required before BACnet OT PASS (hosted **599999** discoverability). See `docs/agent/linux-edge-tester-stack-recipes-prompt.md`.

--- a/docker/compose.central.yml
+++ b/docker/compose.central.yml
@@ -49,6 +49,10 @@ services:
       dockerfile: Dockerfile
     environment:
       OPENFDD_API_BASE: http://central:8080
+      OPENFDD_API_TOKEN: ${OPENFDD_API_TOKEN:-}
+      OPENFDD_UI_USERNAME: ${OPENFDD_UI_USERNAME:-admin}
+      OPENFDD_UI_PASSWORD: ${OPENFDD_UI_PASSWORD:-}
+      OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
     ports:
       - "${OPENFDD_UI_BIND:-0.0.0.0}:3000:8501"
     depends_on:

--- a/docker/compose.csv.yml
+++ b/docker/compose.csv.yml
@@ -28,6 +28,10 @@ services:
       dockerfile: Dockerfile
     environment:
       OPENFDD_API_BASE: http://central:8080
+      OPENFDD_API_TOKEN: ${OPENFDD_API_TOKEN:-}
+      OPENFDD_UI_USERNAME: ${OPENFDD_UI_USERNAME:-admin}
+      OPENFDD_UI_PASSWORD: ${OPENFDD_UI_PASSWORD:-}
+      OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
     ports:
       - "${OPENFDD_UI_BIND:-0.0.0.0}:3000:8501"
     depends_on:

--- a/docker/compose.standalone.yml
+++ b/docker/compose.standalone.yml
@@ -52,6 +52,11 @@ services:
       dockerfile: Dockerfile
     environment:
       OPENFDD_API_BASE: http://central:8080
+      # JWT-secured central: set OPENFDD_API_TOKEN or OPENFDD_ADMIN_PASSWORD (UI logs in as admin).
+      OPENFDD_API_TOKEN: ${OPENFDD_API_TOKEN:-}
+      OPENFDD_UI_USERNAME: ${OPENFDD_UI_USERNAME:-admin}
+      OPENFDD_UI_PASSWORD: ${OPENFDD_UI_PASSWORD:-}
+      OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
     ports:
       # Bind all interfaces so LAN clients can reach http://<bench-ip>:3000
       - "${OPENFDD_UI_BIND:-0.0.0.0}:3000:8501"

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -26,6 +26,19 @@ fn sql_rules_dir() -> PathBuf {
     PathBuf::from("sql_rules")
 }
 
+/// Map Streamlit / pandas cookbook slider keys onto SQL registry parameter keys.
+fn alias_ui_param_key<'a>(rule_id: &str, key: &'a str) -> &'a str {
+    match (rule_id, key) {
+        ("VAV-1", "zone_lo") => "zone_t_lo",
+        ("VAV-1", "zone_hi") => "zone_t_hi",
+        ("FC1", "duct_static_err") => "eps_dsp",
+        ("SV-SPIKE", "spike_scale_temperature" | "spike_scale_humidity" | "spike_scale_pressure") => {
+            "spike_scale"
+        }
+        _ => key,
+    }
+}
+
 fn parquet_root() -> PathBuf {
     if let Ok(p) = std::env::var("OPENFDD_PARQUET_ROOT") {
         return PathBuf::from(p);
@@ -468,25 +481,48 @@ pub fn run_registry(payload: &Value) -> Value {
                     .find_map(|alias| params_by_rule.get(alias))
             });
             if let Some(p) = supplied.and_then(|v| v.as_object()) {
+                // UI vibe19 sliders store confirm_min (minutes). Always fold into
+                // rule.confirm_seconds AND typed overrides so parameter-default
+                // CONFIRM_SECONDS cannot wipe the slider (soak BUG-2).
+                let mut confirm_override: Option<f64> = None;
                 if let Some(cm) = p.get("confirm_min").and_then(|v| v.as_f64()) {
                     rule.confirm_seconds = (cm * 60.0).round() as u32;
+                    confirm_override = Some(rule.confirm_seconds as f64);
                 }
                 if let Some(cs) = p.get("confirm_seconds").and_then(|v| v.as_f64()) {
                     rule.confirm_seconds = cs.round() as u32;
+                    confirm_override = Some(rule.confirm_seconds as f64);
                 }
                 let mut typed = HashMap::new();
                 for (key, value) in p {
-                    let Some(number) = value.as_f64() else {
+                    if key == "confirm_min" {
+                        continue;
+                    }
+                    let Some(mut number) = value.as_f64() else {
                         continue;
                     };
-                    if rule.parameters.contains_key(key) {
+                    // FC1 legacy fan_hi (fan-on frac) → eps_vfd_spd = 1 - fan_hi
+                    let mut mapped = alias_ui_param_key(&rule.rule_id, key).to_string();
+                    if rule.rule_id == "FC1" && key == "fan_hi" {
+                        if p.get("eps_vfd_spd").and_then(|v| v.as_f64()).is_some() {
+                            continue;
+                        }
+                        mapped = "eps_vfd_spd".into();
+                        number = (1.0 - number).clamp(0.0, 1.0);
+                    }
+                    if rule.parameters.contains_key(&mapped) {
+                        typed.insert(mapped, number);
+                    } else if rule.parameters.contains_key(key) {
                         typed.insert(key.clone(), number);
-                    } else if let Some((param_key, _)) = rule
-                        .parameters
-                        .iter()
-                        .find(|(_, def)| def.sql_placeholder == *key)
-                    {
+                    } else if let Some((param_key, _)) = rule.parameters.iter().find(|(_, def)| {
+                        def.sql_placeholder == *key || def.sql_placeholder == mapped
+                    }) {
                         typed.insert(param_key.clone(), number);
+                    }
+                }
+                if let Some(cs) = confirm_override {
+                    if rule.parameters.contains_key("confirm_seconds") {
+                        typed.insert("confirm_seconds".into(), cs);
                     }
                 }
                 if !typed.is_empty() {

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -32,9 +32,10 @@ fn alias_ui_param_key<'a>(rule_id: &str, key: &'a str) -> &'a str {
         ("VAV-1", "zone_lo") => "zone_t_lo",
         ("VAV-1", "zone_hi") => "zone_t_hi",
         ("FC1", "duct_static_err") => "eps_dsp",
-        ("SV-SPIKE", "spike_scale_temperature" | "spike_scale_humidity" | "spike_scale_pressure") => {
-            "spike_scale"
-        }
+        (
+            "SV-SPIKE",
+            "spike_scale_temperature" | "spike_scale_humidity" | "spike_scale_pressure",
+        ) => "spike_scale",
         _ => key,
     }
 }

--- a/services/ui/.env.example
+++ b/services/ui/.env.example
@@ -7,6 +7,18 @@
 # Step 3 — Validate: Advanced tab → Validate all SPARQL presets
 # Step 4 — FDD + analytics use the synced RDF model (no hardcoded CSV paths)
 
+# Central API (compose sets OPENFDD_API_BASE=http://central:8080)
+# OPENFDD_API_BASE=http://127.0.0.1:8080
+#
+# When central has OPENFDD_JWT_SECRET, give the UI a Bearer:
+# OPENFDD_API_TOKEN=...          # preferred (pre-minted JWT)
+# OPENFDD_ADMIN_PASSWORD=...     # or login as admin (also OPENFDD_UI_USERNAME)
+# OPENFDD_UI_USERNAME=admin
+# OPENFDD_UI_PASSWORD=...
+#
+# Emergency only — agent/export pandas FDD (default is SQL-only):
+# OPENFDD_ALLOW_PANDAS_FDD=1
+
 # Relative path (works when data/hvac_systems_CLEANED is symlinked to your CSV tree)
 HVAC_DATA_ROOT=./data/hvac_systems_CLEANED
 HVAC_BUILDING=BUILDING_100

--- a/services/ui/app/agent_api.py
+++ b/services/ui/app/agent_api.py
@@ -305,48 +305,133 @@ def run_rules(
     *,
     require_operational_gates: bool = True,
 ) -> AgentRun:
-    """Run all 50 canonical rules (optionally filtered) — never silently omit."""
+    """Run FDD via central DataFusion SQL (default). Pandas only if explicitly allowed."""
+    import os
+
+    from app import central_client
+    from app.rules.base import RuleResult
+
     merged_params = {**dataset.params, **(params or {})}
-    _attach_role_map(dataset.frames, dataset.role_map)
     eq_filter = set(equipment_ids) if equipment_ids is not None else None
     t_rules = time.perf_counter()
-    if require_operational_gates:
-        results = run_batch(
-            dataset.frames,
-            params_by_rule=merged_params,
-            weather=dataset.weather,
-            equipment_filter=eq_filter,
-        )
-    else:
-        from app.role_map import apply_role_map
-        from app.rules.runner import run_all_cookbook_rules
 
-        results = []
-        for eq_id, raw_df in sorted(dataset.frames.items()):
-            if eq_filter is not None and eq_id not in eq_filter:
+    allow_pandas = (os.environ.get("OPENFDD_ALLOW_PANDAS_FDD") or "").strip() in {
+        "1",
+        "true",
+        "TRUE",
+        "yes",
+        "YES",
+    }
+    engine = "datafusion"
+
+    if not allow_pandas:
+        # Prefer SQL — dataset must already be ingested to central (same building_id).
+        float_params: dict[str, dict[str, float]] = {}
+        for rid, block in merged_params.items():
+            if not isinstance(block, dict):
                 continue
-            mapped = apply_role_map(raw_df, eq_id, dataset.role_map)
-            mapped.attrs.update(raw_df.attrs)
-            poll = float(raw_df.attrs.get("poll_seconds") or 300.0)
-            results.extend(
-                run_all_cookbook_rules(
-                    mapped,
-                    equipment_id=eq_id,
-                    poll_seconds=poll,
-                    params_by_rule=merged_params,
-                    weather=dataset.weather,
-                    site_id=str(raw_df.attrs.get("site_id", "")),
-                    building_id=str(raw_df.attrs.get("building_id", dataset.building_id)),
-                    equipment_type=resolve_equipment_type(
-                        eq_id, df=raw_df, role_map=dataset.role_map
-                    ),
-                    require_operational_gates=False,
+            float_params[str(rid)] = {
+                str(k): float(v) for k, v in block.items() if isinstance(v, (int, float))
+            }
+        selected_rules = list(rule_ids) if rule_ids is not None else [r.id for r in RULES]
+        equipment_id = None
+        if eq_filter is not None and len(eq_filter) == 1:
+            equipment_id = next(iter(eq_filter))
+        body = central_client.run_fdd(
+            rule_ids=selected_rules,
+            params=float_params or None,
+            equipment_id=equipment_id,
+        )
+        if not body.get("ok", False):
+            err = body.get("error") or "SQL FDD run failed"
+            raise RuntimeError(
+                f"{err} (set OPENFDD_ALLOW_PANDAS_FDD=1 only for emergency local pandas)"
+            )
+        rows = body.get("results") or []
+        if not isinstance(rows, list) or not rows:
+            cached = central_client.fdd_results()
+            rows = cached.get("results") or []
+        if eq_filter is not None:
+            rows = [
+                r
+                for r in rows
+                if isinstance(r, dict) and r.get("equipment_id") in eq_filter
+            ]
+        if rule_ids is not None:
+            allow = set(rule_ids)
+            rows = [r for r in rows if isinstance(r, dict) and r.get("rule_id") in allow]
+        meta = {r.id: r for r in RULES}
+        results: list[RuleResult] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            rid = str(row.get("rule_id") or "")
+            eq = str(row.get("equipment_id") or "")
+            if not rid or not eq:
+                continue
+            rule = meta.get(rid)
+            title = str(row.get("title") or (getattr(rule, "title", "") if rule else "") or rid)
+            status = str(row.get("status") or "PASS")
+            fh = row.get("fault_hours")
+            fp = row.get("fault_pct")
+            notes = row.get("notes")
+            if notes is not None and not isinstance(notes, str):
+                notes = str(notes)
+            results.append(
+                RuleResult(
+                    rule_id=rid,
+                    equipment_id=eq,
+                    status=status,  # type: ignore[arg-type]
+                    applicable=status not in {"NOT_APPLICABLE_EQUIPMENT_TYPE"},
+                    equipment_type=str(row.get("equipment_type") or ""),
+                    building_id=str(dataset.building_id or ""),
+                    missing_roles=list(row.get("missing_roles") or []),
+                    fault_hours=float(fh) if fh is not None else None,
+                    fault_pct=float(fp) if fp is not None else None,
+                    notes=notes or f"DataFusion SQL · {title}",
                 )
             )
+    else:
+        engine = "pandas"
+        _attach_role_map(dataset.frames, dataset.role_map)
+        if require_operational_gates:
+            results = run_batch(
+                dataset.frames,
+                params_by_rule=merged_params,
+                weather=dataset.weather,
+                equipment_filter=eq_filter,
+            )
+        else:
+            from app.role_map import apply_role_map
+            from app.rules.runner import run_all_cookbook_rules
+
+            results = []
+            for eq_id, raw_df in sorted(dataset.frames.items()):
+                if eq_filter is not None and eq_id not in eq_filter:
+                    continue
+                mapped = apply_role_map(raw_df, eq_id, dataset.role_map)
+                mapped.attrs.update(raw_df.attrs)
+                poll = float(raw_df.attrs.get("poll_seconds") or 300.0)
+                results.extend(
+                    run_all_cookbook_rules(
+                        mapped,
+                        equipment_id=eq_id,
+                        poll_seconds=poll,
+                        params_by_rule=merged_params,
+                        weather=dataset.weather,
+                        site_id=str(raw_df.attrs.get("site_id", "")),
+                        building_id=str(raw_df.attrs.get("building_id", dataset.building_id)),
+                        equipment_type=resolve_equipment_type(
+                            eq_id, df=raw_df, role_map=dataset.role_map
+                        ),
+                        require_operational_gates=False,
+                    )
+                )
+        if rule_ids is not None:
+            allow = set(rule_ids)
+            results = [r for r in results if r.rule_id in allow]
+
     rule_execution_seconds = round(time.perf_counter() - t_rules, 6)
-    if rule_ids is not None:
-        allow = set(rule_ids)
-        results = [r for r in results if r.rule_id in allow]
     # Ensure every requested rule id still appears conceptually — when filtering,
     # callers asked for a subset; full catalog length is len(RULES)*equip when unfiltered.
     summary = results_summary_table(results)
@@ -375,6 +460,7 @@ def run_rules(
             "prefer_web_oat": dataset.prefer_web_oat,
             "require_operational_gates": require_operational_gates,
             "rule_execution_seconds": rule_execution_seconds,
+            "fdd_engine": engine,
         },
     )
 

--- a/services/ui/app/central_client.py
+++ b/services/ui/app/central_client.py
@@ -1,24 +1,220 @@
-"""Thin HTTP client for openfdd-central (package ingest, dataset delete, SQL FDD)."""
+"""Thin HTTP client for openfdd-central (package ingest, dataset delete, SQL FDD).
+
+Auth (BUG-1): when central has ``OPENFDD_JWT_SECRET``, attach Bearer via:
+
+1. ``OPENFDD_API_TOKEN`` / ``OPENFDD_JWT`` — pre-minted service token, or
+2. ``OPENFDD_UI_USERNAME`` + ``OPENFDD_UI_PASSWORD`` (defaults: admin +
+   ``OPENFDD_ADMIN_PASSWORD``) — login to ``POST /api/auth/login`` and cache JWT.
+"""
 
 from __future__ import annotations
 
 import os
+import threading
+import time
 from typing import Any
 
 import requests
 
 DEFAULT_API_BASE = "http://127.0.0.1:8080"
 
+# UI cookbook / pandas keys → SQL registry parameter keys (BUG-3).
+# Special mapped values: "_fan_hi_to_eps_vfd".
+_PARAM_ALIASES: dict[str, dict[str, str]] = {
+    "VAV-1": {
+        "zone_lo": "zone_t_lo",
+        "zone_hi": "zone_t_hi",
+    },
+    "FC1": {
+        "duct_static_err": "eps_dsp",
+        # fan_hi is "fan at/above this frac" → SQL eps_vfd_spd = 1 - fan_hi
+        "fan_hi": "_fan_hi_to_eps_vfd",
+    },
+    "SV-SPIKE": {
+        "spike_scale_temperature": "spike_scale",
+        "spike_scale_humidity": "spike_scale",
+        "spike_scale_pressure": "spike_scale",
+    },
+}
+
+_token_lock = threading.Lock()
+_cached_token: str | None = None
+_cached_token_exp: float = 0.0
+
 
 def api_base() -> str:
     return (os.environ.get("OPENFDD_API_BASE") or DEFAULT_API_BASE).rstrip("/")
+
+
+def _env_token() -> str | None:
+    for key in ("OPENFDD_API_TOKEN", "OPENFDD_JWT", "OPENFDD_UI_TOKEN"):
+        val = (os.environ.get(key) or "").strip()
+        if val:
+            return val
+    return None
+
+
+def _login_credentials() -> tuple[str, str] | None:
+    user = (os.environ.get("OPENFDD_UI_USERNAME") or "admin").strip()
+    password = (
+        os.environ.get("OPENFDD_UI_PASSWORD")
+        or os.environ.get("OPENFDD_ADMIN_PASSWORD")
+        or ""
+    ).strip()
+    if not password:
+        return None
+    return user, password
+
+
+def _fetch_login_token(timeout: float = 15.0) -> str | None:
+    creds = _login_credentials()
+    if not creds:
+        return None
+    user, password = creds
+    try:
+        resp = requests.post(
+            f"{api_base()}/api/auth/login",
+            json={"username": user, "password": password},
+            timeout=timeout,
+        )
+        body = resp.json() if resp.content else {}
+    except requests.RequestException:
+        return None
+    if not isinstance(body, dict):
+        return None
+    token = body.get("access_token") or body.get("token")
+    if isinstance(token, str) and token.strip():
+        return token.strip()
+    return None
+
+
+def clear_auth_cache() -> None:
+    global _cached_token, _cached_token_exp
+    with _token_lock:
+        _cached_token = None
+        _cached_token_exp = 0.0
+
+
+def bearer_token(*, force_refresh: bool = False) -> str | None:
+    """Resolve Bearer token for central API calls (env token preferred, else login)."""
+    global _cached_token, _cached_token_exp
+    env = _env_token()
+    if env:
+        return env
+    now = time.time()
+    with _token_lock:
+        if (
+            not force_refresh
+            and _cached_token
+            and _cached_token_exp > now + 60
+        ):
+            return _cached_token
+    token = _fetch_login_token()
+    if not token:
+        return None
+    with _token_lock:
+        _cached_token = token
+        # Login mints ~8h tokens; refresh early.
+        _cached_token_exp = now + 7 * 3600
+        return _cached_token
+
+
+def _auth_headers() -> dict[str, str]:
+    token = bearer_token()
+    if not token or token == "open":
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _merge_headers(extra: dict[str, str] | None = None) -> dict[str, str]:
+    headers = dict(_auth_headers())
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    timeout: float,
+    headers: dict[str, str] | None = None,
+    retry_on_401: bool = True,
+    **kwargs: Any,
+) -> requests.Response:
+    hdrs = _merge_headers(headers)
+    resp = requests.request(method, url, headers=hdrs, timeout=timeout, **kwargs)
+    if resp.status_code == 401 and retry_on_401 and not _env_token():
+        clear_auth_cache()
+        bearer_token(force_refresh=True)
+        hdrs = _merge_headers(headers)
+        resp = requests.request(method, url, headers=hdrs, timeout=timeout, **kwargs)
+    return resp
+
+
+def normalize_rule_params(rule_id: str, params: dict[str, float]) -> dict[str, float]:
+    """Map UI / cookbook slider keys onto SQL registry parameter keys."""
+    aliases = _PARAM_ALIASES.get(rule_id, {})
+    out: dict[str, float] = {}
+
+    for key, value in params.items():
+        if key == "confirm_min":
+            continue
+        out[key] = float(value)
+
+    # UI stores confirm_min (minutes); SQL registry uses confirm_seconds.
+    if "confirm_seconds" not in out and "confirm_min" in params:
+        out["confirm_seconds"] = float(params["confirm_min"]) * 60.0
+
+    for ui_key, mapped in aliases.items():
+        if ui_key not in params:
+            continue
+        if mapped == "_fan_hi_to_eps_vfd":
+            if "eps_vfd_spd" not in params:
+                out["eps_vfd_spd"] = max(0.0, min(1.0, 1.0 - float(params[ui_key])))
+            out.pop("fan_hi", None)
+            continue
+        if mapped not in params:
+            out[mapped] = float(params[ui_key])
+        out.pop(ui_key, None)
+    return out
+
+
+def normalize_params_payload(
+    params: dict[str, dict[str, float]] | None,
+) -> dict[str, dict[str, float]] | None:
+    if not params:
+        return None
+    return {rid: normalize_rule_params(rid, dict(p)) for rid, p in params.items() if p}
+
+
+def _parse_json_response(resp: requests.Response) -> dict[str, Any]:
+    try:
+        body = resp.json()
+    except Exception:
+        return {"ok": False, "error": f"central HTTP {resp.status_code}: {resp.text[:400]}"}
+    if not isinstance(body, dict):
+        return {"ok": False, "error": f"unexpected central response: {body!r}"}
+    if resp.status_code == 401:
+        body = {
+            **body,
+            "ok": False,
+            "error": body.get("error")
+            or "Authorization: Bearer <token> required "
+            "(set OPENFDD_API_TOKEN or OPENFDD_ADMIN_PASSWORD for the UI)",
+            "auth_required": True,
+        }
+    elif resp.status_code >= 400 and "ok" not in body:
+        body = {**body, "ok": False, "error": body.get("error") or f"HTTP {resp.status_code}"}
+    return body
 
 
 def post_package_zip(zip_bytes: bytes, filename: str = "package.zip", timeout: float = 600.0) -> dict[str, Any]:
     """POST raw zip to /api/csv/import/package. Returns JSON body (ok/error)."""
     url = f"{api_base()}/api/csv/import/package"
     try:
-        resp = requests.post(
+        resp = _request(
+            "POST",
             url,
             data=zip_bytes,
             headers={
@@ -29,15 +225,7 @@ def post_package_zip(zip_bytes: bytes, filename: str = "package.zip", timeout: f
         )
     except requests.RequestException as exc:
         return {"ok": False, "error": f"central unreachable ({api_base()}): {exc}", "central_down": True}
-    try:
-        body = resp.json()
-    except Exception:
-        return {"ok": False, "error": f"central HTTP {resp.status_code}: {resp.text[:400]}"}
-    if not isinstance(body, dict):
-        return {"ok": False, "error": f"unexpected central response: {body!r}"}
-    if resp.status_code >= 400 and "ok" not in body:
-        body = {**body, "ok": False, "error": body.get("error") or f"HTTP {resp.status_code}"}
-    return body
+    return _parse_json_response(resp)
 
 
 def delete_dataset(dataset_id: str, timeout: float = 60.0) -> dict[str, Any]:
@@ -47,22 +235,19 @@ def delete_dataset(dataset_id: str, timeout: float = 60.0) -> dict[str, Any]:
         return {"ok": False, "error": "dataset id required"}
     url = f"{api_base()}/api/datasets"
     try:
-        resp = requests.delete(url, params={"id": did}, timeout=timeout)
+        resp = _request("DELETE", url, params={"id": did}, timeout=timeout)
     except requests.RequestException as exc:
         return {"ok": False, "error": f"central unreachable ({api_base()}): {exc}", "central_down": True}
-    try:
-        body = resp.json()
-    except Exception:
-        return {"ok": False, "error": f"central HTTP {resp.status_code}: {resp.text[:400]}"}
-    if not isinstance(body, dict):
-        return {"ok": False, "error": f"unexpected central response: {body!r}"}
-    return body
+    return _parse_json_response(resp)
 
 
 def list_datasets(timeout: float = 30.0) -> dict[str, Any]:
     try:
-        resp = requests.get(f"{api_base()}/api/datasets", timeout=timeout)
-        return resp.json() if resp.ok else {"ok": False, "error": f"HTTP {resp.status_code}"}
+        resp = _request("GET", f"{api_base()}/api/datasets", timeout=timeout)
+        return _parse_json_response(resp) if resp.ok or resp.status_code == 401 else {
+            "ok": False,
+            "error": f"HTTP {resp.status_code}",
+        }
     except requests.RequestException as exc:
         return {"ok": False, "error": str(exc), "central_down": True}
 
@@ -78,12 +263,14 @@ def run_fdd(
     payload: dict[str, Any] = {"mode": "registry"}
     if rule_ids:
         payload["rule_ids"] = list(rule_ids)
-    if params:
-        payload["params"] = params
+    normalized = normalize_params_payload(params)
+    if normalized:
+        payload["params"] = normalized
     if equipment_id:
         payload["equipment_id"] = equipment_id
     try:
-        resp = requests.post(
+        resp = _request(
+            "POST",
             f"{api_base()}/api/fdd/run",
             json=payload,
             headers={"Content-Type": "application/json"},
@@ -91,19 +278,16 @@ def run_fdd(
         )
     except requests.RequestException as exc:
         return {"ok": False, "error": f"central unreachable ({api_base()}): {exc}", "central_down": True}
-    try:
-        body = resp.json()
-    except Exception:
-        return {"ok": False, "error": f"central HTTP {resp.status_code}: {resp.text[:400]}"}
-    if not isinstance(body, dict):
-        return {"ok": False, "error": f"unexpected central response: {body!r}"}
-    return body
+    return _parse_json_response(resp)
 
 
 def fdd_results(timeout: float = 60.0) -> dict[str, Any]:
     try:
-        resp = requests.get(f"{api_base()}/api/fdd/results", timeout=timeout)
-        return resp.json() if resp.ok else {"ok": False, "error": f"HTTP {resp.status_code}"}
+        resp = _request("GET", f"{api_base()}/api/fdd/results", timeout=timeout)
+        return _parse_json_response(resp) if resp.ok or resp.status_code == 401 else {
+            "ok": False,
+            "error": f"HTTP {resp.status_code}",
+        }
     except requests.RequestException as exc:
         return {"ok": False, "error": str(exc), "central_down": True}
 
@@ -117,3 +301,12 @@ def health_ok(timeout: float = 3.0) -> bool:
         return bool(data.get("ok", True))
     except Exception:
         return False
+
+
+def auth_status(timeout: float = 5.0) -> dict[str, Any]:
+    try:
+        resp = requests.get(f"{api_base()}/api/auth/status", timeout=timeout)
+        body = resp.json() if resp.content else {}
+        return body if isinstance(body, dict) else {"ok": False}
+    except requests.RequestException as exc:
+        return {"ok": False, "error": str(exc), "central_down": True}

--- a/services/ui/app/test_central_client_normalize.py
+++ b/services/ui/app/test_central_client_normalize.py
@@ -1,0 +1,41 @@
+"""Unit tests for UI → SQL param normalization (no central required)."""
+
+from __future__ import annotations
+
+from app.central_client import normalize_params_payload, normalize_rule_params
+
+
+def test_confirm_min_becomes_confirm_seconds() -> None:
+    out = normalize_rule_params("FC1", {"confirm_min": 120.0, "eps_dsp": 0.12})
+    assert out["confirm_seconds"] == 7200.0
+    assert "confirm_min" not in out
+    assert out["eps_dsp"] == 0.12
+
+
+def test_confirm_seconds_wins_over_confirm_min() -> None:
+    out = normalize_rule_params(
+        "FC1", {"confirm_min": 120.0, "confirm_seconds": 60.0}
+    )
+    assert out["confirm_seconds"] == 60.0
+
+
+def test_vav_zone_aliases() -> None:
+    out = normalize_rule_params("VAV-1", {"zone_lo": 68.0, "zone_hi": 76.0})
+    assert out["zone_t_lo"] == 68.0
+    assert out["zone_t_hi"] == 76.0
+    assert "zone_lo" not in out
+
+
+def test_fc1_fan_hi_to_eps_vfd() -> None:
+    out = normalize_rule_params("FC1", {"fan_hi": 0.87})
+    assert abs(out["eps_vfd_spd"] - 0.13) < 1e-9
+    assert "fan_hi" not in out
+
+
+def test_payload_normalize() -> None:
+    payload = normalize_params_payload(
+        {"FC1": {"confirm_min": 5.0}, "VAV-1": {"zone_lo": 70.0}}
+    )
+    assert payload is not None
+    assert payload["FC1"]["confirm_seconds"] == 300.0
+    assert payload["VAV-1"]["zone_t_lo"] == 70.0

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -1,4 +1,4 @@
-"""Vibe Code App 19 — 50-rule pandas/Streamlit FDD demo."""
+"""Open-FDD Streamlit lab — zip → Feather/SQL; Run Rules via central DataFusion."""
 
 from __future__ import annotations
 
@@ -120,7 +120,8 @@ def _render_app_hero() -> None:
     """Brand header: title → subtitle → compact logo → how-it-works."""
     st.title(APP_TITLE)
     st.markdown(
-        "Educational Streamlit + pandas lab for the Open-FDD 50-rule cookbook. "
+        "Streamlit lab for Open-FDD: Load zip → central Feather store; Run Rules → DataFusion SQL. "
+        "Rule-tuning sliders map to SQL registry params (confirm delay = confirm_min → confirm_seconds). "
         "CSVs stay as-is — you only map columns to roles."
     )
     if _HERO_IMG.is_file():


### PR DESCRIPTION
## Summary
Fixes tip soak P0/P1 against `sha-f454792` (JWT bench + slider honesty):

- **#560 / BUG-1:** `central_client` Bearer via `OPENFDD_API_TOKEN` or admin login (`OPENFDD_ADMIN_PASSWORD`); compose passes auth env to `ui`
- **#561 / BUG-2:** `confirm_min` → `confirm_seconds` / `CONFIRM_ROWS` (API overrides + runner re-assert)
- **BUG-3:** UI→SQL key aliases (`zone_lo`→`zone_t_lo`, `fan_hi`→`eps_vfd_spd`, …)
- **BUG-4:** `agent_api.run_rules` defaults to DataFusion; pandas only with `OPENFDD_ALLOW_PANDAS_FDD=1`
- VERSION_MANIFEST pin → `sha-f454792`; CI runs normalize unit tests

## Test plan
- [x] `pytest app/test_central_client_normalize.py` (5 passed)
- [x] `cargo test -p fdd_rules` / registry_api lib tests
- [ ] CI green on this PR (CodeRabbit + Actions)
- [ ] Bench: set `OPENFDD_ADMIN_PASSWORD` on ui+central → Run Rules with confirm_min=120 changes fault hours
- [ ] Merge → nightly refresh

Closes #560
Closes #561


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated UI connectivity to the central API using tokens or login credentials.
  - FDD runs now use the central SQL engine by default, with an optional pandas fallback.
  - Added clearer handling for rule-tuning parameters, including confirmation timing and equipment-specific aliases.
  - Added authentication status reporting and improved API error handling.

- **Documentation**
  - Updated setup examples, Docker configuration, verified nightly references, and UI workflow guidance.

- **Style**
  - Refreshed Streamlit branding and workflow descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->