### PR TITLE
docs(d0): Milestone C→D gap register + cookbook fortress

### DIFF
--- a/docs/migration/MILESTONE_C_CLOSEOUT.md
+++ b/docs/migration/MILESTONE_C_CLOSEOUT.md
@@ -6,7 +6,7 @@ nav_order: 23
 
 # Milestone C closeout
 
-**Date:** 2026-07-28 · Branch `milestone-c/c1-c2-analytics-runtime`
+**Date:** 2026-07-28 · Tip `7fed6fb8` (#589)
 
 ## Executive summary
 
@@ -17,8 +17,9 @@ remaining families have **minimal real compute** (not empty schema stubs), with
 honest warnings that DataFusion SQL / MemTable historian loads and full UI
 cutover are follow-ups.
 
-This is a **partial** Milestone C closeout for the C1–C2 runtime branch — not
-full pandas retirement or `sha-*` full-stack acceptance.
+This is a **partial** Milestone C closeout — not full pandas retirement or
+`sha-*` full-stack acceptance. Gap register for Milestone D:
+[`MILESTONE_C_TO_D_GAP_REGISTER.md`](MILESTONE_C_TO_D_GAP_REGISTER.md).
 
 ## What is live
 
@@ -32,19 +33,24 @@ full pandas retirement or `sha-*` full-stack acceptance.
 | Sensor health — coverage / flatline / missingness / min-max-mean | **Minimal compute** |
 | Schedule — occupied hours + optional after-hours fan hours | **Minimal compute** |
 | Mechanical cooling — evidence hierarchy (pump/valve ≠ compressor) | **Minimal compute** |
-| RCx AHU — sat_sp / duct_static_sp coverage stub fields | **Minimal compute** |
-| RCx VAV — zone comfort ranking (zone_temp vs setpoint) | **Minimal compute** |
+| RCx AHU / VAV / plant | **Minimal compute** |
 | Metering — monthly kWh sum | **Minimal compute** |
 
-## Explicit follow-ups (not claimed done)
+## GHCR
+
+| Field | Value |
+|-------|-------|
+| Open-FDD SHA | `7fed6fb8` |
+| Expected tags | `ghcr.io/bbartling/openfdd-{central,ui}:sha-7fed6fb8` and `:nightly` |
+| Notes | Publish workflow triggered by #589; confirm digests when Actions green |
+
+## Explicit follow-ups (Milestone D / finish C)
 
 - DataFusion SQL / MemTable per family; bump `engine` only when SQL path is live
 - Historian / job Feather load into analytics handlers
-- Full Streamlit cutover for sensor / schedule / mech / RCx / metering; Overview economizer compact link
-- Pandas production path retirement after cutover (oracle stays)
-- SQL rule parity residual beyond fixture notes / mutation checklist
-- Benchmark table fill for medium/large fixtures
-- Full-stack immutable `sha-*` acceptance
+- Full Streamlit cutover; pandas production retirement (oracle stays)
+- SQL rule parity + mutation checks; filled benches; `sha-*` soak
+- Phase 8 WattLab job-native + restricted EnergyPlus runner
 
 ## Engine honesty
 
@@ -53,6 +59,7 @@ Responses use `engine: "central-analytics-v1"`. Do **not** advertise
 
 ## Related
 
+- [C→D gap register](MILESTONE_C_TO_D_GAP_REGISTER.md)
 - [Analytics matrix](MILESTONE_C_ANALYTICS_MATRIX.md)
 - [Acceptance](MILESTONE_C_ACCEPTANCE.md)
 - [Rule parity](MILESTONE_C_RULE_PARITY.md)

--- a/docs/migration/MILESTONE_C_TO_D_GAP_REGISTER.md
+++ b/docs/migration/MILESTONE_C_TO_D_GAP_REGISTER.md
@@ -1,0 +1,73 @@
+---
+title: Milestone C → D gap register
+parent: Migration
+nav_order: 24
+---
+
+# Milestone C → D gap register
+
+**Date:** 2026-07-28  
+**Open-FDD tip:** `7fed6fb8`  
+**Playground tip:** `d553e31` (`develop`)  
+**Roadmap:** [#581](https://github.com/bbartling/open-fdd/issues/581) — C = Phases 6–7; D = Phase 8 + cleanup
+
+Statuses: `VERIFIED` | `PARTIAL` | `NOT_DONE` | `DEFERRED`
+
+## Hygiene
+
+| Check | Status | Evidence |
+|-------|--------|----------|
+| open-fdd open PRs | VERIFIED | 0 |
+| open-fdd remotes | VERIFIED | `master` only |
+| playground open PRs | VERIFIED | 0 |
+| playground remotes | VERIFIED | `develop` only |
+| GHCR tip `sha-7fed6fb8` | PARTIAL | Publish run after #589 — verify digests in closeout when green |
+
+## Milestone A residuals
+
+| Item | Status |
+|------|--------|
+| `open_fdd.contracts` + generated rule manifest | DEFERRED |
+| Remaining vibe20 ECM twins | DEFERRED |
+| Playground GHCR retirement | DEFERRED |
+| Broader forbidden-import suites | DEFERRED |
+
+## Milestone B
+
+| Item | Status |
+|------|--------|
+| Jobs FS + central API + stale/findings | VERIFIED (C0 adversarial) |
+| RUNNING restart recovery | VERIFIED |
+| Browser Playwright jobs soak | NOT_DONE |
+| WattLab dump v2/v3 deep compat | PARTIAL |
+
+## Milestone C (must finish before Phase 8)
+
+| Item | Status | Notes |
+|------|--------|-------|
+| C0 adversarial + README/cookbook honesty | VERIFIED | #587 #588 |
+| Typed `/api/analytics/*` envelopes | VERIFIED | #589 |
+| Runtime Δt + economizer + UI prefer-central | PARTIAL | Live; pandas weekly fallback may remain |
+| Sensor / schedule / mech / RCx / metering / plant | PARTIAL | Minimal compute; UI mostly pandas |
+| Engine `datafusion` | NOT_DONE | Honest `central-analytics-v1` today |
+| Historian / Feather → analytics | NOT_DONE | Inline samples only |
+| Phase 6 exit: Streamlit → central only | NOT_DONE | |
+| Phase 7 SQL parity evidence levels | PARTIAL | Docs residual |
+| Pandas production retirement | NOT_DONE | |
+| Filled benches + `sha-*` soak | NOT_DONE | |
+
+## Cookbook / docs fortress
+
+| Item | Status |
+|------|--------|
+| Dual cookbooks present | VERIFIED |
+| Parity matrix + ownership CI | VERIFIED |
+| README badge block + PyPI + 59/63 honesty | VERIFIED |
+| Floor-size fortress asserts (D0) | VERIFIED after this PR |
+
+## Milestone D scope (after C exit)
+
+1. Finish Phase 6–7 (D1–D2)
+2. Phase 8 job-native WattLab (D3)
+3. Restricted EnergyPlus runner (D4)
+4. Escape-hatch deletion + D closeout (D5)

--- a/scripts/architecture_ownership_check.py
+++ b/scripts/architecture_ownership_check.py
@@ -24,6 +24,13 @@ REQUIRED_COOKBOOKS = (
     "parity-matrix.md",
 )
 
+# Dual cookbooks are large expression catalogs — reject vibe-coded stubs.
+COOKBOOK_MIN_BYTES = {
+    "datafusion-sql-cookbook.md": 40_000,
+    "pandas-cookbook.md": 40_000,
+    "parity-matrix.md": 1_500,
+}
+
 # README navigation / product wording invariants (C0).
 README_REQUIRED_MARKERS = (
     "FDD Rule Cookbook",
@@ -124,8 +131,23 @@ def main() -> int:
         path = COOKBOOK / name
         if not path.is_file():
             errors.append(f"missing cookbook {path.relative_to(ROOT)}")
-        elif path.stat().st_size < 200:
-            errors.append(f"cookbook suspiciously small: {path.relative_to(ROOT)}")
+            continue
+        size = path.stat().st_size
+        floor = COOKBOOK_MIN_BYTES.get(name, 200)
+        if size < floor:
+            errors.append(
+                f"cookbook too small (docs fortress): {path.relative_to(ROOT)} "
+                f"has {size} bytes, need >= {floor}"
+            )
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if name.endswith("cookbook.md"):
+            if "required" not in text.lower() and "Required" not in text:
+                errors.append(f"{name}: missing required-roles style content")
+            if text.count("#") < 20:
+                errors.append(f"{name}: too few markdown headings (catalog must not shrink)")
+        if name == "parity-matrix.md":
+            if "59" not in text or "63" not in text:
+                errors.append("parity-matrix.md must state cookbook 59 and registry 63")
 
     _check_readme(errors)
 


### PR DESCRIPTION
## Summary
- `MILESTONE_C_TO_D_GAP_REGISTER.md` — honest A/B/C gaps before Phase 8
- Update C closeout with tip `7fed6fb8` + GHCR expected tags
- Docs fortress: cookbook min bytes (40k/40k/1.5k) + heading/59–63 asserts

## Test plan
- [x] `python3 scripts/architecture_ownership_check.py`
- [ ] cookbook-parity CI green
- [ ] Confirm GHCR `sha-7fed6fb8` when publish finishes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Milestone C closeout with current build references, partial-status clarification, GHCR image-tag expectations, and revised follow-up guidance.
  - Added a Milestone C→D gap register covering outstanding work, evidence, status definitions, and planned Milestone D scope.
  - Linked the new gap register from related migration documentation.

- **Validation**
  - Strengthened architecture and cookbook checks for required content, minimum completeness, heading coverage, and parity references.
  - Improved handling of missing cookbook files during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->