### PR TITLE
fix(ecm): require openpyxl for 4.2.0 honesty export

### DIFF
--- a/open_fdd/ecm_engineering/__init__.py
+++ b/open_fdd/ecm_engineering/__init__.py
@@ -2,7 +2,6 @@
 from .algorithms import calculate, list_calculators
 from .crosscheck import crosscheck
 from .finance import npv, simple_payback
-from .honesty_export import build_honesty_workbook
 from .honesty_status import MeasureHonestyStatus, classify_measure_status
 from .job import ECMJob, list_ecm_modules
 from .provenance import EvidenceValue, ProvenanceClass
@@ -15,6 +14,13 @@ from .contracts import (
 )
 from .calc_trace import CalculationTrace
 from .stage2_workbook import build_stage2_workbook
+
+
+def build_honesty_workbook(*args, **kwargs):
+    from .honesty_export import build_honesty_workbook as _build
+
+    return _build(*args, **kwargs)
+
 
 __all__ = [
     "calculate",

--- a/open_fdd/ecm_engineering/honesty_export.py
+++ b/open_fdd/ecm_engineering/honesty_export.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from openpyxl import Workbook
-
 from .honesty_status import (
     MeasureHonestyStatus,
     classify_measure_status,
@@ -34,6 +32,8 @@ def build_honesty_workbook(
     Skips Cover, Formula_Trace, and Documentation dumps (fold into Contents).
     Emits Demand when ``twin_payload`` includes demand; Twin_Calibrate when attached.
     """
+    from openpyxl import Workbook
+
     payload = twin_payload or {}
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/open_fdd/ecm_engineering/job.py
+++ b/open_fdd/ecm_engineering/job.py
@@ -5,7 +5,6 @@ from typing import Any
 import re
 
 from .algorithms import calculate
-from .honesty_export import build_honesty_workbook
 from .workbook import OpenFDDECMWorkbook
 
 MODULE_ALIASES = {
@@ -369,6 +368,8 @@ class ECMJob:
         """
         target = Path(output_path) if output_path is not None else Path(self.path)
         if self._export_honesty or self._twin_compare is not None:
+            from .honesty_export import build_honesty_workbook
+
             return build_honesty_workbook(
                 target,
                 twin_payload=self._twin_compare,

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,10 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-07-30 — PyPI 4.2.0 publish fix (openpyxl)
+
+- Core dep `openpyxl`; lazy honesty_export import so wheel smoke / bare install works.
+
 ## 2026-07-30 — PyPI ECM bugfix train (4.2.0)
 
 - BUG-OFDD-ECM-007: toolkit modules `chiller_lockout` / `load_shed` / `schedule_align`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,9 @@ keywords = [
     "building-automation",
     "open-fdd",
 ]
-dependencies = []
+dependencies = [
+    "openpyxl>=3.1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/bbartling/open-fdd"


### PR DESCRIPTION
## Summary
- Add `openpyxl` as a core dependency (honesty export is part of 4.2.0 ECM).
- Lazy-import honesty_export / openpyxl so package import stays robust.
- Retries failed `open-fdd-v4.2.0` PyPI publish (tag never uploaded).

## Test plan
- [x] `pytest tests/ecm`
- [ ] CI green → merge → delete/retag `open-fdd-v4.2.0` → publish success
- [ ] `pip install open-fdd==4.2.0` smoke


Made with [Cursor](https://cursor.com)