### PR TITLE
docs(migration): P1-M0-02 seed React/Rust capability and exit ledgers

### DIFF
--- a/docs/migration/react-rust/API_CONTRACT_MATRIX.md
+++ b/docs/migration/react-rust/API_CONTRACT_MATRIX.md
@@ -1,0 +1,36 @@
+# API contract matrix (P1-M0-02 seed)
+
+Source: `services/central/src/routes.rs` at inventory time. Versioning/`/api/v1` policy lands in P1-M2-01.
+
+| route family | methods (see OpenAPI) | owner | React consumer target | contract status | notes |
+|---|---|---|---|---|---|
+| `/api/agent` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/agent/tools |
+| `/api/analytics` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/analytics/economizer, /api/analytics/mechanical-cooling, /api/analytics/metering, /api/analytics/rcx/ahu (+6) |
+| `/api/auth` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/auth/login, /api/auth/me, /api/auth/status |
+| `/api/building` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/building/snapshot |
+| `/api/capabilities` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/capabilities |
+| `/api/commands` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/commands, /api/commands/{command_id}/ack |
+| `/api/csv` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/csv/import/execute, /api/csv/import/package, /api/csv/import/package/roles, /api/csv/import/plan (+6) |
+| `/api/data-management` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/data-management/summary |
+| `/api/datasets` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/datasets, /api/datasets/{dataset_id}/preview |
+| `/api/edges` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/edges, /api/edges/{edge_id}, /api/edges/{edge_id}/discovery, /api/edges/{edge_id}/metadata |
+| `/api/export` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/export/meta |
+| `/api/faults` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/faults/status, /api/faults/summary |
+| `/api/fdd` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/fdd/cache/status, /api/fdd/equipment, /api/fdd/results, /api/fdd/roles (+6) |
+| `/api/fdd-rules` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/fdd-rules |
+| `/api/fdd-schema` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/fdd-schema/tables |
+| `/api/health` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/health, /api/health/stack |
+| `/api/host` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/host/stats |
+| `/api/ingest` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/ingest/stats |
+| `/api/jobs` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/jobs, /api/jobs/{job_id}, /api/jobs/{job_id}/archive, /api/jobs/{job_id}/dispositions (+9) |
+| `/api/reports` | see OpenAPI | central | Phase 1 React | EXISTS | e.g. /api/reports, /api/reports/draft, /api/reports/engineering-findings, /api/reports/templates (+3) |
+
+## Gaps for React (P1-M2+)
+
+| gap | needed by | status |
+|---|---|---|
+| Unified error envelope + request IDs | all screens | NOT_STARTED (M2-01) |
+| Async operation poll/cancel substrate | FDD run, import, reports | PARTIAL via fdd/status + jobs runs |
+| Typed TS client generation | SPA | NOT_STARTED (M2-02) |
+| Package upload streaming defenses in Rust | CAP-UPLOAD | PARTIAL (csv import exists; hostile ZIP suite TBD) |
+| Plot dataset contracts (not chart HTML) | CAP-PLOTS | NOT_STARTED (M5-B) |

--- a/docs/migration/react-rust/CAPABILITY_MATRIX.md
+++ b/docs/migration/react-rust/CAPABILITY_MATRIX.md
@@ -1,0 +1,29 @@
+# Capability matrix (P1-M0-02 seed)
+
+Generated from code inventory 2026-07-31. Statuses are honest; UNKNOWN means characterize in M1.
+
+Columns: capability_id | user scenario | Streamlit/Python owner | current API/storage | target React | target Rust | target SQL | parity class | fixture(s) | feature flag | status | deletion blocker
+
+| capability_id | user scenario | Streamlit/Python owner | current API/storage | target React | target Rust | target SQL | parity class | fixtures | flag | status | deletion blocker |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| CAP-AUTH | Login / JWT session | services/ui/streamlit_app.py + central_client | /api/auth/* | AuthPage | auth.rs | NONE | EXACT | UNKNOWN | react_ui | NOT_STARTED | Streamlit default |
+| CAP-UPLOAD | Upload CSV/ZIP package + hostile validation | package_io, multi_zip, data_loader | /api/csv/import/* | UploadPage | routes csv_import | NONE | SECURITY+EXACT | UNKNOWN | react_ui | NOT_STARTED | Python ZIP defenses still used |
+| CAP-SITE | Building/site selection + delete site data | site_model, streamlit_app | datasets + workspace paths | SitesPage | UNKNOWN | NONE | EXACT | UNKNOWN | react_ui | NOT_STARTED | Filesystem side effects |
+| CAP-JOBS | Jobs CRUD archive/restore/duplicate | ui_jobs, job_store | /api/jobs* | JobsPage | jobs.rs | NONE | EXACT | UNKNOWN | react_ui | PARTIAL_API | UI still Streamlit |
+| CAP-MAP | Role mapping + VAV/AHU relationships | mapping_wizard, role_map, role_map_gap | /api/fdd/roles + session-config | MappingPage | fdd routes | NONE | EXACT | UNKNOWN | react_ui | NOT_STARTED | UNKNOWN dual paths |
+| CAP-RULES | Rule catalog, tuning, run-all/selected | rule_card, central_client, streamlit_app | /api/fdd/rules*, /api/fdd/run | RulesPage | fdd_rules + routes | sql_rules/ | EXACT+NUMERIC | UNKNOWN | react_ui | PARTIAL_API | Pandas runner gated residual |
+| CAP-OVERVIEW | Overview metrics + equipment inventory | dashboard_contract, data_model_tree | /api/fdd/equipment, analytics/* | OverviewPage | routes + analytics | analytics SQL | NUMERIC | UNKNOWN | react_ui | NOT_STARTED |  |
+| CAP-PLOTS | FDD plots + fault overlays | charts, rule_plot_meta, rcx_plots | /api/fdd/series, results | PlotsPage | fdd series | SQL downsample | VISUAL+SEMANTIC | UNKNOWN | react_ui | NOT_STARTED |  |
+| CAP-RCX | RCx presets and rollups | ui_rcx_tab, analytics | /api/analytics/rcx/* | RcxPage | analytics.rs | SQL | NUMERIC | UNKNOWN | react_ui | PARTIAL_API |  |
+| CAP-WEATHER | Weather provenance + BAS vs reference | weather_resolver, open_meteo, weather_psychrometrics | UNKNOWN + weather helpers | WeatherPanel | UNKNOWN | NONE | TEMPORAL+NUMERIC | UNKNOWN | react_ui | NOT_STARTED | Python Open-Meteo client |
+| CAP-METER | Metering totals/periods | metering, ui_analytics | /api/analytics/metering | MeteringPanel | analytics | SQL | NUMERIC | UNKNOWN | react_ui | PARTIAL_API |  |
+| CAP-FINDINGS | Engineering findings + dispositions | eng_findings | /api/jobs/*/findings|dispositions, /api/reports/engineering-findings | FindingsPage | jobs.rs | NONE | EXACT | UNKNOWN | react_ui | PARTIAL_API |  |
+| CAP-REPORTS | Report/artifact generation + downloads | reports, report_downloads, docx_report, tuning_report | /api/reports* | ReportsPage | reports routes | NONE | ARTIFACT | UNKNOWN | react_ui | PARTIAL_API | DOCX may stay Python/oracle |
+| CAP-WATTLAB | WattLab dump + job-native handoff | wattlab_dump, ui_wattlab_job, ui_wattlab_studio | /api/jobs/*/wattlab/handoffs | WattLabPage | jobs wattlab | NONE | ARTIFACT | UNKNOWN | react_ui | PARTIAL_API |  |
+| CAP-ECM | ECM honesty / open-fdd package job UI | ui_ecm_job | PyPI open_fdd.ecm_engineering | EcmPage | UNKNOWN | NONE | ARTIFACT | UNKNOWN | react_ui | NOT_STARTED | PyPI wheel not Rust |
+| CAP-ERRORS | Auth errors, empty states, long-running work | browser_session, central_client | structured errors (M2) | shell | error envelope | NONE | INTERACTION | UNKNOWN | react_ui | NOT_STARTED |  |
+
+## Module coverage checklist (`services/ui/app/`)
+
+Every non-test callable module must appear in Python exit matrix and map to ≥1 capability or ORACLE-ONLY/TEST.
+

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,7 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-07-31 | Seed ledgers from code inventory; UNKNOWN dispositions until M1 | Accepted |
 | 2026-07-31 | ADR-001: React+TS SPA; central Rust backend; DataFusion FDD; no FastAPI sidecar; Streamlit default until Phase 2 | Accepted |
 | 2026-07-31 | Program kit lives in-repo at `tools/open-fdd-modernization/` | Accepted |
 | 2026-07-31 | Durable ledgers under `docs/migration/react-rust/` | Accepted |

--- a/docs/migration/react-rust/PARITY_EVIDENCE.md
+++ b/docs/migration/react-rust/PARITY_EVIDENCE.md
@@ -1,0 +1,14 @@
+# Parity evidence log (P1-M0-02 seed)
+
+No golden fixtures or screenshot baselines yet — those land in **P1-M1**.
+
+| date | capability_id | fixture hash | source commit | engine versions | result | mismatch class | PR |
+|------|---------------|--------------|---------------|-----------------|--------|----------------|-----|
+| — | — | — | — | — | — | — | — |
+
+## Rules
+
+- Record immutable commit SHAs and fixture content hashes.
+- Classify mismatches: EXACT / NUMERIC / TEMPORAL / INTERACTION / VISUAL / ARTIFACT / SECURITY / UNKNOWN.
+- UNKNOWN blocks “parity done.”
+- Do not treat FITTED ECM sheet≈E+ as independent validation (see ECM honesty docs).

--- a/docs/migration/react-rust/PYTHON_EXIT_MATRIX.md
+++ b/docs/migration/react-rust/PYTHON_EXIT_MATRIX.md
@@ -1,0 +1,76 @@
+# Python exit matrix (P1-M0-02 seed)
+
+Disposition UNKNOWN until M1 characterization proves REPLACE / ORACLE-ONLY / DELETE-P2 / ARCHIVE-DECISION / BLOCKED.
+
+| path | purpose | production consumers | oracle value | target owner | disposition | evidence required | deletion blocker |
+|---|---|---|---|---|---|---|---|
+| services/ui/streamlit_app.py | Product Streamlit entry | openfdd-ui image | behavioral reference | React SPA (Phase 2 delete) | UNKNOWN | parity + soak | default UI |
+| services/ui/requirements.txt | Streamlit deps | openfdd-ui | — | web image without Streamlit | UNKNOWN | image SBOM | default UI |
+| services/ui/app/agent_api.py | Local/agent helpers around UI workflows | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/agent_prerun.py | Pre-run checks before FDD | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/analytics.py | Pandas analytics helpers (oracle/UI) | services/ui | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/analytics_baseline.py | Baseline analytics helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/bootstrap.py | UI bootstrap / env wiring | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/browser_session.py | Streamlit browser session helpers | services/ui | MAYBE | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/cache.py | UI cache helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/central_client.py | HTTP client to central Rust /api | services/ui | MAYBE | generated TS client | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/charts.py | Plotly chart builders | services/ui | YES | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/column_map_json.py | Column map JSON IO | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/config.py | UI config | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/dashboard_contract.py | Dashboard contract shapes | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/data_contract.py | Dataset/package contracts | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/data_loader.py | CSV/package load into frames | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/data_model_tree.py | Equipment/model tree UI data | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/daytypes.py | Day-type classification | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/docx_report.py | DOCX report generation | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/eng_findings.py | Engineering findings UI/API glue | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/job_store.py | Jobs thin client (central SoT) | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/load_satisfaction.py | Load satisfaction analytics | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/mapping_wizard.py | Role/column mapping wizard | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/metering.py | Metering rollups (pandas path) | services/ui | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/model_seed.py | Model seed helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/multi_zip.py | Multi-ZIP package handling | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/occupancy.py | Occupancy helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/open_meteo.py | Open-Meteo weather fetch | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/package_io.py | Package ZIP IO / validation | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rcx_plots.py | RCx plot builders | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/report_downloads.py | Report download helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/reports.py | Report orchestration | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/role_map.py | Role map resolve/persist | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/role_map_gap.py | Role-map gap analysis | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rule_card.py | Rule card UI helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rule_plot_meta.py | Rule plot metadata | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/base.py | Rule base classes (emergency/oracle path) | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/common.py | Shared rule utilities | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/cookbook_catalog.py | Cookbook catalog shim | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/custom_boilerplate.py | Custom rule boilerplate | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/custom_registry.py | Custom rule registry | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/custom_rules.py | CUSTOM-* rule implementations | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/economizer_weather.py | Economizer weather helpers | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/operational_gate.py | Operational gate helpers | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/pid_hunting.py | PID hunting helpers | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/runner.py | Pandas rule runner (gated) | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/sensor_rate.py | Sensor rate helpers | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/rules/sensor_rate_profiles.py | Sensor rate profiles | services/ui (OPENFDD_ALLOW_PANDAS_FDD / custom rules) | YES | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/runtime_intervals.py | Runtime interval math | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/sidecar_maps.py | Sidecar map files | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/site_model.py | Site/building model helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/source_profile.py | Source profile helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/sql_sources.py | SQL source references for UI | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/topology_enrich.py | Topology enrichment | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/tuning_report.py | Tuning report export | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/ui_analytics.py | Analytics Streamlit section | services/ui | MAYBE | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/ui_ecm_job.py | ECM job / honesty UI | services/ui | MAYBE | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/ui_jobs.py | Jobs Streamlit section | services/ui | MAYBE | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/ui_rcx_tab.py | RCx Streamlit tab | services/ui | MAYBE | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/ui_wattlab_job.py | WattLab job handoff UI | services/ui | MAYBE | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/ui_wattlab_studio.py | WattLab Studio embed/section | services/ui | MAYBE | React | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/unit_system.py | Unit system preference | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/units.py | Unit conversion helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/wattlab_dump.py | WattLab dump ZIP builder | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/weather_psychrometrics.py | Psychrometric helpers | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| services/ui/app/weather_resolver.py | Weather series resolve | services/ui | MAYBE | Rust/DataFusion or React presentation | UNKNOWN | call-site + parity | UNKNOWN |
+| open_fdd/ecm_engineering | ECM workbooks (PyPI) | ui_ecm_job, Jobs/MCP docs | YES (engineering) | keep PyPI; React consumes API/export | KEEP-AS-LIB | packaging tests | customer ECM path |
+| open_fdd/rules | Pandas oracle | UI cookbook / emergency FDD / PyPI | YES | ORACLE-ONLY in prod images | UNKNOWN | no silent prod fallback | cookbook forever |
+| open_fdd/analytics | Pandas analytics libs | UI analytics shims / PyPI | YES | DataFusion analytics API | UNKNOWN | numeric parity | UNKNOWN |
+| open_fdd/reporting | Findings reporting libs | eng findings / PyPI | YES | Rust reports or ORACLE | UNKNOWN | artifact parity | UNKNOWN |

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,12 @@
 
 Newest first.
 
+## 2026-07-31 — P1-M0-02
+
+- Seeded CAPABILITY_MATRIX, PYTHON_EXIT_MATRIX, API_CONTRACT_MATRIX, PARITY_EVIDENCE from code inventory.
+- 16 capability rows; 64 production UI modules + streamlit entry; central `/api` families listed.
+- Dispositions remain UNKNOWN pending M1 characterization.
+
 ## 2026-07-31 — P1-M0-01
 
 - ADR-001 accepted; instruction hierarchy reconciled; policy CI wired.

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -141,7 +141,7 @@ Ledgers: [`docs/migration/react-rust/`](../docs/migration/react-rust/README.md) 
 ADR: [`ADR-001`](../docs/architecture/adr-001-react-rust-modernization.md)
 
 - [x] P1-M0-01 — ADR + instruction reconciliation + policy CI
-- [ ] P1-M0-02 — Capability / Python-exit / API ledgers
+- [x] P1-M0-02 — Capability / Python-exit / API ledgers
 - [ ] P1-M1 — Fixtures / oracle exporter / Streamlit baseline
 - [ ] P1-M2 — Rust contracts + React shell + async ops
 - [ ] P1-M3 — Parity shell / widgets / navigation

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,11 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-07-31 — P1-M0-02 migration ledgers
+
+- Seeded `docs/migration/react-rust/` capability / Python-exit / API / parity matrices from code.
+- openfdd_agent_spec BUILD_CHECKPOINTS updated (M0 complete).
+
 ## 2026-07-31 — P1-M0-01 React/Rust modernization ADR
 
 - Accepted ADR-001 (React+TS SPA → central Rust `/api`; DataFusion FDD; no FastAPI).


### PR DESCRIPTION
## Summary
- Seed `CAPABILITY_MATRIX`, `PYTHON_EXIT_MATRIX`, `API_CONTRACT_MATRIX`, `PARITY_EVIDENCE` under `docs/migration/react-rust/`.
- Code-truth inventory: Streamlit UI modules + central route families.
- Update `openfdd_agent_spec` BUILD_CHECKPOINTS / SESSION_LOG (M0 gate complete).

## Test plan
- [ ] Docs-only; CI green
- [ ] Address CodeRabbit if actionable
- [ ] Confirm every `services/ui/app/**/*.py` (non-test) appears in PYTHON_EXIT_MATRIX


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added React–Rust migration matrices covering API contracts, capabilities, Python components, and parity evidence.
  * Documented migration decisions, inventory status, validation requirements, and known gaps.
  * Added a session log for the migration-ledger milestone.
* **Chores**
  * Marked migration checkpoint P1-M0-02 as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->