### PR TITLE
feat(ui): workspace/jobs Job contract + thin Jobs UI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -74,17 +74,18 @@ jobs:
           test -f services/ui/streamlit_app.py
           test -f services/ui/requirements.txt
           test -f services/ui/app/central_client.py
-          python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py services/ui/app/agent_api.py
+          python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py services/ui/app/agent_api.py services/ui/app/job_store.py services/ui/app/ui_jobs.py
           grep -q "Rule tuning" services/ui/streamlit_app.py
           grep -q "Delete dataset" services/ui/streamlit_app.py
           grep -q "def _run_rule_list" services/ui/streamlit_app.py
           grep -q "DataFusion" services/ui/streamlit_app.py || grep -q "run_fdd" services/ui/app/central_client.py
           grep -q "Authorization" services/ui/app/central_client.py
           grep -q "confirm_seconds" services/ui/app/central_client.py
+          grep -q "Jobs (persistent)" services/ui/app/ui_jobs.py
           ! test -d workspace/dashboard/src
           ! test -f workspace/dashboard/package.json
           pip install -q pytest requests
-          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py -q)
+          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py app/test_job_store.py -q)
       - name: BACnet NIC helper guards
         run: |
           test -x scripts/openfdd_bacnet_nic_setup.sh

--- a/docs/architecture/job-workspaces.md
+++ b/docs/architecture/job-workspaces.md
@@ -6,7 +6,7 @@ nav_order: 11
 
 # Job workspaces
 
-**Status:** target contract. Filesystem layout lands in migration **PR1**.
+**Status:** filesystem contract + thin Streamlit Jobs entry (migration PR1).
 
 A browser session is not the project database. `st.session_state` is not durable storage.
 
@@ -25,6 +25,14 @@ workspace/jobs/<job_id>/
 ```
 
 Telemetry stays in Feather / parquet (site historian). Jobs hold **pointers**, configs, run outputs, and findings — not SQLite historian tables.
+
+## Implementation
+
+| Piece | Path |
+|-------|------|
+| Store | [`services/ui/app/job_store.py`](../../services/ui/app/job_store.py) |
+| Streamlit entry | [`services/ui/app/ui_jobs.py`](../../services/ui/app/ui_jobs.py) sidebar expander **Jobs (persistent)** |
+| Tests | `services/ui/app/test_job_store.py` |
 
 ## `job.json` (minimum)
 
@@ -47,10 +55,11 @@ Telemetry stays in Feather / parquet (site historian). Jobs hold **pointers**, c
 }
 ```
 
-## Lifecycle
+## Lifecycle (PR1)
 
-Create · Open · Save · Duplicate · Rename · Archive · Delete (confirm) · Export/Import (later).
+Create · Open · Save mapping · Archive · Delete (confirm, API).  
+Duplicate / Export / Import / full restore of FDD runs → later PRs.
 
-Stale results must not present as CURRENT when mapping/config/dataset revisions change.
+Stale results must not present as CURRENT when mapping/config/dataset revisions change (PR5+).
 
 See [VIBE19_VIBE20_OPENFDD_AUDIT.md](../migration/VIBE19_VIBE20_OPENFDD_AUDIT.md) §F–H.

--- a/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
+++ b/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
@@ -202,8 +202,8 @@ Contracts: [datafusion-first](../architecture/datafusion-first.md) · [job-works
 
 | Stage | Scope | Status |
 |-------|--------|--------|
-| **PR0** | This audit + matrices + tip pin + architecture stubs | This PR |
-| **PR1** | Job filesystem contract + tests + thin Jobs UI entry | Next |
+| **PR0** | This audit + matrices + tip pin + architecture stubs | Merged (#571) |
+| **PR1** | Job filesystem contract + tests + thin Jobs UI entry | This PR |
 | **PR2** | DataFusion analytics service boundary + instrumentation | Planned |
 | **PR3** | FDD oracle push (`ported` → `proven`) | Planned |
 | **PR4** | RCx family → SQL views | Planned |

--- a/services/ui/app/dashboard_contract.py
+++ b/services/ui/app/dashboard_contract.py
@@ -52,4 +52,7 @@ REQUIRED_UI_ENTRYPOINTS: tuple[str, ...] = (
     "app.model_seed:infer_schedules",
     "app.model_seed:operating_signatures",
     "app.open_meteo:fetch_open_meteo",
+    "app.ui_jobs:render_jobs_sidebar",
+    "app.job_store:create_job",
+    "app.job_store:load_job",
 )

--- a/services/ui/app/job_store.py
+++ b/services/ui/app/job_store.py
@@ -1,0 +1,298 @@
+"""Persistent analysis Job store under ``workspace/jobs/<job_id>/``.
+
+Filesystem contract for Open-FDD engineering Jobs (migration PR1).
+Telemetry stays in Feather/parquet; this store holds metadata, mapping,
+configs, and run/findings directories — never SQLite historian tables.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+SCHEMA_VERSION = 1
+_JOB_ID_RE = re.compile(r"^job-[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$")
+_SUBDIRS = (
+    "mapping",
+    "configs",
+    "runs",
+    "findings",
+    "reports",
+    "wattlab",
+    "artifacts",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def workspace_root(explicit: str | Path | None = None) -> Path:
+    """Resolve site workspace root (bind-mounted ``workspace/`` in containers)."""
+    if explicit is not None:
+        return Path(explicit).expanduser().resolve()
+    env = os.environ.get("OPENFDD_WORKSPACE") or os.environ.get("OPENFDD_WORKSPACE_DIR")
+    if env:
+        return Path(env).expanduser().resolve()
+    # Common local / compose defaults
+    for candidate in (Path("workspace"), Path("/workspace"), Path.cwd() / "workspace"):
+        if candidate.is_dir():
+            return candidate.resolve()
+    return (Path.cwd() / "workspace").resolve()
+
+
+def jobs_root(ws: Path | None = None) -> Path:
+    root = (ws or workspace_root()) / "jobs"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+@dataclass
+class JobRevisions:
+    dataset: str | None = None
+    mapping: str | None = None
+    config: str | None = None
+    engine: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> JobRevisions:
+        if not isinstance(raw, dict):
+            return cls()
+        return cls(
+            dataset=raw.get("dataset"),
+            mapping=raw.get("mapping"),
+            config=raw.get("config"),
+            engine=raw.get("engine"),
+        )
+
+
+@dataclass
+class JobMeta:
+    schema_version: int
+    job_id: str
+    job_name: str
+    site_name: str | None = None
+    building_name: str | None = None
+    description: str | None = None
+    status: str = "active"  # active | archived
+    created_at: str = ""
+    updated_at: str = ""
+    tags: list[str] = field(default_factory=list)
+    revisions: JobRevisions = field(default_factory=JobRevisions)
+    mapping_path: str | None = None  # relative to job dir when set
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return d
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> JobMeta:
+        if not isinstance(raw, dict):
+            raise ValueError("job.json must be an object")
+        job_id = raw.get("job_id")
+        if not isinstance(job_id, str) or not _JOB_ID_RE.match(job_id):
+            raise ValueError(f"invalid job_id: {job_id!r}")
+        name = raw.get("job_name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("job_name is required")
+        ver = raw.get("schema_version", SCHEMA_VERSION)
+        if ver != SCHEMA_VERSION:
+            raise ValueError(f"unsupported schema_version: {ver}")
+        status = raw.get("status") or "active"
+        if status not in ("active", "archived"):
+            raise ValueError(f"invalid status: {status!r}")
+        tags = raw.get("tags") or []
+        if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
+            raise ValueError("tags must be a list of strings")
+        return cls(
+            schema_version=int(ver),
+            job_id=job_id,
+            job_name=name.strip(),
+            site_name=raw.get("site_name"),
+            building_name=raw.get("building_name"),
+            description=raw.get("description"),
+            status=status,
+            created_at=str(raw.get("created_at") or ""),
+            updated_at=str(raw.get("updated_at") or ""),
+            tags=list(tags),
+            revisions=JobRevisions.from_dict(raw.get("revisions")),
+            mapping_path=raw.get("mapping_path"),
+        )
+
+
+def new_job_id() -> str:
+    return f"job-{uuid.uuid4()}"
+
+
+def job_dir(job_id: str, ws: Path | None = None) -> Path:
+    if not _JOB_ID_RE.match(job_id):
+        raise ValueError(f"invalid job_id: {job_id!r}")
+    return jobs_root(ws) / job_id
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=".job-", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _ensure_layout(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    for name in _SUBDIRS:
+        (path / name).mkdir(parents=True, exist_ok=True)
+
+
+def create_job(
+    job_name: str,
+    *,
+    site_name: str | None = None,
+    building_name: str | None = None,
+    description: str | None = None,
+    tags: Iterable[str] | None = None,
+    ws: Path | None = None,
+) -> JobMeta:
+    now = _utc_now()
+    meta = JobMeta(
+        schema_version=SCHEMA_VERSION,
+        job_id=new_job_id(),
+        job_name=job_name.strip(),
+        site_name=site_name,
+        building_name=building_name,
+        description=description,
+        status="active",
+        created_at=now,
+        updated_at=now,
+        tags=list(tags or []),
+    )
+    if not meta.job_name:
+        raise ValueError("job_name is required")
+    path = job_dir(meta.job_id, ws)
+    if path.exists():
+        raise RuntimeError(f"job directory already exists: {path}")
+    _ensure_layout(path)
+    _atomic_write_json(path / "job.json", meta.to_dict())
+    return meta
+
+
+def save_job(meta: JobMeta, *, ws: Path | None = None) -> JobMeta:
+    """Persist metadata (updates ``updated_at``)."""
+    meta = JobMeta.from_dict(meta.to_dict())  # validate
+    meta.updated_at = _utc_now()
+    path = job_dir(meta.job_id, ws)
+    if not path.is_dir():
+        raise FileNotFoundError(f"job not found: {meta.job_id}")
+    _ensure_layout(path)
+    _atomic_write_json(path / "job.json", meta.to_dict())
+    return meta
+
+
+def load_job(job_id: str, *, ws: Path | None = None) -> JobMeta:
+    path = job_dir(job_id, ws) / "job.json"
+    if not path.is_file():
+        raise FileNotFoundError(f"job not found: {job_id}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed job.json for {job_id}: {exc}") from exc
+    return JobMeta.from_dict(raw)
+
+
+def list_jobs(*, ws: Path | None = None, include_archived: bool = True) -> list[JobMeta]:
+    root = jobs_root(ws)
+    out: list[JobMeta] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or not child.name.startswith("job-"):
+            continue
+        meta_path = child / "job.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = load_job(child.name, ws=ws)
+        except (ValueError, FileNotFoundError, OSError):
+            continue
+        if not include_archived and meta.status == "archived":
+            continue
+        out.append(meta)
+    out.sort(key=lambda m: m.updated_at or m.created_at, reverse=True)
+    return out
+
+
+def archive_job(job_id: str, *, ws: Path | None = None) -> JobMeta:
+    meta = load_job(job_id, ws=ws)
+    meta.status = "archived"
+    return save_job(meta, ws=ws)
+
+
+def rename_job(job_id: str, job_name: str, *, ws: Path | None = None) -> JobMeta:
+    meta = load_job(job_id, ws=ws)
+    meta.job_name = job_name.strip()
+    if not meta.job_name:
+        raise ValueError("job_name is required")
+    return save_job(meta, ws=ws)
+
+
+def save_mapping(
+    job_id: str,
+    mapping: dict[str, Any],
+    *,
+    mapping_revision: str | None = None,
+    ws: Path | None = None,
+) -> JobMeta:
+    """Write ``mapping/role_map.json`` and stamp mapping revision."""
+    meta = load_job(job_id, ws=ws)
+    path = job_dir(job_id, ws)
+    rel = "mapping/role_map.json"
+    _atomic_write_json(path / rel, mapping)
+    meta.mapping_path = rel
+    rev = mapping_revision or _utc_now()
+    meta.revisions.mapping = rev
+    return save_job(meta, ws=ws)
+
+
+def load_mapping(job_id: str, *, ws: Path | None = None) -> dict[str, Any] | None:
+    meta = load_job(job_id, ws=ws)
+    if not meta.mapping_path:
+        return None
+    path = job_dir(job_id, ws) / meta.mapping_path
+    if not path.is_file():
+        raise FileNotFoundError(f"mapping missing for {job_id}: {meta.mapping_path}")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("mapping must be a JSON object")
+    return raw
+
+
+def delete_job(job_id: str, *, ws: Path | None = None, confirm: bool = False) -> None:
+    if not confirm:
+        raise ValueError("delete_job requires confirm=True")
+    path = job_dir(job_id, ws)
+    if not path.is_dir():
+        raise FileNotFoundError(f"job not found: {job_id}")
+    # Safety: only delete under jobs_root
+    root = jobs_root(ws).resolve()
+    resolved = path.resolve()
+    if root not in resolved.parents and resolved != root:
+        raise RuntimeError("refusing to delete path outside jobs root")
+    import shutil
+
+    shutil.rmtree(resolved)

--- a/services/ui/app/test_job_store.py
+++ b/services/ui/app/test_job_store.py
@@ -1,0 +1,105 @@
+"""Tests for workspace/jobs Job store (filesystem contract)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app import job_store
+
+
+@pytest.fixture()
+def ws(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    return root
+
+
+def test_create_list_load_roundtrip(ws: Path) -> None:
+    meta = job_store.create_job("Bench AHU study", site_name="demo-site", ws=ws)
+    assert meta.job_id.startswith("job-")
+    assert (job_store.job_dir(meta.job_id, ws) / "job.json").is_file()
+    for name in ("mapping", "configs", "runs", "findings", "reports", "wattlab", "artifacts"):
+        assert (job_store.job_dir(meta.job_id, ws) / name).is_dir()
+
+    loaded = job_store.load_job(meta.job_id, ws=ws)
+    assert loaded.job_name == "Bench AHU study"
+    assert loaded.site_name == "demo-site"
+    assert loaded.status == "active"
+
+    listed = job_store.list_jobs(ws=ws)
+    assert len(listed) == 1
+    assert listed[0].job_id == meta.job_id
+
+
+def test_save_reopen_restores_mapping(ws: Path) -> None:
+    meta = job_store.create_job("Map test", ws=ws)
+    mapping = {"AHU-1": {"supply_air_temp": "AV:1", "fan_status": "BV:2"}}
+    job_store.save_mapping(meta.job_id, mapping, mapping_revision="map-v1", ws=ws)
+
+    again = job_store.load_job(meta.job_id, ws=ws)
+    assert again.revisions.mapping == "map-v1"
+    assert again.mapping_path == "mapping/role_map.json"
+    assert job_store.load_mapping(meta.job_id, ws=ws) == mapping
+
+
+def test_archive_and_rename(ws: Path) -> None:
+    meta = job_store.create_job("Old name", ws=ws)
+    renamed = job_store.rename_job(meta.job_id, "New name", ws=ws)
+    assert renamed.job_name == "New name"
+    archived = job_store.archive_job(meta.job_id, ws=ws)
+    assert archived.status == "archived"
+    assert job_store.list_jobs(ws=ws, include_archived=False) == []
+    assert len(job_store.list_jobs(ws=ws, include_archived=True)) == 1
+
+
+def test_malformed_job_json_raises(ws: Path) -> None:
+    meta = job_store.create_job("Broken", ws=ws)
+    path = job_store.job_dir(meta.job_id, ws) / "job.json"
+    path.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed"):
+        job_store.load_job(meta.job_id, ws=ws)
+
+
+def test_invalid_schema_and_id(ws: Path) -> None:
+    with pytest.raises(ValueError, match="invalid job_id"):
+        job_store.job_dir("not-a-job", ws=ws)
+    meta = job_store.create_job("ok", ws=ws)
+    path = job_store.job_dir(meta.job_id, ws) / "job.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["schema_version"] = 99
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        job_store.load_job(meta.job_id, ws=ws)
+
+
+def test_atomic_write_survives_reader(ws: Path) -> None:
+    meta = job_store.create_job("Atomic", ws=ws)
+    path = job_store.job_dir(meta.job_id, ws) / "job.json"
+    before = path.read_text(encoding="utf-8")
+    meta.job_name = "Atomic2"
+    job_store.save_job(meta, ws=ws)
+    after = path.read_text(encoding="utf-8")
+    assert "Atomic2" in after
+    # prior content was valid JSON; new content must parse
+    json.loads(before)
+    json.loads(after)
+
+
+def test_delete_requires_confirm(ws: Path) -> None:
+    meta = job_store.create_job("Doomed", ws=ws)
+    with pytest.raises(ValueError, match="confirm"):
+        job_store.delete_job(meta.job_id, ws=ws)
+    job_store.delete_job(meta.job_id, ws=ws, confirm=True)
+    with pytest.raises(FileNotFoundError):
+        job_store.load_job(meta.job_id, ws=ws)
+
+
+def test_missing_mapping_file_raises(ws: Path) -> None:
+    meta = job_store.create_job("No map file", ws=ws)
+    meta.mapping_path = "mapping/role_map.json"
+    job_store.save_job(meta, ws=ws)
+    with pytest.raises(FileNotFoundError, match="mapping missing"):
+        job_store.load_mapping(meta.job_id, ws=ws)

--- a/services/ui/app/ui_jobs.py
+++ b/services/ui/app/ui_jobs.py
@@ -1,0 +1,109 @@
+"""Thin Streamlit Jobs entry — create / open / archive persistent analysis Jobs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import streamlit as st
+
+from app import job_store
+
+
+def _ws() -> Path:
+    return job_store.workspace_root()
+
+
+def _apply_job_to_session(meta: job_store.JobMeta, mapping: dict[str, Any] | None) -> None:
+    st.session_state["openfdd_job_id"] = meta.job_id
+    st.session_state["openfdd_job_name"] = meta.job_name
+    st.session_state["openfdd_job_status"] = meta.status
+    if meta.site_name:
+        st.session_state["site_id"] = meta.site_name
+    if meta.building_name:
+        st.session_state["building_id"] = meta.building_name
+    if mapping is not None:
+        st.session_state["role_map"] = mapping
+
+
+def render_jobs_sidebar() -> None:
+    """Sidebar expander: list / create / open / archive Jobs under workspace/jobs/."""
+    with st.sidebar.expander("Jobs (persistent)", expanded=False):
+        st.caption(
+            "Analysis Jobs live under `workspace/jobs/` — not `st.session_state`. "
+            "Telemetry stays in Feather/parquet."
+        )
+        try:
+            jobs = job_store.list_jobs(ws=_ws(), include_archived=False)
+        except OSError as exc:
+            st.warning(f"Jobs store unavailable: {exc}")
+            return
+
+        current = st.session_state.get("openfdd_job_id")
+        if current:
+            st.success(f"Open: `{st.session_state.get('openfdd_job_name') or current}`")
+
+        labels = [f"{j.job_name} ({j.job_id[-12:]})" for j in jobs]
+        id_by_label = {f"{j.job_name} ({j.job_id[-12:]})": j.job_id for j in jobs}
+
+        if labels:
+            pick = st.selectbox("Open job", ["(none)"] + labels, key="jobs_pick")
+            if pick != "(none)" and st.button("Open selected", key="jobs_open_btn"):
+                jid = id_by_label[pick]
+                try:
+                    meta = job_store.load_job(jid, ws=_ws())
+                    mapping = None
+                    try:
+                        mapping = job_store.load_mapping(jid, ws=_ws())
+                    except FileNotFoundError:
+                        mapping = None
+                    _apply_job_to_session(meta, mapping)
+                    st.rerun()
+                except (ValueError, OSError) as exc:
+                    st.error(str(exc))
+        else:
+            st.caption("No active jobs yet.")
+
+        st.markdown("**New job**")
+        name = st.text_input("Job name", key="jobs_new_name", placeholder="e.g. Building 100 RCx")
+        if st.button("Create job", key="jobs_create_btn", disabled=not (name or "").strip()):
+            try:
+                meta = job_store.create_job(
+                    name.strip(),
+                    site_name=st.session_state.get("site_id"),
+                    building_name=st.session_state.get("building_id"),
+                    ws=_ws(),
+                )
+                # Snapshot current role map if present
+                role_map = st.session_state.get("role_map")
+                if isinstance(role_map, dict) and role_map:
+                    job_store.save_mapping(meta.job_id, role_map, ws=_ws())
+                    meta = job_store.load_job(meta.job_id, ws=_ws())
+                _apply_job_to_session(
+                    meta,
+                    role_map if isinstance(role_map, dict) else None,
+                )
+                st.rerun()
+            except (ValueError, OSError) as exc:
+                st.error(str(exc))
+
+        if current and st.button("Save mapping to job", key="jobs_save_map_btn"):
+            role_map = st.session_state.get("role_map")
+            if not isinstance(role_map, dict) or not role_map:
+                st.warning("No role_map in session to save.")
+            else:
+                try:
+                    job_store.save_mapping(current, role_map, ws=_ws())
+                    st.success("Mapping saved to job.")
+                except (ValueError, OSError) as exc:
+                    st.error(str(exc))
+
+        if current and st.button("Archive open job", key="jobs_archive_btn"):
+            try:
+                job_store.archive_job(current, ws=_ws())
+                st.session_state.pop("openfdd_job_id", None)
+                st.session_state.pop("openfdd_job_name", None)
+                st.session_state.pop("openfdd_job_status", None)
+                st.rerun()
+            except (ValueError, OSError) as exc:
+                st.error(str(exc))

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -2420,6 +2420,9 @@ def main() -> None:
     defaults_cfg = cached_rule_defaults(str(cfg.rule_defaults_path))
     _apply_agent_bootstrap_once()
     _apply_browser_autoload_once()
+    from app.ui_jobs import render_jobs_sidebar
+
+    render_jobs_sidebar()
     _load_data(cfg)
     _sidebar_sliders(defaults_cfg)
 


### PR DESCRIPTION
## Summary
- Persistent analysis Jobs under `workspace/jobs/<job_id>/` with atomic `job.json` writes.
- APIs: create / list / load / save / rename / archive / delete(confirm) / save+load mapping.
- Thin Streamlit sidebar **Jobs (persistent)** (create/open/save mapping/archive).
- Tests: `app/test_job_store.py` (round-trip, malformed JSON, schema, missing mapping, atomic write).
- CI: compile + pytest job_store; dashboard_contract entrypoints.

Does **not** move historian into SQLite, migrate RCx, or add REST job APIs yet (later stages).

## Test plan
- [ ] `cd services/ui && PYTHONPATH=. pytest app/test_job_store.py -q`
- [ ] Product CI green (Streamlit UI checks + rust-ci)
- [ ] Manual: sidebar Jobs expander creates job under `workspace/jobs/`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent Jobs management in the Streamlit sidebar.
  * Users can create, open, rename, archive, and delete jobs.
  * Job metadata and role mappings are saved and restored from the workspace.
  * Added validation to protect job data and prevent invalid or unsafe operations.

* **Documentation**
  * Updated job workspace lifecycle, implementation references, and migration status.

* **Tests**
  * Expanded automated coverage for job storage, mappings, validation, archiving, deletion, and UI contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->