### PR TITLE
test(fdd): prove ECON-5/6/7 SQL↔pandas; SCHED-247 screening

### DIFF
--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -266,10 +266,7 @@ timestamp_utc,web_oat,oa_d
             "econ6_econ_freezing.sql",
             300.0,
             600,
-            &[
-                ("ECON6_OAT_MAX_F", "25"),
-                ("ECON6_DAMPER_MAX", "0.25"),
-            ],
+            &[("ECON6_OAT_MAX_F", "25"), ("ECON6_DAMPER_MAX", "0.25")],
         )
         .await;
 
@@ -369,8 +366,7 @@ timestamp_utc,fan_col
             rows,
         );
 
-        let got =
-            run_rule_fault_hours(&building, "sched247_always_on.sql", 300.0, 600, &[]).await;
+        let got = run_rule_fault_hours(&building, "sched247_always_on.sql", 300.0, 600, &[]).await;
 
         let raw = [false, false, true, true, true, false];
         let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -171,6 +171,213 @@ timestamp_utc,web_oat,web_dp,oa_d,clg_col
     }
 
     #[tokio::test]
+    async fn econ5_preheat_over_matches_pandas_reference() {
+        // Matches vibe19 econ5: htg open + (OAT>SAT⇒preheat−OAT>ΔT | OAT<SAT⇒preheat−SAT>ΔT).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON5");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // over=2.2; OAT < SAT branch: preheat - sat_sp > 2.2 while htg open.
+        // Sequence: 0,0,1,1,1,0
+        let rows = "\
+timestamp_utc,preheat,sat,oat,htg
+2026-01-01T00:00:00Z,58,55,40,0
+2026-01-01T00:05:00Z,56,55,40,50
+2026-01-01T00:10:00Z,58,55,40,50
+2026-01-01T00:15:00Z,59,55,40,50
+2026-01-01T00:20:00Z,60,55,40,50
+2026-01-01T00:25:00Z,60,55,40,0
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "preheat",
+                    role: "preheat_leave_t",
+                },
+                RoleCol {
+                    csv_col: "sat",
+                    role: "sat_sp",
+                },
+                RoleCol {
+                    csv_col: "oat",
+                    role: "oa_t",
+                },
+                RoleCol {
+                    csv_col: "htg",
+                    role: "htg_valve_pct",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "econ5_preheat_over.sql",
+            300.0,
+            600,
+            &[("PREHEAT_OVER_F", "2.2")],
+        )
+        .await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "ECON-5 SQL");
+    }
+
+    #[tokio::test]
+    async fn econ6_freezing_economizer_matches_pandas_reference() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON6");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // web_oa_t < 25 and oa_d > 0.25. Sequence: 0,0,1,1,1,0
+        let rows = "\
+timestamp_utc,web_oat,oa_d
+2026-01-01T00:00:00Z,30,0.5
+2026-01-01T00:05:00Z,20,0.1
+2026-01-01T00:10:00Z,20,0.5
+2026-01-01T00:15:00Z,15,0.4
+2026-01-01T00:20:00Z,10,0.6
+2026-01-01T00:25:00Z,20,0.1
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "web_oat",
+                    role: "web_oa_t",
+                },
+                RoleCol {
+                    csv_col: "oa_d",
+                    role: "oa_damper_pct",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "econ6_econ_freezing.sql",
+            300.0,
+            600,
+            &[
+                ("ECON6_OAT_MAX_F", "25"),
+                ("ECON6_DAMPER_MAX", "0.25"),
+            ],
+        )
+        .await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "ECON-6 SQL");
+    }
+
+    #[tokio::test]
+    async fn econ7_ok_not_economizing_matches_pandas_reference() {
+        // Matches vibe19 econ7 with cooling-valve demand proxy (clg > 0.05).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON7");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // 35<=DB<72, DP<60, clg>0.05, oa_d < 0.5. Sequence: 0,0,1,1,1,0
+        let rows = "\
+timestamp_utc,web_oat,web_dp,oa_d,clg_col
+2026-01-01T00:00:00Z,30,50,0.2,50
+2026-01-01T00:05:00Z,50,50,0.2,0
+2026-01-01T00:10:00Z,50,50,0.2,50
+2026-01-01T00:15:00Z,55,55,0.3,50
+2026-01-01T00:20:00Z,60,58,0.4,50
+2026-01-01T00:25:00Z,50,50,0.8,50
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "web_oat",
+                    role: "web_oa_t",
+                },
+                RoleCol {
+                    csv_col: "web_dp",
+                    role: "web_oa_dp",
+                },
+                RoleCol {
+                    csv_col: "oa_d",
+                    role: "oa_damper_pct",
+                },
+                RoleCol {
+                    csv_col: "clg_col",
+                    role: "clg_valve_pct",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "econ7_ok_not_economizing.sql",
+            300.0,
+            600,
+            &[
+                ("ECON7_DB_MIN", "35"),
+                ("ECON7_DB_MAX", "72"),
+                ("ECON7_DP_MAX", "60"),
+                ("ECON7_DAMPER_MIN", "0.5"),
+            ],
+        )
+        .await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "ECON-7 SQL");
+    }
+
+    #[tokio::test]
+    async fn sched247_fan_cmd_screening_confirm_streak() {
+        // Screening: SQL confirms fan_cmd>=0.05 streaks — not vibe19 window always_on_pct.
+        // Keep parity_status ported_from_cookbook until SQL matches _sched247.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SCHED247");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,fan_col
+2026-01-01T00:00:00Z,0
+2026-01-01T00:05:00Z,0
+2026-01-01T00:10:00Z,50
+2026-01-01T00:15:00Z,50
+2026-01-01T00:20:00Z,50
+2026-01-01T00:25:00Z,0
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[RoleCol {
+                csv_col: "fan_col",
+                role: "fan_cmd",
+            }],
+            rows,
+        );
+
+        let got =
+            run_rule_fault_hours(&building, "sched247_always_on.sql", 300.0, 600, &[]).await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "SCHED-247 screening SQL");
+    }
+
+    #[tokio::test]
     async fn vav7_underflow_confirm_matches_pandas_reference() {
         let tmp = tempfile::TempDir::new().unwrap();
         let building = tmp.path().join("BUILDING_VAV7");

--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -23,8 +23,8 @@ Open-FDD UI is **one Streamlit app** (vibe19 + WattLab export). Do not delete pa
 
 | `parity_status` | Count (registry) | Meaning |
 |-----------------|-----------------:|---------|
-| `proven_building_100` | 21 | Exercised against BUILDING_100-style fixtures / production soak with matching fault-hour intent |
-| `ported_from_cookbook` | 41 | SQL exists and compiles; **ported ≠ oracle-proven**. Mask / confirm / rolling behavior may still diverge from Pandas |
+| `proven_building_100` | 24 | Exercised against BUILDING_100-style fixtures / production soak with matching fault-hour intent |
+| `ported_from_cookbook` | 38 | SQL exists and compiles; **ported ≠ oracle-proven**. Mask / confirm / rolling behavior may still diverge from Pandas |
 | `skipped_missing_roles` | 1 | `FC7` — skipped until required roles are modeled |
 
 **Do not claim “54 full parity.”** That figure was aspirational catalog coverage, not mask-level SQL↔Pandas agreement.
@@ -35,11 +35,11 @@ Oracle harness (phase 1, #550): `crates/fdd_rules` mask/fault-hour fixtures patt
 
 ## Proven vs ported (high level)
 
-### `proven_building_100` (21)
+### `proven_building_100` (24)
 
-`AVG-ZONE-TEMP`, `ECON-1`, `ECON-2`, `ECON-3`, `ECON-4`, `FAN-RUNTIME-HOURS`, `FAULT-ELAPSED-HOURS`, `FC1`, `FC2`, `FC3`, `FC8`, `FC9`, `FC10`, `FC11`, `FC12`, `FC13-SAT-HIGH`, `MECH-OAT-1`, `OAT-METEO`, `SCHED-1`, `VAV-1`, `ZONE-COMFORT-PCT`
+`AVG-ZONE-TEMP`, `ECON-1`, `ECON-2`, `ECON-3`, `ECON-4`, `ECON-5`, `ECON-6`, `ECON-7`, `FAN-RUNTIME-HOURS`, `FAULT-ELAPSED-HOURS`, `FC1`, `FC2`, `FC3`, `FC8`, `FC9`, `FC10`, `FC11`, `FC12`, `FC13-SAT-HIGH`, `MECH-OAT-1`, `OAT-METEO`, `SCHED-1`, `VAV-1`, `ZONE-COMFORT-PCT`
 
-Oracle fixtures (2026-07-26): `SCHED-1`, `MECH-OAT-1` (web OAT + `clg_valve_pct` proxy), `ECON-3` (strict web DB+DP) in `crates/fdd_rules/src/oracle_parity_test.rs`.
+Oracle fixtures (2026-07-26): `SCHED-1`, `MECH-OAT-1`, `ECON-3`, `ECON-5` (OAT-relative preheat), `ECON-6`/`ECON-7` (web weather + damper) in `crates/fdd_rules/src/oracle_parity_test.rs`. `SCHED-247` remains **ported** (screening streak ≠ window `always_on_pct`).
 
 ### Representative `ported_from_cookbook` risk set (phase-1 oracle focus)
 
@@ -49,10 +49,10 @@ These are the mismatch classes called out in #550 — SQL is present; treat resu
 |--------|----------|---------------|
 | sensor | `SV-RANGE`, `SV-FLATLINE`, `SV-SPIKE`, `SV-STALE`, `SV-RATE` | Rolling / multi-sensor / rate context simplified in SQL |
 | control | `PID-HUNT-1`, `FC4` | Hunting metrics screening vs full TV/reversal |
-| ahu | `FC6`, `FC14`, `FC15`, ECON-5/6/7, … | Mix / coil / remaining economizer gates |
+| ahu | `FC6`, `FC14`, `FC15`, … | Mix / coil gates |
 | vav | `VAV-4`, `VAV-7`, … | Rolling “fixed high” / high-min SP incomplete in SQL |
 | plant | `CHW-NOLOAD-1`, … | Load proxies simplified |
-| trim / schedule | `TRIM-*`, `SCHED-247` | Long confirm / always-on semantics |
+| trim / schedule | `TRIM-*`, `SCHED-247` | Long confirm / always-on window fraction |
 
 ---
 
@@ -62,11 +62,11 @@ These are the mismatch classes called out in #550 — SQL is present; treat resu
 |--------|-----------------|:--------:|:---------------:|:--------------:|
 | sensor | SV-* | ✅ | ✅ | mostly **ported** (screening fixtures for SV-RATE) |
 | control | PID-HUNT-1 | ✅* | ✅ | **ported** |
-| ahu | FC*, AHU-*, ECON-*, OAT-METEO, MECH-OAT-1, … | ✅ | ✅ | mixed (`ECON-1..4`, `MECH-OAT-1` proven) |
+| ahu | FC*, AHU-*, ECON-*, OAT-METEO, MECH-OAT-1, … | ✅ | ✅ | mixed (`ECON-1..7`, `MECH-OAT-1` proven) |
 | vav | VAV-1, VAV-3–5, VAV-7, VAV-REHEAT, VAV-AHU-LEAVE | ✅ | ✅ | mixed (`VAV-1` proven) |
 | plant | CHW-*, CW-*, … | ✅ | ✅ | **ported** |
 | trim | TRIM-1/3/4 | ✅ | ✅ | **ported** |
-| schedule | SCHED-1, SCHED-247 | ✅ | ✅ | mixed (`SCHED-1` proven) |
+| schedule | SCHED-1, SCHED-247 | ✅ | ✅ | mixed (`SCHED-1` proven; `SCHED-247` screening) |
 
 \* SQL often ships a **screening** variant; see per-rule caveats in the SQL cookbook.
 

--- a/sql_rules/econ5_preheat_over.sql
+++ b/sql_rules/econ5_preheat_over.sql
@@ -1,9 +1,11 @@
--- econ5_preheat_over.sql — Preheat over-conditioning
+-- econ5_preheat_over.sql — Preheat over-conditioning (matches vibe19 econ5)
+-- Target = OAT when OAT > SAT SP; else SAT SP. Fault when preheat exceeds target by ΔT
+-- while heating valve is open.
 WITH h AS (
   SELECT
     equipment_id,
     timestamp_utc,
-    preheat_leave_t, sat_sp,
+    preheat_leave_t, sat_sp, oa_t,
     CASE WHEN htg_valve_pct IS NULL THEN 0.0 WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg
   FROM history
 ),
@@ -12,8 +14,11 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
-      WHEN preheat_leave_t IS NULL OR sat_sp IS NULL THEN 0
-      WHEN htg > 0.01 AND preheat_leave_t > sat_sp + {{PREHEAT_OVER_F}} THEN 1
+      WHEN preheat_leave_t IS NULL OR sat_sp IS NULL OR oa_t IS NULL THEN 0
+      WHEN htg > 0.01 AND (
+        (oa_t > sat_sp AND preheat_leave_t - oa_t > {{PREHEAT_OVER_F}})
+        OR (oa_t < sat_sp AND preheat_leave_t - sat_sp > {{PREHEAT_OVER_F}})
+      ) THEN 1
       ELSE 0
     END AS INT) AS raw_fault
   FROM h

--- a/sql_rules/econ7_ok_not_economizing.sql
+++ b/sql_rules/econ7_ok_not_economizing.sql
@@ -15,7 +15,7 @@ base AS (
     CAST(CASE
       WHEN web_oa_t IS NULL OR web_oa_dp IS NULL OR oa_d IS NULL OR clg IS NULL THEN 0
       WHEN web_oa_t >= {{ECON7_DB_MIN}} AND web_oa_t < {{ECON7_DB_MAX}} AND web_oa_dp < {{ECON7_DP_MAX}}
-       AND clg > 0.01 AND oa_d < {{ECON7_DAMPER_MIN}} THEN 1
+       AND clg > 0.05 AND oa_d < {{ECON7_DAMPER_MIN}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
   FROM h

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -1021,10 +1021,10 @@ rules:
     sql_file: econ5_preheat_over.sql
     pandas_function: null
     description: Preheat over-conditioning
-    required_roles: [preheat_leave_t, sat_sp, htg_valve_pct]
+    required_roles: [preheat_leave_t, sat_sp, oa_t, htg_valve_pct]
     output_columns: [equipment_id, fault_hours]
     priority: P0
-    parity_status: ported_from_cookbook
+    parity_status: proven_building_100
     dashboard_wired: false
     delete_python_candidate: false
     confirm_seconds: 600
@@ -1055,7 +1055,7 @@ rules:
     required_roles: [web_oa_t, oa_damper_pct]
     output_columns: [equipment_id, fault_hours]
     priority: P0
-    parity_status: ported_from_cookbook
+    parity_status: proven_building_100
     dashboard_wired: false
     delete_python_candidate: false
     confirm_seconds: 600
@@ -1095,7 +1095,7 @@ rules:
     required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
     output_columns: [equipment_id, fault_hours]
     priority: P0
-    parity_status: ported_from_cookbook
+    parity_status: proven_building_100
     dashboard_wired: false
     delete_python_candidate: false
     confirm_seconds: 600


### PR DESCRIPTION
## Summary
- Align `econ5_preheat_over.sql` to vibe19 OAT-relative preheat math (`oa_t` required).
- Align ECON-7 cooling demand threshold to pandas (`clg > 0.05`).
- Oracle fixtures for ECON-5/6/7 → `proven_building_100` (24 proven / 38 ported).
- SCHED-247 screening fixture only — leave `ported_from_cookbook` (SQL streak ≠ window `always_on_pct`).

## Test plan
- [x] `cargo test -p fdd_rules oracle_parity`
- [x] `python3 scripts/cookbook_parity_check.py --docs-only`
- [ ] CI green + GHCR after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preheat fault detection by comparing conditions against the appropriate outdoor and supply air temperature targets.
  * Refined economizing fault detection to reduce false-positive results.
  * Updated rule coverage and validation status for several economizer checks.

* **Tests**
  * Added validation scenarios covering additional economizer and scheduling conditions.

* **Documentation**
  * Updated parity coverage metrics, fixture notes, and rule-family status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->