### PR TITLE
docs(d5): Milestone D closeout, acceptance, and gap register

### DIFF
--- a/docs/PORT_FROM_VIBE19_REMOVALS.md
+++ b/docs/PORT_FROM_VIBE19_REMOVALS.md
@@ -5,7 +5,7 @@ Checkpoint commit **`4fe1dc99`** recorded the gutted Open-FDD tree before port.
 ## Removed (531 files)
 
 - **`edge/`** — monolithic edge binary (auth, drivers, csv ingest, old DataFusion FDD)
-- **`workspace/dashboard/`** — React/Vite dashboard (future production UI TBD)
+- **`workspace/dashboard/`** — React/Vite dashboard (**historical**; production UI is Streamlit `services/ui`, not Vite `:5173`)
 - **Docker / compose / Caddy** — deployment stacks for old architecture
 - **Legacy docs** — archive, agent prompts, web-app routes, driver guides tied to removed code
 

--- a/docs/migration/MILESTONE_D_ACCEPTANCE.md
+++ b/docs/migration/MILESTONE_D_ACCEPTANCE.md
@@ -41,6 +41,6 @@ is **not** claimed complete.
 
 | Field | Value |
 |-------|-------|
-| open-fdd tip (pre-D5) | `7da7c310` + #593 (D3/D4) |
+| open-fdd tip (pre-D5) | e5bd0ffd |
 | playground | `d553e31` |
 | Notes | Focused PRs #590–#593; D5 is docs/escape-hatch closeout |

--- a/docs/migration/MILESTONE_D_ACCEPTANCE.md
+++ b/docs/migration/MILESTONE_D_ACCEPTANCE.md
@@ -1,0 +1,46 @@
+---
+title: Milestone D acceptance
+parent: Migration
+nav_order: 34
+---
+
+# Milestone D acceptance
+
+**Date:** 2026-07-28 · Branch `milestone-d/d5-closeout`
+
+Honest acceptance for D0–D5. Full Milestone D / Phase 8
+(`sha-*` Job → SQL FDD → DF analytics → finding → WattLab → E+ attach → restart)
+is **not** claimed complete.
+
+## Automated evidence
+
+| Check | Command / evidence | Result |
+|-------|-------------------|--------|
+| D1 historian / analytics | `cargo test -p openfdd-central analytics` | Required green |
+| D4 eplus policy + queue | `cargo test -p openfdd-central eplus` | Required green |
+| Clippy | `cargo clippy -p openfdd-central -- -D warnings` | Required clean |
+| Ownership | `python3 scripts/architecture_ownership_check.py` | Required green |
+| D2 mutation | `python3 scripts/rule_parity_mutation_check.py` | Required green |
+| D3 handoff shape | `pytest services/ui/app/test_wattlab_job_handoff.py` | Required green |
+| Full-stack `sha-*` | Operator / GHCR after merge | **Not claimed** |
+
+## Slice acceptance
+
+| Slice | Bar on this branch |
+|-------|--------------------|
+| D2 | Registry ≥ 63; dual cookbooks ≥ 59 headings; high-risk keywords; missing cookbook path fails |
+| D3 | Payload has `source=job_native`, `kind=wattlab_handoff`; central create mocked |
+| D4 | Invalid digest / path escape / root runner rejected; QUEUED JSON under `wattlab/runs/` |
+| D5 | No production `Vite :5173` develop hint in edge dev_stack; docs closeout honest |
+
+## Manual / deferred
+
+1. External runner claims QUEUED eplus runs and attaches artifact hashes.
+2. BUILDING_100 multi-rule parity evidence beyond fixtures.
+3. Publish GHCR `sha-<tip>` and run Job → handoff → optional E+ queue soak.
+
+| Field | Value |
+|-------|-------|
+| open-fdd tip (pre-D5) | `7da7c310` + #593 (D3/D4) |
+| playground | `d553e31` |
+| Notes | Focused PRs #590–#593; D5 is docs/escape-hatch closeout |

--- a/docs/migration/MILESTONE_D_ACCEPTANCE.md
+++ b/docs/migration/MILESTONE_D_ACCEPTANCE.md
@@ -41,6 +41,6 @@ is **not** claimed complete.
 
 | Field | Value |
 |-------|-------|
-| open-fdd tip (pre-D5) | e5bd0ffd |
+| open-fdd tip (pre-D5) | `e5bd0ffd` |
 | playground | `d553e31` |
 | Notes | Focused PRs #590–#593; D5 is docs/escape-hatch closeout |

--- a/docs/migration/MILESTONE_D_CLOSEOUT.md
+++ b/docs/migration/MILESTONE_D_CLOSEOUT.md
@@ -10,7 +10,7 @@ nav_order: 33
 
 | Pin | Value |
 |-----|-------|
-| open-fdd (pre-D5 tip) | `7da7c310` (D0–D2 merged; D3/D4 via #593) |
+| open-fdd (pre-D5 tip) | `e5bd0ffd` (D0–D4 merged) |
 | playground | `d553e31` (`develop`) |
 | PyPI | `open-fdd` ≥ 4.1.1 (oracle extras) |
 

--- a/docs/migration/MILESTONE_D_CLOSEOUT.md
+++ b/docs/migration/MILESTONE_D_CLOSEOUT.md
@@ -1,0 +1,57 @@
+---
+title: Milestone D closeout
+parent: Migration
+nav_order: 33
+---
+
+# Milestone D closeout
+
+**Date:** 2026-07-28 · Branch `milestone-d/d5-closeout`
+
+| Pin | Value |
+|-----|-------|
+| open-fdd (pre-D5 tip) | `7da7c310` (D0–D2 merged; D3/D4 via #593) |
+| playground | `d553e31` (`develop`) |
+| PyPI | `open-fdd` ≥ 4.1.1 (oracle extras) |
+
+## Executive summary
+
+Milestone D closes **selected C residuals** and starts the EnergyPlus / WattLab
+bridge without claiming full Phase 8 production readiness. D0–D5 land as focused
+PRs. Full-stack `sha-*` soak, multi-building parity, and a live external E+
+worker remain **residuals**.
+
+## What is done
+
+| Slice | Status |
+|-------|--------|
+| D0 — C→D gap register + cookbook fortress CI | **Done** (#590) |
+| D1 — Historian DF + Streamlit central cutover | **Done** (#591) |
+| D2 — `rule_parity_mutation_check.py` + multi-building inventory | **Done** (#592) |
+| D3 — Job-native WattLab handoff UI + payload tests | **Done** (#593) |
+| D3 — Zip remains additive; job-native documented as SoT | **Done** |
+| D4 — `RunnerPolicy` validation + `POST .../eplus/runs` QUEUED stub | **Done** (#593) |
+| D5 — Vite `:5173` production hint scrub (Streamlit `:8501`) | **Done** |
+| D5 — Closeout / acceptance / gap register / BUILD_CHECKPOINTS | **Done** |
+
+## Explicit residuals (not claimed)
+
+- Live external EnergyPlus worker claiming QUEUED runs + full artifact attach UX
+- Logical SQL gate mutation tests (fan-on / occupancy / ΔT) beyond path guards
+- `PROVEN_MULTI_BUILDING` qualification
+- Remaining analytics family DF MemTable + full Streamlit cutover (C3–C9, C8 plant)
+- Production pandas path retirement and immutable `sha-*` full-stack acceptance
+- Playground GHCR retirement / dead workflow purge beyond Vite hint scrub
+
+## Engine / ownership honesty
+
+- Central does **not** execute EnergyPlus or attach a Docker socket.
+- Production UI is **Streamlit** (`services/ui`), not Vite/Caddy.
+- Dual cookbooks remain protected; registry 63 vs public ~59 stays honest.
+
+## Related
+
+- [Gap register](MILESTONE_D_GAP_REGISTER.md)
+- [Acceptance](MILESTONE_D_ACCEPTANCE.md)
+- [Rule parity](MILESTONE_D_RULE_PARITY.md)
+- [Job workspaces](../architecture/job-workspaces.md)

--- a/docs/migration/MILESTONE_D_GAP_REGISTER.md
+++ b/docs/migration/MILESTONE_D_GAP_REGISTER.md
@@ -6,22 +6,22 @@ nav_order: 30
 
 # Milestone D gap register
 
-**Date:** 2026-07-28 · Branch `milestone-d/d1-historian-datafusion-runtime`
+**Date:** 2026-07-28 · Branch `milestone-d/d5-closeout`
 
-Tracks C→D gaps and status after D1–D5 work. Companion matrices:
+Tracks C→D gaps after D0–D5. Companion matrices:
 [`vibe20_integration_matrix.md`](vibe20_integration_matrix.md),
 [`MILESTONE_C_ANALYTICS_MATRIX.md`](MILESTONE_C_ANALYTICS_MATRIX.md).
 
 | ID | Gap | Status | Notes |
 |----|-----|--------|-------|
-| D1 | Historian → DataFusion runtime analytics | **Improved** | Parquet bridge live for runtime; other families still minimal / MemTable residual |
+| D0 | Tip/GHCR audit + gap register + docs fortress | **Done** | #590; `sha-*` tip tags may lag `:nightly` |
+| D1 | Historian → DataFusion analytics + UI cutover | **Improved** | #591 family DF bridges; plant descriptive counts only |
 | D1b | Silent pandas Overview fallback | **Improved** | Oracle flag required (`OPENFDD_ANALYTICS_ORACLE=1`) |
-| D2 | SQL rule parity mutation CI | **Improved** | Path + keyword harness in CI; logical gate mutations residual |
-| D2b | `PROVEN_MULTI_BUILDING` / BUILDING_100 | **Open** | BUILDING_100 = single-building evidence path; multi-building not claimed |
-| D3 | Job-native WattLab SoT | **Improved** | Central handoff + UI helper; zip additive |
-| D4 | Restricted E+ runner | **Improved (stub)** | Policy + QUEUED persist; no Docker socket / in-process E+ |
-| D4b | External runner claim + artifact attach loop | **Open** | `attach_artifact_meta` types exist; worker not wired |
-| D5 | Vite `:5173` production hints | **Improved** | Dev-stack hint → Streamlit `:8501`; archive/historical docs kept |
-| C8 | Plant / chiller-boiler analytics | **Open** | Not started |
-| C11 | Full pandas production retirement + `sha-*` | **Open** | Residual |
+| D2 | SQL rule parity mutation CI | **Done** | #592 path + logical keyword + fixture inventory |
+| D2b | `PROVEN_MULTI_BUILDING` / BUILDING_100 | **Open** | Inventory only; multi-building not claimed |
+| D3 | Job-native WattLab SoT | **Improved** | #593 central handoff + UI; zip additive |
+| D4 | Restricted E+ runner | **Improved (stub)** | #593 policy + QUEUED persist; no Docker socket / in-process E+ |
+| D4b | External runner claim + artifact attach loop | **Open** | Worker not wired |
+| D5 | Vite `:5173` / escape-hatch scrub | **Improved** | Dev-stack → Streamlit `:8501` |
+| C11 | Full pandas production retirement + `sha-*` soak | **Open** | Residual; GHCR `sha-e5bd0ffd` not yet pullable |
 | A | `open_fdd.contracts` | **Deferred** | Milestone A residual |

--- a/docs/migration/MILESTONE_D_GAP_REGISTER.md
+++ b/docs/migration/MILESTONE_D_GAP_REGISTER.md
@@ -1,0 +1,27 @@
+---
+title: Milestone D gap register
+parent: Migration
+nav_order: 30
+---
+
+# Milestone D gap register
+
+**Date:** 2026-07-28 · Branch `milestone-d/d1-historian-datafusion-runtime`
+
+Tracks C→D gaps and status after D1–D5 work. Companion matrices:
+[`vibe20_integration_matrix.md`](vibe20_integration_matrix.md),
+[`MILESTONE_C_ANALYTICS_MATRIX.md`](MILESTONE_C_ANALYTICS_MATRIX.md).
+
+| ID | Gap | Status | Notes |
+|----|-----|--------|-------|
+| D1 | Historian → DataFusion runtime analytics | **Improved** | Parquet bridge live for runtime; other families still minimal / MemTable residual |
+| D1b | Silent pandas Overview fallback | **Improved** | Oracle flag required (`OPENFDD_ANALYTICS_ORACLE=1`) |
+| D2 | SQL rule parity mutation CI | **Improved** | Path + keyword harness in CI; logical gate mutations residual |
+| D2b | `PROVEN_MULTI_BUILDING` / BUILDING_100 | **Open** | BUILDING_100 = single-building evidence path; multi-building not claimed |
+| D3 | Job-native WattLab SoT | **Improved** | Central handoff + UI helper; zip additive |
+| D4 | Restricted E+ runner | **Improved (stub)** | Policy + QUEUED persist; no Docker socket / in-process E+ |
+| D4b | External runner claim + artifact attach loop | **Open** | `attach_artifact_meta` types exist; worker not wired |
+| D5 | Vite `:5173` production hints | **Improved** | Dev-stack hint → Streamlit `:8501`; archive/historical docs kept |
+| C8 | Plant / chiller-boiler analytics | **Open** | Not started |
+| C11 | Full pandas production retirement + `sha-*` | **Open** | Residual |
+| A | `open_fdd.contracts` | **Deferred** | Milestone A residual |

--- a/docs/migration/vibe20_integration_matrix.md
+++ b/docs/migration/vibe20_integration_matrix.md
@@ -8,7 +8,11 @@ nav_order: 3
 
 **Open-FDD tip:** `sha-d631e9c` · **vibe20 reference:** playground `vibe_code_apps_20` / `wattlab/` on `develop`.
 
-Open-FDD does **not** run EnergyPlus. It produces engineering evidence and a dump zip; vibe20 consumes it.
+Open-FDD does **not** run EnergyPlus in-process. It produces engineering evidence,
+job-native WattLab handoffs, and optional zip dumps; vibe20 / an approved external
+runner consumes them. Central may **queue** E+ run metadata
+(`POST /api/jobs/{id}/eplus/runs` → `wattlab/runs/*.json`) and attach artifact
+hashes — never a Docker socket.
 
 | Capability | vibe20 consumer | Open-FDD producer today | Job-native target | Status |
 |------------|-----------------|-------------------------|-------------------|--------|
@@ -21,14 +25,15 @@ Open-FDD does **not** run EnergyPlus. It produces engineering evidence and a dum
 | Weather provenance | weather / EPW | BAS vs web helpers + dump | Explicit source tags in artifacts | PARTIAL |
 | Operating signatures | seed | `model_seed.operating_signatures` | Persist + DF profiles | PARTIAL |
 | 24h / weekday profiles | seed | `diurnal_profiles` (pandas) | DF | PARTIAL |
-| FDD results | seed findings | registry results + `fdd_findings.csv` | `job/runs/` + `job/findings/` | PARTIAL |
+| FDD results | seed findings | registry results + `fdd_findings.csv` | `job/runs/` + `job/findings/` | DONE |
 | Mech cooling evidence | honesty rules | analytics / dump | Documented hierarchy; DF later | PARTIAL |
 | Utility bills | `import_bills.py` | optional upload | `job/wattlab/utility_bills.*` | MISSING |
 | Model assumptions | studio | gaps in dump README | `assumptions.json` + NEEDS_INPUT | MISSING |
-| EnergyPlus IDF / sim | `wattlab/energyplus/` | — | Out of process; store hashes/status only | N/A (external) |
+| WattLab handoff | seed / bundle | zip + job-native JSON | `job/wattlab/handoffs/` (SoT) | DONE |
+| EnergyPlus IDF / sim | `wattlab/energyplus/` | queue metadata only | Out of process; hashes/status on job | PARTIAL (D4 stub) |
 | ECM / finance | ecm / finance | — | External; link results under job | N/A (external) |
 | Calibration history | calibrate* | — | `job/wattlab/calibration/` metadata | MISSING |
-| Dump zip v3 | `wattlab/seed/bundle.py` | `wattlab_dump` Export | Write into `job/wattlab/exports/` | DONE |
+| Dump zip v3 | `wattlab/seed/bundle.py` | `wattlab_dump` Export | Additive; SoT is job-native handoff | DONE |
 
 ## Honesty rules (keep)
 

--- a/edge/src/ops/dev_stack.rs
+++ b/edge/src/ops/dev_stack.rs
@@ -53,7 +53,11 @@ pub fn run_script(body: &Value) -> Value {
     }
     let script_key = body.get("script").and_then(|v| v.as_str()).unwrap_or("");
     let (label, rel, extra): (&str, &str, &str) = match script_key {
-        "ui_dev" => ("Streamlit UI dev server", "scripts/openfdd_ui_dev.sh", "--lan"),
+        "ui_dev" => (
+            "Streamlit UI dev server",
+            "scripts/openfdd_ui_dev.sh",
+            "--lan",
+        ),
         other => {
             return json!({
                 "ok": false,

--- a/edge/src/ops/dev_stack.rs
+++ b/edge/src/ops/dev_stack.rs
@@ -53,7 +53,7 @@ pub fn run_script(body: &Value) -> Value {
     }
     let script_key = body.get("script").and_then(|v| v.as_str()).unwrap_or("");
     let (label, rel, extra): (&str, &str, &str) = match script_key {
-        "ui_dev" => ("Vite UI dev server", "scripts/openfdd_ui_dev.sh", "--lan"),
+        "ui_dev" => ("Streamlit UI dev server", "scripts/openfdd_ui_dev.sh", "--lan"),
         other => {
             return json!({
                 "ok": false,
@@ -99,7 +99,7 @@ pub fn run_script(body: &Value) -> Value {
             "label": label,
             "log": log.display().to_string(),
             "hint": if script_key == "ui_dev" {
-                "Open http://127.0.0.1:5173/ after a few seconds"
+                "Open http://127.0.0.1:8501/ after a few seconds"
             } else {
                 "Refresh AI integrations status in ~10s"
             }

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -96,3 +96,22 @@ Docs: [`MILESTONE_C_CLOSEOUT.md`](../docs/migration/MILESTONE_C_CLOSEOUT.md),
 - [~] C9 — Metering monthly kWh sum (minimal)
 - [~] C10 — Rule parity fixture notes + mutation checklist (harness residual)
 - [ ] C11 — Retire production pandas paths; filled benchmarks; `sha-*` acceptance
+
+---
+
+# Milestone D — Gaps bridge + WattLab / E+ (2026-07-28)
+
+**Status:** **Partial** on branch `milestone-d/d1-historian-datafusion-runtime`.
+Docs: [`MILESTONE_D_CLOSEOUT.md`](../docs/migration/MILESTONE_D_CLOSEOUT.md),
+[`MILESTONE_D_ACCEPTANCE.md`](../docs/migration/MILESTONE_D_ACCEPTANCE.md),
+[`MILESTONE_D_RULE_PARITY.md`](../docs/migration/MILESTONE_D_RULE_PARITY.md),
+[`MILESTONE_D_GAP_REGISTER.md`](../docs/migration/MILESTONE_D_GAP_REGISTER.md).
+
+- [x] D1 — Historian DataFusion bridge for runtime analytics
+- [x] D2 — SQL rule parity mutation path check + CI + BUILDING_100 note
+- [x] D3 — Job-native WattLab handoff UI (zip additive)
+- [x] D4 — Restricted E+ runner policy + QUEUED persist stub (no in-process E+)
+- [x] D5 — Vite `:5173` hint scrub + closeout / acceptance / gap register
+- [ ] D4b — External runner claim loop + full artifact attach UX
+- [ ] D2b — Logical gate mutations + `PROVEN_MULTI_BUILDING`
+- [ ] D5z — Full-stack `sha-*` soak


### PR DESCRIPTION
## Summary
- `MILESTONE_D_{CLOSEOUT,ACCEPTANCE,GAP_REGISTER}.md` — honest D0–D5 status
- Streamlit `:8501` escape-hatch scrub (no Vite production hint)
- Pins: open-fdd `e5bd0ffd`, playground `d553e31`; `sha-*` soak residual (GHCR lag)

## Test plan
- [x] ownership + rule_parity scripts
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Milestone D acceptance, closeout, and gap-register documentation, including completed work, open items, and validation criteria.
  * Updated integration guidance to clarify EnergyPlus run handling, artifact tracking, and job-native handoffs.
  * Refined historical UI documentation and updated milestone build checkpoints.

* **Developer Experience**
  * Updated the UI development server guidance to reference Streamlit and its local address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->