### PR TITLE
docs(agent_spec): Liberty soak closeout tip sha-f904715

### DIFF
--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -120,7 +120,7 @@ Docs: [`MILESTONE_D_CLOSEOUT.md`](../docs/migration/MILESTONE_D_CLOSEOUT.md),
 
 # Liberty soak turnkey (2026-07-30) — post-064eadb
 
-**Status:** open-fdd PR **#601 open** (not merged) · playground #69 **merged** (`2323f28` on develop).
+**Status:** open-fdd #601 **merged** (`f904715` / `sha-f904715`) · playground #69 **merged** (`2323f28`).
 
 - [x] Phase 0 — GH tidy + csv+caddy on `sha-064eadb`
 - [x] OFDD-070b economizer CTE + OFDD-076b `building_id`→`site_id`
@@ -130,4 +130,4 @@ Docs: [`MILESTONE_D_CLOSEOUT.md`](../docs/migration/MILESTONE_D_CLOSEOUT.md),
 - [x] OFDD-UI-V20 WattLab section + compose.wattlab + Caddy smoke
 - [x] OFDD-069 findings draft persist + OFDD-065 Liberty deltas + MCP-IT doc
 - [x] ECM-ERV-001 HAS_EP_PROTOTYPE residual stub (not product cascade)
-- [ ] Merge #601 → GHCR `:sha-<final>` + `:nightly` → re-soak checklist
+- [x] Merge #601 → GHCR `:sha-<final>` + `:nightly` → re-soak checklist

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,14 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-07-30 — Liberty soak turnkey closeout
+
+- Merged open-fdd #601 → master `f904715` / GHCR `sha-f904715` (`f9047154dab631f0fecf81094bcc177c23c69712`).
+- Playground #69 on develop `2323f28` (BUG-ECM-015 + ECM-ERV stub).
+- Stack refreshed: csv + caddy (+ wattlab) on `sha-f904715` (API host :18080; Caddy :80).
+- Health: `3.3.0+f9047154dab6`. Re-soak: Site UI 1-site; Delete…; economizer;
+  Eng Findings 200; WattLab pages; Studio ss_*; MCP companion; no `d631e9c` pin.
+
 ## 2026-07-30 — Liberty soak turnkey (implementation)
 
 - OFDD-070b CTE damper project; OFDD-076b `building_id`→`site_id`; Brand Open FDD;

--- a/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
+++ b/openfdd_agent_spec/docs/MIGRATION_MATRIX.md
@@ -15,7 +15,7 @@ Do not fork parallel truth. Update existing audits when code changes.
 | [`BUILD_CHECKPOINTS.md`](../BUILD_CHECKPOINTS.md) | Milestone + Liberty soak checklist |
 
 **Tip under Liberty turnkey:** playground develop `2323f28` (BUG-ECM-015 + ERV stub).
-open-fdd PR **#601 is still open** — tip advances on merge (was `064eadbc` / `sha-064eadb`).
+open-fdd tip: `f9047154dab631f0fecf81094bcc177c23c69712` / GHCR `sha-f904715` (PR #601 merged).
 
 ---
 


### PR DESCRIPTION
## Summary
- Record Liberty soak turnkey closeout: open-fdd #601 → `sha-f904715`, playground #69 on develop.
- Tick BUILD_CHECKPOINTS merge/re-soak item; sync MIGRATION_MATRIX tip.

## Test plan
- [x] Docs-only
- [ ] Merge when CI/docs-guard green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Liberty turnkey status to reflect the merged open-fdd change.
  - Marked the related GHCR image and re-soak checklist items as complete.
  - Recorded updated integration details, image references, service endpoints, and health verification results.
  - Refreshed the migration guidance with the latest open-fdd tip and GHCR digest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->