### PR TITLE
docs: Vibe19/Vibe20 Open-FDD superset audit

### DIFF
--- a/docker/VERSION_MANIFEST.md
+++ b/docker/VERSION_MANIFEST.md
@@ -46,20 +46,20 @@ Bump all three together when cutting a coordinated stack release.
 
 ## Latest verified nightlies
 
-Published successfully from soak follow-up tip **`58e0d0e9`** (merge #567 — Who-Is hosted merge, edges `site_id`, Streamlit gates):
+Published successfully from tip **`d631e9c8`** (merge #569 — FDD `building_id` hive scope):
 
 | Images | Immutable tag | Workflow |
 |--------|---------------|----------|
-| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-58e0d0e` | [29832414780](https://github.com/bbartling/open-fdd/actions/runs/29832414780) — success |
-| `openfdd-mcp` | `sha-58e0d0e` | [29832414898](https://github.com/bbartling/open-fdd/actions/runs/29832414898) — success |
+| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-d631e9c` | [29867342284](https://github.com/bbartling/open-fdd/actions/runs/29867342284) — success |
+| `openfdd-mcp` | `sha-d631e9c` | [29867342248](https://github.com/bbartling/open-fdd/actions/runs/29867342248) — success |
 
 ```bash
-export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-58e0d0e
-export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-58e0d0e
-export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-58e0d0e
-export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-58e0d0e
-export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-58e0d0e
-# or OPENFDD_IMAGE_TAG=sha-58e0d0e / :nightly (same digest as of 2026-07-21 publish)
+export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-d631e9c
+export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-d631e9c
+export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-d631e9c
+export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-d631e9c
+export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-d631e9c
+# or OPENFDD_IMAGE_TAG=sha-d631e9c / :nightly (same digest as of 2026-07-25 publish)
 ```
 
 UI is Streamlit (`services/ui`); FDD operator path is central DataFusion SQL.
@@ -67,7 +67,8 @@ When `OPENFDD_JWT_SECRET` is set, also set `OPENFDD_ADMIN_PASSWORD` (or
 `OPENFDD_API_TOKEN`) on **both** central and ui so Run Rules / package ingest
 can authenticate.
 
-In-repo Streamlit gates 10–12: `scripts/release/smoke_streamlit_ui_gates.sh` (#564 overlays still need to call it).
+Superset migration audit: `docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md`.
+In-repo Streamlit gates 10–12: `scripts/release/smoke_streamlit_ui_gates.sh`.
 
 Workspace Cargo version remains **3.3.0** (no semver bump for this integration tip —
 nightlies key off `sha-*`). Bump workspace + `VERSION` together only when cutting a

--- a/docs/agent/linux-edge-tester-stack-recipes-prompt.md
+++ b/docs/agent/linux-edge-tester-stack-recipes-prompt.md
@@ -10,11 +10,11 @@ nav_order: 12
 change). Do **not** create dated copies (`*-2026-07-17.md`, `bench-NNN-*`, etc.).
 One path forever: `docs/agent/linux-edge-tester-stack-recipes-prompt.md`.
 
-**Pinned tip (2026-07-21):** full `58e0d0e919fdc2f3b4296ff83bf350db0423e108`
-(merge #567 — Who-Is hosted merge, edges `site_id`, Streamlit gates smoke).
-Prefer `OPENFDD_IMAGE_TAG=sha-58e0d0e` (GHCR short sha tag) or `:nightly` only after
+**Pinned tip (2026-07-25):** full `d631e9c8c47a9fc4f1308218cf68834afd9f8093`
+(merge #569 — FDD `building_id` hive scope; prior #567 Who-Is/`site_id`/Streamlit gates).
+Prefer `OPENFDD_IMAGE_TAG=sha-d631e9c` (GHCR short sha tag) or `:nightly` only after
 confirming `org.opencontainers.image.revision` matches on central/ui/fieldbus/mqtt/**mcp**.
-Prior soak pin `sha-884aaed` (#565) remains valid for bisect of Streamlit SQL P0s.
+Bisect pins: `sha-58e0d0e` (#567), `sha-884aaed` (#565 Streamlit SQL P0s).
 
 Copy-paste prompt for a **second OT bench**. Pulls GHCR nightlies, exercises all four
 compose build recipes, validates BACnet / Modbus / Haystack / (new) REST drivers, then
@@ -41,8 +41,8 @@ devices **599999** (bench) and **600000** (Pi edge, if present).
 You are the Open-FDD second-bench soak agent on the OT / edge tester machine.
 
 Charter:
-- GHCR tip for this soak: prefer `OPENFDD_IMAGE_TAG=sha-58e0d0e` (or `:nightly` with
-  matching `org.opencontainers.image.revision=58e0d0e919fd…` on **every** stack image —
+- GHCR tip for this soak: prefer `OPENFDD_IMAGE_TAG=sha-d631e9c` (or `:nightly` with
+  matching `org.opencontainers.image.revision=d631e9c8c47a…` on **every** stack image —
   central, ui, fieldbus, mqtt, and mcp). No local product builds, no product code PRs.
 - UI is **Streamlit** at http://<bench-ip>:3000 (not React). JWT stacks need
   `OPENFDD_ADMIN_PASSWORD` (or `OPENFDD_API_TOKEN`) on ui **and** central so Run Rules /
@@ -155,11 +155,12 @@ Recommendations mean:
 
 Current known board (update if gh list differs):
 KEEP OPEN / retest:
-- #564 harness scripts on overlays may still assert React — in-repo `scripts/release/smoke_streamlit_ui_gates.sh` is the Streamlit replacement; close #564 when overlays call it
 - Human Workbench discoverability of hosted **599999** (human gate)
 - Phantom Workbench network **28271** — JCI/Niagara `.200` wire noise, **not** Open-FDD
 
 Expect CLOSED on tip nightlies (confirm still green; do not reopen if PASS):
+- #570 obsolete `openfdd-edge-rust` Who-Is report (closed — use fieldbus tip)
+- #564 Streamlit gates (in-repo smoke; overlays may still lag)
 - #526 fieldbus Who-Is co-located hosted (#567 synthesize `hosted_local`) — confirm on tip Who-Is
 - #514 package ZIP, #515 session_config
 - #549 React dashboard APIs (superseded by Streamlit #559)
@@ -203,8 +204,8 @@ Final report structure (paste back to product agent):
 See [Build recipes](../operations/build-recipes.md). Helper scripts:
 
 ```bash
-export OPENFDD_IMAGE_TAG=sha-58e0d0e
-# pin when bisecting: e.g. OPENFDD_IMAGE_TAG=sha-884aaed (#565 Streamlit SQL P0s)
+export OPENFDD_IMAGE_TAG=sha-d631e9c
+# pin when bisecting: e.g. OPENFDD_IMAGE_TAG=sha-58e0d0e (#567) or sha-884aaed (#565)
 ./scripts/openfdd_stack_pull.sh all
 ./scripts/openfdd_stack_pull.sh mcp
 ./scripts/openfdd_stack_up.sh csv

--- a/docs/architecture/analytics-boundary.md
+++ b/docs/architecture/analytics-boundary.md
@@ -1,0 +1,29 @@
+---
+title: Analytics boundary
+parent: Architecture
+nav_order: 12
+---
+
+# Analytics boundary
+
+**Status:** target contract (PR2+). Do not scatter ad-hoc SQL through Streamlit.
+
+## Boundary
+
+```text
+Streamlit asks → typed service call → DataFusion SQL / views → Arrow → thin UI frame
+```
+
+## Domains (planned)
+
+runtime · sensor_health · weather · economizer · comfort · airside · hydronic ·
+mechanical_cooling · metering · schedules · equipment · rcx · wattlab_exports
+
+Each domain: typed inputs, params, SQL, Arrow schema, null/unit rules, tests.
+
+## Today
+
+- FDD: `crates/fdd_sql` + `fdd_rules` (production)
+- RCx / analytics: still largely `services/ui/app/analytics.py` + `rcx_plots.py` (pandas) — migrate per audit inventory
+
+No arbitrary operator SQL editor. Integrator SQL lab (if any) is separate and gated.

--- a/docs/architecture/datafusion-first.md
+++ b/docs/architecture/datafusion-first.md
@@ -1,0 +1,34 @@
+---
+title: DataFusion-first policy
+parent: Architecture
+nav_order: 10
+---
+
+# DataFusion-first policy
+
+**Status:** target contract (audit 2026-07-25). Implementation deepens in migration PR2+.
+
+For tabular building telemetry computation:
+
+> If the operation can reasonably be expressed as DataFusion SQL, it belongs in DataFusion SQL.
+
+## Allowed pandas
+
+| Class | When |
+|-------|------|
+| UI boundary | Tiny final frame for Streamlit/Plotly **after** DF aggregation |
+| Test oracle | Independent reference vs SQL |
+| Non-SQL | ZIP/IO, IDF, DOCX, config parse, Plotly figure build |
+
+## Forbidden
+
+- Silent pandas FDD fallback when DataFusion fails
+- Millions of raw rows into Streamlit for Python downsample
+- Downsampling before fault math
+
+## Production FDD today
+
+Canonical path: `sql_rules/` + `crates/fdd_rules` + `POST /api/fdd/run`.  
+Pandas cookbook only with explicit `OPENFDD_ALLOW_PANDAS_FDD=1`.
+
+See [VIBE19_VIBE20_OPENFDD_AUDIT.md](../migration/VIBE19_VIBE20_OPENFDD_AUDIT.md).

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -8,10 +8,13 @@ permalink: /architecture/
 
 # Architecture
 
-Open-FDD is a **Rust edge application** with a React web UI, Arrow historian, DataFusion SQL engine, and Project Haystack semantic model.
+Open-FDD is a **container stack** (central / Streamlit UI / fieldbus / mqtt / mcp) with Arrow historian, DataFusion SQL FDD, and Project Haystack semantic model.
 
 | Topic | Document |
 |-------|----------|
-| [Services](services.html) | Bridge, commission, Haystack gateway, compose profiles |
-| [Data flow](data-flow.html) | Drivers → model → historian → FDD → dashboard |
+| [Services](services.html) | Stack images and compose roles |
+| [Data flow](data-flow.html) | Drivers → model → historian → FDD → UI |
 | [Storage & DataFusion](storage-and-datafusion.html) | Feather historian and SQL rules |
+| [DataFusion-first](datafusion-first.html) | Pandas policy and production SQL rule |
+| [Job workspaces](job-workspaces.html) | Persistent analysis Jobs under `workspace/jobs/` |
+| [Analytics boundary](analytics-boundary.html) | Typed DF analytics vs Streamlit |

--- a/docs/architecture/job-workspaces.md
+++ b/docs/architecture/job-workspaces.md
@@ -1,0 +1,56 @@
+---
+title: Job workspaces
+parent: Architecture
+nav_order: 11
+---
+
+# Job workspaces
+
+**Status:** target contract. Filesystem layout lands in migration **PR1**.
+
+A browser session is not the project database. `st.session_state` is not durable storage.
+
+## Layout
+
+```text
+workspace/jobs/<job_id>/
+  job.json
+  mapping/
+  configs/
+  runs/
+  findings/
+  reports/
+  wattlab/
+  artifacts/
+```
+
+Telemetry stays in Feather / parquet (site historian). Jobs hold **pointers**, configs, run outputs, and findings — not SQLite historian tables.
+
+## `job.json` (minimum)
+
+```json
+{
+  "schema_version": 1,
+  "job_id": "job-…",
+  "job_name": "…",
+  "site_name": null,
+  "building_name": null,
+  "status": "active",
+  "created_at": "…",
+  "updated_at": "…",
+  "revisions": {
+    "dataset": null,
+    "mapping": null,
+    "config": null,
+    "engine": null
+  }
+}
+```
+
+## Lifecycle
+
+Create · Open · Save · Duplicate · Rename · Archive · Delete (confirm) · Export/Import (later).
+
+Stale results must not present as CURRENT when mapping/config/dataset revisions change.
+
+See [VIBE19_VIBE20_OPENFDD_AUDIT.md](../migration/VIBE19_VIBE20_OPENFDD_AUDIT.md) §F–H.

--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -22,15 +22,15 @@ ghcr.io/bbartling/openfdd-mcp:${OPENFDD_IMAGE_TAG:-nightly}
 | Container | Image | Role |
 |-----------|-------|------|
 | `central` | `openfdd-central` | REST API (`:8080`), JWT auth, historian, DataFusion FDD engine, reports, MCP API surface |
-| `ui` | `openfdd-ui` | Caddy static React dashboard (`:3000`), proxies `/api` to central |
+| `ui` | `openfdd-ui` | Streamlit vibe19 lab (`:3000`); talks to central REST for SQL FDD |
 | `fieldbus` | `openfdd-fieldbus` | BACnet/IP poll (`network_mode: host`), publishes over MQTTS |
 | `mqtt` | `openfdd-mqtt` | Mosquitto broker, MQTTS on `:8883` |
 | `mcp` | `openfdd-mcp` | Slim Rust MCP server for external agents |
 
 ```text
 ┌──────────────────────┐        ┌──────────────────────────────┐
-│ ui (Caddy :3000)     │──/api─▶│ central (:8080)              │
-└──────────────────────┘        │ REST · JWT · historian · FDD │
+│ ui (Streamlit :3000) │───────▶│ central (:8080)              │
+└──────────────────────┘  REST  │ JWT · historian · SQL FDD    │
                                  └──────────────────────────────┘
                                           ▲ MQTTS (8883)
                                           │

--- a/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
+++ b/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
@@ -1,0 +1,227 @@
+---
+title: Vibe19 / Vibe20 / Open-FDD audit
+parent: Migration
+nav_order: 1
+---
+
+# Vibe19 × Vibe20 × Open-FDD audit
+
+**Audit date:** 2026-07-25 · **Tip under audit:** `d631e9c8` (`sha-d631e9c`, merge #569)  
+**Rule:** trust tested current code over historical `docs/migration/vibe19/*` stage notes.
+
+Reference checkouts (not vendored into open-fdd):
+
+| Tree | Path |
+|------|------|
+| vibe19 | `/mnt/c/Users/ben/Documents/py-bacnet-stacks-playground/vibe_code_apps_19` (`develop`) |
+| vibe20 | `/mnt/c/Users/ben/Documents/py-bacnet-stacks-playground/vibe_code_apps_20` (`develop`) |
+| open-fdd UI (vendored vibe19 lab) | [`services/ui/`](../../services/ui/) |
+
+Companion matrices:
+
+- [vibe19 capability parity](vibe19_parity_matrix.md)
+- [vibe20 / WattLab integration](vibe20_integration_matrix.md)
+- Rule SQL↔pandas honesty: [docs/rules/cookbook/parity-matrix.md](../rules/cookbook/parity-matrix.md)
+
+---
+
+## A. Open-FDD current state
+
+### Stack
+
+| Image | Role (code truth) |
+|-------|-------------------|
+| `openfdd-central` | JWT REST, Feather ingest, DataFusion FDD (`POST /api/fdd/run` registry mode) |
+| `openfdd-ui` | **Streamlit** vibe19 lab (`services/ui`) — not React |
+| `openfdd-fieldbus` | BACnet / Modbus / Haystack / REST OT |
+| `openfdd-mqtt` | MQTTS broker |
+| `openfdd-mcp` | Optional MCP stdio → central |
+
+Retired: `openfdd-edge-rust` monolith (see closed #570).
+
+### FDD execution path
+
+```text
+Package / CSV / OT → Feather + parquet (.cache/parquet)
+        → POST /api/fdd/run { mode: registry }
+        → edge registry_api + crates/fdd_rules
+        → sql_rules/*.sql via DataFusion (fdd_sql)
+        → .cache/rule_results/<RULE_ID>.json
+```
+
+- Canonical registry: [`sql_rules/registry.yaml`](../../sql_rules/registry.yaml) — **63** rules / **63** SQL files.
+- Pandas cookbook: [`services/ui/app/rules/cookbook_catalog.py`](../../services/ui/app/rules/cookbook_catalog.py) — **59** rules; emergency only via `OPENFDD_ALLOW_PANDAS_FDD=1`.
+- Parity tags (2026-07-19 matrix): **18** `proven_building_100`, **44** `ported_from_cookbook`, **1** `skipped_missing_roles` (`FC7`).
+
+### Durable site state (not analysis Jobs)
+
+Under bind-mounted [`workspace/`](../quick-start/site-lifecycle.md):
+
+| Path | Purpose |
+|------|---------|
+| `workspace/data/session_config.json` | FDD session / fault settings (`/api/fdd/session-config`) |
+| `workspace/data/datasets/` | Dataset registry |
+| `workspace/data/csv_buildings/` | Package materializations |
+| `workspace/data/feather_store/` | Historian |
+| `workspace/data/import_jobs/` | CSV **import** tickets (`import-{millis}`) — not FDD analysis Jobs |
+
+Streamlit continuity today: `st.session_state` + browser download/upload of `session_config.json` ([`streamlit_app.py`](../../services/ui/streamlit_app.py)).
+
+### UI sections (frozen contract)
+
+[`dashboard_contract.py`](../../services/ui/app/dashboard_contract.py): Overview · Data Model · Run Rules · Results by Category · FDD Plots · RCx Plots · Metering · Export.  
+**No Jobs page.** Single large `streamlit_app.py` (not multipage).
+
+### WattLab / EnergyPlus
+
+- Export handoff implemented: [`wattlab_dump.py`](../../services/ui/app/wattlab_dump.py) (`wattlab_dump_v3`).
+- EnergyPlus / ECM / calibration live in **external** vibe20 (`wattlab/`), not in this repo.
+
+---
+
+## B. Vibe19 features missing or partial in Open-FDD
+
+| Capability | Vibe19 | Open-FDD gap |
+|------------|--------|--------------|
+| Persistent named Jobs | Session-oriented demo | **Missing** product Job save/open/reopen |
+| Multipage IA | Similar section radio | Same 8 sections; no Jobs / Findings / History pages |
+| FDD rule math | Pandas cookbook | **SQL default** (good); catalog skew 59 vs 63 |
+| RCx analytics | `rcx_plots.py` + analytics | Vendored pandas path; not DataFusion-first |
+| Engineering findings as first-class entities | reporting / HITL in playground | Export CSVs only; no persisted dispositions |
+| Filled RCx DOCX | playground reporting pipeline | Template download only (`docx_report.py`) |
+| Dual BAS vs web OAT honesty | Present | Present in UI/weather helpers — keep |
+| Mech cooling proof hierarchy | Specs under `services/ui/docs/superpowers/` | Logic in pandas analytics; needs DF migration later |
+
+See [vibe19_parity_matrix.md](vibe19_parity_matrix.md) for Intake → Findings rows.
+
+---
+
+## C. Vibe20 features worth integrating (handoff, not rewrite)
+
+Integrate **into the Job model** as consumers of Open-FDD evidence:
+
+| Area | vibe20 path | Open-FDD action |
+|------|-------------|-----------------|
+| Seed / dump import | `wattlab/seed/bundle.py` | Persist handoff under `job/wattlab/`; avoid full pandas recompute |
+| Assumptions / gaps | studio / seed honesty | Persist `NEEDS_INPUT` gaps with job |
+| EnergyPlus runs | `wattlab/energyplus/` | Out of process; store run metadata + hashes only |
+| ECM / finance | `wattlab/ecm/`, `finance.py` | Out of process |
+| Bills | `wattlab/seed/import_bills.py` | Optional job artifact |
+
+Do **not** vendor EnergyPlus into open-fdd.
+
+---
+
+## D. Pandas inventory (significant `services/ui` uses)
+
+| Module | Class | Notes |
+|--------|-------|-------|
+| `app/rules/cookbook_catalog.py`, `runner.py`, `pid_hunting.py`, `sensor_rate.py`, `operational_gate.py`, `economizer_weather.py` | **TEST_ORACLE** (+ emergency FDD) | Keep until SQL proven; never silent prod fallback |
+| `app/analytics.py`, `analytics_baseline.py` | **MIGRATE_TO_DATAFUSION** | Motor runtime, mech cooling, sensor health |
+| `app/rcx_plots.py`, `ui_rcx_tab.py` | **MIGRATE_TO_DATAFUSION** | Plot datasets must be DF-prepared |
+| `app/metering.py` | **MIGRATE_TO_DATAFUSION** | Meter aggregations |
+| `app/wattlab_dump.py`, `model_seed.py` | **MIGRATE_TO_DATAFUSION** (prep) + **KEEP_NON_SQL** (zip/IO) | Stats/profiles → SQL; zip assembly stays Python |
+| `app/charts.py`, `streamlit_app.py`, `reports.py` | **UI_BOUNDARY** | After aggregation only |
+| `app/data_loader.py`, `package_io.py`, `sql_sources.py`, weather helpers | **KEEP_NON_SQL** / thin frames | I/O and package validation |
+| `app/agent_api.py` | Mixed | Prefer central SQL for FDD; analytics still pandas |
+
+---
+
+## E. Duplicate algorithms
+
+| Concern | Locations | Resolution |
+|---------|-----------|------------|
+| Rule catalog | `sql_rules/registry.yaml` vs cookbook 59 | SQL is production SoT; cookbook = oracle |
+| FC13 naming | SQL `FC13-SAT-HIGH` + alias `FC13` | Keep alias; document |
+| Session config | central `session_config` vs Streamlit download | Unify under Job config revision |
+| WattLab findings | `wattlab_dump.fdd_findings_table` vs Results UI | One findings schema under Job |
+| RCx presets | UI `REQUIRED_RCX_PRESET_IDS` vs playground | Keep open-fdd contract; port behavior not bugs |
+
+---
+
+## F. Job persistence state
+
+| Exists | Missing |
+|--------|---------|
+| Site `workspace/` durability | Named analysis `job_id` |
+| CSV import job tickets | Create / open / save / duplicate / archive Jobs UX |
+| session_config round-trip | Revision/provenance stamps on FDD/RCx/findings |
+| Rule result JSON cache | Stale detection vs mapping/config change |
+| WattLab zip in session | Job-attached wattlab/ run history |
+
+**Target layout (PR1+):**
+
+```text
+workspace/jobs/<job_id>/
+  job.json                 # metadata + revision hashes
+  mapping/
+  configs/
+  runs/
+  findings/
+  reports/
+  wattlab/
+  artifacts/
+  # telemetry: pointers / links into feather_store + parquet — never SQLite blobs
+```
+
+SQLite (if introduced later) = **job metadata index only**.
+
+---
+
+## G. Proposed target architecture
+
+```text
+                ┌─────────────────────┐
+                │   STREAMLIT UI      │
+                │ Jobs + engineering  │
+                └──────────┬──────────┘
+                           │ thin typed calls
+         ┌─────────────────▼─────────────────┐
+         │   OPEN-FDD SERVICES (central)     │
+         │ jobs / mapping / runs / findings  │
+         └───────────────┬───────────────────┘
+                         │
+          ┌──────────────▼──────────────┐
+          │ RUST + ARROW + DATAFUSION   │
+          │ FDD / RCx / analytics SQL   │
+          └──────────────┬──────────────┘
+                         │
+              Feather / parquet under workspace
+                         │
+                         ▼ engineering evidence
+             ┌────────────────────────┐
+             │ WATTLAB / ENERGYPLUS   │  (external vibe20)
+             └────────────────────────┘
+```
+
+Contracts: [datafusion-first](../architecture/datafusion-first.md) · [job-workspaces](../architecture/job-workspaces.md) · [analytics-boundary](../architecture/analytics-boundary.md).
+
+---
+
+## H. Migration stages (backlog)
+
+| Stage | Scope | Status |
+|-------|--------|--------|
+| **PR0** | This audit + matrices + tip pin + architecture stubs | This PR |
+| **PR1** | Job filesystem contract + tests + thin Jobs UI entry | Next |
+| **PR2** | DataFusion analytics service boundary + instrumentation | Planned |
+| **PR3** | FDD oracle push (`ported` → `proven`) | Planned |
+| **PR4** | RCx family → SQL views | Planned |
+| **PR5** | Full Jobs UX restore (mapping/params/runs) | Planned |
+| **PR6** | FDD/RCx UI parity (registry-driven sliders; DF plots) | Planned |
+| **PR7** | Findings + job reports | Planned |
+| **PR8** | WattLab bridge v2 (job-native handoff) | Planned |
+| **PR9** | Energy model metadata under job (external EP) | Planned |
+| **PR10** | Perf benches + delete production pandas paths after parity | Planned |
+
+### Non-goals
+
+- Wholesale copy of vibe19/vibe20 trees  
+- React UI rewrite  
+- Historian in SQLite  
+- Silent pandas FDD fallback  
+- Claiming full SQL↔pandas parity  
+
+### Next recommended code PR
+
+**PR1 — Job contract** under `workspace/jobs/<job_id>/` with create / list / get / archive, atomic `job.json` writes, reopen restores metadata + mapping pointers, thin Streamlit Jobs entry. Defer multipage IA rewrite to PR5.

--- a/docs/migration/vibe19_parity_matrix.md
+++ b/docs/migration/vibe19_parity_matrix.md
@@ -1,0 +1,43 @@
+---
+title: Vibe19 capability parity matrix
+parent: Migration
+nav_order: 2
+---
+
+# Vibe19 → Open-FDD capability parity matrix
+
+**Audit tip:** `sha-d631e9c` · **Rule SQL honesty:** [parity-matrix.md](../rules/cookbook/parity-matrix.md) (do not duplicate rule-level tables here).
+
+Status legend: **DONE** · **PARTIAL** · **MISSING** · **N/A** (intentional).
+
+| Capability | Vibe19 path | Open-FDD equivalent | Backend | DataFusion? | UI parity? | Tests? | Status | Notes |
+|------------|-------------|---------------------|---------|-------------|------------|--------|--------|-------|
+| Folder import | `data_loader` / folder picker | Streamlit folder when `allow_server_paths` | UI + package_io | N/A | Yes | Partial | PARTIAL | Zip always on; folder gated |
+| ZIP / package import | `package_io` | `package_io` + central Feather | UI + edge csv package | Ingest→parquet | Yes | Yes | DONE | Hostile ZIP handling in package path |
+| Multi-file workflows | package | package + datasets API | edge datasets | Via parquet | Yes | Yes | DONE | |
+| Package validation | package_io | package_io + report | UI | N/A | Yes | Yes | DONE | |
+| Session configuration | session_config | `/api/fdd/session-config` + download/upload | edge session_config | N/A | PARTIAL | Yes | PARTIAL | Not job-scoped yet |
+| Equipment inventory | data model tree | `data_model_tree` | UI | N/A | Yes | Guards | DONE | |
+| Role mapping | mapping wizard / role_map | Data Model section | UI + central roles | N/A | Yes | Partial | PARTIAL | No mapping revision stamp |
+| VAV→AHU relationships | data model | tree / attrs | UI | N/A | PARTIAL | Partial | PARTIAL | |
+| Overview summary | Overview tab | Overview section | UI | N/A | Yes | Guards | DONE | |
+| Occupancy calendar | occupancy schedule | session + Overview | UI | **Need SQL view** | PARTIAL | Partial | PARTIAL | Not a DF relation yet |
+| BAS vs web OAT | weather helpers | weather_resolver / open_meteo / charts | UI | Migrate | Yes | Partial | PARTIAL | Provenance must stay explicit |
+| FDD run all / selected | rules runner | `POST /api/fdd/run` registry | fdd_rules | **Yes** | Yes | Yes | DONE | Default SQL; pandas quarantine |
+| Rule param tuning | sliders / cookbook | left-rail + aliases | UI + registry_api | Params→SQL | PARTIAL | Soak #565 | PARTIAL | Dual catalog 59 vs 63 |
+| Fault statuses | cookbook statuses | SQL result statuses | fdd_rules | Yes | Yes | Fixtures | PARTIAL | Ported ≠ proven for 44 rules |
+| Confirmation windows | confirm_fault | CONFIRM_ROWS / confirm_min | runner | Yes | Yes | #565 | DONE | |
+| FDD Plots | charts | FDD Plots section | UI charts | UI boundary | Yes | Guards | PARTIAL | Still frame-fed |
+| RCx presets (~20) | rcx_plots | RCx Plots + REQUIRED_RCX_PRESET_IDS | pandas | **No** | Yes | Coverage helper | PARTIAL | Migrate datasets to DF |
+| Motor / weekly runtime | analytics | analytics.py | pandas | **No** | Yes | Partial | PARTIAL | MIGRATE |
+| Mech cooling evidence | analytics / specs | analytics + superpowers specs | pandas | **No** | PARTIAL | Specs | PARTIAL | Keep hierarchy; move math to DF |
+| Metering | metering | Metering section | pandas | **No** | Yes | Partial | PARTIAL | MIGRATE |
+| Engineering findings HITL | reporting/ | Export CSVs / wattlab findings | export | N/A | **No** page | Partial | MISSING | Need persisted findings |
+| Filled RCx DOCX | reporting pipeline | Template download only | docx_report | N/A | Partial | Guards | MISSING | No python-docx fill |
+| WattLab dump | wattlab_dump | Export “WattLab dump” | wattlab_dump | Mixed | Yes | Fixtures | DONE | Recompute cost still high |
+| Named Jobs persistence | (demo session) | — | — | — | No | — | MISSING | PR1 |
+| Agent / REST tools | agent_api | central `/api/agent/tools` + MCP | central | FDD SQL | N/A | Smoke | DONE | Extend with job tools later |
+
+## Registry honesty (pointer)
+
+Do not claim “54 full parity.” Use `parity_status` on each rule in `sql_rules/registry.yaml`. UI cookbook count **59** vs SQL **63** is intentional (SQL rollups + FC13 alias).

--- a/docs/migration/vibe20_integration_matrix.md
+++ b/docs/migration/vibe20_integration_matrix.md
@@ -1,0 +1,46 @@
+---
+title: Vibe20 / WattLab integration matrix
+parent: Migration
+nav_order: 3
+---
+
+# Vibe20 / WattLab ↔ Open-FDD integration matrix
+
+**Open-FDD tip:** `sha-d631e9c` · **vibe20 reference:** playground `vibe_code_apps_20` / `wattlab/` on `develop`.
+
+Open-FDD does **not** run EnergyPlus. It produces engineering evidence and a dump zip; vibe20 consumes it.
+
+| Capability | vibe20 consumer | Open-FDD producer today | Job-native target | Status |
+|------------|-----------------|-------------------------|-------------------|--------|
+| Equipment inventory | seed / studio | package + data model | `job/mapping/` + inventory JSON | PARTIAL |
+| Role map | seed | session / package | `job/mapping/role_map.json` | PARTIAL |
+| Dataset window | seed | package report / frames | `job.json` window + dataset_revision | PARTIAL |
+| Schedules | seed / model | `model_seed.infer_schedules` | Persist under job configs | PARTIAL |
+| Setpoints | seed | `wattlab_dump.setpoints_table` | DF query → artifact | PARTIAL |
+| Sensor statistics | seed | `sensor_stats_tables` (pandas) | analytics_sql | PARTIAL |
+| Weather provenance | weather / EPW | BAS vs web helpers + dump | Explicit source tags in artifacts | PARTIAL |
+| Operating signatures | seed | `model_seed.operating_signatures` | Persist + DF profiles | PARTIAL |
+| 24h / weekday profiles | seed | `diurnal_profiles` (pandas) | DF | PARTIAL |
+| FDD results | seed findings | registry results + `fdd_findings.csv` | `job/runs/` + `job/findings/` | PARTIAL |
+| Mech cooling evidence | honesty rules | analytics / dump | Documented hierarchy; DF later | PARTIAL |
+| Utility bills | `import_bills.py` | optional upload | `job/wattlab/utility_bills.*` | MISSING |
+| Model assumptions | studio | gaps in dump README | `assumptions.json` + NEEDS_INPUT | MISSING |
+| EnergyPlus IDF / sim | `wattlab/energyplus/` | — | Out of process; store hashes/status only | N/A (external) |
+| ECM / finance | ecm / finance | — | External; link results under job | N/A (external) |
+| Calibration history | calibrate* | — | `job/wattlab/calibration/` metadata | MISSING |
+| Dump zip v3 | `wattlab/seed/bundle.py` | `wattlab_dump` Export | Write into `job/wattlab/exports/` | DONE |
+
+## Honesty rules (keep)
+
+- Never invent building type, floor area, city, lat/lon, capacity, or utility bills.
+- Missing inputs stay visible as `NEEDS_INPUT` (or equivalent).
+- Detection ≠ engineering finding; findings need review disposition once PR7 lands.
+- Chilled-water pump runtime alone does **not** prove compressor operation.
+
+## Anti-pattern to retire
+
+```text
+Open-FDD → giant CSV → reload everything in pandas in vibe20 → rediscover
+```
+
+Target: Job is canonical; WattLab seed reads job artifacts / handoff without recomputing the whole telemetry model.


### PR DESCRIPTION
## Summary
- Add `docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md` (sections A–H) plus vibe19/vibe20 matrices.
- Add architecture contracts: datafusion-first, job-workspaces, analytics-boundary.
- Pin living soak prompt + VERSION_MANIFEST to tip `sha-d631e9c` (#569).
- Fix architecture docs that still claimed React UI.
- #570 closed separately (retired edge-rust image).

## Test plan
- [ ] Docs-only; product CI green
- [ ] Next code PR: Job contract under `workspace/jobs/` (PR1 in audit backlog)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added architecture guidance for analytics boundaries, DataFusion-first processing, job workspaces, and service interactions.
  - Added migration audit and parity documentation covering Vibe19/Vibe20 integration, current capabilities, gaps, and future work.
  - Updated deployment guidance with the latest verified image references and refreshed testing notes.
  - Clarified the Streamlit interface’s role and its connection to central services.
  - Documented job persistence, lifecycle expectations, artifact handling, and analytics data contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->