### PR TITLE
feat: Gate B+C Eng Findings, economizer scope, ECM Jobs (OFDD-069…076)

### DIFF
--- a/docs/migration/OFDD_065_076_PARITY.md
+++ b/docs/migration/OFDD_065_076_PARITY.md
@@ -6,7 +6,8 @@ nav_order: 40
 
 # OFDD 065–076 parity register
 
-**Date:** 2026-07-29 · Branch `fix/ofdd-gate-a-sites-sql-413`
+**Date:** 2026-07-29 · Branches `fix/ofdd-gate-a-sites-sql-413` (Gate A) →
+`fix/ofdd-gate-b-c-findings-ecm` (Gate B + Gate C, built on the Gate A tip)
 
 Tracks the Liberty B50/B100 parity hunt tickets OFDD-065…076 across the three
 gates defined in the combined vibe19+vibe20 plan. This file records **VERIFIED**
@@ -61,11 +62,27 @@ Next step (Gate A exit): run the `sha-*` soak, fill the deltas table above, then
 tighten SV-STALE/VAV-1/FC1 gates within documented bands without regressing
 `crates/fdd_rules` oracle-parity benches.
 
-## Later gates (tracked, not in this branch)
+## Gate B — vibe19 tip UI / Findings / economizer (branch `fix/ofdd-gate-b-c-findings-ecm`)
 
-| Ticket | Scope | Gate | Status |
-|--------|-------|------|--------|
-| OFDD-074 / 069 | Eng Findings HITL; retire Generic RCx DOCX story | B | Open |
-| OFDD-070 | Economizer historian/building-scoped Overview | B | Open |
-| OFDD-071 | OpenAPI live routes + health version = tip SHA | B | Open |
-| OFDD-076 / 072 | In-product vibe20 Jobs agent-build + cascade-if-ready | C | Open |
+| Ticket | Scope | Gate | Status | Notes |
+|--------|-------|------|--------|-------|
+| OFDD-074 / 069 | Eng Findings HITL; retire Generic RCx DOCX story | B | **VERIFIED** | Overview report story is now `app.eng_findings.render_engineering_findings_panel` over `open_fdd.reporting` (HITL: max-findings, pin/drop refs, `REF=note` notes → prioritized findings + DOCX/XLSX/JSON downloads). The active site's `batch_results` are `open_fdd.rules.base.RuleResult`, fed straight to `candidates_from_rule_results`. When the `reporting` extra is absent, the panel falls back to central `/api/reports` (list/draft) instead of a static DOCX. Static Generic RCx DOCX demoted to a secondary expander. Helper unit tests green. `dashboard_contract` updated. |
+| OFDD-070 | Economizer historian/building-scoped Overview | B | **VERIFIED** | `AnalyticsQuery.building_id` added; `economizer_from_history` + `open_history_scoped` register only `building={id}/**/*.parquet` (rejects path-escape ids; returns `None` for an un-ingested site rather than leaking the whole tree). UI (`ui_rcx_tab`/`ui_analytics.fetch_economizer_analytics`) forwards the active `building_id`. IT: two ingested buildings → each scope sees only its own AHU; coverage echoes `building_id`. |
+| OFDD-071 | OpenAPI live routes + health version = tip SHA | B | **VERIFIED** | `/api/health` `version` = `resolve_build_version()` → `{CARGO_PKG_VERSION}+{OPENFDD_GIT_SHA}` (runtime) or `OPENFDD_BUILD_GIT_SHA` (compile-time), else bare crate version (no more stale-only `3.3.0`). `/openapi.json` now advertises live jobs / analytics / datasets / fdd-results / reports routes (doc-only `#[utoipa::path]` descriptors + new tags). Tests: `openapi_lists_live_*`, `version_prefers_runtime_git_sha_then_crate_version`. |
+
+## Gate C — vibe20 in-product Jobs / ECM (branch `fix/ofdd-gate-b-c-findings-ecm`)
+
+| Ticket | Scope | Gate | Status | Notes |
+|--------|-------|------|--------|-------|
+| OFDD-076 / 072 | In-product vibe20 Jobs agent-build + cascade-if-ready | C | **VERIFIED (delegated)** | Jobs sidebar surfaces **create Job from active site** (site/building caption + scoped WattLab/ECM). New `app.ui_ecm_job` writes a job-native **ECM package request** under `wattlab/ecm/*.json` with `honesty.openfdd = "delegated"` when `open_fdd.ecm_engineering` imports (`"unavailable"` otherwise); WattLab notebook builder shell-out is detected and recorded when present. **cascade-if-ready**: when docker.sock **and** `energyplus-mcp-dev` are present, an external E+ run is queued via the existing `POST /api/jobs/{id}/eplus/runs` (`eplus_runner`, QUEUED-only); otherwise an honest `esco_screening_only` stamp — central stays free of IDF/E+ logic. Unit tests cover honesty states, the cascade gate, queue-when-ready, and the on-disk request. |
+
+## Gate B/C honesty caveats
+
+- **No Liberty zips in this environment**, so Eng Findings / economizer parity is
+  proven on synthetic fixtures + unit/integration tests, not a B50/B100 soak. The
+  `sha-*` soak (Gate A exit) still owns filling the FAULT deltas table above and
+  the vibe19-tip UX comparison screenshots.
+- ECM agent-build and any EnergyPlus calibration are **delegated** (WattLab /
+  external runner). open-fdd is not marketed as vibe20-complete: the in-product
+  path records requests and queues external runs; it does not itself parse IDF or
+  run EnergyPlus.

--- a/services/central/src/analytics/economizer.rs
+++ b/services/central/src/analytics/economizer.rs
@@ -268,7 +268,15 @@ pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
 pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     if req.series.is_none() {
         let dt_min = req.dt_min_f.unwrap_or(DEFAULT_DT_MIN_F);
-        match historian::economizer_from_history(req.query.equipment_ids.as_deref(), dt_min).await {
+        // OFDD-070: scope the historian read to the site when building_id is set
+        // so an Overview economizer for one building never mixes in another's parquet.
+        match historian::economizer_from_history(
+            req.query.equipment_ids.as_deref(),
+            dt_min,
+            req.query.building_id.as_deref(),
+        )
+        .await
+        {
             Ok(Some(env)) => return finalize_historian(req, env, QV_ECONOMIZER),
             Ok(None) => {}
             Err(e) => {

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -64,14 +64,53 @@ pub fn parquet_root() -> PathBuf {
 /// Register `history` from parquet_root when the tree exists and has data.
 /// Returns `Ok(true)` on success, `Ok(false)` when missing/empty/unusable.
 pub async fn try_register_history(ctx: &SessionContext) -> Result<bool> {
+    try_register_history_scoped(ctx, None).await
+}
+
+/// Sanitize a `building_id` for use as a Hive path segment. Rejects any value
+/// with path separators or `..` so a query field can never escape the parquet
+/// root; returns `None` for empty/unsafe ids (caller falls back to whole tree).
+fn safe_building_segment(building_id: Option<&str>) -> Option<String> {
+    let bid = building_id.map(str::trim).filter(|s| !s.is_empty())?;
+    if bid.contains('/') || bid.contains('\\') || bid.contains("..") || bid.contains('\0') {
+        return None;
+    }
+    Some(bid.to_string())
+}
+
+/// Register `history` for an optional `building_id` scope (OFDD-070).
+///
+/// When `building_id` is set and `building={id}/` exists under the parquet root,
+/// only that site's parquet is registered (mirrors the edge FDD registry Hive
+/// layout `building={id}/equipment={eq}/history.parquet`). Otherwise the whole
+/// tree is registered. Returns `Ok(false)` when nothing usable is present.
+pub async fn try_register_history_scoped(
+    ctx: &SessionContext,
+    building_id: Option<&str>,
+) -> Result<bool> {
     let root = parquet_root();
     if !root.is_dir() {
         return Ok(false);
     }
-    match register_parquet_tree(ctx, &root).await {
+    let scoped = match safe_building_segment(building_id) {
+        Some(bid) => {
+            let dir = root.join(format!("building={bid}"));
+            if dir.is_dir() {
+                Some(dir)
+            } else {
+                // Requested site has no parquet yet — do not silently fall back to
+                // the whole tree (that would mix other buildings into the scope).
+                tracing::debug!(building = %bid, "no building-scoped parquet; historian scope empty");
+                return Ok(false);
+            }
+        }
+        None => None,
+    };
+    let target = scoped.as_deref().unwrap_or(&root);
+    match register_parquet_tree(ctx, target).await {
         Ok(_) => Ok(true),
         Err(e) => {
-            tracing::debug!(error = %e, root = %root.display(), "historian parquet register skipped");
+            tracing::debug!(error = %e, root = %target.display(), "historian parquet register skipped");
             Ok(false)
         }
     }
@@ -312,8 +351,15 @@ ORDER BY i.equipment_id
 /// Register `history` and return `(ctx, columns, row_count)` when the parquet
 /// tree exists and has rows; `Ok(None)` when missing/empty (caller falls back).
 async fn open_history() -> Result<Option<(SessionContext, HashSet<String>, i64)>> {
+    open_history_scoped(None).await
+}
+
+/// Like [`open_history`] but scoped to an optional `building_id` (OFDD-070).
+async fn open_history_scoped(
+    building_id: Option<&str>,
+) -> Result<Option<(SessionContext, HashSet<String>, i64)>> {
     let ctx = SessionContext::new();
-    if !try_register_history(&ctx).await? {
+    if !try_register_history_scoped(&ctx, building_id).await? {
         return Ok(None);
     }
     let count = run_sql(&ctx, "SELECT COUNT(*) AS n FROM history").await?;
@@ -553,8 +599,9 @@ ORDER BY equipment_id
 pub async fn economizer_from_history(
     equipment_filter: Option<&[String]>,
     dt_min_f: f64,
+    building_id: Option<&str>,
 ) -> Result<Option<AnalyticsEnvelope>> {
-    let Some((ctx, cols, n)) = open_history().await? else {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
         return Ok(None);
     };
     if !(cols.contains("oa_t") && cols.contains("rat") && cols.contains("mat")) {
@@ -626,6 +673,7 @@ ORDER BY equipment_id
         "history_rows": n,
         "dt_min_f": dt_min,
         "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
     }));
     Ok(Some(env))
 }
@@ -846,6 +894,91 @@ mod tests {
         assert!(!env.rows.is_empty());
         assert_eq!(env.rows[0]["history_rows"].as_u64().unwrap(), 2);
         assert!(env.warnings.iter().any(|w| w.contains("not fabricated")));
+    }
+
+    #[tokio::test]
+    async fn economizer_from_history_is_building_scoped() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let parquet = tmp.path().join("parquet_econ");
+
+        // Two buildings with distinct AHU ids, each with oat/rat/mat + fan.
+        for (bid, eq) in [("BUILDING_50", "AHU_B50"), ("BUILDING_100", "AHU_B100")] {
+            let building = tmp.path().join(bid);
+            let ahu = building.join(eq);
+            std::fs::create_dir_all(&ahu).unwrap();
+            std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+            std::fs::write(
+                ahu.join("columns.csv"),
+                "col,point_role\noat,outside_air_temp\nrat,return_air_temp\n\
+                 mat,mixed_air_temp\nfan,fan_status\n",
+            )
+            .unwrap();
+            let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
+            writeln!(f, "timestamp_utc,oat,rat,mat,fan").unwrap();
+            writeln!(f, "2026-01-01T00:00:00Z,40,70,55,1").unwrap();
+            writeln!(f, "2026-01-01T00:05:00Z,41,70,56,1").unwrap();
+            fdd_store::ingest_building(tmp.path(), bid, &parquet).unwrap();
+        }
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let b50 = economizer_from_history(None, 10.0, Some("BUILDING_50"))
+            .await
+            .unwrap()
+            .expect("B50 economizer envelope");
+        let b100 = economizer_from_history(None, 10.0, Some("BUILDING_100"))
+            .await
+            .unwrap()
+            .expect("B100 economizer envelope");
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+
+        // Each scope sees only its own AHU — no cross-building bleed.
+        let ids_b50: Vec<String> = b50
+            .equipment
+            .iter()
+            .filter_map(|e| e["equipment_id"].as_str().map(str::to_string))
+            .collect();
+        let ids_b100: Vec<String> = b100
+            .equipment
+            .iter()
+            .filter_map(|e| e["equipment_id"].as_str().map(str::to_string))
+            .collect();
+        assert_eq!(ids_b50, vec!["AHU_B50".to_string()]);
+        assert_eq!(ids_b100, vec!["AHU_B100".to_string()]);
+        assert_eq!(
+            b50.coverage.as_ref().unwrap()["building_id"],
+            serde_json::json!("BUILDING_50")
+        );
+    }
+
+    #[tokio::test]
+    async fn economizer_from_history_none_for_unknown_building() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let parquet = tmp.path().join("parquet_econ_missing");
+        let building = tmp.path().join("BUILDING_50");
+        let ahu = building.join("AHU_B50");
+        std::fs::create_dir_all(&ahu).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        std::fs::write(
+            ahu.join("columns.csv"),
+            "col,point_role\noat,outside_air_temp\nrat,return_air_temp\n\
+             mat,mixed_air_temp\nfan,fan_status\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,oat,rat,mat,fan").unwrap();
+        writeln!(f, "2026-01-01T00:00:00Z,40,70,55,1").unwrap();
+        fdd_store::ingest_building(tmp.path(), "BUILDING_50", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        // Requesting a site that was never ingested must not fall back to the
+        // whole tree (that would leak BUILDING_50 into a BUILDING_999 scope).
+        let out = economizer_from_history(None, 10.0, Some("BUILDING_999"))
+            .await
+            .unwrap();
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+        assert!(out.is_none());
     }
 
     #[test]

--- a/services/central/src/analytics/mod.rs
+++ b/services/central/src/analytics/mod.rs
@@ -42,6 +42,11 @@ pub struct AnalyticsQuery {
     pub job_id: Option<String>,
     #[serde(default)]
     pub run_id: Option<String>,
+    /// Site / building scope (OFDD-070). When set, historian analytics read only
+    /// `building={id}/` under the parquet root so a site's Overview economizer
+    /// (and other historian families) are not contaminated by other packages.
+    #[serde(default)]
+    pub building_id: Option<String>,
     #[serde(default)]
     pub equipment_ids: Option<Vec<String>>,
     #[serde(default)]

--- a/services/central/src/openapi.rs
+++ b/services/central/src/openapi.rs
@@ -9,6 +9,150 @@ use crate::auth::{JwtClaims, Role};
 use crate::models::*;
 use openfdd_contracts::{CommandAck, CommandEnvelope, TelemetryEnvelope};
 
+/// Doc-only OpenAPI path descriptors (OFDD-071).
+///
+/// These functions are never invoked; they exist so the live jobs / analytics /
+/// datasets / fdd-results / reports routes appear in `/openapi.json` without
+/// forcing `ToSchema`/`IntoParams` derives onto every axum extractor type. Bodies
+/// are documented as free-form JSON (`serde_json::Value`) because the handlers
+/// return `{ "ok": true, ... }` envelopes assembled at runtime.
+mod live_routes {
+    #![allow(dead_code)]
+
+    #[utoipa::path(
+        get, path = "/api/jobs", tag = "jobs",
+        params(
+            ("include_archived" = Option<bool>, Query, description = "Include archived jobs"),
+            ("status" = Option<String>, Query, description = "Filter by status"),
+            ("site_id" = Option<String>, Query, description = "Filter by site id"),
+            ("tag" = Option<String>, Query, description = "Filter by tag")
+        ),
+        responses((status = 200, description = "List analysis jobs", body = serde_json::Value))
+    )]
+    pub fn jobs_list() {}
+
+    #[utoipa::path(
+        post, path = "/api/jobs", tag = "jobs",
+        request_body = serde_json::Value,
+        responses((status = 201, description = "Create an analysis job", body = serde_json::Value))
+    )]
+    pub fn jobs_create() {}
+
+    #[utoipa::path(
+        get, path = "/api/jobs/{job_id}", tag = "jobs",
+        params(("job_id" = String, Path, description = "Job id")),
+        responses(
+            (status = 200, description = "Get an analysis job", body = serde_json::Value),
+            (status = 404, description = "Job not found")
+        )
+    )]
+    pub fn jobs_get() {}
+
+    #[utoipa::path(
+        post, path = "/api/jobs/{job_id}/wattlab/handoffs", tag = "jobs",
+        params(("job_id" = String, Path, description = "Job id")),
+        request_body = serde_json::Value,
+        responses((status = 201, description = "Create a job-native WattLab handoff", body = serde_json::Value))
+    )]
+    pub fn jobs_create_wattlab_handoff() {}
+
+    #[utoipa::path(
+        post, path = "/api/jobs/{job_id}/eplus/runs", tag = "jobs",
+        params(("job_id" = String, Path, description = "Job id")),
+        request_body = serde_json::Value,
+        responses((status = 201, description = "Queue an external EnergyPlus run (central persists QUEUED only)", body = serde_json::Value))
+    )]
+    pub fn jobs_queue_eplus_run() {}
+
+    #[utoipa::path(
+        get, path = "/api/datasets", tag = "datasets",
+        responses((status = 200, description = "List ingested datasets / sites", body = serde_json::Value))
+    )]
+    pub fn datasets_list() {}
+
+    #[utoipa::path(
+        delete, path = "/api/datasets", tag = "datasets",
+        params(("id" = String, Query, description = "Building / dataset id to delete (Delete site)")),
+        responses((status = 200, description = "Delete a site's history / results", body = serde_json::Value))
+    )]
+    pub fn datasets_delete() {}
+
+    #[utoipa::path(
+        get, path = "/api/fdd/results", tag = "fdd",
+        params(("building_id" = Option<String>, Query, description = "Scope results to building={id}")),
+        responses((status = 200, description = "Site-scoped FDD rule results", body = serde_json::Value))
+    )]
+    pub fn fdd_results() {}
+
+    #[utoipa::path(
+        get, path = "/api/fdd/equipment", tag = "fdd",
+        params(("building_id" = Option<String>, Query, description = "Scope equipment to building={id}")),
+        responses((status = 200, description = "Site-scoped equipment inventory", body = serde_json::Value))
+    )]
+    pub fn fdd_equipment() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/runtime", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Runtime hours (historian Δt or inline)", body = serde_json::Value))
+    )]
+    pub fn analytics_runtime() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/economizer", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Economizer diagnostics; building-scoped historian when building_id set", body = serde_json::Value))
+    )]
+    pub fn analytics_economizer() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/sensor-health", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Sensor coverage / missingness / flatline", body = serde_json::Value))
+    )]
+    pub fn analytics_sensor_health() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/mechanical-cooling", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Mechanical cooling diagnostics", body = serde_json::Value))
+    )]
+    pub fn analytics_mechanical_cooling() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/metering", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Metering descriptive analytics", body = serde_json::Value))
+    )]
+    pub fn analytics_metering() {}
+
+    #[utoipa::path(
+        get, path = "/api/reports", tag = "reports",
+        responses((status = 200, description = "List report artifacts / drafts", body = serde_json::Value))
+    )]
+    pub fn reports_list() {}
+
+    #[utoipa::path(
+        get, path = "/api/reports/templates", tag = "reports",
+        responses((status = 200, description = "List report templates", body = serde_json::Value))
+    )]
+    pub fn reports_templates() {}
+
+    #[utoipa::path(
+        post, path = "/api/reports/draft", tag = "reports",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Create a report draft", body = serde_json::Value))
+    )]
+    pub fn reports_draft() {}
+
+    #[utoipa::path(
+        get, path = "/api/reports/{report_id}", tag = "reports",
+        params(("report_id" = String, Path, description = "Report id")),
+        responses((status = 200, description = "Get a report by id", body = serde_json::Value))
+    )]
+    pub fn reports_get() {}
+}
+
 #[derive(OpenApi)]
 #[openapi(
     paths(
@@ -26,6 +170,25 @@ use openfdd_contracts::{CommandAck, CommandEnvelope, TelemetryEnvelope};
         crate::routes::auth_status,
         crate::routes::auth_me,
         crate::routes::auth_login,
+        // OFDD-071: live jobs / analytics / datasets / fdd-results / reports routes.
+        live_routes::jobs_list,
+        live_routes::jobs_create,
+        live_routes::jobs_get,
+        live_routes::jobs_create_wattlab_handoff,
+        live_routes::jobs_queue_eplus_run,
+        live_routes::datasets_list,
+        live_routes::datasets_delete,
+        live_routes::fdd_results,
+        live_routes::fdd_equipment,
+        live_routes::analytics_runtime,
+        live_routes::analytics_economizer,
+        live_routes::analytics_sensor_health,
+        live_routes::analytics_mechanical_cooling,
+        live_routes::analytics_metering,
+        live_routes::reports_list,
+        live_routes::reports_templates,
+        live_routes::reports_draft,
+        live_routes::reports_get,
     ),
     components(schemas(
         OkHealthResponse,
@@ -62,7 +225,14 @@ use openfdd_contracts::{CommandAck, CommandEnvelope, TelemetryEnvelope};
             **Claims:** `sub` (subject), `role` one of `viewer`, `operator`, `admin`. \
             `POST /api/commands` requires `operator` or `admin` when auth is enabled."
     ),
-    tags((name = "central", description = "Open-FDD Central control plane"))
+    tags(
+        (name = "central", description = "Open-FDD Central control plane"),
+        (name = "jobs", description = "Persistent analysis Jobs + WattLab / EnergyPlus handoff"),
+        (name = "analytics", description = "Typed analytics envelopes (historian DataFusion / inline)"),
+        (name = "datasets", description = "Ingested site datasets (Delete site)"),
+        (name = "fdd", description = "Site-scoped FDD rule results / equipment"),
+        (name = "reports", description = "Report artifacts, templates, and drafts")
+    )
 )]
 pub struct ApiDoc;
 
@@ -93,5 +263,26 @@ mod tests {
     fn openapi_router_builds_without_overlapping_routes() {
         // Axum panics on duplicate path+method; this was the nightly central crash (#502).
         let _ = router();
+    }
+
+    #[test]
+    fn openapi_lists_live_jobs_analytics_datasets_reports_routes() {
+        // OFDD-071: /openapi.json must advertise the live routes an operator uses,
+        // not just the original edge/command/auth subset.
+        let doc = ApiDoc::openapi();
+        let paths = doc.paths.paths;
+        for expected in [
+            "/api/jobs",
+            "/api/jobs/{job_id}",
+            "/api/datasets",
+            "/api/fdd/results",
+            "/api/analytics/economizer",
+            "/api/reports",
+        ] {
+            assert!(
+                paths.contains_key(expected),
+                "missing OpenAPI path {expected}"
+            );
+        }
     }
 }

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -179,6 +179,43 @@ pub fn router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+/// Resolve the reported build version (OFDD-071).
+///
+/// Preference order so `/api/health` reflects the deployed tip, not the stale
+/// crate literal:
+/// 1. Runtime `OPENFDD_GIT_SHA` → `{CARGO_PKG_VERSION}+{sha}` (CI/deploy stamps this).
+/// 2. Compile-time `OPENFDD_BUILD_GIT_SHA` (build.rs / docker `--build-arg`).
+/// 3. Bare `CARGO_PKG_VERSION` fallback.
+pub fn resolve_build_version() -> String {
+    let base = env!("CARGO_PKG_VERSION");
+    if let Ok(sha) = std::env::var("OPENFDD_GIT_SHA") {
+        let sha = sha.trim();
+        if !sha.is_empty() {
+            return format!("{base}+{}", short_sha(sha));
+        }
+    }
+    if let Some(sha) = option_env!("OPENFDD_BUILD_GIT_SHA") {
+        let sha = sha.trim();
+        if !sha.is_empty() {
+            return format!("{base}+{}", short_sha(sha));
+        }
+    }
+    base.to_string()
+}
+
+fn short_sha(sha: &str) -> String {
+    let clean: String = sha
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(12)
+        .collect();
+    if clean.is_empty() {
+        "unknown".into()
+    } else {
+        clean
+    }
+}
+
 #[utoipa::path(
     get,
     path = "/api/health",
@@ -189,7 +226,7 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Json<OkHealthResponse
     Json(OkHealthResponse {
         ok: true,
         service: "openfdd-central".into(),
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: resolve_build_version(),
         edges: state.edges.len(),
         ingest_ok: *state.ingest_ok.lock().unwrap(),
         ingest_dup: *state.ingest_dup.lock().unwrap(),
@@ -1518,4 +1555,30 @@ async fn analytics_metering(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
         "ok": true,
         "analytics": analytics::metering::handle_async(&req).await.to_json(),
     }))
+}
+
+#[cfg(test)]
+mod version_tests {
+    use super::resolve_build_version;
+
+    // Single test so the shared `OPENFDD_GIT_SHA` env var is never raced by a
+    // parallel sibling test.
+    #[test]
+    fn version_prefers_runtime_git_sha_then_crate_version() {
+        std::env::set_var("OPENFDD_GIT_SHA", "abcdef1234567890deadbeef");
+        let v = resolve_build_version();
+        assert!(v.starts_with(env!("CARGO_PKG_VERSION")), "v={v}");
+        assert!(v.contains('+'), "expected version+sha, got {v}");
+        // Short SHA capped at 12 alphanumerics.
+        assert_eq!(v.split('+').nth(1).unwrap(), "abcdef123456");
+
+        std::env::remove_var("OPENFDD_GIT_SHA");
+        let fallback = resolve_build_version();
+        // Without a runtime SHA it may still carry a compile-time build SHA;
+        // at minimum it must start with the crate version.
+        assert!(
+            fallback.starts_with(env!("CARGO_PKG_VERSION")),
+            "v={fallback}"
+        );
+    }
 }

--- a/services/ui/app/central_client.py
+++ b/services/ui/app/central_client.py
@@ -443,6 +443,67 @@ def jobs_create_wattlab_handoff(job_id: str, handoff: dict[str, Any]) -> dict[st
         return {"ok": False, "error": str(exc), "central_down": True}
 
 
+def jobs_queue_eplus_run(job_id: str, run: dict[str, Any], *, timeout: float = 30.0) -> dict[str, Any]:
+    """POST an external EnergyPlus run request (central persists QUEUED metadata only).
+
+    Central never opens a Docker socket or parses IDF; an approved external runner
+    (playground vibe20 / energyplus-mcp) claims QUEUED records. See eplus_runner.rs.
+    """
+    try:
+        resp = _request(
+            "POST",
+            f"{api_base()}/api/jobs/{job_id}/eplus/runs",
+            timeout=timeout,
+            json=run or {},
+            headers={"Content-Type": "application/json"},
+        )
+        return _parse_json_response(resp)
+    except requests.RequestException as exc:
+        return {"ok": False, "error": str(exc), "central_down": True}
+
+
+# Reports (OFDD-074/069) — Engineering Findings artifacts / templates / drafts.
+def reports_list(*, timeout: float = 30.0) -> dict[str, Any]:
+    try:
+        resp = _request("GET", f"{api_base()}/api/reports", timeout=timeout)
+        return _parse_json_response(resp)
+    except requests.RequestException as exc:
+        return {"ok": False, "error": str(exc), "central_down": True}
+
+
+def reports_templates(*, timeout: float = 30.0) -> dict[str, Any]:
+    try:
+        resp = _request("GET", f"{api_base()}/api/reports/templates", timeout=timeout)
+        return _parse_json_response(resp)
+    except requests.RequestException as exc:
+        return {"ok": False, "error": str(exc), "central_down": True}
+
+
+def reports_draft(body: dict[str, Any], *, timeout: float = 60.0) -> dict[str, Any]:
+    try:
+        resp = _request(
+            "POST",
+            f"{api_base()}/api/reports/draft",
+            timeout=timeout,
+            json=body or {},
+            headers={"Content-Type": "application/json"},
+        )
+        return _parse_json_response(resp)
+    except requests.RequestException as exc:
+        return {"ok": False, "error": str(exc), "central_down": True}
+
+
+def reports_get(report_id: str, *, timeout: float = 30.0) -> dict[str, Any]:
+    rid = (report_id or "").strip()
+    if not rid:
+        return {"ok": False, "error": "report_id required"}
+    try:
+        resp = _request("GET", f"{api_base()}/api/reports/{rid}", timeout=timeout)
+        return _parse_json_response(resp)
+    except requests.RequestException as exc:
+        return {"ok": False, "error": str(exc), "central_down": True}
+
+
 # Milestone C — typed analytics envelopes (no Plotly JSON).
 ANALYTICS_FAMILIES: frozenset[str] = frozenset(
     {

--- a/services/ui/app/dashboard_contract.py
+++ b/services/ui/app/dashboard_contract.py
@@ -45,6 +45,9 @@ REQUIRED_UI_ENTRYPOINTS: tuple[str, ...] = (
     "app.rule_card:build_rule_card",
     "app.docx_report:load_generic_rcx_report",
     "app.docx_report:applicable_rules_for_equipment",
+    # OFDD-074/069: Engineering Findings (open_fdd.reporting HITL) is the Overview
+    # report story. The static Generic RCx DOCX remains as a secondary template.
+    "app.eng_findings:render_engineering_findings_panel",
     "app.report_downloads:render_overview_rcx_download",
     "app.browser_session:write_browser_session_pointer",
     "app.browser_session:read_browser_session_pointer",
@@ -55,4 +58,8 @@ REQUIRED_UI_ENTRYPOINTS: tuple[str, ...] = (
     "app.ui_jobs:render_jobs_sidebar",
     "app.job_store:create_job",
     "app.job_store:load_job",
+    # OFDD-076/072: in-product vibe20 Jobs — WattLab handoff + ECM agent-build.
+    "app.ui_wattlab_job:render_job_native_wattlab_handoff",
+    "app.ui_ecm_job:render_ecm_agent_build_panel",
+    "app.job_store:save_ecm_request",
 )

--- a/services/ui/app/eng_findings.py
+++ b/services/ui/app/eng_findings.py
@@ -1,0 +1,307 @@
+"""Engineering Findings panel (OFDD-074 / OFDD-069).
+
+Replaces the Overview "Generic RCx DOCX" template as the Engineering Findings
+story. Detection ≠ finding: rule hits are *candidates* until deterministic
+evidence review.
+
+Primary path: the ``open_fdd.reporting`` HITL pipeline over the **active site's**
+rule results (``st.session_state.batch_results``) → prioritized findings +
+DOCX / XLSX / JSON artifacts.
+
+Fallback path: when ``open_fdd.reporting`` is not in the installed package
+(older PyPI ``open-fdd``), surface central ``/api/reports`` endpoints instead of
+the retired static DOCX template.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import streamlit as st
+
+from app import central_client
+
+_MIME = {
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "json": "application/json",
+}
+
+
+def reporting_available() -> bool:
+    """True when ``open_fdd.reporting`` (HITL Engineering Findings) is importable."""
+    try:
+        import open_fdd.reporting  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _safe_name(s: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in (s or ""))[:80] or "Building"
+
+
+def _split_refs(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [tok.strip() for tok in str(raw).replace("\n", ",").split(",") if tok.strip()]
+
+
+def _parse_notes(raw: str | None) -> dict[str, str]:
+    """Parse ``REF=note`` lines into a HITL notes dict (blank/invalid lines ignored)."""
+    out: dict[str, str] = {}
+    if not raw:
+        return out
+    for line in str(raw).splitlines():
+        line = line.strip()
+        if not line or "=" not in line:
+            continue
+        ref, note = line.split("=", 1)
+        ref = ref.strip()
+        note = note.strip()
+        if ref and note:
+            out[ref] = note
+    return out
+
+
+def _analysis_period_from_session() -> str:
+    start = st.session_state.get("dataset_start_str") or st.session_state.get("dataset_start")
+    end = st.session_state.get("dataset_end_str") or st.session_state.get("dataset_end")
+    if start and end:
+        return f"{start} → {end}"
+    return ""
+
+
+def _overview_context_from_session() -> dict[str, Any] | None:
+    ctx = st.session_state.get("overview_context")
+    return ctx if isinstance(ctx, dict) else None
+
+
+def build_findings(
+    results: list,
+    *,
+    building: str,
+    analysis_period: str = "",
+    overview_context: dict[str, Any] | None = None,
+    context: dict[str, Any] | None = None,
+    max_findings: int = 7,
+    pin: list[str] | None = None,
+    drop: list[str] | None = None,
+    notes: dict[str, str] | None = None,
+):
+    """Run the ``open_fdd.reporting`` HITL pipeline over rule results.
+
+    ``results`` are ``open_fdd.rules.base.RuleResult`` objects (the UI's
+    ``batch_results`` are exactly this type via the ``app.rules.base`` shim), so
+    they feed ``candidates_from_rule_results`` directly. Returns ``ReportArtifacts``.
+    """
+    from open_fdd.reporting import build_engineering_findings
+
+    return build_engineering_findings(
+        building=building,
+        analysis_period=analysis_period,
+        rule_results=list(results),
+        context=context,
+        overview_context=overview_context,
+        max_findings=int(max_findings),
+        pin_findings=pin or None,
+        drop_findings=drop or None,
+        notes=notes or None,
+    )
+
+
+def render_findings_bytes(
+    artifacts,
+    *,
+    basename: str | None = None,
+    docx: bool = True,
+    xlsx: bool = True,
+) -> tuple[dict[str, bytes], str | None]:
+    """Render artifacts to a temp dir and return ``({filename: bytes}, error_or_None)``.
+
+    Partial outputs are still captured when an optional writer (python-docx /
+    openpyxl) is missing, so the operator always gets at least the JSON findings.
+    """
+    from open_fdd.reporting import render_engineering_report
+
+    files: dict[str, bytes] = {}
+    err: str | None = None
+    with tempfile.TemporaryDirectory(prefix="ofdd-eng-findings-") as td:
+        tmp = Path(td)
+        try:
+            render_engineering_report(
+                artifacts,
+                tmp,
+                docx=docx,
+                json_out=True,
+                charts=False,
+                xlsx=xlsx,
+                basename=basename,
+            )
+        except Exception as exc:  # keep partial JSON/XLSX outputs on writer errors
+            err = str(exc)
+        for p in sorted(tmp.glob("*")):
+            if p.is_file():
+                try:
+                    files[p.name] = p.read_bytes()
+                except OSError:
+                    continue
+    return files, err
+
+
+def _render_findings_summary(art: dict[str, Any]) -> None:
+    import pandas as pd
+
+    metrics = art.get("metrics") or {}
+    st.caption(
+        f"{metrics.get('n_priority_findings', 0)} priority finding(s) · "
+        f"{metrics.get('n_candidates', 0)} candidate(s) · "
+        f"strong {metrics.get('n_strongly_supported', 0)} / "
+        f"probable {metrics.get('n_probable', 0)} / "
+        f"inconclusive {metrics.get('n_inconclusive', 0)}"
+    )
+    gate = art.get("quality_gate") or {}
+    if gate and not gate.get("ok", True):
+        st.warning("Quality gate flagged issues: " + ", ".join(str(x) for x in (gate.get("reasons") or [])))
+
+    findings = [f for f in (art.get("findings") or []) if f.get("include_in_report", True)]
+    if not findings:
+        st.info("No findings met the evidence bar for this report.")
+        return
+    rows = [
+        {
+            "F-id": f.get("finding_id"),
+            "priority": f.get("priority"),
+            "title": f.get("title"),
+            "classification": f.get("effective_classification") or f.get("classification"),
+            "equipment": ", ".join(f.get("equipment_ids") or []),
+            "rules": ", ".join(f.get("rule_ids") or []),
+        }
+        for f in findings
+    ]
+    df = pd.DataFrame(rows)
+    st.dataframe(df, hide_index=True, width="stretch", height=min(360, 80 + 28 * len(df)))
+
+
+def _render_findings_downloads(files: dict[str, bytes], *, key: str) -> None:
+    if not files:
+        return
+    st.markdown("###### Download findings")
+    for name in sorted(files):
+        ext = name.rsplit(".", 1)[-1].lower()
+        st.download_button(
+            f"Download {name}",
+            data=files[name],
+            file_name=name,
+            mime=_MIME.get(ext, "application/octet-stream"),
+            key=f"{key}_dl_{name}",
+            use_container_width=True,
+        )
+
+
+def _render_central_reports_fallback(*, building: str, key: str) -> None:
+    st.caption(
+        "`open_fdd.reporting` is not in this build — using central `/api/reports`. "
+        "Install `open-fdd[reporting]` for the in-UI HITL findings pipeline."
+    )
+    if not central_client.health_ok():
+        st.info(
+            "Engineering Findings requires either `open_fdd.reporting` (not installed) "
+            "or a reachable openfdd-central `/api/reports`."
+        )
+        return
+    listing = central_client.reports_list()
+    if listing.get("ok") is False:
+        st.warning(f"Central reports unavailable: {listing.get('error') or 'error'}")
+        return
+    reports = listing.get("reports") or listing.get("items") or []
+    if reports:
+        import pandas as pd
+
+        st.dataframe(pd.DataFrame(reports), hide_index=True, width="stretch")
+    else:
+        st.caption("No central report artifacts yet.")
+    if st.button("Create central report draft", key=f"{key}_central_draft"):
+        resp = central_client.reports_draft({"building": building, "kind": "engineering_findings"})
+        if resp.get("ok") is False:
+            st.error(resp.get("error") or "draft create failed")
+        else:
+            st.success("Central report draft created.")
+
+
+def render_engineering_findings_panel(*, key: str = "overview_eng_findings") -> None:
+    """Overview Engineering Findings story (retires the static Generic RCx DOCX)."""
+    st.markdown("##### Engineering Findings")
+    st.caption(
+        "Detection ≠ finding: rule hits are candidates until deterministic evidence "
+        "review (`open_fdd.reporting` HITL) → prioritized findings + DOCX/XLSX/JSON."
+    )
+
+    if not reporting_available():
+        _render_central_reports_fallback(
+            building=(st.session_state.get("building_id") or "").strip() or "BUILDING",
+            key=key,
+        )
+        return
+
+    results = st.session_state.get("batch_results") or []
+    building = (st.session_state.get("building_id") or "").strip() or "BUILDING"
+    if not results:
+        st.info("Run Rules first — Engineering Findings reviews the active site's rule results.")
+        return
+
+    faults = [r for r in results if getattr(r, "status", "") == "FAULT"]
+    st.caption(f"{len(faults)} FAULT candidate(s) across {len(results)} evaluations for `{building}`.")
+
+    with st.expander("Findings review (HITL)", expanded=False):
+        max_findings = st.number_input(
+            "Max findings", min_value=1, max_value=30, value=7, step=1, key=f"{key}_max"
+        )
+        pin_raw = st.text_input(
+            "Pin findings (comma refs: rule_id / equipment_id / F-id)", key=f"{key}_pin"
+        )
+        drop_raw = st.text_input("Drop findings (comma refs)", key=f"{key}_drop")
+        notes_raw = st.text_area(
+            "Engineer notes (one `REF=note` per line)", key=f"{key}_notes", height=80
+        )
+        want_docx = st.checkbox("Word (DOCX)", value=True, key=f"{key}_docx")
+        want_xlsx = st.checkbox("Excel (XLSX)", value=True, key=f"{key}_xlsx")
+
+    if st.button(
+        "Generate Engineering Findings",
+        key=f"{key}_gen",
+        type="primary",
+        disabled=not faults,
+    ):
+        with st.spinner("Building engineering findings…"):
+            try:
+                artifacts = build_findings(
+                    results,
+                    building=building,
+                    analysis_period=_analysis_period_from_session(),
+                    overview_context=_overview_context_from_session(),
+                    max_findings=int(max_findings),
+                    pin=_split_refs(pin_raw),
+                    drop=_split_refs(drop_raw),
+                    notes=_parse_notes(notes_raw),
+                )
+                files, err = render_findings_bytes(
+                    artifacts,
+                    basename=f"{_safe_name(building)}_Engineering_Findings",
+                    docx=bool(want_docx),
+                    xlsx=bool(want_xlsx),
+                )
+            except Exception as exc:  # surface to operator instead of crashing Overview
+                st.error(f"Findings generation failed: {exc}")
+                return
+        st.session_state[f"{key}_artifacts"] = artifacts.to_dict()
+        st.session_state[f"{key}_files"] = files
+        if err:
+            st.warning(f"Some artifacts skipped (optional writer missing): {err}")
+
+    art = st.session_state.get(f"{key}_artifacts")
+    if isinstance(art, dict):
+        _render_findings_summary(art)
+        _render_findings_downloads(st.session_state.get(f"{key}_files") or {}, key=key)

--- a/services/ui/app/job_store.py
+++ b/services/ui/app/job_store.py
@@ -547,3 +547,36 @@ def save_wattlab_handoff(
     path = job_dir(job_id, ws) / "wattlab" / "handoffs" / f"{hid}.json"
     _atomic_write_json(path, payload)
     return path
+
+
+def save_ecm_request(
+    job_id: str,
+    request: dict[str, Any],
+    *,
+    request_id: str | None = None,
+    ws: Path | None = None,
+) -> Path:
+    """Write an ECM package (agent-build) request under ``wattlab/ecm/`` (OFDD-076).
+
+    Central stays free of ECM/IDF logic; this is a job-native placeholder request
+    that the WattLab / open_fdd.ecm_engineering agent-build path consumes. Does not
+    duplicate telemetry.
+    """
+    if not isinstance(request, dict):
+        raise ValueError("ecm request must be an object")
+    rid = request_id or f"ecm-{uuid.uuid4()}"
+    if "/" in rid or "\\" in rid or ".." in rid:
+        raise ValueError("invalid ecm request id")
+    meta = load_job(job_id, ws=ws)
+    payload = {
+        "schema_version": "1",
+        "kind": "ecm_package_request",
+        "request_id": rid,
+        "job_id": job_id,
+        "run_id": request.get("run_id") or meta.latest_run_id,
+        "created_at": _utc_now(),
+        **{k: v for k, v in request.items() if k not in {"schema_version", "kind", "request_id", "job_id"}},
+    }
+    path = job_dir(job_id, ws) / "wattlab" / "ecm" / f"{rid}.json"
+    _atomic_write_json(path, payload)
+    return path

--- a/services/ui/app/test_eng_findings.py
+++ b/services/ui/app/test_eng_findings.py
@@ -1,0 +1,36 @@
+"""OFDD-074/069 — Engineering Findings panel helpers (mock streamlit).
+
+Heavy pipeline (``open_fdd.reporting`` → pandas) is exercised in the reporting
+package's own suite; here we cover the UI glue helpers that must be correct
+regardless of whether the reporting extra is installed.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("streamlit", MagicMock())
+
+from app import eng_findings  # noqa: E402
+
+
+def test_split_refs_handles_commas_and_newlines() -> None:
+    assert eng_findings._split_refs("FC1, VAV-1\nF01 ,") == ["FC1", "VAV-1", "F01"]
+    assert eng_findings._split_refs("") == []
+    assert eng_findings._split_refs(None) == []
+
+
+def test_parse_notes_ref_equals_note() -> None:
+    notes = eng_findings._parse_notes("F01=verify damper\n\nbad line\nFC1 = fan off ok")
+    assert notes == {"F01": "verify damper", "FC1": "fan off ok"}
+
+
+def test_reporting_available_is_bool() -> None:
+    # Must never raise even when the reporting extra is absent.
+    assert isinstance(eng_findings.reporting_available(), bool)
+
+
+def test_safe_name() -> None:
+    assert eng_findings._safe_name("Building 100 / RCx") == "Building_100___RCx"
+    assert eng_findings._safe_name("") == "Building"

--- a/services/ui/app/test_ui_ecm_job.py
+++ b/services/ui/app/test_ui_ecm_job.py
@@ -1,0 +1,104 @@
+"""OFDD-076/072 — ECM package agent-build request + cascade-if-ready honesty (mock streamlit)."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("streamlit", MagicMock())
+
+from app import job_store, ui_ecm_job  # noqa: E402
+
+
+def test_build_ecm_request_honesty_delegated_when_engine_present() -> None:
+    req = ui_ecm_job.build_ecm_package_request(
+        job_id="job-11111111-1111-1111-1111-111111111111",
+        building_id="BUILDING_100",
+        run_id="run-22222222-2222-2222-2222-222222222222",
+        ecm_available=True,
+        wattlab_cli="/usr/bin/wattlab",
+    )
+    assert req["kind"] == "ecm_package_request"
+    assert req["building_id"] == "BUILDING_100"
+    assert req["honesty"]["openfdd"] == "delegated"
+    assert req["engine"]["open_fdd_ecm_engineering"] is True
+    assert req["engine"]["wattlab_agent_build"] == "/usr/bin/wattlab"
+
+
+def test_build_ecm_request_honesty_unavailable_without_engine() -> None:
+    req = ui_ecm_job.build_ecm_package_request(
+        job_id="job-1",
+        building_id="B50",
+        ecm_available=False,
+    )
+    assert req["honesty"]["openfdd"] == "unavailable"
+    assert req["engine"]["open_fdd_ecm_engineering"] is False
+
+
+def test_cascade_readiness_gate(monkeypatch) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("OPENFDD_ENERGYPLUS_MCP", raising=False)
+    monkeypatch.delenv("OPENFDD_ENERGYPLUS_MCP_IMAGE", raising=False)
+    monkeypatch.setenv("OPENFDD_DOCKER_SOCK", "/nonexistent/docker.sock")
+    r = ui_ecm_job.cascade_readiness()
+    assert r["ready"] is False
+    assert r["reasons"]
+
+    monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+    monkeypatch.setenv("OPENFDD_ENERGYPLUS_MCP", "1")
+    r2 = ui_ecm_job.cascade_readiness()
+    assert r2["ready"] is True
+    assert r2["docker_sock"] is True
+    assert r2["energyplus_mcp"] is True
+
+
+def test_maybe_cascade_escoscreen_only_when_not_ready(monkeypatch) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("OPENFDD_ENERGYPLUS_MCP", raising=False)
+    monkeypatch.delenv("OPENFDD_ENERGYPLUS_MCP_IMAGE", raising=False)
+    monkeypatch.setenv("OPENFDD_DOCKER_SOCK", "/nonexistent/docker.sock")
+    out = ui_ecm_job.maybe_cascade_eplus("job-1")
+    assert out["cascaded"] is False
+    assert out["honesty"] == "esco_screening_only"
+
+
+def test_maybe_cascade_queues_when_ready(monkeypatch) -> None:
+    monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+    monkeypatch.setenv("OPENFDD_ENERGYPLUS_MCP", "1")
+    fake = {"ok": True, "run": {"eplus_run_id": "eplus-1", "status": "QUEUED"}}
+    with patch.object(
+        ui_ecm_job.central_client, "jobs_queue_eplus_run", return_value=fake
+    ) as mock_q:
+        out = ui_ecm_job.maybe_cascade_eplus("job-1", model_ref="model.idf")
+    assert out["cascaded"] is True
+    assert out["honesty"] == "delegated_external_runner"
+    mock_q.assert_called_once()
+
+
+def test_create_ecm_request_writes_under_job_wattlab(tmp_path, monkeypatch) -> None:
+    ws = tmp_path / "workspace"
+    meta = job_store.create_job("ECM Test", building_name="BUILDING_100", ws=ws)
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("OPENFDD_ENERGYPLUS_MCP", raising=False)
+    monkeypatch.setenv("OPENFDD_DOCKER_SOCK", "/nonexistent/docker.sock")
+
+    result = ui_ecm_job.create_ecm_package_request(
+        meta.job_id,
+        building_id="BUILDING_100",
+        notes="unit test",
+        do_cascade=False,
+        ws=ws,
+    )
+    assert result["ok"] is True
+    from pathlib import Path
+
+    path = Path(result["path"])
+    assert path.is_file()
+    assert "wattlab" in path.parts and "ecm" in path.parts
+    import json
+
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["kind"] == "ecm_package_request"
+    assert saved["job_id"] == meta.job_id
+    assert saved["building_id"] == "BUILDING_100"
+    assert "honesty" in saved

--- a/services/ui/app/ui_analytics.py
+++ b/services/ui/app/ui_analytics.py
@@ -282,9 +282,15 @@ def fetch_economizer_analytics(
     dt_min_f: float = 10.0,
     max_points: int = 8000,
     equipment_ids: list[str] | None = None,
+    building_id: str | None = None,
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """POST economizer series to central when healthy; return error dict on failure."""
+    """POST economizer series to central when healthy; return error dict on failure.
+
+    OFDD-070: when ``building_id`` is provided it is forwarded so central can scope
+    the historian read to ``building={id}/`` (no cross-site parquet bleed). Inline
+    series is still built from the active site's frames.
+    """
     if not central_client.health_ok():
         return {"ok": False, "error": "central health check failed", "central_down": True}
     series = build_economizer_series(
@@ -304,6 +310,9 @@ def fetch_economizer_analytics(
     }
     if equipment_ids:
         payload["equipment_ids"] = list(equipment_ids)
+    bid = (building_id or "").strip()
+    if bid:
+        payload["building_id"] = bid
     if extra:
         payload.update(extra)
     resp = central_client.analytics_post("economizer", payload)

--- a/services/ui/app/ui_ecm_job.py
+++ b/services/ui/app/ui_ecm_job.py
@@ -1,0 +1,288 @@
+"""In-product ECM package agent-build entry (OFDD-076 / OFDD-072).
+
+Creates a job-native **ECM package request** from the active Job/site. The heavy
+agent-build (Excel workbook + notebook) and any EnergyPlus/IDF calibration are
+**delegated** to WattLab / the external EnergyPlus runner — open-fdd central never
+parses IDF or runs E+ in-process.
+
+Two agent-build paths, in order of preference:
+
+1. **WattLab notebook builder** when a ``wattlab`` CLI / module is installed (the
+   request records the shell-out target for pickup).
+2. Otherwise a placeholder ECM package request JSON under the job's
+   ``wattlab/ecm/`` with ``honesty.openfdd = "delegated"`` when
+   ``open_fdd.ecm_engineering`` imports (``"unavailable"`` when it does not).
+
+**cascade-if-ready:** when a Docker socket **and** an ``energyplus-mcp-dev`` image
+are present, an external EnergyPlus run is queued via the existing central
+``/api/jobs/{id}/eplus/runs`` (QUEUED metadata only). Otherwise an honest
+ESCO/ECM-screening-only stamp is recorded — no fabricated calibrated compare.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+from typing import Any
+
+import streamlit as st
+
+from app import central_client, job_store
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def ecm_engineering_available() -> bool:
+    """True when ``open_fdd.ecm_engineering`` (ECM workbook toolkit) is importable."""
+    try:
+        return importlib.util.find_spec("open_fdd.ecm_engineering") is not None
+    except Exception:
+        return False
+
+
+def ecm_engineering_version() -> str | None:
+    try:
+        import open_fdd.ecm_engineering as ecm
+
+        return getattr(ecm, "__version__", None)
+    except Exception:
+        return None
+
+
+def wattlab_agent_build_available() -> str | None:
+    """Detect a WattLab agent-build entry (env override, CLI, or importable module)."""
+    env = (os.environ.get("OPENFDD_WATTLAB_CLI") or "").strip()
+    if env:
+        return env
+    found = shutil.which("wattlab")
+    if found:
+        return found
+    try:
+        if importlib.util.find_spec("wattlab") is not None:
+            return "wattlab (module)"
+    except Exception:
+        pass
+    return None
+
+
+def _energyplus_mcp_present() -> bool:
+    """Honest detection of an ``energyplus-mcp-dev`` runner (env-gated, no fabrication)."""
+    if (os.environ.get("OPENFDD_ENERGYPLUS_MCP") or "").strip().lower() in _TRUTHY:
+        return True
+    return bool((os.environ.get("OPENFDD_ENERGYPLUS_MCP_IMAGE") or "").strip())
+
+
+def _docker_sock_present() -> bool:
+    if (os.environ.get("DOCKER_HOST") or "").strip():
+        return True
+    sock = (os.environ.get("OPENFDD_DOCKER_SOCK") or "/var/run/docker.sock").strip()
+    try:
+        return os.path.exists(sock)
+    except OSError:
+        return False
+
+
+def cascade_readiness() -> dict[str, Any]:
+    """cascade-if-ready gate: both docker.sock and energyplus-mcp-dev must be present."""
+    has_sock = _docker_sock_present()
+    has_mcp = _energyplus_mcp_present()
+    reasons: list[str] = []
+    if not has_sock:
+        reasons.append("no docker.sock / DOCKER_HOST")
+    if not has_mcp:
+        reasons.append("energyplus-mcp-dev not detected (set OPENFDD_ENERGYPLUS_MCP)")
+    return {
+        "docker_sock": has_sock,
+        "energyplus_mcp": has_mcp,
+        "ready": has_sock and has_mcp,
+        "reasons": reasons,
+    }
+
+
+def build_ecm_package_request(
+    *,
+    job_id: str,
+    building_id: str,
+    run_id: str | None = None,
+    findings_revision: str | None = None,
+    notes: str | None = None,
+    ecm_available: bool | None = None,
+    wattlab_cli: str | None = None,
+    cascade: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Shape the ECM package request payload (pure — no I/O). Honesty-first."""
+    if ecm_available is None:
+        ecm_available = ecm_engineering_available()
+    honesty_state = "delegated" if ecm_available else "unavailable"
+    return {
+        "kind": "ecm_package_request",
+        "source": "openfdd_ui",
+        "job_id": job_id,
+        "building_id": building_id or None,
+        "run_id": run_id,
+        "findings_revision": findings_revision,
+        "engine": {
+            "open_fdd_ecm_engineering": bool(ecm_available),
+            "open_fdd_ecm_engineering_version": ecm_engineering_version() if ecm_available else None,
+            "wattlab_agent_build": wattlab_cli or None,
+        },
+        "honesty": {
+            "openfdd": honesty_state,
+            "detail": (
+                "ECM package agent-build (Excel workbook + notebook) and any "
+                "EnergyPlus/IDF calibration are delegated to WattLab / the external "
+                "EnergyPlus runner. open-fdd central never parses IDF or runs E+."
+            ),
+        },
+        "cascade": cascade or {},
+        "notes": notes,
+    }
+
+
+def maybe_cascade_eplus(
+    job_id: str,
+    *,
+    model_ref: str | None = None,
+    handoff_id: str | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Queue an external E+ run via central when ready; else return an honesty stamp."""
+    readiness = cascade_readiness()
+    if not readiness["ready"]:
+        return {
+            "ok": False,
+            "cascaded": False,
+            "readiness": readiness,
+            "honesty": "esco_screening_only",
+            "detail": (
+                "cascade-if-ready gate not satisfied; ESCO/ECM screening only "
+                "(no calibrated EnergyPlus compare)."
+            ),
+        }
+    run: dict[str, Any] = {}
+    if model_ref:
+        run["model_ref"] = model_ref
+    if handoff_id:
+        run["handoff_id"] = handoff_id
+    if notes:
+        run["notes"] = notes
+    resp = central_client.jobs_queue_eplus_run(job_id, run)
+    cascaded = bool(resp.get("ok"))
+    return {
+        "ok": cascaded,
+        "cascaded": cascaded,
+        "readiness": readiness,
+        "response": resp,
+        "honesty": "delegated_external_runner" if cascaded else "queue_failed",
+    }
+
+
+def create_ecm_package_request(
+    job_id: str,
+    *,
+    building_id: str,
+    run_id: str | None = None,
+    findings_revision: str | None = None,
+    notes: str | None = None,
+    do_cascade: bool = False,
+    model_ref: str | None = None,
+    handoff_id: str | None = None,
+    ws: Any | None = None,
+) -> dict[str, Any]:
+    """Write a job-native ECM package request (and optionally queue an E+ cascade)."""
+    ecm_available = ecm_engineering_available()
+    wattlab = wattlab_agent_build_available()
+    cascade_result = (
+        maybe_cascade_eplus(job_id, model_ref=model_ref, handoff_id=handoff_id, notes=notes)
+        if do_cascade
+        else None
+    )
+    request = build_ecm_package_request(
+        job_id=job_id,
+        building_id=building_id,
+        run_id=run_id,
+        findings_revision=findings_revision,
+        notes=notes,
+        ecm_available=ecm_available,
+        wattlab_cli=wattlab,
+        cascade=cascade_result or cascade_readiness(),
+    )
+    path = job_store.save_ecm_request(job_id, request, ws=ws)
+    return {"ok": True, "path": str(path), "request": request, "cascade": cascade_result}
+
+
+def render_ecm_agent_build_panel() -> None:
+    """Streamlit panel: create an ECM package request from the active Job/site."""
+    st.markdown("##### ECM package (agent-build)")
+    st.caption(
+        "Create an ECM Excel/notebook package request from the active Job. Heavy "
+        "agent-build + EnergyPlus/IDF stay delegated to WattLab / the external E+ "
+        "runner — open-fdd central never parses IDF."
+    )
+    job_id = st.session_state.get("openfdd_job_id")
+    if not job_id:
+        st.info("Open or create a Job (sidebar → Jobs) from the active site to build an ECM package.")
+        return
+
+    if ecm_engineering_available():
+        ver = ecm_engineering_version() or "?"
+        st.caption(f"`open_fdd.ecm_engineering` v{ver} present → `honesty.openfdd = delegated`.")
+    else:
+        st.caption(
+            "`open_fdd.ecm_engineering` not installed → `honesty.openfdd = unavailable` "
+            "(request still recorded for pickup)."
+        )
+
+    wattlab = wattlab_agent_build_available()
+    if wattlab:
+        st.caption(f"WattLab agent-build detected: `{wattlab}` (notebook builder path).")
+    else:
+        st.caption("WattLab agent-build CLI not detected — request is recorded for later pickup.")
+
+    readiness = cascade_readiness()
+    if readiness["ready"]:
+        st.success(
+            "cascade-if-ready: docker.sock + energyplus-mcp-dev present → "
+            "external E+ compare can be queued."
+        )
+    else:
+        st.warning(
+            "cascade-if-ready gate not met ("
+            + "; ".join(readiness["reasons"])
+            + ") → ESCO/ECM screening only."
+        )
+
+    notes = st.text_input("Notes", key="ecm_job_notes")
+    model_ref = st.text_input(
+        "E+ model ref (relative path under job, optional)", key="ecm_job_model_ref"
+    )
+    do_cascade = st.checkbox(
+        "Queue EnergyPlus cascade when ready",
+        value=bool(readiness["ready"]),
+        key="ecm_job_cascade",
+    )
+
+    if st.button("Create ECM package request", key="ecm_job_create", type="primary"):
+        try:
+            result = create_ecm_package_request(
+                str(job_id),
+                building_id=(st.session_state.get("building_id") or ""),
+                run_id=st.session_state.get("openfdd_latest_run_id"),
+                findings_revision=st.session_state.get("openfdd_findings_revision"),
+                notes=notes or None,
+                do_cascade=bool(do_cascade),
+                model_ref=(model_ref.strip() or None),
+            )
+        except Exception as exc:  # keep the Export tab alive on failure
+            st.error(f"ECM package request failed: {exc}")
+            return
+        st.success(f"ECM package request written: `{result['path']}`")
+        cascade = result.get("cascade")
+        if cascade:
+            if cascade.get("cascaded"):
+                st.success("Queued external EnergyPlus run (cascade-if-ready).")
+            else:
+                st.info("Cascade not queued: " + (cascade.get("detail") or "gate not satisfied"))
+        st.session_state["openfdd_last_ecm_request"] = result["request"]
+        st.json(result["request"])

--- a/services/ui/app/ui_jobs.py
+++ b/services/ui/app/ui_jobs.py
@@ -136,6 +136,16 @@ def render_jobs_sidebar() -> None:
             st.caption("No active jobs yet.")
 
         st.markdown("**New job**")
+        active_site = st.session_state.get("site_id")
+        active_building = st.session_state.get("building_id")
+        if active_building or active_site:
+            st.caption(
+                "Creates from active site: "
+                f"`{active_site or '—'}` / building `{active_building or '—'}` "
+                "(scopes WattLab handoff + ECM agent-build to this site)."
+            )
+        else:
+            st.caption("Load a site first to scope the job to a building.")
         name = st.text_input("Job name", key="jobs_new_name", placeholder="e.g. Building 100 RCx")
         if st.button("Create job", key="jobs_create_btn", disabled=not (name or "").strip()):
             try:

--- a/services/ui/app/ui_rcx_tab.py
+++ b/services/ui/app/ui_rcx_tab.py
@@ -69,6 +69,7 @@ def _render_economizer_diagnostics(
             weather=weather,
             prefer_web_oat=prefer_web,
             dt_min_f=dt_min,
+            building_id=st.session_state.get("building_id"),
         )
 
     if not result.get("ok"):

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -2782,9 +2782,17 @@ def main() -> None:
         d2.metric("Dataset end", end_s)
         d3.metric("Span (h)", f"{span['span_hours']:.1f}")
 
-        from app.report_downloads import render_overview_rcx_download
+        # OFDD-074/069: Engineering Findings (open_fdd.reporting HITL) is the
+        # Overview report story now — the static Generic RCx DOCX template is
+        # demoted to a secondary download below, not the primary narrative.
+        from app.eng_findings import render_engineering_findings_panel
 
-        render_overview_rcx_download(key="overview_generic_rcx_docx")
+        render_engineering_findings_panel(key="overview_eng_findings")
+
+        with st.expander("RCx report template (static DOCX)", expanded=False):
+            from app.report_downloads import render_overview_rcx_download
+
+            render_overview_rcx_download(key="overview_generic_rcx_docx")
 
         min_air_hours = _render_building_schedule_overview()
         if isinstance(central_runtime, dict) and central_runtime.get("ok"):
@@ -3940,6 +3948,10 @@ def main() -> None:
         from app.ui_wattlab_job import render_job_native_wattlab_handoff
 
         render_job_native_wattlab_handoff()
+
+        from app.ui_ecm_job import render_ecm_agent_build_panel
+
+        render_ecm_agent_build_panel()
 
         st.markdown("##### WattLab dump zip (additive)")
         if not frames:


### PR DESCRIPTION
## Summary
- **OFDD-074/069:** Engineering Findings HITL via `open_fdd.reporting`; Generic RCx DOCX demoted
- **OFDD-070:** building-scoped economizer historian + UI `building_id`
- **OFDD-071:** health tip SHA version; OpenAPI lists live jobs/analytics/datasets/reports
- **OFDD-076/072:** Jobs ECM agent-build request + cascade-if-ready via eplus queue stub

Depends on Gate A (#596) already on master.

## Test plan
- [x] cargo/clippy + economizer tests; UI eng_findings/ecm unit tests
- [ ] CI + CodeRabbit all green
- [ ] After merge: pull tip GHCR + recreate stack


Made with [Cursor](https://cursor.com)