### PR TITLE
feat(analytics): C1–C2 central runtime + economizer APIs and UI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -85,7 +85,7 @@ jobs:
           grep -q "Jobs (persistent)" services/ui/app/ui_jobs.py
           ! test -d workspace/dashboard/src
           ! test -f workspace/dashboard/package.json
-          pip install -q pytest requests pandas
+          pip install -q pytest requests pandas pyyaml
           (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py app/test_job_store.py app/test_jobs_central_client.py app/test_ui_analytics.py -q)
       - name: BACnet NIC helper guards
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -85,8 +85,8 @@ jobs:
           grep -q "Jobs (persistent)" services/ui/app/ui_jobs.py
           ! test -d workspace/dashboard/src
           ! test -f workspace/dashboard/package.json
-          pip install -q pytest requests
-          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py app/test_job_store.py app/test_jobs_central_client.py -q)
+          pip install -q pytest requests pandas
+          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py app/test_job_store.py app/test_jobs_central_client.py app/test_ui_analytics.py -q)
       - name: BACnet NIC helper guards
         run: |
           test -x scripts/openfdd_bacnet_nic_setup.sh

--- a/docs/architecture/PANDAS_USAGE_INVENTORY.md
+++ b/docs/architecture/PANDAS_USAGE_INVENTORY.md
@@ -29,8 +29,8 @@ product Streamlit UI so agents do not confuse lab/oracle paths with production.
 |------|---------|--------------|-------|--------|--------|
 |services/ui/app/agent_api.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
 |services/ui/app/agent_prerun.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|services/ui/app/analytics.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|services/ui/app/analytics_baseline.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
+|services/ui/app/analytics.py|oracle/analytics helpers (lab path); production callers → central `/api/analytics/*`|services/ui Streamlit|MIGRATE_TO_DATAFUSION|temporary_ok|central-analytics-v1 APIs now; DataFusion SQL follow-up per family|
+|services/ui/app/analytics_baseline.py|oracle/analytics helpers (lab path); production callers → central `/api/analytics/*`|services/ui Streamlit|MIGRATE_TO_DATAFUSION|temporary_ok|central-analytics-v1 APIs now; DataFusion SQL follow-up per family|
 |services/ui/app/cache.py|UI/lab pandas usage|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
 |services/ui/app/charts.py|Streamlit plots / UI tables|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|approved|keep display; FDD exec via central SQL|
 |services/ui/app/column_map_json.py|CSV/package/WattLab I/O|services/ui Streamlit (not central FDD)|PACKAGE_IO|approved|keep|
@@ -40,12 +40,12 @@ product Streamlit UI so agents do not confuse lab/oracle paths with production.
 |services/ui/app/daytypes.py|UI/lab pandas usage|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
 |services/ui/app/docx_report.py|report rendering|services/ui Streamlit (not central FDD)|REPORT_RENDERING|approved|open_fdd.reporting where shared|
 |services/ui/app/load_satisfaction.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|services/ui/app/metering.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
+|services/ui/app/metering.py|oracle/analytics helpers (lab path); production → `/api/analytics/metering`|services/ui Streamlit|MIGRATE_TO_DATAFUSION|temporary_ok|central metering stub live; DF SQL follow-up|
 |services/ui/app/model_seed.py|UI/lab pandas usage|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
 |services/ui/app/occupancy.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
 |services/ui/app/open_meteo.py|UI/lab pandas usage|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
 |services/ui/app/package_io.py|CSV/package/WattLab I/O|services/ui Streamlit (not central FDD)|PACKAGE_IO|approved|keep|
-|services/ui/app/rcx_plots.py|Streamlit plots / UI tables|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|approved|keep display; FDD exec via central SQL|
+|services/ui/app/rcx_plots.py|Streamlit plots; production series → `/api/analytics/rcx/*`|services/ui Streamlit|MIGRATE_TO_DATAFUSION|temporary_ok|display stays; compute via central analytics|
 |services/ui/app/reports.py|report rendering|services/ui Streamlit (not central FDD)|REPORT_RENDERING|approved|open_fdd.reporting where shared|
 |services/ui/app/role_map.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
 |services/ui/app/role_map_gap.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
@@ -64,12 +64,12 @@ product Streamlit UI so agents do not confuse lab/oracle paths with production.
 |services/ui/app/rules/runner.py|pandas oracle / custom rule surface|services/ui Streamlit (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
 |services/ui/app/rules/sensor_rate.py|pandas oracle / custom rule surface|services/ui Streamlit (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
 |services/ui/app/rules/sensor_rate_profiles.py|pandas oracle / custom rule surface|services/ui Streamlit (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|services/ui/app/runtime_intervals.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
+|services/ui/app/runtime_intervals.py|oracle/analytics helpers; production → `/api/analytics/runtime`|services/ui Streamlit|MIGRATE_TO_DATAFUSION|temporary_ok|central runtime Δt compute live; keep oracle for vibe19 parity|
 |services/ui/app/source_profile.py|CSV/package/WattLab I/O|services/ui Streamlit (not central FDD)|PACKAGE_IO|approved|keep|
 |services/ui/app/sql_sources.py|SQL/DataFusion bridge helpers using pandas frames|services/ui Streamlit (not central FDD)|MIGRATE_TO_DATAFUSION|temporary_ok|central DataFusion-first APIs|
 |services/ui/app/topology_enrich.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
 |services/ui/app/tuning_report.py|report rendering|services/ui Streamlit (not central FDD)|REPORT_RENDERING|approved|open_fdd.reporting where shared|
-|services/ui/app/ui_rcx_tab.py|Streamlit plots / UI tables|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|approved|keep display; FDD exec via central SQL|
+|services/ui/app/ui_rcx_tab.py|Streamlit plots; production analytics → `/api/analytics/*`|services/ui Streamlit|MIGRATE_TO_DATAFUSION|temporary_ok|cut over to central envelopes; keep display/Plotly in UI|
 |services/ui/app/unit_system.py|UI/lab pandas usage|services/ui Streamlit (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
 |services/ui/app/wattlab_dump.py|CSV/package/WattLab I/O|services/ui Streamlit (not central FDD)|PACKAGE_IO|approved|keep|
 |services/ui/app/weather_psychrometrics.py|oracle/analytics helpers (lab path)|services/ui Streamlit (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
@@ -91,5 +91,6 @@ runners are **oracle / lab** paths only.
 ## Related
 
 - [Analytics boundary](analytics-boundary.md)
+- [Milestone C analytics matrix](../migration/MILESTONE_C_ANALYTICS_MATRIX.md)
 - [Milestone A closeout](../migration/MILESTONE_A_CLOSEOUT.md)
 - [openfdd_agent_spec ARCHITECTURE](../../openfdd_agent_spec/ARCHITECTURE.md)

--- a/docs/architecture/analytics-boundary.md
+++ b/docs/architecture/analytics-boundary.md
@@ -24,6 +24,9 @@ Each domain: typed inputs, params, SQL, Arrow schema, null/unit rules, tests.
 ## Today
 
 - FDD: `crates/fdd_sql` + `fdd_rules` (production)
-- RCx / analytics: still largely `services/ui/app/analytics.py` + `rcx_plots.py` (pandas) — migrate per audit inventory
+- Analytics APIs: `services/central/src/analytics/` + `POST /api/analytics/{runtime,sensor-health,schedule,mechanical-cooling,economizer,rcx/ahu,rcx/vav,metering}`
+  - Engine: `central-analytics-v1` (pure Rust; DataFusion SQL wiring next — see [MILESTONE_C_ANALYTICS_MATRIX](../migration/MILESTONE_C_ANALYTICS_MATRIX.md))
+  - Runtime + economizer: live compute from inline samples/series; other families schema stubs
+- RCx / Overview UI: still largely pandas via `services/ui/app/analytics.py` + `rcx_plots.py` — migrate per matrix
 
 No arbitrary operator SQL editor. Integrator SQL lab (if any) is separate and gated.

--- a/docs/benchmarks/MILESTONE_C_ANALYTICS.md
+++ b/docs/benchmarks/MILESTONE_C_ANALYTICS.md
@@ -1,0 +1,47 @@
+---
+title: Milestone C analytics benchmarks
+parent: Benchmarks
+nav_order: 30
+---
+
+# Milestone C analytics benchmarks
+
+**Date:** 2026-07-28 · Engine `central-analytics-v1` (pure Rust; DataFusion MemTable follow-up)
+
+Placeholder structure for family wall-time / memory notes. Fill measured rows when
+historian-backed loads and larger fixtures land. Unit tests today are micro-scale
+inline fixtures only.
+
+## Placeholder results table
+
+| Family | Fixture scale | Rows / points | Wall time (ms) | Peak RSS (MB) | Engine | Notes |
+|--------|---------------|---------------|----------------|---------------|--------|-------|
+| Runtime | unit (13 pts / eq) | ~13 | _TBD_ | _TBD_ | `central-analytics-v1` | Δt integration + gap clip; see `runtime.rs` tests |
+| Sensor health | unit (≤8 pts / series) | ~8 | _TBD_ | _TBD_ | `central-analytics-v1` | coverage / flatline / stats |
+| Schedule | unit (2–3 mask pts) | ~3 | _TBD_ | _TBD_ | `central-analytics-v1` | occupied + after-hours fan hours |
+| Mechanical cooling | unit (1–2 evidence rows) | ~2 | _TBD_ | _TBD_ | `central-analytics-v1` | evidence hierarchy gate only |
+| Economizer | unit (1–N points) | ~1–N | _TBD_ | _TBD_ | `central-analytics-v1` | fan-on, ΔT gate, OA frac, MAT resid |
+| RCx AHU | unit (coverage stub) | ~2 | _TBD_ | _TBD_ | `central-analytics-v1` | sat_sp / duct_static_sp coverage |
+| RCx VAV | unit (comfort rank) | ~3 | _TBD_ | _TBD_ | `central-analytics-v1` | zone_temp vs setpoint |
+| Metering | unit (3 monthly rows) | ~3 | _TBD_ | _TBD_ | `central-analytics-v1` | monthly kWh sum |
+
+## Local microbench notes (from unit tests)
+
+Commands (from repo root):
+
+```bash
+cargo test -p openfdd-central analytics -- --nocapture
+```
+
+Observed locally on this branch (developer workstation; not CI gate):
+
+| Check | Observation |
+|-------|-------------|
+| `analytics::` unit suite | Completes in well under 1s wall on a warm build; no separate criterion harness yet |
+| Runtime 1 h @ 5 min | Exact `run_hours == 1.0` (12 × 300 s) |
+| Sensor flatline | `std == 0` with `n > 5` → `flatline_flag` |
+| Mech cooling | Pump-only rejected; compressor/chiller accepted |
+| Economizer 50% mix | OA fraction 50%, MAT residual ~0 with matched damper |
+
+**Follow-up:** add small/medium/(large) Feather fixtures, measure wall + RSS, and
+compare to pandas oracle tolerances once DF SQL MemTable paths exist.

--- a/docs/migration/MILESTONE_C_ACCEPTANCE.md
+++ b/docs/migration/MILESTONE_C_ACCEPTANCE.md
@@ -1,0 +1,57 @@
+---
+title: Milestone C acceptance
+parent: Migration
+nav_order: 24
+---
+
+# Milestone C acceptance
+
+**Date:** 2026-07-28 · Branch `milestone-c/c1-c2-analytics-runtime`
+
+Honest acceptance for the C1–C2 analytics runtime slice. Full Milestone C
+(pandas retirement + DF MemTable + `sha-*` stack) remains open.
+
+## Automated evidence
+
+| Check | Command / evidence | Result |
+|-------|-------------------|--------|
+| C0 B adversarial | [`MILESTONE_B_ADVERSARIAL_VERIFICATION.md`](MILESTONE_B_ADVERSARIAL_VERIFICATION.md) | Done |
+| Analytics unit tests | `cargo test -p openfdd-central analytics` | Required green on this branch |
+| Clippy | `cargo clippy -p openfdd-central -- -D warnings` | Required clean |
+| Engine label | Envelope `engine` == `central-analytics-v1` | Contract |
+| Runtime compute | Δt integration tests in `runtime.rs` | Live |
+| Economizer compute | Mixing / fan-off / ΔT tests in `economizer.rs` | Live |
+| Sensor / schedule / mech / rcx / metering | Minimal compute + unit tests | Live (minimal) |
+| DF SQL MemTable | — | **Follow-up** |
+| Rule parity residual | [`MILESTONE_C_RULE_PARITY.md`](MILESTONE_C_RULE_PARITY.md) | Doc + fixtures; full harness residual |
+| Full-stack `sha-*` | Operator / GHCR after merge | **Not claimed** on this branch tip alone |
+
+## Family acceptance snapshot
+
+| Family | `query_version` | Acceptance bar on this branch |
+|--------|-----------------|-------------------------------|
+| Runtime | `runtime-v1` | Inline samples → equipment run_hours |
+| Economizer | `economizer-diagnostics-v1` | Inline points → metrics/points/skipped |
+| Sensor health | `sensor-health-v1` | Inline points → coverage/flatline/stats |
+| Schedule | `schedule-v1` | Occupied mask → hours; fan → after-hours |
+| Mechanical cooling | `mechanical-cooling-v1` | Pump-only reject; compressor accept |
+| RCx AHU | `rcx-ahu-v1` | sat_sp / duct_static_sp coverage fields |
+| RCx VAV | `rcx-vav-v1` | Comfort ranking from zone_temp vs SP |
+| Metering | `metering-v1` | Monthly sum of `{period, kwh}` |
+
+## Manual / stack (deferred)
+
+1. Publish GHCR `sha-<tip>` for central + UI after merge.
+2. Smoke Overview runtime cards + RCx economizer against central.
+3. Confirm no silent pandas fallback when central is down (visible error).
+
+| Field | Value |
+|-------|-------|
+| Branch | `milestone-c/c1-c2-analytics-runtime` |
+| Engine | `central-analytics-v1` |
+| Notes | C0 done; C1–C2 runtime+economizer live; other families minimal compute |
+
+## GitHub Actions
+
+Rust Stack CI, Streamlit UI, Cookbook parity, Docs, AppSec must stay green on
+the PR that lands this branch.

--- a/docs/migration/MILESTONE_C_ANALYTICS_MATRIX.md
+++ b/docs/migration/MILESTONE_C_ANALYTICS_MATRIX.md
@@ -1,0 +1,56 @@
+---
+title: Milestone C analytics matrix
+parent: Migration
+nav_order: 22
+---
+
+# Milestone C analytics matrix
+
+**Date:** 2026-07-28 · Branch `milestone-c/c1-c2-analytics-runtime`
+
+Production analytics move family-by-family into central typed APIs under
+`/api/analytics/*`. Responses use `AnalyticsEnvelope` (no Plotly JSON).
+Oracle pandas paths in `open_fdd.analytics` / Vibe 19 remain for parity.
+
+## Engine honesty
+
+| Field | Value |
+|-------|-------|
+| Current `engine` | `central-analytics-v1` |
+| Meaning | Pure Rust algorithms in `services/central/src/analytics/` (Arrow-ready) |
+| Follow-up | Wire DataFusion SQL / MemTable per family; bump engine label only when SQL path is live |
+
+Do **not** label envelopes `engine: datafusion` until a family actually executes via DataFusion.
+
+## Families
+
+| Family | Source (pandas oracle) | Central API | `query_version` | Impl status | Fixture / parity | UI cutover | Retirement |
+|--------|------------------------|-------------|-----------------|-------------|------------------|------------|------------|
+| Runtime | `open_fdd.analytics.runtime_intervals` + motor rollups | `POST /api/analytics/runtime` | `runtime-v1` | **Compute live** (Δt integration + gap clip; inline `samples`) | Unit tests in `runtime.rs` | Pending Overview cards | After Streamlit typed client |
+| Sensor health | `sensor_health_matrix` | `POST /api/analytics/sensor-health` | `sensor-health-v1` | Schema stub | Pending | Pending | — |
+| Schedule / comfort | occupancy helpers | `POST /api/analytics/schedule` | `schedule-v1` | Schema stub | Pending | Pending | — |
+| Mechanical cooling | `mech_cooling_*` | `POST /api/analytics/mechanical-cooling` | `mechanical-cooling-v1` | Schema stub (evidence hierarchy TBD) | Pending | Pending | — |
+| Economizer diagnostics | `economizer_free_cooling_diagnostics` | `POST /api/analytics/economizer` | `economizer-diagnostics-v1` | **Compute live** (fan-on, ΔT gate, OA frac, MAT resid; inline `series`) | Unit tests in `economizer.rs` | Pending RCx/AHU + Overview link | After cutover |
+| RCx AHU | `rcx_plots` AHU presets | `POST /api/analytics/rcx/ahu` | `rcx-ahu-v1` | Schema stub | Pending | Pending | — |
+| RCx VAV | zone comfort / VAV presets | `POST /api/analytics/rcx/vav` | `rcx-vav-v1` | Schema stub | Pending | Pending | — |
+| Metering | `app/metering.py` | `POST /api/analytics/metering` | `metering-v1` | Schema stub | Pending | Pending | — |
+
+## Envelope fields
+
+`schema_version`, `query_version`, `job_id`, `run_id`, `input_fingerprint`,
+`generated_at`, `engine`, `coverage`, `warnings`, `rows`, `equipment`,
+`points`, `skipped`.
+
+## Request body
+
+`AnalyticsRequest`: query fields (`job_id`, `run_id`, `equipment_ids`, `start`,
+`end`, `max_points`, `query_version`) plus optional inline `samples` (runtime)
+or `series` (economizer / later families). Optional `max_gap_seconds`, `dt_min_f`.
+
+Historian / job Feather load is the next wiring step after these contracts.
+
+## Related
+
+- [Pandas usage inventory](../architecture/PANDAS_USAGE_INVENTORY.md)
+- [Analytics boundary](../architecture/analytics-boundary.md)
+- [DataFusion-first](../architecture/datafusion-first.md)

--- a/docs/migration/MILESTONE_C_ANALYTICS_MATRIX.md
+++ b/docs/migration/MILESTONE_C_ANALYTICS_MATRIX.md
@@ -26,14 +26,14 @@ Do **not** label envelopes `engine: datafusion` until a family actually executes
 
 | Family | Source (pandas oracle) | Central API | `query_version` | Impl status | Fixture / parity | UI cutover | Retirement |
 |--------|------------------------|-------------|-----------------|-------------|------------------|------------|------------|
-| Runtime | `open_fdd.analytics.runtime_intervals` + motor rollups | `POST /api/analytics/runtime` | `runtime-v1` | **Compute live** (Δt integration + gap clip; inline `samples`) | Unit tests in `runtime.rs` | Pending Overview cards | After Streamlit typed client |
-| Sensor health | `sensor_health_matrix` | `POST /api/analytics/sensor-health` | `sensor-health-v1` | Schema stub | Pending | Pending | — |
-| Schedule / comfort | occupancy helpers | `POST /api/analytics/schedule` | `schedule-v1` | Schema stub | Pending | Pending | — |
-| Mechanical cooling | `mech_cooling_*` | `POST /api/analytics/mechanical-cooling` | `mechanical-cooling-v1` | Schema stub (evidence hierarchy TBD) | Pending | Pending | — |
-| Economizer diagnostics | `economizer_free_cooling_diagnostics` | `POST /api/analytics/economizer` | `economizer-diagnostics-v1` | **Compute live** (fan-on, ΔT gate, OA frac, MAT resid; inline `series`) | Unit tests in `economizer.rs` | Pending RCx/AHU + Overview link | After cutover |
-| RCx AHU | `rcx_plots` AHU presets | `POST /api/analytics/rcx/ahu` | `rcx-ahu-v1` | Schema stub | Pending | Pending | — |
-| RCx VAV | zone comfort / VAV presets | `POST /api/analytics/rcx/vav` | `rcx-vav-v1` | Schema stub | Pending | Pending | — |
-| Metering | `app/metering.py` | `POST /api/analytics/metering` | `metering-v1` | Schema stub | Pending | Pending | — |
+| Runtime | `open_fdd.analytics.runtime_intervals` + motor rollups | `POST /api/analytics/runtime` | `runtime-v1` | **Compute live** (Δt integration + gap clip; inline `samples`) | Unit tests in `runtime.rs` | Partial Streamlit wire | After full Overview cutover |
+| Sensor health | `sensor_health_matrix` | `POST /api/analytics/sensor-health` | `sensor-health-v1` | **Minimal compute** (coverage, flatline, missingness, min/max/mean) | Unit tests in `sensor_health.rs` | Pending | — |
+| Schedule / comfort | occupancy helpers | `POST /api/analytics/schedule` | `schedule-v1` | **Minimal compute** (occupied hours + after-hours fan hours) | Unit tests in `schedule.rs` | Pending | — |
+| Mechanical cooling | `mech_cooling_*` | `POST /api/analytics/mechanical-cooling` | `mechanical-cooling-v1` | **Minimal compute** (evidence hierarchy; pump/valve ≠ compressor) | Unit tests in `mechanical_cooling.rs` | Pending | — |
+| Economizer diagnostics | `economizer_free_cooling_diagnostics` | `POST /api/analytics/economizer` | `economizer-diagnostics-v1` | **Compute live** (fan-on, ΔT gate, OA frac, MAT resid; inline `series`) | Unit tests in `economizer.rs` | Partial Streamlit wire | After cutover |
+| RCx AHU | `rcx_plots` AHU presets | `POST /api/analytics/rcx/ahu` | `rcx-ahu-v1` | **Minimal compute** (sat_sp / duct_static_sp coverage stub) | Unit tests in `rcx.rs` | Pending | — |
+| RCx VAV | zone comfort / VAV presets | `POST /api/analytics/rcx/vav` | `rcx-vav-v1` | **Minimal compute** (zone_temp vs setpoint ranking) | Unit tests in `rcx.rs` | Pending | — |
+| Metering | `app/metering.py` | `POST /api/analytics/metering` | `metering-v1` | **Minimal compute** (monthly kWh sum) | Unit tests in `metering.rs` | Pending | — |
 
 ## Envelope fields
 
@@ -47,7 +47,12 @@ Do **not** label envelopes `engine: datafusion` until a family actually executes
 `end`, `max_points`, `query_version`) plus optional inline `samples` (runtime)
 or `series` (economizer / later families). Optional `max_gap_seconds`, `dt_min_f`.
 
-Historian / job Feather load is the next wiring step after these contracts.
+Historian / job Feather load and DataFusion SQL MemTable are the next wiring
+steps after these contracts. Closeout / acceptance:
+[`MILESTONE_C_CLOSEOUT.md`](MILESTONE_C_CLOSEOUT.md),
+[`MILESTONE_C_ACCEPTANCE.md`](MILESTONE_C_ACCEPTANCE.md).
+Rule parity: [`MILESTONE_C_RULE_PARITY.md`](MILESTONE_C_RULE_PARITY.md).
+Benchmarks: [`../benchmarks/MILESTONE_C_ANALYTICS.md`](../benchmarks/MILESTONE_C_ANALYTICS.md).
 
 ## Related
 

--- a/docs/migration/MILESTONE_C_CLOSEOUT.md
+++ b/docs/migration/MILESTONE_C_CLOSEOUT.md
@@ -1,0 +1,59 @@
+---
+title: Milestone C closeout
+parent: Migration
+nav_order: 23
+---
+
+# Milestone C closeout
+
+**Date:** 2026-07-28 · Branch `milestone-c/c1-c2-analytics-runtime`
+
+## Executive summary
+
+Milestone C introduces typed central `/api/analytics/*` envelopes and family
+compute under engine label **`central-analytics-v1`**. C0 (B adversarial + README
+invariants) is done. C1–C2 deliver **live** runtime and economizer diagnostics;
+remaining families have **minimal real compute** (not empty schema stubs), with
+honest warnings that DataFusion SQL / MemTable historian loads and full UI
+cutover are follow-ups.
+
+This is a **partial** Milestone C closeout for the C1–C2 runtime branch — not
+full pandas retirement or `sha-*` full-stack acceptance.
+
+## What is live
+
+| Area | Status |
+|------|--------|
+| C0 adversarial B verification + README/cookbook honesty | **Done** |
+| Analytics envelope + query_version contracts | **Done** |
+| `POST /api/analytics/runtime` — Δt run hours + gap clip | **Live** |
+| `POST /api/analytics/economizer` — fan-on, ΔT gate, OA frac, MAT resid | **Live** |
+| Streamlit typed client for runtime + economizer | **Wired** (central preferred) |
+| Sensor health — coverage / flatline / missingness / min-max-mean | **Minimal compute** |
+| Schedule — occupied hours + optional after-hours fan hours | **Minimal compute** |
+| Mechanical cooling — evidence hierarchy (pump/valve ≠ compressor) | **Minimal compute** |
+| RCx AHU — sat_sp / duct_static_sp coverage stub fields | **Minimal compute** |
+| RCx VAV — zone comfort ranking (zone_temp vs setpoint) | **Minimal compute** |
+| Metering — monthly kWh sum | **Minimal compute** |
+
+## Explicit follow-ups (not claimed done)
+
+- DataFusion SQL / MemTable per family; bump `engine` only when SQL path is live
+- Historian / job Feather load into analytics handlers
+- Full Streamlit cutover for sensor / schedule / mech / RCx / metering; Overview economizer compact link
+- Pandas production path retirement after cutover (oracle stays)
+- SQL rule parity residual beyond fixture notes / mutation checklist
+- Benchmark table fill for medium/large fixtures
+- Full-stack immutable `sha-*` acceptance
+
+## Engine honesty
+
+Responses use `engine: "central-analytics-v1"`. Do **not** advertise
+`engine: datafusion` until a family executes via DataFusion.
+
+## Related
+
+- [Analytics matrix](MILESTONE_C_ANALYTICS_MATRIX.md)
+- [Acceptance](MILESTONE_C_ACCEPTANCE.md)
+- [Rule parity](MILESTONE_C_RULE_PARITY.md)
+- [Benchmarks](../benchmarks/MILESTONE_C_ANALYTICS.md)

--- a/docs/migration/MILESTONE_C_RULE_PARITY.md
+++ b/docs/migration/MILESTONE_C_RULE_PARITY.md
@@ -1,0 +1,65 @@
+---
+title: Milestone C SQL rule parity
+parent: Migration
+nav_order: 25
+---
+
+# Milestone C SQL rule parity
+
+**Date:** 2026-07-28
+
+Tracks honest SQL ↔ Pandas cookbook parity states for Milestone C. Full mutation
+harness and family-by-family `PROVEN_MULTI_BUILDING` claims are **residuals**.
+
+## Canonical states
+
+| State | Meaning |
+|-------|---------|
+| `UNPORTED` | No SQL expression / not in registry path under test |
+| `SCHEMA_ONLY` | Contract or stub without behavioral parity |
+| `FIXTURE_PASS` | Passes obvious-fault / normal JSONL fixtures |
+| `PARITY_TOLERANCED` | Matches pandas within documented tolerances |
+| `PROVEN_SINGLE_BUILDING` | Validated on one real building export |
+| `PROVEN_MULTI_BUILDING` | Validated across multiple buildings (C10 goal) |
+
+Public cookbook vs registry counts must stay honest (see README / cookbooks);
+do not silently diverge badge vs `sql_rules/registry.yaml`.
+
+## Fixture library
+
+Synthetic `telemetry_pivot` JSONL under
+[`docs/rules/cookbook/fixtures/`](../rules/cookbook/fixtures/):
+
+| Fixture | Intent |
+|---------|--------|
+| `fc1_obvious_fault.jsonl` / `fc2_obvious_fault.jsonl` | AHU FC obvious faults |
+| `reset1_obvious_fault.jsonl` / `reset1_normal.jsonl` | Reset fault vs normal |
+| `sched1_obvious_fault.jsonl` / `sched247_obvious_fault.jsonl` | Schedule faults |
+| `vav1_obvious_fault.jsonl` / `vav6_obvious_fault.jsonl` / `vav7_obvious_fault.jsonl` | VAV faults |
+
+Run: `python3 scripts/cookbook_parity_check.py --all`
+
+See also [`fixtures/README.md`](../rules/cookbook/fixtures/README.md).
+
+## Mutation-check section (checklist — harness residual)
+
+High-risk families should get selective mutation checks before claiming parity.
+Until a harness lands, reviewers manually verify that tests **fail** if any of
+the following regressions are introduced:
+
+| Mutation | Expected failure signal |
+|----------|-------------------------|
+| Remove fan-on / occupancy gate | False positives on economizer / schedule / comfort |
+| Flip `>` / `<` on ΔT or comfort band | Inverted OA fraction or comfort ranking |
+| Duration = sample count (not Δt) | Runtime / occupied hours inflate with poll rate |
+| Treat pump or valve as compressor proof | Mechanical cooling eligibility becomes true on pump-only |
+| Drop `|OAT−RAT|` identifiability gate | OA fraction on non-identifiable samples |
+
+Central analytics already encodes the pump≠compressor gate in
+`mechanical_cooling.rs` unit tests and Δt runtime in `runtime.rs`.
+
+## Residual
+
+- Broader SQL rule fixture coverage per family
+- Automated mutation CI job
+- Honest per-rule state column in the parity matrix beyond docs-only notes

--- a/docs/rules/cookbook/fixtures/README.md
+++ b/docs/rules/cookbook/fixtures/README.md
@@ -3,3 +3,17 @@
 Synthetic `telemetry_pivot` JSONL for offline Pandas parity checks. Not published to GitHub Pages.
 
 Run: `python3 scripts/cookbook_parity_check.py --all`
+
+## Canonical files
+
+| File | Family intent |
+|------|---------------|
+| `fc1_obvious_fault.jsonl`, `fc2_obvious_fault.jsonl` | AHU FC obvious faults |
+| `reset1_obvious_fault.jsonl`, `reset1_normal.jsonl` | Reset fault vs normal |
+| `sched1_obvious_fault.jsonl`, `sched247_obvious_fault.jsonl` | Schedule faults |
+| `vav1_obvious_fault.jsonl`, `vav6_obvious_fault.jsonl`, `vav7_obvious_fault.jsonl` | VAV faults |
+
+## Milestone C parity states
+
+Honest SQL rule parity states and a mutation-check checklist (no full harness yet)
+live in [`docs/migration/MILESTONE_C_RULE_PARITY.md`](../../../migration/MILESTONE_C_RULE_PARITY.md).

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -71,3 +71,28 @@ Legend: `[x]` done · `[~]` partial / residual · `[ ]` remaining
 - [x] B7 — Streamlit Jobs on central API + stale banner
 - [x] B8 — WattLab handoff manifest (job-native)
 - [x] B9 — Acceptance doc + GHCR publish on merge
+
+---
+
+# Milestone C — DataFusion analytics cutover (2026-07-28)
+
+**Status:** **Partial** on branch `milestone-c/c1-c2-analytics-runtime`.
+Engine label: `central-analytics-v1` (DF SQL MemTable follow-up).
+Docs: [`MILESTONE_C_CLOSEOUT.md`](../docs/migration/MILESTONE_C_CLOSEOUT.md),
+[`MILESTONE_C_ACCEPTANCE.md`](../docs/migration/MILESTONE_C_ACCEPTANCE.md),
+[`MILESTONE_C_ANALYTICS_MATRIX.md`](../docs/migration/MILESTONE_C_ANALYTICS_MATRIX.md),
+[`MILESTONE_C_RULE_PARITY.md`](../docs/migration/MILESTONE_C_RULE_PARITY.md),
+[`MILESTONE_C_ANALYTICS.md`](../docs/benchmarks/MILESTONE_C_ANALYTICS.md).
+
+- [x] C0 — B adversarial verification + README / cookbook honesty
+- [x] C1 — Analytics envelope + `/api/analytics/*` contracts
+- [x] C2 — Runtime Δt compute + economizer diagnostics (live)
+- [~] C3 — Sensor health minimal compute (coverage / flatline / stats)
+- [~] C4 — Schedule occupied + after-hours fan hours (minimal)
+- [~] C5 — Mechanical cooling evidence hierarchy (minimal; OAT bins residual)
+- [~] C6 — Economizer live; RCx AHU coverage stub; full RCx UI residual
+- [~] C7 — VAV comfort ranking minimal; full VAV RCx residual
+- [ ] C8 — Plant evidence (chiller/boiler) — not started
+- [~] C9 — Metering monthly kWh sum (minimal)
+- [~] C10 — Rule parity fixture notes + mutation checklist (harness residual)
+- [ ] C11 — Retire production pandas paths; filled benchmarks; `sha-*` acceptance

--- a/services/central/src/analytics/economizer.rs
+++ b/services/central/src/analytics/economizer.rs
@@ -182,7 +182,7 @@ pub fn compute_economizer_diagnostics(
         } else {
             resid_vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             let mid = resid_vals.len() / 2;
-            let median = if resid_vals.len() % 2 == 0 {
+            let median = if resid_vals.len().is_multiple_of(2) {
                 (resid_vals[mid - 1] + resid_vals[mid]) / 2.0
             } else {
                 resid_vals[mid]

--- a/services/central/src/analytics/economizer.rs
+++ b/services/central/src/analytics/economizer.rs
@@ -1,0 +1,380 @@
+//! AHU free-cooling economizer diagnostics (Guideline 36–aligned mixing).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::{envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_ECONOMIZER};
+
+pub const DEFAULT_DT_MIN_F: f64 = 10.0;
+
+/// One mixed-air diagnostic sample.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EconomizerPointIn {
+    pub equipment_id: String,
+    #[serde(default)]
+    pub equipment_type: Option<String>,
+    pub timestamp: DateTime<Utc>,
+    pub oat_f: f64,
+    pub rat_f: f64,
+    pub mat_f: f64,
+    #[serde(default)]
+    pub sat_f: Option<f64>,
+    pub fan_on: bool,
+    /// OA damper feedback, percent 0–100 (optional).
+    #[serde(default)]
+    pub oa_damper_pct: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EconomizerPointOut {
+    pub timestamp: DateTime<Utc>,
+    pub equipment_id: String,
+    pub equipment_type: String,
+    pub oat_f: f64,
+    pub rat_f: f64,
+    pub mat_f: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sat_f: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub damper_fb_pct: Option<f64>,
+    pub fan_on: bool,
+    pub delta_or_f: f64,
+    pub delta_mr_f: f64,
+    pub identifiable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oa_frac_temp_pct: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mat_pred_f: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mat_resid_f: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EconomizerMetrics {
+    pub equipment_id: String,
+    pub equipment_type: String,
+    pub n_fan_on_samples: u64,
+    pub n_identifiable: u64,
+    pub has_damper: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub median_mat_resid_f: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mat_resid_mae_f: Option<f64>,
+    pub dt_min_f: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EconomizerSkipped {
+    pub equipment_id: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EconomizerResult {
+    pub metrics: Vec<EconomizerMetrics>,
+    pub points: Vec<EconomizerPointOut>,
+    pub skipped: Vec<EconomizerSkipped>,
+}
+
+/// Compute economizer diagnostics from inline points.
+///
+/// - Fan-on gate: only `fan_on == true` rows contribute points.
+/// - Equipment with no fan-on rows → skipped (`no_fan_on_rows`).
+/// - Identifiable when `|OAT−RAT| >= dt_min_f`.
+/// - OA fraction (%) = `100 * (MAT−RAT) / (OAT−RAT)` when identifiable.
+/// - MAT residual when damper present: `MAT − (RAT + damper_frac * (OAT−RAT))`.
+pub fn compute_economizer_diagnostics(
+    points: &[EconomizerPointIn],
+    dt_min_f: f64,
+    max_points_per_eq: usize,
+) -> EconomizerResult {
+    use std::collections::BTreeMap;
+
+    let mut by_eq: BTreeMap<String, Vec<&EconomizerPointIn>> = BTreeMap::new();
+    for p in points {
+        by_eq.entry(p.equipment_id.clone()).or_default().push(p);
+    }
+
+    let mut metrics = Vec::new();
+    let mut out_points = Vec::new();
+    let mut skipped = Vec::new();
+    let dt_min = dt_min_f.max(0.0);
+
+    for (eq_id, pts) in by_eq {
+        let fan_on_pts: Vec<_> = pts.iter().copied().filter(|p| p.fan_on).collect();
+        if fan_on_pts.is_empty() {
+            skipped.push(EconomizerSkipped {
+                equipment_id: eq_id,
+                reason: "no_fan_on_rows".into(),
+            });
+            continue;
+        }
+
+        let et = fan_on_pts
+            .first()
+            .and_then(|p| p.equipment_type.clone())
+            .unwrap_or_else(|| "AHU".into());
+        let has_damper = fan_on_pts.iter().any(|p| p.oa_damper_pct.is_some());
+
+        let mut eq_points = Vec::with_capacity(fan_on_pts.len());
+        let mut resid_vals: Vec<f64> = Vec::new();
+        let mut n_ident = 0_u64;
+
+        for p in &fan_on_pts {
+            let delta_or = p.oat_f - p.rat_f;
+            let delta_mr = p.mat_f - p.rat_f;
+            let identifiable = delta_or.abs() >= dt_min;
+            if identifiable {
+                n_ident += 1;
+            }
+
+            let oa_frac = if identifiable && delta_or.abs() > 1e-12 {
+                Some((100.0 * delta_mr / delta_or).clamp(-20.0, 120.0))
+            } else {
+                None
+            };
+
+            let (mat_pred, mat_resid) = match p.oa_damper_pct {
+                Some(damp) => {
+                    let pred = p.rat_f + (damp / 100.0) * delta_or;
+                    let resid = p.mat_f - pred;
+                    if identifiable {
+                        resid_vals.push(resid);
+                    }
+                    (Some(pred), Some(resid))
+                }
+                None => (None, None),
+            };
+
+            eq_points.push(EconomizerPointOut {
+                timestamp: p.timestamp,
+                equipment_id: eq_id.clone(),
+                equipment_type: et.clone(),
+                oat_f: p.oat_f,
+                rat_f: p.rat_f,
+                mat_f: p.mat_f,
+                sat_f: p.sat_f,
+                damper_fb_pct: p.oa_damper_pct,
+                fan_on: true,
+                delta_or_f: delta_or,
+                delta_mr_f: delta_mr,
+                identifiable,
+                oa_frac_temp_pct: oa_frac,
+                mat_pred_f: mat_pred,
+                mat_resid_f: mat_resid,
+            });
+        }
+
+        // Downsample if needed (stride).
+        if eq_points.len() > max_points_per_eq && max_points_per_eq > 0 {
+            let step = (eq_points.len() / max_points_per_eq).max(1);
+            eq_points = eq_points
+                .into_iter()
+                .enumerate()
+                .filter(|(i, _)| i % step == 0)
+                .map(|(_, p)| p)
+                .collect();
+        }
+
+        let (median_resid, mae_resid) = if resid_vals.is_empty() {
+            (None, None)
+        } else {
+            resid_vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let mid = resid_vals.len() / 2;
+            let median = if resid_vals.len() % 2 == 0 {
+                (resid_vals[mid - 1] + resid_vals[mid]) / 2.0
+            } else {
+                resid_vals[mid]
+            };
+            let mae = resid_vals.iter().map(|v| v.abs()).sum::<f64>() / resid_vals.len() as f64;
+            (Some(round2(median)), Some(round2(mae)))
+        };
+
+        metrics.push(EconomizerMetrics {
+            equipment_id: eq_id,
+            equipment_type: et,
+            n_fan_on_samples: fan_on_pts.len() as u64,
+            n_identifiable: n_ident,
+            has_damper,
+            median_mat_resid_f: median_resid,
+            mat_resid_mae_f: mae_resid,
+            dt_min_f: dt_min,
+        });
+        out_points.extend(eq_points);
+    }
+
+    EconomizerResult {
+        metrics,
+        points: out_points,
+        skipped,
+    }
+}
+
+pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_ECONOMIZER);
+    let dt_min = req.dt_min_f.unwrap_or(DEFAULT_DT_MIN_F);
+    let max_pts = req.query.max_points.unwrap_or(8000);
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    let points = parse_points(req);
+    match points {
+        Some(pts) if !pts.is_empty() => {
+            let mut filtered = pts;
+            if let Some(ids) = &req.query.equipment_ids {
+                if !ids.is_empty() {
+                    filtered.retain(|p| ids.contains(&p.equipment_id));
+                }
+            }
+            let result = compute_economizer_diagnostics(&filtered, dt_min, max_pts);
+            env.equipment = result
+                .metrics
+                .iter()
+                .map(|m| serde_json::to_value(m).unwrap_or(json!({})))
+                .collect();
+            env.points = result
+                .points
+                .iter()
+                .map(|p| serde_json::to_value(p).unwrap_or(json!({})))
+                .collect();
+            env.skipped = result
+                .skipped
+                .iter()
+                .map(|s| serde_json::to_value(s).unwrap_or(json!({})))
+                .collect();
+            env.coverage = Some(json!({
+                "equipment_count": env.equipment.len(),
+                "point_count": env.points.len(),
+                "skipped_count": env.skipped.len(),
+                "dt_min_f": dt_min,
+            }));
+        }
+        _ => {
+            warnings.push(
+                "no inline series/points provided; historian/job economizer load is next".into(),
+            );
+            env.warnings = warnings;
+        }
+    }
+    env
+}
+
+fn parse_points(req: &AnalyticsRequest) -> Option<Vec<EconomizerPointIn>> {
+    let series = req.series.as_ref()?;
+    // Accept `{ "points": [...] }` or a bare array.
+    let arr = if let Some(a) = series.as_array() {
+        a.clone()
+    } else if let Some(a) = series.get("points").and_then(|v| v.as_array()) {
+        a.clone()
+    } else {
+        return None;
+    };
+    let mut out = Vec::new();
+    for v in arr {
+        if let Ok(p) = serde_json::from_value::<EconomizerPointIn>(v) {
+            out.push(p);
+        }
+    }
+    Some(out)
+}
+
+fn round2(x: f64) -> f64 {
+    (x * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    #[test]
+    fn fifty_percent_mixing_oa_fraction() {
+        // OAT=40, RAT=70, MAT=55 → (55-70)/(40-70) = 0.5 → 50%
+        let pts = vec![EconomizerPointIn {
+            equipment_id: "AHU-1".into(),
+            equipment_type: Some("AHU".into()),
+            timestamp: ts(0),
+            oat_f: 40.0,
+            rat_f: 70.0,
+            mat_f: 55.0,
+            sat_f: None,
+            fan_on: true,
+            oa_damper_pct: Some(50.0),
+        }];
+        let result = compute_economizer_diagnostics(&pts, 10.0, 8000);
+        assert_eq!(result.skipped.len(), 0);
+        assert_eq!(result.points.len(), 1);
+        let p = &result.points[0];
+        assert!(p.identifiable);
+        let frac = p.oa_frac_temp_pct.unwrap();
+        assert!((frac - 50.0).abs() < 1e-6);
+        // Perfect damper match → residual ~0
+        assert!((p.mat_resid_f.unwrap()).abs() < 1e-9);
+        assert_eq!(result.metrics[0].n_identifiable, 1);
+        assert!(result.metrics[0].has_damper);
+    }
+
+    #[test]
+    fn fan_off_skips_equipment() {
+        let pts = vec![EconomizerPointIn {
+            equipment_id: "AHU-2".into(),
+            equipment_type: Some("AHU".into()),
+            timestamp: ts(0),
+            oat_f: 40.0,
+            rat_f: 70.0,
+            mat_f: 55.0,
+            sat_f: None,
+            fan_on: false,
+            oa_damper_pct: Some(50.0),
+        }];
+        let result = compute_economizer_diagnostics(&pts, 10.0, 8000);
+        assert!(result.points.is_empty());
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(result.skipped[0].reason, "no_fan_on_rows");
+    }
+
+    #[test]
+    fn small_delta_t_not_identifiable() {
+        let pts = vec![EconomizerPointIn {
+            equipment_id: "AHU-1".into(),
+            equipment_type: Some("AHU".into()),
+            timestamp: ts(0),
+            oat_f: 68.0,
+            rat_f: 70.0,
+            mat_f: 69.0,
+            sat_f: None,
+            fan_on: true,
+            oa_damper_pct: None,
+        }];
+        let result = compute_economizer_diagnostics(&pts, 10.0, 8000);
+        assert!(!result.points[0].identifiable);
+        assert!(result.points[0].oa_frac_temp_pct.is_none());
+        assert_eq!(result.metrics[0].n_identifiable, 0);
+    }
+
+    #[test]
+    fn handle_from_series_json() {
+        let req = AnalyticsRequest {
+            series: Some(json!({
+                "points": [{
+                    "equipment_id": "AHU-1",
+                    "timestamp": "2024-01-01T00:00:00Z",
+                    "oat_f": 40.0,
+                    "rat_f": 70.0,
+                    "mat_f": 55.0,
+                    "fan_on": true,
+                    "oa_damper_pct": 50.0
+                }]
+            })),
+            ..Default::default()
+        };
+        let env = handle(&req);
+        assert_eq!(env.query_version, QV_ECONOMIZER);
+        assert_eq!(env.points.len(), 1);
+        assert!(env.to_json().get("plotly").is_none());
+    }
+}

--- a/services/central/src/analytics/mechanical_cooling.rs
+++ b/services/central/src/analytics/mechanical_cooling.rs
@@ -1,33 +1,285 @@
-//! Mechanical cooling analytics — schema stub (full port in progress).
+//! Mechanical cooling eligibility — strict evidence hierarchy.
 //!
-//! Evidence hierarchy (pump/valve alone ≠ compressor) will be enforced in the
-//! DataFusion port — see MILESTONE_C_ANALYTICS_MATRIX.md.
+//! Pump or valve alone is **not** compressor proof. Compressor/chiller status
+//! (or equivalent) is required for eligible mechanical-cooling analytics.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::{
-    empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_MECHANICAL_COOLING,
+    envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_MECHANICAL_COOLING,
 };
+
+/// Evidence kinds recognized by the hierarchy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKind {
+    PumpStatus,
+    ValveCmd,
+    ValveFeedback,
+    CompressorStatus,
+    ChillerStatus,
+    /// Unknown / other — treated as insufficient alone.
+    #[serde(other)]
+    Other,
+}
+
+impl EvidenceKind {
+    pub fn is_sufficient_primary(self) -> bool {
+        matches!(self, Self::CompressorStatus | Self::ChillerStatus)
+    }
+
+    pub fn is_insufficient_alone(self) -> bool {
+        matches!(
+            self,
+            Self::PumpStatus | Self::ValveCmd | Self::ValveFeedback
+        )
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EvidenceRow {
+    pub equipment_id: String,
+    pub evidence_kind: EvidenceKind,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub present: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MechCoolingEligibility {
+    pub equipment_id: String,
+    pub eligible: bool,
+    pub confidence: String,
+    pub evidence_kinds: Vec<String>,
+    pub reason: String,
+}
+
+/// Evaluate eligibility per equipment from evidence rows.
+///
+/// Rules:
+/// - At least one `compressor_status` or `chiller_status` → eligible, confidence high
+///   (medium if only one primary sample and also pump/valve present as support).
+/// - Pump-only or valve-only (any combination of pump/valve without compressor/chiller)
+///   → not eligible, confidence none, reason insufficient_evidence.
+pub fn evaluate_evidence(rows: &[EvidenceRow]) -> Vec<MechCoolingEligibility> {
+    let mut by_eq: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut kinds_by_eq: BTreeMap<String, Vec<EvidenceKind>> = BTreeMap::new();
+
+    for r in rows {
+        let present = r.present.unwrap_or(true);
+        if !present {
+            continue;
+        }
+        let label = serde_json::to_value(r.evidence_kind)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_else(|| "other".into());
+        by_eq
+            .entry(r.equipment_id.clone())
+            .or_default()
+            .insert(label);
+        kinds_by_eq
+            .entry(r.equipment_id.clone())
+            .or_default()
+            .push(r.evidence_kind);
+    }
+
+    let mut out = Vec::with_capacity(by_eq.len());
+    for (equipment_id, labels) in by_eq {
+        let kinds = kinds_by_eq.get(&equipment_id).cloned().unwrap_or_default();
+        let has_primary = kinds.iter().any(|k| k.is_sufficient_primary());
+        let only_insufficient = !kinds.is_empty()
+            && kinds
+                .iter()
+                .all(|k| k.is_insufficient_alone() || matches!(k, EvidenceKind::Other))
+            && !has_primary
+            && kinds.iter().any(|k| k.is_insufficient_alone());
+
+        let evidence_kinds: Vec<String> = labels.into_iter().collect();
+
+        let (eligible, confidence, reason) = if has_primary {
+            let has_support = kinds.iter().any(|k| k.is_insufficient_alone());
+            let confidence = if has_support { "high" } else { "medium" };
+            (
+                true,
+                confidence.to_string(),
+                "primary_compressor_or_chiller_status".into(),
+            )
+        } else if only_insufficient || kinds.iter().all(|k| k.is_insufficient_alone()) {
+            (
+                false,
+                "none".into(),
+                "insufficient_evidence_pump_or_valve_only".into(),
+            )
+        } else {
+            (
+                false,
+                "none".into(),
+                "insufficient_evidence_no_primary_status".into(),
+            )
+        };
+
+        out.push(MechCoolingEligibility {
+            equipment_id,
+            eligible,
+            confidence,
+            evidence_kinds,
+            reason,
+        });
+    }
+    out
+}
 
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_MECHANICAL_COOLING);
-    let mut env = empty_stub(&qv, &req.query, "mechanical_cooling");
-    warnings.append(&mut env.warnings);
-    env.warnings = warnings;
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    let rows = parse_evidence(req);
+    match rows {
+        Some(evidence) if !evidence.is_empty() => {
+            let mut filtered = evidence;
+            if let Some(ids) = &req.query.equipment_ids {
+                if !ids.is_empty() {
+                    filtered.retain(|r| ids.contains(&r.equipment_id));
+                }
+            }
+            let results = evaluate_evidence(&filtered);
+            env.rows = results
+                .iter()
+                .map(|r| serde_json::to_value(r).unwrap_or(json!({})))
+                .collect();
+            env.equipment = env.rows.clone();
+            env.coverage = Some(json!({
+                "equipment_count": env.equipment.len(),
+                "evidence_row_count": filtered.len(),
+            }));
+            warnings.push(
+                "mechanical_cooling: evidence-hierarchy gate only (OAT bins / DF port next)".into(),
+            );
+            env.warnings = warnings;
+        }
+        _ => {
+            warnings.push(
+                "no inline evidence rows provided; historian/job mechanical-cooling load is next"
+                    .into(),
+            );
+            env.warnings = warnings;
+        }
+    }
     env
+}
+
+fn parse_evidence(req: &AnalyticsRequest) -> Option<Vec<EvidenceRow>> {
+    let series = req.series.as_ref()?;
+    let arr = if let Some(a) = series.as_array() {
+        a.clone()
+    } else if let Some(a) = series.get("evidence").and_then(|v| v.as_array()) {
+        a.clone()
+    } else if let Some(a) = series.get("points").and_then(|v| v.as_array()) {
+        a.clone()
+    } else {
+        return None;
+    };
+    let mut out = Vec::new();
+    for v in arr {
+        if let Ok(p) = serde_json::from_value::<EvidenceRow>(v) {
+            out.push(p);
+        }
+    }
+    Some(out)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analytics::AnalyticsQuery;
 
     #[test]
-    fn stub_returns_expected_query_version() {
-        let env = handle(&AnalyticsRequest {
-            query: AnalyticsQuery::default(),
+    fn pump_only_rejected() {
+        let rows = vec![EvidenceRow {
+            equipment_id: "CH-1".into(),
+            evidence_kind: EvidenceKind::PumpStatus,
+            role: Some("chw_pump".into()),
+            present: Some(true),
+        }];
+        let out = evaluate_evidence(&rows);
+        assert_eq!(out.len(), 1);
+        assert!(!out[0].eligible);
+        assert_eq!(out[0].confidence, "none");
+        assert!(out[0].reason.contains("pump_or_valve"));
+    }
+
+    #[test]
+    fn valve_only_rejected() {
+        let rows = vec![
+            EvidenceRow {
+                equipment_id: "AHU-1".into(),
+                evidence_kind: EvidenceKind::ValveCmd,
+                role: None,
+                present: Some(true),
+            },
+            EvidenceRow {
+                equipment_id: "AHU-1".into(),
+                evidence_kind: EvidenceKind::ValveFeedback,
+                role: None,
+                present: Some(true),
+            },
+        ];
+        let out = evaluate_evidence(&rows);
+        assert!(!out[0].eligible);
+        assert!(out[0].reason.contains("insufficient"));
+    }
+
+    #[test]
+    fn compressor_status_accepted() {
+        let rows = vec![EvidenceRow {
+            equipment_id: "CH-2".into(),
+            evidence_kind: EvidenceKind::CompressorStatus,
+            role: Some("comp_1".into()),
+            present: Some(true),
+        }];
+        let out = evaluate_evidence(&rows);
+        assert!(out[0].eligible);
+        assert!(out[0].confidence == "medium" || out[0].confidence == "high");
+        assert_eq!(out[0].reason, "primary_compressor_or_chiller_status");
+    }
+
+    #[test]
+    fn chiller_status_with_pump_support_high_confidence() {
+        let rows = vec![
+            EvidenceRow {
+                equipment_id: "CH-3".into(),
+                evidence_kind: EvidenceKind::ChillerStatus,
+                role: None,
+                present: Some(true),
+            },
+            EvidenceRow {
+                equipment_id: "CH-3".into(),
+                evidence_kind: EvidenceKind::PumpStatus,
+                role: None,
+                present: Some(true),
+            },
+        ];
+        let out = evaluate_evidence(&rows);
+        assert!(out[0].eligible);
+        assert_eq!(out[0].confidence, "high");
+    }
+
+    #[test]
+    fn handle_pump_only_via_series() {
+        let req = AnalyticsRequest {
+            series: Some(json!({
+                "evidence": [
+                    {"equipment_id": "CH-1", "evidence_kind": "pump_status", "present": true}
+                ]
+            })),
             ..Default::default()
-        });
+        };
+        let env = handle(&req);
         assert_eq!(env.query_version, QV_MECHANICAL_COOLING);
-        assert!(env.rows.is_empty());
-        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+        assert_eq!(env.rows.len(), 1);
+        assert_eq!(env.rows[0]["eligible"], false);
     }
 }

--- a/services/central/src/analytics/mechanical_cooling.rs
+++ b/services/central/src/analytics/mechanical_cooling.rs
@@ -10,7 +10,7 @@ use super::{
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_MECHANICAL_COOLING);
     let mut env = empty_stub(&qv, &req.query, "mechanical_cooling");
-    warnings.extend(env.warnings.drain(..));
+    warnings.append(&mut env.warnings);
     env.warnings = warnings;
     env
 }

--- a/services/central/src/analytics/mechanical_cooling.rs
+++ b/services/central/src/analytics/mechanical_cooling.rs
@@ -1,0 +1,33 @@
+//! Mechanical cooling analytics — schema stub (full port in progress).
+//!
+//! Evidence hierarchy (pump/valve alone ≠ compressor) will be enforced in the
+//! DataFusion port — see MILESTONE_C_ANALYTICS_MATRIX.md.
+
+use super::{
+    empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_MECHANICAL_COOLING,
+};
+
+pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_MECHANICAL_COOLING);
+    let mut env = empty_stub(&qv, &req.query, "mechanical_cooling");
+    warnings.extend(env.warnings.drain(..));
+    env.warnings = warnings;
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::AnalyticsQuery;
+
+    #[test]
+    fn stub_returns_expected_query_version() {
+        let env = handle(&AnalyticsRequest {
+            query: AnalyticsQuery::default(),
+            ..Default::default()
+        });
+        assert_eq!(env.query_version, QV_MECHANICAL_COOLING);
+        assert!(env.rows.is_empty());
+        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+    }
+}

--- a/services/central/src/analytics/metering.rs
+++ b/services/central/src/analytics/metering.rs
@@ -7,7 +7,7 @@ use super::{empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsReque
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_METERING);
     let mut env = empty_stub(&qv, &req.query, "metering");
-    warnings.extend(env.warnings.drain(..));
+    warnings.append(&mut env.warnings);
     env.warnings = warnings;
     env
 }

--- a/services/central/src/analytics/metering.rs
+++ b/services/central/src/analytics/metering.rs
@@ -1,0 +1,30 @@
+//! Metering aggregations — schema stub (full port in progress).
+//!
+//! No finance / EnergyPlus calibration in central.
+
+use super::{empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_METERING};
+
+pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_METERING);
+    let mut env = empty_stub(&qv, &req.query, "metering");
+    warnings.extend(env.warnings.drain(..));
+    env.warnings = warnings;
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::AnalyticsQuery;
+
+    #[test]
+    fn stub_returns_expected_query_version() {
+        let env = handle(&AnalyticsRequest {
+            query: AnalyticsQuery::default(),
+            ..Default::default()
+        });
+        assert_eq!(env.query_version, QV_METERING);
+        assert!(env.rows.is_empty());
+        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+    }
+}

--- a/services/central/src/analytics/metering.rs
+++ b/services/central/src/analytics/metering.rs
@@ -1,30 +1,158 @@
-//! Metering aggregations — schema stub (full port in progress).
-//!
-//! No finance / EnergyPlus calibration in central.
+//! Metering aggregations — monthly kWh sum (no finance / EnergyPlus).
 
-use super::{empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_METERING};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::BTreeMap;
+
+use super::{envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_METERING};
+
+/// One metering energy row: period label (e.g. `2024-01`) + kWh.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MeterRow {
+    /// Calendar period key, typically `YYYY-MM` or any stable monthly label.
+    pub period: String,
+    pub kwh: f64,
+    #[serde(default)]
+    pub meter_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MonthlySum {
+    pub period: String,
+    pub kwh: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meter_id: Option<String>,
+    pub n_rows: u64,
+}
+
+/// Sum kWh by (period, optional meter_id).
+pub fn monthly_sum(rows: &[MeterRow]) -> Vec<MonthlySum> {
+    let mut map: BTreeMap<(String, Option<String>), (f64, u64)> = BTreeMap::new();
+    for r in rows {
+        if !r.kwh.is_finite() {
+            continue;
+        }
+        let entry = map
+            .entry((r.period.clone(), r.meter_id.clone()))
+            .or_insert((0.0, 0));
+        entry.0 += r.kwh;
+        entry.1 += 1;
+    }
+    map.into_iter()
+        .map(|((period, meter_id), (kwh, n_rows))| MonthlySum {
+            period,
+            kwh: round4(kwh),
+            meter_id,
+            n_rows,
+        })
+        .collect()
+}
 
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_METERING);
-    let mut env = empty_stub(&qv, &req.query, "metering");
-    warnings.append(&mut env.warnings);
-    env.warnings = warnings;
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    let rows = parse_rows(req);
+    match rows {
+        Some(meter_rows) if !meter_rows.is_empty() => {
+            let sums = monthly_sum(&meter_rows);
+            env.rows = sums
+                .iter()
+                .map(|r| serde_json::to_value(r).unwrap_or(json!({})))
+                .collect();
+            env.coverage = Some(json!({
+                "period_count": env.rows.len(),
+                "input_row_count": meter_rows.len(),
+                "total_kwh": round4(sums.iter().map(|s| s.kwh).sum::<f64>()),
+            }));
+            warnings.push(
+                "metering: monthly kWh sum only (no finance / EnergyPlus calibration)".into(),
+            );
+            env.warnings = warnings;
+        }
+        _ => {
+            warnings.push(
+                "no inline {period,kwh} rows provided; historian/job metering load is next".into(),
+            );
+            env.warnings = warnings;
+        }
+    }
     env
+}
+
+fn parse_rows(req: &AnalyticsRequest) -> Option<Vec<MeterRow>> {
+    let series = req.series.as_ref()?;
+    let arr = if let Some(a) = series.as_array() {
+        a.clone()
+    } else if let Some(a) = series
+        .get("rows")
+        .or_else(|| series.get("points"))
+        .and_then(|v| v.as_array())
+    {
+        a.clone()
+    } else {
+        return None;
+    };
+    let mut out = Vec::new();
+    for v in arr {
+        if let Ok(p) = serde_json::from_value::<MeterRow>(v) {
+            out.push(p);
+        }
+    }
+    Some(out)
+}
+
+fn round4(x: f64) -> f64 {
+    (x * 10_000.0).round() / 10_000.0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analytics::AnalyticsQuery;
 
     #[test]
-    fn stub_returns_expected_query_version() {
-        let env = handle(&AnalyticsRequest {
-            query: AnalyticsQuery::default(),
+    fn monthly_sum_aggregates_periods() {
+        let rows = vec![
+            MeterRow {
+                period: "2024-01".into(),
+                kwh: 100.0,
+                meter_id: None,
+            },
+            MeterRow {
+                period: "2024-01".into(),
+                kwh: 50.5,
+                meter_id: None,
+            },
+            MeterRow {
+                period: "2024-02".into(),
+                kwh: 200.0,
+                meter_id: None,
+            },
+        ];
+        let sums = monthly_sum(&rows);
+        assert_eq!(sums.len(), 2);
+        assert_eq!(sums[0].period, "2024-01");
+        assert!((sums[0].kwh - 150.5).abs() < 1e-9);
+        assert_eq!(sums[0].n_rows, 2);
+        assert_eq!(sums[1].period, "2024-02");
+        assert!((sums[1].kwh - 200.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn handle_from_series() {
+        let req = AnalyticsRequest {
+            series: Some(json!({
+                "rows": [
+                    {"period": "2024-03", "kwh": 10.0},
+                    {"period": "2024-03", "kwh": 5.0}
+                ]
+            })),
             ..Default::default()
-        });
+        };
+        let env = handle(&req);
         assert_eq!(env.query_version, QV_METERING);
-        assert!(env.rows.is_empty());
-        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+        assert_eq!(env.rows.len(), 1);
+        assert_eq!(env.rows[0]["kwh"], 15.0);
+        assert_eq!(env.engine, super::super::ENGINE);
     }
 }

--- a/services/central/src/analytics/mod.rs
+++ b/services/central/src/analytics/mod.rs
@@ -123,17 +123,6 @@ pub fn envelope(
     }
 }
 
-/// Empty stub response with a “full port in progress” warning.
-pub fn empty_stub(query_version: &str, query: &AnalyticsQuery, family: &str) -> AnalyticsEnvelope {
-    envelope(
-        query_version,
-        query,
-        vec![format!(
-            "{family}: schema-complete stub — full DataFusion / historian port in progress"
-        )],
-    )
-}
-
 /// Reject unknown query_version with a stable warning (still returns envelope).
 pub fn version_mismatch_warning(expected: &str, got: Option<&str>) -> Option<String> {
     match got {
@@ -187,14 +176,14 @@ mod tests {
     }
 
     #[test]
-    fn empty_stub_warns() {
-        let env = empty_stub(
-            QV_SENSOR_HEALTH,
-            &AnalyticsQuery::default(),
-            "sensor_health",
-        );
+    fn missing_inline_data_warns_honestly() {
+        let env = sensor_health::handle(&AnalyticsRequest {
+            query: AnalyticsQuery::default(),
+            ..Default::default()
+        });
         assert!(env.equipment.is_empty());
-        assert!(env.warnings[0].contains("in progress"));
+        assert!(env.warnings.iter().any(|w| w.contains("no inline")));
+        assert_eq!(env.engine, ENGINE);
     }
 
     #[test]

--- a/services/central/src/analytics/mod.rs
+++ b/services/central/src/analytics/mod.rs
@@ -7,6 +7,7 @@
 pub mod economizer;
 pub mod mechanical_cooling;
 pub mod metering;
+pub mod plant;
 pub mod rcx;
 pub mod runtime;
 pub mod schedule;

--- a/services/central/src/analytics/mod.rs
+++ b/services/central/src/analytics/mod.rs
@@ -95,7 +95,7 @@ pub struct AnalyticsEnvelope {
 }
 
 impl AnalyticsEnvelope {
-    pub fn to_json(self) -> Value {
+    pub fn to_json(&self) -> Value {
         serde_json::to_value(self).unwrap_or_else(|_| json!({ "ok": false }))
     }
 }

--- a/services/central/src/analytics/mod.rs
+++ b/services/central/src/analytics/mod.rs
@@ -1,0 +1,206 @@
+//! Central analytics envelopes and family compute modules (Milestone C).
+//!
+//! Engine label is honestly `central-analytics-v1` (pure Rust / Arrow-ready
+//! algorithms). DataFusion SQL MemTable wiring is the documented follow-up in
+//! `docs/migration/MILESTONE_C_ANALYTICS_MATRIX.md`.
+
+pub mod economizer;
+pub mod mechanical_cooling;
+pub mod metering;
+pub mod rcx;
+pub mod runtime;
+pub mod schedule;
+pub mod sensor_health;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Honest engine id until DataFusion SQL paths land per family.
+pub const ENGINE: &str = "central-analytics-v1";
+pub const SCHEMA_VERSION: &str = "analytics-envelope-v1";
+
+pub const QV_RUNTIME: &str = "runtime-v1";
+pub const QV_SENSOR_HEALTH: &str = "sensor-health-v1";
+pub const QV_SCHEDULE: &str = "schedule-v1";
+pub const QV_MECHANICAL_COOLING: &str = "mechanical-cooling-v1";
+pub const QV_ECONOMIZER: &str = "economizer-diagnostics-v1";
+pub const QV_RCX_AHU: &str = "rcx-ahu-v1";
+pub const QV_RCX_VAV: &str = "rcx-vav-v1";
+pub const QV_METERING: &str = "metering-v1";
+
+/// Shared query fields for `/api/analytics/*` requests.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct AnalyticsQuery {
+    #[serde(default)]
+    pub job_id: Option<String>,
+    #[serde(default)]
+    pub run_id: Option<String>,
+    #[serde(default)]
+    pub equipment_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub start: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub end: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub max_points: Option<usize>,
+    #[serde(default)]
+    pub query_version: Option<String>,
+}
+
+/// Request body: query fields plus optional inline samples/series for compute.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct AnalyticsRequest {
+    #[serde(flatten)]
+    pub query: AnalyticsQuery,
+    /// Runtime boolean samples (equipment_id, timestamp, on).
+    #[serde(default)]
+    pub samples: Option<Vec<runtime::RuntimeSample>>,
+    /// Family-specific inline series / point payloads (JSON object or array).
+    #[serde(default)]
+    pub series: Option<Value>,
+    /// Gap clip for runtime Δt integration (seconds).
+    #[serde(default)]
+    pub max_gap_seconds: Option<f64>,
+    /// Economizer |OAT−RAT| identifiability gate (°F).
+    #[serde(default)]
+    pub dt_min_f: Option<f64>,
+}
+
+/// Typed analytics response envelope (no Plotly JSON).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalyticsEnvelope {
+    pub schema_version: String,
+    pub query_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_fingerprint: Option<String>,
+    pub generated_at: DateTime<Utc>,
+    pub engine: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<Value>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    #[serde(default)]
+    pub rows: Vec<Value>,
+    #[serde(default)]
+    pub equipment: Vec<Value>,
+    #[serde(default)]
+    pub points: Vec<Value>,
+    #[serde(default)]
+    pub skipped: Vec<Value>,
+}
+
+impl AnalyticsEnvelope {
+    pub fn to_json(self) -> Value {
+        serde_json::to_value(self).unwrap_or_else(|_| json!({ "ok": false }))
+    }
+}
+
+/// Build a populated envelope from query context.
+pub fn envelope(
+    query_version: &str,
+    query: &AnalyticsQuery,
+    warnings: Vec<String>,
+) -> AnalyticsEnvelope {
+    AnalyticsEnvelope {
+        schema_version: SCHEMA_VERSION.into(),
+        query_version: query_version.into(),
+        job_id: query.job_id.clone(),
+        run_id: query.run_id.clone(),
+        input_fingerprint: None,
+        generated_at: Utc::now(),
+        engine: ENGINE.into(),
+        coverage: None,
+        warnings,
+        rows: Vec::new(),
+        equipment: Vec::new(),
+        points: Vec::new(),
+        skipped: Vec::new(),
+    }
+}
+
+/// Empty stub response with a “full port in progress” warning.
+pub fn empty_stub(query_version: &str, query: &AnalyticsQuery, family: &str) -> AnalyticsEnvelope {
+    envelope(
+        query_version,
+        query,
+        vec![format!(
+            "{family}: schema-complete stub — full DataFusion / historian port in progress"
+        )],
+    )
+}
+
+/// Reject unknown query_version with a stable warning (still returns envelope).
+pub fn version_mismatch_warning(expected: &str, got: Option<&str>) -> Option<String> {
+    match got {
+        None => None,
+        Some(v) if v == expected => None,
+        Some(v) => Some(format!(
+            "unknown or unsupported query_version '{v}'; responding with '{expected}'"
+        )),
+    }
+}
+
+pub fn resolve_query_version(req: &AnalyticsRequest, expected: &str) -> (String, Vec<String>) {
+    let mut warnings = Vec::new();
+    if let Some(w) = version_mismatch_warning(expected, req.query.query_version.as_deref()) {
+        warnings.push(w);
+    }
+    (expected.to_string(), warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_has_stable_field_names() {
+        let q = AnalyticsQuery {
+            job_id: Some("job-1".into()),
+            run_id: Some("run-1".into()),
+            ..Default::default()
+        };
+        let env = envelope(QV_RUNTIME, &q, vec!["note".into()]);
+        let v = env.to_json();
+        for key in [
+            "schema_version",
+            "query_version",
+            "job_id",
+            "run_id",
+            "generated_at",
+            "engine",
+            "warnings",
+            "rows",
+            "equipment",
+            "points",
+            "skipped",
+        ] {
+            assert!(v.get(key).is_some(), "missing {key}");
+        }
+        assert_eq!(v["engine"], ENGINE);
+        assert_eq!(v["query_version"], QV_RUNTIME);
+        assert!(v.get("plotly").is_none());
+    }
+
+    #[test]
+    fn empty_stub_warns() {
+        let env = empty_stub(
+            QV_SENSOR_HEALTH,
+            &AnalyticsQuery::default(),
+            "sensor_health",
+        );
+        assert!(env.equipment.is_empty());
+        assert!(env.warnings[0].contains("in progress"));
+    }
+
+    #[test]
+    fn unknown_query_version_warns() {
+        let w = version_mismatch_warning(QV_RUNTIME, Some("runtime-v99"));
+        assert!(w.unwrap().contains("runtime-v99"));
+        assert!(version_mismatch_warning(QV_RUNTIME, Some(QV_RUNTIME)).is_none());
+    }
+}

--- a/services/central/src/analytics/plant.rs
+++ b/services/central/src/analytics/plant.rs
@@ -1,0 +1,93 @@
+//! Plant RCx — chiller / boiler descriptive evidence (minimal C8).
+
+use serde_json::json;
+
+use super::{envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest};
+
+pub const QV_RCX_CHILLER: &str = "rcx-chiller-v1";
+pub const QV_RCX_BOILER: &str = "rcx-boiler-v1";
+
+/// Evidence rows: equipment_id, kind (chiller|boiler), run_hours, oat_at_run_mean (optional),
+/// short_cycle_count (optional). Never invents kW/ton without power+flow inputs.
+pub fn handle_chiller(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    handle_plant(req, QV_RCX_CHILLER, "chiller")
+}
+
+pub fn handle_boiler(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    handle_plant(req, QV_RCX_BOILER, "boiler")
+}
+
+fn handle_plant(req: &AnalyticsRequest, expected_qv: &str, kind: &str) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, expected_qv);
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+    let Some(series) = req.series.as_ref() else {
+        warnings.push(format!(
+            "{kind} plant: provide series.equipment[] with run_hours; kW/ton omitted without power+flow"
+        ));
+        env.warnings = warnings;
+        return env;
+    };
+    let rows = series
+        .get("equipment")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    for row in rows {
+        let eq = row
+            .get("equipment_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let run_hours = row.get("run_hours").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let oat = row.get("oat_at_run_mean_f").and_then(|v| v.as_f64());
+        let short_cycles = row
+            .get("short_cycle_count")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let has_power = row.get("power_kw").and_then(|v| v.as_f64()).is_some();
+        let has_flow = row.get("flow_gpm").and_then(|v| v.as_f64()).is_some();
+        let kw_ton = if has_power && has_flow {
+            row.get("kw_per_ton").cloned()
+        } else {
+            None
+        };
+        if !has_power || !has_flow {
+            warnings.push(format!(
+                "{eq}: kW/ton not computed (requires power_kw and flow_gpm)"
+            ));
+        }
+        env.equipment.push(json!({
+            "equipment_id": eq,
+            "plant_kind": kind,
+            "run_hours": run_hours,
+            "oat_at_run_mean_f": oat,
+            "short_cycle_count": short_cycles,
+            "kw_per_ton": kw_ton,
+            "evidence_class": "descriptive_rcx",
+        }));
+    }
+    env.coverage = Some(json!({"equipment_count": env.equipment.len()}));
+    env.warnings = warnings;
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::AnalyticsQuery;
+    use serde_json::json;
+
+    #[test]
+    fn chiller_does_not_invent_kw_ton() {
+        let req = AnalyticsRequest {
+            query: AnalyticsQuery::default(),
+            series: Some(json!({
+                "equipment": [{"equipment_id": "CH-1", "run_hours": 10.0}]
+            })),
+            ..Default::default()
+        };
+        let env = handle_chiller(&req);
+        assert_eq!(env.query_version, QV_RCX_CHILLER);
+        assert!(env.equipment[0].get("kw_per_ton").unwrap().is_null());
+        assert!(env.warnings.iter().any(|w| w.contains("kW/ton")));
+    }
+}

--- a/services/central/src/analytics/rcx.rs
+++ b/services/central/src/analytics/rcx.rs
@@ -7,7 +7,7 @@ use super::{
 pub fn handle_ahu(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_RCX_AHU);
     let mut env = empty_stub(&qv, &req.query, "rcx/ahu");
-    warnings.extend(env.warnings.drain(..));
+    warnings.append(&mut env.warnings);
     env.warnings = warnings;
     env
 }
@@ -15,7 +15,7 @@ pub fn handle_ahu(req: &AnalyticsRequest) -> AnalyticsEnvelope {
 pub fn handle_vav(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_RCX_VAV);
     let mut env = empty_stub(&qv, &req.query, "rcx/vav");
-    warnings.extend(env.warnings.drain(..));
+    warnings.append(&mut env.warnings);
     env.warnings = warnings;
     env
 }

--- a/services/central/src/analytics/rcx.rs
+++ b/services/central/src/analytics/rcx.rs
@@ -1,37 +1,403 @@
-//! RCx AHU / VAV analytics — schema stubs (full port in progress).
+//! RCx AHU reset evidence + VAV zone comfort ranking (minimal compute).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::BTreeMap;
 
 use super::{
-    empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_RCX_AHU, QV_RCX_VAV,
+    envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_RCX_AHU, QV_RCX_VAV,
 };
+
+/// Generic series point used for AHU reset coverage stubs.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RcxSeriesPoint {
+    pub equipment_id: String,
+    pub role: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(default)]
+    pub value: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AhuResetEvidence {
+    pub equipment_id: String,
+    pub has_sat_sp: bool,
+    pub has_duct_static_sp: bool,
+    pub sat_sp_coverage_pct: f64,
+    pub duct_static_sp_coverage_pct: f64,
+    pub reset_evidence_stub: bool,
+}
+
+/// VAV zone comfort sample: zone temp vs setpoint (optional occupied flag).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ZoneComfortPoint {
+    pub equipment_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub zone_temp: f64,
+    pub setpoint: f64,
+    #[serde(default)]
+    pub occupied: Option<bool>,
+    /// Half-band around setpoint for comfort (°F). Default 2.0 if omitted at compute time.
+    #[serde(default)]
+    pub band_f: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ZoneComfortRank {
+    pub equipment_id: String,
+    pub n_samples: u64,
+    pub n_outside: u64,
+    pub outside_pct: f64,
+    pub mean_abs_error_f: f64,
+}
+
+const RESET_ROLES_SAT: &[&str] = &["sat_sp", "sat_setpoint", "supply_air_temp_sp"];
+const RESET_ROLES_DUCT: &[&str] = &["duct_static_sp", "duct_sp", "static_sp"];
+
+fn role_is_sat_sp(role: &str) -> bool {
+    let r = role.to_ascii_lowercase();
+    RESET_ROLES_SAT.iter().any(|k| r == *k)
+}
+
+fn role_is_duct_sp(role: &str) -> bool {
+    let r = role.to_ascii_lowercase();
+    RESET_ROLES_DUCT.iter().any(|k| r == *k)
+}
+
+/// Build AHU reset evidence stub fields from series (coverage only is OK).
+pub fn compute_ahu_reset_evidence(points: &[RcxSeriesPoint]) -> Vec<AhuResetEvidence> {
+    let mut by_eq: BTreeMap<String, Vec<&RcxSeriesPoint>> = BTreeMap::new();
+    for p in points {
+        by_eq.entry(p.equipment_id.clone()).or_default().push(p);
+    }
+
+    let mut out = Vec::with_capacity(by_eq.len());
+    for (equipment_id, pts) in by_eq {
+        let sat: Vec<_> = pts
+            .iter()
+            .copied()
+            .filter(|p| role_is_sat_sp(&p.role))
+            .collect();
+        let duct: Vec<_> = pts
+            .iter()
+            .copied()
+            .filter(|p| role_is_duct_sp(&p.role))
+            .collect();
+
+        let sat_cov = coverage_pct(&sat);
+        let duct_cov = coverage_pct(&duct);
+        let has_sat = !sat.is_empty();
+        let has_duct = !duct.is_empty();
+
+        out.push(AhuResetEvidence {
+            equipment_id,
+            has_sat_sp: has_sat,
+            has_duct_static_sp: has_duct,
+            sat_sp_coverage_pct: round2(sat_cov),
+            duct_static_sp_coverage_pct: round2(duct_cov),
+            reset_evidence_stub: has_sat || has_duct,
+        });
+    }
+    out
+}
+
+fn coverage_pct(pts: &[&RcxSeriesPoint]) -> f64 {
+    if pts.is_empty() {
+        return 0.0;
+    }
+    let finite = pts
+        .iter()
+        .filter(|p| p.value.map(|v| v.is_finite()).unwrap_or(false))
+        .count();
+    100.0 * finite as f64 / pts.len() as f64
+}
+
+/// Rank zones by % of samples outside comfort band around setpoint.
+///
+/// When `occupied` is present on any point for an equipment, only occupied
+/// samples contribute; otherwise all samples are used.
+pub fn compute_vav_comfort_ranking(
+    points: &[ZoneComfortPoint],
+    default_band_f: f64,
+) -> Vec<ZoneComfortRank> {
+    let mut by_eq: BTreeMap<String, Vec<&ZoneComfortPoint>> = BTreeMap::new();
+    for p in points {
+        by_eq.entry(p.equipment_id.clone()).or_default().push(p);
+    }
+
+    let mut ranks = Vec::with_capacity(by_eq.len());
+    for (equipment_id, pts) in by_eq {
+        let use_occ = pts.iter().any(|p| p.occupied.is_some());
+        let selected: Vec<_> = if use_occ {
+            pts.into_iter()
+                .filter(|p| p.occupied.unwrap_or(false))
+                .collect()
+        } else {
+            pts
+        };
+
+        if selected.is_empty() {
+            ranks.push(ZoneComfortRank {
+                equipment_id,
+                n_samples: 0,
+                n_outside: 0,
+                outside_pct: 0.0,
+                mean_abs_error_f: 0.0,
+            });
+            continue;
+        }
+
+        let mut n_outside = 0_u64;
+        let mut abs_err_sum = 0.0_f64;
+        for p in &selected {
+            let band = p.band_f.unwrap_or(default_band_f).abs();
+            let err = (p.zone_temp - p.setpoint).abs();
+            abs_err_sum += err;
+            if err > band {
+                n_outside += 1;
+            }
+        }
+        let n = selected.len() as u64;
+        ranks.push(ZoneComfortRank {
+            equipment_id,
+            n_samples: n,
+            n_outside,
+            outside_pct: round2(100.0 * n_outside as f64 / n as f64),
+            mean_abs_error_f: round4(abs_err_sum / n as f64),
+        });
+    }
+
+    ranks.sort_by(|a, b| {
+        b.outside_pct
+            .partial_cmp(&a.outside_pct)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.equipment_id.cmp(&b.equipment_id))
+    });
+    ranks
+}
 
 pub fn handle_ahu(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_RCX_AHU);
-    let mut env = empty_stub(&qv, &req.query, "rcx/ahu");
-    warnings.append(&mut env.warnings);
-    env.warnings = warnings;
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    let points = parse_rcx_series(req);
+    match points {
+        Some(pts) if !pts.is_empty() => {
+            let mut filtered = pts;
+            if let Some(ids) = &req.query.equipment_ids {
+                if !ids.is_empty() {
+                    filtered.retain(|p| ids.contains(&p.equipment_id));
+                }
+            }
+            let rows = compute_ahu_reset_evidence(&filtered);
+            let rows: Vec<_> = rows.into_iter().filter(|r| r.reset_evidence_stub).collect();
+            env.rows = rows
+                .iter()
+                .map(|r| serde_json::to_value(r).unwrap_or(json!({})))
+                .collect();
+            env.equipment = env.rows.clone();
+            env.coverage = Some(json!({
+                "equipment_count": env.equipment.len(),
+                "point_count": filtered.len(),
+            }));
+            warnings.push(
+                "rcx/ahu: reset evidence coverage stub only (full reset diagnostics next)".into(),
+            );
+            env.warnings = warnings;
+        }
+        _ => {
+            warnings.push("no inline series for rcx/ahu; historian/job load is next".into());
+            env.warnings = warnings;
+        }
+    }
     env
 }
 
 pub fn handle_vav(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_RCX_VAV);
-    let mut env = empty_stub(&qv, &req.query, "rcx/vav");
-    warnings.append(&mut env.warnings);
-    env.warnings = warnings;
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    let points = parse_zone_points(req);
+    match points {
+        Some(pts) if !pts.is_empty() => {
+            let mut filtered = pts;
+            if let Some(ids) = &req.query.equipment_ids {
+                if !ids.is_empty() {
+                    filtered.retain(|p| ids.contains(&p.equipment_id));
+                }
+            }
+            let ranks = compute_vav_comfort_ranking(&filtered, 2.0);
+            env.rows = ranks
+                .iter()
+                .map(|r| serde_json::to_value(r).unwrap_or(json!({})))
+                .collect();
+            env.equipment = env.rows.clone();
+            env.coverage = Some(json!({
+                "equipment_count": env.equipment.len(),
+                "point_count": filtered.len(),
+            }));
+            warnings
+                .push("rcx/vav: zone comfort ranking from zone_temp vs setpoint (minimal)".into());
+            env.warnings = warnings;
+        }
+        _ => {
+            warnings.push(
+                "no inline zone_temp/setpoint series for rcx/vav; historian/job load is next"
+                    .into(),
+            );
+            env.warnings = warnings;
+        }
+    }
     env
+}
+
+fn parse_rcx_series(req: &AnalyticsRequest) -> Option<Vec<RcxSeriesPoint>> {
+    let series = req.series.as_ref()?;
+    let arr = if let Some(a) = series.as_array() {
+        a.clone()
+    } else if let Some(a) = series.get("points").and_then(|v| v.as_array()) {
+        a.clone()
+    } else {
+        return None;
+    };
+    let mut out = Vec::new();
+    for v in arr {
+        if let Ok(p) = serde_json::from_value::<RcxSeriesPoint>(v) {
+            out.push(p);
+        }
+    }
+    Some(out)
+}
+
+fn parse_zone_points(req: &AnalyticsRequest) -> Option<Vec<ZoneComfortPoint>> {
+    let series = req.series.as_ref()?;
+    let arr = if let Some(a) = series.as_array() {
+        a.clone()
+    } else if let Some(a) = series
+        .get("zones")
+        .or_else(|| series.get("points"))
+        .and_then(|v| v.as_array())
+    {
+        a.clone()
+    } else {
+        return None;
+    };
+    let mut out = Vec::new();
+    for v in arr {
+        if let Ok(p) = serde_json::from_value::<ZoneComfortPoint>(v) {
+            out.push(p);
+        }
+    }
+    Some(out)
+}
+
+fn round2(x: f64) -> f64 {
+    (x * 100.0).round() / 100.0
+}
+fn round4(x: f64) -> f64 {
+    (x * 10_000.0).round() / 10_000.0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analytics::AnalyticsQuery;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
 
     #[test]
-    fn ahu_and_vav_query_versions() {
-        let req = AnalyticsRequest {
-            query: AnalyticsQuery::default(),
+    fn ahu_sat_sp_coverage() {
+        let pts = vec![
+            RcxSeriesPoint {
+                equipment_id: "AHU-1".into(),
+                role: "sat_sp".into(),
+                timestamp: ts(0),
+                value: Some(55.0),
+            },
+            RcxSeriesPoint {
+                equipment_id: "AHU-1".into(),
+                role: "sat_sp".into(),
+                timestamp: ts(300),
+                value: None,
+            },
+            RcxSeriesPoint {
+                equipment_id: "AHU-1".into(),
+                role: "mat".into(),
+                timestamp: ts(0),
+                value: Some(60.0),
+            },
+        ];
+        let rows = compute_ahu_reset_evidence(&pts);
+        let ahu = rows.iter().find(|r| r.equipment_id == "AHU-1").unwrap();
+        assert!(ahu.has_sat_sp);
+        assert!(!ahu.has_duct_static_sp);
+        assert!((ahu.sat_sp_coverage_pct - 50.0).abs() < 1e-9);
+        assert!(ahu.reset_evidence_stub);
+    }
+
+    #[test]
+    fn vav_comfort_ranking_orders_worst_first() {
+        let pts = vec![
+            ZoneComfortPoint {
+                equipment_id: "VAV-OK".into(),
+                timestamp: ts(0),
+                zone_temp: 72.0,
+                setpoint: 72.0,
+                occupied: Some(true),
+                band_f: Some(2.0),
+            },
+            ZoneComfortPoint {
+                equipment_id: "VAV-BAD".into(),
+                timestamp: ts(0),
+                zone_temp: 80.0,
+                setpoint: 72.0,
+                occupied: Some(true),
+                band_f: Some(2.0),
+            },
+            ZoneComfortPoint {
+                equipment_id: "VAV-BAD".into(),
+                timestamp: ts(300),
+                zone_temp: 79.0,
+                setpoint: 72.0,
+                occupied: Some(true),
+                band_f: Some(2.0),
+            },
+        ];
+        let ranks = compute_vav_comfort_ranking(&pts, 2.0);
+        assert_eq!(ranks[0].equipment_id, "VAV-BAD");
+        assert_eq!(ranks[0].outside_pct, 100.0);
+        assert_eq!(ranks[1].equipment_id, "VAV-OK");
+        assert_eq!(ranks[1].outside_pct, 0.0);
+    }
+
+    #[test]
+    fn handle_ahu_and_vav() {
+        let ahu_req = AnalyticsRequest {
+            series: Some(json!({
+                "points": [
+                    {"equipment_id": "AHU-1", "role": "duct_static_sp", "timestamp": "2024-01-01T00:00:00Z", "value": 1.2}
+                ]
+            })),
             ..Default::default()
         };
-        assert_eq!(handle_ahu(&req).query_version, QV_RCX_AHU);
-        assert_eq!(handle_vav(&req).query_version, QV_RCX_VAV);
+        let env = handle_ahu(&ahu_req);
+        assert_eq!(env.query_version, QV_RCX_AHU);
+        assert_eq!(env.rows.len(), 1);
+        assert_eq!(env.rows[0]["has_duct_static_sp"], true);
+
+        let vav_req = AnalyticsRequest {
+            series: Some(json!({
+                "zones": [
+                    {"equipment_id": "VAV-1", "timestamp": "2024-01-01T00:00:00Z", "zone_temp": 75.0, "setpoint": 72.0}
+                ]
+            })),
+            ..Default::default()
+        };
+        let env = handle_vav(&vav_req);
+        assert_eq!(env.query_version, QV_RCX_VAV);
+        assert_eq!(env.rows.len(), 1);
     }
 }

--- a/services/central/src/analytics/rcx.rs
+++ b/services/central/src/analytics/rcx.rs
@@ -1,0 +1,37 @@
+//! RCx AHU / VAV analytics — schema stubs (full port in progress).
+
+use super::{
+    empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_RCX_AHU, QV_RCX_VAV,
+};
+
+pub fn handle_ahu(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_RCX_AHU);
+    let mut env = empty_stub(&qv, &req.query, "rcx/ahu");
+    warnings.extend(env.warnings.drain(..));
+    env.warnings = warnings;
+    env
+}
+
+pub fn handle_vav(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_RCX_VAV);
+    let mut env = empty_stub(&qv, &req.query, "rcx/vav");
+    warnings.extend(env.warnings.drain(..));
+    env.warnings = warnings;
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::AnalyticsQuery;
+
+    #[test]
+    fn ahu_and_vav_query_versions() {
+        let req = AnalyticsRequest {
+            query: AnalyticsQuery::default(),
+            ..Default::default()
+        };
+        assert_eq!(handle_ahu(&req).query_version, QV_RCX_AHU);
+        assert_eq!(handle_vav(&req).query_version, QV_RCX_VAV);
+    }
+}

--- a/services/central/src/analytics/runtime.rs
+++ b/services/central/src/analytics/runtime.rs
@@ -1,0 +1,249 @@
+//! Motor / equipment runtime hours via actual timestamp Δt (not samples × poll).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+use super::{envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_RUNTIME};
+
+/// One runtime boolean sample for inline compute.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RuntimeSample {
+    pub equipment_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub on: bool,
+}
+
+/// Per-equipment runtime rollup row.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeEquipmentRow {
+    pub equipment_id: String,
+    pub run_hours: f64,
+    pub coverage_pct: f64,
+    pub samples: u64,
+    pub on_samples: u64,
+}
+
+/// Integrate on-hours from sorted timestamps using forward Δt with gap clipping.
+///
+/// For each consecutive pair `(i, i+1)`:
+/// - `dt = min(ts[i+1] - ts[i], max_gap_seconds)` (lower-bounded at 0)
+/// - if `on[i]` is true, add `dt` to run seconds
+/// - always add `dt` to covered elapsed seconds
+///
+/// The last sample contributes no duration (forward-interval convention).
+/// Duplicate timestamps yield `dt = 0` and do not inflate hours.
+pub fn compute_runtime_hours(
+    timestamps: &[DateTime<Utc>],
+    on: &[bool],
+    max_gap_seconds: f64,
+) -> RuntimeEquipmentRow {
+    assert_eq!(
+        timestamps.len(),
+        on.len(),
+        "timestamps and on masks must be same length"
+    );
+    let n = timestamps.len();
+    let samples = n as u64;
+    let on_samples = on.iter().filter(|&&b| b).count() as u64;
+
+    if n < 2 {
+        return RuntimeEquipmentRow {
+            equipment_id: String::new(),
+            run_hours: 0.0,
+            coverage_pct: 0.0,
+            samples,
+            on_samples,
+        };
+    }
+
+    let cap = max_gap_seconds.max(0.0);
+    let mut run_secs = 0.0_f64;
+    let mut covered_secs = 0.0_f64;
+
+    for i in 0..n - 1 {
+        let raw = (timestamps[i + 1] - timestamps[i]).num_milliseconds() as f64 / 1000.0;
+        let dt = raw.clamp(0.0, cap);
+        covered_secs += dt;
+        if on[i] {
+            run_secs += dt;
+        }
+    }
+
+    let span_secs = (timestamps[n - 1] - timestamps[0])
+        .num_milliseconds()
+        .max(0) as f64
+        / 1000.0;
+    let coverage_pct = if span_secs > 0.0 {
+        100.0 * covered_secs / span_secs
+    } else {
+        0.0
+    };
+
+    RuntimeEquipmentRow {
+        equipment_id: String::new(),
+        run_hours: run_secs / 3600.0,
+        coverage_pct,
+        samples,
+        on_samples,
+    }
+}
+
+/// Group inline samples by equipment, sort by timestamp, compute rows.
+pub fn compute_runtime_from_samples(
+    samples: &[RuntimeSample],
+    max_gap_seconds: f64,
+) -> Vec<RuntimeEquipmentRow> {
+    let mut by_eq: BTreeMap<String, Vec<(DateTime<Utc>, bool)>> = BTreeMap::new();
+    for s in samples {
+        by_eq
+            .entry(s.equipment_id.clone())
+            .or_default()
+            .push((s.timestamp, s.on));
+    }
+
+    let mut rows = Vec::with_capacity(by_eq.len());
+    for (eq_id, mut pts) in by_eq {
+        pts.sort_by_key(|(ts, _)| *ts);
+        let timestamps: Vec<_> = pts.iter().map(|(t, _)| *t).collect();
+        let on: Vec<_> = pts.iter().map(|(_, o)| *o).collect();
+        let mut row = compute_runtime_hours(&timestamps, &on, max_gap_seconds);
+        row.equipment_id = eq_id;
+        rows.push(row);
+    }
+    rows
+}
+
+pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_RUNTIME);
+    let max_gap = req.max_gap_seconds.unwrap_or(900.0);
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    match &req.samples {
+        Some(samples) if !samples.is_empty() => {
+            let mut rows = compute_runtime_from_samples(samples, max_gap);
+            if let Some(ids) = &req.query.equipment_ids {
+                if !ids.is_empty() {
+                    rows.retain(|r| ids.contains(&r.equipment_id));
+                }
+            }
+            env.equipment = rows
+                .into_iter()
+                .map(|r| {
+                    json!({
+                        "equipment_id": r.equipment_id,
+                        "run_hours": round2(r.run_hours),
+                        "coverage_pct": round2(r.coverage_pct),
+                        "samples": r.samples,
+                        "on_samples": r.on_samples,
+                    })
+                })
+                .collect();
+            env.rows = env.equipment.clone();
+            env.coverage = Some(json!({
+                "equipment_count": env.equipment.len(),
+                "max_gap_seconds": max_gap,
+            }));
+        }
+        _ => {
+            warnings.push(
+                "no inline samples provided; historian/job series load for runtime is next".into(),
+            );
+            env.warnings = warnings;
+        }
+    }
+    env
+}
+
+fn round2(x: f64) -> f64 {
+    (x * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    #[test]
+    fn regular_five_minute_all_on_one_hour() {
+        // t=0..3600 inclusive every 300s → 13 samples, 12 intervals × 300s = 1.0 h
+        let timestamps: Vec<_> = (0..=12).map(|i| ts(i * 300)).collect();
+        let on = vec![true; timestamps.len()];
+        let row = compute_runtime_hours(&timestamps, &on, 900.0);
+        assert!((row.run_hours - 1.0).abs() < 1e-9);
+        assert_eq!(row.samples, 13);
+        assert_eq!(row.on_samples, 13);
+        assert!((row.coverage_pct - 100.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn gap_clipping_limits_credited_hours() {
+        // Two points 1 hour apart, on at first — without clip would be 1.0 h;
+        // with max_gap=600s credits only 600/3600 h.
+        let timestamps = vec![ts(0), ts(3600)];
+        let on = vec![true, false];
+        let row = compute_runtime_hours(&timestamps, &on, 600.0);
+        assert!((row.run_hours - (600.0 / 3600.0)).abs() < 1e-9);
+        // Covered seconds clipped; span is still 3600 → coverage 600/3600*100
+        assert!((row.coverage_pct - (600.0 / 3600.0 * 100.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn duplicate_timestamps_do_not_inflate_runtime() {
+        let timestamps = vec![ts(0), ts(0), ts(300), ts(300), ts(600)];
+        let on = vec![true, true, true, true, true];
+        let row = compute_runtime_hours(&timestamps, &on, 900.0);
+        // Forward intervals: 0 + 300 + 0 + 300 = 600s = 1/6 h
+        assert!((row.run_hours - (600.0 / 3600.0)).abs() < 1e-9);
+        assert_eq!(row.samples, 5);
+    }
+
+    #[test]
+    fn off_intervals_excluded_from_run_hours() {
+        let timestamps: Vec<_> = (0..=4).map(|i| ts(i * 300)).collect();
+        // on, off, on, off, on — credits intervals 0 and 2 only
+        let on = vec![true, false, true, false, true];
+        let row = compute_runtime_hours(&timestamps, &on, 900.0);
+        assert!((row.run_hours - (600.0 / 3600.0)).abs() < 1e-9);
+        assert_eq!(row.on_samples, 3);
+    }
+
+    #[test]
+    fn handle_groups_by_equipment() {
+        let req = AnalyticsRequest {
+            samples: Some(vec![
+                RuntimeSample {
+                    equipment_id: "AHU-1".into(),
+                    timestamp: ts(0),
+                    on: true,
+                },
+                RuntimeSample {
+                    equipment_id: "AHU-1".into(),
+                    timestamp: ts(300),
+                    on: true,
+                },
+                RuntimeSample {
+                    equipment_id: "FAN-2".into(),
+                    timestamp: ts(0),
+                    on: false,
+                },
+                RuntimeSample {
+                    equipment_id: "FAN-2".into(),
+                    timestamp: ts(300),
+                    on: false,
+                },
+            ]),
+            max_gap_seconds: Some(900.0),
+            ..Default::default()
+        };
+        let env = handle(&req);
+        assert_eq!(env.query_version, QV_RUNTIME);
+        assert_eq!(env.equipment.len(), 2);
+        assert!(env.to_json().get("plotly").is_none());
+    }
+}

--- a/services/central/src/analytics/runtime.rs
+++ b/services/central/src/analytics/runtime.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::json;
 use std::collections::BTreeMap;
 
 use super::{envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_RUNTIME};

--- a/services/central/src/analytics/schedule.rs
+++ b/services/central/src/analytics/schedule.rs
@@ -5,7 +5,7 @@ use super::{empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsReque
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_SCHEDULE);
     let mut env = empty_stub(&qv, &req.query, "schedule");
-    warnings.extend(env.warnings.drain(..));
+    warnings.append(&mut env.warnings);
     env.warnings = warnings;
     env
 }

--- a/services/central/src/analytics/schedule.rs
+++ b/services/central/src/analytics/schedule.rs
@@ -1,0 +1,28 @@
+//! Schedule / occupancy analytics — schema stub (full port in progress).
+
+use super::{empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_SCHEDULE};
+
+pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_SCHEDULE);
+    let mut env = empty_stub(&qv, &req.query, "schedule");
+    warnings.extend(env.warnings.drain(..));
+    env.warnings = warnings;
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::AnalyticsQuery;
+
+    #[test]
+    fn stub_returns_expected_query_version() {
+        let env = handle(&AnalyticsRequest {
+            query: AnalyticsQuery::default(),
+            ..Default::default()
+        });
+        assert_eq!(env.query_version, QV_SCHEDULE);
+        assert!(env.equipment.is_empty());
+        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+    }
+}

--- a/services/central/src/analytics/schedule.rs
+++ b/services/central/src/analytics/schedule.rs
@@ -1,28 +1,272 @@
-//! Schedule / occupancy analytics — schema stub (full port in progress).
+//! Schedule / occupancy hours — occupied mask + optional after-hours fan hours.
 
-use super::{empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_SCHEDULE};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::{envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_SCHEDULE};
+
+/// Occupied-mask sample (boolean occupancy at a timestamp).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OccupiedSample {
+    pub timestamp: DateTime<Utc>,
+    pub occupied: bool,
+}
+
+/// Optional fan status sample aligned to the same timeline (or nearby).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FanSample {
+    pub timestamp: DateTime<Utc>,
+    pub fan_on: bool,
+    #[serde(default)]
+    pub equipment_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScheduleRollup {
+    pub occupied_hours: f64,
+    pub unoccupied_hours: f64,
+    pub coverage_hours: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_hours_fan_hours: Option<f64>,
+    pub occupied_samples: u64,
+    pub total_samples: u64,
+}
+
+/// Integrate occupied / unoccupied hours from sorted occupied mask via forward Δt.
+///
+/// Gap clipping mirrors runtime: `dt = min(ts[i+1]-ts[i], max_gap_seconds)`.
+pub fn compute_occupied_hours(occupied: &[OccupiedSample], max_gap_seconds: f64) -> ScheduleRollup {
+    let mut pts = occupied.to_vec();
+    pts.sort_by_key(|p| p.timestamp);
+    let n = pts.len();
+    let occupied_samples = pts.iter().filter(|p| p.occupied).count() as u64;
+    if n < 2 {
+        return ScheduleRollup {
+            occupied_hours: 0.0,
+            unoccupied_hours: 0.0,
+            coverage_hours: 0.0,
+            after_hours_fan_hours: None,
+            occupied_samples,
+            total_samples: n as u64,
+        };
+    }
+
+    let cap = max_gap_seconds.max(0.0);
+    let mut occ_secs = 0.0_f64;
+    let mut unocc_secs = 0.0_f64;
+    for i in 0..n - 1 {
+        let raw = (pts[i + 1].timestamp - pts[i].timestamp).num_milliseconds() as f64 / 1000.0;
+        let dt = raw.clamp(0.0, cap);
+        if pts[i].occupied {
+            occ_secs += dt;
+        } else {
+            unocc_secs += dt;
+        }
+    }
+
+    ScheduleRollup {
+        occupied_hours: occ_secs / 3600.0,
+        unoccupied_hours: unocc_secs / 3600.0,
+        coverage_hours: (occ_secs + unocc_secs) / 3600.0,
+        after_hours_fan_hours: None,
+        occupied_samples,
+        total_samples: n as u64,
+    }
+}
+
+/// After-hours fan hours: intervals where fan is on and occupancy is false.
+///
+/// For each consecutive fan sample pair, look up occupancy at the start of the
+/// interval (last occupied mask sample with `ts <= fan_ts`, else nearest).
+pub fn compute_after_hours_fan_hours(
+    occupied: &[OccupiedSample],
+    fan: &[FanSample],
+    max_gap_seconds: f64,
+) -> f64 {
+    if occupied.is_empty() || fan.len() < 2 {
+        return 0.0;
+    }
+    let mut occ = occupied.to_vec();
+    occ.sort_by_key(|p| p.timestamp);
+    let mut fans = fan.to_vec();
+    fans.sort_by_key(|p| p.timestamp);
+
+    let cap = max_gap_seconds.max(0.0);
+    let mut secs = 0.0_f64;
+    for i in 0..fans.len() - 1 {
+        if !fans[i].fan_on {
+            continue;
+        }
+        let raw = (fans[i + 1].timestamp - fans[i].timestamp).num_milliseconds() as f64 / 1000.0;
+        let dt = raw.clamp(0.0, cap);
+        let is_occ = occupancy_at(&occ, fans[i].timestamp);
+        if !is_occ {
+            secs += dt;
+        }
+    }
+    secs / 3600.0
+}
+
+fn occupancy_at(occupied: &[OccupiedSample], ts: DateTime<Utc>) -> bool {
+    // Last sample at or before ts; if none, use first sample.
+    match occupied.iter().rfind(|p| p.timestamp <= ts) {
+        Some(p) => p.occupied,
+        None => occupied.first().map(|p| p.occupied).unwrap_or(false),
+    }
+}
 
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_SCHEDULE);
-    let mut env = empty_stub(&qv, &req.query, "schedule");
-    warnings.append(&mut env.warnings);
-    env.warnings = warnings;
+    let max_gap = req.max_gap_seconds.unwrap_or(900.0);
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    let (occ, fan) = parse_series(req);
+    match occ {
+        Some(occupied) if !occupied.is_empty() => {
+            let mut rollup = compute_occupied_hours(&occupied, max_gap);
+            if let Some(fan_samples) = fan {
+                if !fan_samples.is_empty() {
+                    let ah = compute_after_hours_fan_hours(&occupied, &fan_samples, max_gap);
+                    rollup.after_hours_fan_hours = Some(round4(ah));
+                }
+            }
+            rollup.occupied_hours = round4(rollup.occupied_hours);
+            rollup.unoccupied_hours = round4(rollup.unoccupied_hours);
+            rollup.coverage_hours = round4(rollup.coverage_hours);
+
+            let row = serde_json::to_value(&rollup).unwrap_or(json!({}));
+            env.rows = vec![row.clone()];
+            env.equipment = vec![row];
+            env.coverage = Some(json!({
+                "max_gap_seconds": max_gap,
+                "occupied_samples": rollup.occupied_samples,
+                "total_samples": rollup.total_samples,
+            }));
+            warnings.push(
+                "schedule: minimal central-analytics-v1 occupied-mask integration (not full DF port)"
+                    .into(),
+            );
+            env.warnings = warnings;
+        }
+        _ => {
+            warnings.push(
+                "no inline occupied mask provided; historian/job schedule load is next".into(),
+            );
+            env.warnings = warnings;
+        }
+    }
     env
+}
+
+fn parse_series(req: &AnalyticsRequest) -> (Option<Vec<OccupiedSample>>, Option<Vec<FanSample>>) {
+    let Some(series) = req.series.as_ref() else {
+        return (None, None);
+    };
+
+    let occ_arr = series
+        .get("occupied")
+        .and_then(|v| v.as_array())
+        .or_else(|| series.get("points").and_then(|v| v.as_array()))
+        .or_else(|| series.as_array());
+
+    let occupied = occ_arr.map(|arr| {
+        arr.iter()
+            .filter_map(|v| serde_json::from_value::<OccupiedSample>(v.clone()).ok())
+            .collect::<Vec<_>>()
+    });
+
+    let fan = series.get("fan").and_then(|v| v.as_array()).map(|arr| {
+        arr.iter()
+            .filter_map(|v| serde_json::from_value::<FanSample>(v.clone()).ok())
+            .collect::<Vec<_>>()
+    });
+
+    (occupied, fan)
+}
+
+fn round4(x: f64) -> f64 {
+    (x * 10_000.0).round() / 10_000.0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analytics::AnalyticsQuery;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
 
     #[test]
-    fn stub_returns_expected_query_version() {
-        let env = handle(&AnalyticsRequest {
-            query: AnalyticsQuery::default(),
+    fn occupied_hours_from_mask() {
+        // 0–3600 occupied, 3600–7200 unoccupied → 1.0 h each
+        let occ = vec![
+            OccupiedSample {
+                timestamp: ts(0),
+                occupied: true,
+            },
+            OccupiedSample {
+                timestamp: ts(3600),
+                occupied: false,
+            },
+            OccupiedSample {
+                timestamp: ts(7200),
+                occupied: false,
+            },
+        ];
+        let r = compute_occupied_hours(&occ, 9000.0);
+        assert!((r.occupied_hours - 1.0).abs() < 1e-9);
+        assert!((r.unoccupied_hours - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn after_hours_fan_when_unoccupied() {
+        let occ = vec![
+            OccupiedSample {
+                timestamp: ts(0),
+                occupied: false,
+            },
+            OccupiedSample {
+                timestamp: ts(3600),
+                occupied: false,
+            },
+        ];
+        let fan = vec![
+            FanSample {
+                timestamp: ts(0),
+                fan_on: true,
+                equipment_id: Some("AHU-1".into()),
+            },
+            FanSample {
+                timestamp: ts(1800),
+                fan_on: true,
+                equipment_id: Some("AHU-1".into()),
+            },
+        ];
+        let ah = compute_after_hours_fan_hours(&occ, &fan, 9000.0);
+        assert!((ah - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn handle_with_fan_series() {
+        let req = AnalyticsRequest {
+            series: Some(json!({
+                "occupied": [
+                    {"timestamp": "2024-01-01T00:00:00Z", "occupied": false},
+                    {"timestamp": "2024-01-01T01:00:00Z", "occupied": false}
+                ],
+                "fan": [
+                    {"timestamp": "2024-01-01T00:00:00Z", "fan_on": true},
+                    {"timestamp": "2024-01-01T01:00:00Z", "fan_on": false}
+                ]
+            })),
+            max_gap_seconds: Some(7200.0),
             ..Default::default()
-        });
+        };
+        let env = handle(&req);
         assert_eq!(env.query_version, QV_SCHEDULE);
-        assert!(env.equipment.is_empty());
-        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+        assert_eq!(env.rows.len(), 1);
+        assert!(env.rows[0].get("after_hours_fan_hours").is_some());
     }
 }

--- a/services/central/src/analytics/sensor_health.rs
+++ b/services/central/src/analytics/sensor_health.rs
@@ -7,7 +7,7 @@ use super::{
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_SENSOR_HEALTH);
     let mut env = empty_stub(&qv, &req.query, "sensor_health");
-    warnings.extend(env.warnings.drain(..));
+    warnings.append(&mut env.warnings);
     env.warnings = warnings;
     env
 }

--- a/services/central/src/analytics/sensor_health.rs
+++ b/services/central/src/analytics/sensor_health.rs
@@ -1,0 +1,30 @@
+//! Sensor health analytics — schema stub (full port in progress).
+
+use super::{
+    empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_SENSOR_HEALTH,
+};
+
+pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
+    let (qv, mut warnings) = resolve_query_version(req, QV_SENSOR_HEALTH);
+    let mut env = empty_stub(&qv, &req.query, "sensor_health");
+    warnings.extend(env.warnings.drain(..));
+    env.warnings = warnings;
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::AnalyticsQuery;
+
+    #[test]
+    fn stub_returns_expected_query_version() {
+        let env = handle(&AnalyticsRequest {
+            query: AnalyticsQuery::default(),
+            ..Default::default()
+        });
+        assert_eq!(env.query_version, QV_SENSOR_HEALTH);
+        assert!(env.rows.is_empty());
+        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+    }
+}

--- a/services/central/src/analytics/sensor_health.rs
+++ b/services/central/src/analytics/sensor_health.rs
@@ -1,30 +1,266 @@
-//! Sensor health analytics — schema stub (full port in progress).
+//! Sensor health matrix — per-series coverage, flatline, missingness, stats.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::BTreeMap;
 
 use super::{
-    empty_stub, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_SENSOR_HEALTH,
+    envelope, resolve_query_version, AnalyticsEnvelope, AnalyticsRequest, QV_SENSOR_HEALTH,
 };
+
+/// Default minimum sample count before flatline flag can fire.
+pub const DEFAULT_FLATLINE_MIN_N: usize = 5;
+/// Std-dev below this (and n > min_n) → flatline.
+pub const DEFAULT_FLATLINE_STD_EPS: f64 = 1e-9;
+
+/// One sensor series sample for inline compute.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SensorPoint {
+    pub equipment_id: String,
+    pub role: String,
+    pub timestamp: DateTime<Utc>,
+    /// Null / missing values may be omitted or sent as JSON null (parsed as None).
+    #[serde(default)]
+    pub value: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SensorSeriesRow {
+    pub equipment_id: String,
+    pub role: String,
+    pub n: u64,
+    pub n_finite: u64,
+    pub coverage_pct: f64,
+    pub missingness: f64,
+    pub flatline_flag: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mean: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub std: Option<f64>,
+}
+
+/// Compute per-(equipment_id, role) health stats from inline points.
+pub fn compute_sensor_health(
+    points: &[SensorPoint],
+    flatline_min_n: usize,
+    flatline_std_eps: f64,
+) -> Vec<SensorSeriesRow> {
+    let mut by_key: BTreeMap<(String, String), Vec<Option<f64>>> = BTreeMap::new();
+    for p in points {
+        by_key
+            .entry((p.equipment_id.clone(), p.role.clone()))
+            .or_default()
+            .push(p.value.filter(|v| v.is_finite()));
+    }
+
+    let mut rows = Vec::with_capacity(by_key.len());
+    for ((equipment_id, role), vals) in by_key {
+        let n = vals.len() as u64;
+        let finite: Vec<f64> = vals.into_iter().flatten().collect();
+        let n_finite = finite.len() as u64;
+        let coverage_pct = if n > 0 {
+            100.0 * n_finite as f64 / n as f64
+        } else {
+            0.0
+        };
+        let missingness = if n > 0 {
+            1.0 - (n_finite as f64 / n as f64)
+        } else {
+            0.0
+        };
+
+        let (min, max, mean, std) = if finite.is_empty() {
+            (None, None, None, None)
+        } else {
+            let min_v = finite.iter().copied().fold(f64::INFINITY, f64::min);
+            let max_v = finite.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            let mean_v = finite.iter().sum::<f64>() / finite.len() as f64;
+            let var = if finite.len() > 1 {
+                finite
+                    .iter()
+                    .map(|v| {
+                        let d = v - mean_v;
+                        d * d
+                    })
+                    .sum::<f64>()
+                    / (finite.len() as f64)
+            } else {
+                0.0
+            };
+            let std_v = var.sqrt();
+            (
+                Some(round4(min_v)),
+                Some(round4(max_v)),
+                Some(round4(mean_v)),
+                Some(round6(std_v)),
+            )
+        };
+
+        let flatline_flag = n_finite as usize > flatline_min_n
+            && std.map(|s| s <= flatline_std_eps).unwrap_or(false);
+
+        rows.push(SensorSeriesRow {
+            equipment_id,
+            role,
+            n,
+            n_finite,
+            coverage_pct: round2(coverage_pct),
+            missingness: round4(missingness),
+            flatline_flag,
+            min,
+            max,
+            mean,
+            std,
+        });
+    }
+    rows
+}
 
 pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     let (qv, mut warnings) = resolve_query_version(req, QV_SENSOR_HEALTH);
-    let mut env = empty_stub(&qv, &req.query, "sensor_health");
-    warnings.append(&mut env.warnings);
-    env.warnings = warnings;
+    let mut env = envelope(&qv, &req.query, warnings.clone());
+
+    let points = parse_points(req);
+    match points {
+        Some(pts) if !pts.is_empty() => {
+            let mut filtered = pts;
+            if let Some(ids) = &req.query.equipment_ids {
+                if !ids.is_empty() {
+                    filtered.retain(|p| ids.contains(&p.equipment_id));
+                }
+            }
+            let rows =
+                compute_sensor_health(&filtered, DEFAULT_FLATLINE_MIN_N, DEFAULT_FLATLINE_STD_EPS);
+            env.rows = rows
+                .iter()
+                .map(|r| serde_json::to_value(r).unwrap_or(json!({})))
+                .collect();
+            env.equipment = env.rows.clone();
+            env.coverage = Some(json!({
+                "series_count": env.rows.len(),
+                "point_count": filtered.len(),
+            }));
+            warnings.push(
+                "sensor_health: minimal central-analytics-v1 stats (not full DF MemTable port)"
+                    .into(),
+            );
+            env.warnings = warnings;
+        }
+        _ => {
+            warnings.push(
+                "no inline series points provided; historian/job sensor-health load is next".into(),
+            );
+            env.warnings = warnings;
+        }
+    }
     env
+}
+
+fn parse_points(req: &AnalyticsRequest) -> Option<Vec<SensorPoint>> {
+    let series = req.series.as_ref()?;
+    let arr = if let Some(a) = series.as_array() {
+        a.clone()
+    } else if let Some(a) = series.get("points").and_then(|v| v.as_array()) {
+        a.clone()
+    } else {
+        return None;
+    };
+    let mut out = Vec::new();
+    for v in arr {
+        if let Ok(p) = serde_json::from_value::<SensorPoint>(v) {
+            out.push(p);
+        }
+    }
+    Some(out)
+}
+
+fn round2(x: f64) -> f64 {
+    (x * 100.0).round() / 100.0
+}
+fn round4(x: f64) -> f64 {
+    (x * 10_000.0).round() / 10_000.0
+}
+fn round6(x: f64) -> f64 {
+    (x * 1_000_000.0).round() / 1_000_000.0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analytics::AnalyticsQuery;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    fn pt(eq: &str, role: &str, t: i64, v: Option<f64>) -> SensorPoint {
+        SensorPoint {
+            equipment_id: eq.into(),
+            role: role.into(),
+            timestamp: ts(t),
+            value: v,
+        }
+    }
 
     #[test]
-    fn stub_returns_expected_query_version() {
-        let env = handle(&AnalyticsRequest {
-            query: AnalyticsQuery::default(),
+    fn coverage_and_stats_for_varied_series() {
+        let pts = vec![
+            pt("AHU-1", "sat", 0, Some(55.0)),
+            pt("AHU-1", "sat", 300, Some(56.0)),
+            pt("AHU-1", "sat", 600, Some(54.0)),
+            pt("AHU-1", "sat", 900, None),
+        ];
+        let rows = compute_sensor_health(&pts, 5, 1e-9);
+        assert_eq!(rows.len(), 1);
+        let r = &rows[0];
+        assert_eq!(r.n, 4);
+        assert_eq!(r.n_finite, 3);
+        assert!((r.coverage_pct - 75.0).abs() < 1e-9);
+        assert!((r.missingness - 0.25).abs() < 1e-9);
+        assert!(!r.flatline_flag);
+        assert_eq!(r.min, Some(54.0));
+        assert_eq!(r.max, Some(56.0));
+        assert!((r.mean.unwrap() - 55.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn flatline_when_std_near_zero_and_n_gt_min() {
+        let pts: Vec<_> = (0..8)
+            .map(|i| pt("SEN-1", "zone_t", i * 300, Some(72.0)))
+            .collect();
+        let rows = compute_sensor_health(&pts, 5, 1e-9);
+        assert!(rows[0].flatline_flag);
+        assert_eq!(rows[0].std, Some(0.0));
+    }
+
+    #[test]
+    fn no_flatline_when_n_le_min() {
+        let pts: Vec<_> = (0..4)
+            .map(|i| pt("SEN-1", "zone_t", i * 300, Some(72.0)))
+            .collect();
+        let rows = compute_sensor_health(&pts, 5, 1e-9);
+        assert!(!rows[0].flatline_flag);
+    }
+
+    #[test]
+    fn handle_groups_series() {
+        let req = AnalyticsRequest {
+            series: Some(json!({
+                "points": [
+                    {"equipment_id": "AHU-1", "role": "sat", "timestamp": "2024-01-01T00:00:00Z", "value": 55.0},
+                    {"equipment_id": "AHU-1", "role": "mat", "timestamp": "2024-01-01T00:00:00Z", "value": 60.0}
+                ]
+            })),
             ..Default::default()
-        });
+        };
+        let env = handle(&req);
         assert_eq!(env.query_version, QV_SENSOR_HEALTH);
-        assert!(env.rows.is_empty());
-        assert!(env.warnings.iter().any(|w| w.contains("in progress")));
+        assert_eq!(env.rows.len(), 2);
+        assert_eq!(env.engine, super::super::ENGINE);
     }
 }

--- a/services/central/src/main.rs
+++ b/services/central/src/main.rs
@@ -1,5 +1,6 @@
 //! Open-FDD Central — MQTTS ingest + REST/OpenAPI control plane.
 
+mod analytics;
 mod auth;
 mod ingest;
 mod jobs;

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -153,6 +153,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/analytics/economizer", post(analytics_economizer))
         .route("/api/analytics/rcx/ahu", post(analytics_rcx_ahu))
         .route("/api/analytics/rcx/vav", post(analytics_rcx_vav))
+        .route("/api/analytics/rcx/chiller", post(analytics_rcx_chiller))
+        .route("/api/analytics/rcx/boiler", post(analytics_rcx_boiler))
         .route("/api/analytics/metering", post(analytics_metering))
         .merge(csv)
         .layer(middleware::from_fn_with_state(
@@ -1426,6 +1428,20 @@ async fn analytics_rcx_vav(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
     Json(json!({
         "ok": true,
         "analytics": analytics::rcx::handle_vav(&req).to_json(),
+    }))
+}
+
+async fn analytics_rcx_chiller(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::plant::handle_chiller(&req).to_json(),
+    }))
+}
+
+async fn analytics_rcx_boiler(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::plant::handle_boiler(&req).to_json(),
     }))
 }
 

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -14,6 +14,7 @@ use openfdd_mqtt::publish_json;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::analytics::{self, AnalyticsRequest};
 use crate::auth;
 use crate::jobs;
 use crate::models::{
@@ -139,6 +140,20 @@ pub fn router(state: Arc<AppState>) -> Router {
             "/api/jobs/{job_id}/wattlab/handoffs",
             post(jobs_create_wattlab_handoff),
         )
+        .route("/api/analytics/runtime", post(analytics_runtime))
+        .route(
+            "/api/analytics/sensor-health",
+            post(analytics_sensor_health),
+        )
+        .route("/api/analytics/schedule", post(analytics_schedule))
+        .route(
+            "/api/analytics/mechanical-cooling",
+            post(analytics_mechanical_cooling),
+        )
+        .route("/api/analytics/economizer", post(analytics_economizer))
+        .route("/api/analytics/rcx/ahu", post(analytics_rcx_ahu))
+        .route("/api/analytics/rcx/vav", post(analytics_rcx_vav))
+        .route("/api/analytics/metering", post(analytics_metering))
         .merge(csv)
         .layer(middleware::from_fn_with_state(
             Arc::clone(&state),
@@ -188,7 +203,8 @@ pub async fn capabilities() -> Json<Value> {
             "faults": true,
             "health_stack": true,
             "fdd_rules_authoring": true,
-            "fdd_schema": true
+            "fdd_schema": true,
+            "analytics": true
         }
     }))
 }
@@ -1358,4 +1374,64 @@ async fn jobs_create_wattlab_handoff(
         StatusCode::CREATED,
         Json(json!({"ok": true, "handoff": handoff})),
     ))
+}
+
+// ---------------------------------------------------------------------------
+// Analytics (Milestone C) — typed envelopes, no Plotly JSON
+// ---------------------------------------------------------------------------
+
+async fn analytics_runtime(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::runtime::handle(&req).to_json(),
+    }))
+}
+
+async fn analytics_sensor_health(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::sensor_health::handle(&req).to_json(),
+    }))
+}
+
+async fn analytics_schedule(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::schedule::handle(&req).to_json(),
+    }))
+}
+
+async fn analytics_mechanical_cooling(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::mechanical_cooling::handle(&req).to_json(),
+    }))
+}
+
+async fn analytics_economizer(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::economizer::handle(&req).to_json(),
+    }))
+}
+
+async fn analytics_rcx_ahu(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::rcx::handle_ahu(&req).to_json(),
+    }))
+}
+
+async fn analytics_rcx_vav(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::rcx::handle_vav(&req).to_json(),
+    }))
+}
+
+async fn analytics_metering(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "analytics": analytics::metering::handle(&req).to_json(),
+    }))
 }

--- a/services/ui/app/central_client.py
+++ b/services/ui/app/central_client.py
@@ -441,3 +441,77 @@ def jobs_create_wattlab_handoff(job_id: str, handoff: dict[str, Any]) -> dict[st
         return _parse_json_response(resp)
     except requests.RequestException as exc:
         return {"ok": False, "error": str(exc), "central_down": True}
+
+
+# Milestone C — typed analytics envelopes (no Plotly JSON).
+ANALYTICS_FAMILIES: frozenset[str] = frozenset(
+    {
+        "runtime",
+        "sensor-health",
+        "schedule",
+        "mechanical-cooling",
+        "economizer",
+        "rcx/ahu",
+        "rcx/vav",
+        "metering",
+    }
+)
+
+
+def analytics_post(family: str, payload: dict[str, Any], *, timeout: float = 120.0) -> dict[str, Any]:
+    """POST ``/api/analytics/{family}`` — returns central JSON (ok + analytics envelope)."""
+    fam = (family or "").strip().strip("/")
+    if fam not in ANALYTICS_FAMILIES:
+        return {
+            "ok": False,
+            "error": f"unknown analytics family '{family}' "
+            f"(expected one of: {', '.join(sorted(ANALYTICS_FAMILIES))})",
+        }
+    url = f"{api_base()}/api/analytics/{fam}"
+    try:
+        resp = _request(
+            "POST",
+            url,
+            timeout=timeout,
+            json=payload or {},
+            headers={"Content-Type": "application/json"},
+        )
+    except requests.RequestException as exc:
+        return {
+            "ok": False,
+            "error": f"central unreachable ({api_base()}): {exc}",
+            "central_down": True,
+        }
+    return _parse_json_response(resp)
+
+
+def analytics_runtime(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("runtime", payload, **kwargs)
+
+
+def analytics_economizer(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("economizer", payload, **kwargs)
+
+
+def analytics_sensor_health(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("sensor-health", payload, **kwargs)
+
+
+def analytics_schedule(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("schedule", payload, **kwargs)
+
+
+def analytics_mechanical_cooling(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("mechanical-cooling", payload, **kwargs)
+
+
+def analytics_rcx_ahu(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("rcx/ahu", payload, **kwargs)
+
+
+def analytics_rcx_vav(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("rcx/vav", payload, **kwargs)
+
+
+def analytics_metering(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    return analytics_post("metering", payload, **kwargs)

--- a/services/ui/app/test_ui_analytics.py
+++ b/services/ui/app/test_ui_analytics.py
@@ -1,0 +1,158 @@
+"""Milestone C — ui_analytics payload builders (mocked central; no Streamlit required)."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+# ui_rcx_tab / streamlit imports are not required here; keep streamlit mock for safety
+# if transitive imports pull it in.
+sys.modules.setdefault("streamlit", MagicMock())
+
+from app import central_client, ui_analytics  # noqa: E402
+
+
+def _fan_frame() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=4, freq="5min", tz="UTC")
+    return pd.DataFrame(
+        {
+            "fan_status": [1, 1, 0, 0],
+            "return_air_temp": [70.0, 70.0, 70.0, 70.0],
+            "mixed_air_temp": [55.0, 55.0, 55.0, 55.0],
+            "outside_air_temp": [40.0, 40.0, 40.0, 40.0],
+            "outside_air_damper": [50.0, 50.0, 50.0, 50.0],
+            "discharge_air_temp": [55.0, 55.0, 55.0, 55.0],
+        },
+        index=idx,
+    )
+
+
+def test_build_runtime_samples_prefers_fan_status() -> None:
+    frames = {"AHU-1": _fan_frame()}
+    role_map = {
+        "AHU-1": {
+            "fan-status": "fan_status",
+            "fan-cmd": "fan_status",  # same col; status path wins by role order
+        }
+    }
+    samples = ui_analytics.build_runtime_samples(frames, role_map)
+    assert len(samples) == 4
+    assert samples[0]["equipment_id"] == "AHU-1"
+    assert samples[0]["on"] is True
+    assert samples[2]["on"] is False
+    assert "T" in samples[0]["timestamp"] or "Z" in samples[0]["timestamp"]
+
+
+def test_build_runtime_samples_fan_cmd_fallback() -> None:
+    idx = pd.date_range("2024-01-01", periods=2, freq="5min", tz="UTC")
+    frames = {
+        "AHU-2": pd.DataFrame({"sf_cmd": [100.0, 0.0]}, index=idx),
+    }
+    role_map = {"AHU-2": {"fan-cmd": "sf_cmd"}}
+    samples = ui_analytics.build_runtime_samples(frames, role_map)
+    assert len(samples) == 2
+    assert samples[0]["on"] is True
+    assert samples[1]["on"] is False
+
+
+def test_fetch_runtime_analytics_skips_when_unhealthy() -> None:
+    with patch.object(central_client, "health_ok", return_value=False):
+        out = ui_analytics.fetch_runtime_analytics({"AHU-1": _fan_frame()}, {})
+    assert out.get("ok") is False
+    assert out.get("central_down") is True
+
+
+def test_fetch_runtime_analytics_posts_samples() -> None:
+    frames = {"AHU-1": _fan_frame()}
+    role_map = {"AHU-1": {"fan-status": "fan_status"}}
+    fake = {
+        "ok": True,
+        "analytics": {
+            "engine": "central-analytics-v1",
+            "query_version": "runtime-v1",
+            "run_id": "run-1",
+            "rows": [{"equipment_id": "AHU-1", "run_hours": 0.17}],
+        },
+    }
+    with patch.object(central_client, "health_ok", return_value=True):
+        with patch.object(central_client, "analytics_post", return_value=fake) as post:
+            out = ui_analytics.fetch_runtime_analytics(frames, role_map)
+    assert out.get("ok") is True
+    assert out["analytics"]["rows"][0]["equipment_id"] == "AHU-1"
+    args, kwargs = post.call_args
+    assert args[0] == "runtime"
+    payload = args[1]
+    assert "samples" in payload
+    assert len(payload["samples"]) == 4
+    assert payload["query_version"] == "runtime-v1"
+
+
+def test_fetch_runtime_surfaces_central_error_no_fallback() -> None:
+    frames = {"AHU-1": _fan_frame()}
+    role_map = {"AHU-1": {"fan-status": "fan_status"}}
+    with patch.object(central_client, "health_ok", return_value=True):
+        with patch.object(
+            central_client,
+            "analytics_post",
+            return_value={"ok": False, "error": "boom", "central_down": True},
+        ):
+            out = ui_analytics.fetch_runtime_analytics(frames, role_map)
+    assert out.get("ok") is False
+    assert out.get("error") == "boom"
+    assert "analytics" not in out or out.get("analytics") is None
+
+
+def test_build_economizer_series_points() -> None:
+    frames = {"AHU-1": _fan_frame()}
+    role_map = {
+        "AHU-1": {
+            "fan-status": "fan_status",
+            "return-air-temp": "return_air_temp",
+            "mixed-air-temp": "mixed_air_temp",
+            "outside-air-temp": "outside_air_temp",
+            "outside-air-damper": "outside_air_damper",
+            "discharge-air-temp": "discharge_air_temp",
+            "equipment_type": "AHU",
+        }
+    }
+    series = ui_analytics.build_economizer_series(frames, role_map)
+    pts = series["points"]
+    assert len(pts) == 4
+    assert pts[0]["equipment_id"] == "AHU-1"
+    assert pts[0]["oat_f"] == 40.0
+    assert pts[0]["rat_f"] == 70.0
+    assert pts[0]["mat_f"] == 55.0
+    assert pts[0]["fan_on"] is True
+    assert "oa_damper_pct" in pts[0]
+
+
+def test_provenance_caption() -> None:
+    cap = ui_analytics.provenance_caption(
+        {
+            "engine": "central-analytics-v1",
+            "query_version": "runtime-v1",
+            "run_id": "run-abc",
+        }
+    )
+    assert "central-analytics-v1" in cap
+    assert "runtime-v1" in cap
+    assert "run-abc" in cap
+
+
+def test_analytics_post_rejects_unknown_family() -> None:
+    out = central_client.analytics_post("not-a-family", {})
+    assert out.get("ok") is False
+    assert "unknown" in (out.get("error") or "").lower()
+
+
+def test_analytics_post_posts_to_path() -> None:
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.content = b'{"ok": true, "analytics": {}}'
+    fake_resp.json.return_value = {"ok": True, "analytics": {}}
+    with patch.object(central_client, "_request", return_value=fake_resp) as req:
+        out = central_client.analytics_post("runtime", {"samples": []})
+    assert out.get("ok") is True
+    assert "/api/analytics/runtime" in req.call_args[0][1]

--- a/services/ui/app/ui_analytics.py
+++ b/services/ui/app/ui_analytics.py
@@ -1,0 +1,311 @@
+"""Streamlit helpers for Milestone C central analytics APIs.
+
+Builds inline payloads from frames/role_map and calls ``central_client.analytics_post``.
+Does **not** silently fall back to pandas — callers decide on error dicts.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pandas as pd
+
+from app import central_client
+from app.role_map import apply_role_map
+from app.site_model import normalize_equipment_type, resolve_equipment_type
+
+FAN_ROLES: tuple[str, ...] = ("fan-status", "fan-cmd")
+ECON_AIR_TYPES = frozenset({"AHU", "RTU"})
+
+
+def _is_on(series: pd.Series) -> pd.Series:
+    """True when a command/status indicates the motor is running."""
+    num = pd.to_numeric(series, errors="coerce")
+    if num.notna().any():
+        scaled = num.where(num <= 1.5, num / 100.0)
+        return scaled.fillna(0) > 0.05
+    return series.fillna(False).astype(bool)
+
+
+def _ts_iso(ts: Any) -> str | None:
+    """Serialize a timestamp to UTC ISO-8601 for central DateTime<Utc>."""
+    try:
+        t = pd.Timestamp(ts)
+    except Exception:
+        return None
+    if pd.isna(t):
+        return None
+    if t.tzinfo is None:
+        t = t.tz_localize("UTC")
+    else:
+        t = t.tz_convert("UTC")
+    return t.isoformat().replace("+00:00", "Z")
+
+
+def prefer_central_analytics() -> bool:
+    """True when env forces central or central health responds ok."""
+    flag = (os.environ.get("OPENFDD_ANALYTICS_CENTRAL") or "").strip().lower()
+    if flag in ("1", "true", "yes", "on"):
+        return True
+    return central_client.health_ok()
+
+
+def provenance_caption(envelope: dict[str, Any] | None) -> str:
+    """Dev provenance string from an analytics envelope (engine / query_version / run_id)."""
+    if not isinstance(envelope, dict):
+        return ""
+    engine = envelope.get("engine") or "—"
+    qv = envelope.get("query_version") or "—"
+    run_id = envelope.get("run_id") or envelope.get("job_id") or "—"
+    return f"analytics provenance · engine={engine} · query_version={qv} · run_id={run_id}"
+
+
+def build_runtime_samples(
+    frames: dict[str, pd.DataFrame],
+    role_map: dict | None,
+    *,
+    equipment_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Build ``{equipment_id, timestamp, on}`` samples (fan-status preferred over fan-cmd)."""
+    role_map = role_map or {}
+    samples: list[dict[str, Any]] = []
+    ids = equipment_ids or list(frames.keys())
+    for eq_id in ids:
+        raw = frames.get(eq_id)
+        if raw is None or raw.empty:
+            continue
+        mapped = apply_role_map(raw, eq_id, role_map)
+        on_ser: pd.Series | None = None
+        for role in FAN_ROLES:
+            if role in mapped.columns and mapped[role].notna().any():
+                on_ser = _is_on(mapped[role])
+                break
+        if on_ser is None:
+            continue
+        idx = mapped.index
+        if not isinstance(idx, pd.DatetimeIndex):
+            continue
+        for ts, on_val in zip(idx, on_ser.fillna(False).astype(bool)):
+            iso = _ts_iso(ts)
+            if iso is None:
+                continue
+            samples.append(
+                {
+                    "equipment_id": str(eq_id),
+                    "timestamp": iso,
+                    "on": bool(on_val),
+                }
+            )
+    return samples
+
+
+def fetch_runtime_analytics(
+    frames: dict[str, pd.DataFrame],
+    role_map: dict | None,
+    *,
+    max_gap_seconds: float = 900.0,
+    equipment_ids: list[str] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """POST runtime samples to central when healthy; return error dict on failure (no pandas)."""
+    if not central_client.health_ok():
+        return {"ok": False, "error": "central health check failed", "central_down": True}
+    samples = build_runtime_samples(frames, role_map, equipment_ids=equipment_ids)
+    if not samples:
+        return {"ok": False, "error": "no fan-status/fan-cmd samples to send"}
+    payload: dict[str, Any] = {
+        "samples": samples,
+        "max_gap_seconds": float(max_gap_seconds),
+        "query_version": "runtime-v1",
+    }
+    if equipment_ids:
+        payload["equipment_ids"] = list(equipment_ids)
+    if extra:
+        payload.update(extra)
+    resp = central_client.analytics_post("runtime", payload)
+    if not isinstance(resp, dict):
+        return {"ok": False, "error": f"unexpected central response: {resp!r}"}
+    if resp.get("ok") is False or resp.get("central_down"):
+        return resp
+    analytics = resp.get("analytics")
+    if not isinstance(analytics, dict):
+        return {"ok": False, "error": "central response missing analytics envelope", **resp}
+    return {"ok": True, "analytics": analytics, **{k: v for k, v in resp.items() if k != "analytics"}}
+
+
+def _econ_fan_on_mask(mapped: pd.DataFrame) -> pd.Series:
+    masks: list[pd.Series] = []
+    for role in FAN_ROLES:
+        if role in mapped.columns and mapped[role].notna().any():
+            masks.append(_is_on(mapped[role]).fillna(False).astype(bool))
+    if not masks:
+        return pd.Series(False, index=mapped.index)
+    out = masks[0]
+    for m in masks[1:]:
+        out = out | m
+    return out
+
+
+def _econ_resolve_oat(mapped: pd.DataFrame, *, prefer_web_oat: bool = False) -> pd.Series | None:
+    bas = None
+    if "outside-air-temp" in mapped.columns and mapped["outside-air-temp"].notna().any():
+        bas = pd.to_numeric(mapped["outside-air-temp"], errors="coerce")
+    elif "bas-outside-air-temp" in mapped.columns and mapped["bas-outside-air-temp"].notna().any():
+        bas = pd.to_numeric(mapped["bas-outside-air-temp"], errors="coerce")
+    web = None
+    if "web-outside-air-temp" in mapped.columns and mapped["web-outside-air-temp"].notna().any():
+        web = pd.to_numeric(mapped["web-outside-air-temp"], errors="coerce")
+    elif "oa_t_effective" in mapped.columns and mapped["oa_t_effective"].notna().any():
+        web = pd.to_numeric(mapped["oa_t_effective"], errors="coerce")
+    if prefer_web_oat and web is not None and web.notna().any():
+        return web
+    if bas is not None and bas.notna().any():
+        return bas
+    return web
+
+
+def _is_econ_air_equipment(eq_id: str, et: str) -> bool:
+    et_n = normalize_equipment_type(et) if et else ""
+    if et_n in ECON_AIR_TYPES:
+        return True
+    upper = str(eq_id).upper()
+    return any(tok in upper for tok in ("AHU", "RTU", "MAU", "AIRHAND"))
+
+
+def _damper_pct(series: pd.Series) -> pd.Series:
+    """Normalize damper feedback to percent 0–100 (accepts 0–1 or 0–100)."""
+    num = pd.to_numeric(series, errors="coerce")
+    # Values ≤ 1.5 treated as fraction → percent.
+    return num.where(num > 1.5, num * 100.0)
+
+
+def build_economizer_series(
+    frames: dict[str, pd.DataFrame],
+    role_map: dict | None,
+    *,
+    weather: pd.DataFrame | None = None,
+    prefer_web_oat: bool = False,
+    equipment_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build ``{"points": [...]}`` payload for ``POST /api/analytics/economizer``."""
+    role_map = role_map or {}
+    points: list[dict[str, Any]] = []
+    ids = equipment_ids or list(frames.keys())
+
+    for eq_id in ids:
+        raw = frames.get(eq_id)
+        if raw is None or raw.empty:
+            continue
+        et = resolve_equipment_type(eq_id, df=raw, role_map=role_map)
+        if not _is_econ_air_equipment(eq_id, et or ""):
+            continue
+        et_n = normalize_equipment_type(et) if et else ""
+        if et_n not in ECON_AIR_TYPES:
+            et_n = et_n or "AHU"
+
+        mapped = apply_role_map(raw, eq_id, role_map)
+        if weather is not None and not weather.empty:
+            try:
+                from app.rules.runner import merge_weather
+
+                mapped = merge_weather(mapped, weather)
+            except Exception:
+                pass
+        fan_on = _econ_fan_on_mask(mapped)
+        oat = _econ_resolve_oat(mapped, prefer_web_oat=prefer_web_oat)
+        rat = (
+            pd.to_numeric(mapped["return-air-temp"], errors="coerce")
+            if "return-air-temp" in mapped.columns
+            else None
+        )
+        mat = (
+            pd.to_numeric(mapped["mixed-air-temp"], errors="coerce")
+            if "mixed-air-temp" in mapped.columns
+            else None
+        )
+        if oat is None or rat is None or mat is None:
+            continue
+
+        sat = (
+            pd.to_numeric(mapped["discharge-air-temp"], errors="coerce")
+            if "discharge-air-temp" in mapped.columns
+            else None
+        )
+        damper = None
+        if "outside-air-damper" in mapped.columns and mapped["outside-air-damper"].notna().any():
+            damper = _damper_pct(mapped["outside-air-damper"])
+
+        idx = mapped.index
+        if not isinstance(idx, pd.DatetimeIndex):
+            continue
+
+        for i, ts in enumerate(idx):
+            iso = _ts_iso(ts)
+            if iso is None:
+                continue
+            oat_v = float(oat.iloc[i]) if oat is not None else float("nan")
+            rat_v = float(rat.iloc[i]) if rat is not None else float("nan")
+            mat_v = float(mat.iloc[i]) if mat is not None else float("nan")
+            if any(pd.isna(v) for v in (oat_v, rat_v, mat_v)):
+                continue
+            row: dict[str, Any] = {
+                "equipment_id": str(eq_id),
+                "equipment_type": et_n or "AHU",
+                "timestamp": iso,
+                "oat_f": oat_v,
+                "rat_f": rat_v,
+                "mat_f": mat_v,
+                "fan_on": bool(fan_on.iloc[i]) if i < len(fan_on) else False,
+            }
+            if sat is not None and not pd.isna(sat.iloc[i]):
+                row["sat_f"] = float(sat.iloc[i])
+            if damper is not None and not pd.isna(damper.iloc[i]):
+                row["oa_damper_pct"] = float(damper.iloc[i])
+            points.append(row)
+
+    return {"points": points}
+
+
+def fetch_economizer_analytics(
+    frames: dict[str, pd.DataFrame],
+    role_map: dict | None,
+    *,
+    weather: pd.DataFrame | None = None,
+    prefer_web_oat: bool = False,
+    dt_min_f: float = 10.0,
+    max_points: int = 8000,
+    equipment_ids: list[str] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """POST economizer series to central when healthy; return error dict on failure."""
+    if not central_client.health_ok():
+        return {"ok": False, "error": "central health check failed", "central_down": True}
+    series = build_economizer_series(
+        frames,
+        role_map,
+        weather=weather,
+        prefer_web_oat=prefer_web_oat,
+        equipment_ids=equipment_ids,
+    )
+    if not series.get("points"):
+        return {"ok": False, "error": "no economizer points to send"}
+    payload: dict[str, Any] = {
+        "series": series,
+        "dt_min_f": float(dt_min_f),
+        "max_points": int(max_points),
+        "query_version": "economizer-diagnostics-v1",
+    }
+    if equipment_ids:
+        payload["equipment_ids"] = list(equipment_ids)
+    if extra:
+        payload.update(extra)
+    resp = central_client.analytics_post("economizer", payload)
+    if not isinstance(resp, dict):
+        return {"ok": False, "error": f"unexpected central response: {resp!r}"}
+    if resp.get("ok") is False or resp.get("central_down"):
+        return resp
+    analytics = resp.get("analytics")
+    if not isinstance(analytics, dict):
+        return {"ok": False, "error": "central response missing analytics envelope", **resp}
+    return {"ok": True, "analytics": analytics, **{k: v for k, v in resp.items() if k != "analytics"}}

--- a/services/ui/app/ui_rcx_tab.py
+++ b/services/ui/app/ui_rcx_tab.py
@@ -30,6 +30,110 @@ from app.rcx_plots import (
 )
 from app.reports import to_csv_bytes
 from app.unit_system import convert_series
+from app import ui_analytics
+
+
+def _render_economizer_diagnostics(
+    frames: dict[str, pd.DataFrame],
+    role_map: dict,
+    *,
+    weather: pd.DataFrame | None,
+) -> None:
+    """AHU free-cooling economizer diagnostics via central ``/api/analytics/economizer``."""
+    st.markdown("##### Economizer diagnostics")
+    st.caption(
+        "Central analytics (Guideline 36–aligned mixing). Fan-on samples only; "
+        "identifiability when |OAT−RAT| ≥ dt_min."
+    )
+    prefer_web = bool(st.session_state.get("prefer_web_oat", True))
+    dt_min = float(st.session_state.get("econ_dt_min_f", 10.0))
+
+    if not ui_analytics.prefer_central_analytics():
+        st.info("Central analytics unavailable — economizer diagnostics need openfdd-central.")
+        return
+
+    with st.spinner("Running central economizer diagnostics…"):
+        result = ui_analytics.fetch_economizer_analytics(
+            frames,
+            role_map,
+            weather=weather,
+            prefer_web_oat=prefer_web,
+            dt_min_f=dt_min,
+        )
+
+    if not result.get("ok"):
+        st.warning(
+            f"Economizer diagnostics unavailable: {result.get('error') or 'central error'}"
+        )
+        return
+
+    env = result.get("analytics") or {}
+    cap = ui_analytics.provenance_caption(env)
+    if cap:
+        st.caption(cap)
+    for w in env.get("warnings") or []:
+        st.caption(f"⚠ {w}")
+
+    equip = env.get("equipment") or []
+    skipped = env.get("skipped") or []
+    points = env.get("points") or []
+
+    if equip:
+        metrics_df = pd.DataFrame(equip)
+        st.markdown("###### Equipment metrics")
+        st.dataframe(metrics_df, hide_index=True, width="stretch", height=min(320, 80 + 28 * len(metrics_df)))
+    else:
+        st.info("No economizer equipment metrics returned.")
+
+    if skipped:
+        skip_df = pd.DataFrame(skipped)
+        st.markdown("###### Skipped equipment")
+        st.dataframe(skip_df, hide_index=True, width="stretch", height=min(240, 80 + 28 * len(skip_df)))
+
+    if points:
+        pts_df = pd.DataFrame(points)
+        # Prefer API delta_* fields; fall back to oat/mat − rat if present.
+        if "delta_or_f" in pts_df.columns:
+            pts_df = pts_df.assign(oat_minus_rat=pts_df["delta_or_f"])
+        elif {"oat_f", "rat_f"}.issubset(pts_df.columns):
+            pts_df = pts_df.assign(oat_minus_rat=pts_df["oat_f"] - pts_df["rat_f"])
+        if "delta_mr_f" in pts_df.columns:
+            pts_df = pts_df.assign(mat_minus_rat=pts_df["delta_mr_f"])
+        elif {"mat_f", "rat_f"}.issubset(pts_df.columns):
+            pts_df = pts_df.assign(mat_minus_rat=pts_df["mat_f"] - pts_df["rat_f"])
+
+        if {"oat_minus_rat", "mat_minus_rat"}.issubset(pts_df.columns):
+            try:
+                import plotly.express as px
+
+                fig = px.scatter(
+                    pts_df,
+                    x="oat_minus_rat",
+                    y="mat_minus_rat",
+                    color="equipment_id" if "equipment_id" in pts_df.columns else None,
+                    title="Economizer ΔT scatter (OAT−RAT vs MAT−RAT)",
+                    labels={
+                        "oat_minus_rat": "OAT − RAT (°F)",
+                        "mat_minus_rat": "MAT − RAT (°F)",
+                    },
+                )
+                st.plotly_chart(
+                    fig,
+                    width="stretch",
+                    config=plotly_config(filename="economizer_delta_scatter"),
+                    key="rcx_econ_delta_scatter",
+                )
+            except Exception as exc:
+                st.caption(f"Scatter unavailable: {exc}")
+
+        st.download_button(
+            "Download economizer points CSV",
+            to_csv_bytes(pts_df),
+            "economizer_diagnostics_points.csv",
+            key="dl_rcx_econ_points",
+        )
+    else:
+        st.info("No economizer diagnostic points returned.")
 
 
 def _convert_map(series_map: dict[str, pd.Series], role: str, system: str) -> tuple[dict[str, pd.Series], str]:
@@ -177,6 +281,11 @@ def render_rcx_plots_tab(
             key="dl_rcx_coverage",
         )
     family_presets = presets_for_family(family)
+
+    # Economizer diagnostics — AHU family only (central API; presets unchanged below).
+    if str(family).startswith("AHU"):
+        _render_economizer_diagnostics(frames, role_map, weather=weather)
+
     if not family_presets:
         st.info(
             f"No RCx chart presets in **{family}** yet — use the Word template above "

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -2478,17 +2478,30 @@ def main() -> None:
     motor_weekly = pd.DataFrame()
     cool_bins = pd.DataFrame()
     cool_coverage = pd.DataFrame()
+    central_runtime: dict | None = None
     if section == "Overview":
+        # Prefer central runtime when OPENFDD_ANALYTICS_CENTRAL=1 or health_ok.
         try:
-            motor_weekly = motor_run_hours_weekly(
-                frames,
-                st.session_state.role_map,
-                chw_leave_max_f=float(st.session_state.get("chw_leave_max_f", 48.0)),
-                weather=st.session_state.weather,
-                prefer_web_oat=bool(st.session_state.get("prefer_web_oat", True)),
-            )
+            from app import ui_analytics as _ui_analytics
+
+            if _ui_analytics.prefer_central_analytics():
+                central_runtime = _ui_analytics.fetch_runtime_analytics(
+                    frames,
+                    st.session_state.role_map,
+                )
         except Exception as exc:
-            st.warning(f"Weekly motor hours unavailable: {exc}")
+            central_runtime = {"ok": False, "error": str(exc)}
+        if not (isinstance(central_runtime, dict) and central_runtime.get("ok")):
+            try:
+                motor_weekly = motor_run_hours_weekly(
+                    frames,
+                    st.session_state.role_map,
+                    chw_leave_max_f=float(st.session_state.get("chw_leave_max_f", 48.0)),
+                    weather=st.session_state.weather,
+                    prefer_web_oat=bool(st.session_state.get("prefer_web_oat", True)),
+                )
+            except Exception as exc:
+                st.warning(f"Weekly motor hours unavailable: {exc}")
         try:
             cool_bins = mech_cooling_oat_bins(
                 frames,
@@ -2558,12 +2571,41 @@ def main() -> None:
         render_overview_rcx_download(key="overview_generic_rcx_docx")
 
         min_air_hours = _render_building_schedule_overview()
-        _render_plant_motor_weekly(
-            motor_weekly,
-            key_prefix="overview",
-            show_table=True,
-            min_air_hours=min_air_hours,
-        )
+        if isinstance(central_runtime, dict) and central_runtime.get("ok"):
+            from app import ui_analytics as _ui_analytics
+
+            env = central_runtime.get("analytics") or {}
+            rows = env.get("rows") or env.get("equipment") or []
+            st.markdown("##### Motor run hours (central analytics)")
+            cap = _ui_analytics.provenance_caption(env)
+            if cap:
+                st.caption(cap)
+            for w in env.get("warnings") or []:
+                st.caption(f"⚠ {w}")
+            if rows:
+                runtime_df = pd.DataFrame(rows)
+                st.dataframe(
+                    runtime_df,
+                    hide_index=True,
+                    width="stretch",
+                    height=min(360, 80 + 28 * len(runtime_df)),
+                )
+                st.download_button(
+                    "Download central runtime CSV",
+                    to_csv_bytes(runtime_df),
+                    "motor_runtime_central.csv",
+                    key="overview_dl_central_runtime",
+                )
+            else:
+                st.info("Central runtime returned no equipment rows.")
+        else:
+            st.caption("runtime via pandas oracle (central analytics unavailable)")
+            _render_plant_motor_weekly(
+                motor_weekly,
+                key_prefix="overview",
+                show_table=True,
+                min_air_hours=min_air_hours,
+            )
 
         st.markdown("##### Mechanical cooling hours by OAT bin")
         st.caption(

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -2711,6 +2711,10 @@ def main() -> None:
                 "economizer_weather.csv",
                 key="dl_econ_weather_overview",
             )
+            st.info(
+                "Detailed free-cooling / mixing diagnostics (delta scatter, MAT residual, OA fraction) "
+                "live under **RCx Plots → AHU → Economizer diagnostics** (canonical central dataset)."
+            )
 
         st.markdown("##### BAS vs web outdoor-air temperature")
         st.caption(


### PR DESCRIPTION
## Summary
- Typed `/api/analytics/*` envelope (`central-analytics-v1`) for runtime, sensor-health, schedule, mechanical-cooling, economizer, rcx/ahu, rcx/vav, metering
- Runtime: actual Δt integration with gap clipping (not samples×poll)
- Economizer diagnostics: fan-on gate, |OAT−RAT| identifiability, OA fraction, MAT residual
- Streamlit Overview prefers central runtime; RCx AHU economizer diagnostics section
- Analytics matrix + inventory updates; stubs for remaining families

## Test plan
- [x] `cargo test -p openfdd-central --bin openfdd-central analytics` (17)
- [x] `pytest app/test_ui_analytics.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized analytics for runtime hours, sensor health, schedules, economizer diagnostics, mechanical cooling, metering, and RCx insights.
  * Added Overview support for centralized motor run-hour data with CSV export and fallback calculations.
  * Added RCx economizer visualizations, equipment metrics, warnings, provenance, and downloadable diagnostic data.
* **Bug Fixes**
  * Improved handling of unavailable analytics services and incomplete data.
* **Documentation**
  * Added Milestone C architecture, migration, benchmark, acceptance, and parity guidance.
* **Tests**
  * Expanded UI analytics coverage and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->