### PR TITLE
docs: add openfdd_agent_spec engineering agent OS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Open-FDD ships as a **container stack**: `openfdd-central`, `openfdd-ui`, `openf
 
 **Docs:** [Build recipes](docs/operations/build-recipes.md) · [External agents](docs/examples/external-agents.md) · [MCP README](mcp/README.md) · [ECM engineering (PyPI)](docs/ecm/README.md)
 
+**Software-engineering agent OS:** [`openfdd_agent_spec/`](openfdd_agent_spec/) — architecture locks, skills, Milestone A ([`openfdd_agent_spec/MILESTONE_A.md`](openfdd_agent_spec/MILESTONE_A.md)). Ops/edge soak prompts stay under [`docs/agent/`](docs/agent/).
+
 **PyPI (`open-fdd` 4.1+):** ECM engineering + pandas oracle (`open_fdd.rules` / `analytics` / `reporting`) via extras. Production FDD is DataFusion/GHCR, not this wheel.
 
 ## Start session
@@ -53,3 +55,5 @@ Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:808
 - embed vendor chat relays or model API keys in the stack
 
 See [docs/agent/index.md](docs/agent/index.md) for external-agent architecture and API context.
+
+For library/migration/PR missions (Milestone A), start at [openfdd_agent_spec/AGENTS.md](openfdd_agent_spec/AGENTS.md).

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -10,11 +10,13 @@ permalink: /agent/
 
 Open-FDD is a **vendor-neutral, local-first edge platform**. It does **not** ship an embedded AI chatbot or in-dashboard LLM runtime.
 
+**Split:** this folder holds **ops / edge / GHCR soak** prompts. Software-engineering missions (architecture, PyPI oracle, Milestone A) live in [`openfdd_agent_spec/`](../../openfdd_agent_spec/).
+
 ## Open-FDD core (GHCR edge)
 
 | Layer | Components |
 |-------|------------|
-| Runtime | `central` (API/FDD), `ui` (Caddy), `fieldbus` (BACnet→MQTTS), `mqtt` (broker) |
+| Runtime | `central` (API/FDD), `ui` (Streamlit), `fieldbus` (BACnet→MQTTS), `mqtt` (broker) |
 | Data | Arrow/Feather historian, DataFusion SQL FDD |
 | Model | Haystack RDF, assignments, FDD wires |
 | API | JWT REST, `/api/agent/tools` catalog |
@@ -53,6 +55,7 @@ See [examples/external-agents.md](../examples/external-agents.md).
 
 | Path | Role |
 |------|------|
+| [`openfdd_agent_spec/`](../../openfdd_agent_spec/) | Software-engineering agent OS (Milestone A, skills) |
 | `.codex/` | Codex CLI project agents + MCP |
 | `.cursor/agents/` | Cursor external development agents |
 | `.agents/skills/` | Portable review skills (not edge runtime) |

--- a/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
+++ b/docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md
@@ -9,6 +9,8 @@ nav_order: 1
 **Audit date:** 2026-07-25 · **Tip under audit:** `8850b0bf` (`sha-8850b0b`, merges #571 audit + #572 Jobs)  
 **Rule:** trust tested current code over historical `docs/migration/vibe19/*` stage notes.
 
+**Milestone A agent OS:** [`openfdd_agent_spec/MILESTONE_A.md`](../../openfdd_agent_spec/MILESTONE_A.md) · checkpoints [`openfdd_agent_spec/BUILD_CHECKPOINTS.md`](../../openfdd_agent_spec/BUILD_CHECKPOINTS.md).
+
 **Hard product rules (2026-07-25):**
 
 1. Open-FDD Rust/central FDD = **DataFusion SQL only** (`sql_rules/registry.yaml`).

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -1,0 +1,117 @@
+# Open-FDD agent workspace — orientation
+
+Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
+similar agents. Product code lives in `open_fdd/`, `services/`, `sql_rules/`,
+`mcp/`, `edge/`, `os/`. Orchestration lives in **`openfdd_agent_spec/`**.
+
+**Primary agent prompt (paste into new sessions):** [`../AGENTS.md`](../AGENTS.md)
+
+**Software-engineering mission:** [`MILESTONE_A.md`](MILESTONE_A.md)
+
+**Ops / edge soak prompts (separate):** [`../docs/agent/`](../docs/agent/) — GHCR
+bench, nightly retest, WSL sleep. Do not confuse those with this engineering OS.
+
+---
+
+## Product vs orchestration
+
+| Layer | Owns |
+| --- | --- |
+| `open_fdd/` | PyPI libraries: ECM + pandas oracle (`rules` / `analytics` / `reporting`) |
+| `services/` + `sql_rules/` | Production stack: central DataFusion SQL FDD, Streamlit UI, fieldbus, mqtt |
+| `mcp/` | Optional read-first MCP → central |
+| `edge/`, `os/` | Future concepts — **never delete** |
+| `docs/rules/cookbook/` | Dual expression cookbooks (SQL + pandas) + parity matrix |
+| `openfdd_agent_spec/` | Agent law, Milestone A, skills, session log |
+| Playground vibe19/20 | Educational/demo apps; consumers of PyPI; interim GHCR |
+
+**Repos naming (code truth):**
+
+| Concept | Module / extra |
+| --- | --- |
+| Pandas oracle | `open_fdd.rules` (+ `open_fdd.analytics`) |
+| Pip extras | `oracle`, `reporting`, `vibe19` |
+| ECM math | `open_fdd.ecm_engineering` |
+| Shared contracts | `open_fdd.contracts` — **Phase 2 target (not shipped)** |
+
+Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit product decision.
+
+---
+
+## AI agent quick rules (read first)
+
+1. Production FDD = **DataFusion SQL** on GHCR (`sql_rules/`). Never silent pandas fallback in central.
+2. Pandas oracle stays forever — cookbooks + vibe19 + PyPI `rules`/`analytics`. Never delete the pandas cookbook because production uses SQL.
+3. Never delete the SQL cookbook because pandas remains the oracle.
+4. One Streamlit product UI: `services/ui` → `openfdd-ui`. Not a Vite/Caddy SPA.
+5. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`).
+6. Playground images: `ghcr.io/bbartling/vibe19:develop`, `vibe20:develop`.
+7. `edge/` and `os/` are future concepts — never delete.
+8. Bounded PRs only — see [`PR_PROTOCOL.md`](PR_PROTOCOL.md).
+9. Migration pattern: inventory → characterization → shared impl → parity → cutover → **delete twin** → regression → docs.
+10. Do not copy code into Open-FDD and leave both implementations active.
+11. Vibe 19 may keep Streamlit UX, custom `CUSTOM-*` rules, demos — not canonical rule/analytics twins.
+12. Vibe 20 owns EnergyPlus — keep IDF/sim/orchestration; delete only **generic** ECM twins after parity.
+13. Prefer exact wheel install tests over editable-only validation for packaging PRs.
+14. Never trust a moving GHCR tag as proof a local container updated — pull immutable `sha-*`, then recreate.
+15. Append [`SESSION_LOG.md`](SESSION_LOG.md) after non-trivial work.
+16. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) when Milestone A status changes.
+17. CodeRabbit: fix actionable defects; reject suggestions that violate architecture.
+18. Do not retire playground GHCR without an open-fdd capability parity matrix.
+19. vibe21 = separate plan — not Milestone A.
+20. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
+
+---
+
+## Bootstrap reading order
+
+1. [`../AGENTS.md`](../AGENTS.md) — stack + MCP safety
+2. This file
+3. [`ARCHITECTURE.md`](ARCHITECTURE.md) + [`ownership.yaml`](ownership.yaml)
+4. [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) — what is already done
+5. [`MILESTONE_A.md`](MILESTONE_A.md) — full mission if executing Milestone A
+6. [`PR_PROTOCOL.md`](PR_PROTOCOL.md) before opening a PR
+7. Skill matching the work (below)
+8. Code truth: `docs/migration/`, `docs/rules/cookbook/`, `docs/architecture/`
+
+---
+
+## Local repositories
+
+```text
+/home/ben/open-fdd                          # bbartling/open-fdd  (default: master)
+/home/ben/py-bacnet-stacks-playground       # bbartling/py-bacnet-stacks-playground (default: develop)
+  vibe_code_apps_19/
+  vibe_code_apps_20/
+```
+
+---
+
+## Skill index
+
+| Skill | Use when |
+| --- | --- |
+| [`openfdd-architecture`](skills/openfdd-architecture/SKILL.md) | Ownership, forbidden imports, dual cookbooks |
+| [`openfdd-pypi-oracle`](skills/openfdd-pypi-oracle/SKILL.md) | `open_fdd.rules` / analytics / reporting / extras |
+| [`openfdd-ecm-engineering`](skills/openfdd-ecm-engineering/SKILL.md) | ECM calculators, vibe20 twin deletion |
+| [`openfdd-sql-fdd`](skills/openfdd-sql-fdd/SKILL.md) | DataFusion registry, `sql_rules/`, no pandas in central |
+| [`openfdd-cookbook-parity`](skills/openfdd-cookbook-parity/SKILL.md) | Cookbook CI, parity matrix, docs headings |
+| [`openfdd-stack-ghcr`](skills/openfdd-stack-ghcr/SKILL.md) | Nightly stack pull, labels, smoke |
+| [`openfdd-milestone-a-pr`](skills/openfdd-milestone-a-pr/SKILL.md) | Inventory → parity → cutover → delete loop |
+
+---
+
+## Repo map (engineering)
+
+| Path | Role |
+| --- | --- |
+| `open_fdd/ecm_engineering/` | Default-install ECM math + CLI |
+| `open_fdd/rules/` | Pandas cookbook oracle |
+| `open_fdd/analytics/` | Oracle analytics helpers |
+| `open_fdd/reporting/` | Findings / DOCX / xlsx reporting |
+| `sql_rules/` | Production SQL registry + rule files |
+| `services/ui/` | Product Streamlit (SQL FDD + WattLab export) |
+| `services/central/` | Rust API + DataFusion |
+| `docs/rules/cookbook/` | Human-readable SQL + pandas cookbooks |
+| `docs/migration/` | Historical audit + matrices |
+| `.github/workflows/` | See [`docs/WORKFLOWS.md`](docs/WORKFLOWS.md) |

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -53,13 +53,14 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 11. Vibe 19 may keep Streamlit UX, custom `CUSTOM-*` rules, demos — not canonical rule/analytics twins.
 12. Vibe 20 owns EnergyPlus — keep IDF/sim/orchestration; delete only **generic** ECM twins after parity.
 13. Prefer exact wheel install tests over editable-only validation for packaging PRs.
-14. Never trust a moving GHCR tag as proof a local container updated — pull immutable `sha-*`, then recreate.
+14. Never trust a moving GHCR tag alone — resolve/pull immutable `sha-*`, recreate containers, then record the digest.
 15. Append [`SESSION_LOG.md`](SESSION_LOG.md) after non-trivial work.
-16. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) when Milestone A status changes.
+16. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) whenever Milestone A status changes (not only after merge).
 17. CodeRabbit: fix actionable defects; reject suggestions that violate architecture.
 18. Do not retire playground GHCR without an open-fdd capability parity matrix.
 19. vibe21 = separate plan — not Milestone A.
 20. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
+21. Bound each PR to its declared scope — docs-only PRs do not require cross-repo pin bumps or GHCR refreshes.
 
 ---
 
@@ -78,13 +79,16 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 
 ## Local repositories
 
+Default checkouts on Ben’s WSL (adjust if your clone paths differ):
+
 ```text
-/home/ben/open-fdd                          # bbartling/open-fdd  (default: master)
-/home/ben/py-bacnet-stacks-playground       # bbartling/py-bacnet-stacks-playground (default: develop)
+~/open-fdd                          # bbartling/open-fdd  (default: master)
+~/py-bacnet-stacks-playground       # bbartling/py-bacnet-stacks-playground (default: develop)
   vibe_code_apps_19/
   vibe_code_apps_20/
 ```
 
+Sibling-repo locations are **examples** — resolve via `git rev-parse --show-toplevel` / env, not hardcoded usernames.
 ---
 
 ## Skill index

--- a/openfdd_agent_spec/ARCHITECTURE.md
+++ b/openfdd_agent_spec/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Open-FDD architecture locks
+
+Human-readable ownership. Machine-readable twin: [`ownership.yaml`](ownership.yaml).
+
+Trust **tested current code** over historical `docs/migration/vibe19/*` stage notes.
+Update this file when code truth changes.
+
+---
+
+## Surfaces
+
+| Surface | Role | Must not |
+| --- | --- | --- |
+| **Open-FDD production** (GHCR stack) | Rust central, Arrow/Feather, DataFusion SQL FDD, JWT REST, `openfdd-ui` Streamlit | Silent pandas FDD fallback; claim UI is Vite/Caddy SPA |
+| **Open-FDD PyPI** (`open-fdd`) | Reusable libs: `ecm_engineering`, `rules`, `analytics`, `reporting` | Be the production FDD runtime |
+| **Vibe 19** (playground) | Educational pandas oracle + Streamlit demo + GHCR demo image | Remain canonical home of duplicated rule/analytics/reporting once migrated |
+| **Vibe 20** (playground) | EnergyPlus twin, calibration, ECM cross-check, Studio | Retain duplicate **generic** ECM formulas after Open-FDD parity |
+| **MCP** (`openfdd-mcp`) | Read-first stdio tools → central | Embed EnergyPlus / WattLab dial tools without an explicit product decision |
+| **`edge/`, `os/`** | Future OS / edge concepts | Be deleted “for cleanup” |
+
+---
+
+## Rule cookbooks (both forever)
+
+| Cookbook | Location | Role |
+| --- | --- | --- |
+| DataFusion SQL expression cookbook | `docs/rules/cookbook/datafusion-sql-cookbook.md` + `sql_rules/` | Production execution SoT |
+| Pandas expression cookbook | `docs/rules/cookbook/pandas-cookbook.md` + `open_fdd.rules` | Oracle / engineering explanation |
+| Parity matrix | `docs/rules/cookbook/parity-matrix.md` | Honesty about gaps |
+
+Never replace cookbooks with generated API docs alone.
+Never delete one cookbook because the other engine “won.”
+
+**Execution SoT:** SQL registry (`sql_rules/registry.yaml`).
+**Identity/metadata SoT (Phase 2 target):** shared rule manifest under `open_fdd.contracts` (not shipped yet).
+**Oracle SoT:** pandas cookbook + `open_fdd.rules`.
+
+---
+
+## Pandas allowed-use boundaries
+
+**Allowed:** vibe19; PyPI oracle extras; notebooks; characterization/parity tests; UI plotting/display helpers that do not replace `/api/fdd/run`.
+
+**Forbidden:** production central computing FDD via pandas; silent fallback from SQL to pandas when a rule fails; documentation claiming production FDD is pandas.
+
+---
+
+## ECM ownership
+
+| Kind | Owner |
+| --- | --- |
+| Generic HVAC / finance formulas | `open_fdd.ecm_engineering` |
+| EnergyPlus IDF, sim orchestration, APIHelper, calibration tied to E+ | vibe20 |
+| Adapters / field-name translation | vibe20 (no recomputation of canonical formulas) |
+
+---
+
+## Reporting ownership
+
+| Kind | Owner |
+| --- | --- |
+| Portable report builders / schemas | `open_fdd.reporting` |
+| Streamlit download UX / session wiring | vibe19 and/or `services/ui` |
+| Engineering Findings product rules | vibe19 agent skills + reporting lib |
+
+---
+
+## Container ownership
+
+| Image | Channel for test | Notes |
+| --- | --- | --- |
+| `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt` | `:nightly` on master | Also `sha-<short>` immutable |
+| `openfdd-mcp` | `:nightly` | Separate workflow |
+| `vibe19`, `vibe20` | `:develop` | Interim; retire only after parity matrix |
+
+---
+
+## Versioning ownership
+
+See [`docs/VERSIONING.md`](docs/VERSIONING.md). Do not leave contradictory root README version claims.

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -1,6 +1,7 @@
 # Milestone A — build checkpoints
 
-Track durable progress. Update when PRs merge. Detail lives in
+Track durable progress. Update whenever Milestone A status changes (merge,
+blocker, or intentional exception). Detail lives in
 [`MILESTONE_A.md`](MILESTONE_A.md) and [`docs/MIGRATION_MATRIX.md`](docs/MIGRATION_MATRIX.md).
 
 Legend: `[x]` done · `[~]` partial · `[ ]` remaining

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -1,0 +1,66 @@
+# Milestone A — build checkpoints
+
+Track durable progress. Update when PRs merge. Detail lives in
+[`MILESTONE_A.md`](MILESTONE_A.md) and [`docs/MIGRATION_MATRIX.md`](docs/MIGRATION_MATRIX.md).
+
+Legend: `[x]` done · `[~]` partial · `[ ]` remaining
+
+---
+
+## Phase 0 — Architecture freeze
+
+- [x] Human architecture locks in this agent spec ([`ARCHITECTURE.md`](ARCHITECTURE.md))
+- [x] Machine-readable seed ([`ownership.yaml`](ownership.yaml))
+- [ ] CI: ownership schema validation
+- [ ] CI: forbidden import / no silent pandas fallback tests
+- [ ] CI: required cookbook path + terminology consistency tests
+
+## Phase 1 — Packaging / release / containers
+
+- [x] PyPI `open-fdd` 4.1.0 rules+analytics+reporting; 4.1.1 topology enrich
+- [x] vibe19 / UI pins `>=4.1.1,<5`
+- [~] Version policy documented ([`docs/VERSIONING.md`](docs/VERSIONING.md)) — generated manifest not yet shipped
+- [ ] Constraints/lock so rebuilds do not silently float newer PyPI mid-tag
+- [~] Image metadata / nightly channel works; deepen labels + in-container asserts
+- [x] Stack + MCP GHCR green on master tip (post UI twin retirement)
+
+## Phase 2 — Shared contracts + rule manifest
+
+- [ ] `open_fdd.contracts` package (pandas-free base)
+- [ ] Canonical machine-readable rule manifest
+- [ ] Manifest ↔ SQL registry ↔ pandas cookbook CI agreement
+- [ ] Derived doc tables from manifest (keep hand-written expressions)
+
+## Phase 3 — Vibe 19 thin-oracle cutover
+
+- [x] Thin shims for most `app/rules/*` → PyPI
+- [x] `app/rules/runner.py` + `app/analytics.py` → package shims (playground #59, open-fdd #580)
+- [~] Remaining local keepers: custom_registry / custom_rules / Streamlit UX (intentional)
+- [ ] Full migration matrix with KEEP/SHIM/MOVE/DELETE for every significant module
+- [ ] Clean-install + container smoke checklist recorded per release
+
+## Phase 4 — Vibe 20 generic ECM migration
+
+- [x] Open-FDD ECM package + 8 delegated twins (fan affinity, schedule reduction, OA sensible, kW/ton, boiler eff, scheduling fan/cool/heat bins)
+- [~] ~18 esco/algorithm keepers remain (documented in playground `OPENFDD_ECM_TWINS.md`)
+- [ ] Richer calculator result contracts (bins detail / provenance)
+- [ ] Delete remaining generic twins after parity
+- [ ] Docker-socket runner hardening = follow-on (document only in Milestone A)
+
+## Cross-cutting
+
+- [x] Dual cookbooks present and documented
+- [~] Cookbook parity CI exists (`cookbook-parity.yml`) — harden vs mission checklist
+- [ ] Final Milestone A qualification + [`COMPLETION_REPORT.md`](COMPLETION_REPORT.md) filled
+- [ ] Playground GHCR retirement — **explicitly out of Milestone A** (needs parity matrix)
+
+---
+
+## Known intentional exceptions
+
+| Exception | Why |
+| --- | --- |
+| vibe19 keeps custom rule loading | Product extension surface |
+| vibe20 EnergyPlus code stays local | Not generic math |
+| `open_fdd.rules` not renamed to `.oracle` | Code truth; pip extra is `oracle` |
+| Pre-existing vibe19 test fail `test_supply_air_startup_uses_transient_threshold` | Fails with local twins on develop too — do not weaken tests to hide |

--- a/openfdd_agent_spec/COMPLETION_REPORT.md
+++ b/openfdd_agent_spec/COMPLETION_REPORT.md
@@ -1,0 +1,64 @@
+# Milestone A Completion Report
+
+Fill this at final qualification. Distinguish **verified facts** from follow-on
+recommendations. See [`MILESTONE_A.md`](MILESTONE_A.md) § Final agent report.
+
+---
+
+## Executive result
+
+_Status: not complete — agent spec only as of 2026-07-28._
+
+## Merged PRs
+
+| PR | Repo | Phase | Purpose | Status |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Architecture enforcement
+
+## Packaging and versioning
+
+## Shared contracts
+
+## Rule manifest
+
+## Pandas expression cookbook status
+
+## DataFusion SQL expression cookbook status
+
+## Vibe 19 migration
+
+## Vibe 20 ECM migration
+
+## Tests added
+
+## GitHub Actions results
+
+## CodeRabbit review resolution
+
+## GHCR images and tested digests
+
+| Image | Tag | Digest | Verified |
+| --- | --- | --- | --- |
+| | | | |
+
+## Local container refresh status
+
+## Deleted duplicate code
+
+## Remaining intentional exceptions
+
+## Milestone B handoff
+
+---
+
+## Evidence appendix (required at completion)
+
+- PR numbers and merge SHAs
+- Package / schema versions
+- Image tags and digests
+- Exact test commands and counts
+- Skipped-test reasons
+- Workflow run URLs or IDs
+- Unresolved external blockers

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -1,65 +1,74 @@
 # Container agent — GHCR refresh and verify
 
-Test channel for Open-FDD stack: **`nightly`** (master publishes retarget
-`:nightly` to tip `sha-*`).
+Test **channel** for Open-FDD stack: **`nightly`** (master publishes retarget
+`:nightly` to tip `sha-*`). Treat `nightly` as a pointer only — always verify
+and run against the resolved immutable `sha-<7>` digest.
 
-Playground demos: **`develop`** tags for `vibe19` / `vibe20`.
+Playground demos: **`develop`** tags for `vibe19` / `vibe20` (same rule:
+resolve to digest / `sha-*` when verifying a merge).
 
 Never trust the GHCR web “Latest” alone. Never assume a running container
 updated itself.
 
 ---
 
-## Open-FDD stack (nightly)
+## Open-FDD stack (nightly → immutable)
 
 ```bash
-export OPENFDD_IMAGE_TAG=nightly   # or leave default if scripts already use nightly
-cd /home/ben/open-fdd
-./scripts/openfdd_stack_pull.sh standalone   # or csv / central
+# 1) Discover tip SHA after merge (or use known short SHA)
+SHORT=$(git -C ~/open-fdd rev-parse --short=7 origin/master)
+
+# 2) Pull immutable tags for every standalone image
+for img in openfdd-central openfdd-ui openfdd-fieldbus openfdd-mqtt; do
+  docker pull "ghcr.io/bbartling/${img}:sha-${SHORT}"
+done
+
+# 3) Prove nightly currently points at the same digests
+for img in openfdd-central openfdd-ui openfdd-fieldbus openfdd-mqtt; do
+  n=$(docker buildx imagetools inspect "ghcr.io/bbartling/${img}:nightly" --format '{{println .Manifest.Digest}}')
+  s=$(docker buildx imagetools inspect "ghcr.io/bbartling/${img}:sha-${SHORT}" --format '{{println .Manifest.Digest}}')
+  test "$n" = "$s" || { echo "MISMATCH $img nightly=$n sha=$s"; exit 1; }
+done
+
+# 4) Bring stack up pinned to that SHA (scripts honor OPENFDD_IMAGE_TAG)
+export OPENFDD_IMAGE_TAG="sha-${SHORT}"
+cd ~/open-fdd
+./scripts/openfdd_stack_pull.sh standalone
 ./scripts/openfdd_stack_up.sh standalone
 curl -fsS http://127.0.0.1:8080/api/health
 curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
-```
 
-Immutable verify after a merge:
-
-```bash
-SHORT=<7-char-sha>
-docker pull ghcr.io/bbartling/openfdd-ui:sha-$SHORT
-docker pull ghcr.io/bbartling/openfdd-central:sha-$SHORT
-docker buildx imagetools inspect ghcr.io/bbartling/openfdd-ui:nightly
-# Confirm nightly digest == sha-$SHORT digest before recreating local containers
-```
-
-Inspect labels / installed package when debugging UI:
-
-```bash
-docker image inspect ghcr.io/bbartling/openfdd-ui:nightly
-docker run --rm ghcr.io/bbartling/openfdd-ui:nightly \
+# 5) Optional UI package assert inside the immutable image
+docker run --rm "ghcr.io/bbartling/openfdd-ui:sha-${SHORT}" \
   python -c "import open_fdd; print(open_fdd.__version__)"
 ```
+
+Day-to-day convenience may set `OPENFDD_IMAGE_TAG=nightly`, but Milestone
+qualification and post-merge verification must use `sha-*` as above.
 
 ---
 
 ## Playground vibe19 / vibe20
 
-Adjust ports to local docs if different:
-
 ```bash
+# After develop merge — pull and recreate (do not expect in-place update)
 docker pull ghcr.io/bbartling/vibe19:develop
 docker pull ghcr.io/bbartling/vibe20:develop
-# Recreate named containers rather than expecting in-place update
+# Prefer recording digests:
+docker buildx imagetools inspect ghcr.io/bbartling/vibe19:develop --format '{{.Manifest.Digest}}'
 ```
 
 After PyPI API changes: update playground pins → PR → merge → wait for
-`vibe19-ghcr` / `vibe20-ghcr` on `develop` → pull → recreate.
+`vibe19-ghcr` / `vibe20-ghcr` on `develop` → pull → **recreate** containers.
 
 ---
 
 ## MCP
 
 ```bash
-docker pull ghcr.io/bbartling/openfdd-mcp:nightly
+SHORT=$(git -C ~/open-fdd rev-parse --short=7 origin/master)
+docker pull "ghcr.io/bbartling/openfdd-mcp:sha-${SHORT}" 2>/dev/null \
+  || docker pull ghcr.io/bbartling/openfdd-mcp:nightly
 ```
 
 Separate workflow from the stack. Hub/network flakes: diagnose, one documented

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -1,0 +1,74 @@
+# Container agent — GHCR refresh and verify
+
+Test channel for Open-FDD stack: **`nightly`** (master publishes retarget
+`:nightly` to tip `sha-*`).
+
+Playground demos: **`develop`** tags for `vibe19` / `vibe20`.
+
+Never trust the GHCR web “Latest” alone. Never assume a running container
+updated itself.
+
+---
+
+## Open-FDD stack (nightly)
+
+```bash
+export OPENFDD_IMAGE_TAG=nightly   # or leave default if scripts already use nightly
+cd /home/ben/open-fdd
+./scripts/openfdd_stack_pull.sh standalone   # or csv / central
+./scripts/openfdd_stack_up.sh standalone
+curl -fsS http://127.0.0.1:8080/api/health
+curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
+```
+
+Immutable verify after a merge:
+
+```bash
+SHORT=<7-char-sha>
+docker pull ghcr.io/bbartling/openfdd-ui:sha-$SHORT
+docker pull ghcr.io/bbartling/openfdd-central:sha-$SHORT
+docker buildx imagetools inspect ghcr.io/bbartling/openfdd-ui:nightly
+# Confirm nightly digest == sha-$SHORT digest before recreating local containers
+```
+
+Inspect labels / installed package when debugging UI:
+
+```bash
+docker image inspect ghcr.io/bbartling/openfdd-ui:nightly
+docker run --rm ghcr.io/bbartling/openfdd-ui:nightly \
+  python -c "import open_fdd; print(open_fdd.__version__)"
+```
+
+---
+
+## Playground vibe19 / vibe20
+
+Adjust ports to local docs if different:
+
+```bash
+docker pull ghcr.io/bbartling/vibe19:develop
+docker pull ghcr.io/bbartling/vibe20:develop
+# Recreate named containers rather than expecting in-place update
+```
+
+After PyPI API changes: update playground pins → PR → merge → wait for
+`vibe19-ghcr` / `vibe20-ghcr` on `develop` → pull → recreate.
+
+---
+
+## MCP
+
+```bash
+docker pull ghcr.io/bbartling/openfdd-mcp:nightly
+```
+
+Separate workflow from the stack. Hub/network flakes: diagnose, one documented
+rerun, then fix — do not infinite-rerun.
+
+---
+
+## Safety
+
+- Never `docker compose down -v` or `docker volume prune` against a live site workspace
+- Never expose stack on the public internet
+- Record tested image digests in Milestone logs / [`COMPLETION_REPORT.md`](COMPLETION_REPORT.md)

--- a/openfdd_agent_spec/DATA_CONTRACT.md
+++ b/openfdd_agent_spec/DATA_CONTRACT.md
@@ -1,0 +1,86 @@
+# Data contracts (agent-facing)
+
+Portable artifact shapes agents must respect. Prefer versioned schemas; do not
+silently reinterpret old fields when meaning changes.
+
+When `open_fdd.contracts` ships (Milestone A Phase 2), this doc points at those
+models. Until then, code truth lives in the paths below.
+
+---
+
+## WattLab dump
+
+| Item | Truth |
+| --- | --- |
+| Producer | vibe19 / `services/ui` Export (v3 preferred) |
+| Consumer | vibe20 Studio / WattLab loaders |
+| Spec pointers | playground vibe19 `docs/PACKAGE_SPEC.md`; vibe20 `DATA_CONTRACT.md` |
+
+Agents must stamp `data_window` / telemetry years on export README so twin
+agents see weather year vs bill year mismatches.
+
+---
+
+## Rule result (pandas oracle)
+
+Canonical statuses and shapes come from `open_fdd.rules.base.RuleResult` and
+cookbook catalog metadata. Custom rules:
+
+- Use reserved `CUSTOM-*` IDs
+- Never override canonical IDs
+- Declare required roles, parameters, equipment applicability
+- Fail safely
+- Excluded from production SQL parity claims unless explicitly migrated
+
+---
+
+## Findings / reporting
+
+`open_fdd.reporting` owns portable builders. Detection ≠ finding — see vibe19
+`vibe19-engineering-report` skill. UI owns download buttons and session state.
+
+---
+
+## ECM calculator results
+
+`open_fdd.ecm_engineering` calculators should return enough detail for vibe20
+rendering without recomputing formulas (summary + bins/detail + assumptions +
+warnings + provenance). Adapters may translate field names only.
+
+Target shape (Phase 4 hardening):
+
+```json
+{
+  "schema_version": "1",
+  "calculator_id": "scheduling_cooling_bins",
+  "summary": {
+    "baseline_kwh": 0.0,
+    "proposed_kwh": 0.0,
+    "saved_kwh": 0.0
+  },
+  "bins": [],
+  "assumptions": {},
+  "warnings": [],
+  "provenance": {}
+}
+```
+
+---
+
+## Production FDD run
+
+| Item | Truth |
+| --- | --- |
+| API | `POST /api/fdd/run` (registry / DataFusion) |
+| Registry | `sql_rules/registry.yaml` |
+| Storage | Arrow / Feather via central |
+
+Agents must not treat pandas oracle output as production FDD execution.
+
+---
+
+## Units and roles
+
+Role aliases and equipment types: `open_fdd.analytics` / site model helpers and
+docs under `docs/rules/cookbook/` + migration `ROLE_MAPPING_PARITY.md`.
+Phase 2 consolidates into shared contracts.

--- a/openfdd_agent_spec/MILESTONE_A.md
+++ b/openfdd_agent_spec/MILESTONE_A.md
@@ -11,8 +11,10 @@ Progress snapshot: [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md).
 PR loop: [`PR_PROTOCOL.md`](PR_PROTOCOL.md).
 Containers: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md).
 
-Do not stop after plans or scaffolding. Implement, test, push, review, correct,
-merge, refresh GHCR, and verify — until exit criteria or a genuine external
+Do not stop after plans or scaffolding. For each **bounded PR**, implement,
+test, push, review, correct, and merge what that PR declared — then refresh
+GHCR/dependents **only when the PR’s packaging or image scope requires it**.
+Continue across PRs until Milestone A exit criteria or a genuine external
 blocker.
 
 ---
@@ -20,11 +22,13 @@ blocker.
 ## Local repositories
 
 ```bash
-/home/ben/open-fdd                         # bbartling/open-fdd → master
-/home/ben/py-bacnet-stacks-playground      # bbartling/py-bacnet-stacks-playground → develop
+~/open-fdd                         # bbartling/open-fdd → master
+~/py-bacnet-stacks-playground      # bbartling/py-bacnet-stacks-playground → develop
   vibe_code_apps_19/
   vibe_code_apps_20/
 ```
+
+(Adjust clone roots; Ben’s WSL often uses `/home/ben/...`.)
 
 ---
 

--- a/openfdd_agent_spec/MILESTONE_A.md
+++ b/openfdd_agent_spec/MILESTONE_A.md
@@ -1,0 +1,278 @@
+# Milestone A: Reproducible and Unified Libraries
+
+Agent mission for Cursor/Codex operating in Ben’s WSL environment.
+
+**Adapted 2026-07-28** to code truth: pandas oracle = `open_fdd.rules` (+
+`analytics`); pip extra `oracle` / `vibe19`; ECM = `open_fdd.ecm_engineering`;
+`open_fdd.contracts` is a Phase 2 target (not shipped). Do not rename modules
+unless product explicitly decides.
+
+Progress snapshot: [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md).
+PR loop: [`PR_PROTOCOL.md`](PR_PROTOCOL.md).
+Containers: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md).
+
+Do not stop after plans or scaffolding. Implement, test, push, review, correct,
+merge, refresh GHCR, and verify — until exit criteria or a genuine external
+blocker.
+
+---
+
+## Local repositories
+
+```bash
+/home/ben/open-fdd                         # bbartling/open-fdd → master
+/home/ben/py-bacnet-stacks-playground      # bbartling/py-bacnet-stacks-playground → develop
+  vibe_code_apps_19/
+  vibe_code_apps_20/
+```
+
+---
+
+## 1. Non-negotiable architecture
+
+### Vibe 19
+
+Educational pandas rule/analytics oracle; Streamlit demo; CSV/mapping/weather/
+reports/custom rules test bed; standalone GHCR demo. May keep pandas
+intentionally. Must not remain the canonical home of duplicated Open-FDD rule,
+analytics, reporting, schema, or generic engineering implementations once
+migrated.
+
+### Vibe 20
+
+EnergyPlus digital-twin / calibration / ECM cross-check; owns EnergyPlus-
+specific behavior. Must not retain duplicate **generic** HVAC formulas once
+parity-proven in Open-FDD.
+
+### Open-FDD PyPI
+
+Reusable libraries:
+
+```text
+open_fdd.ecm_engineering     # default install
+open_fdd.rules               # pandas cookbook oracle (not open_fdd.oracle module)
+open_fdd.analytics           # oracle/reference analytics
+open_fdd.reporting
+open_fdd.contracts           # Phase 2 target
+```
+
+Optional pandas extras for notebooks, vibe19, tests, oracle comparisons.
+PyPI is **not** the production DataFusion FDD runtime.
+
+### Open-FDD production
+
+Rust services; Arrow/Feather; DataFusion SQL; canonical SQL registry; JWT APIs;
+GHCR stack; combined Streamlit UI (`services/ui`). Must not silently fall back
+from SQL to pandas.
+
+---
+
+## 2. Preserve both expression rule cookbooks
+
+SQL and pandas cookbooks remain documented, readable, tested, discoverable,
+synchronized in identity/metadata, honest about parity gaps.
+
+Never replace cookbooks with generated API docs alone.
+Never delete pandas cookbook because production uses SQL.
+Never delete SQL cookbook because pandas remains the oracle.
+
+Protect:
+
+```text
+DataFusion SQL expression cookbook
+Pandas expression cookbook
+Rule parity matrix
+Rule metadata / manifest (Phase 2)
+Required-role / parameter / gate / applicability docs
+```
+
+CI should detect missing headings, duplicate IDs, missing SQL/pandas entries,
+undocumented production-only SQL, bad aliases, metadata drift, accidental
+shrinkage, broken links, non-importable examples.
+
+**Execution SoT:** SQL registry.
+**Identity/metadata SoT (target):** shared rule manifest.
+**Oracle SoT:** pandas cookbook + `open_fdd.rules`.
+
+---
+
+## 3. Autonomous engineering loop
+
+Follow [`PR_PROTOCOL.md`](PR_PROTOCOL.md) for every PR (sync → read → inspect →
+bound → branch → test-first → validate → commit → draft PR → Actions →
+CodeRabbit → merge → refresh dependents/containers).
+
+Migration pattern:
+
+```text
+inventory → characterization test → shared implementation → parity proof
+→ caller cutover → duplicate deletion → regression → documentation
+```
+
+Do not copy into Open-FDD and call migration complete while both
+implementations remain active.
+
+---
+
+## 4. Phase sequence
+
+Modify subdivision only when current state proves a task done or needs a split.
+See [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) for done/partial marks.
+
+### Phase 0 — Architecture freeze and enforcement
+
+**Objective:** Turn architecture into testable repository policy.
+
+- Keep [`ARCHITECTURE.md`](ARCHITECTURE.md) + [`ownership.yaml`](ownership.yaml) current.
+- Add CI: ownership schema validation; forbidden imports (central must not
+  import pandas for FDD; production UI must not bypass SQL for production FDD
+  computation); required cookbook paths; terminology consistency; no silent
+  pandas fallback; duplicate canonical-module detection.
+- Ban production computation paths that bypass DataFusion — not plotting/display.
+
+**Exit:** Boundaries in human + machine form; CI fails on prohibited deps;
+both cookbooks protected.
+
+### Phase 1 — Packaging, release, container reproducibility
+
+**Objective:** Deterministic, inspectable builds.
+
+- Document version axes ([`docs/VERSIONING.md`](docs/VERSIONING.md)): platform,
+  PyPI package, SQL registry hash, pandas cookbook/oracle, WattLab schema,
+  contracts schema, container git SHA.
+- Prefer generated version manifest from canonical files.
+- Truthful lower bounds for vibe19/vibe20 (do not claim 4.0.0 if APIs need 4.1.1+).
+- Image labels / env / endpoint expose versions; pin/constraints so rebuilds do
+  not silently float newer PyPI.
+- Wheel integrity: build once → test that wheel → publish that wheel.
+
+**Already done (do not redo):** PyPI 4.1.0/4.1.1; consumer pins `>=4.1.1,<5`;
+nightly GHCR channel.
+
+**Exit:** No ambiguous root version claim; pinned/constraints images; workflows green.
+
+### Phase 2 — Shared contracts and canonical rule manifest
+
+**Objective:** Eliminate duplicated identity/schema/units/metadata.
+
+- Implement `open_fdd.contracts` (base install without pandas).
+- Models for rule ID/alias/category/status/parity/applicability/parameters/
+  roles/gates/equipment/findings/jobs/runs/provenance/units/WattLab/ECM results.
+- Machine-readable rule manifest supporting both cookbooks (no formula bodies
+  in the manifest — expressions stay in cookbooks).
+- Tests: unique IDs, alias resolve, roles/units, defaults match, SQL/pandas
+  presence, cookbook headings, registry agreement, no accidental shrink.
+
+**Exit:** Consumers share contracts; cookbooks remain readable and CI-protected;
+`import open_fdd.contracts` works without pandas.
+
+### Phase 3 — Vibe 19 thin-oracle cutover
+
+**Objective:** Vibe 19 consumes Open-FDD oracle/reporting — not a duplicate repo.
+
+**Already done:** Most rules shims; `runner.py` + `analytics.py` package rebinds
+(playground #59, open-fdd UI #580).
+
+**Still required:**
+
+- Full KEEP/SHIM/MOVE/DELETE matrix for significant modules.
+- Keep: Streamlit UX, custom `CUSTOM-*` loading, demos, prototype-only utils.
+- Characterization + parity before any further deletes.
+- GHCR smoke after cutovers (sidebar version, package upload, rules, WattLab export).
+
+**Exit:** No active canonical twins of migrated modules; clean-install tests;
+GHCR runs; cookbook examples valid against installed package.
+
+### Phase 4 — Vibe 20 generic ECM migration
+
+**Objective:** Generic math in `open_fdd.ecm_engineering`; EnergyPlus stays in vibe20.
+
+**Already done:** Eight twins delegated (fan affinity, schedule reduction,
+outside-air sensible, kW/ton, boiler efficiency, scheduling fan/cooling/heating
+bins). Keepers listed in playground `vibe_code_apps_20/docs/OPENFDD_ECM_TWINS.md`.
+
+**Still required:**
+
+- Inventory remaining generic formulas (finance, pumps, enthalpy helpers, etc.).
+- Richer result contracts so adapters do not recompute.
+- Parity → cutover → delete → remove parity bridges that import deleted code.
+- Mutation spot-checks on critical formulas (record in PR; need not commit harness).
+- Document Docker-socket E+ runner as trusted local-dev — not hardened production;
+  follow-on for restricted runner.
+
+**Exit:** No duplicate generic ECM formulas; adapters translate only; E+ code
+remains; tests + GHCR green.
+
+---
+
+## 5. Cross-repository tests
+
+Contract compatibility matrix covering package × vibe19 × vibe20 × rule-manifest
+× WattLab dump versions. Fixtures: small synthetics in default CI; Building 100
+optional/local. Explicit numeric tolerances by output type; categorical IDs exact.
+
+Required classes: unit, schema, contract, parity, regression, package, docs,
+cookbook, container, browser smoke, cross-repo compatibility.
+
+---
+
+## 6. GitHub Actions
+
+Discover actual workflow names ([`docs/WORKFLOWS.md`](docs/WORKFLOWS.md)).
+For every PR: `gh pr checks --watch`; inspect all checks. After merge, confirm
+default-branch GHCR publication for the **merged** commit.
+
+---
+
+## 7. Container refresh
+
+Per [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md): immutable `sha-*` → inspect →
+temp smoke → then refresh moving `:nightly` / `:develop` local containers.
+Record digests in the completion report.
+
+---
+
+## 8. Milestone documentation
+
+Durable progress: this file + [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) +
+[`docs/MIGRATION_MATRIX.md`](docs/MIGRATION_MATRIX.md) +
+`docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md` (update, do not fork truth).
+
+Suggested execution log path for long runs:
+`docs/migration/MILESTONE_A_EXECUTION.md` (create when Phase 0 coding starts).
+
+---
+
+## 9. Final qualification
+
+Clean sync of both default branches. Run full open-fdd Rust/Python/ECM/oracle/
+reporting/cookbook/docs/package/container gates practical on the agent host.
+Run vibe19 + vibe20 suites + clean-install + container smokes. Prove:
+
+```text
+vibe19 → pandas oracle → findings → WattLab v3 → vibe20 load
+→ open_fdd.ecm_engineering → EnergyPlus path still available
+
+open-fdd base install → no pandas
+open-fdd[oracle] → pandas rules available
+production container → SQL/DataFusion FDD path
+```
+
+GitHub gate: all Milestone A PRs merged; no actionable CodeRabbit left; GHCR
+green; digests tested; branches clean; no undocumentated migration shims.
+
+---
+
+## 10. Stop conditions
+
+Do **not** stop merely because a plan, matrix, copy, local-only green, or
+moving tag exists. Stop when exit criteria met **or** genuine blocker
+(credentials, permissions, missing secrets, optional private dataset, dirty
+unrelated work, unsafe product decision). Then: finish non-blocked work; record
+exact command/error; leave repos recoverable.
+
+---
+
+## 11. Final agent report
+
+Fill [`COMPLETION_REPORT.md`](COMPLETION_REPORT.md) with verified facts only.

--- a/openfdd_agent_spec/PR_PROTOCOL.md
+++ b/openfdd_agent_spec/PR_PROTOCOL.md
@@ -1,0 +1,85 @@
+# PR protocol (Milestone A)
+
+Every pull request follows this loop. Prefer **one architectural purpose** per PR.
+
+Branch naming:
+
+```text
+milestone-a/00-architecture-contract
+milestone-a/01-release-manifest
+milestone-a/02-shared-contracts
+milestone-a/03-rule-manifest
+milestone-a/04-vibe19-oracle-cutover
+milestone-a/05-vibe19-reporting-cutover
+milestone-a/06-vibe20-ecm-scheduling
+milestone-a/07-vibe20-ecm-bins
+milestone-a/08-delete-ecm-twins
+milestone-a/09-final-audit
+docs/openfdd-agent-spec   # docs-only OK
+```
+
+---
+
+## Steps
+
+1. **Sync** — `git fetch --prune`; switch `master` (open-fdd) or `develop` (playground); `pull --ff-only`. Do not destructive-reset unrelated dirty work.
+2. **Read** — root `AGENTS.md`, this spec, applicable skills, nearby `AGENTS.md`.
+3. **Inspect** — `git log -15`; `gh pr list`; `gh run list --limit 20`. Do not duplicate open work.
+4. **Bound the PR** — in-scope / out-of-scope / acceptance / tests / docs.
+5. **Branch** — `git switch -c milestone-a/<work>`.
+6. **Test-first migration** — inventory → characterize → implement shared → parity → cutover → delete twin → regression → docs.
+7. **Validate locally** — smallest tests, then affected suite; clean venv wheel install for packaging.
+8. **Commit intentionally** — focused messages (`feat`, `fix`, `test`, `docs`, `refactor`).
+9. **Draft PR** — `gh pr create --draft` with body template below.
+10. **Watch Actions** — `gh pr checks --watch`; classify failures; fix code-owned issues.
+11. **CodeRabbit** — classify comments; fix actionable; reply; do not violate architecture.
+12. **Ready + merge** — `gh pr ready`; prefer squash unless repo policy differs; delete branch.
+13. **Refresh dependents** — bump playground pins; separate playground PR; GHCR refresh per [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md).
+
+---
+
+## PR body template
+
+```markdown
+## Purpose
+
+## Architecture impact
+
+## Changes
+
+## Tests
+
+## Cookbook impact
+
+## Packaging impact
+
+## Container impact
+
+## Compatibility and migration
+
+## Known non-goals
+
+## Acceptance checklist
+- [ ] Targeted tests pass
+- [ ] Broader affected suite pass
+- [ ] Docs match code
+- [ ] No duplicate canonical modules left active (or exception documented)
+- [ ] CodeRabbit actionable threads resolved
+```
+
+---
+
+## Failure classes
+
+```text
+CODE_FAILURE
+TEST_FAILURE
+PACKAGING_FAILURE
+DOCS_FAILURE
+COOKBOOK_PARITY_FAILURE
+CONTAINER_BUILD_FAILURE
+FLAKY_INFRASTRUCTURE
+UNRELATED_BASE_BRANCH_FAILURE
+```
+
+One documented rerun for apparent infra flakes; if it repeats, diagnose.

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,0 +1,22 @@
+# Session log
+
+Newest first. Append after non-trivial agent work.
+
+---
+
+## 2026-07-28 — openfdd_agent_spec created
+
+- Added `openfdd_agent_spec/` (orientation, Milestone A mission, architecture,
+  ownership seed, skills, PR protocol, container protocol).
+- Wired pointers from root `AGENTS.md`, `docs/agent/index.md`, migration audit.
+- Docs-only; Milestone A Phases 0–4 code not executed in this pass.
+
+## 2026-07-27 — twin retirement + GHCR refresh
+
+- Playground #59: vibe19 runner/analytics → PyPI shims; pin `>=4.1.1`; vibe20
+  workspace_tools `pick_best_twin_run` + `agent_build_ecm_packages`.
+- open-fdd #580: `services/ui` runner/analytics shims; Streamlit docs honesty.
+- GHCR: vibe19/vibe20 `:develop` green; open-fdd stack `:nightly` matches
+  `sha-f5207f6` (post-#580); MCP GHCR green.
+- Prior: PyPI 4.1.0/4.1.1; playground #55–#58; open-fdd #578/#579; eight vibe20
+  ECM twins delegated.

--- a/openfdd_agent_spec/docs/COOKBOOK_OWNERSHIP.md
+++ b/openfdd_agent_spec/docs/COOKBOOK_OWNERSHIP.md
@@ -1,0 +1,26 @@
+# Cookbook ownership
+
+Both expression cookbooks are **permanent project deliverables**.
+
+| Cookbook | Path | Engine |
+| --- | --- | --- |
+| DataFusion SQL | [`docs/rules/cookbook/datafusion-sql-cookbook.md`](../../docs/rules/cookbook/datafusion-sql-cookbook.md) | Production (`sql_rules/`) |
+| Pandas | [`docs/rules/cookbook/pandas-cookbook.md`](../../docs/rules/cookbook/pandas-cookbook.md) | Oracle (`open_fdd.rules`) |
+| Parity matrix | [`docs/rules/cookbook/parity-matrix.md`](../../docs/rules/cookbook/parity-matrix.md) | Honesty layer |
+| Gap / taxonomy / schema | sibling files under `docs/rules/cookbook/` | Supporting |
+
+## Rules for agents
+
+1. Never delete either cookbook because the other engine is “canonical for production.”
+2. Never replace cookbooks with generated API documentation alone.
+3. Keep rule IDs and metadata synchronized; be honest about parity gaps.
+4. Hand-written engineering expressions stay in cookbooks — manifests hold identity/metadata only.
+5. CI entrypoint today: `.github/workflows/cookbook-parity.yml` → `scripts/cookbook_parity_check.py`.
+6. When adding a production SQL rule, update registry + SQL file + cookbook heading + parity row.
+7. When adding a pandas oracle rule, update `open_fdd.rules` + pandas cookbook + parity row.
+
+## Milestone A hardening targets
+
+Detect: missing headings, duplicate IDs, missing SQL files, missing pandas entries,
+undocumented SQL-only rules, broken aliases, parameter/role drift, accidental
+shrinkage, broken links, examples that no longer import.

--- a/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
+++ b/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
@@ -1,0 +1,45 @@
+# Migration matrix (pointers + status)
+
+Do not fork parallel truth. Update existing audits when code changes.
+
+| Document | Role |
+| --- | --- |
+| [`docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md`](../../docs/migration/VIBE19_VIBE20_OPENFDD_AUDIT.md) | Cross-product audit |
+| [`docs/migration/vibe19_parity_matrix.md`](../../docs/migration/vibe19_parity_matrix.md) | vibe19 capability parity |
+| [`docs/migration/vibe20_integration_matrix.md`](../../docs/migration/vibe20_integration_matrix.md) | WattLab / vibe20 integration |
+| [`docs/rules/cookbook/parity-matrix.md`](../../docs/rules/cookbook/parity-matrix.md) | SQL ↔ pandas rule honesty |
+| Playground `vibe_code_apps_20/docs/OPENFDD_ECM_TWINS.md` | ECM twin vs keeper list |
+| [`BUILD_CHECKPOINTS.md`](../BUILD_CHECKPOINTS.md) | Milestone A checklist |
+
+When Phase 0 coding starts, add `docs/migration/MILESTONE_A_EXECUTION.md` with
+per-PR and per-module tables.
+
+---
+
+## Vibe 19 — high-level status (2026-07-28)
+
+| Area | Action | Status |
+| --- | --- | --- |
+| `app/rules/*` (most modules) | SHIM → `open_fdd.rules` | Done |
+| `app/rules/runner.py` | SHIM | Done (#59 / UI #580) |
+| `app/analytics.py` | SHIM → `open_fdd.analytics.core` | Done |
+| `app/rules/custom_registry.py` / `custom_rules.py` | KEEP | Intentional |
+| Streamlit / session / demos | KEEP | Intentional |
+| Remaining analytics helpers still local under `app/` | Inventory | Phase 3 matrix |
+| Reporting twins | Inventory → SHIM/MOVE | Phase 3 |
+
+## Vibe 20 ECM — high-level status
+
+| Area | Action | Status |
+| --- | --- | --- |
+| 8 parity-proven calcs | DELEGATE via adapter | Done |
+| ~18 esco/algorithm keepers | KEEP until Open-FDD twin + parity | Partial |
+| EnergyPlus / IDF / Studio | KEEP | Forever (Milestone A) |
+| Downloads/tools deltas | Prefer `examples/workspace_tools/` | Partial (#59 seeded pick_best + agent_build) |
+
+## Open-FDD UI
+
+| Area | Action | Status |
+| --- | --- | --- |
+| Rules / runner / analytics twins | SHIM | Done (#579/#580) |
+| Production FDD path | KEEP SQL via central | Forever |

--- a/openfdd_agent_spec/docs/VERSIONING.md
+++ b/openfdd_agent_spec/docs/VERSIONING.md
@@ -1,0 +1,31 @@
+# Versioning
+
+Distinguish these axes — do not collapse them into one “Open-FDD version” claim.
+
+| Axis | Where it lives today | Notes |
+| --- | --- | --- |
+| Platform / Rust workspace | Root `Cargo.toml` `version` | Stack image semver tags |
+| Python package | `open_fdd/__init__.py` / `pyproject.toml` | PyPI `open-fdd` (e.g. 4.1.1) |
+| SQL rule registry | `sql_rules/registry.yaml` (+ file tree) | Prefer content hash in future manifest |
+| Pandas cookbook / oracle | Docs + `open_fdd.rules` | Tied to package version when shipped |
+| WattLab dump schema | vibe19 package / export code | v2/v3 compatibility matrix |
+| Shared contracts schema | **Not shipped** | Phase 2 `open_fdd.contracts` |
+| Container git SHA | GHCR `sha-<7>` + `:nightly` on master | Immutable verify uses `sha-*` |
+| EnergyPlus version | vibe20 image / runtime | When applicable |
+
+## Agent rules
+
+1. Root README / Pages must not contradict PyPI or Cargo versions.
+2. Consumer lower bounds must be truthful (`>=4.1.1` if APIs require 4.1.1).
+3. Milestone A Phase 1 should add a **generated** version manifest (JSON) derived
+   from canonical files — not hand-copied triples.
+4. Container rebuilds should install a pinned/constraints Open-FDD wheel so the
+   same source commit does not silently pull a newer PyPI release later.
+5. Test channel for stack: `OPENFDD_IMAGE_TAG=nightly`.
+
+## Wheel integrity
+
+```text
+build one wheel → test that exact wheel → publish that exact wheel
+→ dependent images install the expected released artifact
+```

--- a/openfdd_agent_spec/docs/WORKFLOWS.md
+++ b/openfdd_agent_spec/docs/WORKFLOWS.md
@@ -1,0 +1,36 @@
+# Workflows (discover before assuming names)
+
+Actual workflow files under `.github/workflows/` (open-fdd). Re-list with
+`ls .github/workflows` before changing CI assumptions.
+
+| File | Typical purpose |
+| --- | --- |
+| `rust-ci.yml` | Rust workspace CI (+ docs-only cookbook check) |
+| `fdd-engine-ci.yml` | FDD engine / DataFusion focused CI |
+| `python-package.yml` | Python package tests |
+| `ecm-python.yml` | ECM Python package tests |
+| `cookbook-parity.yml` | Cookbook parity (`scripts/cookbook_parity_check.py`) |
+| `docs-pages.yml` | GitHub Pages |
+| `docs-pdf.yml` | Docs PDF |
+| `publish-open-fdd.yml` | Publish `open-fdd` to PyPI |
+| `ghcr-openfdd-stack.yml` | Publish stack images; retarget `:nightly` on master |
+| `rust-ghcr-mcp.yml` | Publish `openfdd-mcp` (`:nightly`) |
+| `ghcr-prune.yml` | GHCR retention |
+| `rust-release.yml` | Rust release |
+| `security.yml` / `appsec.yml` | Security / AppSec |
+
+## Playground (reference)
+
+| Workflow | Role |
+| --- | --- |
+| `vibe19-ghcr.yml` | vibe19 image |
+| `vibe20-ghcr.yml` | vibe20 image |
+
+## Agent commands
+
+```bash
+gh workflow list --repo bbartling/open-fdd
+gh pr checks --watch
+gh run list --branch master --limit 20
+gh run view <id> --log-failed
+```

--- a/openfdd_agent_spec/ownership.yaml
+++ b/openfdd_agent_spec/ownership.yaml
@@ -80,8 +80,9 @@ components:
       protected: true
 
   future_concepts:
-    - edge/
-    - os/
+    paths:
+      - edge/
+      - os/
     policy: never_delete
 
   mcp:

--- a/openfdd_agent_spec/ownership.yaml
+++ b/openfdd_agent_spec/ownership.yaml
@@ -1,0 +1,89 @@
+# ownership.yaml — Phase 0 seed (schema_version 1)
+# CI validation of this file is a Milestone A Phase 0 deliverable; this PR only seeds it.
+schema_version: 1
+
+components:
+  rule_metadata:
+    canonical_owner: open_fdd.contracts  # Phase 2 target — not shipped yet
+    interim_owners:
+      - sql_rules/registry.yaml
+      - open_fdd.rules.cookbook_catalog
+      - docs/rules/cookbook/
+
+  pandas_rule_execution:
+    canonical_owner: open_fdd.rules
+    related:
+      - open_fdd.analytics
+    pip_extras:
+      - oracle
+      - vibe19
+    allowed_consumers:
+      - vibe19
+      - services/ui  # display / lab paths only — production FDD via central SQL
+      - tests
+      - notebooks
+
+  production_rule_execution:
+    canonical_owner: openfdd-central
+    engine: datafusion_sql
+    registry: sql_rules/registry.yaml
+    forbidden:
+      - silent_pandas_fallback
+
+  generic_ecm_math:
+    canonical_owner: open_fdd.ecm_engineering
+    allowed_consumers:
+      - vibe20
+      - services/ui
+      - notebooks
+      - tests
+
+  energyplus_modeling:
+    canonical_owner: vibe20
+    includes:
+      - idf_editing
+      - simulation_orchestration
+      - apihelper_processing
+      - eplus_calibration
+
+  reporting:
+    canonical_owner: open_fdd.reporting
+    allowed_consumers:
+      - vibe19
+      - services/ui
+      - tests
+
+  product_streamlit_ui:
+    canonical_owner: services/ui
+    image: ghcr.io/bbartling/openfdd-ui
+    note: Single Streamlit surface — not Vite/Caddy SPA
+
+  vibe19_demo:
+    canonical_owner: vibe_code_apps_19
+    image: ghcr.io/bbartling/vibe19
+    role: educational_pandas_oracle_demo
+
+  vibe20_studio:
+    canonical_owner: vibe_code_apps_20
+    image: ghcr.io/bbartling/vibe20
+    role: energyplus_twin_and_ecm_crosscheck
+
+  cookbooks:
+    sql:
+      path: docs/rules/cookbook/datafusion-sql-cookbook.md
+      protected: true
+    pandas:
+      path: docs/rules/cookbook/pandas-cookbook.md
+      protected: true
+    parity_matrix:
+      path: docs/rules/cookbook/parity-matrix.md
+      protected: true
+
+  future_concepts:
+    - edge/
+    - os/
+    policy: never_delete
+
+  mcp:
+    canonical_owner: openfdd-mcp
+    role: read_first_central_tools

--- a/openfdd_agent_spec/skills/openfdd-architecture/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-architecture/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: openfdd-architecture
+description: >-
+  Use when enforcing Open-FDD product boundaries: production DataFusion SQL vs
+  pandas oracle, vibe19/vibe20 ownership, dual cookbooks, edge/os never-delete,
+  ownership.yaml, forbidden imports. Triggers on: architecture, ownership,
+  pandas fallback, cookbook delete, Milestone A Phase 0.
+---
+
+# Open-FDD architecture
+
+Read [`ARCHITECTURE.md`](../../ARCHITECTURE.md) and [`ownership.yaml`](../../ownership.yaml).
+
+## Non-negotiables
+
+- Production FDD = DataFusion SQL (`sql_rules/`) — no silent pandas fallback in central.
+- Pandas oracle = `open_fdd.rules` + `analytics` — permanent.
+- Both cookbooks permanent — see [`docs/COOKBOOK_OWNERSHIP.md`](../../docs/COOKBOOK_OWNERSHIP.md).
+- One Streamlit product UI: `services/ui` (not Vite/Caddy SPA).
+- Never delete `edge/` or `os/`.
+- Do not rename `open_fdd.rules` → `open_fdd.oracle` without product decision.
+
+## Phase 0 coding (when executing)
+
+Add CI that validates `ownership.yaml` and fails on prohibited imports /
+missing cookbook paths / terminology regressions.

--- a/openfdd_agent_spec/skills/openfdd-cookbook-parity/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-cookbook-parity/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: openfdd-cookbook-parity
+description: >-
+  Use when editing rule cookbooks, parity matrix, or cookbook CI
+  (cookbook-parity.yml, cookbook_parity_check.py). Triggers on: pandas cookbook,
+  SQL cookbook, parity-matrix, gap-matrix, rule headings.
+---
+
+# Cookbook parity
+
+See [`docs/COOKBOOK_OWNERSHIP.md`](../../docs/COOKBOOK_OWNERSHIP.md).
+
+```bash
+python scripts/cookbook_parity_check.py --all
+# or --docs-only in lighter CI jobs
+```
+
+Workflow: `.github/workflows/cookbook-parity.yml`.
+
+When changing rule identity or count, update both cookbooks and the parity
+matrix in the same PR family. Accidental cookbook shrinkage must fail CI
+(harden under Milestone A Phase 0/2).

--- a/openfdd_agent_spec/skills/openfdd-ecm-engineering/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-ecm-engineering/SKILL.md
@@ -16,7 +16,7 @@ EnergyPlus-specific code stays in vibe20.
 
 ```text
 inventory → golden/characterize → implement/confirm in Open-FDD
-→ parity → switch adapter → delete twin → remove dead imports → docs
+→ parity → switch adapter → delete twin → regression → docs
 ```
 
 ## Already delegated (do not re-port)

--- a/openfdd_agent_spec/skills/openfdd-ecm-engineering/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-ecm-engineering/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: openfdd-ecm-engineering
+description: >-
+  Use when migrating or changing generic ECM math in open_fdd.ecm_engineering
+  or deleting vibe20 twins after parity. Triggers on: ECM, fan affinity,
+  scheduling bins, boiler efficiency, esco calculator, OPENFDD_ECM_TWINS,
+  Milestone A Phase 4.
+---
+
+# ECM engineering
+
+Canonical generic math: `open_fdd.ecm_engineering`.
+EnergyPlus-specific code stays in vibe20.
+
+## Migration pattern
+
+```text
+inventory → golden/characterize → implement/confirm in Open-FDD
+→ parity → switch adapter → delete twin → remove dead imports → docs
+```
+
+## Already delegated (do not re-port)
+
+fan_affinity, schedule_reduction, outside_air_sensible, kw_per_ton_improvement,
+boiler_efficiency_improvement, scheduling_fan/cooling/heating_bins.
+
+Keepers: playground `vibe_code_apps_20/docs/OPENFDD_ECM_TWINS.md`.
+
+## Result contracts
+
+Return enough detail (summary, bins, assumptions, warnings, provenance) so
+vibe20 adapters do not recompute formulas.

--- a/openfdd_agent_spec/skills/openfdd-milestone-a-pr/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-milestone-a-pr/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: openfdd-milestone-a-pr
+description: >-
+  Use when executing Milestone A bounded PRs: inventory, parity tests, cutover,
+  twin deletion, CodeRabbit loop, cross-repo pin bumps. Triggers on: Milestone A,
+  twin delete, parity proof, PR_PROTOCOL, migration matrix.
+---
+
+# Milestone A PR skill
+
+1. Read [`MILESTONE_A.md`](../../MILESTONE_A.md) + [`BUILD_CHECKPOINTS.md`](../../BUILD_CHECKPOINTS.md).
+2. Follow [`PR_PROTOCOL.md`](../../PR_PROTOCOL.md) exactly.
+3. One architectural purpose per PR; use `milestone-a/<name>` branches.
+4. Required pattern:
+
+```text
+inventory → characterize → shared impl → parity → cutover
+→ delete duplicate → regression → docs → SESSION_LOG
+```
+
+5. After Open-FDD PyPI changes: separate playground PR + GHCR refresh.
+6. Fill evidence into PR body; update checkpoints when phase status changes.
+7. Stop only on exit criteria or documented external blocker.

--- a/openfdd_agent_spec/skills/openfdd-pypi-oracle/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-pypi-oracle/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: openfdd-pypi-oracle
+description: >-
+  Use when changing open-fdd PyPI pandas oracle libraries: open_fdd.rules,
+  analytics, reporting, extras oracle/vibe19/reporting, wheel publish, consumer
+  pins. Triggers on: PyPI, open-fdd package, rules runner, analytics.core,
+  reporting, oracle extra, 4.1.x.
+---
+
+# PyPI pandas oracle
+
+## Layout
+
+| Module | Role |
+| --- | --- |
+| `open_fdd.rules` | Cookbook runner / catalog / gates |
+| `open_fdd.analytics` | Analytics helpers (`core`, weather, topology, …) |
+| `open_fdd.reporting` | Portable reports |
+| Extras | `oracle`, `reporting`, `vibe19` |
+
+Not production FDD. Consumers: vibe19, `services/ui` lab paths, tests, notebooks.
+
+## Agent rules
+
+1. Prefer clean venv + wheel install over editable-only proof.
+2. After API changes: bump package → publish → bump playground/UI pins → GHCR.
+3. Shim pattern in apps: `sys.modules[__name__] = open_fdd...` for private imports.
+4. Keep custom rules local to vibe19/UI (`CUSTOM-*`).

--- a/openfdd_agent_spec/skills/openfdd-pypi-oracle/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-pypi-oracle/SKILL.md
@@ -23,6 +23,6 @@ Not production FDD. Consumers: vibe19, `services/ui` lab paths, tests, notebooks
 ## Agent rules
 
 1. Prefer clean venv + wheel install over editable-only proof.
-2. After API changes: bump package → publish → bump playground/UI pins → GHCR.
+2. After API changes: bump package → **build one wheel → test that exact wheel → publish that exact wheel** → bump playground/UI pins → GHCR.
 3. Shim pattern in apps: `sys.modules[__name__] = open_fdd...` for private imports.
 4. Keep custom rules local to vibe19/UI (`CUSTOM-*`).

--- a/openfdd_agent_spec/skills/openfdd-sql-fdd/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-sql-fdd/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: openfdd-sql-fdd
+description: >-
+  Use when working on production DataFusion SQL FDD: sql_rules registry, central
+  /api/fdd/run, parity with pandas oracle, no pandas in central. Triggers on:
+  sql_rules, DataFusion, registry.yaml, FDD engine, SQL cookbook.
+---
+
+# Production SQL FDD
+
+- Registry: `sql_rules/registry.yaml`
+- Engine: openfdd-central DataFusion
+- Docs: `docs/rules/cookbook/datafusion-sql-cookbook.md`
+- Architecture: `docs/architecture/datafusion-first.md`
+
+## Hard rules
+
+1. Never add silent pandas fallback in central.
+2. New production rules need SQL file + registry + cookbook + parity row.
+3. Pandas oracle may differ — document in parity/gap matrices; do not paper over.
+4. UI production path calls central REST — not local pandas runner for “real” FDD.

--- a/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: openfdd-stack-ghcr
+description: >-
+  Use when pulling, rebuilding, or verifying Open-FDD GHCR stack images.
+  Test channel is nightly. Triggers on: nightly, openfdd-ui, openfdd-central,
+  GHCR, openfdd_stack_up, OPENFDD_IMAGE_TAG.
+---
+
+# Stack GHCR (nightly)
+
+Full protocol: [`CONTAINER_AGENT.md`](../../CONTAINER_AGENT.md).
+
+```bash
+export OPENFDD_IMAGE_TAG=nightly
+./scripts/openfdd_stack_pull.sh standalone
+./scripts/openfdd_stack_up.sh standalone
+```
+
+Verify immutable `sha-<commit>` matches `:nightly` before trusting a refresh.
+Workflow: `ghcr-openfdd-stack.yml` (retargets nightly on master).
+MCP: separate `rust-ghcr-mcp.yml`.

--- a/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
@@ -6,16 +6,13 @@ description: >-
   GHCR, openfdd_stack_up, OPENFDD_IMAGE_TAG.
 ---
 
-# Stack GHCR (nightly)
+# Stack GHCR (nightly channel → immutable verify)
 
 Full protocol: [`CONTAINER_AGENT.md`](../../CONTAINER_AGENT.md).
 
-```bash
-export OPENFDD_IMAGE_TAG=nightly
-./scripts/openfdd_stack_pull.sh standalone
-./scripts/openfdd_stack_up.sh standalone
-```
+`nightly` is the channel selector. Qualification pulls `sha-<commit>` for
+central/ui/fieldbus/mqtt, asserts digests match `:nightly`, then starts the
+stack with `OPENFDD_IMAGE_TAG=sha-<commit>`.
 
-Verify immutable `sha-<commit>` matches `:nightly` before trusting a refresh.
 Workflow: `ghcr-openfdd-stack.yml` (retargets nightly on master).
 MCP: separate `rust-ghcr-mcp.yml`.


### PR DESCRIPTION
## Purpose

Add an open-fdd agent orchestration tree modeled on vibe19/vibe20 `*_agent_spec`, encoding architecture locks and Milestone A against current code truth.

## Architecture impact

Docs/spec only. No package renames. Locks `open_fdd.rules` as pandas oracle; `open_fdd.contracts` marked Phase 2 target.

## Changes

- New `openfdd_agent_spec/` (AGENTS, MILESTONE_A, ARCHITECTURE, ownership.yaml, skills, PR/container protocols)
- Pointers from root `AGENTS.md`, `docs/agent/index.md`, migration audit

## Tests

- Docs Pages workflow on PR/merge

## Cookbook impact

None (ownership docs only)

## Packaging impact

None

## Container impact

None

## Compatibility and migration

Documents partial Milestone A progress already shipped (#59/#580, PyPI 4.1.x, 8 ECM twins).

## Known non-goals

Executing Phases 0–4 code; renaming modules; retiring playground GHCR.

## Acceptance checklist

- [x] Spec tree complete per plan
- [ ] Docs Pages green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive “Milestone A” agent workspace guidance, including PR protocol, build checkpoints, completion-report template, session logging, and a migration matrix.
  * Introduced architecture boundary “locks,” a portable data contract, and detailed versioning/version-axis rules.
  * Added operational runbooks for refreshing and verifying container images (including immutable digest checks) and clarified repo navigation/responsibilities.
  * Added ownership guidance for cookbooks and skills covering architecture enforcement, SQL FDD vs pandas oracle usage, cookbook parity, and ECM engineering workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->