### PR TITLE
feat: Liberty soak turnkey (070b–MCP + Sites + WattLab)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -77,16 +77,19 @@ jobs:
           test -f services/ui/app/central_client.py
           python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py services/ui/app/agent_api.py services/ui/app/job_store.py services/ui/app/ui_jobs.py
           grep -q "Rule tuning" services/ui/streamlit_app.py
-          grep -q "Delete site" services/ui/streamlit_app.py
+          grep -q "Delete…" services/ui/streamlit_app.py || grep -q "Delete site" services/ui/streamlit_app.py
+          grep -q "Active site" services/ui/streamlit_app.py
           grep -q "def _run_rule_list" services/ui/streamlit_app.py
           grep -q "DataFusion" services/ui/streamlit_app.py || grep -q "run_fdd" services/ui/app/central_client.py
           grep -q "Authorization" services/ui/app/central_client.py
           grep -q "confirm_seconds" services/ui/app/central_client.py
           grep -q "Jobs (persistent)" services/ui/app/ui_jobs.py
+          grep -q "WattLab" services/ui/app/dashboard_contract.py
+          grep -q "render_wattlab_section" services/ui/app/ui_wattlab_studio.py
           ! test -d workspace/dashboard/src
           ! test -f workspace/dashboard/package.json
           pip install -q pytest requests pandas pyyaml
-          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py app/test_job_store.py app/test_jobs_central_client.py app/test_ui_analytics.py -q)
+          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py app/test_job_store.py app/test_jobs_central_client.py app/test_ui_analytics.py app/test_ui_ecm_job.py -q)
       - name: BACnet NIC helper guards
         run: |
           test -x scripts/openfdd_bacnet_nic_setup.sh
@@ -128,7 +131,12 @@ jobs:
           bash -n scripts/openfdd_stack_lib.sh
           bash -n scripts/openfdd_stack_pull.sh
           bash -n scripts/openfdd_stack_up.sh
+          bash -n scripts/openfdd_caddy_smoke.sh
           bash -n scripts/release/smoke_standalone_mqtts.sh
+          test -f docker/compose.wattlab.yml
+          test -f docker/compose.caddy.yml
+          test -f docs/mcp-agents/companion-wattlab-energyplus.md
+          test -f docs/mcp-agents/dual-site-mcp-it.md
 
   lifecycle-scripts:
     name: Stack script syntax
@@ -140,5 +148,8 @@ jobs:
           bash -n scripts/openfdd_stack_lib.sh
           bash -n scripts/openfdd_stack_pull.sh
           bash -n scripts/openfdd_stack_up.sh
+          bash -n scripts/openfdd_caddy_smoke.sh
           bash -n scripts/openfdd_csv_import_sidecar.sh
           bash -n scripts/openfdd_csv_export_sidecar.sh
+          test -f docker/compose.wattlab.yml
+          test -f docs/mcp-agents/companion-wattlab-energyplus.md

--- a/docker/compose.wattlab.yml
+++ b/docker/compose.wattlab.yml
@@ -1,0 +1,22 @@
+# Optional WattLab workspace + vibe20 source mount (OFDD-UI-V20 Option A).
+#
+#   OPENFDD_CADDY=1 ./scripts/openfdd_stack_up.sh csv \
+#     -f docker/compose.wattlab.yml
+#   # or append via COMPOSE_FILE / manual docker compose -f …
+#
+# Host paths (override as needed):
+#   OPENFDD_WATTLAB_HOST_WORKSPACE  → /data in ui (default: ~/wattlab_workspace)
+#   OPENFDD_WATTLAB_HOST_SRC        → PYTHONPATH package root (default: playground vibe20)
+
+services:
+  ui:
+    environment:
+      WATTLAB_STUDIO_WORKSPACE: /data
+      WATTLAB_WORKSPACE: /data
+      OPENFDD_WATTLAB_WORKSPACE: /data
+      # Prefer host-mounted vibe20 package until GHCR bakes a wattlab wheel.
+      PYTHONPATH: /opt/wattlab_src
+      OPENFDD_ENERGYPLUS_MCP: ${OPENFDD_ENERGYPLUS_MCP:-0}
+    volumes:
+      - ${OPENFDD_WATTLAB_HOST_WORKSPACE:-${HOME}/wattlab_workspace}:/data
+      - ${OPENFDD_WATTLAB_HOST_SRC:-${HOME}/py-bacnet-stacks-playground/vibe_code_apps_20}:/opt/wattlab_src:ro

--- a/docs/mcp-agents/companion-wattlab-energyplus.md
+++ b/docs/mcp-agents/companion-wattlab-energyplus.md
@@ -1,0 +1,79 @@
+---
+title: Companion — WattLab + EnergyPlus-MCP
+parent: MCP Agents
+nav_order: 5
+---
+
+# Companion: WattLab tools + EnergyPlus-MCP
+
+**Read this when the task involves Twin calibrate, Fuel bills, ECM Excel, or IDF/EnergyPlus.**  
+`openfdd-mcp` alone is **FDD / sites / historian** — it does **not** perform EnergyPlus IDF surgery.
+
+## Three surfaces (do not collapse)
+
+| Surface | Role | How agents reach it |
+|---------|------|---------------------|
+| **openfdd-mcp** | JWT → central REST: health, CSV ingest, FDD SQL, Haystack, reports | Cursor `mcp.json` `openfdd` server; `mcp/INSTRUCTIONS.md` |
+| **EnergyPlus-MCP** | LBNL ~35 tools in `wattlab_workspace/third_party/EnergyPlus-MCP` → image `energyplus-mcp-dev` | Separate MCP server **or** `wattlab energyplus-ensure` + `wattlab mcp-exec` |
+| **WattLab `tools/` + skills** | CLIs, playbooks, full-parity Excel builders, Cursor skills | Files under `~/wattlab_workspace/tools/`; `~/.cursor/skills/wattlab-*` |
+
+Hard rule: **never** embed EnergyPlus IDF surgery inside `openfdd-mcp`. Always point Twin/ECM work at EnergyPlus-MCP / vibe20 wrappers.
+
+## Golden loop (Liberty Twin → ECM)
+
+```text
+A. Context (every Twin/ECM session)
+   1. ~/wattlab_workspace/WORKSPACE.md
+   2. tools/AGENT_CONTEXT.md + tools/BEST_PRACTICES_EPLUS_MCP_ECM.md
+   3. reports/BUG_REPORT.md (OFDD-* / BUG-ECM-*)
+   4. Skills: wattlab-energyplus-mcp, wattlab-twin-calibrate-dial,
+      wattlab-agent-driven-ecm-excel
+
+B. FDD / sites / historian  →  openfdd-mcp (or JWT REST)
+C. Twin / IDF / simulate     →  EnergyPlus-MCP or vibe20 mcp-exec
+   docker exec vibe20 wattlab energyplus-ensure
+   docker exec vibe20 wattlab mcp-exec -- <tool> …
+D. ECM Excel / Compare       →  vibe20 + tools/ scripts
+   python /data/tools/build_full_parity_ecm_workbook_v2.py
+   Preferred book: reports/notebooks/full_parity_ecm/ECM_FULL_PARITY.xlsx
+```
+
+## Paths
+
+| Host | In vibe20 / UI container |
+|------|--------------------------|
+| `~/wattlab_workspace` | `/data` |
+| `…/third_party/EnergyPlus-MCP` | `/data/third_party/EnergyPlus-MCP` |
+| `…/tools/` | `/data/tools/` |
+| `…/reports/notebooks/full_parity_ecm/ECM_FULL_PARITY.xlsx` | same under `/data/reports/…` |
+
+## Preferred ECM workbook (SoT)
+
+- **Preferred:** `ECM_FULL_PARITY.xlsx` via `build_full_parity_ecm_workbook_v2.py`
+- Studio merge: `reports/ecm_full_parity_compare.json` with top-level `rows` + `annual_usd` (BUG-ECM-015)
+- Do **not** treat matched-hours / `ECM_EPLUS_MATCHED_HOURS.xlsx` as the product SoT
+
+## Cursor dual-MCP snippet
+
+Wire **both** servers. openfdd-only = FDD-blind-to-Twin.
+
+```json
+{
+  "mcpServers": {
+    "openfdd": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/bbartling/openfdd-mcp:nightly"]
+    },
+    "energyplus": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "/path/to/wattlab_workspace:/data",
+        "energyplus-mcp-dev"
+      ]
+    }
+  }
+}
+```
+
+See also: [mcp.md](mcp.md), [cursor-openclaw.md](cursor-openclaw.md), root `mcp/INSTRUCTIONS.md`.

--- a/docs/mcp-agents/companion-wattlab-energyplus.md
+++ b/docs/mcp-agents/companion-wattlab-energyplus.md
@@ -57,12 +57,20 @@ D. ECM Excel / Compare       →  vibe20 + tools/ scripts
 
 Wire **both** servers. openfdd-only = FDD-blind-to-Twin.
 
+Point `OPENFDD_API_BASE` at a **reachable LAN/VPN** Central (not the MCP container’s loopback unless you use `--network host`). Inject the integrator JWT via env — do **not** paste tokens into checked-in snippets.
+
 ```json
 {
   "mcpServers": {
     "openfdd": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/bbartling/openfdd-mcp:nightly"]
+      "args": [
+        "run", "--rm", "-i", "--network", "host",
+        "-e", "OPENFDD_API_BASE=http://127.0.0.1:8080",
+        "-e", "OPENFDD_MCP_TOKEN",
+        "ghcr.io/bbartling/openfdd-mcp:nightly"
+      ],
+      "env": { "OPENFDD_MCP_TOKEN": "<integrator JWT>" }
     },
     "energyplus": {
       "command": "docker",
@@ -75,5 +83,7 @@ Wire **both** servers. openfdd-only = FDD-blind-to-Twin.
   }
 }
 ```
+
+Inside Compose, use `OPENFDD_API_BASE=http://central:8080` (or the published Caddy URL on the LAN) instead of host loopback.
 
 See also: [mcp.md](mcp.md), [cursor-openclaw.md](cursor-openclaw.md), root `mcp/INSTRUCTIONS.md`.

--- a/docs/mcp-agents/dual-site-mcp-it.md
+++ b/docs/mcp-agents/dual-site-mcp-it.md
@@ -1,0 +1,23 @@
+---
+title: Dual-site MCP IT (Liberty / OFDD-MCP-IT)
+parent: MCP agents
+nav_order: 35
+---
+
+# Dual-site MCP integration checklist (OFDD-MCP-IT)
+
+Use after csv(+caddy) stack is up on tip `sha-*` with Liberty B50 + B100 loaded.
+
+## ENH-13h — A / B / C
+
+| Case | Assert |
+|------|--------|
+| **A** Accuracy | `openfdd_fdd_accuracy_snapshot` for Active `BUILDING_50` ≠ `BUILDING_100` (distinct equipment / FAULT totals). |
+| **B** Historian | `openfdd_historian_query` with `site_id` / building filter returns scoped rows only. |
+| **C** Findings | After Eng Findings generate (or `openfdd_reports_draft` with `kind=engineering_findings`), `GET /api/reports/engineering-findings` → **200**. |
+
+## Pointers (OFDD-MCP-CTX)
+
+Call `openfdd_agent_context_pointers` — read-only companion paths; **never** IDF surgery in openfdd-mcp.
+
+See [`companion-wattlab-energyplus.md`](companion-wattlab-energyplus.md).

--- a/docs/mcp-agents/dual-site-mcp-it.md
+++ b/docs/mcp-agents/dual-site-mcp-it.md
@@ -12,9 +12,9 @@ Use after csv(+caddy) stack is up on tip `sha-*` with Liberty B50 + B100 loaded.
 
 | Case | Assert |
 |------|--------|
-| **A** Accuracy | `openfdd_fdd_accuracy_snapshot` for Active `BUILDING_50` ≠ `BUILDING_100` (distinct equipment / FAULT totals). |
-| **B** Historian | `openfdd_historian_query` with `site_id` / building filter returns scoped rows only. |
-| **C** Findings | After Eng Findings generate (or `openfdd_reports_draft` with `kind=engineering_findings`), `GET /api/reports/engineering-findings` → **200**. |
+| **A** Sites distinct | `openfdd_datasets` (or equipment list) shows distinct canonical IDs `BUILDING_50` vs `BUILDING_100`. Note: `openfdd_fdd_accuracy_snapshot` is **global** registry/result parity — not per-site. |
+| **B** Historian | `openfdd_historian_query` with `site_id=BUILDING_50` vs `BUILDING_100` returns scoped rows only. |
+| **C** Findings | With `OPENFDD_MCP_ALLOW_WRITES=1` on the MCP server, call `openfdd_reports_draft` with `confirm:true` and `kind=engineering_findings` (or Eng Findings UI generate); then `GET /api/reports/engineering-findings` → **200**. |
 
 ## Pointers (OFDD-MCP-CTX)
 

--- a/docs/mcp-agents/index.md
+++ b/docs/mcp-agents/index.md
@@ -13,6 +13,8 @@ Open-FDD supports **MCP (Model Context Protocol)** for AI-assisted commissioning
 | Guide | Content |
 |-------|---------|
 | [MCP setup](mcp.html) | Images, entrypoints, tools |
+| [Companion — WattLab + EnergyPlus](companion-wattlab-energyplus.html) | Twin/ECM: three surfaces, golden loop, dual-MCP |
+| [Dual-site MCP IT](dual-site-mcp-it.html) | Liberty B50≠B100 accuracy / historian / findings |
 | [Agent safety](agent-safety.html) | Hard boundaries for automation |
 | [Cursor & OpenClaw](cursor-openclaw.html) | IDE and edge agent wiring |
 | [External agent workflow](../examples/external-agents.html) | Codex, Cursor, MCP patterns |

--- a/docs/mcp-agents/mcp.md
+++ b/docs/mcp-agents/mcp.md
@@ -26,6 +26,8 @@ Inside the compose network, point at central directly:
 
 ## Cursor `mcp.json` (illustrative)
 
+**FDD-only** (openfdd) leaves agents blind to Twin/ECM. Prefer **dual-MCP** — see [companion-wattlab-energyplus.md](companion-wattlab-energyplus.html).
+
 ```json
 {
   "mcpServers": {
@@ -38,6 +40,14 @@ Inside the compose network, point at central directly:
         "ghcr.io/bbartling/openfdd-mcp:latest"
       ],
       "env": { "OPENFDD_MCP_TOKEN": "<integrator JWT>" }
+    },
+    "energyplus": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-v", "/path/to/wattlab_workspace:/data",
+        "energyplus-mcp-dev"
+      ]
     }
   }
 }

--- a/docs/migration/CATALOG_RULE_PARITY_ONEPASS.md
+++ b/docs/migration/CATALOG_RULE_PARITY_ONEPASS.md
@@ -28,21 +28,25 @@ UI pandas cookbook recipes: **59**. SQL registry: **63**. Dual-catalog banner is
 | SCHED-1 | Excess runtime when zone satisfied | Zone comfort band when `zone_t` present; base-only when absent/NULL | SQL + optional_roles inject + oracle zone fixture | None for mask intent; Liberty hours still soak |
 | SCHED-247 | Always-on | Screening streak ≠ window `always_on_pct` | No flip to proven | Keep ported |
 | CHW-NOLOAD-1 | Plant running while load satisfied | Oracle screening fixture already present | Listed; no SQL gap found this pass | Keep ported until plant soak |
-| SV-STALE | Stale sensor | Fan-on gate present (OFDD-065) | No further SQL change | Liberty `_tbd_` deltas |
-| VAV-1 | Comfort | Zone-only schema safe (no fan_cmd in SQL) | No change | Liberty `_tbd_` |
+| SV-STALE | Stale sensor | Fan-on gate present (OFDD-065) | No further SQL change | Liberty **WIDE** (B50 +2500 / B100 +2728 hrs) |
+| VAV-1 | Comfort | Zone-only schema safe (no fan_cmd in SQL) | No change | Liberty **WIDE** (B50 +21k / B100 +17k hrs) |
 | SV-RANGE / FLATLINE / SPIKE / RATE | Sensor family | Screening oracles only | No flip | Keep ported |
 | FC4 / PID-HUNT-1 | Hunting | Screening oracles only | No flip | Keep ported |
 | FC7 | Missing roles | skipped_missing_roles | Untouched | Needs role model |
 
 ## Liberty FAULT deltas
 
-Do **not** invent. Fill only when local soak zips exist:
+Filled from Liberty soak `parity_hunt_20260730T003200Z` (tip `sha-064eadb`). Do **not** flip `proven` from hours alone:
 
 | Rule | Site | pandas h | SQL h | Δ | Status |
 |------|------|---------:|------:|--:|--------|
-| SV-STALE | B50/B100 | _tbd_ | _tbd_ | _tbd_ | soak required |
-| VAV-1 | B50/B100 | _tbd_ | _tbd_ | _tbd_ | soak required |
-| SCHED-1 zone gate | B50/B100 | _tbd_ | _tbd_ | _tbd_ | soak required |
+| SV-STALE | B50 | 884 | 3384 | +2500 | **WIDE** |
+| SV-STALE | B100 | 543 | 3271 | +2728 | **WIDE** |
+| VAV-1 | B50 | 2815 | 24550 | +21735 | **WIDE** |
+| VAV-1 | B100 | 3789 | 21615 | +17826 | **WIDE** |
+| SCHED-247 | B50 | 0 | 3235 | +3235 | **WIDE** (streak residual) |
+| ECON-1 | B50 | 700 | 0.6 | −699 | **WIDE** |
+| ECON-2 | B50 | 191 | 3143 | +2952 | **WIDE** |
 
 ## Docs discipline
 

--- a/docs/migration/CATALOG_RULE_PARITY_ONEPASS.md
+++ b/docs/migration/CATALOG_RULE_PARITY_ONEPASS.md
@@ -6,7 +6,8 @@ nav_order: 45
 
 # Catalog pandas ↔ DataFusion SQL parity — one-pass residuals
 
-**Date:** 2026-07-29 · **Scope:** best-effort alignment; honest residuals — not “all 63 proven.”
+**Date:** 2026-07-30 · **Scope:** best-effort alignment; honest residuals — not “all 63 proven.”
+**Updated:** Liberty soak deltas from `parity_hunt_20260730T003200Z` (tip `sha-064eadb`).
 
 Machine-readable claims remain `parity_status` in `sql_rules/registry.yaml`.
 This page records the one-pass inventory after SCHED-1 zone-comfort (PR C).

--- a/docs/migration/OFDD_065_076_PARITY.md
+++ b/docs/migration/OFDD_065_076_PARITY.md
@@ -6,8 +6,9 @@ nav_order: 40
 
 # OFDD 065–076 parity register
 
-**Date:** 2026-07-29 · Branches `fix/ofdd-gate-a-sites-sql-413` (Gate A) →
-`fix/ofdd-gate-b-c-findings-ecm` (Gate B + Gate C, built on the Gate A tip)
+**Date:** 2026-07-30 · Branches `fix/ofdd-gate-a-sites-sql-413` (Gate A) →
+`fix/ofdd-gate-b-c-findings-ecm` (Gate B + Gate C, built on the Gate A tip).
+**Updated:** Liberty soak `parity_hunt_20260730T003200Z` residuals filled below.
 
 Tracks the Liberty B50/B100 parity hunt tickets OFDD-065…076 across the three
 gates defined in the combined vibe19+vibe20 plan. This file records **VERIFIED**

--- a/docs/migration/OFDD_065_076_PARITY.md
+++ b/docs/migration/OFDD_065_076_PARITY.md
@@ -28,39 +28,36 @@ Companion matrices:
 | OFDD-066 | Skip-not-crash on missing roles | A | **VERIFIED** | Runner preflights `required_roles` vs history schema and classifies DataFusion schema errors → `SKIPPED_MISSING_ROLES` (`rules_skipped`), not `rules_failed`. `results_response` emits per-row status (`SKIPPED_MISSING_ROLES`/`FAULT`/`PASS`). |
 | OFDD-068 | Weather table/view | A | **VERIFIED** | `register_weather_if_present` falls back to a `weather` SQL view over `history` weather-station rows (`equipment_id ILIKE '%weather%'/'%meteo%'/'%oat%'`) when no `weather/` sidecar. Unit test covers the fallback. |
 | OFDD-075 | Analytics 413 | A | **VERIFIED** | `DefaultBodyLimit::max(128 MiB)` on the protected router (analytics + `fdd/run`); CSV nest already had its own limit. |
-| OFDD-065 | Directional FAULT parity (SV-STALE / VAV-1 / FC1) | A | **DIRECTIONAL / residual** | SV-STALE fan-on gate + `required_roles: [fan_cmd]` (synthetic oracle green). VAV-1 left without fan_cmd SQL refs so zone-only schemas do not SKIP; Liberty VAV-1/FC1 deltas still `_tbd_` until tip soak. |
+| OFDD-065 | Directional FAULT parity (SV-STALE / VAV-1 / FC1) | A | **DIRECTIONAL / residual** | Liberty 2026-07-30 deltas filled (SV-STALE/VAV-1 still **WIDE**; FC1/OAT-METEO **TIGHT**). Do not close with bench-only. |
+| OFDD-070 | Economizer historian | B | **FIXED tip (OFDD-070b CTE)** | Damper projected into CTE; Liberty re-soak required to clear stub residual. |
+| OFDD-076 | Jobs site bind | C | **FIXED tip (OFDD-076b)** | `CreateJobBody.building_id` → `site_id` when empty. |
 
-## Known FAULT deltas (Liberty B50/B100 — placeholders)
+## Known FAULT deltas (Liberty B50/B100 — soak 2026-07-30)
 
-Populate from a `sha-*` soak comparing open-fdd SQL `results` vs vibe19
-`fdd_summary.csv` on `~/wattlab_workspace/uploads/openfdd/raw_BUILDING_{50,100}_openfdd.zip`.
-Rows are placeholders until the zips are available on the soak host (absent in
-this environment, so numbers are not fabricated here).
+From Liberty soak `parity_hunt_20260730T003200Z` vs tip `sha-064eadb` (vibe19
+`fdd_summary.csv`). Do **not** flip `proven` from these alone — WIDE bands need
+smoking-gun SQL + cheap fixtures first.
 
 | Rule | Building | vibe19 FAULT hrs | open-fdd FAULT hrs | Δ | Band | Root-cause hypothesis |
-|------|----------|------------------|--------------------|---|------|-----------------------|
-| SV-STALE | B50 | _tbd_ | _tbd_ | _tbd_ | ±? | fan-off applicability / stale-window confirm alignment |
-| SV-STALE | B100 | _tbd_ | _tbd_ | _tbd_ | ±? | as above |
-| VAV-1 | B50 | _tbd_ | _tbd_ | _tbd_ | ±? | comfort-band confirm rows vs pandas `confirm_fault()` |
-| VAV-1 | B100 | _tbd_ | _tbd_ | _tbd_ | ±? | as above |
-| FC1 | B50 | _tbd_ | _tbd_ | _tbd_ | ±? | duct-static ε / fan-on fraction mapping (`fan_hi`→`eps_vfd_spd`) |
-| FC1 | B100 | _tbd_ | _tbd_ | _tbd_ | ±? | as above |
+|------|----------|------------------:|-------------------:|--:|------|-----------------------|
+| SV-STALE | B50 | 884 | 3384 | +2500 | **WIDE** | stale-window / fan-on confirm vs pandas |
+| SV-STALE | B100 | 543 | 3271 | +2728 | **WIDE** | as above |
+| VAV-1 | B50 | 2815 | 24550 | +21735 | **WIDE** | comfort-band confirm vs pandas `confirm_fault()` |
+| VAV-1 | B100 | 3789 | 21615 | +17826 | **WIDE** | as above |
+| FC1 | B100 | 205 | 220 | +15 | **TIGHT** | duct-static ε / fan-on fraction |
+| OAT-METEO | both | match | match | 0 | **TIGHT** | — |
+| ECON-1 | B50 | 700 | 0.6 | −699 | **WIDE** | inverted / role mapping |
+| ECON-2 | B50 | 191 | 3143 | +2952 | **WIDE** | screening vs pandas |
+| FAULT-ELAPSED-HOURS | B50 | 0 | 11325 | +11325 | **WIDE** | SQL-only status rollup honesty |
+| SCHED-247 | B50 | 0 | 3235 | +3235 | **WIDE** | streak ≠ window `always_on_pct` |
 
 ## OFDD-065 residual (honest)
 
-Fan-off applicability and confirm-window semantics for **SV-STALE**, **VAV-1**,
-and **FC1** are the likely remaining SQL-vs-pandas divergences once building
-scoping (OFDD-067) removes cross-building contamination. This pass did **not**
-alter those SQL gates because:
-
-- No Liberty zips are present in this environment, so any gate change could not be
-  validated against the oracle or the existing `fdd_rules` benches.
-- The plan's operating law forbids bench-only closes; gate edits must be proven on
-  B50+B100 vs vibe19 before landing.
-
-Next step (Gate A exit): run the `sha-*` soak, fill the deltas table above, then
-tighten SV-STALE/VAV-1/FC1 gates within documented bands without regressing
-`crates/fdd_rules` oracle-parity benches.
+Liberty deltas are filled (above). **SV-STALE** / **VAV-1** remain **WIDE**;
+**FC1** / **OAT-METEO** are **TIGHT**. This pass does **not** flip registry
+`proven` without smoking-gun SQL + cheap fixtures. Priority tighten targets:
+VAV-1 confirm/band, ECON-1/2 inverted, FAULT-ELAPSED-HOURS honesty, SCHED-247
+residual note. Re-soak after OFDD-070b CTE for economizer Overview.
 
 ## Gate B — vibe19 tip UI / Findings / economizer (branch `fix/ofdd-gate-b-c-findings-ecm`)
 

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -267,17 +267,24 @@ pub fn create_draft(body: &Value) -> Value {
     for plot in suggested_plot_blocks() {
         sections.push(plot);
     }
+    let report_type = body
+        .get("report_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or(template);
     let doc = json!({
         "ok": true,
         "report_id": report_id,
         "title": title,
         "template_id": template,
+        "report_type": report_type,
+        "kind": template,
         "created_at": Utc::now().to_rfc3339(),
         "updated_at": Utc::now().to_rfc3339(),
         "sections": sections,
         "metadata": {
             "generator": "open-fdd-rust-report-builder",
             "template_id": template,
+            "report_type": report_type,
             "pdf_ready": false
         }
     });
@@ -585,7 +592,15 @@ pub fn list_reports() -> Value {
             records.push(json!({
                 "report_id": id,
                 "title": doc.get("title").cloned().unwrap_or(json!(null)),
-                "report_type": meta.get("template_id").or(doc.get("template_id")).cloned().unwrap_or(json!("validation-summary")),
+                "report_type": meta
+                    .get("report_type")
+                    .or_else(|| doc.get("report_type"))
+                    .or_else(|| meta.get("template_id"))
+                    .or_else(|| doc.get("template_id"))
+                    .cloned()
+                    .unwrap_or(json!("validation-summary")),
+                "template_id": doc.get("template_id").cloned().unwrap_or(json!(null)),
+                "kind": doc.get("kind").cloned().unwrap_or(json!(null)),
                 "validation_run_id": meta.get("validation_run_id").cloned().unwrap_or(json!(null)),
                 "status": meta.get("validation_status").cloned().unwrap_or(json!("draft")),
                 "created_at": meta.get("created_at").cloned().or_else(|| doc.get("created_at").cloned()).unwrap_or(json!(null)),
@@ -864,6 +879,42 @@ mod tests {
         let doc = create_draft(&json!({"title": "Test Report"}));
         assert_eq!(doc["ok"], true, "draft error: {:?}", doc.get("error"));
         assert!(doc["sections"].as_array().unwrap().len() >= 5);
+        std::env::remove_var("OPENFDD_WORKSPACE");
+        let _ = std::fs::remove_dir_all(tmp);
+    }
+
+    #[test]
+    fn engineering_findings_draft_listed_for_ofdd_069() {
+        // OFDD-069: synthetic draft must be discoverable via list_reports kind/template.
+        let _guard = workspace_test_lock();
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let n = NEXT.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ofdd-eng-findings-{}-{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", tmp.to_string_lossy().as_ref());
+        let doc = create_draft(&json!({
+            "title": "Engineering Findings",
+            "kind": "engineering_findings",
+            "template_id": "engineering_findings",
+            "report_type": "engineering_findings"
+        }));
+        assert_eq!(doc["ok"], true, "draft error: {:?}", doc.get("error"));
+        assert_eq!(doc["template_id"], "engineering_findings");
+        assert_eq!(doc["report_type"], "engineering_findings");
+        let listed = list_reports();
+        let records = listed["records"].as_array().cloned().unwrap_or_default();
+        assert!(
+            records.iter().any(|r| {
+                r.get("report_type")
+                    .or_else(|| r.get("template_id"))
+                    .and_then(|v| v.as_str())
+                    .map(|t| t.contains("engineering_finding"))
+                    .unwrap_or(false)
+            }),
+            "engineering_findings missing from list: {listed}"
+        );
         std::env::remove_var("OPENFDD_WORKSPACE");
         let _ = std::fs::remove_dir_all(tmp);
     }

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -890,7 +890,8 @@ mod tests {
         use std::sync::atomic::{AtomicU64, Ordering};
         static NEXT: AtomicU64 = AtomicU64::new(0);
         let n = NEXT.fetch_add(1, Ordering::Relaxed);
-        let tmp = std::env::temp_dir().join(format!("ofdd-eng-findings-{}-{n}", std::process::id()));
+        let tmp =
+            std::env::temp_dir().join(format!("ofdd-eng-findings-{}-{n}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
         std::env::set_var("OPENFDD_WORKSPACE", tmp.to_string_lossy().as_ref());

--- a/edge/src/reports/mod.rs
+++ b/edge/src/reports/mod.rs
@@ -267,24 +267,32 @@ pub fn create_draft(body: &Value) -> Value {
     for plot in suggested_plot_blocks() {
         sections.push(plot);
     }
+    // Prefer explicit `kind` over `template_id` so mixed payloads stay discoverable
+    // (e.g. template_id=validation-summary with kind=engineering_findings).
+    let kind = body
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or(template);
     let report_type = body
         .get("report_type")
         .and_then(|v| v.as_str())
-        .unwrap_or(template);
+        .unwrap_or(kind);
     let doc = json!({
         "ok": true,
         "report_id": report_id,
         "title": title,
         "template_id": template,
         "report_type": report_type,
-        "kind": template,
+        "kind": kind,
         "created_at": Utc::now().to_rfc3339(),
         "updated_at": Utc::now().to_rfc3339(),
         "sections": sections,
+        "summary": body.get("summary").cloned().unwrap_or(json!(null)),
         "metadata": {
             "generator": "open-fdd-rust-report-builder",
             "template_id": template,
             "report_type": report_type,
+            "kind": kind,
             "pdf_ready": false
         }
     });
@@ -595,6 +603,7 @@ pub fn list_reports() -> Value {
                 "report_type": meta
                     .get("report_type")
                     .or_else(|| doc.get("report_type"))
+                    .or_else(|| doc.get("kind"))
                     .or_else(|| meta.get("template_id"))
                     .or_else(|| doc.get("template_id"))
                     .cloned()
@@ -899,16 +908,20 @@ mod tests {
             "title": "Engineering Findings",
             "kind": "engineering_findings",
             "template_id": "engineering_findings",
-            "report_type": "engineering_findings"
+            "report_type": "engineering_findings",
+            "summary": {"faults": 3, "note": "soak"}
         }));
         assert_eq!(doc["ok"], true, "draft error: {:?}", doc.get("error"));
         assert_eq!(doc["template_id"], "engineering_findings");
         assert_eq!(doc["report_type"], "engineering_findings");
+        assert_eq!(doc["kind"], "engineering_findings");
+        assert_eq!(doc["summary"]["faults"], 3);
         let listed = list_reports();
         let records = listed["records"].as_array().cloned().unwrap_or_default();
         assert!(
             records.iter().any(|r| {
-                r.get("report_type")
+                r.get("kind")
+                    .or_else(|| r.get("report_type"))
                     .or_else(|| r.get("template_id"))
                     .and_then(|v| v.as_str())
                     .map(|t| t.contains("engineering_finding"))
@@ -916,6 +929,22 @@ mod tests {
             }),
             "engineering_findings missing from list: {listed}"
         );
+
+        // kind must win over a mismatched template_id for discoverability.
+        let mixed = create_draft(&json!({
+            "title": "Mixed",
+            "template_id": "validation-summary",
+            "kind": "engineering_findings"
+        }));
+        assert_eq!(
+            mixed["ok"],
+            true,
+            "mixed draft error: {:?}",
+            mixed.get("error")
+        );
+        assert_eq!(mixed["template_id"], "validation-summary");
+        assert_eq!(mixed["kind"], "engineering_findings");
+        assert_eq!(mixed["report_type"], "engineering_findings");
         std::env::remove_var("OPENFDD_WORKSPACE");
         let _ = std::fs::remove_dir_all(tmp);
     }

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -2,6 +2,16 @@
 
 Read-first MCP sidecar for the Rust edge bridge. Requires JWT via `OPENFDD_MCP_TOKEN` or unauthenticated `/api/health` only.
 
+## Twin / ECM / EnergyPlus?
+
+**This server is FDD + sites + historian only.** For WattLab Twin calibrate, Fuel, ECM Excel, or IDF surgery, read:
+
+→ [`docs/mcp-agents/companion-wattlab-energyplus.md`](../docs/mcp-agents/companion-wattlab-energyplus.md)
+
+Wire **EnergyPlus-MCP** (or `wattlab energyplus-ensure` / `mcp-exec`) separately. Never expect openfdd-mcp to patch IDFs.
+
+**MCP tools:** `openfdd_agent_context_pointers` — companion doc paths + dual-site checklist (read-only).
+
 ## Login / credentials (agents)
 
 MCP runs on the **host** and resolves passwords locally — never from bcrypt hashes in `auth.env.local`.

--- a/mcp/src/bridge.rs
+++ b/mcp/src/bridge.rs
@@ -570,9 +570,9 @@ impl BridgeClient {
             "energyplus_mcp": "Use EnergyPlus-MCP + tools/ for IDF edits — openfdd-mcp is pointer-only.",
             "dual_site_checklist": [
                 "openfdd_datasets — confirm BUILDING_50 and BUILDING_100 distinct",
-                "openfdd_fdd_accuracy_snapshot with Active site scope",
-                "openfdd_historian_query site_id=B50 vs B100",
-                "GET /api/reports/engineering-findings after findings draft"
+                "openfdd_fdd_accuracy_snapshot is global (registry/equipment/results) — not site-scoped",
+                "openfdd_historian_query site_id=BUILDING_50 vs BUILDING_100",
+                "openfdd_reports_draft needs OPENFDD_MCP_ALLOW_WRITES=1 + confirm:true; then GET /api/reports/engineering-findings"
             ]
         })
     }

--- a/mcp/src/bridge.rs
+++ b/mcp/src/bridge.rs
@@ -557,6 +557,26 @@ impl BridgeClient {
         })
     }
 
+    /// OFDD-MCP-CTX / ENH-13f: pointer-only companion paths (no IDF surgery).
+    pub fn agent_context_pointers(&self) -> Value {
+        json!({
+            "ok": true,
+            "never_idf_surgery_in_openfdd_mcp": true,
+            "companion_doc": "docs/mcp-agents/companion-wattlab-energyplus.md",
+            "mcp_instructions": "mcp/INSTRUCTIONS.md",
+            "wattlab_workspace_env": ["WATTLAB_STUDIO_WORKSPACE", "WATTLAB_WORKSPACE", "OPENFDD_WATTLAB_WORKSPACE"],
+            "full_parity_workbook": "ECM_FULL_PARITY.xlsx",
+            "full_parity_builder": "build_full_parity_ecm_workbook_v2.py",
+            "energyplus_mcp": "Use EnergyPlus-MCP + tools/ for IDF edits — openfdd-mcp is pointer-only.",
+            "dual_site_checklist": [
+                "openfdd_datasets — confirm BUILDING_50 and BUILDING_100 distinct",
+                "openfdd_fdd_accuracy_snapshot with Active site scope",
+                "openfdd_historian_query site_id=B50 vs B100",
+                "GET /api/reports/engineering-findings after findings draft"
+            ]
+        })
+    }
+
     pub fn driver_status(&self) -> Value {
         let endpoints = [
             ("/api/health", "GET"),

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -464,7 +464,9 @@ mod tests {
             .dispatch_tool("openfdd_agent_context_pointers", &json!({}))
             .expect("pointers");
         assert_eq!(payload["ok"], true);
-        assert!(payload["never_idf_surgery_in_openfdd_mcp"].as_bool().unwrap_or(false));
+        assert!(payload["never_idf_surgery_in_openfdd_mcp"]
+            .as_bool()
+            .unwrap_or(false));
         assert!(payload["companion_doc"]
             .as_str()
             .unwrap_or("")

--- a/mcp/src/protocol.rs
+++ b/mcp/src/protocol.rs
@@ -188,6 +188,7 @@ impl Server {
             tool("openfdd_datasets", "GET /api/datasets — list Feather/Arrow datasets in registry", json!({})),
             tool("openfdd_timeseries_series", "GET /api/timeseries/series — plot catalog after CSV save", json!({"site_id": {"type": "string"}})),
             tool("openfdd_auth_credentials_hint", "Where MCP/agents find Open-FDD login (workspace/bootstrap_credentials.once.txt, auth.env.local) — no secrets returned", json!({})),
+            tool("openfdd_agent_context_pointers", "Read-only pointers to WattLab / EnergyPlus companion docs and lab paths (OFDD-MCP-CTX); never performs IDF surgery", json!({})),
             tool("openfdd_auth_login", "Login as integrator/agent/operator/admin — returns JWT from handoff/env (password never echoed)", json!({
                 "role": {"type": "string", "description": "integrator (default), agent, operator, admin"}
             })),
@@ -377,6 +378,7 @@ impl Server {
                 }
             }
             "openfdd_auth_credentials_hint" => Ok(crate::auth::credentials_hint()),
+            "openfdd_agent_context_pointers" => Ok(self.bridge.agent_context_pointers()),
             "openfdd_auth_login" => {
                 let role = args.get("role").and_then(|v| v.as_str()).unwrap_or("integrator");
                 let base = std::env::var("OPENFDD_API_BASE")
@@ -449,8 +451,23 @@ mod tests {
             "openfdd_fdd_series",
             "openfdd_fdd_session_config",
             "openfdd_fdd_accuracy_snapshot",
+            "openfdd_agent_context_pointers",
         ] {
             assert!(names.contains(&expected), "missing MCP tool {expected}");
         }
+    }
+
+    #[test]
+    fn agent_context_pointers_are_read_only_docs() {
+        let server = Server::new(BridgeClient::from_env());
+        let payload = server
+            .dispatch_tool("openfdd_agent_context_pointers", &json!({}))
+            .expect("pointers");
+        assert_eq!(payload["ok"], true);
+        assert!(payload["never_idf_surgery_in_openfdd_mcp"].as_bool().unwrap_or(false));
+        assert!(payload["companion_doc"]
+            .as_str()
+            .unwrap_or("")
+            .contains("companion-wattlab-energyplus"));
     }
 }

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -115,3 +115,19 @@ Docs: [`MILESTONE_D_CLOSEOUT.md`](../docs/migration/MILESTONE_D_CLOSEOUT.md),
 - [ ] D4b — External runner claim loop + full artifact attach UX
 - [ ] D2b — Logical gate mutations + `PROVEN_MULTI_BUILDING`
 - [ ] D5z — Full-stack `sha-*` soak
+
+---
+
+# Liberty soak turnkey (2026-07-30) — post-064eadb
+
+**Status:** open-fdd PR #601 · playground #69 **merged** (`2323f28` on develop).
+
+- [x] Phase 0 — GH tidy + csv+caddy on `sha-064eadb`
+- [x] OFDD-070b economizer CTE + OFDD-076b `building_id`→`site_id`
+- [x] BUG-ECM-015 rows/`annual_usd` (playground)
+- [x] OFDD-UI-BRAND + OFDD-MCP-CTX companion docs + pointers tool
+- [x] OFDD-UI-SITE / JOBS (Hive picker, Delete…, Jobs expander off default)
+- [x] OFDD-UI-V20 WattLab section + compose.wattlab + Caddy smoke
+- [x] OFDD-069 findings draft persist + OFDD-065 Liberty deltas + MCP-IT doc
+- [x] ECM-ERV-001 HAS_EP_PROTOTYPE residual stub (not product cascade)
+- [ ] Merge #601 → GHCR `:sha-<final>` + `:nightly` → re-soak checklist

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -120,7 +120,7 @@ Docs: [`MILESTONE_D_CLOSEOUT.md`](../docs/migration/MILESTONE_D_CLOSEOUT.md),
 
 # Liberty soak turnkey (2026-07-30) — post-064eadb
 
-**Status:** open-fdd PR #601 · playground #69 **merged** (`2323f28` on develop).
+**Status:** open-fdd PR **#601 open** (not merged) · playground #69 **merged** (`2323f28` on develop).
 
 - [x] Phase 0 — GH tidy + csv+caddy on `sha-064eadb`
 - [x] OFDD-070b economizer CTE + OFDD-076b `building_id`→`site_id`

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,22 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-07-30 — Liberty soak turnkey (implementation)
+
+- OFDD-070b CTE damper project; OFDD-076b `building_id`→`site_id`; Brand Open FDD;
+  Sites Hive picker + Delete…; Jobs expander off default chrome; WattLab section +
+  compose.wattlab / Caddy smoke; Eng Findings draft persist; OFDD-065 Liberty deltas;
+  MCP companion + `openfdd_agent_context_pointers` + dual-site IT doc.
+- Playground: BUG-ECM-015 + ECM-ERV-001 HAS_EP_PROTOTYPE stub (PR #69).
+
+## 2026-07-30 — Liberty soak turnkey start (post-064eadb)
+
+- Tip: open-fdd `064eadbc` / GHCR `sha-064eadb` · playground `4f3cdfd`.
+- Phase 0: fetch/prune clean; no open PRs; csv stack + Caddy `:80` → UI,
+  `/api/health` → `3.3.0+064eadbceda2` (central also on `:18080`).
+- Campaign: OFDD-070b/076b, BUG-ECM-015, Brand, Sites/Jobs, WattLab V20,
+  Findings, OFDD-065 deltas, MCP-CTX/IT, ERV P2, agent_spec sync.
+
 ## 2026-07-28 — Milestone B closeout (B6–B9)
 
 - #585 merged: central `/api/jobs`, runs, stale, UI client.

--- a/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
+++ b/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
@@ -15,7 +15,7 @@ Do not fork parallel truth. Update existing audits when code changes.
 | [`BUILD_CHECKPOINTS.md`](../BUILD_CHECKPOINTS.md) | Milestone + Liberty soak checklist |
 
 **Tip under Liberty turnkey:** playground develop `2323f28` (BUG-ECM-015 + ERV stub).
-open-fdd tip advances on merge of PR #601 (was `064eadbc` / `sha-064eadb`).
+open-fdd PR **#601 is still open** — tip advances on merge (was `064eadbc` / `sha-064eadb`).
 
 ---
 

--- a/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
+++ b/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
@@ -8,11 +8,14 @@ Do not fork parallel truth. Update existing audits when code changes.
 | [`docs/migration/vibe19_parity_matrix.md`](../../docs/migration/vibe19_parity_matrix.md) | vibe19 capability parity |
 | [`docs/migration/vibe20_integration_matrix.md`](../../docs/migration/vibe20_integration_matrix.md) | WattLab / vibe20 integration |
 | [`docs/rules/cookbook/parity-matrix.md`](../../docs/rules/cookbook/parity-matrix.md) | SQL ↔ pandas rule honesty |
+| [`docs/migration/OFDD_065_076_PARITY.md`](../../docs/migration/OFDD_065_076_PARITY.md) | Liberty B50/B100 FAULT deltas + Gate A–C |
+| [`docs/mcp-agents/companion-wattlab-energyplus.md`](../../docs/mcp-agents/companion-wattlab-energyplus.md) | Dual-MCP / no IDF in openfdd-mcp |
+| [`docs/mcp-agents/dual-site-mcp-it.md`](../../docs/mcp-agents/dual-site-mcp-it.md) | OFDD-MCP-IT A/B/C checklist |
 | Playground `vibe_code_apps_20/docs/OPENFDD_ECM_TWINS.md` | ECM twin vs keeper list |
-| [`BUILD_CHECKPOINTS.md`](../BUILD_CHECKPOINTS.md) | Milestone A checklist |
+| [`BUILD_CHECKPOINTS.md`](../BUILD_CHECKPOINTS.md) | Milestone + Liberty soak checklist |
 
-When Phase 0 coding starts, add `docs/migration/MILESTONE_A_EXECUTION.md` with
-per-PR and per-module tables.
+**Tip under Liberty turnkey:** playground develop `2323f28` (BUG-ECM-015 + ERV stub).
+open-fdd tip advances on merge of PR #601 (was `064eadbc` / `sha-064eadb`).
 
 ---
 

--- a/scripts/openfdd_caddy_smoke.sh
+++ b/scripts/openfdd_caddy_smoke.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# OFDD-CADDY soak IT: GET / and GET /api/health via Caddy (default http://127.0.0.1).
+set -euo pipefail
+BASE="${OPENFDD_CADDY_BASE:-http://127.0.0.1}"
+fail=0
+
+code_root="$(curl -sS -o /tmp/openfdd_caddy_root.body -w '%{http_code}' --max-time 15 "$BASE/" || echo 000)"
+if [[ "$code_root" != "200" ]]; then
+  echo "FAIL GET / → HTTP $code_root (expected 200)" >&2
+  fail=1
+else
+  echo "OK GET / → 200"
+fi
+
+code_health="$(curl -sS -o /tmp/openfdd_caddy_health.json -w '%{http_code}' --max-time 15 "$BASE/api/health" || echo 000)"
+if [[ "$code_health" != "200" ]]; then
+  echo "FAIL GET /api/health → HTTP $code_health (expected 200)" >&2
+  fail=1
+else
+  echo "OK GET /api/health → 200"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import json
+from pathlib import Path
+doc = json.loads(Path("/tmp/openfdd_caddy_health.json").read_text())
+assert doc.get("ok") is True or "version" in doc or "status" in doc, doc
+print("OK health JSON keys:", sorted(doc)[:12])
+PY
+  fi
+fi
+
+exit "$fail"

--- a/scripts/openfdd_caddy_smoke.sh
+++ b/scripts/openfdd_caddy_smoke.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 BASE="${OPENFDD_CADDY_BASE:-http://127.0.0.1}"
 fail=0
 
-code_root="$(curl -sS -o /tmp/openfdd_caddy_root.body -w '%{http_code}' --max-time 15 "$BASE/" || echo 000)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/openfdd-caddy.XXXXXX")"
+trap 'rm -rf -- "$tmp_dir"' EXIT
+root_body="$tmp_dir/root.body"
+health_body="$tmp_dir/health.json"
+
+code_root="$(curl -sS -o "$root_body" -w '%{http_code}' --max-time 15 "$BASE/" || echo 000)"
 if [[ "$code_root" != "200" ]]; then
   echo "FAIL GET / → HTTP $code_root (expected 200)" >&2
   fail=1
@@ -12,17 +17,18 @@ else
   echo "OK GET / → 200"
 fi
 
-code_health="$(curl -sS -o /tmp/openfdd_caddy_health.json -w '%{http_code}' --max-time 15 "$BASE/api/health" || echo 000)"
+code_health="$(curl -sS -o "$health_body" -w '%{http_code}' --max-time 15 "$BASE/api/health" || echo 000)"
 if [[ "$code_health" != "200" ]]; then
   echo "FAIL GET /api/health → HTTP $code_health (expected 200)" >&2
   fail=1
 else
   echo "OK GET /api/health → 200"
   if command -v python3 >/dev/null 2>&1; then
-    python3 - <<'PY'
+    HEALTH_BODY="$health_body" python3 - <<'PY'
 import json
+import os
 from pathlib import Path
-doc = json.loads(Path("/tmp/openfdd_caddy_health.json").read_text())
+doc = json.loads(Path(os.environ["HEALTH_BODY"]).read_text())
 assert doc.get("ok") is True or "version" in doc or "status" in doc, doc
 print("OK health JSON keys:", sorted(doc)[:12])
 PY

--- a/scripts/openfdd_stack_up.sh
+++ b/scripts/openfdd_stack_up.sh
@@ -32,13 +32,16 @@ Recipes:
 
 Options:
   --caddy     Also start Caddy on :80 → Streamlit UI (/api* → central)
+  --wattlab   Mount WattLab /data + vibe20 PYTHONPATH (compose.wattlab.yml)
 
 Env: OPENFDD_IMAGE_TAG, OPENFDD_*_IMAGE, OPENFDD_JWT_SECRET, OPENFDD_ADMIN_PASSWORD
      OPENFDD_CADDY=1 (same as --caddy), OPENFDD_CENTRAL_BIND=127.0.0.1 (LAN via Caddy)
+     OPENFDD_WATTLAB=1 (same as --wattlab), OPENFDD_WATTLAB_HOST_WORKSPACE, OPENFDD_WATTLAB_HOST_SRC
 EOF
       exit 0
       ;;
     --caddy) export OPENFDD_CADDY=1; shift ;;
+    --wattlab) export OPENFDD_WATTLAB=1; shift ;;
     *) EXTRA+=("$1"); shift ;;
   esac
 done
@@ -60,6 +63,13 @@ if [[ "${OPENFDD_CADDY:-0}" == "1" || "${OPENFDD_CADDY:-}" == "true" ]]; then
     ARGS+=(-f "$ROOT/docker/compose.caddy.yml")
   fi
 fi
+if [[ "${OPENFDD_WATTLAB:-0}" == "1" || "${OPENFDD_WATTLAB:-}" == "true" ]]; then
+  if [[ "$RECIPE" == "edge" ]]; then
+    echo "WARN: --wattlab ignored for edge recipe (no UI)" >&2
+  else
+    ARGS+=(-f "$ROOT/docker/compose.wattlab.yml")
+  fi
+fi
 if [[ "$DO_BUILD" -eq 1 ]]; then
   docker compose "${ARGS[@]}" up -d --build --remove-orphans "${EXTRA[@]+"${EXTRA[@]}"}"
 else
@@ -71,6 +81,9 @@ if [[ "$RECIPE" != "edge" ]]; then
   echo "UI: http://127.0.0.1:3000  API: ${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
   if [[ "${OPENFDD_CADDY:-0}" == "1" || "${OPENFDD_CADDY:-}" == "true" ]]; then
     echo "Caddy: http://<host>/  (UI)  http://<host>/api/health  (central)"
+  fi
+  if [[ "${OPENFDD_WATTLAB:-0}" == "1" || "${OPENFDD_WATTLAB:-}" == "true" ]]; then
+    echo "WattLab: WATTLAB_STUDIO_WORKSPACE=/data (host ${OPENFDD_WATTLAB_HOST_WORKSPACE:-~/wattlab_workspace})"
   fi
 fi
 echo "OK recipe=${RECIPE} up"

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -636,11 +636,12 @@ pub async fn economizer_from_history(
     };
     let dt_min = dt_min_f.max(0.0);
     let eq_filter = equipment_filter_sql(equipment_filter);
-    let has_damper_col = cols.contains("oa_damper_pct");
-    let damper_present = if has_damper_col {
-        "COUNT(oa_damper_pct)"
+    // OFDD-070b: project damper into the CTE — COUNT(oa_damper_pct) from `base`
+    // fails when the column exists on `history` but was never selected into `base`.
+    let damper_proj = if cols.contains("oa_damper_pct") {
+        "oa_damper_pct"
     } else {
-        "0"
+        "CAST(NULL AS DOUBLE) AS oa_damper_pct"
     };
 
     let sql = format!(
@@ -651,7 +652,8 @@ WITH base AS (
     {oat_col} AS oa_t,
     {rat_col} AS rat,
     {mat_col} AS mat,
-    {on_sql} AS fan_on
+    {on_sql} AS fan_on,
+    {damper_proj}
   FROM history
   WHERE equipment_id IS NOT NULL{eq_filter}
 )
@@ -660,7 +662,7 @@ SELECT
   SUM(CASE WHEN fan_on THEN 1 ELSE 0 END) AS n_fan_on,
   SUM(CASE WHEN fan_on AND oa_t IS NOT NULL AND rat IS NOT NULL
              AND ABS(oa_t - rat) >= {dt_min} THEN 1 ELSE 0 END) AS n_identifiable,
-  {damper_present} AS n_damper
+  COUNT(oa_damper_pct) AS n_damper
 FROM base
 GROUP BY equipment_id
 ORDER BY equipment_id
@@ -978,6 +980,44 @@ mod tests {
             b50.coverage.as_ref().unwrap()["building_id"],
             serde_json::json!("BUILDING_50")
         );
+    }
+
+    #[tokio::test]
+    async fn economizer_from_history_with_damper_column_ok() {
+        // OFDD-070b: oa_damper_pct present on history must not schema-error.
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let parquet = tmp.path().join("parquet_econ_damp");
+        let building = tmp.path().join("BUILDING_50");
+        let ahu = building.join("AHU_1");
+        std::fs::create_dir_all(&ahu).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        std::fs::write(
+            ahu.join("columns.csv"),
+            "col,point_role\noat,outside_air_temp\nrat,return_air_temp\n\
+             mat,mixed_air_temp\nfan,fan_status\ndamp,oa_damper_pct\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,oat,rat,mat,fan,damp").unwrap();
+        writeln!(f, "2026-01-01T00:00:00Z,40,70,55,1,0.4").unwrap();
+        writeln!(f, "2026-01-01T00:05:00Z,41,70,56,1,0.5").unwrap();
+        fdd_store::ingest_building(tmp.path(), "BUILDING_50", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let env = economizer_from_history(None, 10.0, Some("BUILDING_50"))
+            .await
+            .unwrap()
+            .expect("economizer with damper");
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+
+        assert_eq!(env.engine, DF_ENGINE);
+        assert!(!env.equipment.is_empty());
+        assert!(env.equipment[0]["has_damper"].as_bool().unwrap_or(false));
+        assert!(!env
+            .warnings
+            .iter()
+            .any(|w| w.contains("historian/job economizer load is next")));
     }
 
     #[tokio::test]

--- a/services/central/src/jobs.rs
+++ b/services/central/src/jobs.rs
@@ -840,6 +840,27 @@ mod tests {
     }
 
     #[test]
+    fn create_job_persists_site_id() {
+        // OFDD-076b: callers (routes) map building_id → site_id before create_job.
+        with_tmp_ws(|_dir| {
+            let meta = create_job(
+                "Bound",
+                Some("BUILDING_100".into()),
+                Some("Liberty B100".into()),
+                Some("BUILDING_100".into()),
+                None,
+                vec![],
+                None,
+            )
+            .unwrap();
+            assert_eq!(meta.site_id.as_deref(), Some("BUILDING_100"));
+            assert_eq!(meta.building_name.as_deref(), Some("BUILDING_100"));
+            let loaded = load_job(&meta.job_id).unwrap();
+            assert_eq!(loaded.site_id.as_deref(), Some("BUILDING_100"));
+        });
+    }
+
+    #[test]
     fn create_list_archive_restore() {
         with_tmp_ws(|_dir| {
             let meta = create_job("Test", None, None, None, None, vec!["t".into()], None).unwrap();

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1260,6 +1260,9 @@ struct CreateJobBody {
     site_id: Option<String>,
     #[serde(default)]
     site_name: Option<String>,
+    /// OFDD-076b: agents may send building_id; maps to site_id when site_id empty.
+    #[serde(default)]
+    building_id: Option<String>,
     #[serde(default)]
     building_name: Option<String>,
     #[serde(default)]
@@ -1331,11 +1334,29 @@ async fn jobs_list(
 async fn jobs_create(
     Json(body): Json<CreateJobBody>,
 ) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
+    // OFDD-076b: building_id → site_id when site_id absent; also fill building_name.
+    let building_id = body
+        .building_id
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let site_id = body
+        .site_id
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| building_id.clone());
+    let building_name = body
+        .building_name
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| building_id.clone());
     let meta = jobs::create_job(
         &body.job_name,
-        body.site_id,
+        site_id,
         body.site_name,
-        body.building_name,
+        building_name,
         body.description,
         body.tags,
         body.created_by,

--- a/services/central/tests/jobs_api_integration.rs
+++ b/services/central/tests/jobs_api_integration.rs
@@ -140,11 +140,27 @@ fn jobs_crud_runs_stale_findings_wattlab() {
     let server = Server::start();
     let port = server.port;
 
-    let create = json!({"job_name": "C0 Job", "tags": ["c0"]}).to_string();
+    let create = json!({
+        "job_name": "C0 Job",
+        "tags": ["c0"],
+        "building_id": "BUILDING_100"
+    })
+    .to_string();
     let (st, body) = http("POST", port, "/api/jobs", Some(&create), None);
     assert_eq!(st, 201, "{body}");
     let job = &json_body(&body)["job"];
     let job_id = job["job_id"].as_str().unwrap();
+    // OFDD-076b: building_id maps to site_id when site_id omitted
+    assert_eq!(
+        job["site_id"].as_str(),
+        Some("BUILDING_100"),
+        "building_id must bind site_id: {body}"
+    );
+    assert_eq!(
+        job["building_name"].as_str(),
+        Some("BUILDING_100"),
+        "{body}"
+    );
     let rev = job["meta_revision"].as_str().unwrap().to_string();
 
     let (st, body) = http("GET", port, "/api/jobs", None, None);

--- a/services/ui/Dockerfile
+++ b/services/ui/Dockerfile
@@ -30,7 +30,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 ARG WATTLAB_PIP_SPEC=
 RUN if [ -n "$WATTLAB_PIP_SPEC" ]; then pip install --no-cache-dir "$WATTLAB_PIP_SPEC"; fi
 
-ENV WATTLAB_STUDIO_WORKSPACE=/data
+# Do not bake WATTLAB_STUDIO_WORKSPACE here — compose.wattlab.yml sets it when
+# /data is actually mounted; a baked ENV would defeat the UI mount warning.
 
 COPY . .
 

--- a/services/ui/Dockerfile
+++ b/services/ui/Dockerfile
@@ -25,6 +25,13 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Optional WattLab package bake (OFDD-UI-V20). Lab soak usually mounts vibe20 via
+# docker/compose.wattlab.yml instead; set WATTLAB_PIP_SPEC at build for GHCR tips.
+ARG WATTLAB_PIP_SPEC=
+RUN if [ -n "$WATTLAB_PIP_SPEC" ]; then pip install --no-cache-dir "$WATTLAB_PIP_SPEC"; fi
+
+ENV WATTLAB_STUDIO_WORKSPACE=/data
+
 COPY . .
 
 EXPOSE 8501

--- a/services/ui/app/dashboard_contract.py
+++ b/services/ui/app/dashboard_contract.py
@@ -11,7 +11,7 @@ REQUIRED_MAIN_SECTIONS: tuple[str, ...] = (
     "FDD Plots",
     "RCx Plots",
     "Metering",
-    "Export",
+    "WattLab",
 )
 
 # Public chart helpers in app/charts.py used by FDD Plots / RCx / Overview / Metering.
@@ -55,10 +55,10 @@ REQUIRED_UI_ENTRYPOINTS: tuple[str, ...] = (
     "app.model_seed:infer_schedules",
     "app.model_seed:operating_signatures",
     "app.open_meteo:fetch_open_meteo",
-    "app.ui_jobs:render_jobs_sidebar",
     "app.job_store:create_job",
     "app.job_store:load_job",
-    # OFDD-076/072: in-product vibe20 Jobs — WattLab handoff + ECM agent-build.
+    # WattLab section (OFDD-UI-V20) — vibe20 studio pages + handoff/dump advanced
+    "app.ui_wattlab_studio:render_wattlab_section",
     "app.ui_wattlab_job:render_job_native_wattlab_handoff",
     "app.ui_ecm_job:render_ecm_agent_build_panel",
     "app.job_store:save_ecm_request",

--- a/services/ui/app/eng_findings.py
+++ b/services/ui/app/eng_findings.py
@@ -319,8 +319,17 @@ def render_engineering_findings_panel(*, key: str = "overview_eng_findings") -> 
                 st.caption(f"Central findings draft not stored: {draft.get('error')}")
             else:
                 st.caption("Central engineering_findings draft stored (GET /api/reports/engineering-findings).")
-        except Exception as exc:
+        except (OSError, ConnectionError, TimeoutError, ValueError, TypeError, KeyError) as exc:
             st.caption(f"Central findings draft skipped: {exc}")
+        except Exception as exc:  # central_client may raise requests-like errors
+            if type(exc).__module__.startswith("requests") or type(exc).__name__ in {
+                "HTTPError",
+                "RequestException",
+                "CentralError",
+            }:
+                st.caption(f"Central findings draft skipped: {exc}")
+            else:
+                raise
 
     art = st.session_state.get(f"{key}_artifacts")
     if isinstance(art, dict):

--- a/services/ui/app/eng_findings.py
+++ b/services/ui/app/eng_findings.py
@@ -300,6 +300,27 @@ def render_engineering_findings_panel(*, key: str = "overview_eng_findings") -> 
         st.session_state[f"{key}_files"] = files
         if err:
             st.warning(f"Some artifacts skipped (optional writer missing): {err}")
+        # OFDD-069: persist a central draft so GET /api/reports/engineering-findings works.
+        try:
+            from app import central_client
+
+            draft = central_client.reports_draft(
+                {
+                    "building": building,
+                    "kind": "engineering_findings",
+                    "template_id": "engineering_findings",
+                    "report_type": "engineering_findings",
+                    "summary": artifacts.to_dict().get("summary")
+                    if hasattr(artifacts, "to_dict")
+                    else None,
+                }
+            )
+            if draft.get("ok") is False:
+                st.caption(f"Central findings draft not stored: {draft.get('error')}")
+            else:
+                st.caption("Central engineering_findings draft stored (GET /api/reports/engineering-findings).")
+        except Exception as exc:
+            st.caption(f"Central findings draft skipped: {exc}")
 
     art = st.session_state.get(f"{key}_artifacts")
     if isinstance(art, dict):

--- a/services/ui/app/ui_wattlab_studio.py
+++ b/services/ui/app/ui_wattlab_studio.py
@@ -1,0 +1,126 @@
+"""WattLab section — vibe20 Uploads → Fuel → Twin → ECMs inside open-fdd (OFDD-UI-V20).
+
+Imports ``wattlab.studio.pages.*`` when the package is available (ui image / lab).
+Otherwise shows an honest runner/workspace status instead of a fake Studio.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import streamlit as st
+
+WATTLab_PAGES = (
+    "Uploads",
+    "Fuel dashboard",
+    "Twin / calibrate",
+    "ECMs",
+)
+
+
+def _workspace_root() -> str | None:
+    for key in ("WATTLAB_STUDIO_WORKSPACE", "WATTLAB_WORKSPACE", "OPENFDD_WATTLAB_WORKSPACE"):
+        v = (os.environ.get(key) or "").strip()
+        if v:
+            return v
+    return None
+
+
+def _try_import_page(mod_name: str):
+    try:
+        import importlib
+
+        return importlib.import_module(f"wattlab.studio.pages.{mod_name}")
+    except Exception:
+        return None
+
+
+def render_wattlab_section(*, building_id: str | None = None) -> None:
+    """Main-section WattLab workspace (replaces Export-as-only-story)."""
+    st.subheader("WattLab")
+    active = (building_id or st.session_state.get("building_id") or st.session_state.get("active_site") or "").strip()
+    if active:
+        st.caption(f"Scoped to Active site `{active}`.")
+    else:
+        st.caption("No Active site — load a package and pick a Site first.")
+
+    ws = _workspace_root()
+    st.info(
+        "WattLab hosts Fuel / Twin / ECMs. EnergyPlus runs need DinD + "
+        "`energyplus-mcp-dev` (or an external runner) — never invented savings."
+    )
+    if ws:
+        st.caption(f"Workspace: `{ws}`")
+    else:
+        st.warning(
+            "No `WATTLAB_STUDIO_WORKSPACE` / `WATTLAB_WORKSPACE` mount — "
+            "Twin/Fuel files will not resolve until the ui container shares `/data`."
+        )
+
+    page = st.radio(
+        "WattLab workflow",
+        list(WATTLab_PAGES),
+        horizontal=True,
+        key="wattlab_studio_page",
+        help="Uploads → Fuel → Twin → ECMs (same spine as vibe20 Studio).",
+    )
+
+    profile: dict[str, Any] = {}
+    if active:
+        profile["building_id"] = active
+        profile["site_id"] = active
+
+    rendered = False
+    if page == "Uploads":
+        mod = _try_import_page("uploads")
+        if mod and hasattr(mod, "render"):
+            mod.render(profile=profile)
+            rendered = True
+    elif page == "Fuel dashboard":
+        mod = _try_import_page("fuel_dashboard")
+        if mod and hasattr(mod, "render"):
+            mod.render(profile=profile)
+            rendered = True
+    elif page == "Twin / calibrate":
+        mod = _try_import_page("twin_calibrate")
+        if mod and hasattr(mod, "render"):
+            mod.render(profile=profile)
+            rendered = True
+    elif page == "ECMs":
+        mod = _try_import_page("ecms")
+        if mod and hasattr(mod, "render"):
+            mod.render(profile=profile)
+            rendered = True
+
+    if not rendered:
+        st.warning(
+            f"**{page}** UI requires the `wattlab` package in the openfdd-ui image "
+            "(Option A embed). Until then use vibe20 Studio on `:8520` or install wattlab."
+        )
+        docker_sock = os.path.exists("/var/run/docker.sock")
+        st.caption(
+            f"Docker sock attached: {'yes' if docker_sock else 'no'} · "
+            f"EnergyPlus MCP: set `OPENFDD_ENERGYPLUS_MCP=1` when runner is available."
+        )
+
+    with st.expander("Advanced — handoff / dump / agent-build", expanded=False):
+        st.caption(
+            "Dump zip and ECM package requests remain available for external pickup. "
+            "They are not a substitute for the WattLab pages above."
+        )
+        try:
+            from app.ui_wattlab_job import render_job_native_wattlab_handoff
+
+            render_job_native_wattlab_handoff()
+        except Exception as exc:
+            st.caption(f"WattLab handoff panel unavailable: {exc}")
+        try:
+            from app.ui_ecm_job import render_ecm_agent_build_panel
+
+            render_ecm_agent_build_panel()
+        except Exception as exc:
+            st.caption(f"ECM agent-build panel unavailable: {exc}")
+
+
+__all__ = ["WATTLab_PAGES", "render_wattlab_section"]

--- a/services/ui/app/ui_wattlab_studio.py
+++ b/services/ui/app/ui_wattlab_studio.py
@@ -32,7 +32,8 @@ def _try_import_page(mod_name: str):
         import importlib
 
         return importlib.import_module(f"wattlab.studio.pages.{mod_name}")
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
+        # Missing package / page only — surface other import-time bugs to the UI.
         return None
 
 

--- a/services/ui/shared/branding.py
+++ b/services/ui/shared/branding.py
@@ -1,3 +1,3 @@
 """App branding — shared across dashboard and data model UI."""
 
-APP_TITLE = "Open FDD Vibe Coder"
+APP_TITLE = "Open FDD"

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -103,7 +103,7 @@ from app.site_model import (  # noqa: E402
 try:
     from shared.branding import APP_TITLE
 except ImportError:  # pragma: no cover
-    APP_TITLE = "Open FDD Vibe Coder"
+    APP_TITLE = "Open FDD"
 
 st.set_page_config(page_title=APP_TITLE, layout="wide")
 
@@ -117,13 +117,9 @@ _HERO_IMG = APP_ROOT / "assets" / "image_new_chiller.png"
 
 
 def _render_app_hero() -> None:
-    """Brand header: title → subtitle → compact logo → how-it-works."""
+    """Brand header: title → one product line → logo → how-it-works."""
     st.title(APP_TITLE)
-    st.markdown(
-        "Streamlit lab for Open-FDD: Load zip → central Feather store; Run Rules → DataFusion SQL. "
-        "Rule-tuning sliders map to SQL registry params (confirm delay = confirm_min → confirm_seconds). "
-        "CSVs stay as-is — you only map columns to roles."
-    )
+    st.markdown("Fault detection + WattLab energy twin — sites, FDD, and calibrated models.")
     if _HERO_IMG.is_file():
         # Narrower than full-bleed stretch so the logo sits under the brand, not above it
         _logo_l, _logo_m, _logo_r = st.columns([1, 2, 1])
@@ -131,15 +127,14 @@ def _render_app_hero() -> None:
             st.image(str(_HERO_IMG), width="stretch")
     st.markdown(
         """
-**How it works (2 pieces + run)**
+**How it works**
 
-1. **Data package** — Folder or `openfdd_package_v1` zip of historian CSVs  
-2. **Data model** — JSON column→role map (Mapping tab) or `session_config.json` role_map in the zip  
-3. **Run** — **Run Rules** → **FDD Plots** / **RCx Plots**
+1. **Sites** — Load a package zip; pick the active building from the Site list  
+2. **Data model** — Column→role map for the active site  
+3. **FDD / WattLab** — Run Rules, then WattLab (Fuel / Twin / ECMs) scoped to the site
         """.strip()
     )
     st.markdown(
-        f"[AGENTS.md]({_AGENTS_MD_URL}) · "
         f"[Open-FDD docs]({_OPENFDD_DOCS_URL}) · "
         f"[Open-FDD repo]({_OPENFDD_REPO_URL})"
     )
@@ -1589,38 +1584,90 @@ def _sync_active_site() -> None:
     _snapshot_site(bid)
 
 
+def _hive_site_ids() -> list[str]:
+    """Building ids from central GET /api/datasets (Hive registry)."""
+    try:
+        from app import central_client
+
+        resp = central_client.list_datasets(timeout=10.0)
+    except Exception:
+        return []
+    if not resp.get("ok"):
+        return []
+    out: list[str] = []
+    for d in resp.get("datasets") or []:
+        if isinstance(d, dict):
+            bid = d.get("id") or d.get("building_id") or d.get("dataset_id")
+            if bid:
+                out.append(str(bid).strip())
+        elif isinstance(d, str) and d.strip():
+            out.append(d.strip())
+    return out
+
+
+def _all_site_ids() -> list[str]:
+    """Union of Hive datasets and in-session snapshots (Active site = building_id)."""
+    return sorted({*(_sites().keys()), *_hive_site_ids()} - {""})
+
+
 def _render_site_selector() -> None:
-    """Sidebar Site picker — switch rebinds the whole per-site session."""
-    ids = sorted(_sites().keys())
-    if len(ids) < 2:
+    """Sidebar Sites card — always visible; Hive-driven (OFDD-UI-SITE)."""
+    st.sidebar.markdown("##### Sites")
+    ids = _all_site_ids()
+    if not ids:
+        st.sidebar.caption("No sites — load a package.")
         return
-    active = str(st.session_state.get("active_site") or "")
+    active = str(
+        st.session_state.get("active_site") or st.session_state.get("building_id") or ""
+    ).strip()
     idx = ids.index(active) if active in ids else 0
+    frames = st.session_state.get("equipment_frames") or {}
+    n_eq = len(frames) if active and active == st.session_state.get("building_id") else None
+    help_txt = "Active site = building_id from the package / Hive. Switch rebinds FDD data."
+    if n_eq is not None:
+        help_txt += f" Equip in session: {n_eq}."
     sel = st.sidebar.selectbox(
-        "Site",
+        "Active site",
         ids,
         index=idx,
         key="site_selector",
-        help="Switch between loaded buildings. Each site keeps its own data, faults, and Overview.",
+        help=help_txt,
     )
+    if sel and sel in _sites() and frames and active == sel:
+        st.sidebar.caption(f"Equip {len(frames)} · Feather/Hive yes")
+    elif sel and sel not in _sites():
+        st.sidebar.caption(
+            "Listed from central Hive — load/re-open this package to bind session data."
+        )
     if sel and sel != active:
-        _snapshot_site(active)
-        _load_site(sel)
+        if active and active in _sites():
+            _snapshot_site(active)
+        if sel in _sites():
+            _load_site(sel)
+        else:
+            st.session_state.active_site = sel
+            st.session_state.building_id = sel
+            st.session_state.central_dataset_id = sel
         st.rerun()
 
 
 def _delete_site_and_clear() -> None:
-    """Delete the active site's central data, drop its snapshot, and switch to a
-    remaining site (or clear when none remain)."""
+    """Delete the Active site's Feathers + results (confirm via sidebar checkbox)."""
     from app import central_client
 
     dataset_id = (
-        st.session_state.get("central_dataset_id")
+        st.session_state.get("active_site")
+        or st.session_state.get("central_dataset_id")
         or st.session_state.get("building_id")
         or ""
     ).strip()
     if not dataset_id:
-        st.sidebar.warning("No site loaded — nothing to delete on central")
+        st.sidebar.warning("No site selected — nothing to delete")
+        return
+    if not st.session_state.get("_confirm_delete_site"):
+        st.sidebar.error(
+            f"Confirm delete for `{dataset_id}`: check **Confirm delete** below, then click Delete again."
+        )
         return
     result = central_client.delete_dataset(dataset_id)
     if result.get("central_down"):
@@ -1635,14 +1682,47 @@ def _delete_site_and_clear() -> None:
 
     wipe_workdir(st.session_state.get("upload_workdir"))
     clear_browser_session_pointer()
+    # Cascade local job folders keyed to this building when present
+    try:
+        from pathlib import Path
+        from app import job_store
+
+        ws = Path(job_store.workspace_root())
+        jobs_root = ws / "jobs"
+        if jobs_root.is_dir():
+            for meta_path in jobs_root.glob("*/job.json"):
+                try:
+                    import json
+
+                    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+                except Exception:
+                    continue
+                sid = str(meta.get("site_id") or meta.get("building_name") or "")
+                if sid == dataset_id:
+                    import shutil
+
+                    shutil.rmtree(meta_path.parent, ignore_errors=True)
+    except Exception:
+        pass
+
     _purge_site(st.session_state.get("active_site") or dataset_id)
     _purge_site(dataset_id)
+    st.session_state.pop("_confirm_delete_site", None)
 
-    remaining = sorted(_sites().keys())
-    if remaining:
+    remaining = _all_site_ids()
+    remaining = [r for r in remaining if r != dataset_id]
+    if remaining and remaining[0] in _sites():
         _load_site(remaining[0])
         st.sidebar.success(
             f"Deleted site `{dataset_id}` — switched to `{remaining[0]}`"
+        )
+    elif remaining:
+        st.session_state.active_site = remaining[0]
+        st.session_state.building_id = remaining[0]
+        st.session_state.central_dataset_id = remaining[0]
+        st.session_state.equipment_frames = {}
+        st.sidebar.success(
+            f"Deleted site `{dataset_id}` — active `{remaining[0]}` (reload package for session data)"
         )
     else:
         st.session_state.upload_workdir = None
@@ -1655,7 +1735,7 @@ def _delete_site_and_clear() -> None:
         st.session_state.building_id = ""
         st.session_state.active_site = ""
         st.session_state.pop("central_dataset_id", None)
-        st.sidebar.success(f"Deleted site `{dataset_id}` (session / fault sliders kept)")
+        st.sidebar.success(f"Deleted site `{dataset_id}`")
     st.session_state.zip_uploader_key = int(st.session_state.get("zip_uploader_key", 0)) + 1
 
 
@@ -2039,9 +2119,14 @@ def _load_data(cfg: AppConfig) -> None:
             key="load_zip_unified",
         )
         delete_clicked = c2.button(
-            "Delete site",
+            "Delete…",
             key="delete_dataset_unified",
-            help="Delete Feather/parquet for the active site's building id, then switch to a remaining site. Keeps fault sliders & session maps.",
+            help="Purge Feathers + FDD results for the Active site (building_id). Other sites untouched.",
+        )
+        st.sidebar.checkbox(
+            f"Confirm delete Active site",
+            key="_confirm_delete_site",
+            help="Required before Delete… removes historian Feathers + rule_results for that building only.",
         )
         if delete_clicked:
             _delete_site_and_clear()
@@ -2615,9 +2700,8 @@ def main() -> None:
     defaults_cfg = cached_rule_defaults(str(cfg.rule_defaults_path))
     _apply_agent_bootstrap_once()
     _apply_browser_autoload_once()
-    from app.ui_jobs import render_jobs_sidebar
-
-    render_jobs_sidebar()
+    # OFDD-UI-JOBS: default Jobs expander removed — Site spine owns building switch.
+    # /api/jobs remains for WattLab worksheets / advanced handoff.
     _sync_active_site()
     _render_site_selector()
     _load_data(cfg)
@@ -3945,76 +4029,70 @@ def main() -> None:
                 key=f"dl_meter_{kind}",
             )
 
-    if section == "Export":
-        st.subheader("Export")
-        st.caption(
-            "One big dump for WattLab (vibe20): every FDD rule, analytic CSVs, "
-            "sensor stats / 24h diurnal profiles (fan on/off × weekday/weekend/holiday), "
-            "setpoints, schedules, weather, data-derived model seed, and MANIFEST.json. "
-            "Session restore stays below; individual CSVs live under the expander."
+    if section == "WattLab":
+        from app.ui_wattlab_studio import render_wattlab_section
+
+        render_wattlab_section(
+            building_id=str(
+                st.session_state.get("building_id")
+                or st.session_state.get("active_site")
+                or ""
+            )
         )
         results = st.session_state.batch_results
-
-        from app.ui_wattlab_job import render_job_native_wattlab_handoff
-
-        render_job_native_wattlab_handoff()
-
-        from app.ui_ecm_job import render_ecm_agent_build_panel
-
-        render_ecm_agent_build_panel()
-
-        st.markdown("##### WattLab dump zip (additive)")
-        if not frames:
-            st.info("Load a package first — the dump needs equipment data.")
-        else:
-            profile_options = {
-                "Summary (default)": "summary",
-                "Diagnostic": "diagnostic",
-                "Forensic": "forensic",
-            }
-            # Durable non-widget key survives Export unmount; widget key is re-seeded.
-            if "wattlab_export_profile" not in st.session_state:
-                st.session_state["wattlab_export_profile"] = "summary"
-            if "wattlab_export_profile_label" not in st.session_state:
-                rev = {v: k for k, v in profile_options.items()}
-                st.session_state["wattlab_export_profile_label"] = rev.get(
-                    st.session_state["wattlab_export_profile"],
-                    "Summary (default)",
-                )
-            profile_label = st.selectbox(
-                "Export profile",
-                options=list(profile_options),
-                key="wattlab_export_profile_label",
-                help=(
-                    "Summary: shared telemetry + analytic tables, no per-rule timeseries. "
-                    "Diagnostic: FAULT/ERROR evidence. Forensic: applicable evidence."
-                ),
-            )
-            st.session_state["wattlab_export_profile"] = profile_options.get(
-                str(profile_label), "summary"
-            )
-            if st.button("Build WattLab dump (zip)", type="primary", key="wattlab_dump_build"):
-                with st.spinner("Running analytics + writing bundle…"):
-                    try:
-                        data, fname = _build_wattlab_dump_zip(
-                            profile=st.session_state.get("wattlab_export_profile", "summary")
-                        )
-                        st.session_state["wattlab_dump_zip"] = (data, fname)
-                        st.success(f"Dump ready · {len(data) / 1e6:.1f} MB — see README_WATTLAB.md inside")
-                    except Exception as exc:
-                        st.error(f"WattLab dump failed: {exc}")
-            dump = st.session_state.get("wattlab_dump_zip")
-            if dump:
-                st.download_button(
-                    "Download WattLab dump (zip)",
-                    data=dump[0],
-                    file_name=dump[1],
-                    mime="application/zip",
-                    key="wattlab_dump_dl",
-                )
-
         st.markdown("##### Session restore")
-        _render_session_config_io(key_prefix="export")
+        _render_session_config_io(key_prefix="wattlab")
+
+        with st.expander("WattLab dump zip (additive)", expanded=False):
+            if not frames:
+                st.info("Load a package first — the dump needs equipment data.")
+            else:
+                profile_options = {
+                    "Summary (default)": "summary",
+                    "Diagnostic": "diagnostic",
+                    "Forensic": "forensic",
+                }
+                if "wattlab_export_profile" not in st.session_state:
+                    st.session_state["wattlab_export_profile"] = "summary"
+                if "wattlab_export_profile_label" not in st.session_state:
+                    rev = {v: k for k, v in profile_options.items()}
+                    st.session_state["wattlab_export_profile_label"] = rev.get(
+                        st.session_state["wattlab_export_profile"],
+                        "Summary (default)",
+                    )
+                profile_label = st.selectbox(
+                    "Dump profile",
+                    options=list(profile_options),
+                    key="wattlab_export_profile_label",
+                    help=(
+                        "Summary: shared telemetry + analytic tables, no per-rule timeseries. "
+                        "Diagnostic: FAULT/ERROR evidence. Forensic: applicable evidence."
+                    ),
+                )
+                st.session_state["wattlab_export_profile"] = profile_options.get(
+                    str(profile_label), "summary"
+                )
+                if st.button("Build WattLab dump (zip)", type="primary", key="wattlab_dump_build"):
+                    with st.spinner("Running analytics + writing bundle…"):
+                        try:
+                            data, fname = _build_wattlab_dump_zip(
+                                profile=st.session_state.get("wattlab_export_profile", "summary")
+                            )
+                            st.session_state["wattlab_dump_zip"] = (data, fname)
+                            st.success(
+                                f"Dump ready · {len(data) / 1e6:.1f} MB — see README_WATTLAB.md inside"
+                            )
+                        except Exception as exc:
+                            st.error(f"WattLab dump failed: {exc}")
+                dump = st.session_state.get("wattlab_dump_zip")
+                if dump:
+                    st.download_button(
+                        "Download WattLab dump (zip)",
+                        data=dump[0],
+                        file_name=dump[1],
+                        mime="application/zip",
+                        key="wattlab_dump_dl",
+                    )
 
         with st.expander("Individual exports (summary CSV, column map, gap report, tuning report)"):
             if results:
@@ -4053,8 +4131,6 @@ def main() -> None:
                     trep = build_tuning_assistant_report(
                         tuned=results or [],
                         params=st.session_state.get("params") or {},
-                        has_web_weather=st.session_state.weather is not None,
-                        gap_report=gap_df,
                     )
                     st.download_button(
                         "Download tuning_assistant_report.json",
@@ -4069,6 +4145,7 @@ def main() -> None:
         st.caption(
             "Word report: download the Generic RCx template from the **Overview** section."
         )
+
 
 
 if __name__ == "__main__":

--- a/services/ui/streamlit_app.py
+++ b/services/ui/streamlit_app.py
@@ -1651,9 +1651,15 @@ def _render_site_selector() -> None:
         st.rerun()
 
 
-def _delete_site_and_clear() -> None:
-    """Delete the Active site's Feathers + results (confirm via sidebar checkbox)."""
+def _delete_site_and_clear() -> bool:
+    """Delete the Active site's Feathers + results (confirm via sidebar checkbox).
+
+    Returns True only when deletion completed so the caller can ``st.rerun()``.
+    """
+    import logging
     from app import central_client
+
+    _logger = logging.getLogger(__name__)
 
     dataset_id = (
         st.session_state.get("active_site")
@@ -1663,19 +1669,19 @@ def _delete_site_and_clear() -> None:
     ).strip()
     if not dataset_id:
         st.sidebar.warning("No site selected — nothing to delete")
-        return
+        return False
     if not st.session_state.get("_confirm_delete_site"):
         st.sidebar.error(
             f"Confirm delete for `{dataset_id}`: check **Confirm delete** below, then click Delete again."
         )
-        return
+        return False
     result = central_client.delete_dataset(dataset_id)
     if result.get("central_down"):
         st.sidebar.warning(result.get("error") or "central unreachable")
-        return
+        return False
     if not result.get("ok", False):
         st.sidebar.warning(result.get("error") or f"delete failed for `{dataset_id}`")
-        return
+        return False
 
     from app.browser_session import clear_browser_session_pointer
     from app.package_io import wipe_workdir
@@ -1695,15 +1701,16 @@ def _delete_site_and_clear() -> None:
                     import json
 
                     meta = json.loads(meta_path.read_text(encoding="utf-8"))
-                except Exception:
+                except Exception as exc:
+                    _logger.debug("skip unreadable job meta %s: %s", meta_path, exc)
                     continue
                 sid = str(meta.get("site_id") or meta.get("building_name") or "")
                 if sid == dataset_id:
                     import shutil
 
                     shutil.rmtree(meta_path.parent, ignore_errors=True)
-    except Exception:
-        pass
+    except Exception as exc:
+        _logger.warning("job-folder cascade cleanup failed for %s: %s", dataset_id, exc)
 
     _purge_site(st.session_state.get("active_site") or dataset_id)
     _purge_site(dataset_id)
@@ -1737,6 +1744,7 @@ def _delete_site_and_clear() -> None:
         st.session_state.pop("central_dataset_id", None)
         st.sidebar.success(f"Deleted site `{dataset_id}`")
     st.session_state.zip_uploader_key = int(st.session_state.get("zip_uploader_key", 0)) + 1
+    return True
 
 
 def _commit_frames(
@@ -2124,13 +2132,13 @@ def _load_data(cfg: AppConfig) -> None:
             help="Purge Feathers + FDD results for the Active site (building_id). Other sites untouched.",
         )
         st.sidebar.checkbox(
-            f"Confirm delete Active site",
+            "Confirm delete Active site",
             key="_confirm_delete_site",
             help="Required before Delete… removes historian Feathers + rule_results for that building only.",
         )
         if delete_clicked:
-            _delete_site_and_clear()
-            st.rerun()
+            if _delete_site_and_clear():
+                st.rerun()
         if load_clicked and zip_files:
             wipe_workdir(st.session_state.get("upload_workdir"))
             st.session_state.upload_workdir = None


### PR DESCRIPTION
## Summary
- **OFDD-070b / 076b:** economizer CTE projects `oa_damper_pct`; `CreateJobBody.building_id` → `site_id`.
- **Brand + MCP-CTX:** `APP_TITLE = Open FDD`; companion WattLab/EnergyPlus doc + INSTRUCTIONS links; `openfdd_agent_context_pointers`.
- **Sites/Jobs:** Hive `GET /api/datasets` Site picker always; Delete… confirm; Jobs expander removed from default chrome.
- **WattLab V20:** main section Export→WattLab; `ui_wattlab_studio` embeds vibe20 pages; `compose.wattlab.yml` + `--wattlab`; Caddy smoke script.
- **Findings / 065 / MCP-IT:** Eng Findings draft persist; Liberty FAULT deltas filled; dual-site MCP IT doc.

Companion playground: [#69](https://github.com/bbartling/py-bacnet-stacks-playground/pull/69) (BUG-ECM-015 + ECM-ERV stub) — merged.

## Test plan
- [x] `economizer_from_history_with_damper_column_ok`
- [x] `create_job_persists_site_id`
- [x] `engineering_findings_draft_listed_for_ofdd_069`
- [x] `agent_context_pointers_are_read_only_docs`
- [ ] CI green + CodeRabbit addressed
- [ ] After merge: GHCR tip refresh + csv+caddy(+wattlab) re-soak checklist


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated WattLab section covering uploads, Fuel/EnergyPlus, Twin calibration, ECM workflows, and a downloadable WattLab package.
  * Added central-driven site selection and building ID mapping when creating jobs (including persisted site/building info).
  * Added a read-only MCP context tool and EnergyPlus companion guidance, enabling integration via companion docs.
  * Engineering findings can now be saved as central drafts.

* **Bug Fixes**
  * Improved historian economizer handling when damper data is present.
  * Improved report type discovery and filtering for listed report drafts.

* **Documentation**
  * Added dual-site MCP IT and WattLab/EnergyPlus agent guides; refreshed migration parity results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->