### PR TITLE
docs: SQL/pandas honesty + united Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Open-FDD is an open-source analytics platform for building automation that combi
 The platform includes:
 
 - Semantic building modeling using **Project Haystack** knowledge graphs
-- JWT authentication and a modern React web interface
+- JWT authentication and a modern **Streamlit** engineering UI (`openfdd-ui`)
 - Apache Arrow & Feather columnar data storage
 - Apache DataFusion SQL analytics and fault detection (59+ cookbook rules)
 - BACnet, Modbus, Haystack, and JSON API drivers (fieldbus container)
@@ -87,7 +87,7 @@ Rules use generic Haystack semantic roles, so they are portable across any model
 | Image | Role |
 |-------|------|
 | [`ghcr.io/bbartling/openfdd-central`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-central) | MQTTS ingest, Feather historian, FDD registry, REST API |
-| [`ghcr.io/bbartling/openfdd-ui`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-ui) | React operator dashboard (Caddy → central) |
+| [`ghcr.io/bbartling/openfdd-ui`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-ui) | Streamlit operator UI (vibe19 + WattLab export → central) |
 | [`ghcr.io/bbartling/openfdd-fieldbus`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-fieldbus) | BACnet / Modbus / Haystack edge |
 | [`ghcr.io/bbartling/openfdd-mqtt`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mqtt) | Mosquitto MQTTS broker |
 | [`ghcr.io/bbartling/openfdd-mcp`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mcp) | Optional slim MCP stdio sidecar → central API |

--- a/docker/VERSION_MANIFEST.md
+++ b/docker/VERSION_MANIFEST.md
@@ -46,32 +46,27 @@ Bump all three together when cutting a coordinated stack release.
 
 ## Latest verified nightlies
 
-Published successfully from tip **`d631e9c8`** (merge #569 — FDD `building_id` hive scope):
+Published successfully from tip **`8850b0bf`** (merge #572 — Jobs contract; #571 audit):
 
 | Images | Immutable tag | Workflow |
 |--------|---------------|----------|
-| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-d631e9c` | [29867342284](https://github.com/bbartling/open-fdd/actions/runs/29867342284) — success |
-| `openfdd-mcp` | `sha-d631e9c` | [29867342248](https://github.com/bbartling/open-fdd/actions/runs/29867342248) — success |
+| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `sha-8850b0b` | [30176649928](https://github.com/bbartling/open-fdd/actions/runs/30176649928) — success |
+| `openfdd-mcp` | `sha-8850b0b` | [30176649926](https://github.com/bbartling/open-fdd/actions/runs/30176649926) — success |
 
 ```bash
-export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-d631e9c
-export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-d631e9c
-export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-d631e9c
-export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-d631e9c
-export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-d631e9c
-# or OPENFDD_IMAGE_TAG=sha-d631e9c / :nightly (same digest as of 2026-07-25 publish)
+export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-8850b0b
+export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:sha-8850b0b
+export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-8850b0b
+export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-8850b0b
+export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-8850b0b
+# or OPENFDD_IMAGE_TAG=sha-8850b0b / :nightly
 ```
 
-UI is Streamlit (`services/ui`); FDD operator path is central DataFusion SQL.
-When `OPENFDD_JWT_SECRET` is set, also set `OPENFDD_ADMIN_PASSWORD` (or
-`OPENFDD_API_TOKEN`) on **both** central and ui so Run Rules / package ingest
-can authenticate.
+UI is **one Streamlit app** (`services/ui`): vibe19 FDD/RCx/Jobs + WattLab export.  
+Production FDD = DataFusion SQL (`sql_rules/`, 63). Pandas cookbook (59) stays online + in-tree as oracle.
 
-Superset migration audit: `docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md`.
-In-repo Streamlit gates 10–12: `scripts/release/smoke_streamlit_ui_gates.sh`.
+Superset audit: `docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md`.
 
-Workspace Cargo version remains **3.3.0** (no semver bump for this integration tip —
-nightlies key off `sha-*`). Bump workspace + `VERSION` together only when cutting a
-coordinated release.
+Workspace Cargo version remains **3.3.0**.
 
-**Human Workbench gate** still required before BACnet OT PASS (hosted **599999** discoverability). See `docs/agent/linux-edge-tester-stack-recipes-prompt.md`.
+**Human Workbench gate** still required before BACnet OT PASS (hosted **599999**). See `docs/agent/linux-edge-tester-stack-recipes-prompt.md`.

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -18,7 +18,7 @@ Open-FDD is a **vendor-neutral, local-first edge platform**. It does **not** shi
 | Data | Arrow/Feather historian, DataFusion SQL FDD |
 | Model | Haystack RDF, assignments, FDD wires |
 | API | JWT REST, `/api/agent/tools` catalog |
-| UI | React dashboard (no chat panel) |
+| UI | Streamlit (`services/ui`) — vibe19 + WattLab export |
 | Optional MCP | `openfdd-mcp` stdio — [mcp/README.md](../../mcp/README.md) |
 
 ## External agent layer (outside Open-FDD)

--- a/docs/agent/linux-edge-tester-stack-recipes-prompt.md
+++ b/docs/agent/linux-edge-tester-stack-recipes-prompt.md
@@ -10,11 +10,11 @@ nav_order: 12
 change). Do **not** create dated copies (`*-2026-07-17.md`, `bench-NNN-*`, etc.).
 One path forever: `docs/agent/linux-edge-tester-stack-recipes-prompt.md`.
 
-**Pinned tip (2026-07-25):** full `d631e9c8c47a9fc4f1308218cf68834afd9f8093`
-(merge #569 — FDD `building_id` hive scope; prior #567 Who-Is/`site_id`/Streamlit gates).
-Prefer `OPENFDD_IMAGE_TAG=sha-d631e9c` (GHCR short sha tag) or `:nightly` only after
+**Pinned tip (2026-07-25):** full `8850b0bf62ad95977c0c1f7de6ede6d06a942e8f`
+(merge #572 Jobs + #571 audit; prior #569 building_id scope).
+Prefer `OPENFDD_IMAGE_TAG=sha-8850b0b` (GHCR short sha tag) or `:nightly` only after
 confirming `org.opencontainers.image.revision` matches on central/ui/fieldbus/mqtt/**mcp**.
-Bisect pins: `sha-58e0d0e` (#567), `sha-884aaed` (#565 Streamlit SQL P0s).
+Bisect pins: `sha-d631e9c` (#569), `sha-58e0d0e` (#567), `sha-884aaed` (#565).
 
 Copy-paste prompt for a **second OT bench**. Pulls GHCR nightlies, exercises all four
 compose build recipes, validates BACnet / Modbus / Haystack / (new) REST drivers, then
@@ -41,8 +41,8 @@ devices **599999** (bench) and **600000** (Pi edge, if present).
 You are the Open-FDD second-bench soak agent on the OT / edge tester machine.
 
 Charter:
-- GHCR tip for this soak: prefer `OPENFDD_IMAGE_TAG=sha-d631e9c` (or `:nightly` with
-  matching `org.opencontainers.image.revision=d631e9c8c47a…` on **every** stack image —
+- GHCR tip for this soak: prefer `OPENFDD_IMAGE_TAG=sha-8850b0b` (or `:nightly` with
+  matching `org.opencontainers.image.revision=8850b0bf62ad…` on **every** stack image —
   central, ui, fieldbus, mqtt, and mcp). No local product builds, no product code PRs.
 - UI is **Streamlit** at http://<bench-ip>:3000 (not React). JWT stacks need
   `OPENFDD_ADMIN_PASSWORD` (or `OPENFDD_API_TOKEN`) on ui **and** central so Run Rules /
@@ -204,8 +204,8 @@ Final report structure (paste back to product agent):
 See [Build recipes](../operations/build-recipes.md). Helper scripts:
 
 ```bash
-export OPENFDD_IMAGE_TAG=sha-d631e9c
-# pin when bisecting: e.g. OPENFDD_IMAGE_TAG=sha-58e0d0e (#567) or sha-884aaed (#565)
+export OPENFDD_IMAGE_TAG=sha-8850b0b
+# pin when bisecting: e.g. OPENFDD_IMAGE_TAG=sha-d631e9c (#569) or sha-884aaed (#565)
 ./scripts/openfdd_stack_pull.sh all
 ./scripts/openfdd_stack_pull.sh mcp
 ./scripts/openfdd_stack_up.sh csv

--- a/docs/architecture/datafusion-first.md
+++ b/docs/architecture/datafusion-first.md
@@ -12,23 +12,28 @@ For tabular building telemetry computation:
 
 > If the operation can reasonably be expressed as DataFusion SQL, it belongs in DataFusion SQL.
 
-## Allowed pandas
+Pandas may remain as:
 
 | Class | When |
 |-------|------|
 | UI boundary | Tiny final frame for Streamlit/Plotly **after** DF aggregation |
-| Test oracle | Independent reference vs SQL |
+| Test oracle | Independent reference vs SQL (online Pandas cookbook + vibe19 playground) |
 | Non-SQL | ZIP/IO, IDF, DOCX, config parse, Plotly figure build |
+| In-tree catalog | `services/ui/app/rules/` — **do not delete**; emergency FDD only with `OPENFDD_ALLOW_PANDAS_FDD=1` |
 
 ## Forbidden
 
 - Silent pandas FDD fallback when DataFusion fails
 - Millions of raw rows into Streamlit for Python downsample
 - Downsampling before fault math
+- Vibe-coding away the pandas cookbook because SQL exists
+- A second Streamlit app for WattLab/EnergyPlus (keep Export handoff in the united UI)
 
 ## Production FDD today
 
 Canonical path: `sql_rules/` + `crates/fdd_rules` + `POST /api/fdd/run`.  
 Pandas cookbook only with explicit `OPENFDD_ALLOW_PANDAS_FDD=1`.
 
-See [VIBE19_VIBE20_OPENFDD_AUDIT.md](../migration/VIBE19_VIBE20_OPENFDD_AUDIT.md).
+UI: **one** Streamlit app (`services/ui`) for vibe19 + WattLab export.
+
+See [VIBE19_VIBE20_OPENFDD_AUDIT.md](../migration/VIBE19_VIBE20_OPENFDD_AUDIT.md) · [Rule Cookbook](../rules/cookbook/).

--- a/docs/deployment/RELEASE_CHANNELS.md
+++ b/docs/deployment/RELEASE_CHANNELS.md
@@ -29,8 +29,8 @@ ghcr.io/bbartling/openfdd-mcp
 
 The container stack:
 
-- `openfdd-central` — HTTP API at `/api/*` and the FDD engine
-- `openfdd-ui` — Caddy serving the compiled React dashboard, proxying `/api` to central
+- `openfdd-central` — HTTP API at `/api/*` and the DataFusion FDD engine
+- `openfdd-ui` — Streamlit engineering UI (vibe19 + WattLab export), talks to central REST
 - `openfdd-fieldbus` — BACnet/IP poller publishing over MQTTS
 - `openfdd-mqtt` — Mosquitto broker
 - `openfdd-mcp` — slim Rust MCP server

--- a/docs/frontend/REACT_TYPESCRIPT_CUTOVER_PLAN.md
+++ b/docs/frontend/REACT_TYPESCRIPT_CUTOVER_PLAN.md
@@ -1,6 +1,8 @@
 # React / TypeScript dashboard cutover plan
 
-**Status:** **Shipped (vibe19 parity train)** — registry APIs on master (#505); SQL catalog 59+ (#506); React lab `/lab` with Plotly chart parity (#507). Remaining: GHCR nightly verify + bench handoff.
+> **OBSOLETE (2026-07-25).** Product UI is **Streamlit** (`services/ui` / `openfdd-ui`). The React dashboard was retired. Kept as historical cutover notes only — do not implement.
+
+**Former status:** Shipped then superseded by Streamlit #559. Registry APIs remain on central; chart parity lives in Streamlit Plotly helpers.
 
 ## Current layout
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,11 @@ Open-FDD is open-source building analytics software for operators, integrators, 
 - Collects live data from **BACnet**, **Modbus**, **Haystack**, **JSON API**, and **CSV** imports
 - Stores telemetry in an **Apache Arrow / Feather** historian at the edge
 - Models sites, equipment, and points with **Project Haystack** semantics
-- Runs **DataFusion SQL** rules for supervisory fault detection
-- Serves a **React** dashboard for commissioning, plots, and PDF reports
+- Runs **DataFusion SQL** rules for supervisory fault detection (`sql_rules/` registry)
+- Serves a **Streamlit** engineering UI (`openfdd-ui`) — vibe19 FDD/RCx workflows plus vibe20 WattLab export handoff in **one** app
 - Exposes a **JWT-protected REST API** and **MCP** tools for AI-assisted engineering workflows
+
+Pandas rule recipes remain published in the [Pandas cookbook](rules/cookbook/pandas-cookbook.html) as the analyst/oracle mirror (tested in the vibe19 playground). Production Open-FDD FDD math is DataFusion SQL only.
 
 ## Who it is for
 

--- a/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
+++ b/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
@@ -6,8 +6,14 @@ nav_order: 1
 
 # Vibe19 × Vibe20 × Open-FDD audit
 
-**Audit date:** 2026-07-25 · **Tip under audit:** `d631e9c8` (`sha-d631e9c`, merge #569)  
+**Audit date:** 2026-07-25 · **Tip under audit:** `8850b0bf` (`sha-8850b0b`, merges #571 audit + #572 Jobs)  
 **Rule:** trust tested current code over historical `docs/migration/vibe19/*` stage notes.
+
+**Hard product rules (2026-07-25):**
+
+1. Open-FDD Rust/central FDD = **DataFusion SQL only** (`sql_rules/registry.yaml`).
+2. **Pandas is not deleted** — online Pandas cookbook + vibe19 playground are the oracle/test home; in-tree `services/ui/app/rules/` stays.
+3. **One Streamlit app** unites vibe19 + vibe20 concepts (WattLab = Export handoff, not a second app).
 
 Reference checkouts (not vendored into open-fdd):
 
@@ -32,7 +38,7 @@ Companion matrices:
 | Image | Role (code truth) |
 |-------|-------------------|
 | `openfdd-central` | JWT REST, Feather ingest, DataFusion FDD (`POST /api/fdd/run` registry mode) |
-| `openfdd-ui` | **Streamlit** vibe19 lab (`services/ui`) — not React |
+| `openfdd-ui` | **One Streamlit app** (`services/ui`) — vibe19 FDD/RCx/Jobs + vibe20 WattLab **export** (not a second Streamlit; EnergyPlus stays external) |
 | `openfdd-fieldbus` | BACnet / Modbus / Haystack / REST OT |
 | `openfdd-mqtt` | MQTTS broker |
 | `openfdd-mcp` | Optional MCP stdio → central |
@@ -70,7 +76,8 @@ Streamlit continuity today: `st.session_state` + browser download/upload of `ses
 ### UI sections (frozen contract)
 
 [`dashboard_contract.py`](../../services/ui/app/dashboard_contract.py): Overview · Data Model · Run Rules · Results by Category · FDD Plots · RCx Plots · Metering · Export.  
-**No Jobs page.** Single large `streamlit_app.py` (not multipage).
+**Jobs:** sidebar **Jobs (persistent)** → `workspace/jobs/` ([`ui_jobs.py`](../../services/ui/app/ui_jobs.py) / [`job_store.py`](../../services/ui/app/job_store.py)).  
+**United app:** vibe19 + WattLab export share this single Streamlit process — not separate apps.
 
 ### WattLab / EnergyPlus
 

--- a/docs/migration/vibe19_parity_matrix.md
+++ b/docs/migration/vibe19_parity_matrix.md
@@ -6,7 +6,9 @@ nav_order: 2
 
 # Vibe19 → Open-FDD capability parity matrix
 
-**Audit tip:** `sha-d631e9c` · **Rule SQL honesty:** [parity-matrix.md](../rules/cookbook/parity-matrix.md) (do not duplicate rule-level tables here).
+**Audit tip:** `sha-8850b0b` · **Rule SQL honesty:** [parity-matrix.md](../rules/cookbook/parity-matrix.md) (do not duplicate rule-level tables here).
+
+**Product UI:** one Streamlit app (`services/ui`) — vibe19 workflows + WattLab export. Pandas cookbook stays online + vibe19-tested; Open-FDD RS FDD is DataFusion SQL only.
 
 Status legend: **DONE** · **PARTIAL** · **MISSING** · **N/A** (intentional).
 
@@ -35,7 +37,7 @@ Status legend: **DONE** · **PARTIAL** · **MISSING** · **N/A** (intentional).
 | Engineering findings HITL | reporting/ | Export CSVs / wattlab findings | export | N/A | **No** page | Partial | MISSING | Need persisted findings |
 | Filled RCx DOCX | reporting pipeline | Template download only | docx_report | N/A | Partial | Guards | MISSING | No python-docx fill |
 | WattLab dump | wattlab_dump | Export “WattLab dump” | wattlab_dump | Mixed | Yes | Fixtures | DONE | Recompute cost still high |
-| Named Jobs persistence | (demo session) | — | — | — | No | — | MISSING | PR1 |
+| Named Jobs persistence | (demo session) | `workspace/jobs/` + sidebar | job_store | N/A | Thin | Yes | PARTIAL | PR1 landed; full restore UX later |
 | Agent / REST tools | agent_api | central `/api/agent/tools` + MCP | central | FDD SQL | N/A | Smoke | DONE | Extend with job tools later |
 
 ## Registry honesty (pointer)

--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -6,9 +6,11 @@ nav_order: 1
 
 # DataFusion SQL FDD Cookbook
 
-Open-FDD edge executes fault detection as **DataFusion SQL** against Apache Arrow historian tables. Copy-paste rules into the **SQL FDD Rules** tab or `POST /api/fdd-rules/{id}/test-sql`.
+Open-FDD executes production fault detection as **DataFusion SQL** against Apache Arrow / parquet historian tables via the canonical registry [`sql_rules/registry.yaml`](https://github.com/bbartling/open-fdd/blob/master/sql_rules/registry.yaml) (**63** rules). Operator path: Streamlit **Run Rules** → `POST /api/fdd/run` (`mode=registry`). Integrators may also exercise rules through the registry APIs — raw arbitrary SQL is rejected.
 
-**Validated rule IDs** match the vibe19 pandas catalog (**59 rules**). Analyst mirror: [Pandas cookbook](pandas-cookbook.html).
+**Pandas mirror:** the [Pandas cookbook](pandas-cookbook.html) documents the **59**-rule vibe19 oracle catalog (kept in-tree under `services/ui/app/rules/` and tested in the vibe19 playground). Do **not** treat “59” as the production registry size. See [parity matrix](parity-matrix.html).
+
+**Updated:** 2026-07-25 · tip `sha-8850b0b`
 
 ---
 

--- a/docs/rules/cookbook/index.md
+++ b/docs/rules/cookbook/index.md
@@ -10,16 +10,25 @@ permalink: /rules/cookbook/
 
 Open-source, **standards-first** fault detection for commercial HVAC. Rules use generic semantic variables / Haystack roles (`discharge-air-temp`, `outside-air-temp`, `fan-cmd`, …) — portable across modeled sites and generic BAS telemetry.
 
-**Validated catalog:** **59 rules** from the vibe19 Streamlit-tested pandas catalog. IDs below are canonical.
+**Two catalogs (do not conflate):**
 
-## Two cookbooks — parity target
+| Catalog | Count | Role |
+|---------|------:|------|
+| **DataFusion SQL** — [`sql_rules/registry.yaml`](https://github.com/bbartling/open-fdd/blob/master/sql_rules/registry.yaml) | **63** | **Production** FDD in Open-FDD Rust / central (`POST /api/fdd/run`) |
+| **Pandas** — vibe19 `cookbook_catalog.py` | **59** | **Oracle / docs / notebooks** — maintained in this cookbook and tested in the vibe19 playground; **not** deleted from `services/ui` |
+
+Parity honesty ([parity matrix](parity-matrix.html), audit 2026-07-19): **18** `proven_building_100` · **44** `ported_from_cookbook` · **1** skipped (`FC7`). SQL presence ≠ oracle-proven. Do not claim “54 full parity.”
+
+## Two cookbooks — complementary, not identical
 
 | Cookbook | Runtime | Use when |
 |----------|---------|----------|
-| [**DataFusion SQL**](datafusion-sql-cookbook.html) | **Open-FDD edge** | Live historian, `/sql-fdd`, API `test-sql`, confirmation engine |
-| [**Pandas**](pandas-cookbook.html) | **Outside Open-FDD** | CSV exports, notebooks, RCx, parity checks, public benchmarks |
+| [**DataFusion SQL**](datafusion-sql-cookbook.html) | **Open-FDD central / edge** | Live historian, registry SQL FDD, confirmation engine |
+| [**Pandas**](pandas-cookbook.html) | **Docs + vibe19 playground (+ emergency `OPENFDD_ALLOW_PANDAS_FDD=1`)** | CSV exports, notebooks, RCx studies, parity oracles |
 
-Every **validated** rule exists in **both** cookbooks. Rolling / multi-sensor screens (e.g. `SV-RATE`, `PID-HUNT-1`) ship a **simplified SQL** variant with an explicit caveat — full logic is Pandas-validated. See the [parity matrix](parity-matrix.html).
+SQL adds rollups (`FAN-RUNTIME-HOURS`, `AVG-ZONE-TEMP`, `ZONE-COMFORT-PCT`, `FAULT-ELAPSED-HOURS`) and aliases `FC13` → `FC13-SAT-HIGH`. Rolling / multi-sensor screens (e.g. `SV-RATE`, `PID-HUNT-1`) may ship a **simplified SQL** variant with an explicit caveat — full logic stays Pandas-validated until proven.
+
+Open-FDD ships **one Streamlit app** (`services/ui`) for vibe19 engineering + vibe20 WattLab **export** — not two Streamlit apps.
 
 ## Framework
 

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -6,9 +6,13 @@ nav_order: 2
 
 # Pandas FDD Cookbook
 
-**Validated source of truth:** the Streamlit-tested vibe19 catalog (`app/rules/cookbook_catalog.py`) — **59 rules**. Open-FDD edge runs **Rust + Apache Arrow + DataFusion SQL**; this cookbook mirrors every validated rule for notebooks, CSV exports, RCx studies, and parity testing.
+**Oracle / documentation catalog:** the Streamlit-tested vibe19 catalog (`services/ui/app/rules/cookbook_catalog.py` and the external vibe19 playground) — **59 rules**.
 
-See also the [DataFusion SQL cookbook](datafusion-sql-cookbook.html) and [P0 rule catalog](p0-rule-catalog.html).
+This cookbook is **intentionally maintained**. It is **not** vibe-coded away. Production Open-FDD FDD math runs **Rust + Apache Arrow + DataFusion SQL** (`sql_rules/registry.yaml`, **63** rules). Use this pandas catalog for notebooks, CSV exports, RCx studies, and SQL↔pandas parity testing. In the Open-FDD UI, pandas FDD runs only with explicit `OPENFDD_ALLOW_PANDAS_FDD=1` (emergency / oracle) — never as a silent fallback.
+
+See also the [DataFusion SQL cookbook](datafusion-sql-cookbook.html), [parity matrix](parity-matrix.html), and [P0 rule catalog](p0-rule-catalog.html).
+
+**Updated:** 2026-07-25 · tip `sha-8850b0b`
 
 ---
 

--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -6,7 +6,16 @@ nav_order: 6
 
 # SQL ↔ Pandas parity matrix
 
-**Audit date:** 2026-07-19 · **Registry source:** `sql_rules/registry.yaml` · **Target:** zero silent drift
+**Audit date:** 2026-07-19 · **Tip cross-check:** `sha-8850b0b` (2026-07-25) — counts below still match `sql_rules/registry.yaml` · **Target:** zero silent drift
+
+## Product split (read this first)
+
+| Surface | Count | Role |
+|---------|------:|------|
+| DataFusion SQL registry | **63** | Production Open-FDD FDD |
+| Pandas vibe19 catalog | **59** | Online docs + playground oracle (kept) |
+
+Open-FDD UI is **one Streamlit app** (vibe19 + WattLab export). Do not delete pandas because SQL exists.
 
 ## Honesty first
 

--- a/docs/rules/cookbook/roadmap.md
+++ b/docs/rules/cookbook/roadmap.md
@@ -8,7 +8,9 @@ nav_order: 7
 
 Implementation order for expanding the public Open-FDD cookbooks. Priorities derive from **public literature frequency** (ASHRAE GL36 AFDD, Berkeley fault taxonomy, PNNL AIRCx, NIST Cx) and the **validated vibe19 catalog**.
 
-## P0 — validated catalog ✅ (59 rules)
+## P0 — validated pandas catalog ✅ (59 rules)
+
+Production Open-FDD SQL registry is **63** rules (`sql_rules/registry.yaml`). The **59** figure is the pandas oracle catalog floor (see [parity matrix](parity-matrix.html)).
 
 - Sensor sweeps: SV-RANGE, SV-FLATLINE, SV-SPIKE, SV-STALE, SV-RATE
 - Control: PID-HUNT-1

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -14,7 +14,7 @@ Supervisory fault detection runs as **DataFusion SQL** against Arrow historian t
 
 | Guide | Content |
 |-------|---------|
-| [**Rule Cookbook hub**](cookbook/) | **DataFusion SQL + Pandas** — validated vibe19 catalog (59 rules) |
+| [**Rule Cookbook hub**](cookbook/) | **DataFusion SQL** (production registry, 63 rules) + **Pandas** (59-rule oracle / docs) |
 | [DataFusion SQL cookbook](cookbook/datafusion-sql-cookbook.html) | Edge runtime — copy-paste rules for `/sql-fdd` and API |
 | [Pandas cookbook](cookbook/pandas-cookbook.html) | Same validated rules for analyst workflows **outside** Open-FDD |
 

--- a/docs/web-app/index.md
+++ b/docs/web-app/index.md
@@ -8,11 +8,15 @@ permalink: /web-app/
 
 # Web application
 
-The dashboard is a **React** SPA served by the bridge at port 8080. Most tabs require JWT login; the home dashboard is public when auth is enabled.
+The operator UI is a **single Streamlit app** (`services/ui` → `openfdd-ui` on port **3000**). It unites vibe19 FDD / RCx / Jobs workflows with vibe20 **WattLab dump** export — not a separate Streamlit process and not a React SPA.
+
+Central REST (`:8080`) owns JWT auth, historian, and **DataFusion SQL** FDD (`POST /api/fdd/run`). Most central APIs require JWT when auth is enabled.
 
 | Guide | Content |
 |-------|---------|
-| [Routes](routes.html) | Sidebar tabs and URLs |
-| [SQL FDD Rules](sql-fdd-rules.html) | Historian SQL workbench |
+| [Routes](routes.html) | Historical route notes (prefer Streamlit sections) |
+| [SQL FDD Rules](sql-fdd-rules.html) | Registry SQL FDD on central |
 | [CSV batch import](csv-batch-import.html) | Headless CSV ingest API |
-| [Plots & reports](plots-and-reports.html) | Trends and PDF builder |
+| [Plots & reports](plots-and-reports.html) | Trends and reports |
+
+See [Architecture → Services](../architecture/services.html) and the [Rule Cookbook](../rules/cookbook/).

--- a/scripts/cookbook_parity_check.py
+++ b/scripts/cookbook_parity_check.py
@@ -141,6 +141,42 @@ def run_docs_integrity() -> None:
             raise AssertionError(f"README.md missing required docs link: {required_link}")
     print("PASS README cookbook + docs links present")
 
+    # Published product UI must not claim React; SQL registry size must stay honest.
+    home = (ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+    if re.search(r"Serves a \*\*React\*\*", home) or re.search(
+        r"\*\*React\*\* dashboard", home
+    ):
+        raise AssertionError("docs/index.md still claims React product dashboard")
+    if "Streamlit" not in home:
+        raise AssertionError("docs/index.md must mention Streamlit product UI")
+    print("PASS docs/index.md Streamlit (no React product claim)")
+
+    registry = (ROOT / "sql_rules" / "registry.yaml").read_text(encoding="utf-8")
+    # Count top-level rule id entries of form `- id:` or `id:` under rules list.
+    reg_ids = re.findall(r"(?m)^\s+-\s+rule_id:\s+\S+", registry)
+    if len(reg_ids) < 63:
+        raise AssertionError(
+            f"sql_rules/registry.yaml expected >= 63 rule ids, found {len(reg_ids)}"
+        )
+    print(f"PASS sql_rules/registry.yaml ({len(reg_ids)} rule ids)")
+
+    hub = (COOKBOOK / "index.md").read_text(encoding="utf-8")
+    if "63" not in hub or "59" not in hub:
+        raise AssertionError(
+            "cookbook/index.md must state both SQL registry 63 and pandas catalog 59"
+        )
+    sql_intro = (COOKBOOK / "datafusion-sql-cookbook.md").read_text(encoding="utf-8")[:2500]
+    pd_intro = (COOKBOOK / "pandas-cookbook.md").read_text(encoding="utf-8")[:2500]
+    if "63" not in sql_intro:
+        raise AssertionError("datafusion-sql-cookbook.md intro must mention registry 63")
+    if "59" not in pd_intro or "not" not in pd_intro.lower():
+        # require "not" near keep/delete messaging — soft check for retention language
+        if "not vibe-coded away" not in pd_intro and "intentionally maintained" not in pd_intro:
+            raise AssertionError(
+                "pandas-cookbook.md intro must state catalog is maintained (not deleted)"
+            )
+    print("PASS cookbook hub + intros dual-catalog honesty")
+
     for name in ("pandas-cookbook.md", "datafusion-sql-cookbook.md"):
         text = (COOKBOOK / name).read_text(encoding="utf-8")
         n = len(RULE_HEADING_RE.findall(text))

--- a/services/ui/README.md
+++ b/services/ui/README.md
@@ -1,162 +1,36 @@
-# Vibe Code App 19 — Open FDD Vibe Coder
+# Open-FDD UI (`services/ui`) — Streamlit engineering app
 
-Educational **Streamlit + pandas** lab for the [Open-FDD 50-rule Pandas Cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html). Historian CSVs stay as-is; you map columns to logical roles, tune thresholds, run rules, and review **FDD Plots** validation cards / RCx / FDD DOCX.
+**One Streamlit process** unites vibe19 FDD / RCx / Jobs workflows with vibe20 **WattLab dump** export. There is no second Streamlit app for WattLab/EnergyPlus inside Open-FDD (EnergyPlus stays in the external vibe20 playground).
 
-**This is not the Rust Open-FDD engine.** Production stack: [Open-FDD](https://github.com/bbartling/open-fdd).
+| Concern | Source of truth |
+|---------|-----------------|
+| Production FDD math | Central DataFusion SQL — `sql_rules/registry.yaml` (**63**) via `POST /api/fdd/run` |
+| Pandas cookbook | `app/rules/cookbook_catalog.py` (**59**) — **kept** for docs, plots/analytics, and oracle; emergency FDD only with `OPENFDD_ALLOW_PANDAS_FDD=1` |
+| Online cookbooks | [DataFusion SQL](https://bbartling.github.io/open-fdd/rules/cookbook/datafusion-sql-cookbook.html) · [Pandas](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html) |
+| Jobs | Sidebar **Jobs (persistent)** → `workspace/jobs/` (`app/job_store.py`) |
 
-**Quick links:** agent brief [`AGENTS.md`](AGENTS.md) · **zip layout** [`docs/PACKAGE_SPEC.md`](docs/PACKAGE_SPEC.md) (`openfdd_package_v1`) · fork guide [`vibe19_agent_spec/docs/CUSTOMIZE.md`](vibe19_agent_spec/docs/CUSTOMIZE.md)
+**This is the product UI image** `ghcr.io/bbartling/openfdd-ui` (not a detached educational demo).
 
-## Prep a building zip (send this to your agent)
-
-Human has a cleaned `BUILDING_*` + `weather/` tree and needs an uploadable `openfdd_package_v1` zip (manifest, **per-CSV Haystack maps**, `session_config.json`, weather nested inside the building).
-
-**Point the agent here (copy/paste):**
-
-```text
-vibe_code_apps_19/docs/BUILD_OPENFDD_PACKAGE.md
-```
-
-That doc is the step-by-step agent prompt. Spec + caps: [`docs/PACKAGE_SPEC.md`](docs/PACKAGE_SPEC.md). Multi-part uploads when the zip is too big for the browser: [`vibe19_agent_spec/docs/AGENT_CSV_PREPROCESS.md`](vibe19_agent_spec/docs/AGENT_CSV_PREPROCESS.md).
-
-Suggested human→agent message:
-
-> Read `vibe_code_apps_19/docs/BUILD_OPENFDD_PACKAGE.md` and `docs/PACKAGE_SPEC.md`. Build openfdd JSON maps + session_config for my building folder at `<PATH>`, nest weather inside it, validate with `load_package_from_dir`, then tell me how to zip and upload.
+**Quick links:** package layout [`docs/PACKAGE_SPEC.md`](docs/PACKAGE_SPEC.md) · agent brief root [`AGENTS.md`](../../AGENTS.md) · architecture [DataFusion-first](../../docs/architecture/datafusion-first.md) · [Job workspaces](../../docs/architecture/job-workspaces.md)
 
 ## Highlights
 
-- Full **59 cookbook rules** + optional `CUSTOM-*` agent rules
-- **Zip package** ingest (`openfdd_package_v1`) with temp-only extract (no retained historian on disk)
-- Haystack-*like* **column → role** map (JSON / session config) — no RDF
-- Analytics: motor hours, mech-cooling OAT bins (**compressor devices only** — not CHW pump-alone or AHU chilled-water valves), device-hours + any-active aggregates, RCx plots
-- **WattLab dump v3** (Export tab) — AI-agent handoff zip for vibe20: profiles `summary` (default) / `diagnostic` / `forensic`, shared `telemetry/`, mechanical series + coverage, FDD summary/findings, expanded sensor stats + provenance, `model_seed.json`, and `MANIFEST.json` (`wattlab_dump_v3`)
-- Headless agent API + CLI; session download/restore for Cloud-friendly handoff
-- **Docker / GHCR** image for self-host demos (**Vibe 19 only** — this work does not publish Vibe 20)
+- **Run Rules** → central SQL (JWT-aware `central_client`)
+- Full **59** pandas cookbook retained for analytics / oracle / emergency gate
+- Zip package ingest (`openfdd_package_v1`), role mapping, RCx plots, metering
+- **WattLab dump v3** on Export — handoff zip for external vibe20 (not an in-repo EnergyPlus runner)
+- Persistent **Jobs** under `workspace/jobs/`
 
-## Quick start (local)
+## Quick start (dev)
 
-```powershell
-cd vibe_code_apps_19
-python -m pip install -e ".[dev]"
+```bash
+cd services/ui
+python -m pip install -r requirements.txt
 streamlit run streamlit_app.py
 ```
 
-Open http://localhost:8501 — upload an `openfdd_package_v1` zip (browser limit **500 MB**).
+Against a stack, point at central (`OPENFDD_CENTRAL_URL`) with JWT env as needed.
 
 ## Docker / GHCR
 
-### Why GHCR shows `sha-…` as “Latest”
-
-GitHub’s package page marks the **most recently pushed version** as “Latest” — often a pin like `sha-1170f81`. That is **not** the same as the Docker tag `:latest`, and a **running container never updates itself**.
-
-| Tag | Meaning |
-| --- | --- |
-| `:latest` or `:develop` | Moving tip of **develop** (same tip today — default branch is `develop`) |
-| `:sha-<git>` | Immutable pin for that commit only |
-
-**Always pull, then recreate** the container. `docker run` alone reuses a stale local image if you already pulled once.
-
-### Easy button (recommended)
-
-From `vibe_code_apps_19/`:
-
-**Linux / macOS / Raspberry Pi:**
-
-```bash
-chmod +x scripts/docker_update_vibe19.sh   # once
-./scripts/docker_update_vibe19.sh          # pulls :latest, recreates vibe19 on :8502
-```
-
-**Windows PowerShell:**
-
-```powershell
-.\scripts\docker_update_vibe19.ps1
-# optional: .\scripts\docker_update_vibe19.ps1 -Tag develop -HostPort 8502
-```
-
-Same steps by hand:
-
-```bash
-docker pull ghcr.io/bbartling/vibe19:latest
-docker stop vibe19 2>/dev/null; docker rm vibe19 2>/dev/null
-docker run -d --restart unless-stopped -p 8502:8501 --name vibe19 \
-  ghcr.io/bbartling/vibe19:latest
-```
-
-Open **http://localhost:8502** (host **8502** → container **8501**). On a Pi: `http://<pi-ip>:8502`.
-
-| Flag | What it means (newbie) |
-| --- | --- |
-| `docker pull` | Download the tip of `:latest` / `:develop` (required every update) |
-| `-d` | Detached — stays up after you close the terminal |
-| `--restart unless-stopped` | Comes back after reboot until you `docker stop` |
-| `-p 8502:8501` | Host port → Streamlit 8501 inside the container |
-| `--name vibe19` | Stable name for stop / logs / recreate |
-
-```bash
-docker ps                    # running?
-docker logs -f vibe19        # logs only (Ctrl+C leaves the app running)
-docker stop vibe19           # stop
-```
-
-### One-shot test (foreground, auto-delete)
-
-```bash
-docker pull ghcr.io/bbartling/vibe19:latest
-docker run --rm -p 8502:8501 --name vibe19 ghcr.io/bbartling/vibe19:latest
-```
-
-In the sidebar confirm:
-
-- **Image:** `ghcr.io/bbartling/vibe19:latest` or `:develop` (and a recent sha)
-- zip-item limit **2000** (not **200**)
-
-**Upload:** prefer **one** building openfdd zip (weather is usually already inside). A separate `weather.zip` is optional; selecting both together is OK on current builds. Do not upload weather alone.
-
-If `docker ps` shows only a hash (`caab217c7f84`), that container was started from an image **id** — stop it and re-run with `:latest` / `:develop` above.
-
-More detail: [`docs/DOCKER.md`](docs/DOCKER.md). Image publishes from `.github/workflows/vibe19-ghcr.yml` on `develop` when this tree changes (**Vibe 19 only** — does not publish/update Vibe 20; WattLab consumer stays a local checkout).
-
-| Path | Limit |
-| --- | --- |
-| Browser upload | **500 MB** (`.streamlit/config.toml`) |
-| Agent / CLI / path load | **2048 MB** default (`OPENFDD_MAX_*` env override) |
-
-Large BUILDING packages: prefer `scripts/agent_afdd.py --package …` (bypasses the upload widget).
-
-## WattLab dump (vibe20 handoff)
-
-The **Export** tab builds one zip for WattLab (`vibe_code_apps_20`) so an AI agent can calibrate and iterate an EnergyPlus twin. Schema is **`wattlab_dump_v3`** (additive over v2). Default profile is **`summary`** — compact FDD + analytics + shared `telemetry/<equip>.csv`; it does **not** require legacy `fdd_timeseries/`. Use **`diagnostic`** / **`forensic`** when you need more per-rule evidence. See `README_WATTLAB.md` and `MANIFEST.json` inside the dump (profile, result-status counts, files written/suppressed, stage timings).
-
-**Mechanical cooling in the dump:** rows carry `series_kind` (`individual_device`, `aggregate_device_hours`, `aggregate_active_hours`) and normalized coverage (`eligibility_state`, including `eligible_no_runtime`). Compressor/chiller status, verified command, or **unit-aware** analog power/current above validated thresholds prove runtime — **not** CHW pump status alone, and **not** chilled-water AHU valves. Heat-pump/VRF compressor evidence additionally requires proven cooling mode. Building characteristics (`building_type`, `floor_area_ft2`, utility bills) stay `user_required` in `model_seed.json` for the vibe20 human+agent. Sensor stats include expanded percentiles/coverage; inferred parameters carry provenance/confidence.
-
-Vibe 20 `load_bundle` accepts **v2 and v3** additively and indexes telemetry paths lazily. Turnkey UI smoke: `python -m pytest tests/test_turnkey_app.py -q`.
-
-Optional WattLab docs: [`../vibe_code_apps_20/README.md`](../vibe_code_apps_20/README.md).
-
-## How data maps to rules
-
-```
-CSV headers → column_map / role_map → logical roles on the DataFrame → cookbook rules + analytics
-```
-
-Missing roles → `SKIPPED_MISSING_ROLES` (safe). Equipment type should come from the map (`equipType` / `equipment_type`), not only folder-name guesses.
-
-## Tests
-
-```powershell
-python -m pytest -q
-# Windows locked temp dirs:
-.\scripts\run_tests_local.ps1
-```
-
-## Docs
-
-| Doc | Topic |
-| --- | --- |
-| [`AGENTS.md`](AGENTS.md) | Agent hard rules |
-| [`docs/BUILD_OPENFDD_PACKAGE.md`](docs/BUILD_OPENFDD_PACKAGE.md) | **Agent prompt:** BUILDING → uploadable zip |
-| [`docs/PACKAGE_SPEC.md`](docs/PACKAGE_SPEC.md) | Zip package layout |
-| [`docs/DATA_MODEL_DRIVEN.md`](docs/DATA_MODEL_DRIVEN.md) | Roles → rules / charts |
-| [`docs/DOCKER.md`](docs/DOCKER.md) | Docker + GHCR |
-| [`docs/STREAMLIT_CLOUD.md`](docs/STREAMLIT_CLOUD.md) | Community Cloud |
-| [`vibe19_agent_spec/`](vibe19_agent_spec/) | Skills, customize, session log |
+Use the stack recipes (`docker/compose.standalone.yml`) with `OPENFDD_IMAGE_TAG=sha-*` or `:nightly`. See [`docker/VERSION_MANIFEST.md`](../../docker/VERSION_MANIFEST.md).

--- a/services/ui/docs/STREAMLIT_AGENT_SPEC.md
+++ b/services/ui/docs/STREAMLIT_AGENT_SPEC.md
@@ -1,43 +1,26 @@
-# Streamlit demo — agent specification
+# Streamlit UI — agent specification (`services/ui`)
 
 ## Mission
 
-Maintain **Vibe Code App 19** as a lightweight **educational pandas/Streamlit FDD demo** for BUILDING_100-style CSV data.
-
-## Do not
-
-- Re-add Rust or DataFusion to this repo
-- Re-add Haystack/Oxigraph model services
-- Turn this into Open-FDD or claim production parity
-- Commit client historian CSV trees or generated caches
-- Add FastAPI product architecture unless explicitly requested
-
-## Open-FDD
-
-The production Rust/DataFusion engine lives at:
-
-`C:\Users\ben\Documents\open-fdd`
-
-Port inventory: `docs/PORT_FROM_VIBE19_INVENTORY.md` (in Open-FDD repo).
+Maintain the **single** Open-FDD Streamlit app: vibe19 operator workflows + Jobs + WattLab export handoff. Production FDD is **DataFusion SQL** on central. Pandas stays as the online cookbook / oracle (also tested in the external vibe19 playground).
 
 ## Do
 
-- Keep rules **readable** in `app/rules/`
-- Keep BUILDING_100 demo path easy (`HVAC_DATA_ROOT`, `configs/building_100.yaml`)
-- Support CSV upload, local folder, read-only SQLite/DuckDB
-- Use `st.cache_data` for expensive loads
-- Test with small fixtures under `tests/`
-- Update `docs/STREAMLIT_DEMO_SPEC.md` when behavior changes
+- Keep `app/rules/cookbook_catalog.py` (59) readable and importable
+- Route operator **Run Rules** through `central_client.run_fdd` (registry SQL)
+- Preserve WattLab dump on Export (external vibe20 consumer)
+- Preserve Jobs sidebar → `workspace/jobs/`
+- Update online cookbooks when rule semantics change
 
-## Entry point
+## Do not
 
-```bash
-cd vibe_code_apps_19
-streamlit run streamlit_app.py
-```
+- Delete pandas cookbook modules “because SQL exists”
+- Reintroduce React dashboard
+- Spawn a separate Streamlit app for vibe20 / EnergyPlus
+- Claim production pandas FDD without `OPENFDD_ALLOW_PANDAS_FDD=1`
+- Weaken CI layout guards in `dashboard_contract.py`
 
-## Tests
+## Open-FDD stack
 
-```bash
-python -m pytest -q
-```
+Images: `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt`, `openfdd-mcp`.  
+Docs: [DataFusion-first](../../docs/architecture/datafusion-first.md), [Rule Cookbook](../../docs/rules/cookbook/).

--- a/services/ui/docs/STREAMLIT_DEMO_SPEC.md
+++ b/services/ui/docs/STREAMLIT_DEMO_SPEC.md
@@ -1,41 +1,32 @@
-# Streamlit FDD demo spec
+# Streamlit UI contract (Open-FDD `services/ui`)
 
 ## Purpose
 
-Educational **pandas + Streamlit** lab for BUILDING_100-style CSV historian data. Tunable fault thresholds, readable rules, engineer notes on charts.
+Product **Streamlit** engineering UI for Open-FDD: vibe19 FDD / RCx / Jobs plus vibe20 WattLab **export** in **one** app (`streamlit_app.py`).
 
-**Not** Open-FDD. Production Rust/DataFusion engine: `C:\Users\ben\Documents\open-fdd`.
+| Layer | Engine |
+|-------|--------|
+| Production FDD | Central **DataFusion SQL** (`sql_rules/registry.yaml`, 63 rules) |
+| Pandas cookbook | Retained under `app/rules/` (59) for analytics, docs, oracle — FDD math only if `OPENFDD_ALLOW_PANDAS_FDD=1` |
 
-## Screens (tabs)
+External vibe19 playground remains the preferred place to **test/maintain** pandas recipes before documenting them online. Do **not** delete the in-tree pandas catalog.
 
-1. **Overview** — data source, equipment count, date range, poll interval, missing roles
-2. **Data Preview** — dataframe head, columns, timestamp health
-3. **Role Mapping** — assign semantic roles, save YAML
-4. **Rule Tuning** — sliders from `configs/rule_defaults.yaml`, run rules
-5. **Fault Results** — summary table, top faulted equipment
-6. **Trends** — point plots with optional fault overlay + engineer notes
-7. **Export** — CSV summary, debug CSV, Markdown/HTML report
+## Frozen sections (`dashboard_contract.py`)
 
-## Rules (demo subset)
+1. Overview  
+2. Data Model  
+3. Run Rules  
+4. Results by Category  
+5. FDD Plots  
+6. RCx Plots  
+7. Metering  
+8. Export (includes WattLab dump)
 
-| ID | Module | Notes |
-| --- | --- | --- |
-| FAN-RUNTIME | fan_rules | Fan on hours |
-| VAV-1 | vav_rules | Zone comfort band |
-| AVG-ZONE-TEMP | vav_rules | Analytics |
-| ZONE-COMFORT-PCT | vav_rules | Analytics |
-| SAT-HIGH | ahu_rules | FC13-style |
-| ECON-2 | economizer_rules | Unfavorable economizing |
-| ECON-1 | economizer_rules | Stuck closed |
-| OAT-METEO | economizer_rules | Needs weather CSV |
-| FC2-MAT-LOW | ahu_rules | Mixed air low |
+Plus sidebar: package ingest, Rule tuning, **Jobs (persistent)**.
 
-## Data inputs
+## Do not
 
-See `CSV_INPUT_GUIDE.md`, `SQL_INPUT_GUIDE.md`.
-
-## Performance
-
-- `st.cache_data` on loads
-- Vectorized pandas masks
-- Load selected equipment when possible
+- Revive React LabShell / `/srv/assets`
+- Add a second Streamlit process for WattLab/EnergyPlus
+- Silently fall back to pandas FDD when SQL fails
+- Claim full SQL↔pandas mask parity beyond [parity-matrix](../../docs/rules/cookbook/parity-matrix.md)


### PR DESCRIPTION
## Summary
- Production FDD = DataFusion SQL (`sql_rules/`, **63**); pandas **kept** as online cookbook + vibe19 oracle (**59**), not deleted.
- One Streamlit app (`services/ui`) unites vibe19 + WattLab export — not separate apps.
- Fix React claims in `docs/index.md`, web-app, RELEASE_CHANNELS, root README.
- Refresh cookbook hub/intros, UI README/STREAMLIT specs, audit, tip pin `sha-8850b0b`.
- Strengthen `scripts/cookbook_parity_check.py` honesty gates (no React home claim; registry ≥63; dual 63/59 language).

## Test plan
- [x] `python3 scripts/cookbook_parity_check.py --docs-only`
- [ ] Product CI green; Docs Pages publishes updated cookbooks
- [ ] Confirm no open PRs/branches after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product and deployment documentation to describe the unified Streamlit engineering interface.
  * Clarified support for Vibe19 workflows, Jobs, and WattLab export handoff in one app.
  * Documented DataFusion SQL as the production fault-detection path, with Pandas retained for cookbook and validation use.
  * Updated rule cookbook guidance, parity information, deployment references, and verified image revisions.
  * Marked the former React dashboard documentation as obsolete.

* **Tests**
  * Added documentation integrity checks for Streamlit positioning and rule catalog details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->