### PR TITLE
docs(ecm): mark BUG-ECM-019 fixed via wattlab sat_reset

### DIFF
--- a/docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
+++ b/docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
@@ -34,7 +34,7 @@ Twin / WattLab Studio / EnergyPlus patch + notebook builder code primarily lives
 | **BUG-ECM-014** | Open (doc) | Calendar FanAvail / OAT-bin hours ≠ formula FLH. Pasting calendar into Inputs over-predicts vs E+. Fix: Matchup calendar + FLH Inputs (`build_eplus_matched_ecm_workbook.py` / full-parity builder). |
 | **BUG-ECM-015** | Open | Studio **ECMs** tab does not show full-parity sheet↔E+ results. Page uses `reports/ecm_compare.json` with spreadsheet side `pending_external`; agent xlsx retired; legacy download only globs top-level `notebooks/*.xlsx` (misses `full_parity_ecm/`). |
 | **BUG-ECM-018** | Fixed in **4.2.0** | Exact sheet↔E+ match labeled **BALLPARK** (fitted FLH greenwash). Status must be **FITTED** when hours were reverse-fitted — see [Engineer upsell brief](../ecm/ENGINEER_UPSELL_BRIEF.md). |
-| **BUG-ECM-019** | Open (PyPI train) | Dual-AHU `sat_reset` flat 14°C / Sys1-only showed **−7 MWh**; correct patch (preserve winter dump + raise cool DAT on **both** AHUs) **+122 MWh** / +8.5k therms. Retire broken patch in PyPI → open-fdd. |
+| **BUG-ECM-019** | Fixed in wattlab [#74](https://github.com/bbartling/py-bacnet-stacks-playground/pull/74) | Dual-AHU `sat_reset` preserve winter dump heating SPM + raise cool DAT on **both** AHUs (retire flat 14°C / Sys1-only). open-fdd UI picks tip via `WATTLAB_PIP_SPEC`. |
 
 ---
 
@@ -48,7 +48,7 @@ Twin / WattLab Studio / EnergyPlus patch + notebook builder code primarily lives
 | **BUG-OFDD-ECM-007** | Fixed in **4.2.0** | Modules `chiller_lockout`, `load_shed`, `schedule_align` / `ahu_sched_align` (+ toolkit sheets). |
 | **BUG-OFDD-ECM-009** | Fixed in **4.2.0** | `attach_twin_compare` + honesty export (Contents / Provenance / Inputs / Industry_Screening / Measures / Demand). |
 | **BUG-ECM-018** | Fixed in **4.2.0** | `MeasureHonestyStatus` FITTED / BALLPARK / NO_EP / FAIL_SIGN; wiring_echo vs industry %. |
-| **BUG-ECM-019** | Open → wattlab | Dual-AHU `sat_reset` preserve-dump (playground package bake). |
+| **BUG-ECM-019** | Fixed wattlab #74 | Dual-AHU `sat_reset` preserve-dump (playground package bake → open-fdd UI). |
 
 ---
 


### PR DESCRIPTION
## Summary
- Register BUG-ECM-019 closed after playground [#74](https://github.com/bbartling/py-bacnet-stacks-playground/pull/74).

## Test plan
- [ ] Docs-only; CI green; squash-merge


Made with [Cursor](https://cursor.com)