### PR TITLE
fix(fdd): scope registry runs to building_id

### DIFF
--- a/crates/fdd_rules/src/runner.rs
+++ b/crates/fdd_rules/src/runner.rs
@@ -35,29 +35,36 @@ pub async fn run_all_rules(
     registry: &RuleRegistry,
     out_dir: &Path,
 ) -> Result<RuleRunReport> {
-    run_all_rules_with_overrides(parquet_root, registry, out_dir, &HashMap::new(), None).await
+    run_all_rules_with_overrides(parquet_root, registry, out_dir, &HashMap::new(), None, None).await
 }
 
 /// Run registry rules with request/session parameter overrides.
 ///
 /// Keys are canonical rule IDs and registry parameter names. This keeps the
 /// HTTP layer typed: arbitrary SQL is never accepted from the dashboard.
+///
+/// ``weather_root`` defaults to ``parquet_root``. When history is scoped to
+/// ``building={id}/``, pass the parent parquet cache so ``weather/`` still registers.
 pub async fn run_all_rules_with_overrides(
     parquet_root: &Path,
     registry: &RuleRegistry,
     out_dir: &Path,
     overrides: &HashMap<String, HashMap<String, f64>>,
     equipment_filter: Option<&str>,
+    weather_root: Option<&Path>,
 ) -> Result<RuleRunReport> {
     let started = std::time::Instant::now();
     std::fs::create_dir_all(out_dir)?;
-    let poll_seconds = read_poll_from_cache(parquet_root).unwrap_or(300.0);
+    let poll_seconds = read_poll_from_cache(parquet_root)
+        .or_else(|| weather_root.and_then(read_poll_from_cache))
+        .unwrap_or(300.0);
     let rules_dir = Path::new(&registry.rules_dir);
     let tuning = load_tuning_profiles(rules_dir)?;
 
     let ctx = SessionContext::new();
     register_parquet_tree(&ctx, parquet_root).await?;
-    register_weather_if_present(&ctx, parquet_root).await?;
+    let wx_root = weather_root.unwrap_or(parquet_root);
+    register_weather_if_present(&ctx, wx_root).await?;
 
     let mut timings = Vec::new();
     let mut rules_succeeded = 0usize;

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -430,9 +430,12 @@ pub fn roles_response() -> Value {
 /// `POST /api/fdd/run` body for registry engine (typed params only — no raw SQL).
 ///
 /// ```json
-/// { "mode": "registry", "rule_ids": ["FC1","VAV-1"], "params": { "FC1": { "confirm_min": 5 } } }
+/// { "mode": "registry", "rule_ids": ["FC1","VAV-1"], "params": { "FC1": { "confirm_min": 5 } },
+///   "building_id": "BUILDING_100" }
 /// ```
-/// Omit `rule_ids` to run all. Without parquet cache, returns a clear error.
+/// Omit `rule_ids` to run all. Pass ``building_id`` to scope history to
+/// ``building={id}/`` (avoids bench_* bleed from other packages in the same cache).
+/// Without parquet cache, returns a clear error.
 pub fn run_registry(payload: &Value) -> Value {
     let pq = parquet_root();
     if !pq.is_dir() {
@@ -445,6 +448,29 @@ pub fn run_registry(payload: &Value) -> Value {
             "cache": cache_status(),
         });
     }
+    let building_id = payload
+        .get("building_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let (history_root, weather_root): (PathBuf, PathBuf) = match building_id {
+        Some(bid) => {
+            let scoped = pq.join(format!("building={bid}"));
+            if !scoped.is_dir() {
+                return json!({
+                    "ok": false,
+                    "error": format!(
+                        "no parquet for building_id={bid} under {} — ingest that package first",
+                        pq.display()
+                    ),
+                    "cache": cache_status(),
+                    "building_id": bid,
+                });
+            }
+            (scoped, pq.clone())
+        }
+        None => (pq.clone(), pq.clone()),
+    };
     let reg = match load_reg() {
         Ok(r) => r,
         Err(e) => return json!({"ok": false, "error": e}),
@@ -542,11 +568,12 @@ pub fn run_registry(payload: &Value) -> Value {
         Err(e) => return json!({"ok": false, "error": format!("runtime: {e}")}),
     };
     match rt.block_on(run_all_rules_with_overrides(
-        &pq,
+        &history_root,
         &effective,
         &out,
         &session_overrides,
         payload.get("equipment_id").and_then(Value::as_str),
+        Some(weather_root.as_path()),
     )) {
         Ok(report) => {
             let normalized = results_response();
@@ -554,6 +581,8 @@ pub fn run_registry(payload: &Value) -> Value {
                 "ok": true,
                 "engine": "fdd_rules+DataFusion",
                 "mode": "registry",
+                "building_id": building_id,
+                "history_root": history_root.display().to_string(),
                 "rules_run": report.rules_run,
                 "rules_succeeded": report.rules_succeeded,
                 "rules_failed": report.rules_failed,

--- a/services/ui/app/central_client.py
+++ b/services/ui/app/central_client.py
@@ -257,6 +257,7 @@ def run_fdd(
     rule_ids: list[str] | None = None,
     params: dict[str, dict[str, float]] | None = None,
     equipment_id: str | None = None,
+    building_id: str | None = None,
     timeout: float = 900.0,
 ) -> dict[str, Any]:
     """POST /api/fdd/run — DataFusion SQL registry engine (no pandas)."""
@@ -268,6 +269,8 @@ def run_fdd(
         payload["params"] = normalized
     if equipment_id:
         payload["equipment_id"] = equipment_id
+    if building_id:
+        payload["building_id"] = building_id
     try:
         resp = _request(
             "POST",


### PR DESCRIPTION
## Summary
- Scope parquet history to `building={id}/` when `building_id` is passed
- Register weather from cache root
- Plumb through UI `run_fdd`

## Test plan
- [ ] POST /api/fdd/run with building_id after multi-package ingest — no bench bleed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FDD runs can now be scoped to a specific building.
  * Weather and historical data can be sourced from separate locations for more targeted analysis.
  * Run results now include the selected building and history location.
  * Added support for specifying a building when starting runs through the client interface.

* **Bug Fixes**
  * Improved handling when building-specific data is unavailable by returning a structured error with cache details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->