### PR TITLE
docs: FDD→Twin knobs pointer + README honesty trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,34 +47,40 @@ The platform includes:
 - JWT authentication and a modern **Streamlit** engineering UI (`openfdd-ui`)
 - Apache Arrow & Feather columnar data storage
 - Apache DataFusion SQL analytics and fault detection (59 cookbook rules; 63 SQL registry IDs)
-- BACnet, Modbus, Haystack, and JSON API drivers (fieldbus container)
+- BACnet, Modbus, Haystack, and JSON API drivers (fieldbus container — **coming soon**; not production-ready in current builds)
 - Interactive plotting, dashboards, and CSV job workflows
 - Optional **external** agent integration via MCP stdio and JWT REST (no embedded chatbot)
 - Docker compose **build recipes** published to GitHub Container Registry
 
-Open-FDD supports flexible deployment recipes:
+Open-FDD ships several compose recipes. **What works today** vs **what is still in flight**:
 
-### Standalone (all-on-edge)
+### CSV-only (ready)
 
-`mqtt` + `central` + `ui` + `fieldbus` on one host — internal MQTTS, full OT + analytics.
+`central` + `ui` — bulk CSV / zip packages, historian, DataFusion FDD, Streamlit.
+No MQTT or fieldbus images required. Prefer this for lab soaks and agent workflows.
 
-### Central hub
+### Central hub (ready for analytics; OT edge later)
 
-`mqtt` + `central` + `ui` — cloud or LAN hub; remote fieldbus edges attach over MQTTS.
+`mqtt` + `central` + `ui` — LAN or cloud hub: JWT API, Feather historian, FDD, UI.
 
-### Fieldbus edge only
+Broker: `openfdd-mqtt` is **Mosquitto** with TLS (**MQTTS**). Future remote edges will
+publish telemetry to this broker; central will consume from it (edges will not expose
+central REST on the public internet).
 
-**Not ready yet** — reserved for a future release. Planned shape: a remote IoT
-edge speaking **JSON API**, **BACnet**, **Modbus**, and **Haystack**, forwarding
-telemetry to a remote Open-FDD **central** (cloud or LAN) over **MQTTS**.
+### Standalone (compose present; fieldbus OT not ready)
 
-Broker: the `openfdd-mqtt` image (Mosquitto) terminates TLS MQTTS for edge↔central
-ingest; edges do not talk to central REST over the public internet — they publish
-to the broker, and central consumes from it.
+`mqtt` + `central` + `ui` + `fieldbus` on one host is the intended all-on-edge
+layout (internal MQTTS + OT drivers + analytics). The **fieldbus / OT driver path
+is not ready in any current build** — treat standalone as “hub + broker today,”
+with live BACnet/Modbus/Haystack/JSON ingest landing soon.
 
-### CSV-only
+### Fieldbus edge only (not ready — any build)
 
-`central` + `ui` — bulk CSV jobs and FDD without pulling mqtt or fieldbus images.
+**Not ready yet** in nightly, beta, or local builds — reserved for a near-term
+release. Planned shape: a remote IoT edge speaking **JSON API**, **BACnet**,
+**Modbus**, and **Haystack**, forwarding points to a remote Open-FDD **central**
+(cloud or LAN) over **MQTTS** via the Mosquitto broker above. Do not run
+`./scripts/openfdd_stack_up.sh edge` expecting a supported product path today.
 
 ---
 
@@ -99,7 +105,7 @@ Rules use generic Haystack semantic roles, so they are portable across any model
 |-------|------|
 | [`ghcr.io/bbartling/openfdd-central`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-central) | MQTTS ingest, Feather historian, FDD registry, REST API |
 | [`ghcr.io/bbartling/openfdd-ui`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-ui) | Streamlit operator UI (vibe19 + WattLab export → central) |
-| [`ghcr.io/bbartling/openfdd-fieldbus`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-fieldbus) | BACnet / Modbus / Haystack edge |
+| [`ghcr.io/bbartling/openfdd-fieldbus`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-fieldbus) | BACnet / Modbus / Haystack / JSON edge (**not ready** — image may publish; product path soon) |
 | [`ghcr.io/bbartling/openfdd-mqtt`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mqtt) | Mosquitto MQTTS broker |
 | [`ghcr.io/bbartling/openfdd-mcp`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mcp) | Optional slim MCP stdio sidecar → central API |
 
@@ -119,9 +125,9 @@ export OPENFDD_ADMIN_PASSWORD='change-me'
 ### Other recipes
 
 ```bash
-./scripts/openfdd_stack_up.sh csv          # central + ui only
-./scripts/openfdd_stack_up.sh central      # hub without fieldbus
-./scripts/openfdd_stack_up.sh edge         # fieldbus only (set OPENFDD_MQTT_HOST)
+./scripts/openfdd_stack_up.sh csv          # central + ui only (recommended today)
+./scripts/openfdd_stack_up.sh central      # hub + mqtt broker (no fieldbus)
+./scripts/openfdd_stack_up.sh edge         # fieldbus-only — not a supported path yet
 ```
 
 See [Build recipes](docs/operations/build-recipes.md) and [docker/VERSION_MANIFEST.md](docker/VERSION_MANIFEST.md).

--- a/README.md
+++ b/README.md
@@ -44,11 +44,18 @@ Open-FDD is an open-source analytics platform for building automation that combi
 The platform includes:
 
 - Semantic building modeling using **Project Haystack** knowledge graphs
-- JWT authentication and a modern **Streamlit** engineering UI (`openfdd-ui`)
-- Apache Arrow & Feather columnar data storage
+- JWT authentication and a modern **Streamlit** engineering UI (`openfdd-ui`) —
+  vibe19 FDD/RCx workflows + **WattLab** section (Fuel / Twin / ECMs pages when
+  the `wattlab` package is mounted; otherwise honest “runner not attached”)
+- Apache Arrow & Feather columnar data storage; multi-site Hive (`building_id`)
 - Apache DataFusion SQL analytics and fault detection (59 cookbook rules; 63 SQL registry IDs)
+- Engineering Findings HITL + central report drafts (detection ≠ finding)
+- ECM spreadsheet helpers on **PyPI** (`open_fdd.ecm_engineering`); Studio Compare
+  `ss_*` / cascade handoff when WattLab workspace is shared
+- **EnergyPlus twin / G14 calibrate / IDF** — **not** in-process here; stays in
+  vibe20 + EnergyPlus-MCP (see [WattLab companion](docs/mcp-agents/companion-wattlab-energyplus.md))
 - BACnet, Modbus, Haystack, and JSON API drivers (fieldbus container — **coming soon**; not production-ready in current builds)
-- Interactive plotting, dashboards, and CSV job workflows
+- Interactive plotting, dashboards, and CSV / zip package workflows
 - Optional **external** agent integration via MCP stdio and JWT REST (no embedded chatbot)
 - Docker compose **build recipes** published to GitHub Container Registry
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@
 
 Open-FDD is an open-source analytics platform for building automation that combines **semantic knowledge graph modeling**, **live operational technology (OT) data**, and **high-performance columnar analytics**.
 
-**PyPI (`pip install open-fdd`):** ECM workbooks + optional pandas oracle (`open-fdd[oracle]` / `[reporting]` / `[vibe19]`). See [docs/ecm](docs/ecm/README.md) and [pandas cookbook](docs/rules/cookbook/pandas-cookbook.md). **FDD** (DataFusion SQL) ships via the **GHCR container stack**, not as the default PyPI runtime.
-
 The platform includes:
 
 - Semantic building modeling using **Project Haystack** knowledge graphs
@@ -132,6 +130,23 @@ docker run -i --rm --network host \
 ```
 
 Full tool list: [mcp/README.md](mcp/README.md).
+
+---
+
+## PyPI package (`pip install open-fdd`)
+
+The [PyPI package](https://pypi.org/project/open-fdd/) is a **library** surface — not a substitute for the operator stack.
+
+| Install | What you get |
+|---------|----------------|
+| `pip install open-fdd` | ECM engineering helpers / workbook builders |
+| `pip install "open-fdd[oracle]"` | Optional pandas oracle for rule screening |
+| `pip install "open-fdd[reporting]"` | Engineering findings / report writers |
+| `pip install "open-fdd[vibe19]"` | vibe19-aligned pandas rule helpers |
+
+**FDD (DataFusion SQL)** — historian, registry, Streamlit UI, BACnet/Modbus — ships in the **GHCR container stack** (`openfdd-central` / `openfdd-ui` / …), not as the default PyPI runtime. Use `./scripts/openfdd_stack_up.sh` (above) for that path.
+
+Docs: [ECM](docs/ecm/README.md) · [pandas cookbook](docs/rules/cookbook/pandas-cookbook.md) · [DataFusion SQL cookbook](docs/rules/cookbook/datafusion-sql-cookbook.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@
 
 > **Open-source semantic building analytics and HVAC supervisory fault detection. Local-first. On-premises. Vendor-neutral. Free to run at the edge or offline.**
 
-Open-FDD is an open-source analytics platform for building automation that combines **semantic knowledge graph modeling**, **live operational technology (OT) data**, and **high-performance columnar analytics**.
+Open-FDD is an open-source analytics platform for building automation that combines **Haystack-style semantic point roles** (JSON site/equipment maps), **live or historical OT/CSV data**, and **high-performance columnar analytics**.
 
 The platform includes:
 
-- Semantic building modeling using **Project Haystack** knowledge graphs
+- Building point modeling with **Project Haystack–style tags and roles** in JSON
+  (`column_map` / package maps — equipment → tags → CSV columns). Optional RDF/Turtle
+  + SPARQL views exist on the model API; they are **not** the primary CSV/FDD path
 - JWT authentication and a modern **Streamlit** engineering UI (`openfdd-ui`) —
   vibe19 FDD/RCx workflows + **WattLab** section (Fuel / Twin / ECMs pages when
   the `wattlab` package is mounted; otherwise honest “runner not attached”)

--- a/README.md
+++ b/README.md
@@ -43,23 +43,11 @@ Open-FDD is an open-source analytics platform for building automation that combi
 
 The platform includes:
 
-- Building point modeling with **Project Haystack–style tags and roles** in JSON
-  (`column_map` / package maps — equipment → tags → CSV columns). Optional RDF/Turtle
-  + SPARQL views exist on the model API; they are **not** the primary CSV/FDD path
-- JWT authentication and a modern **Streamlit** engineering UI (`openfdd-ui`) —
-  vibe19 FDD/RCx workflows + **WattLab** section (Fuel / Twin / ECMs pages when
-  the `wattlab` package is mounted; otherwise honest “runner not attached”)
-- Apache Arrow & Feather columnar data storage; multi-site Hive (`building_id`)
-- Apache DataFusion SQL analytics and fault detection (59 cookbook rules; 63 SQL registry IDs)
-- Engineering Findings HITL + central report drafts (detection ≠ finding)
-- ECM spreadsheet helpers on **PyPI** (`open_fdd.ecm_engineering`); Studio Compare
-  `ss_*` / cascade handoff when WattLab workspace is shared
-- **EnergyPlus twin / G14 calibrate / IDF** — **not** in-process here; stays in
-  vibe20 + EnergyPlus-MCP (see [WattLab companion](docs/mcp-agents/companion-wattlab-energyplus.md))
-- BACnet, Modbus, Haystack, and JSON API drivers (fieldbus container — **coming soon**; not production-ready in current builds)
-- Interactive plotting, dashboards, and CSV / zip package workflows
-- Optional **external** agent integration via MCP stdio and JWT REST (no embedded chatbot)
-- Docker compose **build recipes** published to GitHub Container Registry
+- Haystack-style point roles in JSON (`column_map`) — not RDF-first
+- Streamlit UI for CSV / zip FDD, RCx, and findings
+- Arrow historian + DataFusion SQL fault detection (59 cookbook rules)
+- ECM helpers on PyPI; EnergyPlus twin stays in vibe20 / EnergyPlus-MCP
+- Docker compose images on GHCR; OT fieldbus / MQTTS still roadmap
 
 Open-FDD ships compose recipes for lab and production-shaped stacks.
 
@@ -86,10 +74,6 @@ The **[HVAC FDD Rule Cookbook](https://bbartling.github.io/open-fdd/rules/cookbo
 
 - **[DataFusion SQL cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/datafusion-sql-cookbook.html)** — copy-paste SQL that runs on the edge/central Arrow historian
 - **[Pandas cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html)** — the same rules for notebooks, CSV exports, and RCx studies
-
-Rules use generic Haystack semantic roles, so they are portable across any modeled site. CI enforces a minimum of 59 rule headings in both cookbooks (`scripts/cookbook_parity_check.py`) — the catalog can never shrink.
-
-**Count contract (honest):** the public dual cookbooks document **59** rules. The production DataFusion SQL registry (`sql_rules/registry.yaml`) currently lists **63** rule IDs (59 cookbook-covered + SQL-only additions). See the [parity matrix](docs/rules/cookbook/parity-matrix.md). Do not treat badge “59” as the registry length.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,35 +52,22 @@ The platform includes:
 - Optional **external** agent integration via MCP stdio and JWT REST (no embedded chatbot)
 - Docker compose **build recipes** published to GitHub Container Registry
 
-Open-FDD ships several compose recipes. **What works today** vs **what is still in flight**:
+Open-FDD ships compose recipes for lab and production-shaped stacks.
 
-### CSV-only (ready)
+### CSV-only (ready today)
 
 `central` + `ui` — bulk CSV / zip packages, historian, DataFusion FDD, Streamlit.
-No MQTT or fieldbus images required. Prefer this for lab soaks and agent workflows.
+No MQTT or fieldbus required. Prefer this for lab soaks and agent workflows.
 
-### Central hub (ready for analytics; OT edge later)
+`central` (+ optional `mqtt` + `ui`) also covers JWT API hub soaks without OT drivers.
 
-`mqtt` + `central` + `ui` — LAN or cloud hub: JWT API, Feather historian, FDD, UI.
+### Roadmap — OT edge / MQTTS (not ready in any build yet)
 
-Broker: `openfdd-mqtt` is **Mosquitto** with TLS (**MQTTS**). Future remote edges will
-publish telemetry to this broker; central will consume from it (edges will not expose
-central REST on the public internet).
-
-### Standalone (compose present; fieldbus OT not ready)
-
-`mqtt` + `central` + `ui` + `fieldbus` on one host is the intended all-on-edge
-layout (internal MQTTS + OT drivers + analytics). The **fieldbus / OT driver path
-is not ready in any current build** — treat standalone as “hub + broker today,”
-with live BACnet/Modbus/Haystack/JSON ingest landing soon.
-
-### Fieldbus edge only (not ready — any build)
-
-**Not ready yet** in nightly, beta, or local builds — reserved for a near-term
-release. Planned shape: a remote IoT edge speaking **JSON API**, **BACnet**,
-**Modbus**, and **Haystack**, forwarding points to a remote Open-FDD **central**
-(cloud or LAN) over **MQTTS** via the Mosquitto broker above. Do not run
-`./scripts/openfdd_stack_up.sh edge` expecting a supported product path today.
+Soon: remote IoT edges speaking **JSON API**, **BACnet**, **Modbus**, and
+**Haystack**, publishing to a Mosquitto **MQTTS** broker (`openfdd-mqtt`); central
+consumes from the broker (no public REST to the edge). Standalone
+(`mqtt`+`central`+`ui`+`fieldbus`) and `stack_up.sh edge` are placeholders until
+that path ships — do not treat them as supported product recipes today.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -163,15 +163,19 @@ Native Rust: `cargo test --workspace`
 
 ## Releases
 
-| Channel | Tag | When to use |
-|---------|-----|-------------|
-| **Nightly** | `:nightly` / `:sha-*` | Dev, bench, agents (default) |
-| **Beta** | `:beta` / `3.3.0-beta.N` | Pilot sites after bench sign-off |
-| **Stable** | `:latest` / `3.3.0` | Production (when promoted) |
+**What we run day-to-day:** GHCR **`:nightly`** and immutable **`:sha-<7>`** (every
+`master` merge). Health reports Cargo **`3.3.0+<sha>`** (e.g. `3.3.0+f9047154dab6`).
 
-**Maintainers:** Actions → **Rust Release** → set `VERSION` match + channel `beta` or `stable`.
+| Channel | Tag | Status today |
+|---------|-----|----------------|
+| **Nightly** | `:nightly` / `:sha-*` | **Default** — bench, agents, soaks |
+| **Semver alias** | `:3.3.0` | Often retargeted with nightly publish (same digest as `:nightly` right now) — **not** a signed-off stable cut |
+| **Beta** | `:beta` / `3.3.0-beta.N` | **Not published yet** — next candidate in repo `VERSION` is `3.3.0-beta.1` |
+| **Stable** | `:latest` / promoted semver | **Not published yet** |
 
-Full policy: [Release channels](https://bbartling.github.io/open-fdd/operations/release-channels.html) · [GHCR images](https://bbartling.github.io/open-fdd/operations/ghcr-images.html)
+**Maintainers:** Actions → **Rust Release** → set `VERSION` match + channel `beta` or `stable` when promoting off nightly.
+
+Prefer `OPENFDD_IMAGE_TAG=sha-*` (or `nightly`) until a real beta/stable promotion exists. Full policy: [Release channels](https://bbartling.github.io/open-fdd/operations/release-channels.html) · [GHCR images](https://bbartling.github.io/open-fdd/operations/ghcr-images.html)
 
 Open-FDD is for **LAN / VPN / OT networks**, not public internet hosting.
 
@@ -179,4 +183,4 @@ Open-FDD is for **LAN / VPN / OT networks**, not public internet hosting.
 
 MIT — see [LICENSE](LICENSE).
 
-Version: **3.3.0-beta.1** (next release candidate — see [release channels](https://bbartling.github.io/open-fdd/operations/release-channels.html))
+Version: Cargo **`3.3.0`** on `master` · repo `VERSION` next candidate **`3.3.0-beta.1`** · run **`:nightly` / `:sha-*`** (see [release channels](https://bbartling.github.io/open-fdd/operations/release-channels.html))

--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ Open-FDD supports flexible deployment recipes:
 
 ### Fieldbus edge only
 
-`fieldbus` alone — attach to a remote central via MQTTS.
+**Not ready yet** — reserved for a future release. Planned shape: a remote IoT
+edge speaking **JSON API**, **BACnet**, **Modbus**, and **Haystack**, forwarding
+telemetry to a remote Open-FDD **central** (cloud or LAN) over **MQTTS**.
+
+Broker: the `openfdd-mqtt` image (Mosquitto) terminates TLS MQTTS for edge↔central
+ingest; edges do not talk to central REST over the public internet — they publish
+to the broker, and central consumes from it.
 
 ### CSV-only
 

--- a/docs/mcp-agents/companion-wattlab-energyplus.md
+++ b/docs/mcp-agents/companion-wattlab-energyplus.md
@@ -19,6 +19,8 @@ nav_order: 5
 
 Hard rule: **never** embed EnergyPlus IDF surgery inside `openfdd-mcp`. Always point Twin/ECM work at EnergyPlus-MCP / vibe20 wrappers.
 
+When FDD / dump implies as-operated schedules or bills disagree with Twin shape, read [`fdd-ops-to-twin-knobs.md`](fdd-ops-to-twin-knobs.md) then hand off to vibe20 skills (no IDF in openfdd-mcp).
+
 ## Golden loop (Liberty Twin → ECM)
 
 ```text
@@ -27,7 +29,8 @@ A. Context (every Twin/ECM session)
    2. tools/AGENT_CONTEXT.md + tools/BEST_PRACTICES_EPLUS_MCP_ECM.md
    3. reports/BUG_REPORT.md (OFDD-* / BUG-ECM-*)
    4. Skills: wattlab-energyplus-mcp, wattlab-twin-calibrate-dial,
-      wattlab-agent-driven-ecm-excel
+      wattlab-twin-ops-reheat-dial, wattlab-agent-driven-ecm-excel
+      Method SoT: BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md (ops/reheat chess)
 
 B. FDD / sites / historian  →  openfdd-mcp (or JWT REST)
 C. Twin / IDF / simulate     →  EnergyPlus-MCP or vibe20 mcp-exec

--- a/docs/mcp-agents/fdd-ops-to-twin-knobs.md
+++ b/docs/mcp-agents/fdd-ops-to-twin-knobs.md
@@ -1,0 +1,50 @@
+---
+title: FDD ops story → Twin schedule knobs
+parent: MCP Agents
+nav_order: 36
+---
+
+# FDD ops story → Twin schedule knobs (pointer)
+
+**Ownership:** EnergyPlus IDF / G14 calibration stays in **vibe20 / WattLab** —
+never inside `openfdd-mcp`. This page only tells open-fdd agents **where to
+hand off** when FDD / dump / bills disagree with the model.
+
+## When to leave open-fdd
+
+| Signal in Open FDD | Hand off to |
+|--------------------|-------------|
+| Scheduling / always-on / OA / fan runtime findings | vibe20 Twin dial (ops schedules) |
+| Monthly bills vs Twin ±% charts wrong shape | `wattlab-twin-ops-reheat-dial` + playbook §2c |
+| Envelope / glass / infil still annual-short | `wattlab-twin-calibrate-dial` Phase 1 |
+| IDF patch / EnergyPlus simulate | EnergyPlus-MCP / `wattlab mcp-exec` |
+
+## Recipe (generic — no campus IDs)
+
+1. Read monthly ±% (Studio dial charts) and any dump DAT/fan/OA story.
+2. Form **one** schedule/HW hypothesis (see reheat coupling below).
+3. Patch + simulate in vibe20 — score **both** fuels every run.
+4. Do **not** invent ECM savings or flip a previously-passing fuel.
+
+### Reheat coupling
+
+```
+more mechanical cooling (cool DAT, long fans, low OA)
+  → more reheat opportunity
+  → gas up unless HW is scheduled/softened
+```
+
+Prefer **daytime-only HW** in gas-spike months; full HW plant-off usually
+overshoots (that month gas ≈ −100% vs bills).
+
+## Pointers
+
+| Doc | Repo |
+|-----|------|
+| Method SoT | playground `vibe20_agent_spec/docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md` |
+| Playbook §2c | `vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md` |
+| Skills | `wattlab-twin-calibrate-dial`, `wattlab-twin-ops-reheat-dial` |
+| Dual-MCP | [`companion-wattlab-energyplus.md`](companion-wattlab-energyplus.md) |
+| Agent handoff | `/data/tools/AGENT_CONTEXT.md` when workspace mounted |
+
+G14 gate (both fuels): `|NMBE| ≤ 5%` and `CVRMSE ≤ 15%`.

--- a/docs/mcp-agents/index.md
+++ b/docs/mcp-agents/index.md
@@ -15,6 +15,7 @@ Open-FDD supports **MCP (Model Context Protocol)** for AI-assisted commissioning
 | [MCP setup](mcp.html) | Images, entrypoints, tools |
 | [Companion — WattLab + EnergyPlus](companion-wattlab-energyplus.html) | Twin/ECM: three surfaces, golden loop, dual-MCP |
 | [Dual-site MCP IT](dual-site-mcp-it.html) | Liberty B50≠B100 accuracy / historian / findings |
+| [FDD ops → Twin knobs](fdd-ops-to-twin-knobs.html) | Pointer: open-fdd findings → vibe20 G14 dial (no IDF in mcp) |
 | [Agent safety](agent-safety.html) | Hard boundaries for automation |
 | [Cursor & OpenClaw](cursor-openclaw.html) | IDE and edge agent wiring |
 | [External agent workflow](../examples/external-agents.html) | Codex, Cursor, MCP patterns |

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,12 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-07-30 — Twin dial AI context pointer (FDD → vibe20)
+
+- Added `docs/mcp-agents/fdd-ops-to-twin-knobs.md` (pointer-only; no E+ ownership).
+- Linked from mcp-agents index + companion WattLab/EnergyPlus (ops/reheat skills).
+- Docs-only; G14 dial recipe lives in vibe20 `BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`.
+
 ## 2026-07-30 — Liberty soak turnkey closeout
 
 - Merged open-fdd #601 → master `f904715` / GHCR `sha-f904715` (`f9047154dab631f0fecf81094bcc177c23c69712`).


### PR DESCRIPTION
## Summary
- MCP pointer doc: FDD ops story → Twin schedule knobs (no IDF in openfdd-mcp)
- README: honest ready vs roadmap OT/MQTT; nightly-first releases; Haystack = JSON tags/roles not RDF-first
- Trimmed platform bullets and dropped busy cookbook count-contract paragraphs

## Test plan
- [ ] Docs/CI green
- [ ] README skim for accuracy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified current CSV support, roadmap status, container images, package usage, and release channels.
  - Added guidance for handing off FDD findings to Twin schedule adjustments, including ownership boundaries and validation criteria.
  - Expanded companion EnergyPlus documentation with reheat workflow and related method references.
  - Added the new FDD-to-Twin guide to the MCP and agents documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->