### PR TITLE
feat(jobs): D3 job-native WattLab + D4 restricted E+ queue stub

### DIFF
--- a/docs/architecture/job-workspaces.md
+++ b/docs/architecture/job-workspaces.md
@@ -99,6 +99,15 @@ Duplicate copies mapping/config/dataset_refs — **not** runs, findings, or repo
 
 `findings/findings.json` holds machine evidence (SQL row hashes, rule outputs). Each finding requires `correlation_key` and `finding_id`. Dispositions live in `findings/dispositions.json` keyed by `correlation_key` — human status never overwrites evidence rows.
 
+## WattLab (job-native SoT)
+
+**Production source of truth** is job-native handoffs under `wattlab/handoffs/*.json`
+(central `POST /api/jobs/{id}/wattlab/handoffs`, Streamlit helper
+[`ui_wattlab_job.py`](../../services/ui/app/ui_wattlab_job.py)). Zip dumps from Export
+remain **additive** for offline / vibe20 / backup — they do not replace the job
+manifest. External EnergyPlus run metadata (when queued) lands under
+`wattlab/runs/*.json`; central tracks status/artifacts only.
+
 ## Atomicity
 
 Metadata writes use temp file + fsync + rename.

--- a/services/central/src/eplus_runner.rs
+++ b/services/central/src/eplus_runner.rs
@@ -1,0 +1,314 @@
+//! Restricted EnergyPlus runner policy + job-attached run records (Milestone D4).
+//!
+//! **Execution is external** (playground vibe20 / approved runner image). Central
+//! does **not** open a Docker socket, does **not** parse IDF, and does **not**
+//! invoke EnergyPlus in-process. This module only validates runner policy and
+//! persists QUEUED / status / artifact metadata under
+//! `workspace/jobs/<id>/wattlab/runs/*.json`.
+
+use std::path::{Component, Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::jobs::{self, JobError};
+
+/// Constrained runner policy for an external EnergyPlus worker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerPolicy {
+    /// Required immutable image digest (`sha256:…`). Tags alone are rejected.
+    pub image_digest: String,
+    /// Absolute workspace root the runner may read/write under.
+    pub workspace_root: PathBuf,
+    /// CPU limit hint (cores) for the external runner.
+    pub cpu_limit: f64,
+    /// Memory limit hint (MiB) for the external runner.
+    pub memory_limit_mib: u64,
+    /// Wall-clock timeout for the external run.
+    pub timeout_secs: u64,
+    /// Runner must drop privileges (non-root).
+    pub non_root: bool,
+}
+
+impl RunnerPolicy {
+    pub fn validate_policy(&self) -> Result<(), String> {
+        let digest = self.image_digest.trim();
+        if digest.is_empty() {
+            return Err("image_digest is required".into());
+        }
+        if !digest.starts_with("sha256:") || digest.len() < "sha256:".len() + 16 {
+            return Err("image_digest must be a sha256:… digest (not a mutable tag)".into());
+        }
+        if self.workspace_root.as_os_str().is_empty() {
+            return Err("workspace_root is required".into());
+        }
+        if !self.workspace_root.is_absolute() {
+            return Err("workspace_root must be an absolute path".into());
+        }
+        if path_has_escape(&self.workspace_root) {
+            return Err("workspace_root path escape rejected".into());
+        }
+        if self.cpu_limit <= 0.0 {
+            return Err("cpu_limit must be > 0".into());
+        }
+        if self.memory_limit_mib == 0 {
+            return Err("memory_limit_mib must be > 0".into());
+        }
+        if self.timeout_secs == 0 {
+            return Err("timeout_secs must be > 0".into());
+        }
+        if !self.non_root {
+            return Err("non_root must be true (privileged runner rejected)".into());
+        }
+        Ok(())
+    }
+}
+
+fn path_has_escape(path: &Path) -> bool {
+    path.components().any(|c| matches!(c, Component::ParentDir))
+}
+
+/// Request body for `POST /api/jobs/{id}/eplus/runs` (queue only — no execution).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobRunRequest {
+    #[serde(default)]
+    pub run_id: Option<String>,
+    /// Relative path under the job (or approved workspace) to the IDF / model ref.
+    #[serde(default)]
+    pub model_ref: Option<String>,
+    #[serde(default)]
+    pub handoff_id: Option<String>,
+    #[serde(default)]
+    pub policy: Option<RunnerPolicy>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+/// Metadata describing an artifact attached after an external run completes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachArtifactMeta {
+    pub artifact_id: String,
+    pub path: String,
+    #[serde(default)]
+    pub content_sha256: Option<String>,
+    #[serde(default)]
+    pub media_type: Option<String>,
+    #[serde(default)]
+    pub bytes: Option<u64>,
+}
+
+fn utc_now() -> String {
+    Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+fn validate_relative_ref(rel: &str) -> Result<(), JobError> {
+    if rel.is_empty() || rel.contains('\0') {
+        return Err(JobError::Invalid("model_ref invalid".into()));
+    }
+    if rel.starts_with('/') || rel.starts_with('\\') {
+        return Err(JobError::Invalid(
+            "model_ref must be relative (no absolute paths)".into(),
+        ));
+    }
+    let p = Path::new(rel);
+    if path_has_escape(p) {
+        return Err(JobError::Invalid("model_ref path escape rejected".into()));
+    }
+    Ok(())
+}
+
+/// Persist a **QUEUED** external EnergyPlus run record. Does not start a container.
+pub fn queue_external_run(job_id: &str, req: JobRunRequest) -> Result<Value, JobError> {
+    let _ = jobs::load_job(job_id)?;
+    if let Some(ref policy) = req.policy {
+        policy
+            .validate_policy()
+            .map_err(|e| JobError::Invalid(format!("runner policy: {e}")))?;
+    }
+    if let Some(ref model) = req.model_ref {
+        validate_relative_ref(model)?;
+    }
+
+    let eplus_run_id = req
+        .run_id
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| format!("eplus-{}", Uuid::new_v4()));
+    if eplus_run_id.contains("..") || eplus_run_id.contains('/') || eplus_run_id.contains('\\') {
+        return Err(JobError::Invalid("invalid eplus run_id".into()));
+    }
+
+    // Explicit: central only persists status; an external worker claims QUEUED runs.
+    let payload = json!({
+        "schema_version": "1",
+        "kind": "eplus_external_run",
+        "eplus_run_id": eplus_run_id,
+        "job_id": job_id,
+        "status": "QUEUED",
+        "execution": "external",
+        "central_executes_energyplus": false,
+        "docker_socket": false,
+        "model_ref": req.model_ref,
+        "handoff_id": req.handoff_id,
+        "notes": req.notes,
+        "policy": req.policy,
+        "artifacts": Value::Array(vec![]),
+        "created_at": utc_now(),
+        "updated_at": utc_now(),
+    });
+
+    let path = jobs::job_dir(job_id)?
+        .join("wattlab/runs")
+        .join(format!("{eplus_run_id}.json"));
+    jobs::atomic_write_json(&path, &payload)?;
+    Ok(payload)
+}
+
+/// Attach artifact metadata to an existing external run record (no file bytes in central).
+pub fn attach_artifact_meta(
+    job_id: &str,
+    eplus_run_id: &str,
+    artifact: AttachArtifactMeta,
+) -> Result<Value, JobError> {
+    let _ = jobs::load_job(job_id)?;
+    if eplus_run_id.contains("..") || eplus_run_id.contains('/') || eplus_run_id.contains('\\') {
+        return Err(JobError::Invalid("invalid eplus run_id".into()));
+    }
+    validate_relative_ref(&artifact.path)?;
+    let path = jobs::job_dir(job_id)?
+        .join("wattlab/runs")
+        .join(format!("{eplus_run_id}.json"));
+    if !path.is_file() {
+        return Err(JobError::NotFound(format!(
+            "eplus run not found: {eplus_run_id}"
+        )));
+    }
+    let raw = std::fs::read_to_string(&path).map_err(|e| JobError::Io(e.to_string()))?;
+    let mut value: Value =
+        serde_json::from_str(&raw).map_err(|e| JobError::Invalid(format!("malformed run: {e}")))?;
+    let artifacts = value
+        .as_object_mut()
+        .ok_or_else(|| JobError::Invalid("run must be object".into()))?
+        .entry("artifacts")
+        .or_insert_with(|| Value::Array(vec![]));
+    let list = artifacts
+        .as_array_mut()
+        .ok_or_else(|| JobError::Invalid("artifacts must be array".into()))?;
+    list.push(serde_json::to_value(artifact).map_err(|e| JobError::Io(e.to_string()))?);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("updated_at".into(), Value::String(utc_now()));
+    }
+    jobs::atomic_write_json(&path, &value)?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static LOCK: Mutex<()> = Mutex::new(());
+
+    fn valid_policy() -> RunnerPolicy {
+        RunnerPolicy {
+            image_digest: "sha256:0123456789abcdef0123456789abcdef".into(),
+            workspace_root: PathBuf::from("/var/openfdd/workspace"),
+            cpu_limit: 2.0,
+            memory_limit_mib: 4096,
+            timeout_secs: 3600,
+            non_root: true,
+        }
+    }
+
+    #[test]
+    fn policy_rejects_missing_digest() {
+        let mut p = valid_policy();
+        p.image_digest = String::new();
+        assert!(p.validate_policy().unwrap_err().contains("image_digest"));
+    }
+
+    #[test]
+    fn policy_rejects_tag_instead_of_digest() {
+        let mut p = valid_policy();
+        p.image_digest = "ghcr.io/example/eplus:latest".into();
+        assert!(p.validate_policy().unwrap_err().contains("sha256"));
+    }
+
+    #[test]
+    fn policy_rejects_path_escape() {
+        let mut p = valid_policy();
+        p.workspace_root = PathBuf::from("/var/openfdd/../etc");
+        assert!(p.validate_policy().unwrap_err().contains("escape"));
+    }
+
+    #[test]
+    fn policy_rejects_relative_workspace() {
+        let mut p = valid_policy();
+        p.workspace_root = PathBuf::from("workspace");
+        assert!(p.validate_policy().unwrap_err().contains("absolute"));
+    }
+
+    #[test]
+    fn policy_rejects_root_runner() {
+        let mut p = valid_policy();
+        p.non_root = false;
+        assert!(p.validate_policy().unwrap_err().contains("non_root"));
+    }
+
+    #[test]
+    fn policy_ok() {
+        assert!(valid_policy().validate_policy().is_ok());
+    }
+
+    #[test]
+    fn queue_writes_queued_json() {
+        let _g = LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("openfdd-eplus-{}", Uuid::new_v4()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prev = std::env::var("OPENFDD_WORKSPACE").ok();
+        std::env::set_var("OPENFDD_WORKSPACE", &dir);
+
+        let meta = jobs::create_job("Eplus", None, None, None, None, vec![], None).unwrap();
+        let out = queue_external_run(
+            &meta.job_id,
+            JobRunRequest {
+                run_id: Some("eplus-test-1".into()),
+                model_ref: Some("models/building.idf".into()),
+                handoff_id: None,
+                policy: Some(valid_policy()),
+                notes: Some("unit".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(out["status"], "QUEUED");
+        assert_eq!(out["execution"], "external");
+        assert_eq!(out["central_executes_energyplus"], false);
+        assert_eq!(out["docker_socket"], false);
+        let path = jobs::job_dir(&meta.job_id)
+            .unwrap()
+            .join("wattlab/runs/eplus-test-1.json");
+        assert!(path.is_file());
+
+        let attached = attach_artifact_meta(
+            &meta.job_id,
+            "eplus-test-1",
+            AttachArtifactMeta {
+                artifact_id: "art-1".into(),
+                path: "artifacts/eplus_out.zip".into(),
+                content_sha256: Some("deadbeef".into()),
+                media_type: Some("application/zip".into()),
+                bytes: Some(12),
+            },
+        )
+        .unwrap();
+        assert_eq!(attached["artifacts"].as_array().unwrap().len(), 1);
+
+        match prev {
+            Some(v) => std::env::set_var("OPENFDD_WORKSPACE", v),
+            None => std::env::remove_var("OPENFDD_WORKSPACE"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/services/central/src/jobs.rs
+++ b/services/central/src/jobs.rs
@@ -185,7 +185,7 @@ fn ensure_layout(path: &Path) -> Result<(), JobError> {
     Ok(())
 }
 
-fn atomic_write_json(path: &Path, payload: &Value) -> Result<(), JobError> {
+pub(crate) fn atomic_write_json(path: &Path, payload: &Value) -> Result<(), JobError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| JobError::Io(e.to_string()))?;
     }

--- a/services/central/src/main.rs
+++ b/services/central/src/main.rs
@@ -2,6 +2,7 @@
 
 mod analytics;
 mod auth;
+mod eplus_runner;
 mod ingest;
 mod jobs;
 mod models;

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 
 use crate::analytics::{self, AnalyticsRequest};
 use crate::auth;
+use crate::eplus_runner;
 use crate::jobs;
 use crate::models::{
     AgentTool, AgentToolsResponse, AuthLoginRequest, AuthLoginResponse, AuthMeResponse,
@@ -139,6 +140,11 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route(
             "/api/jobs/{job_id}/wattlab/handoffs",
             post(jobs_create_wattlab_handoff),
+        )
+        .route("/api/jobs/{job_id}/eplus/runs", post(jobs_queue_eplus_run))
+        .route(
+            "/api/jobs/{job_id}/eplus/runs/{eplus_run_id}/artifacts",
+            post(jobs_attach_eplus_artifact),
         )
         .route("/api/analytics/runtime", post(analytics_runtime))
         .route(
@@ -1376,6 +1382,28 @@ async fn jobs_create_wattlab_handoff(
         StatusCode::CREATED,
         Json(json!({"ok": true, "handoff": handoff})),
     ))
+}
+
+/// Queue an external EnergyPlus run (Milestone D4).
+///
+/// Central **persists** `QUEUED` metadata under `wattlab/runs/*.json` only.
+/// It does not attach to a Docker socket or execute EnergyPlus in-process;
+/// an approved external runner claims the record and later attaches artifacts.
+async fn jobs_queue_eplus_run(
+    Path(job_id): Path<String>,
+    Json(body): Json<eplus_runner::JobRunRequest>,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
+    let run = eplus_runner::queue_external_run(&job_id, body).map_err(job_err)?;
+    Ok((StatusCode::CREATED, Json(json!({"ok": true, "run": run}))))
+}
+
+/// Record artifact metadata for an external E+ run (hashes/paths only — no bytes).
+async fn jobs_attach_eplus_artifact(
+    Path((job_id, eplus_run_id)): Path<(String, String)>,
+    Json(body): Json<eplus_runner::AttachArtifactMeta>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let run = eplus_runner::attach_artifact_meta(&job_id, &eplus_run_id, body).map_err(job_err)?;
+    Ok(Json(json!({"ok": true, "run": run})))
 }
 
 // ---------------------------------------------------------------------------

--- a/services/ui/app/test_wattlab_job_handoff.py
+++ b/services/ui/app/test_wattlab_job_handoff.py
@@ -1,0 +1,60 @@
+"""Milestone D3 — job-native WattLab handoff payload shape (mock streamlit)."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("streamlit", MagicMock())
+
+from app import ui_wattlab_job  # noqa: E402
+
+
+def test_build_handoff_payload_shape() -> None:
+    payload = ui_wattlab_job.build_handoff_payload(
+        job_id="job-11111111-1111-1111-1111-111111111111",
+        run_id="run-22222222-2222-2222-2222-222222222222",
+        findings_revision="findings-rev-1",
+        profile="diagnostic",
+        notes="d3 test",
+    )
+    assert payload["schema_version"] == "1"
+    assert payload["job_id"].startswith("job-")
+    assert payload["run_id"].startswith("run-")
+    assert payload["findings_revision"] == "findings-rev-1"
+    assert payload["source"] == "job_native"
+    assert payload["kind"] == "wattlab_handoff"
+    assert payload["profile"] == "diagnostic"
+    assert payload["notes"] == "d3 test"
+
+
+def test_create_job_native_handoff_posts_to_central() -> None:
+    fake = {
+        "ok": True,
+        "handoff": {
+            "schema_version": "1",
+            "handoff_id": "handoff-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "job_id": "job-11111111-1111-1111-1111-111111111111",
+            "source": "job_native",
+            "kind": "wattlab_handoff",
+            "profile": "summary",
+            "created_at": "2026-07-28T00:00:00Z",
+        },
+    }
+    with patch.object(
+        ui_wattlab_job.central_client, "jobs_create_wattlab_handoff", return_value=fake
+    ) as mock_post:
+        out = ui_wattlab_job.create_job_native_handoff(
+            "job-11111111-1111-1111-1111-111111111111",
+            profile="summary",
+        )
+    assert out["ok"] is True
+    assert out["handoff"]["handoff_id"].startswith("handoff-")
+    assert out["handoff"]["source"] == "job_native"
+    mock_post.assert_called_once()
+    args, _kwargs = mock_post.call_args
+    assert args[0].startswith("job-")
+    posted = args[1]
+    assert posted["kind"] == "wattlab_handoff"
+    assert posted["source"] == "job_native"
+    assert posted["schema_version"] == "1"

--- a/services/ui/app/ui_wattlab_job.py
+++ b/services/ui/app/ui_wattlab_job.py
@@ -1,0 +1,91 @@
+"""Job-native WattLab handoff UI — production SoT via central `/api/jobs/.../wattlab/handoffs`.
+
+Zip dumps remain additive (Export → Build WattLab dump). Prefer this path when a Job is open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import streamlit as st
+
+from app import central_client
+
+
+def build_handoff_payload(
+    *,
+    job_id: str,
+    run_id: str | None = None,
+    findings_revision: str | None = None,
+    profile: str = "summary",
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Shape posted to ``jobs_create_wattlab_handoff`` (central persists under wattlab/handoffs/)."""
+    payload: dict[str, Any] = {
+        "schema_version": "1",
+        "job_id": job_id,
+        "source": "job_native",
+        "profile": profile or "summary",
+        "kind": "wattlab_handoff",
+    }
+    if run_id:
+        payload["run_id"] = run_id
+    if findings_revision:
+        payload["findings_revision"] = findings_revision
+    if notes:
+        payload["notes"] = notes
+    return payload
+
+
+def create_job_native_handoff(
+    job_id: str,
+    *,
+    run_id: str | None = None,
+    findings_revision: str | None = None,
+    profile: str = "summary",
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """POST job-native handoff via central_client. Returns central JSON dict."""
+    handoff = build_handoff_payload(
+        job_id=job_id,
+        run_id=run_id,
+        findings_revision=findings_revision,
+        profile=profile,
+        notes=notes,
+    )
+    return central_client.jobs_create_wattlab_handoff(job_id, handoff)
+
+
+def render_job_native_wattlab_handoff() -> None:
+    """Streamlit button: create handoff when a Job is open and central is reachable."""
+    job_id = st.session_state.get("openfdd_job_id")
+    st.markdown("##### Job-native WattLab handoff")
+    st.caption(
+        "Production source of truth is `workspace/jobs/<id>/wattlab/handoffs/*.json` "
+        "via central. Zip dump below remains additive for offline / vibe20 backup."
+    )
+    if not job_id:
+        st.info("Open a Job (sidebar) to create a job-native WattLab handoff.")
+        return
+    if not central_client.health_ok():
+        st.warning("Central unavailable — job-native handoff requires `/api/jobs`.")
+        return
+
+    profile = st.selectbox(
+        "Handoff profile",
+        options=["summary", "diagnostic", "forensic"],
+        key="wattlab_job_handoff_profile",
+    )
+    if st.button("Create job-native WattLab handoff", key="wattlab_job_handoff_btn"):
+        resp = create_job_native_handoff(
+            str(job_id),
+            run_id=st.session_state.get("openfdd_latest_run_id"),
+            findings_revision=st.session_state.get("openfdd_findings_revision"),
+            profile=str(profile),
+        )
+        if resp.get("ok") and isinstance(resp.get("handoff"), dict):
+            hid = resp["handoff"].get("handoff_id", "?")
+            st.success(f"Handoff saved: `{hid}`")
+            st.session_state["openfdd_last_wattlab_handoff"] = resp["handoff"]
+        else:
+            st.error(resp.get("error") or "handoff create failed")

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -3794,7 +3794,11 @@ def main() -> None:
         )
         results = st.session_state.batch_results
 
-        st.markdown("##### WattLab dump (vibe20 handoff)")
+        from app.ui_wattlab_job import render_job_native_wattlab_handoff
+
+        render_job_native_wattlab_handoff()
+
+        st.markdown("##### WattLab dump zip (additive)")
         if not frames:
             st.info("Load a package first — the dump needs equipment data.")
         else:


### PR DESCRIPTION
## Summary
- **D3:** Job-native WattLab handoff UI (`ui_wattlab_job.py`); zip remains additive; job-workspaces docs note SoT
- **D4:** Restricted EnergyPlus runner policy + `POST /api/jobs/{id}/eplus/runs` queue stub — central tracks status/artifacts only (no IDF/E+ execution in Rust)

## Test plan
- [x] `cargo test -p openfdd-central eplus` (7)
- [x] `pytest …/test_wattlab_job_handoff.py` (2)
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job-native WattLab handoffs that are stored with the job and can include profiles, run references, findings revisions, and notes.
  * Added options to queue external EnergyPlus runs and attach resulting artifact metadata.
  * Added validation for run policies, resource limits, paths, and execution safety requirements.
  * Updated the Export section to create native handoffs before offering additive WattLab ZIP exports.

* **Documentation**
  * Clarified that job handoffs are the production source of truth and ZIP exports are supplemental.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->