### PR TITLE
test(fdd): prove SCHED-1, MECH-OAT-1, ECON-3 SQL↔pandas

### DIFF
--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -58,6 +58,119 @@ timestamp_utc,occ_col,fan_col
     }
 
     #[tokio::test]
+    async fn mech_oat1_web_oat_clg_proxy_matches_pandas_reference() {
+        // SQL uses web_oa_t + clg_valve_pct proxy (registry roles). Matches vibe19
+        // mech_oat1 when mechanical proof is cooling-valve.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_MECHOAT");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // Fault when web_oa_t < 60 and clg > 0.05. Sequence: 0,0,1,1,1,0
+        let rows = "\
+timestamp_utc,web_oat,clg_col
+2026-01-01T00:00:00Z,65,50
+2026-01-01T00:05:00Z,55,0
+2026-01-01T00:10:00Z,55,50
+2026-01-01T00:15:00Z,50,50
+2026-01-01T00:20:00Z,45,50
+2026-01-01T00:25:00Z,70,50
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "web_oat",
+                    role: "web_oa_t",
+                },
+                RoleCol {
+                    csv_col: "clg_col",
+                    role: "clg_valve_pct",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "mech_oat_1.sql",
+            300.0,
+            600,
+            &[("MECH_OAT_MAX_F", "60")],
+        )
+        .await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "MECH-OAT-1 SQL");
+    }
+
+    #[tokio::test]
+    async fn econ3_web_free_cool_not_integrated_matches_pandas_reference() {
+        // Strict web DB+DP; free-cool band + mech cooling + damper not integrated.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON3");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // Defaults: 60<=DB<72, DP<60, clg>0.01, oa_d<0.9
+        // Rows: no, no, fault, fault, fault, no (damper integrated)
+        let rows = "\
+timestamp_utc,web_oat,web_dp,oa_d,clg_col
+2026-01-01T00:00:00Z,50,50,0.2,50
+2026-01-01T00:05:00Z,65,50,0.2,0
+2026-01-01T00:10:00Z,65,50,0.2,50
+2026-01-01T00:15:00Z,68,55,0.3,50
+2026-01-01T00:20:00Z,70,58,0.4,50
+2026-01-01T00:25:00Z,65,50,0.95,50
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "web_oat",
+                    role: "web_oa_t",
+                },
+                RoleCol {
+                    csv_col: "web_dp",
+                    role: "web_oa_dp",
+                },
+                RoleCol {
+                    csv_col: "oa_d",
+                    role: "oa_damper_pct",
+                },
+                RoleCol {
+                    csv_col: "clg_col",
+                    role: "clg_valve_pct",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "econ3_mech_without_econ.sql",
+            300.0,
+            600,
+            &[
+                ("ECON3_DB_MIN", "60"),
+                ("ECON3_DB_MAX", "72"),
+                ("ECON3_DP_MAX", "60"),
+                ("ECON3_DAMPER_HI", "0.9"),
+            ],
+        )
+        .await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "ECON-3 SQL");
+    }
+
+    #[tokio::test]
     async fn vav7_underflow_confirm_matches_pandas_reference() {
         let tmp = tempfile::TempDir::new().unwrap();
         let building = tmp.path().join("BUILDING_VAV7");

--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -6,7 +6,7 @@ nav_order: 6
 
 # SQL ↔ Pandas parity matrix
 
-**Audit date:** 2026-07-19 · **Tip cross-check:** `sha-8850b0b` (2026-07-25) — counts below still match `sql_rules/registry.yaml` · **Target:** zero silent drift
+**Audit date:** 2026-07-19 · **Tip cross-check:** turnkey SQL port (2026-07-26) — counts match `sql_rules/registry.yaml` · **Target:** zero silent drift
 
 ## Product split (read this first)
 
@@ -23,8 +23,8 @@ Open-FDD UI is **one Streamlit app** (vibe19 + WattLab export). Do not delete pa
 
 | `parity_status` | Count (registry) | Meaning |
 |-----------------|-----------------:|---------|
-| `proven_building_100` | 18 | Exercised against BUILDING_100-style fixtures / production soak with matching fault-hour intent |
-| `ported_from_cookbook` | 44 | SQL exists and compiles; **ported ≠ oracle-proven**. Mask / confirm / rolling behavior may still diverge from Pandas |
+| `proven_building_100` | 21 | Exercised against BUILDING_100-style fixtures / production soak with matching fault-hour intent |
+| `ported_from_cookbook` | 41 | SQL exists and compiles; **ported ≠ oracle-proven**. Mask / confirm / rolling behavior may still diverge from Pandas |
 | `skipped_missing_roles` | 1 | `FC7` — skipped until required roles are modeled |
 
 **Do not claim “54 full parity.”** That figure was aspirational catalog coverage, not mask-level SQL↔Pandas agreement.
@@ -35,9 +35,11 @@ Oracle harness (phase 1, #550): `crates/fdd_rules` mask/fault-hour fixtures patt
 
 ## Proven vs ported (high level)
 
-### `proven_building_100` (18)
+### `proven_building_100` (21)
 
-`AVG-ZONE-TEMP`, `ECON-1`, `ECON-2`, `ECON-4`, `FAN-RUNTIME-HOURS`, `FAULT-ELAPSED-HOURS`, `FC1`, `FC2`, `FC3`, `FC8`, `FC9`, `FC10`, `FC11`, `FC12`, `FC13-SAT-HIGH`, `OAT-METEO`, `VAV-1`, `ZONE-COMFORT-PCT`
+`AVG-ZONE-TEMP`, `ECON-1`, `ECON-2`, `ECON-3`, `ECON-4`, `FAN-RUNTIME-HOURS`, `FAULT-ELAPSED-HOURS`, `FC1`, `FC2`, `FC3`, `FC8`, `FC9`, `FC10`, `FC11`, `FC12`, `FC13-SAT-HIGH`, `MECH-OAT-1`, `OAT-METEO`, `SCHED-1`, `VAV-1`, `ZONE-COMFORT-PCT`
+
+Oracle fixtures (2026-07-26): `SCHED-1`, `MECH-OAT-1` (web OAT + `clg_valve_pct` proxy), `ECON-3` (strict web DB+DP) in `crates/fdd_rules/src/oracle_parity_test.rs`.
 
 ### Representative `ported_from_cookbook` risk set (phase-1 oracle focus)
 
@@ -47,10 +49,10 @@ These are the mismatch classes called out in #550 — SQL is present; treat resu
 |--------|----------|---------------|
 | sensor | `SV-RANGE`, `SV-FLATLINE`, `SV-SPIKE`, `SV-STALE`, `SV-RATE` | Rolling / multi-sensor / rate context simplified in SQL |
 | control | `PID-HUNT-1`, `FC4` | Hunting metrics screening vs full TV/reversal |
-| ahu | `FC6`, `FC14`, `FC15`, `MECH-OAT-1`, … | Mix / coil / mech enable gates |
+| ahu | `FC6`, `FC14`, `FC15`, ECON-5/6/7, … | Mix / coil / remaining economizer gates |
 | vav | `VAV-4`, `VAV-7`, … | Rolling “fixed high” / high-min SP incomplete in SQL |
 | plant | `CHW-NOLOAD-1`, … | Load proxies simplified |
-| trim / schedule | `TRIM-*`, `SCHED-1`, `SCHED-247` | Confirm + occupancy semantics |
+| trim / schedule | `TRIM-*`, `SCHED-247` | Long confirm / always-on semantics |
 
 ---
 
@@ -58,13 +60,13 @@ These are the mismatch classes called out in #550 — SQL is present; treat resu
 
 | Family | IDs in registry | SQL file | Pandas cookbook | Oracle-proven? |
 |--------|-----------------|:--------:|:---------------:|:--------------:|
-| sensor | SV-* | ✅ | ✅ | mostly **ported** |
+| sensor | SV-* | ✅ | ✅ | mostly **ported** (screening fixtures for SV-RATE) |
 | control | PID-HUNT-1 | ✅* | ✅ | **ported** |
-| ahu | FC*, AHU-*, ECON-*, OAT-METEO, MECH-OAT-1, … | ✅ | ✅ | mixed |
+| ahu | FC*, AHU-*, ECON-*, OAT-METEO, MECH-OAT-1, … | ✅ | ✅ | mixed (`ECON-1..4`, `MECH-OAT-1` proven) |
 | vav | VAV-1, VAV-3–5, VAV-7, VAV-REHEAT, VAV-AHU-LEAVE | ✅ | ✅ | mixed (`VAV-1` proven) |
 | plant | CHW-*, CW-*, … | ✅ | ✅ | **ported** |
 | trim | TRIM-1/3/4 | ✅ | ✅ | **ported** |
-| schedule | SCHED-1, SCHED-247 | ✅ | ✅ | **ported** (confirm fixtures landing) |
+| schedule | SCHED-1, SCHED-247 | ✅ | ✅ | mixed (`SCHED-1` proven) |
 
 \* SQL often ships a **screening** variant; see per-rule caveats in the SQL cookbook.
 

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -966,7 +966,7 @@ rules:
     required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
     output_columns: [equipment_id, fault_hours]
     priority: P0
-    parity_status: ported_from_cookbook
+    parity_status: proven_building_100
     dashboard_wired: false
     delete_python_candidate: false
     confirm_seconds: 300
@@ -1153,7 +1153,7 @@ rules:
     required_roles: [web_oa_t, clg_valve_pct]
     output_columns: [equipment_id, fault_hours]
     priority: P0
-    parity_status: ported_from_cookbook
+    parity_status: proven_building_100
     dashboard_wired: false
     delete_python_candidate: false
     confirm_seconds: 600
@@ -2041,7 +2041,7 @@ rules:
     required_roles: [occ_mode, fan_status]
     output_columns: [equipment_id, fault_hours]
     priority: P0
-    parity_status: ported_from_cookbook
+    parity_status: proven_building_100
     dashboard_wired: false
     delete_python_candidate: false
     confirm_seconds: 1800


### PR DESCRIPTION
## Summary
- Oracle fixtures for `SCHED-1`, `MECH-OAT-1` (web OAT + cooling-valve proxy), `ECON-3` (strict web DB+DP).
- Flip `parity_status` → `proven_building_100` (21 / 41 / 1).
- Update parity-matrix counts and risk tables.

## Test plan
- [x] `cargo test -p fdd_rules oracle_parity`
- [x] `python3 scripts/cookbook_parity_check.py --docs-only`
- [ ] CI green + GHCR after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Added validation for additional fault-hour rules against their reference calculations.
  * Improved coverage for equipment configurations and parameter variations.

* **Documentation**
  * Refreshed the SQL-to-reference parity matrix and family coverage details.
  * Updated the list of rules with verified building-level parity.

* **Chores**
  * Marked three additional rules as proven against building data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->