### PR TITLE
ECM Stage 1/2 + Gate C honesty + SCHED-1 zone parity

### DIFF
--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -14,21 +14,22 @@ mod tests {
     async fn sched1_confirm_matches_pandas_reference() {
         // poll=300s, confirm=600s -> CONFIRM_ROWS=2 (narrower than registry default so the
         // synthetic series stays short; still exercises the same streak math).
+        // zone_t left empty → pandas "no zone mapped" base (unoccupied + fan only).
         let tmp = tempfile::TempDir::new().unwrap();
         let building = tmp.path().join("BUILDING_SCHED1");
         std::fs::create_dir_all(&building).unwrap();
 
         // occ unoccupied + fan on => raw 1. Sequence: 0,0,1,1,1,0,1,1
         let rows = "\
-timestamp_utc,occ_col,fan_col
-2026-01-01T00:00:00Z,occupied,1
-2026-01-01T00:05:00Z,occupied,1
-2026-01-01T00:10:00Z,unoccupied,1
-2026-01-01T00:15:00Z,unoccupied,1
-2026-01-01T00:20:00Z,unoccupied,1
-2026-01-01T00:25:00Z,occupied,0
-2026-01-01T00:30:00Z,unoccupied,1
-2026-01-01T00:35:00Z,unoccupied,1
+timestamp_utc,occ_col,fan_col,zone_col
+2026-01-01T00:00:00Z,occupied,1,
+2026-01-01T00:05:00Z,occupied,1,
+2026-01-01T00:10:00Z,unoccupied,1,
+2026-01-01T00:15:00Z,unoccupied,1,
+2026-01-01T00:20:00Z,unoccupied,1,
+2026-01-01T00:25:00Z,occupied,0,
+2026-01-01T00:30:00Z,unoccupied,1,
+2026-01-01T00:35:00Z,unoccupied,1,
 ";
         write_equipment_fixture(
             &building,
@@ -43,18 +44,85 @@ timestamp_utc,occ_col,fan_col
                     csv_col: "fan_col",
                     role: "fan_status",
                 },
+                RoleCol {
+                    csv_col: "zone_col",
+                    role: "zone_t",
+                },
             ],
             rows,
         );
 
-        let got =
-            run_rule_fault_hours(&building, "sched1_unoccupied_runtime.sql", 300.0, 600, &[]).await;
+        let got = run_rule_fault_hours(
+            &building,
+            "sched1_unoccupied_runtime.sql",
+            300.0,
+            600,
+            &[("ZONE_T_LO", "70"), ("ZONE_T_HI", "75")],
+        )
+        .await;
 
         let raw = [false, false, true, true, true, false, true, true];
         let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
         // indices 3,4,7 confirm => 3 * 300/3600 = 0.25h
         assert_hours_close(expected, 0.25, "pandas reference");
         assert_hours_close(got, expected, "SCHED-1 SQL");
+    }
+
+    #[tokio::test]
+    async fn sched1_zone_comfort_gate_matches_pandas() {
+        // When zone_t is mapped: fault only if unoccupied + fan + in comfort band.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SCHED1_ZONE");
+        std::fs::create_dir_all(&building).unwrap();
+
+        // Rows: occ/fan/zone — comfort band 70–75
+        // 0 occupied+fan+72
+        // 1 unoccupied+fan+80 (out of band → 0)
+        // 2–4 unoccupied+fan+72 (in band → 1)
+        // 5 unoccupied+fan+60 (out → 0)
+        let rows = "\
+timestamp_utc,occ_col,fan_col,zone_col
+2026-01-01T00:00:00Z,occupied,1,72
+2026-01-01T00:05:00Z,unoccupied,1,80
+2026-01-01T00:10:00Z,unoccupied,1,72
+2026-01-01T00:15:00Z,unoccupied,1,73
+2026-01-01T00:20:00Z,unoccupied,1,74
+2026-01-01T00:25:00Z,unoccupied,1,60
+";
+        write_equipment_fixture(
+            &building,
+            "VAV_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "occ_col",
+                    role: "occ_mode",
+                },
+                RoleCol {
+                    csv_col: "fan_col",
+                    role: "fan_status",
+                },
+                RoleCol {
+                    csv_col: "zone_col",
+                    role: "zone_t",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "sched1_unoccupied_runtime.sql",
+            300.0,
+            600,
+            &[("ZONE_T_LO", "70"), ("ZONE_T_HI", "75")],
+        )
+        .await;
+
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "SCHED-1 zone-comfort SQL");
     }
 
     #[tokio::test]

--- a/crates/fdd_rules/src/registry.rs
+++ b/crates/fdd_rules/src/registry.rs
@@ -33,6 +33,11 @@ pub struct RuleSpec {
     pub description: String,
     #[serde(default)]
     pub required_roles: Vec<String>,
+    /// Roles referenced by SQL that are optional (pandas-style). When absent
+    /// from history, the runner injects NULL columns so SQL still runs
+    /// (e.g. SCHED-1 zone comfort gate).
+    #[serde(default)]
+    pub optional_roles: Vec<String>,
     #[serde(default)]
     pub output_columns: Vec<String>,
     #[serde(default = "default_confirm")]

--- a/crates/fdd_rules/src/runner.rs
+++ b/crates/fdd_rules/src/runner.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::Result;
-use datafusion::prelude::SessionContext;
+use datafusion::prelude::*;
 use fdd_sql::{register_parquet_tree, register_weather_if_present, run_sql};
 use serde::Serialize;
 
@@ -62,6 +62,53 @@ fn write_skip_marker(out_path: &Path, missing_roles: &[String], note: &str) -> s
         "skipped": true,
     });
     std::fs::write(out_path, serde_json::to_string_pretty(&body)?)
+}
+
+/// Inject NULL Float64 columns for optional roles missing from history, then
+/// rewrite SQL `FROM history` → `FROM history_opt_<rule>` so AHU-only buildings
+/// still run (pandas sched1: no zone → base mask only).
+async fn sql_with_optional_null_roles(
+    ctx: &SessionContext,
+    rule_id: &str,
+    sql: &str,
+    optional_roles: &[String],
+    history_columns: &std::collections::HashSet<String>,
+) -> Result<String> {
+    let missing: Vec<String> = optional_roles
+        .iter()
+        .filter(|role| !history_columns.contains(&role.to_ascii_lowercase()))
+        .cloned()
+        .collect();
+    if missing.is_empty() {
+        return Ok(sql.to_string());
+    }
+    let view_name = format!(
+        "history_opt_{}",
+        rule_id
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect::<String>()
+            .to_ascii_lowercase()
+    );
+    let hist = ctx.table("history").await?;
+    let _ = hist; // ensure history exists
+    // SELECT *, CAST(NULL AS DOUBLE) AS role ... via SQL for portability
+    let null_cols: String = missing
+        .iter()
+        .map(|r| format!("CAST(NULL AS DOUBLE) AS \"{r}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let create_sql = format!(
+        "CREATE OR REPLACE TEMP VIEW {view_name} AS SELECT history.*, {null_cols} FROM history"
+    );
+    ctx.sql(&create_sql).await?.collect().await?;
+    // Replace bare table name history with the augmented view (word-boundary-ish).
+    let rewritten = sql
+        .replace(" FROM history", &format!(" FROM {view_name}"))
+        .replace(" from history", &format!(" from {view_name}"))
+        .replace("\nFROM history", &format!("\nFROM {view_name}"))
+        .replace("\nfrom history", &format!("\nfrom {view_name}"));
+    Ok(rewritten)
 }
 
 pub async fn run_all_rules(
@@ -198,6 +245,28 @@ pub async fn run_all_rules_with_overrides(
                 escaped
             );
         }
+        sql = match sql_with_optional_null_roles(
+            &ctx,
+            &rule.rule_id,
+            &sql,
+            &rule.optional_roles,
+            &history_columns,
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                timings.push(RuleTiming {
+                    rule_id: rule.rule_id.clone(),
+                    row_count: 0,
+                    elapsed_ms: t0.elapsed().as_millis(),
+                    output_path: out_path.display().to_string(),
+                    error: Some(format!("optional role inject: {e}")),
+                });
+                rules_failed += 1;
+                continue;
+            }
+        };
         match run_sql(&ctx, &sql).await {
             Ok(result) => {
                 std::fs::write(

--- a/crates/fdd_rules/src/runner.rs
+++ b/crates/fdd_rules/src/runner.rs
@@ -90,9 +90,6 @@ async fn sql_with_optional_null_roles(
             .collect::<String>()
             .to_ascii_lowercase()
     );
-    let hist = ctx.table("history").await?;
-    let _ = hist; // ensure history exists
-    // SELECT *, CAST(NULL AS DOUBLE) AS role ... via SQL for portability
     let null_cols: String = missing
         .iter()
         .map(|r| format!("CAST(NULL AS DOUBLE) AS \"{r}\""))
@@ -102,7 +99,6 @@ async fn sql_with_optional_null_roles(
         "CREATE OR REPLACE TEMP VIEW {view_name} AS SELECT history.*, {null_cols} FROM history"
     );
     ctx.sql(&create_sql).await?.collect().await?;
-    // Replace bare table name history with the augmented view (word-boundary-ish).
     let rewritten = sql
         .replace(" FROM history", &format!(" FROM {view_name}"))
         .replace(" from history", &format!(" from {view_name}"))

--- a/crates/fdd_rules/src/tuning.rs
+++ b/crates/fdd_rules/src/tuning.rs
@@ -160,6 +160,7 @@ mod tests {
             sql_file: "vav1_comfort_fault.sql".into(),
             description: "test".into(),
             required_roles: vec![],
+            optional_roles: vec![],
             output_columns: vec![],
             confirm_seconds: 900,
             parity_status: String::new(),

--- a/docs/migration/CATALOG_RULE_PARITY_ONEPASS.md
+++ b/docs/migration/CATALOG_RULE_PARITY_ONEPASS.md
@@ -1,0 +1,51 @@
+---
+title: Catalog rule parity one-pass (PR D)
+parent: Migration
+nav_order: 45
+---
+
+# Catalog pandas ↔ DataFusion SQL parity — one-pass residuals
+
+**Date:** 2026-07-29 · **Scope:** best-effort alignment; honest residuals — not “all 63 proven.”
+
+Machine-readable claims remain `parity_status` in `sql_rules/registry.yaml`.
+This page records the one-pass inventory after SCHED-1 zone-comfort (PR C).
+
+## Inventory (registry)
+
+| `parity_status` | Count | Notes |
+|-----------------|------:|-------|
+| `proven_building_100` | 24 | Includes SCHED-1 (zone gate + base fallback) |
+| `ported_from_cookbook` | 38 | Screening / incomplete pandas match |
+| `skipped_missing_roles` | 1 | FC7 |
+
+UI pandas cookbook recipes: **59**. SQL registry: **63**. Dual-catalog banner is intentional.
+
+## High-impact pass results
+
+| Rule | Intent check | SQL vs pandas | Action this pass | Residual |
+|------|--------------|---------------|------------------|----------|
+| SCHED-1 | Excess runtime when zone satisfied | Zone comfort band when `zone_t` present; base-only when absent/NULL | SQL + optional_roles inject + oracle zone fixture | None for mask intent; Liberty hours still soak |
+| SCHED-247 | Always-on | Screening streak ≠ window `always_on_pct` | No flip to proven | Keep ported |
+| CHW-NOLOAD-1 | Plant running while load satisfied | Oracle screening fixture already present | Listed; no SQL gap found this pass | Keep ported until plant soak |
+| SV-STALE | Stale sensor | Fan-on gate present (OFDD-065) | No further SQL change | Liberty `_tbd_` deltas |
+| VAV-1 | Comfort | Zone-only schema safe (no fan_cmd in SQL) | No change | Liberty `_tbd_` |
+| SV-RANGE / FLATLINE / SPIKE / RATE | Sensor family | Screening oracles only | No flip | Keep ported |
+| FC4 / PID-HUNT-1 | Hunting | Screening oracles only | No flip | Keep ported |
+| FC7 | Missing roles | skipped_missing_roles | Untouched | Needs role model |
+
+## Liberty FAULT deltas
+
+Do **not** invent. Fill only when local soak zips exist:
+
+| Rule | Site | pandas h | SQL h | Δ | Status |
+|------|------|---------:|------:|--:|--------|
+| SV-STALE | B50/B100 | _tbd_ | _tbd_ | _tbd_ | soak required |
+| VAV-1 | B50/B100 | _tbd_ | _tbd_ | _tbd_ | soak required |
+| SCHED-1 zone gate | B50/B100 | _tbd_ | _tbd_ | _tbd_ | soak required |
+
+## Docs discipline
+
+- No vibe-out of `docs/rules/` expression cookbook in this pass.
+- Registry description for SCHED-1 updated; migration pages own residual tables.
+- Oracle fixtures: `crates/fdd_rules/src/oracle_parity_test.rs`.

--- a/docs/migration/OFDD_065_076_PARITY.md
+++ b/docs/migration/OFDD_065_076_PARITY.md
@@ -74,7 +74,7 @@ tighten SV-STALE/VAV-1/FC1 gates within documented bands without regressing
 
 | Ticket | Scope | Gate | Status | Notes |
 |--------|-------|------|--------|-------|
-| OFDD-076 / 072 | In-product vibe20 Jobs agent-build + cascade-if-ready | C | **VERIFIED (delegated) / PENDING Liberty soak** | Jobs ECM request path remains delegated (Excel still vibe20). Tip persists `building_id` → `site_id` / `building_name` on `POST /api/jobs` create-from-site (OFDD-076 residual). Gate C exit still requires operator ECM without a separate vibe20 container. |
+| OFDD-076 / 072 | In-product vibe20 Jobs agent-build + cascade-if-ready | C | **VERIFIED (delegated) / PENDING Liberty soak** | Jobs ECM request path remains delegated (Excel still vibe20). Tip persists `building_id` → `site_id` / `building_name` on `POST /api/jobs` create-from-site (OFDD-076 residual). Gate C exit still requires operator ECM without a separate vibe20 container. **ENH-OFDD-007:** UI honestly links real `.xlsx` to vibe20 `wattlab notebook agent-build` / `reports/notebooks/**` — do not market Gate C as vibe20-complete for spreadsheets. |
 
 ## Gate B/C honesty caveats
 

--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -39,7 +39,7 @@ Oracle harness (phase 1, #550): `crates/fdd_rules` mask/fault-hour fixtures patt
 
 `AVG-ZONE-TEMP`, `ECON-1`, `ECON-2`, `ECON-3`, `ECON-4`, `ECON-5`, `ECON-6`, `ECON-7`, `FAN-RUNTIME-HOURS`, `FAULT-ELAPSED-HOURS`, `FC1`, `FC2`, `FC3`, `FC8`, `FC9`, `FC10`, `FC11`, `FC12`, `FC13-SAT-HIGH`, `MECH-OAT-1`, `OAT-METEO`, `SCHED-1`, `VAV-1`, `ZONE-COMFORT-PCT`
 
-Oracle fixtures (2026-07-26): `SCHED-1`, `MECH-OAT-1`, `ECON-3`, `ECON-5` (OAT-relative preheat), `ECON-6`/`ECON-7` (web weather + damper) in `crates/fdd_rules/src/oracle_parity_test.rs`. `SCHED-247` remains **ported** (screening streak ≠ window `always_on_pct`).
+Oracle fixtures (2026-07-29): `SCHED-1` base + **zone comfort gate** (excess runtime when zone satisfied), `MECH-OAT-1`, `ECON-3`, `ECON-5` (OAT-relative preheat), `ECON-6`/`ECON-7` (web weather + damper) in `crates/fdd_rules/src/oracle_parity_test.rs`. `SCHED-247` remains **ported** (screening streak ≠ window `always_on_pct`). One-pass residuals: [`docs/migration/CATALOG_RULE_PARITY_ONEPASS.md`](../../migration/CATALOG_RULE_PARITY_ONEPASS.md).
 
 ### Representative `ported_from_cookbook` risk set (phase-1 oracle focus)
 

--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -39,7 +39,7 @@ Oracle harness (phase 1, #550): `crates/fdd_rules` mask/fault-hour fixtures patt
 
 `AVG-ZONE-TEMP`, `ECON-1`, `ECON-2`, `ECON-3`, `ECON-4`, `ECON-5`, `ECON-6`, `ECON-7`, `FAN-RUNTIME-HOURS`, `FAULT-ELAPSED-HOURS`, `FC1`, `FC2`, `FC3`, `FC8`, `FC9`, `FC10`, `FC11`, `FC12`, `FC13-SAT-HIGH`, `MECH-OAT-1`, `OAT-METEO`, `SCHED-1`, `VAV-1`, `ZONE-COMFORT-PCT`
 
-Oracle fixtures (2026-07-29): `SCHED-1` base + **zone comfort gate** (excess runtime when zone satisfied), `MECH-OAT-1`, `ECON-3`, `ECON-5` (OAT-relative preheat), `ECON-6`/`ECON-7` (web weather + damper) in `crates/fdd_rules/src/oracle_parity_test.rs`. `SCHED-247` remains **ported** (screening streak ≠ window `always_on_pct`). One-pass residuals: [`docs/migration/CATALOG_RULE_PARITY_ONEPASS.md`](../../migration/CATALOG_RULE_PARITY_ONEPASS.md).
+Oracle fixtures (2026-07-26): `SCHED-1`, `MECH-OAT-1`, `ECON-3`, `ECON-5` (OAT-relative preheat), `ECON-6`/`ECON-7` (web weather + damper) in `crates/fdd_rules/src/oracle_parity_test.rs`. `SCHED-247` remains **ported** (screening streak ≠ window `always_on_pct`).
 
 ### Representative `ported_from_cookbook` risk set (phase-1 oracle focus)
 

--- a/open_fdd/ecm_engineering/__init__.py
+++ b/open_fdd/ecm_engineering/__init__.py
@@ -5,6 +5,14 @@ from .finance import npv, simple_payback
 from .job import ECMJob
 from .provenance import EvidenceValue, ProvenanceClass
 from .workbook import OpenFDDECMWorkbook, create_workbook
+from .contracts import (
+    EngineeringInput,
+    MeasureResultMeta,
+    validate_engineering_inputs,
+    validate_simulation_evidence,
+)
+from .calc_trace import CalculationTrace
+from .stage2_workbook import build_stage2_workbook
 
 __all__ = [
     "calculate",
@@ -17,6 +25,12 @@ __all__ = [
     "ProvenanceClass",
     "OpenFDDECMWorkbook",
     "create_workbook",
+    "EngineeringInput",
+    "MeasureResultMeta",
+    "validate_engineering_inputs",
+    "validate_simulation_evidence",
+    "CalculationTrace",
+    "build_stage2_workbook",
 ]
 
-__version__ = "4.1.1"
+__version__ = "4.2.0"

--- a/open_fdd/ecm_engineering/agent_cli.py
+++ b/open_fdd/ecm_engineering/agent_cli.py
@@ -1,0 +1,172 @@
+"""Stage-1 agent CLI stubs: evidence import + dual-rail Inputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .contracts import (
+    EngineeringInput,
+    InputRail,
+    SourceType,
+    AssumptionMethod,
+    list_missing_inputs,
+    validate_engineering_inputs,
+    validate_simulation_evidence,
+)
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _input_from_dict(d: dict[str, Any]) -> EngineeringInput:
+    return EngineeringInput(
+        input_id=str(d["input_id"]),
+        display_name=str(d.get("display_name") or d["input_id"]),
+        value=d.get("value"),
+        unit=str(d.get("unit") or ""),
+        rail=InputRail(d.get("rail") or "shared"),
+        source_type=SourceType(d.get("source_type") or "human_entered"),
+        confidence=str(d.get("confidence") or "unknown"),
+        editable=bool(d.get("editable", True)),
+        validation_status=str(d.get("validation_status") or "ok"),
+        validation_message=str(d.get("validation_message") or ""),
+        assumption_note=str(d.get("assumption_note") or ""),
+        assumption_method=AssumptionMethod(d.get("assumption_method") or "unknown"),
+        linked_measure_ids=list(d.get("linked_measure_ids") or []),
+        source_reference=str(d.get("source_reference") or ""),
+        notes=str(d.get("notes") or ""),
+    )
+
+
+def cmd_import_energyplus_evidence(path: Path, *, strict: bool = True) -> dict[str, Any]:
+    doc = _load_json(path)
+    issues = validate_simulation_evidence(doc, strict=strict)
+    return {
+        "ok": not issues,
+        "path": str(path),
+        "schema_version": doc.get("schema_version") if isinstance(doc, dict) else None,
+        "issues": issues,
+        "measure_count": len((doc or {}).get("individual_measures") or [])
+        if isinstance(doc, dict)
+        else 0,
+    }
+
+
+def cmd_list_workbook_inputs(path: Path) -> dict[str, Any]:
+    doc = _load_json(path)
+    raw = doc.get("inputs") if isinstance(doc, dict) else None
+    if raw is None and isinstance(doc, list):
+        raw = doc
+    if not isinstance(raw, list):
+        return {"ok": False, "issues": ["expected {inputs:[...]} or a list"], "inputs": []}
+    inputs = [_input_from_dict(x) for x in raw if isinstance(x, dict)]
+    issues = validate_engineering_inputs(inputs)
+    return {
+        "ok": not issues,
+        "count": len(inputs),
+        "inputs": [i.as_dict() for i in inputs],
+        "issues": issues,
+        "missing": list_missing_inputs(inputs),
+    }
+
+
+def cmd_list_missing_inputs(path: Path) -> dict[str, Any]:
+    listed = cmd_list_workbook_inputs(path)
+    return {
+        "ok": listed.get("ok", False),
+        "missing": listed.get("missing") or [],
+        "issues": listed.get("issues") or [],
+    }
+
+
+def cmd_propose_input_update(
+    path: Path,
+    *,
+    input_id: str,
+    value: Any,
+    reason: str,
+    assumption_note: str = "",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Propose an Inputs update; Stage 1 always dry_run (no workbook write)."""
+    listed = cmd_list_workbook_inputs(path)
+    if not listed.get("ok") and listed.get("issues"):
+        # Still allow propose against partial manifests
+        pass
+    match = next((i for i in listed.get("inputs") or [] if i.get("input_id") == input_id), None)
+    action = {
+        "action": "propose_input",
+        "input_id": input_id,
+        "old_value": None if match is None else match.get("value"),
+        "new_value": value,
+        "reason": reason,
+        "assumption_note": assumption_note,
+        "dry_run": dry_run,
+        "persisted": False,
+    }
+    if not dry_run:
+        action["warning"] = "Stage 1 CLI does not persist workbook edits yet (use dry_run)"
+    return {"ok": True, "action": action, "manifest_issues": listed.get("issues") or []}
+
+
+def agent_cli_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="open-fdd-ecm-agent")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    imp = sub.add_parser("import_energyplus_evidence")
+    imp.add_argument("path", type=Path)
+    imp.add_argument("--lenient", action="store_true")
+
+    li = sub.add_parser("list_workbook_inputs")
+    li.add_argument("path", type=Path)
+
+    lm = sub.add_parser("list_missing_inputs")
+    lm.add_argument("path", type=Path)
+
+    prop = sub.add_parser("propose_input_update")
+    prop.add_argument("path", type=Path)
+    prop.add_argument("--input-id", required=True)
+    prop.add_argument("--value", required=True)
+    prop.add_argument("--reason", required=True)
+    prop.add_argument("--assumption-note", default="")
+    prop.add_argument("--apply", action="store_true", help="ignored in Stage 1 (dry_run only)")
+
+    args = parser.parse_args(argv)
+    if args.command == "import_energyplus_evidence":
+        out = cmd_import_energyplus_evidence(args.path, strict=not args.lenient)
+    elif args.command == "list_workbook_inputs":
+        out = cmd_list_workbook_inputs(args.path)
+    elif args.command == "list_missing_inputs":
+        out = cmd_list_missing_inputs(args.path)
+    elif args.command == "propose_input_update":
+        raw_val: Any = args.value
+        try:
+            raw_val = json.loads(args.value)
+        except json.JSONDecodeError:
+            pass
+        out = cmd_propose_input_update(
+            args.path,
+            input_id=args.input_id,
+            value=raw_val,
+            reason=args.reason,
+            assumption_note=args.assumption_note,
+            dry_run=not args.apply,
+        )
+    else:
+        parser.error(f"unknown command {args.command}")
+        return 2
+    print(json.dumps(out, indent=2))
+    return 0 if out.get("ok", False) else 1
+
+
+__all__ = [
+    "cmd_import_energyplus_evidence",
+    "cmd_list_workbook_inputs",
+    "cmd_list_missing_inputs",
+    "cmd_propose_input_update",
+    "agent_cli_main",
+]

--- a/open_fdd/ecm_engineering/calc_trace.py
+++ b/open_fdd/ecm_engineering/calc_trace.py
@@ -1,0 +1,25 @@
+"""Calculation trace object for Stage-1 ECM contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class CalculationTrace:
+    trace_id: str
+    equation_id: str
+    equation_text: str
+    inputs_used: list[str] = field(default_factory=list)
+    intermediate: dict[str, Any] = field(default_factory=dict)
+    result: Any = None
+    unit: str = ""
+    comparison_mode: str = ""
+    notes: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+__all__ = ["CalculationTrace"]

--- a/open_fdd/ecm_engineering/cli.py
+++ b/open_fdd/ecm_engineering/cli.py
@@ -3,6 +3,9 @@ import argparse
 import json
 from .algorithms import calculate, list_calculators
 from .job import ECMJob
+from .agent_cli import agent_cli_main
+from .stage2_workbook import build_stage2_workbook
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="open-fdd-ecm")
@@ -15,6 +18,14 @@ def main() -> None:
 
     demo = sub.add_parser("demo")
     demo.add_argument("--out", default="Open_FDD_Demo_ECMs.xlsx")
+
+    stage2 = sub.add_parser("stage2-workbook")
+    stage2.add_argument("--out", default="Open_FDD_Stage2_ECM.xlsx")
+    stage2.add_argument("--project", default="Open-FDD ECM Package")
+    stage2.add_argument("--facility", default="Synthetic Facility")
+
+    agent = sub.add_parser("agent")
+    agent.add_argument("agent_args", nargs=argparse.REMAINDER)
 
     args = parser.parse_args()
     if args.command == "calculators":
@@ -35,6 +46,14 @@ def main() -> None:
             .save()
         )
         print(path)
+    elif args.command == "stage2-workbook":
+        path = build_stage2_workbook(
+            args.out, project_name=args.project, facility_name=args.facility
+        )
+        print(path)
+    elif args.command == "agent":
+        raise SystemExit(agent_cli_main(args.agent_args))
+
 
 if __name__ == "__main__":
     main()

--- a/open_fdd/ecm_engineering/contracts.py
+++ b/open_fdd/ecm_engineering/contracts.py
@@ -1,0 +1,281 @@
+"""Stage-1 ECM contracts: dual-rail inputs, scopes, evidence, publication previews."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class ResultScope(StrEnum):
+    WHOLE_BUILDING = "whole_building"
+    MODEL_AIR_SYSTEM = "model_air_system"
+    PHYSICAL_AHU = "physical_ahu"
+    FLOOR_PROXY = "floor_proxy"
+    ZONE_PROXY = "zone_proxy"
+    PLANT = "plant"
+    METER = "meter"
+
+
+class AllocationStatus(StrEnum):
+    NOT_ALLOCATED = "not_allocated"
+    DIRECTLY_METERED = "directly_metered"
+    MODEL_METERED = "model_metered"
+    ENGINEERING_ALLOCATION = "engineering_allocation"
+    PROXY_ALLOCATION = "proxy_allocation"
+
+
+class ComparisonMode(StrEnum):
+    VS_COMMON_BASELINE = "vs_common_baseline"
+    SEQUENTIAL_INCREMENT = "sequential_increment"
+    EXPLICIT_PACKAGE = "explicit_package"
+    MEASURED_PRE_POST = "measured_pre_post"
+
+
+class AdditiveStatus(StrEnum):
+    NON_ADDITIVE = "non_additive"
+    ADDITIVE_WITHIN_DEFINED_BOUNDARY = "additive_within_defined_boundary"
+    EXPLICIT_PACKAGE_RESULT = "explicit_package_result"
+    SEQUENTIAL_INCREMENT = "sequential_increment"
+
+
+class InteractionStatus(StrEnum):
+    NOT_EVALUATED = "not_evaluated"
+    ESTIMATED = "estimated"
+    SIMULATED = "simulated"
+    MEASURED = "measured"
+
+
+class InputRail(StrEnum):
+    SPREADSHEET = "spreadsheet"
+    ENERGYPLUS = "energyplus"
+    SHARED = "shared"
+
+
+class SourceType(StrEnum):
+    MEASURED = "measured"
+    BAS_DERIVED = "BAS_derived"
+    UTILITY_BILL = "utility_bill"
+    INTERVAL_METER = "interval_meter"
+    TAB_REPORT = "TAB_report"
+    NAMEPLATE = "nameplate"
+    DESIGN_DOCUMENT = "design_document"
+    CONTRACTOR_QUOTE = "contractor_quote"
+    ENERGYPLUS_AUTOSIZED = "EnergyPlus_autosized"
+    ENERGYPLUS_DERIVED = "EnergyPlus_derived"
+    PUBLIC_BENCHMARK = "public_benchmark"
+    ENGINEERING_ASSUMPTION = "engineering_assumption"
+    AGENT_INFERRED = "agent_inferred"
+    HUMAN_ENTERED = "human_entered"
+    SYNTHETIC_REHEARSAL = "synthetic_rehearsal"
+
+
+class AssumptionMethod(StrEnum):
+    NAMEPLATE = "nameplate"
+    EIO_AUTOSIZE = "eio_autosize"
+    AMY_CALENDAR_HOURS = "amy_calendar_hours"
+    FLH_FROM_CASCADE = "flh_from_cascade"
+    BIN_METHOD = "bin_method"
+    TAB_REPORT = "tab_report"
+    OPERATOR_ENTRY = "operator_entry"
+    ENGINEERING_JUDGMENT = "engineering_judgment"
+    UNKNOWN = "unknown"
+
+
+_NEEDS_ASSUMPTION_NOTE = frozenset(
+    {
+        SourceType.AGENT_INFERRED,
+        SourceType.ENGINEERING_ASSUMPTION,
+        SourceType.ENERGYPLUS_DERIVED,
+        SourceType.SYNTHETIC_REHEARSAL,
+    }
+)
+
+
+@dataclass
+class EngineeringInput:
+    input_id: str
+    display_name: str
+    value: Any
+    unit: str
+    rail: InputRail
+    source_type: SourceType
+    confidence: str = "unknown"
+    editable: bool = True
+    validation_status: str = "ok"
+    validation_message: str = ""
+    assumption_note: str = ""
+    assumption_method: AssumptionMethod = AssumptionMethod.UNKNOWN
+    linked_measure_ids: list[str] = field(default_factory=list)
+    source_reference: str = ""
+    notes: str = ""
+
+    def requires_assumption_note(self) -> bool:
+        if self.source_type in _NEEDS_ASSUMPTION_NOTE:
+            return True
+        # Hour / FLH style inputs always need a note when agent- or judgment-derived.
+        lid = self.input_id.lower()
+        if "hour" in lid or lid.endswith("_flh") or "hours_saved" in lid:
+            return self.source_type != SourceType.MEASURED and self.source_type != SourceType.HUMAN_ENTERED
+        return False
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["rail"] = self.rail.value
+        d["source_type"] = self.source_type.value
+        d["assumption_method"] = self.assumption_method.value
+        return d
+
+
+@dataclass
+class MeasureResultMeta:
+    measure_id: str
+    result_scope: ResultScope
+    allocation_status: AllocationStatus
+    comparison_mode: ComparisonMode
+    additive_status: AdditiveStatus
+    interaction_status: InteractionStatus = InteractionStatus.NOT_EVALUATED
+    baseline_run_id: str = ""
+    proposed_run_id: str = ""
+    preceding_run_id: str | None = None
+    package_id: str | None = None
+    physical_system_id: str | None = None
+    model_object_ids: list[str] = field(default_factory=list)
+    overlap_groups: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        for key, enum_val in (
+            ("result_scope", self.result_scope),
+            ("allocation_status", self.allocation_status),
+            ("comparison_mode", self.comparison_mode),
+            ("additive_status", self.additive_status),
+            ("interaction_status", self.interaction_status),
+        ):
+            d[key] = enum_val.value
+        return d
+
+
+EVIDENCE_SCHEMA_VERSION = "ecm_simulation_evidence_v1"
+
+
+def validate_engineering_inputs(inputs: list[EngineeringInput]) -> list[str]:
+    """Return validation issues (empty = ok)."""
+    issues: list[str] = []
+    for inp in inputs:
+        src_ref = (inp.source_reference or "").lower()
+        if inp.source_type == SourceType.MEASURED and "energyplus" in src_ref:
+            issues.append(
+                f"{inp.input_id}: EnergyPlus-derived values must not be labeled measured"
+            )
+        if inp.source_type == SourceType.MEASURED and inp.rail == InputRail.ENERGYPLUS:
+            issues.append(
+                f"{inp.input_id}: EnergyPlus rail values must not be labeled measured"
+            )
+        if inp.requires_assumption_note() and not (inp.assumption_note or "").strip():
+            issues.append(
+                f"{inp.input_id}: assumption_note required for {inp.source_type.value} / estimated hours"
+            )
+    return issues
+
+
+def validate_measure_meta(meta: MeasureResultMeta) -> list[str]:
+    issues: list[str] = []
+    if (
+        meta.result_scope == ResultScope.PHYSICAL_AHU
+        and meta.allocation_status == AllocationStatus.NOT_ALLOCATED
+    ):
+        issues.append(
+            f"{meta.measure_id}: physical_ahu requires allocation evidence "
+            f"(allocation_status != not_allocated)"
+        )
+    if (
+        meta.additive_status == AdditiveStatus.EXPLICIT_PACKAGE_RESULT
+        and meta.comparison_mode == ComparisonMode.VS_COMMON_BASELINE
+        and not meta.package_id
+    ):
+        issues.append(
+            f"{meta.measure_id}: explicit package result needs package_id "
+            "(independent vs_baseline rows are non_additive)"
+        )
+    return issues
+
+
+def validate_simulation_evidence(doc: dict[str, Any], *, strict: bool = True) -> list[str]:
+    """Validate vibe20 ecm_simulation_evidence.json shape."""
+    issues: list[str] = []
+    if not isinstance(doc, dict):
+        return ["evidence root must be an object"]
+    ver = doc.get("schema_version")
+    if ver != EVIDENCE_SCHEMA_VERSION:
+        issues.append(
+            f"schema_version must be {EVIDENCE_SCHEMA_VERSION!r}, got {ver!r}"
+        )
+    for key in ("project", "facility", "baseline", "model", "individual_measures"):
+        if key not in doc:
+            issues.append(f"missing required top-level key: {key}")
+    if strict:
+        known = {
+            "schema_version",
+            "project",
+            "facility",
+            "baseline",
+            "calibration",
+            "model",
+            "weather",
+            "equipment_autosizing",
+            "individual_measures",
+            "package_runs",
+            "sequential_cascades",
+            "run_artifacts",
+            "warnings",
+        }
+        for k in doc:
+            if k not in known:
+                issues.append(f"unknown field (strict): {k}")
+    measures = doc.get("individual_measures") or []
+    if not isinstance(measures, list):
+        issues.append("individual_measures must be a list")
+    else:
+        for i, m in enumerate(measures):
+            if not isinstance(m, dict):
+                issues.append(f"individual_measures[{i}] must be an object")
+                continue
+            for req in ("measure_id", "run_id", "baseline_run_id", "comparison_mode", "result_scope"):
+                if req not in m:
+                    issues.append(f"individual_measures[{i}] missing {req}")
+            if m.get("result_scope") == ResultScope.PHYSICAL_AHU.value:
+                if m.get("allocation_status") in (None, AllocationStatus.NOT_ALLOCATED.value):
+                    issues.append(
+                        f"individual_measures[{i}]: physical_ahu without allocation evidence"
+                    )
+    return issues
+
+
+def list_missing_inputs(inputs: list[EngineeringInput]) -> list[str]:
+    missing: list[str] = []
+    for inp in inputs:
+        if inp.value is None or inp.value == "":
+            missing.append(inp.input_id)
+        elif inp.validation_status == "missing":
+            missing.append(inp.input_id)
+    return missing
+
+
+__all__ = [
+    "ResultScope",
+    "AllocationStatus",
+    "ComparisonMode",
+    "AdditiveStatus",
+    "InteractionStatus",
+    "InputRail",
+    "SourceType",
+    "AssumptionMethod",
+    "EngineeringInput",
+    "MeasureResultMeta",
+    "EVIDENCE_SCHEMA_VERSION",
+    "validate_engineering_inputs",
+    "validate_measure_meta",
+    "validate_simulation_evidence",
+    "list_missing_inputs",
+]

--- a/open_fdd/ecm_engineering/fixtures.py
+++ b/open_fdd/ecm_engineering/fixtures.py
@@ -1,0 +1,79 @@
+"""Synthetic fixtures for Stage-1 ECM contracts / evidence import."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from open_fdd.ecm_engineering.contracts import EVIDENCE_SCHEMA_VERSION
+from open_fdd.ecm_engineering.stage2_workbook import dual_rail_fixture_inputs
+
+
+def synthetic_evidence() -> dict[str, Any]:
+    return {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "project": {"id": "synth-1", "name": "Synthetic ECM Project"},
+        "facility": {"id": "fac-1", "name": "Synthetic Facility", "area_ft2": 85000},
+        "baseline": {"run_id": "baseline-001", "status": "calibrated"},
+        "calibration": {"g14_pass_fail": "PASS", "note": "synthetic"},
+        "model": {"idf_ref": "models/synth.idf", "energyplus_version": "23.2.0"},
+        "weather": {"epw": "USA_IL_Chicago-OHare.epw", "amy_year": 2019},
+        "equipment_autosizing": {
+            "fans": [{"id": "AHU1_SUPPLY", "ep_fan_hp": 22.4, "source": "eio"}],
+            "cooling": [{"id": "CHILLER1", "ep_cooling_tons": 180.0, "source": "eio"}],
+        },
+        "individual_measures": [
+            {
+                "measure_id": "ECM-DSP-RESET",
+                "run_id": "meas-dsp-001",
+                "baseline_run_id": "baseline-001",
+                "comparison_mode": "vs_common_baseline",
+                "result_scope": "whole_building",
+                "allocation_status": "not_allocated",
+                "hour_bases": {
+                    "ep_dsp_reset_hours": 2100,
+                    "ss_dsp_reset_hours": 2200,
+                },
+            },
+            {
+                "measure_id": "ECM-FAN-SCHED",
+                "run_id": "meas-sched-001",
+                "baseline_run_id": "baseline-001",
+                "comparison_mode": "vs_common_baseline",
+                "result_scope": "whole_building",
+                "allocation_status": "not_allocated",
+                "hour_bases": {
+                    "ep_sched_hours_saved": 1085,
+                    "ss_sched_hours_saved": 1200,
+                },
+            },
+        ],
+        "package_runs": [],
+        "sequential_cascades": [],
+        "run_artifacts": {"cascade_dir": "reports/cascade/synth"},
+        "warnings": [],
+    }
+
+
+def synthetic_inputs_manifest() -> dict[str, Any]:
+    return {
+        "schema": "ecm_engineering_inputs_v1",
+        "inputs": [i.as_dict() for i in dual_rail_fixture_inputs()],
+    }
+
+
+def write_fixtures(out_dir: Path) -> dict[str, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    evidence = out_dir / "ecm_simulation_evidence.json"
+    inputs = out_dir / "ecm_engineering_inputs.json"
+    evidence.write_text(json.dumps(synthetic_evidence(), indent=2) + "\n", encoding="utf-8")
+    inputs.write_text(json.dumps(synthetic_inputs_manifest(), indent=2) + "\n", encoding="utf-8")
+    return {"evidence": evidence, "inputs": inputs}
+
+
+__all__ = [
+    "synthetic_evidence",
+    "synthetic_inputs_manifest",
+    "write_fixtures",
+]

--- a/open_fdd/ecm_engineering/stage2_workbook.py
+++ b/open_fdd/ecm_engineering/stage2_workbook.py
@@ -1,0 +1,296 @@
+"""Stage-2 professional ECM workbook builder (Cover → Documentation).
+
+Renders dual-rail Inputs with Assumption_Note as engineer-facing sheets.
+Uses openpyxl when available; otherwise writes a minimal OOXML Inputs pack.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .contracts import EngineeringInput, InputRail
+
+STAGE2_SHEET_ORDER = (
+    "Cover",
+    "Calibrated_Twin",
+    "Inputs",
+    "Measure_Summary",
+    "Equipment_Sizing",
+    "Hours_Bases",
+    "Package_Matrix",
+    "Calculation_Trace",
+    "Agent_Action_Log",
+    "Publication_Gates",
+    "Documentation",
+)
+
+INPUTS_COLUMNS = (
+    "input_id",
+    "display_name",
+    "value",
+    "unit",
+    "rail",
+    "source_type",
+    "confidence",
+    "editable",
+    "validation_status",
+    "assumption_method",
+    "Assumption_Note",
+    "linked_measure_ids",
+    "source_reference",
+)
+
+
+def dual_rail_fixture_inputs() -> list[EngineeringInput]:
+    """Synthetic Stage-1/2 fixture with at least one ss_* / ep_* sizing pair."""
+    from .contracts import AssumptionMethod, SourceType
+
+    return [
+        EngineeringInput(
+            input_id="ss_fan_hp",
+            display_name="Spreadsheet fan power",
+            value=25.0,
+            unit="hp",
+            rail=InputRail.SPREADSHEET,
+            source_type=SourceType.NAMEPLATE,
+            assumption_note="Nameplate from TAB report AHU-1 supply fan.",
+            assumption_method=AssumptionMethod.NAMEPLATE,
+            linked_measure_ids=["ECM-DSP-RESET", "ECM-FAN-SCHED"],
+            source_reference="TAB-2024-AHU1",
+        ),
+        EngineeringInput(
+            input_id="ep_fan_hp",
+            display_name="EnergyPlus autosized fan power",
+            value=22.4,
+            unit="hp",
+            rail=InputRail.ENERGYPLUS,
+            source_type=SourceType.ENERGYPLUS_AUTOSIZED,
+            assumption_note="From baseline .eio Fan:SystemModel Peak Design Power.",
+            assumption_method=AssumptionMethod.EIO_AUTOSIZE,
+            linked_measure_ids=["ECM-DSP-RESET"],
+            source_reference="baseline.eio",
+        ),
+        EngineeringInput(
+            input_id="ss_sched_hours_saved",
+            display_name="Spreadsheet schedule hours saved",
+            value=1200.0,
+            unit="h/yr",
+            rail=InputRail.SPREADSHEET,
+            source_type=SourceType.AGENT_INFERRED,
+            assumption_note=(
+                "FLH back-calc from cascade kWh / ss_fan_kw — not Twin AMY calendar hours "
+                "(BUG-ECM-014). Period = AMY calendar year matching Twin weather."
+            ),
+            assumption_method=AssumptionMethod.FLH_FROM_CASCADE,
+            linked_measure_ids=["ECM-FAN-SCHED"],
+        ),
+        EngineeringInput(
+            input_id="ep_sched_hours_saved",
+            display_name="EnergyPlus schedule hours saved",
+            value=1085.0,
+            unit="h/yr",
+            rail=InputRail.ENERGYPLUS,
+            source_type=SourceType.ENERGYPLUS_DERIVED,
+            assumption_note="FanAvail calendar delta baseline vs schedule measure (AMY).",
+            assumption_method=AssumptionMethod.AMY_CALENDAR_HOURS,
+            linked_measure_ids=["ECM-FAN-SCHED"],
+            source_reference="cascade/FanAvail",
+        ),
+    ]
+
+
+def build_stage2_workbook(
+    output_path: str | Path,
+    *,
+    inputs: list[EngineeringInput] | None = None,
+    project_name: str = "Open-FDD ECM Package",
+    facility_name: str = "Synthetic Facility",
+    action_log: list[dict[str, Any]] | None = None,
+) -> Path:
+    """Write a Stage-2 professional workbook with dual-rail Inputs + Assumption_Note."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    rows = inputs if inputs is not None else dual_rail_fixture_inputs()
+    log = action_log or []
+
+    try:
+        from openpyxl import Workbook
+        from openpyxl.workbook.defined_name import DefinedName
+    except ImportError:
+        return _build_minimal_inputs_json_sidecar(output, rows, project_name, facility_name, log)
+
+    wb = Workbook()
+    # Cover
+    cover = wb.active
+    cover.title = "Cover"
+    cover["A1"] = project_name
+    cover["A2"] = facility_name
+    cover["A3"] = "Stage 2 professional ECM workbook (Open-FDD owned)"
+    cover["A4"] = "Real EnergyPlus / IDF work remains in vibe20; this book holds calcs + Inputs."
+
+    for name in STAGE2_SHEET_ORDER[1:]:
+        if name not in wb.sheetnames:
+            wb.create_sheet(name)
+
+    twin = wb["Calibrated_Twin"]
+    twin["A1"] = "Calibrated Twin (reference only)"
+    twin["A2"] = "Populate from vibe20 ecm_simulation_evidence.json on import."
+
+    inputs_ws = wb["Inputs"]
+    for col, header in enumerate(INPUTS_COLUMNS, start=1):
+        inputs_ws.cell(1, col, header)
+    for r_i, inp in enumerate(rows, start=2):
+        d = inp.as_dict()
+        values = [
+            d.get("input_id"),
+            d.get("display_name"),
+            d.get("value"),
+            d.get("unit"),
+            d.get("rail"),
+            d.get("source_type"),
+            d.get("confidence"),
+            d.get("editable"),
+            d.get("validation_status"),
+            d.get("assumption_method"),
+            d.get("assumption_note"),
+            ",".join(d.get("linked_measure_ids") or []),
+            d.get("source_reference"),
+        ]
+        for c_i, val in enumerate(values, start=1):
+            inputs_ws.cell(r_i, c_i, val)
+
+    # Stable named ranges for dual-rail columns (table-like, not cell B17).
+    # Input_id column + Assumption_Note column whole ranges.
+    n_rows = max(len(rows), 1) + 1
+    wb.defined_names.add(
+        DefinedName(name="Inputs_Table", attr_text=f"Inputs!$A$1:$M${n_rows}")
+    )
+    wb.defined_names.add(
+        DefinedName(name="Assumption_Note", attr_text=f"Inputs!$K$2:$K${n_rows}")
+    )
+    wb.defined_names.add(DefinedName(name="Inputs_input_id", attr_text=f"Inputs!$A$2:$A${n_rows}"))
+
+    eq = wb["Equipment_Sizing"]
+    eq["A1"] = "input_id"
+    eq["B1"] = "rail"
+    eq["C1"] = "value"
+    eq["D1"] = "unit"
+    ri = 2
+    for inp in rows:
+        if "fan" in inp.input_id or "cooling" in inp.input_id or "ahu" in inp.input_id:
+            eq.cell(ri, 1, inp.input_id)
+            eq.cell(ri, 2, inp.rail.value)
+            eq.cell(ri, 3, inp.value)
+            eq.cell(ri, 4, inp.unit)
+            ri += 1
+
+    hours = wb["Hours_Bases"]
+    hours["A1"] = "input_id"
+    hours["B1"] = "rail"
+    hours["C1"] = "value"
+    hours["D1"] = "Assumption_Note"
+    ri = 2
+    for inp in rows:
+        if "hour" in inp.input_id.lower():
+            hours.cell(ri, 1, inp.input_id)
+            hours.cell(ri, 2, inp.rail.value)
+            hours.cell(ri, 3, inp.value)
+            hours.cell(ri, 4, inp.assumption_note)
+            ri += 1
+
+    summary = wb["Measure_Summary"]
+    summary["A1"] = "measure_id"
+    summary["B1"] = "note"
+    summary["A2"] = "(from evidence import)"
+
+    pkg = wb["Package_Matrix"]
+    pkg["A1"] = "Stage 5 enforces package/interaction matrix; Stage 2 reserves the sheet."
+
+    trace = wb["Calculation_Trace"]
+    trace["A1"] = "trace_id"
+    trace["B1"] = "equation"
+    trace["C1"] = "inputs_used"
+    trace["D1"] = "result"
+
+    log_ws = wb["Agent_Action_Log"]
+    log_ws["A1"] = "action"
+    log_ws["B1"] = "input_id"
+    log_ws["C1"] = "reason"
+    log_ws["D1"] = "assumption_note"
+    for i, entry in enumerate(log, start=2):
+        log_ws.cell(i, 1, entry.get("action"))
+        log_ws.cell(i, 2, entry.get("input_id"))
+        log_ws.cell(i, 3, entry.get("reason"))
+        log_ws.cell(i, 4, entry.get("assumption_note"))
+
+    gates = wb["Publication_Gates"]
+    gates["A1"] = "gate"
+    gates["B1"] = "status"
+    gates["A2"] = "assumption_note_required"
+    gates["B2"] = "WARNING (enforced Stage 5)"
+    gates["A3"] = "dual_rail_sizing_pair"
+    gates["B3"] = "preview"
+
+    docs = wb["Documentation"]
+    docs["A1"] = "Ownership"
+    docs["A2"] = "Open-FDD owns schemas, equations, provenance, workbook/DOCX builders."
+    docs["A3"] = "Vibe20 owns IDF/MCP/sim and ecm_simulation_evidence.json export."
+    docs["A4"] = "Never silently paste Twin calendar hours over spreadsheet FLH (BUG-ECM-014)."
+
+    wb.save(output)
+    sidecar = output.with_suffix(".ecm_engineering_inputs.json")
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema": "ecm_engineering_inputs_v1",
+                "project": project_name,
+                "facility": facility_name,
+                "inputs": [i.as_dict() for i in rows],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return output
+
+
+def _build_minimal_inputs_json_sidecar(
+    output: Path,
+    rows: list[EngineeringInput],
+    project_name: str,
+    facility_name: str,
+    log: list[dict[str, Any]],
+) -> Path:
+    """Fallback when openpyxl is missing — still emit Inputs contract + placeholder xlsx note."""
+    manifest = output.with_suffix(".ecm_engineering_inputs.json")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema": "ecm_engineering_inputs_v1",
+                "project": project_name,
+                "facility": facility_name,
+                "inputs": [i.as_dict() for i in rows],
+                "action_log": log,
+                "warning": "openpyxl not installed; xlsx not written",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    output.write_text(
+        "Stage-2 workbook requires openpyxl; see sibling .ecm_engineering_inputs.json\n",
+        encoding="utf-8",
+    )
+    return output
+
+
+__all__ = [
+    "STAGE2_SHEET_ORDER",
+    "INPUTS_COLUMNS",
+    "dual_rail_fixture_inputs",
+    "build_stage2_workbook",
+]

--- a/services/ui/app/test_ui_ecm_job.py
+++ b/services/ui/app/test_ui_ecm_job.py
@@ -102,3 +102,18 @@ def test_create_ecm_request_writes_under_job_wattlab(tmp_path, monkeypatch) -> N
     assert saved["job_id"] == meta.job_id
     assert saved["building_id"] == "BUILDING_100"
     assert "honesty" in saved
+
+
+def test_discover_wattlab_xlsx_nested(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "wattlab_ws"
+    nested = root / "reports" / "notebooks" / "pkg_a"
+    nested.mkdir(parents=True)
+    (nested / "book.xlsx").write_bytes(b"PK")  # minimal placeholder
+    (root / "reports" / "notebooks" / "top.xlsx").write_bytes(b"PK")
+    monkeypatch.setenv("OPENFDD_WATTLAB_WORKSPACE", str(root))
+    monkeypatch.delenv("WATTLAB_WORKSPACE", raising=False)
+    monkeypatch.delenv("OPENFDD_WORKSPACE", raising=False)
+    hits = ui_ecm_job.discover_wattlab_xlsx()
+    assert len(hits) == 2
+    assert any(h.endswith("top.xlsx") for h in hits)
+    assert any("pkg_a" in h and h.endswith("book.xlsx") for h in hits)

--- a/services/ui/app/ui_ecm_job.py
+++ b/services/ui/app/ui_ecm_job.py
@@ -212,9 +212,48 @@ def create_ecm_package_request(
     return {"ok": True, "path": str(path), "request": request, "cascade": cascade_result}
 
 
+def discover_wattlab_xlsx(ws: Any | None = None) -> list[str]:
+    """Find agent-built ECM workbooks under the WattLab workspace (honest handoff)."""
+    roots: list[Any] = []
+    env = (os.environ.get("OPENFDD_WATTLAB_WORKSPACE") or os.environ.get("WATTLAB_WORKSPACE") or "").strip()
+    if env:
+        roots.append(env)
+    if ws is not None:
+        roots.append(ws)
+    # Common lab bind: sibling wattlab_workspace next to OPENFDD_WORKSPACE
+    ofdd_ws = (os.environ.get("OPENFDD_WORKSPACE") or "").strip()
+    if ofdd_ws:
+        roots.append(os.path.join(os.path.dirname(ofdd_ws), "wattlab_workspace"))
+        roots.append(os.path.join(ofdd_ws, "wattlab"))
+    found: list[str] = []
+    seen: set[str] = set()
+    for root in roots:
+        if not root:
+            continue
+        base = os.path.join(str(root), "reports", "notebooks")
+        if not os.path.isdir(base):
+            continue
+        for dirpath, _dirnames, filenames in os.walk(base):
+            for name in filenames:
+                if not name.lower().endswith(".xlsx"):
+                    continue
+                path = os.path.join(dirpath, name)
+                if path in seen:
+                    continue
+                seen.add(path)
+                found.append(path)
+    found.sort()
+    return found[:40]
+
+
 def render_ecm_agent_build_panel() -> None:
     """Streamlit panel: create an ECM package request from the active Job/site."""
     st.markdown("##### ECM package (agent-build)")
+    st.info(
+        "**Gate C honesty:** open-fdd records the ECM package **request** only. "
+        "The real Excel workbook (`.xlsx` / `FORMULA_ESCO_*` / full-parity book) is built in "
+        "**vibe20** via `wattlab notebook agent-build`. open-fdd is not vibe20-complete for spreadsheets."
+    )
     st.caption(
         "Create an ECM Excel/notebook package request from the active Job. Heavy "
         "agent-build + EnergyPlus/IDF stay delegated to WattLab / the external E+ "
@@ -238,8 +277,21 @@ def render_ecm_agent_build_panel() -> None:
     if wattlab:
         st.caption(f"WattLab agent-build detected: `{wattlab}` (notebook builder path).")
     else:
-        st.caption("WattLab agent-build CLI not detected — request is recorded for later pickup.")
+        st.caption(
+            "WattLab agent-build CLI not detected — request is recorded for later pickup. "
+            "Run vibe20: `wattlab notebook agent-build --out reports/notebooks …`."
+        )
 
+    xlsx_hits = discover_wattlab_xlsx()
+    if xlsx_hits:
+        with st.expander(f"Found {len(xlsx_hits)} WattLab ECM workbook(s) (download handoff)", expanded=False):
+            for path in xlsx_hits:
+                st.code(path, language=None)
+    else:
+        st.caption(
+            "No `reports/notebooks/**/*.xlsx` found under WattLab workspace yet — "
+            "build in vibe20, then refresh this panel."
+        )
     readiness = cascade_readiness()
     if readiness["ready"]:
         st.success(

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -2748,6 +2748,16 @@ def main() -> None:
 
     if section == "Overview":
         st.subheader("Overview")
+        # ENH-OFDD-008: dual-catalog honesty (production SQL vs pandas oracle cookbook).
+        st.warning(
+            "**Dual catalog:** production FDD math is DataFusion SQL "
+            "(`sql_rules/registry.yaml`, **63** rules). The pandas cookbook "
+            f"(**{CANONICAL_RULE_COUNT}** UI/oracle recipes) remains for docs, plots, and "
+            "parity — not the default production path. Skip / "
+            "`NOT_APPLICABLE_*` shapes differ; see "
+            "[migration catalog parity](https://github.com/bbartling/open-fdd/blob/master/docs/migration/CATALOG_RULE_PARITY_ONEPASS.md) "
+            "and OFDD residual tables."
+        )
         c1, c2, c3, c4, c5 = st.columns(5)
         c1.metric("Equipment", len(frames))
         _n_custom = len(RULES) - CANONICAL_RULE_COUNT

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -2037,9 +2037,14 @@ rules:
 
   - rule_id: SCHED-1
     sql_file: sched1_unoccupied_runtime.sql
-    pandas_function: null
-    description: Unoccupied runtime
+    pandas_function: sched1
+    aliases: [excess_runtime]
+    description: >-
+      Excess / wasted unoccupied fan runtime when the zone is already in the
+      comfort band (optimal-start / schedule misconfig signal). Without zone_t,
+      falls back to unoccupied + fan_on (pandas sched1 base).
     required_roles: [occ_mode, fan_status]
+    optional_roles: [zone_t]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: proven_building_100
@@ -2056,6 +2061,24 @@ rules:
         unit: sec
         frontend_control: slider
         sql_placeholder: CONFIRM_SECONDS
+      comfort_low_f:
+        label: Zone comfort low
+        default: 70.0
+        min: 50.0
+        max: 80.0
+        step: 0.5
+        unit: °F
+        frontend_control: slider
+        sql_placeholder: ZONE_T_LO
+      comfort_high_f:
+        label: Zone comfort high
+        default: 75.0
+        min: 55.0
+        max: 90.0
+        step: 0.5
+        unit: °F
+        frontend_control: slider
+        sql_placeholder: ZONE_T_HI
 
   - rule_id: SCHED-247
     sql_file: sched247_always_on.sql

--- a/sql_rules/sched1_unoccupied_runtime.sql
+++ b/sql_rules/sched1_unoccupied_runtime.sql
@@ -1,11 +1,20 @@
--- sched1_unoccupied_runtime.sql — Unoccupied runtime
+-- sched1_unoccupied_runtime.sql — Excess / wasted unoccupied runtime
+-- Pandas sched1: unoccupied & fan_on; when zone_t mapped, also require comfort band
+-- (zone already satisfied → optimal-start / bad schedule signal).
+-- When zone_t is absent from history, the runner injects NULL zone_t (optional role)
+-- so behavior matches pandas “no zone → base only”.
 WITH base AS (
   SELECT
     equipment_id,
     timestamp_utc,
         CAST(CASE
           WHEN occ_mode IS NULL OR fan_status IS NULL THEN 0
-          WHEN LOWER(occ_mode) = 'unoccupied' AND fan_status > 0.5 THEN 1
+          WHEN LOWER(occ_mode) = 'unoccupied' AND fan_status > 0.5
+            AND (
+              zone_t IS NULL
+              OR (zone_t >= {{ZONE_T_LO}} AND zone_t <= {{ZONE_T_HI}})
+            )
+          THEN 1
           ELSE 0
         END AS INT) AS raw_fault
   FROM history

--- a/tests/ecm_engineering/test_stage1_contracts.py
+++ b/tests/ecm_engineering/test_stage1_contracts.py
@@ -1,0 +1,175 @@
+"""Stage-1 ECM contracts + Stage-2 workbook + evidence validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from open_fdd.ecm_engineering.agent_cli import (
+    cmd_import_energyplus_evidence,
+    cmd_list_missing_inputs,
+    cmd_list_workbook_inputs,
+    cmd_propose_input_update,
+)
+from open_fdd.ecm_engineering.contracts import (
+    AllocationStatus,
+    ComparisonMode,
+    EngineeringInput,
+    InputRail,
+    MeasureResultMeta,
+    ResultScope,
+    AdditiveStatus,
+    SourceType,
+    AssumptionMethod,
+    validate_engineering_inputs,
+    validate_measure_meta,
+    validate_simulation_evidence,
+)
+from open_fdd.ecm_engineering.fixtures import (
+    synthetic_evidence,
+    synthetic_inputs_manifest,
+    write_fixtures,
+)
+from open_fdd.ecm_engineering.stage2_workbook import (
+    STAGE2_SHEET_ORDER,
+    build_stage2_workbook,
+    dual_rail_fixture_inputs,
+)
+
+
+def test_evidence_round_trip(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    doc = json.loads(paths["evidence"].read_text(encoding="utf-8"))
+    assert validate_simulation_evidence(doc) == []
+    result = cmd_import_energyplus_evidence(paths["evidence"])
+    assert result["ok"] is True
+    assert result["measure_count"] == 2
+
+
+def test_reject_physical_ahu_without_allocation() -> None:
+    meta = MeasureResultMeta(
+        measure_id="ECM-X",
+        result_scope=ResultScope.PHYSICAL_AHU,
+        allocation_status=AllocationStatus.NOT_ALLOCATED,
+        comparison_mode=ComparisonMode.VS_COMMON_BASELINE,
+        additive_status=AdditiveStatus.NON_ADDITIVE,
+    )
+    issues = validate_measure_meta(meta)
+    assert any("allocation" in i for i in issues)
+
+
+def test_reject_ep_labeled_measured() -> None:
+    inp = EngineeringInput(
+        input_id="ep_fan_hp",
+        display_name="EP fan",
+        value=10.0,
+        unit="hp",
+        rail=InputRail.ENERGYPLUS,
+        source_type=SourceType.MEASURED,
+        assumption_note="should still fail",
+    )
+    issues = validate_engineering_inputs([inp])
+    assert any("measured" in i.lower() for i in issues)
+
+
+def test_reject_estimated_hours_without_assumption_note() -> None:
+    inp = EngineeringInput(
+        input_id="ss_sched_hours_saved",
+        display_name="hours",
+        value=1000.0,
+        unit="h",
+        rail=InputRail.SPREADSHEET,
+        source_type=SourceType.AGENT_INFERRED,
+        assumption_note="",
+    )
+    issues = validate_engineering_inputs([inp])
+    assert any("assumption_note" in i for i in issues)
+
+
+def test_dual_rail_presence_in_fixture() -> None:
+    ids = {i.input_id for i in dual_rail_fixture_inputs()}
+    assert any(i.startswith("ss_") for i in ids)
+    assert any(i.startswith("ep_") for i in ids)
+    assert "ss_fan_hp" in ids and "ep_fan_hp" in ids
+
+
+def test_list_inputs_and_propose(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    listed = cmd_list_workbook_inputs(paths["inputs"])
+    assert listed["ok"] is True
+    assert listed["count"] >= 4
+    missing = cmd_list_missing_inputs(paths["inputs"])
+    assert missing["missing"] == []
+    prop = cmd_propose_input_update(
+        paths["inputs"],
+        input_id="ss_fan_hp",
+        value=30.0,
+        reason="TAB update",
+        assumption_note="Revised nameplate",
+        dry_run=True,
+    )
+    assert prop["ok"] is True
+    assert prop["action"]["dry_run"] is True
+    assert prop["action"]["persisted"] is False
+
+
+def test_evidence_rejects_bad_physical_ahu() -> None:
+    doc = synthetic_evidence()
+    doc["individual_measures"].append(
+        {
+            "measure_id": "ECM-BAD",
+            "run_id": "r1",
+            "baseline_run_id": "baseline-001",
+            "comparison_mode": "vs_common_baseline",
+            "result_scope": "physical_ahu",
+            "allocation_status": "not_allocated",
+        }
+    )
+    issues = validate_simulation_evidence(doc)
+    assert any("physical_ahu" in i for i in issues)
+
+
+def test_stage2_workbook_dual_rail(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+    out = tmp_path / "Stage2_ECM.xlsx"
+    path = build_stage2_workbook(out, project_name="Test Project")
+    assert path.is_file()
+    wb = openpyxl.load_workbook(path)
+    for sheet in STAGE2_SHEET_ORDER:
+        assert sheet in wb.sheetnames
+    inputs = wb["Inputs"]
+    headers = [c.value for c in inputs[1]]
+    assert "Assumption_Note" in headers
+    assert "rail" in headers
+    names = {dn.name for dn in wb.defined_names.values()}
+    assert "Assumption_Note" in names
+    assert "Inputs_Table" in names
+    sidecar = path.with_suffix(".ecm_engineering_inputs.json")
+    assert sidecar.is_file()
+    man = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert any(i["input_id"].startswith("ss_") for i in man["inputs"])
+    assert any(i["input_id"].startswith("ep_") for i in man["inputs"])
+
+
+def test_synthetic_inputs_manifest_validates() -> None:
+    man = synthetic_inputs_manifest()
+    from open_fdd.ecm_engineering.contracts import EngineeringInput
+
+    inputs = [
+        EngineeringInput(
+            input_id=d["input_id"],
+            display_name=d["display_name"],
+            value=d["value"],
+            unit=d["unit"],
+            rail=InputRail(d["rail"]),
+            source_type=SourceType(d["source_type"]),
+            assumption_note=d.get("assumption_note") or "",
+            assumption_method=AssumptionMethod(d.get("assumption_method") or "unknown"),
+            linked_measure_ids=list(d.get("linked_measure_ids") or []),
+            source_reference=d.get("source_reference") or "",
+        )
+        for d in man["inputs"]
+    ]
+    assert validate_engineering_inputs(inputs) == []


### PR DESCRIPTION
## Summary
- **Gate C honesty (ENH-OFDD-007/008):** Jobs ECM panel links vibe20 `wattlab notebook agent-build` / nested `reports/notebooks/**/*.xlsx`; Overview dual-catalog banner (SQL 63 vs pandas 59).
- **Stage 1 contracts:** dual-rail Inputs (`ss_*`/`ep_*`) + `assumption_note`, evidence validator, agent CLI stubs, synthetic fixtures/tests.
- **Stage 2 workbook:** professional Cover→Documentation layout with Inputs `Assumption_Note` named range (`open-fdd-ecm stage2-workbook`).
- **SCHED-1:** zone comfort gate when `zone_t` present; optional_roles NULL inject when absent; oracle fixture; `excess_runtime` alias.
- **PR D residuals:** `docs/migration/CATALOG_RULE_PARITY_ONEPASS.md` (honest; no fake proven flips).

GHCR tip `sha-f82dd5f` / `:nightly` confirmed (`/api/health` → `3.3.0+f82dd5f…`).

## Test plan
- [x] `cargo test -p fdd_rules --lib`
- [x] `pytest tests/ecm_engineering/test_stage1_contracts.py services/ui/app/test_ui_ecm_job.py`
- [ ] CI green on PR
- [ ] Optional: recreate csv stack with `OPENFDD_IMAGE_TAG=sha-f82dd5f`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ECM evidence validation, input management, calculation tracing, and Stage-2 workbook generation.
  * Added CLI workflows for importing evidence, listing inputs, identifying missing inputs, and proposing dry-run updates.
  * Added discovery and display of generated ECM workbooks in the UI.
  * Enhanced SCHED-1 runtime detection with zone comfort-band awareness and fallback behavior.
* **Bug Fixes**
  * Rules with missing optional data can now execute safely.
* **Documentation**
  * Updated parity guidance and clarified workbook-generation status and catalog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->