### PR TITLE
docs(c0): README/PyPI/cookbook ownership invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   <a href="https://bbartling.github.io/open-fdd/rules/cookbook/">
     <img src="https://img.shields.io/badge/FDD%20Rule%20Cookbook-59%20rules%20SQL%20%2B%20Pandas-DC2626?style=for-the-badge" alt="FDD Rule Cookbook — DataFusion SQL + Pandas">
   </a>
+  <a href="https://pypi.org/project/open-fdd/">
+    <img src="https://img.shields.io/pypi/v/open-fdd?style=for-the-badge&label=PyPI&color=3775A9" alt="Open-FDD on PyPI">
+  </a>
   <a href="https://bbartling.github.io/open-fdd/quick-start/docker-ghcr.html">
     <img src="https://img.shields.io/badge/Quick%20Start-GHCR%20stack-059669?style=for-the-badge" alt="Quick start">
   </a>
@@ -45,7 +48,7 @@ The platform includes:
 - Semantic building modeling using **Project Haystack** knowledge graphs
 - JWT authentication and a modern **Streamlit** engineering UI (`openfdd-ui`)
 - Apache Arrow & Feather columnar data storage
-- Apache DataFusion SQL analytics and fault detection (59+ cookbook rules)
+- Apache DataFusion SQL analytics and fault detection (59 cookbook rules; 63 SQL registry IDs)
 - BACnet, Modbus, Haystack, and JSON API drivers (fieldbus container)
 - Interactive plotting, dashboards, and CSV job workflows
 - Optional **external** agent integration via MCP stdio and JWT REST (no embedded chatbot)
@@ -79,6 +82,8 @@ The **[HVAC FDD Rule Cookbook](https://bbartling.github.io/open-fdd/rules/cookbo
 - **[Pandas cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html)** — the same rules for notebooks, CSV exports, and RCx studies
 
 Rules use generic Haystack semantic roles, so they are portable across any modeled site. CI enforces a minimum of 59 rule headings in both cookbooks (`scripts/cookbook_parity_check.py`) — the catalog can never shrink.
+
+**Count contract (honest):** the public dual cookbooks document **59** rules. The production DataFusion SQL registry (`sql_rules/registry.yaml`) currently lists **63** rule IDs (59 cookbook-covered + SQL-only additions). See the [parity matrix](docs/rules/cookbook/parity-matrix.md). Do not treat badge “59” as the registry length.
 
 ---
 
@@ -135,8 +140,10 @@ Full tool list: [mcp/README.md](mcp/README.md).
 ```bash
 git clone https://github.com/bbartling/open-fdd.git && cd open-fdd
 ./scripts/openfdd_stack_up.sh csv --build   # or: cargo run -p openfdd-central
-./scripts/openfdd_ui_dev.sh                 # Vite :5173 → API :8080
+./scripts/openfdd_ui_dev.sh                 # Streamlit UI → central API :8080
 ```
+
+The production operator UI is **Streamlit** (`services/ui` / `ghcr.io/bbartling/openfdd-ui`), not a Vite/Caddy SPA.
 
 Native Rust: `cargo test --workspace`
 

--- a/openfdd_agent_spec/ownership.yaml
+++ b/openfdd_agent_spec/ownership.yaml
@@ -88,3 +88,21 @@ components:
   mcp:
     canonical_owner: openfdd-mcp
     role: read_first_central_tools
+
+# Milestone C0 — documentation sections that must not be vibe-coded away.
+protected_docs:
+  root_readme_navigation:
+    path: README.md
+    required_markers:
+      - "FDD Rule Cookbook"
+      - "pypi.org/project/open-fdd"
+      - "Apache DataFusion"
+      - "Apache Arrow"
+      - "datafusion-sql-cookbook"
+      - "pandas-cookbook"
+  pandas_cookbook:
+    path: docs/rules/cookbook/pandas-cookbook.md
+  sql_cookbook:
+    path: docs/rules/cookbook/datafusion-sql-cookbook.md
+  parity_matrix:
+    path: docs/rules/cookbook/parity-matrix.md

--- a/scripts/architecture_ownership_check.py
+++ b/scripts/architecture_ownership_check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Validate openfdd_agent_spec ownership.yaml + required cookbook paths.
+"""Validate openfdd_agent_spec ownership.yaml + required cookbook paths + README invariants.
 
-Lightweight Milestone A Phase 0 CI smoke — does not replace cookbook_parity_check.
+Lightweight Milestone A/C0 CI smoke — does not replace cookbook_parity_check.
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ except ImportError:  # pragma: no cover
 
 ROOT = Path(__file__).resolve().parents[1]
 OWNERSHIP = ROOT / "openfdd_agent_spec" / "ownership.yaml"
+README = ROOT / "README.md"
 COOKBOOK = ROOT / "docs" / "rules" / "cookbook"
 REQUIRED_COOKBOOKS = (
     "datafusion-sql-cookbook.md",
@@ -23,16 +24,56 @@ REQUIRED_COOKBOOKS = (
     "parity-matrix.md",
 )
 
+# README navigation / product wording invariants (C0).
+README_REQUIRED_MARKERS = (
+    "FDD Rule Cookbook",
+    "pypi.org/project/open-fdd",
+    "Apache DataFusion",
+    "Apache Arrow",
+    "datafusion-sql-cookbook",
+    "pandas-cookbook",
+    "img.shields.io/badge/Docs-online",
+    "FDD%20Rule%20Cookbook",
+    "img.shields.io/pypi/v/open-fdd",
+    "Quick%20Start-GHCR%20stack",
+    "Apache%20Arrow-columnar%20data",
+    "DataFusion-SQL%20engine",
+)
+
+
+def _check_readme(errors: list[str]) -> None:
+    if not README.is_file():
+        errors.append("missing README.md")
+        return
+    text = README.read_text(encoding="utf-8")
+    for marker in README_REQUIRED_MARKERS:
+        if marker not in text:
+            errors.append(f"README.md missing required marker: {marker!r}")
+    # Forbidden production-UI claims
+    if "Vite :5173" in text or "Vite/Caddy SPA" in text and "not a Vite" not in text:
+        # Allow explicit negation ("not a Vite/Caddy SPA") but not the old develop hint.
+        if "Vite :5173" in text:
+            errors.append("README.md must not claim Vite :5173 as the UI develop path")
+    if "59" not in text or "63" not in text:
+        errors.append(
+            "README.md must state both public cookbook 59 and SQL registry 63 (count contract)"
+        )
+    if "Streamlit" not in text:
+        errors.append("README.md must identify Streamlit as the operator UI")
+    if "GHCR" not in text and "ghcr.io" not in text:
+        errors.append("README.md must mention GHCR stack for production DataFusion FDD")
+
 
 def main() -> int:
     errors: list[str] = []
     if not OWNERSHIP.is_file():
         errors.append(f"missing {OWNERSHIP.relative_to(ROOT)}")
     elif yaml is None:
-        # stdlib-only fallback: require non-empty YAML-looking file
         text = OWNERSHIP.read_text(encoding="utf-8")
         if "schema_version:" not in text or "components:" not in text:
             errors.append("ownership.yaml missing required keys (install PyYAML for full parse)")
+        if "protected_docs:" not in text:
+            errors.append("ownership.yaml missing protected_docs (install PyYAML for full parse)")
     else:
         data = yaml.safe_load(OWNERSHIP.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
@@ -59,12 +100,34 @@ def main() -> int:
                 elif future is not None:
                     errors.append("future_concepts must be a mapping with paths + policy")
 
+            protected = data.get("protected_docs")
+            if not isinstance(protected, dict):
+                errors.append("protected_docs must be a mapping")
+            else:
+                for key in (
+                    "root_readme_navigation",
+                    "pandas_cookbook",
+                    "sql_cookbook",
+                    "parity_matrix",
+                ):
+                    if key not in protected:
+                        errors.append(f"protected_docs missing {key}")
+                nav = protected.get("root_readme_navigation") or {}
+                if isinstance(nav, dict):
+                    markers = nav.get("required_markers") or []
+                    if not isinstance(markers, list) or len(markers) < 4:
+                        errors.append(
+                            "protected_docs.root_readme_navigation.required_markers incomplete"
+                        )
+
     for name in REQUIRED_COOKBOOKS:
         path = COOKBOOK / name
         if not path.is_file():
             errors.append(f"missing cookbook {path.relative_to(ROOT)}")
         elif path.stat().st_size < 200:
             errors.append(f"cookbook suspiciously small: {path.relative_to(ROOT)}")
+
+    _check_readme(errors)
 
     if errors:
         print("architecture_ownership_check FAILED:", file=sys.stderr)


### PR DESCRIPTION
## Summary
- PyPI badge in centered README navigation block
- Develop path documents Streamlit (not Vite)
- Honest 59 cookbook / 63 SQL registry count contract
- `protected_docs` in ownership.yaml + README marker checks in architecture_ownership_check

## Test plan
- [x] `python3 scripts/architecture_ownership_check.py`
- [ ] cookbook-parity CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a PyPI badge and clarified cookbook and SQL registry counts in the README.
  * Updated development guidance to accurately describe the Streamlit operator UI and central API workflow.
  * Added links and navigation for cookbook documentation and the parity matrix.

* **Chores**
  * Added safeguards to preserve required documentation and validate key README content during project checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->