### PR TITLE
feat(p1-m3-02): accessible parity widget primitives

### DIFF
--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,8 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-07-31 | Widget primitives use native HTML + CSS tokens; PlotlyHost is a placeholder div until M5 chart parity (no plotly npm in M3) | Accepted |
+| 2026-07-31 | Shared `WidgetBaseProps` + `widgetTestId()` convention for all parity controls | Accepted |
 | 2026-07-31 | React shell keeps Jobs/Upload sidebar routes (M4 path) while top tabs mirror Streamlit `REQUIRED_MAIN_SECTIONS` | Accepted |
 | 2026-07-31 | Streamlit has no checked-in theme; React navy/teal tokens + 21rem sidebar are the M3 geometry SoT | Accepted |
 | 2026-07-31 | Seed ledgers from code inventory; UNKNOWN dispositions until M1 | Accepted |

--- a/docs/migration/react-rust/PARITY_EVIDENCE.md
+++ b/docs/migration/react-rust/PARITY_EVIDENCE.md
@@ -2,6 +2,7 @@
 
 | date | capability_id | fixture hash | source commit | engine versions | result | mismatch class | PR |
 |------|---------------|--------------|---------------|-----------------|--------|----------------|-----|
+| 2026-07-31 | CAP-WIDGETS / shell | `widgets.test.tsx` + HomePage gallery | branch `feat/p1-m3-02-widget-primitives` | Vite React shell | Controlled widgets + keyboard/a11y baseline; Plotly host placeholder only | INTERACTION | P1-M3-02 |
 | 2026-07-31 | CAP-ERRORS / shell | LAYOUT_GEOMETRY.md + AppShell tests | branch `feat/p1-m3-01-layout-tokens` | Vite React shell | Frame tokens + section order + collapse; screenshots still deferred to visual harness | INTERACTION | P1-M3-01 |
 | 2026-07-31 | catalog (all CAP-*) | `tests/react_parity/manifest.json` | branch `feat/p1-m1-fixtures-oracle-baseline` | exporter schema `openfdd.react_parity.reference` | M1 fixtures + oracle byte-stable; interaction baseline NONVISUAL → M3 | — | P1-M1 / #615 |
 

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,12 @@
 
 Newest first.
 
+## 2026-07-31 — P1-M3-02
+
+- Accessible widget primitives under `frontend/web/src/components/widgets/` (select, slider, checkbox/radio/toggle, file upload, buttons, tabs, expander, metric, table, progress/badge, Plotly host placeholder, confirm modal, toast/inline alert).
+- `widgets.css` token-driven styles; barrel `index.ts`; vitest coverage for select, slider keyboard, checkbox, modal, expander.
+- Home widget gallery demo on HomePage. Next: P1-M3-03 routing/session.
+
 ## 2026-07-31 — P1-M3-01
 
 - Expanded design tokens + Streamlit-like shell geometry (`LAYOUT_GEOMETRY.md`).

--- a/frontend/web/src/components/widgets/Button.tsx
+++ b/frontend/web/src/components/widgets/Button.tsx
@@ -1,0 +1,56 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface ButtonProps extends Omit<WidgetBaseProps, "label"> {
+  label: string;
+  variant?: "primary" | "secondary" | "danger";
+  type?: "button" | "submit" | "reset";
+  onClick?: () => void;
+}
+
+export function Button({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  variant = "primary",
+  type = "button",
+  onClick,
+}: ButtonProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <div
+      className={`widget widget--button widget--${density}`}
+      data-testid={widgetTestId(`button-${id}`, testId)}
+    >
+      <button
+        id={id}
+        type={type}
+        className={`widget-btn widget-btn--${variant}${density === "compact" ? " widget-btn--compact" : ""}`}
+        disabled={isDisabled}
+        aria-busy={loading || undefined}
+        aria-describedby={description ? `${id}-desc` : undefined}
+        aria-invalid={Boolean(error)}
+        onClick={onClick}
+      >
+        {loading ? <span className="widget-btn__spinner" aria-hidden /> : null}
+        {label}
+      </button>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Checkbox.tsx
+++ b/frontend/web/src/components/widgets/Checkbox.tsx
@@ -1,0 +1,59 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface CheckboxProps extends WidgetBaseProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function Checkbox({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  checked,
+  onChange,
+}: CheckboxProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <div
+      className={`widget widget--checkbox widget--${density}${error ? " widget--error" : ""}${isDisabled ? " widget--disabled" : ""}`}
+      data-testid={widgetTestId(`checkbox-${id}`, testId)}
+    >
+      <div className="widget__check-row">
+        <input
+          id={id}
+          type="checkbox"
+          className="widget__checkbox"
+          checked={checked}
+          disabled={isDisabled}
+          aria-invalid={Boolean(error)}
+          aria-describedby={
+            description ? `${id}-desc` : error ? `${id}-error` : undefined
+          }
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <div>
+          <label className="widget__check-label" htmlFor={id}>
+            {label}
+          </label>
+          {description ? (
+            <p className="widget__description" id={`${id}-desc`}>
+              {description}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {error ? (
+        <p className="widget__error" id={`${id}-error`} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/ConfirmModal.tsx
+++ b/frontend/web/src/components/widgets/ConfirmModal.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import { widgetTestId } from "./types";
+
+export interface ConfirmModalProps {
+  id: string;
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  loading?: boolean;
+  testId?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({
+  id,
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  loading,
+  testId,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      cancelRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="widget-modal-backdrop"
+      data-testid={widgetTestId(`modal-${id}`, testId)}
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        aria-describedby={`${id}-body`}
+        className="widget-modal"
+      >
+        <h2 id={`${id}-title`} className="widget-modal__title">
+          {title}
+        </h2>
+        <p id={`${id}-body`} className="widget-modal__body">
+          {message}
+        </p>
+        <div className="widget-modal__actions">
+          <button
+            ref={cancelRef}
+            type="button"
+            className="widget-btn widget-btn--secondary"
+            disabled={loading}
+            onClick={onCancel}
+            data-testid={`${id}-cancel`}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className="widget-btn widget-btn--danger"
+            disabled={loading}
+            aria-busy={loading || undefined}
+            onClick={onConfirm}
+            data-testid={`${id}-confirm`}
+          >
+            {loading ? <span className="widget-btn__spinner" aria-hidden /> : null}
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/DataTable.tsx
+++ b/frontend/web/src/components/widgets/DataTable.tsx
@@ -1,0 +1,85 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface DataTableColumn<T extends Record<string, unknown>> {
+  key: keyof T & string;
+  header: string;
+}
+
+export interface DataTableProps<T extends Record<string, unknown>>
+  extends WidgetBaseProps {
+  columns: DataTableColumn<T>[];
+  rows: T[];
+}
+
+export function DataTable<T extends Record<string, unknown>>({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  columns,
+  rows,
+}: DataTableProps<T>) {
+  return (
+    <div
+      className={`widget widget--table widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`table-${id}`, testId)}
+      aria-disabled={disabled || undefined}
+      aria-busy={loading || undefined}
+    >
+      <span className="widget__label" id={`${id}-label`}>
+        {label}
+      </span>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <div className="widget-table-wrap">
+        <table
+          className={`widget-table${density === "compact" ? " widget-table--compact" : ""}`}
+          aria-labelledby={`${id}-label`}
+          aria-describedby={description ? `${id}-desc` : undefined}
+        >
+          <thead>
+            <tr>
+              {columns.map((col) => (
+                <th key={col.key} scope="col">
+                  {col.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={columns.length}>Loading…</td>
+              </tr>
+            ) : rows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length}>No data</td>
+              </tr>
+            ) : (
+              rows.map((row, rowIdx) => (
+                <tr key={rowIdx}>
+                  {columns.map((col) => (
+                    <td key={col.key}>{String(row[col.key] ?? "")}</td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/DownloadButton.tsx
+++ b/frontend/web/src/components/widgets/DownloadButton.tsx
@@ -1,0 +1,59 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface DownloadButtonProps extends Omit<WidgetBaseProps, "label"> {
+  label: string;
+  href: string;
+  filename?: string;
+  variant?: "primary" | "secondary";
+}
+
+export function DownloadButton({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  href,
+  filename,
+  variant = "secondary",
+}: DownloadButtonProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <div
+      className={`widget widget--download widget--${density}`}
+      data-testid={widgetTestId(`download-${id}`, testId)}
+    >
+      <a
+        id={id}
+        href={isDisabled ? undefined : href}
+        download={filename}
+        className={`widget-btn widget-btn--${variant}${density === "compact" ? " widget-btn--compact" : ""}`}
+        aria-disabled={isDisabled || undefined}
+        aria-busy={loading || undefined}
+        aria-describedby={description ? `${id}-desc` : undefined}
+        tabIndex={isDisabled ? -1 : 0}
+        onClick={(e) => {
+          if (isDisabled) e.preventDefault();
+        }}
+      >
+        {loading ? <span className="widget-btn__spinner" aria-hidden /> : null}
+        {label}
+      </a>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Expander.tsx
+++ b/frontend/web/src/components/widgets/Expander.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface ExpanderProps extends WidgetBaseProps {
+  expanded: boolean;
+  onChange: (expanded: boolean) => void;
+  children: ReactNode;
+}
+
+export function Expander({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  expanded,
+  onChange,
+  children,
+}: ExpanderProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <div
+      className={`widget widget--expander widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`expander-${id}`, testId)}
+    >
+      <div className={`widget-expander${expanded ? " widget-expander--open" : ""}`}>
+        <button
+          type="button"
+          id={`${id}-trigger`}
+          className="widget-expander__trigger"
+          aria-expanded={expanded}
+          aria-controls={`${id}-content`}
+          aria-describedby={description ? `${id}-desc` : undefined}
+          disabled={isDisabled}
+          onClick={() => onChange(!expanded)}
+        >
+          <span>{label}</span>
+          <span className="widget-expander__icon" aria-hidden>
+            ▼
+          </span>
+        </button>
+        {description ? (
+          <p className="widget__description" id={`${id}-desc`} style={{ padding: "0 var(--space-md)" }}>
+            {description}
+          </p>
+        ) : null}
+        {expanded ? (
+          <div
+            id={`${id}-content`}
+            role="region"
+            aria-labelledby={`${id}-trigger`}
+            className="widget-expander__content"
+          >
+            {children}
+          </div>
+        ) : null}
+      </div>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/FileUpload.tsx
+++ b/frontend/web/src/components/widgets/FileUpload.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useRef, useState } from "react";
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface FileUploadProps extends WidgetBaseProps {
+  accept?: string;
+  multiple?: boolean;
+  files: File[];
+  onChange: (files: File[]) => void;
+}
+
+export function FileUpload({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  accept,
+  multiple = false,
+  files,
+  onChange,
+}: FileUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const isDisabled = disabled || loading;
+
+  const handleFiles = useCallback(
+    (incoming: FileList | null) => {
+      if (!incoming || isDisabled) return;
+      const list = Array.from(incoming);
+      onChange(multiple ? [...files, ...list] : list.slice(0, 1));
+    },
+    [files, isDisabled, multiple, onChange],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      handleFiles(e.dataTransfer.files);
+    },
+    [handleFiles],
+  );
+
+  return (
+    <div
+      className={`widget widget--file widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`file-upload-${id}`, testId)}
+    >
+      <span className="widget__label" id={`${id}-label`}>
+        {label}
+      </span>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <div
+        className={`widget__dropzone${dragOver ? " widget__dropzone--dragover" : ""}${isDisabled ? " widget__dropzone--disabled" : ""}`}
+        role="button"
+        tabIndex={isDisabled ? -1 : 0}
+        aria-labelledby={`${id}-label`}
+        aria-describedby={description ? `${id}-desc` : undefined}
+        aria-disabled={isDisabled}
+        onClick={() => !isDisabled && inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if ((e.key === "Enter" || e.key === " ") && !isDisabled) {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!isDisabled) setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+      >
+        <input
+          ref={inputRef}
+          id={id}
+          type="file"
+          className="widget__dropzone-input"
+          accept={accept}
+          multiple={multiple}
+          disabled={isDisabled}
+          aria-invalid={Boolean(error)}
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        <p>Drop files here or click to browse</p>
+      </div>
+      {files.length > 0 ? (
+        <ul className="widget__file-list" aria-live="polite">
+          {files.map((f) => (
+            <li key={`${f.name}-${f.size}`}>{f.name}</li>
+          ))}
+        </ul>
+      ) : null}
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Metric.tsx
+++ b/frontend/web/src/components/widgets/Metric.tsx
@@ -1,0 +1,54 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface MetricDelta {
+  value: string;
+  direction?: "up" | "down" | "neutral";
+}
+
+export interface MetricProps extends WidgetBaseProps {
+  value: string | number;
+  delta?: MetricDelta;
+}
+
+export function Metric({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  value,
+  delta,
+}: MetricProps) {
+  return (
+    <div
+      className={`widget-metric widget-metric--${density}${error ? " widget--error" : ""}${disabled ? " widget--disabled" : ""}`}
+      data-testid={widgetTestId(`metric-${id}`, testId)}
+      aria-disabled={disabled || undefined}
+      aria-busy={loading || undefined}
+    >
+      <p className="widget-metric__label">{label}</p>
+      {description ? (
+        <p className="widget__description">{description}</p>
+      ) : null}
+      <p className="widget-metric__value" aria-live="polite">
+        {loading ? "…" : value}
+      </p>
+      {delta && !loading ? (
+        <p
+          className={`widget-metric__delta widget-metric__delta--${delta.direction ?? "neutral"}`}
+        >
+          {delta.value}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/PlotlyHost.tsx
+++ b/frontend/web/src/components/widgets/PlotlyHost.tsx
@@ -1,0 +1,45 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface PlotlyHostProps extends Omit<WidgetBaseProps, "label"> {
+  label?: string;
+  /** Reserved for future Plotly figure JSON — not wired in M3-02. */
+  figureId?: string;
+}
+
+export function PlotlyHost({
+  id,
+  label = "Chart",
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  figureId,
+}: PlotlyHostProps) {
+  return (
+    <div
+      className={`widget widget--plotly${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`plotly-host-${id}`, testId)}
+      aria-disabled={disabled || undefined}
+      aria-busy={loading || undefined}
+    >
+      <span className="widget__label">{label}</span>
+      {description ? (
+        <p className="widget__description">{description}</p>
+      ) : null}
+      <div
+        className="widget-plotly-host"
+        data-figure-id={figureId}
+        aria-label={label}
+      >
+        {loading ? "Loading chart…" : "Plotly chart placeholder (M3-02)"}
+      </div>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Progress.tsx
+++ b/frontend/web/src/components/widgets/Progress.tsx
@@ -1,0 +1,119 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface ProgressProps extends WidgetBaseProps {
+  value: number;
+  max?: number;
+  showLabel?: boolean;
+}
+
+export function Progress({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  value,
+  max = 100,
+  showLabel = true,
+}: ProgressProps) {
+  const pct = Math.min(100, Math.max(0, (value / max) * 100));
+
+  return (
+    <div
+      className={`widget widget--progress widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`progress-${id}`, testId)}
+      aria-disabled={disabled || undefined}
+    >
+      <span className="widget__label" id={`${id}-label`}>
+        {label}
+      </span>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <div
+        className="widget-progress"
+        role="progressbar"
+        aria-labelledby={`${id}-label`}
+        aria-describedby={description ? `${id}-desc` : undefined}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-valuenow={loading ? undefined : value}
+        aria-busy={loading || undefined}
+      >
+        <div className="widget-progress__track">
+          <div
+            className="widget-progress__bar"
+            style={{ width: loading ? "30%" : `${pct}%` }}
+          />
+        </div>
+        {showLabel ? (
+          <span className="widget-progress__label">
+            {loading ? "Loading…" : `${Math.round(pct)}%`}
+          </span>
+        ) : null}
+      </div>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export type StatusBadgeVariant =
+  | "success"
+  | "warning"
+  | "danger"
+  | "info"
+  | "neutral";
+
+export interface StatusBadgeProps extends Omit<WidgetBaseProps, "label"> {
+  label: string;
+  variant?: StatusBadgeVariant;
+}
+
+export function StatusBadge({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  variant = "neutral",
+}: StatusBadgeProps) {
+  return (
+    <div
+      className={`widget widget--badge widget--${density}`}
+      data-testid={widgetTestId(`badge-${id}`, testId)}
+    >
+      <span
+        id={id}
+        className={`widget-badge widget-badge--${variant}`}
+        aria-disabled={disabled || undefined}
+        aria-busy={loading || undefined}
+        aria-describedby={description ? `${id}-desc` : undefined}
+      >
+        {loading ? "…" : label}
+      </span>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/RadioGroup.tsx
+++ b/frontend/web/src/components/widgets/RadioGroup.tsx
@@ -1,0 +1,83 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface RadioOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface RadioGroupProps extends WidgetBaseProps {
+  value: string;
+  options: RadioOption[];
+  onChange: (value: string) => void;
+}
+
+export function RadioGroup({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  value,
+  options,
+  onChange,
+}: RadioGroupProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <fieldset
+      className={`widget widget--radio widget--${density}${error ? " widget--error" : ""}${isDisabled ? " widget--disabled" : ""}`}
+      data-testid={widgetTestId(`radio-${id}`, testId)}
+      disabled={isDisabled}
+      aria-invalid={Boolean(error)}
+    >
+      <legend className="widget__label">{label}</legend>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <div
+        className="widget__radio-group"
+        role="radiogroup"
+        aria-labelledby={`${id}-legend`}
+        aria-describedby={description ? `${id}-desc` : undefined}
+      >
+        {options.map((opt) => {
+          const optionId = `${id}-${opt.value}`;
+          return (
+            <div key={opt.value} className="widget__radio-row">
+              <input
+                id={optionId}
+                type="radio"
+                name={id}
+                className="widget__radio"
+                value={opt.value}
+                checked={value === opt.value}
+                disabled={isDisabled}
+                onChange={() => onChange(opt.value)}
+              />
+              <div>
+                <label className="widget__check-label" htmlFor={optionId}>
+                  {opt.label}
+                </label>
+                {opt.description ? (
+                  <p className="widget__description">{opt.description}</p>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </fieldset>
+  );
+}

--- a/frontend/web/src/components/widgets/Select.tsx
+++ b/frontend/web/src/components/widgets/Select.tsx
@@ -1,0 +1,126 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps extends WidgetBaseProps {
+  value: string;
+  options: SelectOption[];
+  onChange: (value: string) => void;
+  multiple?: false;
+}
+
+export interface MultiSelectProps extends WidgetBaseProps {
+  value: string[];
+  options: SelectOption[];
+  onChange: (value: string[]) => void;
+}
+
+export function Select({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  value,
+  options,
+  onChange,
+}: SelectProps) {
+  return (
+    <div
+      className={`widget widget--select widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`select-${id}`, testId)}
+    >
+      <label className="widget__label" htmlFor={id}>
+        {label}
+      </label>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <select
+        id={id}
+        className="widget__control"
+        value={value}
+        disabled={disabled || loading}
+        aria-invalid={Boolean(error)}
+        aria-describedby={description ? `${id}-desc` : undefined}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function MultiSelect({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  value,
+  options,
+  onChange,
+}: MultiSelectProps) {
+  return (
+    <div
+      className={`widget widget--multiselect widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`multiselect-${id}`, testId)}
+    >
+      <span className="widget__label" id={`${id}-label`}>
+        {label}
+      </span>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <select
+        id={id}
+        className="widget__control"
+        multiple
+        value={value}
+        disabled={disabled || loading}
+        aria-labelledby={`${id}-label`}
+        aria-invalid={Boolean(error)}
+        aria-describedby={description ? `${id}-desc` : undefined}
+        onChange={(e) =>
+          onChange(
+            Array.from(e.target.selectedOptions).map((o) => o.value),
+          )
+        }
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Slider.tsx
+++ b/frontend/web/src/components/widgets/Slider.tsx
@@ -1,0 +1,121 @@
+import { useCallback, type KeyboardEvent } from "react";
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface SliderProps extends WidgetBaseProps {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (value: number) => void;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function stepValue(
+  current: number,
+  delta: number,
+  min: number,
+  max: number,
+  step: number,
+): number {
+  const next = current + delta * step;
+  const rounded = Math.round(next / step) * step;
+  return clamp(Number(rounded.toFixed(10)), min, max);
+}
+
+export function Slider({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+}: SliderProps) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (disabled || loading) return;
+
+      let next: number | null = null;
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowUp":
+          next = stepValue(value, 1, min, max, step);
+          break;
+        case "ArrowLeft":
+        case "ArrowDown":
+          next = stepValue(value, -1, min, max, step);
+          break;
+        case "PageUp":
+          next = stepValue(value, 10, min, max, step);
+          break;
+        case "PageDown":
+          next = stepValue(value, -10, min, max, step);
+          break;
+        case "Home":
+          next = min;
+          break;
+        case "End":
+          next = max;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      onChange(next);
+    },
+    [disabled, loading, value, min, max, step, onChange],
+  );
+
+  return (
+    <div
+      className={`widget widget--slider widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`slider-${id}`, testId)}
+    >
+      <label className="widget__label" htmlFor={id}>
+        {label}
+      </label>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <div className="widget__slider-row">
+        <input
+          id={id}
+          type="range"
+          className="widget__slider widget__control"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          disabled={disabled || loading}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={value}
+          aria-invalid={Boolean(error)}
+          aria-describedby={description ? `${id}-desc` : undefined}
+          onChange={(e) => onChange(Number(e.target.value))}
+          onKeyDown={handleKeyDown}
+        />
+        <span className="widget__slider-value" aria-hidden>
+          {value}
+        </span>
+      </div>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Tabs.tsx
+++ b/frontend/web/src/components/widgets/Tabs.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface TabItem {
+  id: string;
+  label: string;
+  content: ReactNode;
+  disabled?: boolean;
+}
+
+export interface TabsProps extends Omit<WidgetBaseProps, "label"> {
+  label: string;
+  tabs: TabItem[];
+  activeTabId: string;
+  onChange: (tabId: string) => void;
+}
+
+export function Tabs({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  tabs,
+  activeTabId,
+  onChange,
+}: TabsProps) {
+  const isDisabled = disabled || loading;
+  const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
+
+  return (
+    <div
+      className={`widget widget--tabs widget--${density}${error ? " widget--error" : ""}`}
+      data-testid={widgetTestId(`tabs-${id}`, testId)}
+    >
+      <span className="widget__label" id={`${id}-label`}>
+        {label}
+      </span>
+      {description ? (
+        <p className="widget__description" id={`${id}-desc`}>
+          {description}
+        </p>
+      ) : null}
+      <div className="widget-tabs">
+        <div
+          role="tablist"
+          aria-labelledby={`${id}-label`}
+          aria-describedby={description ? `${id}-desc` : undefined}
+          className="widget-tabs__list"
+        >
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              id={`${id}-tab-${tab.id}`}
+              className={`widget-tabs__tab${activeTabId === tab.id ? " widget-tabs__tab--active" : ""}`}
+              aria-selected={activeTabId === tab.id}
+              aria-controls={`${id}-panel-${tab.id}`}
+              disabled={isDisabled || tab.disabled}
+              tabIndex={activeTabId === tab.id ? 0 : -1}
+              onClick={() => onChange(tab.id)}
+              onKeyDown={(e) => {
+                const idx = tabs.findIndex((t) => t.id === tab.id);
+                if (e.key === "ArrowRight" && idx < tabs.length - 1) {
+                  e.preventDefault();
+                  onChange(tabs[idx + 1].id);
+                } else if (e.key === "ArrowLeft" && idx > 0) {
+                  e.preventDefault();
+                  onChange(tabs[idx - 1].id);
+                }
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        {activeTab ? (
+          <div
+            role="tabpanel"
+            id={`${id}-panel-${activeTab.id}`}
+            aria-labelledby={`${id}-tab-${activeTab.id}`}
+            className="widget-tabs__panel"
+            tabIndex={0}
+          >
+            {activeTab.content}
+          </div>
+        ) : null}
+      </div>
+      {error ? (
+        <p className="widget__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Toast.tsx
+++ b/frontend/web/src/components/widgets/Toast.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+import { widgetTestId } from "./types";
+
+export type AlertVariant = "info" | "success" | "warning" | "danger";
+
+export interface InlineAlertProps {
+  id: string;
+  variant?: AlertVariant;
+  title?: string;
+  children: ReactNode;
+  testId?: string;
+  onDismiss?: () => void;
+}
+
+export function InlineAlert({
+  id,
+  variant = "info",
+  title,
+  children,
+  testId,
+  onDismiss,
+}: InlineAlertProps) {
+  return (
+    <div
+      className={`widget-inline-alert widget-inline-alert--${variant}`}
+      role="alert"
+      data-testid={widgetTestId(`inline-alert-${id}`, testId)}
+    >
+      {title ? <strong>{title}</strong> : null}
+      {title ? " " : null}
+      {children}
+      {onDismiss ? (
+        <button
+          type="button"
+          className="widget-toast__dismiss"
+          aria-label="Dismiss alert"
+          onClick={onDismiss}
+        >
+          ×
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export interface ToastItem {
+  id: string;
+  message: string;
+  variant?: AlertVariant;
+}
+
+export interface ToastRegionProps {
+  toasts: ToastItem[];
+  onDismiss: (id: string) => void;
+  testId?: string;
+}
+
+export function ToastRegion({
+  toasts,
+  onDismiss,
+  testId,
+}: ToastRegionProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="widget-toast-region"
+      aria-live="polite"
+      aria-relevant="additions"
+      data-testid={widgetTestId("toast-region", testId)}
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={`widget-toast widget-toast--${toast.variant ?? "info"}`}
+          role="status"
+          data-testid={`toast-${toast.id}`}
+        >
+          <span>{toast.message}</span>
+          <button
+            type="button"
+            className="widget-toast__dismiss"
+            aria-label={`Dismiss ${toast.message}`}
+            onClick={() => onDismiss(toast.id)}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/Toggle.tsx
+++ b/frontend/web/src/components/widgets/Toggle.tsx
@@ -1,0 +1,61 @@
+import type { WidgetBaseProps } from "./types";
+import { widgetTestId } from "./types";
+
+export interface ToggleProps extends WidgetBaseProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function Toggle({
+  id,
+  label,
+  description,
+  disabled,
+  loading,
+  error,
+  testId,
+  density = "comfortable",
+  checked,
+  onChange,
+}: ToggleProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <div
+      className={`widget widget--toggle widget--${density}${error ? " widget--error" : ""}${isDisabled ? " widget--disabled" : ""}`}
+      data-testid={widgetTestId(`toggle-${id}`, testId)}
+    >
+      <div className="widget__toggle-row">
+        <input
+          id={id}
+          type="checkbox"
+          role="switch"
+          className="widget__toggle"
+          checked={checked}
+          disabled={isDisabled}
+          aria-checked={checked}
+          aria-invalid={Boolean(error)}
+          aria-describedby={
+            description ? `${id}-desc` : error ? `${id}-error` : undefined
+          }
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <div>
+          <label className="widget__check-label" htmlFor={id}>
+            {label}
+          </label>
+          {description ? (
+            <p className="widget__description" id={`${id}-desc`}>
+              {description}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {error ? (
+        <p className="widget__error" id={`${id}-error`} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/web/src/components/widgets/index.ts
+++ b/frontend/web/src/components/widgets/index.ts
@@ -1,0 +1,54 @@
+export type { WidgetBaseProps } from "./types";
+export { widgetTestId } from "./types";
+
+export { Select, MultiSelect } from "./Select";
+export type { SelectProps, MultiSelectProps, SelectOption } from "./Select";
+
+export { Slider } from "./Slider";
+export type { SliderProps } from "./Slider";
+
+export { Checkbox } from "./Checkbox";
+export type { CheckboxProps } from "./Checkbox";
+
+export { RadioGroup } from "./RadioGroup";
+export type { RadioGroupProps, RadioOption } from "./RadioGroup";
+
+export { Toggle } from "./Toggle";
+export type { ToggleProps } from "./Toggle";
+
+export { FileUpload } from "./FileUpload";
+export type { FileUploadProps } from "./FileUpload";
+
+export { Button } from "./Button";
+export type { ButtonProps } from "./Button";
+
+export { DownloadButton } from "./DownloadButton";
+export type { DownloadButtonProps } from "./DownloadButton";
+
+export { Tabs } from "./Tabs";
+export type { TabsProps, TabItem } from "./Tabs";
+
+export { Expander } from "./Expander";
+export type { ExpanderProps } from "./Expander";
+
+export { Metric } from "./Metric";
+export type { MetricProps, MetricDelta } from "./Metric";
+
+export { DataTable } from "./DataTable";
+export type { DataTableProps, DataTableColumn } from "./DataTable";
+
+export { Progress, StatusBadge } from "./Progress";
+export type {
+  ProgressProps,
+  StatusBadgeProps,
+  StatusBadgeVariant,
+} from "./Progress";
+
+export { PlotlyHost } from "./PlotlyHost";
+export type { PlotlyHostProps } from "./PlotlyHost";
+
+export { ConfirmModal } from "./ConfirmModal";
+export type { ConfirmModalProps } from "./ConfirmModal";
+
+export { InlineAlert, ToastRegion } from "./Toast";
+export type { InlineAlertProps, ToastItem, ToastRegionProps, AlertVariant } from "./Toast";

--- a/frontend/web/src/components/widgets/types.ts
+++ b/frontend/web/src/components/widgets/types.ts
@@ -1,0 +1,15 @@
+/** Shared props for parity widget primitives (P1-M3-02). */
+export interface WidgetBaseProps {
+  id: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  error?: string;
+  testId?: string;
+  density?: "comfortable" | "compact";
+}
+
+export function widgetTestId(base: string, testId?: string): string {
+  return testId ?? base;
+}

--- a/frontend/web/src/components/widgets/widgets.css
+++ b/frontend/web/src/components/widgets/widgets.css
@@ -1,0 +1,692 @@
+/* Parity widget primitives (P1-M3-02) — token-driven, native HTML controls */
+
+.widget {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-md);
+}
+
+.widget--compact {
+  gap: 0.125rem;
+  margin-bottom: var(--space-sm);
+}
+
+.widget--compact .widget__label {
+  font-size: var(--font-size-xs);
+}
+
+.widget--compact .widget__control,
+.widget--compact .widget__input {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
+.widget__label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-navy-800);
+}
+
+.widget__description {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-slate-500);
+}
+
+.widget__error {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-danger);
+}
+
+.widget--error .widget__control,
+.widget--error .widget__input {
+  border-color: var(--color-danger);
+}
+
+.widget__control,
+.widget__input {
+  font: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-700);
+  background: var(--color-white);
+  border: 1px solid var(--color-slate-300);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  max-width: 100%;
+}
+
+.widget__control:disabled,
+.widget__input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: var(--color-slate-100);
+}
+
+/* Slider */
+.widget--slider .widget__slider-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.widget__slider {
+  flex: 1;
+  accent-color: var(--color-teal-500);
+  min-width: 0;
+}
+
+.widget__slider-value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-500);
+  min-width: 3rem;
+  text-align: right;
+}
+
+/* Checkbox / Toggle */
+.widget__check-row,
+.widget__toggle-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+}
+
+.widget__checkbox,
+.widget__radio {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.15rem;
+  accent-color: var(--color-teal-500);
+  flex-shrink: 0;
+}
+
+.widget__toggle {
+  appearance: none;
+  width: 2.5rem;
+  height: 1.375rem;
+  border-radius: 999px;
+  background: var(--color-slate-300);
+  border: none;
+  position: relative;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--transition-fast);
+}
+
+.widget__toggle::after {
+  content: "";
+  position: absolute;
+  top: 0.1875rem;
+  left: 0.1875rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--color-white);
+  transition: transform var(--transition-fast);
+}
+
+.widget__toggle:checked {
+  background: var(--color-teal-500);
+}
+
+.widget__toggle:checked::after {
+  transform: translateX(1.125rem);
+}
+
+.widget__toggle:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.widget__check-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-700);
+  cursor: pointer;
+}
+
+.widget--disabled .widget__check-label {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* Radio group */
+.widget__radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.widget__radio-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+}
+
+/* File upload */
+.widget__dropzone {
+  border: 2px dashed var(--color-slate-300);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  text-align: center;
+  background: var(--color-slate-50);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.widget__dropzone:hover:not(.widget__dropzone--disabled) {
+  border-color: var(--color-teal-400);
+  background: var(--color-teal-100);
+}
+
+.widget__dropzone--dragover {
+  border-color: var(--color-teal-500);
+  background: var(--color-teal-100);
+}
+
+.widget__dropzone--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.widget__dropzone-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.widget__file-list {
+  margin: var(--space-sm) 0 0;
+  padding: 0;
+  list-style: none;
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-600, var(--color-slate-500));
+}
+
+/* Buttons */
+.widget-btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  line-height: var(--line-height-tight);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.widget-btn--primary {
+  background: var(--color-teal-600);
+  color: var(--color-white);
+  border-color: var(--color-teal-600);
+}
+
+.widget-btn--primary:hover:not(:disabled) {
+  background: var(--color-teal-500);
+}
+
+.widget-btn--secondary {
+  background: var(--color-white);
+  color: var(--color-navy-800);
+  border-color: var(--color-slate-300);
+}
+
+.widget-btn--secondary:hover:not(:disabled) {
+  background: var(--color-slate-100);
+}
+
+.widget-btn--danger {
+  background: var(--color-danger);
+  color: var(--color-white);
+  border-color: var(--color-danger);
+}
+
+.widget-btn--compact {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-xs);
+}
+
+.widget-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.widget-btn__spinner {
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid rgb(255 255 255 / 0.35);
+  border-top-color: var(--color-white);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+/* Tabs */
+.widget-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.widget-tabs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  border-bottom: 1px solid var(--color-slate-200);
+  padding-bottom: var(--space-xs);
+}
+
+.widget-tabs__tab {
+  appearance: none;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-slate-500);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  cursor: pointer;
+}
+
+.widget-tabs__tab:hover:not(:disabled) {
+  color: var(--color-navy-800);
+  background: var(--color-slate-100);
+}
+
+.widget-tabs__tab--active {
+  color: var(--color-teal-600);
+  background: var(--color-teal-100);
+  border-color: var(--color-teal-400);
+  font-weight: 600;
+}
+
+.widget-tabs__tab:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.widget-tabs__panel {
+  padding: var(--space-sm) 0;
+}
+
+/* Expander */
+.widget-expander {
+  border: 1px solid var(--color-slate-200);
+  border-radius: var(--radius-md);
+  background: var(--color-white);
+}
+
+.widget-expander__trigger {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-md);
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-navy-800);
+  cursor: pointer;
+  text-align: left;
+}
+
+.widget-expander__trigger:hover:not(:disabled) {
+  background: var(--color-slate-50);
+}
+
+.widget-expander__trigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.widget-expander__icon {
+  transition: transform var(--transition-fast);
+}
+
+.widget-expander--open .widget-expander__icon {
+  transform: rotate(180deg);
+}
+
+.widget-expander__content {
+  padding: 0 var(--space-md) var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-700);
+}
+
+/* Metric */
+.widget-metric {
+  background: var(--color-white);
+  border: 1px solid var(--color-slate-200);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.widget-metric--compact {
+  padding: var(--space-sm);
+}
+
+.widget-metric__label {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-slate-500);
+}
+
+.widget-metric__value {
+  margin: var(--space-xs) 0 0;
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-navy-900);
+  line-height: var(--line-height-tight);
+}
+
+.widget-metric--compact .widget-metric__value {
+  font-size: var(--font-size-lg);
+}
+
+.widget-metric__delta {
+  margin: var(--space-xs) 0 0;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.widget-metric__delta--up {
+  color: var(--color-success);
+}
+
+.widget-metric__delta--down {
+  color: var(--color-danger);
+}
+
+.widget-metric__delta--neutral {
+  color: var(--color-slate-500);
+}
+
+/* DataTable */
+.widget-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--color-slate-200);
+  border-radius: var(--radius-md);
+}
+
+.widget-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.widget-table th,
+.widget-table td {
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+.widget-table th {
+  background: var(--color-slate-100);
+  font-weight: 600;
+  color: var(--color-navy-800);
+}
+
+.widget-table tr:last-child td {
+  border-bottom: none;
+}
+
+.widget-table--compact th,
+.widget-table--compact td {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-xs);
+}
+
+/* Progress */
+.widget-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.widget-progress__track {
+  height: 0.5rem;
+  background: var(--color-slate-200);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.widget-progress__bar {
+  height: 100%;
+  background: var(--color-teal-500);
+  border-radius: 999px;
+  transition: width var(--transition-fast);
+}
+
+.widget-progress__label {
+  font-size: var(--font-size-xs);
+  color: var(--color-slate-500);
+}
+
+/* Status badge */
+.widget-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: 999px;
+  border: 1px solid;
+}
+
+.widget-badge--success {
+  color: var(--color-success);
+  background: var(--color-success-bg);
+  border-color: var(--color-success-border);
+}
+
+.widget-badge--warning {
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning-border);
+}
+
+.widget-badge--danger {
+  color: var(--color-danger);
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger-border);
+}
+
+.widget-badge--info {
+  color: var(--color-info);
+  background: var(--color-info-bg);
+  border-color: var(--color-info-border);
+}
+
+.widget-badge--neutral {
+  color: var(--color-slate-500);
+  background: var(--color-slate-100);
+  border-color: var(--color-slate-300);
+}
+
+/* Plotly host placeholder */
+.widget-plotly-host {
+  min-height: 12rem;
+  background: var(--color-slate-100);
+  border: 1px dashed var(--color-slate-300);
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-slate-500);
+  font-size: var(--font-size-sm);
+}
+
+/* Confirm modal */
+.widget-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgb(15 23 42 / 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-md);
+}
+
+.widget-modal {
+  background: var(--color-white);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  max-width: 28rem;
+  width: 100%;
+  padding: var(--space-lg);
+}
+
+.widget-modal__title {
+  margin: 0 0 var(--space-sm);
+  font-size: var(--font-size-lg);
+  color: var(--color-navy-900);
+}
+
+.widget-modal__body {
+  margin: 0 0 var(--space-lg);
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-700);
+}
+
+.widget-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+
+/* Toast */
+.widget-toast-region {
+  position: fixed;
+  bottom: var(--space-lg);
+  right: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  z-index: 1100;
+  max-width: 24rem;
+}
+
+.widget-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid;
+  box-shadow: var(--shadow-md);
+  font-size: var(--font-size-sm);
+}
+
+.widget-toast--info {
+  background: var(--color-info-bg);
+  border-color: var(--color-info-border);
+  color: var(--color-info);
+}
+
+.widget-toast--success {
+  background: var(--color-success-bg);
+  border-color: var(--color-success-border);
+  color: var(--color-success);
+}
+
+.widget-toast--warning {
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning-border);
+  color: var(--color-warning);
+}
+
+.widget-toast--danger {
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger-border);
+  color: var(--color-danger);
+}
+
+.widget-toast__dismiss {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: var(--font-size-lg);
+  line-height: 1;
+  padding: 0;
+  margin-left: auto;
+}
+
+/* Inline alert (widget variant) */
+.widget-inline-alert {
+  border-radius: var(--radius-sm);
+  border: 1px solid;
+  padding: var(--space-md);
+  font-size: var(--font-size-sm);
+}
+
+.widget-inline-alert--info {
+  background: var(--color-info-bg);
+  border-color: var(--color-info-border);
+  color: var(--color-info);
+}
+
+.widget-inline-alert--success {
+  background: var(--color-success-bg);
+  border-color: var(--color-success-border);
+  color: var(--color-success);
+}
+
+.widget-inline-alert--warning {
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning-border);
+  color: var(--color-warning);
+}
+
+.widget-inline-alert--danger {
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger-border);
+  color: var(--color-danger);
+}
+
+/* Widget gallery demo section */
+.widget-gallery {
+  margin-top: var(--space-xl);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-slate-200);
+}
+
+.widget-gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+  gap: var(--space-md);
+}
+
+.widget-gallery__section {
+  margin-bottom: var(--space-lg);
+}
+
+.widget-gallery__section h3 {
+  margin: 0 0 var(--space-md);
+  font-size: var(--font-size-md);
+  color: var(--color-navy-800);
+}

--- a/frontend/web/src/components/widgets/widgets.test.tsx
+++ b/frontend/web/src/components/widgets/widgets.test.tsx
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { Select } from "./Select";
+import { Slider } from "./Slider";
+import { Checkbox } from "./Checkbox";
+import { ConfirmModal } from "./ConfirmModal";
+import { Expander } from "./Expander";
+
+describe("widget primitives", () => {
+  it("Select fires onChange when value changes", () => {
+    const onChange = vi.fn();
+    render(
+      <Select
+        id="test-select"
+        label="Pick one"
+        value="a"
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Pick one"), {
+      target: { value: "b" },
+    });
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
+
+  it("Slider responds to arrow keys", () => {
+    const onChange = vi.fn();
+    render(
+      <Slider
+        id="test-slider"
+        label="Level"
+        value={50}
+        min={0}
+        max={100}
+        step={5}
+        onChange={onChange}
+      />,
+    );
+
+    const slider = screen.getByLabelText("Level");
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenCalledWith(55);
+
+    onChange.mockClear();
+    fireEvent.keyDown(slider, { key: "ArrowDown" });
+    expect(onChange).toHaveBeenCalledWith(45);
+  });
+
+  it("Checkbox toggles checked state", () => {
+    const onChange = vi.fn();
+    render(
+      <Checkbox
+        id="test-checkbox"
+        label="Accept terms"
+        checked={false}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Accept terms"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("ConfirmModal opens and confirms", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open modal
+          </button>
+          <ConfirmModal
+            id="test-modal"
+            open={open}
+            title="Delete job?"
+            message="This cannot be undone."
+            onConfirm={() => {
+              onConfirm();
+              setOpen(false);
+            }}
+            onCancel={() => {
+              onCancel();
+              setOpen(false);
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(screen.getByText("Open modal"));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Delete job?")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("test-modal-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("Expander toggles expanded content", () => {
+    function Harness() {
+      const [expanded, setExpanded] = useState(false);
+      return (
+        <Expander
+          id="test-expander"
+          label="Details"
+          expanded={expanded}
+          onChange={setExpanded}
+        >
+          <p>Hidden content</p>
+        </Expander>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.queryByText("Hidden content")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Details/i }));
+    expect(screen.getByText("Hidden content")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Details/i }));
+    expect(screen.queryByText("Hidden content")).toBeNull();
+  });
+});

--- a/frontend/web/src/pages/HomePage.tsx
+++ b/frontend/web/src/pages/HomePage.tsx
@@ -2,11 +2,30 @@ import { useEffect, useState } from "react";
 import { AppShell } from "../components/AppShell";
 import { apiFetch } from "../api/client";
 import type { CapabilitiesResponse } from "../api/contract";
+import {
+  Select,
+  Slider,
+  Checkbox,
+  Metric,
+  Expander,
+  InlineAlert,
+  StatusBadge,
+  PlotlyHost,
+  ConfirmModal,
+  ToastRegion,
+} from "../components/widgets";
 
 export function HomePage() {
   const [contractVersion, setContractVersion] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const [demoSelect, setDemoSelect] = useState("a");
+  const [demoSlider, setDemoSlider] = useState(50);
+  const [demoChecked, setDemoChecked] = useState(false);
+  const [demoExpanded, setDemoExpanded] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [toasts, setToasts] = useState<{ id: string; message: string }[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,7 +78,93 @@ export function HomePage() {
             </span>
           </p>
         )}
+
+        <section className="widget-gallery" data-testid="widget-gallery">
+          <h2>Widget primitives (P1-M3-02)</h2>
+          <InlineAlert id="gallery-hint" variant="info">
+            Controlled parity widgets — keyboard and a11y baseline for M3 gate.
+          </InlineAlert>
+
+          <div className="widget-gallery__section">
+            <h3>Form controls</h3>
+            <div className="widget-gallery__grid">
+              <Select
+                id="demo-select"
+                label="Sample select"
+                value={demoSelect}
+                options={[
+                  { value: "a", label: "Option A" },
+                  { value: "b", label: "Option B" },
+                ]}
+                onChange={setDemoSelect}
+              />
+              <Slider
+                id="demo-slider"
+                label="Sample slider"
+                value={demoSlider}
+                min={0}
+                max={100}
+                step={5}
+                onChange={setDemoSlider}
+              />
+              <Checkbox
+                id="demo-checkbox"
+                label="Enable feature"
+                checked={demoChecked}
+                onChange={setDemoChecked}
+              />
+            </div>
+          </div>
+
+          <div className="widget-gallery__section">
+            <h3>Display &amp; feedback</h3>
+            <div className="widget-gallery__grid">
+              <Metric
+                id="demo-metric"
+                label="Energy savings"
+                value="12.4%"
+                delta={{ value: "+2.1%", direction: "up" }}
+              />
+              <StatusBadge
+                id="demo-badge"
+                label="Running"
+                variant="success"
+              />
+              <PlotlyHost id="demo-plot" label="Trend chart" />
+            </div>
+          </div>
+
+          <div className="widget-gallery__section">
+            <Expander
+              id="demo-expander"
+              label="Advanced options"
+              expanded={demoExpanded}
+              onChange={setDemoExpanded}
+            >
+              <p>Expander content for parity demos and future form drafts.</p>
+            </Expander>
+          </div>
+        </section>
       </div>
+
+      <ConfirmModal
+        id="demo-confirm"
+        open={modalOpen}
+        title="Confirm action"
+        message="This is a parity confirm modal."
+        onConfirm={() => {
+          setModalOpen(false);
+          setToasts((t) => [
+            ...t,
+            { id: String(Date.now()), message: "Confirmed" },
+          ]);
+        }}
+        onCancel={() => setModalOpen(false)}
+      />
+      <ToastRegion
+        toasts={toasts}
+        onDismiss={(id) => setToasts((t) => t.filter((x) => x.id !== id))}
+      />
     </AppShell>
   );
 }

--- a/frontend/web/src/styles/app.css
+++ b/frontend/web/src/styles/app.css
@@ -1,4 +1,5 @@
 @import "./tokens.css";
+@import "../components/widgets/widgets.css";
 
 *,
 *::before,


### PR DESCRIPTION
## Summary
- Local parity widgets: select/multiselect, slider, checkbox/radio/toggle, file upload, buttons, tabs, expander, metric, table, progress/status, Plotly host stub, confirm modal, toast/alert.
- Controlled contracts, a11y labels, focus rings, test IDs; HomePage gallery demo.
- Ledgers updated; vitest coverage for key interactions.

## Test plan
- [x] `cd frontend/web && npm test && npm run typecheck && npm run build`
- [ ] CI green + CodeRabbit


Made with [Cursor](https://cursor.com)