### PR TITLE
fix(ecm): PyPI 4.1.2 save same-path, list_ecm_modules, FIELD_ALIASES

### DIFF
--- a/.github/workflows/publish-open-fdd.yml
+++ b/.github/workflows/publish-open-fdd.yml
@@ -84,7 +84,7 @@ jobs:
           import open_fdd
           from open_fdd.ecm_engineering import ECMJob
           from open_fdd.rules import CANONICAL_RULE_COUNT, RULES_BY_ID
-          assert open_fdd.__version__ == "4.1.1"
+          assert open_fdd.__version__ == "4.1.2"
           assert CANONICAL_RULE_COUNT == 59
           assert "SCHED-1" in RULES_BY_ID
           out = Path(tempfile.mkdtemp()) / "smoke.xlsx"

--- a/docs/ecm/README.md
+++ b/docs/ecm/README.md
@@ -62,10 +62,21 @@ job = (
     )
 )
 
+# set_many / add_ecm already persist; save() is idempotent on the same path
+# (BUG-OFDD-ECM-002) and can also copy to another path.
 job.save("Lincoln_Middle_School_ECMs.xlsx")
 ```
 
 The resulting XLSX contains the engineering inputs and formulas for human review.
+
+### Module names vs calculators
+
+```python
+from open_fdd.ecm_engineering import list_ecm_modules, list_calculators
+
+list_ecm_modules()   # names accepted by add_ecm (aliases included)
+list_calculators()   # independent Python benchmarks (job.calc), not sheet names
+```
 
 ## Independent benchmark
 

--- a/docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
+++ b/docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
@@ -38,6 +38,20 @@ Twin / WattLab Studio / EnergyPlus patch + notebook builder code primarily lives
 
 ---
 
+## PyPI `open_fdd.ecm_engineering` (OFDD train)
+
+| ID | Status | Summary |
+|----|--------|---------|
+| **BUG-OFDD-ECM-002** | Fixed in **4.1.2** | `ECMJob.save(same_path)` no longer raises `SameFileError`; inputs already persist via `set_many`. |
+| **BUG-OFDD-ECM-003** | Fixed in **4.1.2** | `list_ecm_modules()` — `add_ecm` names; distinct from `list_calculators()`. |
+| **BUG-OFDD-ECM-012** | Fixed in **4.1.2** | Expanded `FIELD_ALIASES` for DAT/SAT, ERV, occ, econ, schedules, DCV, etc. |
+| **BUG-OFDD-ECM-007** | Open → **4.2.0** | Missing `chiller_lockout` / `load_shed` / `schedule_align` modules. |
+| **BUG-OFDD-ECM-009** | Open → **4.2.0** | Honesty export: Contents / Provenance / Inputs / Industry_Screening / Measures (+ Demand). |
+| **BUG-ECM-018** | Open → **4.2.0** | FITTED vs BALLPARK honesty (see open bugs). |
+| **BUG-ECM-019** | Open → wattlab | Dual-AHU `sat_reset` preserve-dump (playground package bake). |
+
+---
+
 ## Fixed
 
 | ID | Notes |

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -8,6 +8,6 @@ Production FDD runs as DataFusion SQL in the GHCR container stack.
 
 from open_fdd.ecm_engineering import ECMJob
 
-__version__ = "4.1.1"
+__version__ = "4.1.2"
 
 __all__ = ["ECMJob", "__version__"]

--- a/open_fdd/ecm_engineering/__init__.py
+++ b/open_fdd/ecm_engineering/__init__.py
@@ -2,7 +2,7 @@
 from .algorithms import calculate, list_calculators
 from .crosscheck import crosscheck
 from .finance import npv, simple_payback
-from .job import ECMJob
+from .job import ECMJob, list_ecm_modules
 from .provenance import EvidenceValue, ProvenanceClass
 from .workbook import OpenFDDECMWorkbook, create_workbook
 from .contracts import (
@@ -17,6 +17,7 @@ from .stage2_workbook import build_stage2_workbook
 __all__ = [
     "calculate",
     "list_calculators",
+    "list_ecm_modules",
     "crosscheck",
     "npv",
     "simple_payback",
@@ -32,5 +33,3 @@ __all__ = [
     "CalculationTrace",
     "build_stage2_workbook",
 ]
-
-__version__ = "4.2.0"

--- a/open_fdd/ecm_engineering/job.py
+++ b/open_fdd/ecm_engineering/job.py
@@ -62,6 +62,13 @@ FIELD_ALIASES = {
         "pump_kwh": "boilrst.pump_kwh",
         "cost": "boilrst.cost",
     },
+    "ECM_Boiler_Replace": {
+        "therms": "boilrep.therms",
+        "old_eff": "boilrep.old_eff",
+        "new_eff": "boilrep.new_eff",
+        "cost": "boilrep.cost",
+        "load": "boilrep.load",
+    },
     "ECM_CHW_Reset": {
         "base_kwh": "chwrst.base_kwh",
         "reset_f": "chwrst.reset_f",
@@ -79,11 +86,32 @@ FIELD_ALIASES = {
         "pump_kwh": "cwrst.pump_kwh",
         "cost": "cwrst.cost",
     },
+    "ECM_DAT_Reset": {
+        "cool_kwh": "dat.cool_kwh",
+        "reset_f": "dat.reset_f",
+        "gain_per_f": "dat.gain_per_f",
+        "realization": "dat.realization",
+        "cost": "dat.cost",
+    },
     "ECM_Fan_Schedule": {
         "fan_kw": "fan_sched.fan_kw",
         "baseline_hours": "fan_sched.base_hours",
         "proposed_hours": "fan_sched.prop_hours",
         "cost": "fan_sched.cost",
+    },
+    "ECM_Cool_Schedule": {
+        "hours": "cool_sched.hours",
+        "tons": "cool_sched.tons",
+        "load_frac": "cool_sched.load_frac",
+        "kw_per_ton": "cool_sched.kw_per_ton",
+        "cost": "cool_sched.cost",
+    },
+    "ECM_Heat_Schedule": {
+        "hours": "heat_sched.hours",
+        "mbh": "heat_sched.mbh",
+        "load_frac": "heat_sched.load_frac",
+        "eff": "heat_sched.eff",
+        "cost": "heat_sched.cost",
     },
     "ECM_Optimal_Start": {
         "baseline_lead_min": "os.base_min",
@@ -102,6 +130,69 @@ FIELD_ALIASES = {
         "kw_per_ton": "econ.kwpt",
         "cost": "econ.cost",
     },
+    "ECM_Dewpoint_Econ": {
+        "chiller_hours": "dpe.run_hours",
+        "eligible_hours": "dpe.hours",
+        "realization": "dpe.realization",
+        "tons": "dpe.tons",
+        "load_fraction": "dpe.load",
+        "kw_per_ton": "dpe.kwpt",
+        "cost": "dpe.cost",
+    },
+    "ECM_DCV": {
+        "oa_cfm": "dcv.oa_cfm",
+        "reduction": "dcv.reduction",
+        "hours": "dcv.hours",
+        "heat_dt": "dcv.heat_dt",
+        "cool_dh": "dcv.cool_dh",
+        "heat_frac": "dcv.heat_frac",
+        "cool_frac": "dcv.cool_frac",
+        "heat_eff": "dcv.heat_eff",
+        "cop": "dcv.cop",
+        "cost": "dcv.cost",
+    },
+    "ECM_Energy_Recovery": {
+        "oa_cfm": "erv.oa_cfm",
+        "exchange_cfm": "erv.exchange_cfm",
+        "sens_eff": "erv.sens_eff",
+        "heat_dt": "erv.heat_dt",
+        "heat_hours": "erv.heat_hours",
+        "heat_eff": "erv.heat_eff",
+        "cool_dh": "erv.cool_dh",
+        "cool_hours": "erv.cool_hours",
+        "cop": "erv.cop",
+        "dp": "erv.dp",
+        "fan_eff": "erv.fan_eff",
+        "motor_kw": "erv.motor_kw",
+        "cost": "erv.cost",
+    },
+    "ECM_Occ_Sensors": {
+        "fan_kw": "occ.fan_kw",
+        "fan_hours": "occ.fan_hours",
+        "cool_kwh": "occ.cool_kwh",
+        "heat_therm": "occ.heat_therm",
+        "cost": "occ.cost",
+    },
+    "ECM_Unocc_OA_Heat": {
+        "cfm": "uoa_h.cfm",
+        "oa_base": "uoa_h.oa_base",
+        "oa_prop": "uoa_h.oa_prop",
+        "ra_t": "uoa_h.ra_t",
+        "oa_t": "uoa_h.oa_t",
+        "hours": "uoa_h.hours",
+        "eff": "uoa_h.eff",
+        "cost": "uoa_h.cost",
+    },
+    "ECM_Unocc_OA_Cool": {
+        "cfm": "uoa_c.cfm",
+        "oa_base": "uoa_c.oa_base",
+        "oa_prop": "uoa_c.oa_prop",
+        "h_oa": "uoa_c.h_oa",
+        "h_ra": "uoa_c.h_ra",
+        "hours": "uoa_c.hours",
+        "cop": "uoa_c.cop",
+        "cost": "uoa_c.cost",
+    },
     "ECM_Fan_VFD": {
         "design_kw": "fvfd.kw",
         "hours": "fvfd.hours",
@@ -118,7 +209,20 @@ FIELD_ALIASES = {
         "vfd_eff": "pvfd.vfd_eff",
         "cost": "pvfd.cost",
     },
+    "ECM_Dirty_Filter": {
+        "cfm": "filter.cfm",
+        "dp": "filter.dp",
+        "fan_eff": "filter.fan_eff",
+        "motor_eff": "filter.motor_eff",
+        "hours": "filter.hours",
+        "cost": "filter.cost",
+    },
 }
+
+
+def list_ecm_modules() -> list[str]:
+    """Friendly ``ECMJob.add_ecm`` names (not ``list_calculators()`` / ``calculate()``)."""
+    return sorted(MODULE_ALIASES)
 
 def _slug(name: str) -> str:
     clean = re.sub(r"[^A-Za-z0-9._-]+", "_", name.strip())
@@ -201,6 +305,11 @@ class ECMJob:
         return list(self._modules)
 
     def save(self, output_path: str | Path | None = None) -> Path:
+        """Return workbook path; copy when ``output_path`` differs.
+
+        Inputs are already flushed by ``set_global`` / ``add_ecm`` (``set_many``).
+        ``save()`` and ``save(self.path)`` are idempotent (BUG-OFDD-ECM-002).
+        """
         if output_path is not None:
             return self._book.save_as(output_path)
         return Path(self.path)

--- a/open_fdd/ecm_engineering/workbook.py
+++ b/open_fdd/ecm_engineering/workbook.py
@@ -126,8 +126,17 @@ class OpenFDDECMWorkbook:
         tmp.replace(self.path)
 
     def save_as(self, output_path: str | Path) -> Path:
-        output = Path(output_path)
+        """Copy workbook to ``output_path``.
+
+        Idempotent when ``output_path`` resolves to the current path (inputs are
+        already persisted by ``set_many`` / ``create``). Otherwise copies and
+        retargets ``self.path``.
+        """
+        output = Path(output_path).resolve()
+        current = Path(self.path).resolve()
+        if output == current:
+            return current
         output.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(self.path, output)
+        shutil.copyfile(current, output)
         self.path = output
         return output

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,14 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-07-30 — PyPI ECM bugfix train (4.1.2)
+
+- BUG-OFDD-ECM-002: `save_as` same-path guard (no `SameFileError`).
+- BUG-OFDD-ECM-003: `list_ecm_modules()` exported; docs vs `list_calculators()`.
+- BUG-OFDD-ECM-012: expanded `FIELD_ALIASES` for DAT/SAT, ERV, occ, econ, schedules, …
+- Version bump **4.1.1 → 4.1.2**; publish workflow assert updated.
+- Tests: `test_job_save_same_path`, `test_list_ecm_modules`.
+
 ## 2026-07-30 — Twin dial AI context pointer (FDD → vibe20)
 
 - Added `docs/mcp-agents/fdd-ops-to-twin-knobs.md` (pointer-only; no E+ ownership).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "4.1.1"
+version = "4.1.2"
 description = "Open-FDD libraries: ECM engineering workbooks plus pandas oracle rules, analytics, and Engineering Findings reporting. Production FDD remains the DataFusion/GHCR stack."
 readme = "docs/ecm/README.md"
 license = { text = "MIT" }

--- a/tests/ecm/test_job_save_same_path.py
+++ b/tests/ecm/test_job_save_same_path.py
@@ -1,0 +1,53 @@
+"""BUG-OFDD-ECM-002 — ECMJob.save same-path must not raise SameFileError."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from open_fdd.ecm_engineering import ECMJob
+
+
+def test_save_same_path_idempotent(tmp_path: Path) -> None:
+    name = "Lincoln Middle School"
+    # Keep CWD under tmp so default slug path is isolated
+    out = tmp_path / "Lincoln_Middle_School_ECMs.xlsx"
+    job = (
+        ECMJob(name, path=out)
+        .set_global(area_ft2=85000, electric_rate=0.145, gas_rate=0.92)
+        .add_ecm(
+            "static_pressure_reset",
+            fan_kw=55.9,
+            hours=4100,
+            baseline_speed=0.82,
+            proposed_speed=0.67,
+        )
+        .add_ecm(
+            "boiler_reset",
+            base_therms=48000,
+            base_eff=0.86,
+            prop_eff=0.92,
+        )
+    )
+    path = job.save(str(out))
+    assert path.resolve() == out.resolve()
+    assert out.is_file() and out.stat().st_size > 0
+    path2 = job.save()
+    assert path2.resolve() == out.resolve()
+    path3 = job.save(str(out))
+    assert path3.resolve() == out.resolve()
+
+
+def test_save_copy_to_other_path(tmp_path: Path) -> None:
+    src = tmp_path / "job.xlsx"
+    dst = tmp_path / "copy.xlsx"
+    job = ECMJob("Copy Test", path=src).set_global(electric_rate=0.12)
+    job.add_ecm(
+        "static_pressure_reset",
+        fan_kw=10.0,
+        hours=1000,
+        baseline_speed=0.8,
+        proposed_speed=0.7,
+    )
+    job.save(dst)
+    assert dst.is_file() and dst.stat().st_size > 0
+    assert src.is_file()

--- a/tests/ecm/test_list_ecm_modules.py
+++ b/tests/ecm/test_list_ecm_modules.py
@@ -1,0 +1,37 @@
+"""BUG-OFDD-ECM-003 / 012 — list_ecm_modules vs calculators; friendly sat_reset."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from open_fdd.ecm_engineering import ECMJob, list_calculators, list_ecm_modules
+
+
+def test_list_ecm_modules_disjoint_from_calculators() -> None:
+    modules = list_ecm_modules()
+    calcs = list_calculators()
+    assert "static_pressure_reset" in modules
+    assert "sat_reset" in modules
+    assert "fan_affinity" in calcs
+    assert "fan_affinity" not in modules
+    assert modules == sorted(modules)
+
+
+def test_add_ecm_from_list_ecm_modules(tmp_path: Path) -> None:
+    name = list_ecm_modules()[0]
+    job = ECMJob("t", path=tmp_path / "t.xlsx")
+    job.add_ecm(name)  # no KeyError even with no kwargs
+    assert job.selected_modules()
+
+
+def test_sat_reset_friendly_kwargs(tmp_path: Path) -> None:
+    job = ECMJob("sat", path=tmp_path / "sat.xlsx")
+    job.add_ecm(
+        "sat_reset",
+        cool_kwh=100_000.0,
+        reset_f=3.0,
+        gain_per_f=0.02,
+        realization=0.8,
+        cost=5000.0,
+    )
+    assert "ECM_DAT_Reset" in job.selected_modules()


### PR DESCRIPTION
## Summary
- **BUG-OFDD-ECM-002:** `save_as` / `ECMJob.save` same-path is idempotent (no `SameFileError`); inputs already persist via `set_many`.
- **BUG-OFDD-ECM-003:** add `list_ecm_modules()` (distinct from `list_calculators()`); docs/README.
- **BUG-OFDD-ECM-012:** expand `FIELD_ALIASES` for DAT/SAT, ERV, occ, econ, schedules, and related modules.
- Bump package to **4.1.2** (pyproject, `__version__`, publish workflow assert).

## Test plan
- [x] `pytest tests/ecm/test_job_save_same_path.py tests/ecm/test_list_ecm_modules.py`
- [ ] CI green (python-package / ecm-python as applicable)
- [ ] After merge: tag `open-fdd-v4.1.2` (or workflow_dispatch) → PyPI Trusted Publishing
- [ ] `pip install open-fdd==4.1.2` + same-path save smoke


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a way to view available ECM module names.
  - Expanded support for ECM input field names across schedules, sensors, economizers, energy recovery, and related systems.

- **Bug Fixes**
  - Saving a workbook to its existing path is now safe and repeatable.
  - Saving to a different path continues to preserve the original file.

- **Documentation**
  - Clarified workbook save behavior and the distinction between ECM modules and calculators.

- **Release**
  - Updated the package version to 4.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->