### PR TITLE
docs(p1): bridge agent_spec + streamlit-to-react skills

### DIFF
--- a/.cursor/rules/openfdd-phase1-react-parity.mdc
+++ b/.cursor/rules/openfdd-phase1-react-parity.mdc
@@ -1,0 +1,45 @@
+---
+description: Phase 1 React/Rust parity — require openfdd_agent_spec + streamlit-to-react skills
+globs:
+  - frontend/web/**
+  - services/ui/**
+  - docs/migration/react-rust/**
+  - tools/open-fdd-modernization/**
+  - openfdd_agent_spec/**
+  - tests/react_parity/**
+alwaysApply: false
+---
+
+# Open-FDD Phase 1 React parity
+
+When editing files matched by this rule you are in the Streamlit→React /
+Python-exit program.
+
+## Required reads before substantive edits
+
+1. `AGENTS.md` (repo root)
+2. `openfdd_agent_spec/AGENTS.md`
+3. `tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md`
+4. `tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md` (+ needed references)
+5. `tools/open-fdd-modernization/AGENTS.md`
+6. `tools/open-fdd-modernization/AGENT_EXECUTION_SYSTEM.md`
+7. Current ledgers under `docs/migration/react-rust/`
+
+Also load the matching `openfdd_agent_spec/skills/*` skill when touching SQL FDD,
+cookbooks, GHCR, ECM, or ownership.
+
+## Architecture law
+
+- React presentation only (`frontend/web`).
+- APIs/jobs/persistence = `services/central` (Rust).
+- Deterministic FDD/analytics = DataFusion / `sql_rules/`.
+- Python = oracle/characterization only in Phase 1.
+- **No FastAPI** and no Python browser sidecar.
+- No BACnet writes from React.
+- One bounded `P1-M?-??` PR; update ledgers + `openfdd_agent_spec/BUILD_CHECKPOINTS.md` when status changes.
+
+## Parity method
+
+Follow the streamlit-to-react skill workflow: inventory → measure → contract →
+implement → verify. Prefer running Streamlit as the visual/behavioral reference.
+Document intentional differences in `docs/migration/react-rust/DECISIONS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Open-FDD ships as a **container stack**: `openfdd-central`, `openfdd-ui`, `openf
 
 **Software-engineering agent OS:** [`openfdd_agent_spec/`](openfdd_agent_spec/) — architecture locks, skills, Milestone A ([`openfdd_agent_spec/MILESTONE_A.md`](openfdd_agent_spec/MILESTONE_A.md)). Ops/edge soak prompts stay under [`docs/agent/`](docs/agent/).
 
+**React/Rust Phase 1:** [`tools/open-fdd-modernization/`](tools/open-fdd-modernization/README.md) · skill bridge [`AGENT_SKILL_BRIDGE.md`](tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md) · required UI skill [`streamlit-to-react`](tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md).
+
 **PyPI (`open-fdd` 4.1+):** ECM engineering + pandas oracle (`open_fdd.rules` / `analytics` / `reporting`) via extras. Production FDD is DataFusion/GHCR, not this wheel.
 
 ## Start session

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,7 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-07-31 | Phase 1 agents must follow `openfdd_agent_spec` + `streamlit-to-react` skill (via AGENT_SKILL_BRIDGE); FastAPI text in generic skill maps to central Rust | Accepted |
 | 2026-07-31 | Widget primitives use native HTML + CSS tokens; PlotlyHost is a placeholder div until M5 chart parity (no plotly npm in M3) | Accepted |
 | 2026-07-31 | Shared `WidgetBaseProps` + `widgetTestId()` convention for all parity controls | Accepted |
 | 2026-07-31 | React shell keeps Jobs/Upload sidebar routes (M4 path) while top tabs mirror Streamlit `REQUIRED_MAIN_SECTIONS` | Accepted |

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,12 @@
 
 Newest first.
 
+## 2026-07-31 — docs: agent skill bridge
+
+- Wired `openfdd_agent_spec` + streamlit-to-react skills into Phase 1 bootstrap
+  (`AGENT_SKILL_BRIDGE.md`, Cursor rule, Prompt 0).
+- Next: P1-M3-03 routing/session then M4 slice.
+
 ## 2026-07-31 — P1-M3-02
 
 - Accessible widget primitives under `frontend/web/src/components/widgets/` (select, slider, checkbox/radio/toggle, file upload, buttons, tabs, expander, metric, table, progress/badge, Plotly host placeholder, confirm modal, toast/inline alert).

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -65,6 +65,7 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 20. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
 21. Bound each PR to its declared scope — docs-only PRs do not require cross-repo pin bumps or GHCR refreshes.
 22. React/Rust Phase 1: follow [`tools/open-fdd-modernization/`](../tools/open-fdd-modernization/README.md); keep [`docs/migration/react-rust/`](../docs/migration/react-rust/README.md) ledgers current in the same PR.
+23. For any Streamlit→React / `frontend/web` work: read and follow [`tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md`](../tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md) and the bridge [`AGENT_SKILL_BRIDGE.md`](../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md) before editing UI.
 
 ---
 
@@ -79,6 +80,7 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 7. Skill matching the work (below)
 8. Code truth: `docs/migration/`, `docs/migration/react-rust/`, `docs/rules/cookbook/`, `docs/architecture/`
 9. React/Rust program: [`../tools/open-fdd-modernization/README.md`](../tools/open-fdd-modernization/README.md)
+10. Phase 1 skill bridge: [`../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md`](../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md)
 
 ---
 
@@ -107,6 +109,7 @@ Sibling-repo locations are **examples** — resolve via `git rev-parse --show-to
 | [`openfdd-cookbook-parity`](skills/openfdd-cookbook-parity/SKILL.md) | Cookbook CI, parity matrix, docs headings |
 | [`openfdd-stack-ghcr`](skills/openfdd-stack-ghcr/SKILL.md) | Nightly stack pull, labels, smoke |
 | [`openfdd-milestone-a-pr`](skills/openfdd-milestone-a-pr/SKILL.md) | Inventory → parity → cutover → delete loop |
+| [`openfdd-streamlit-to-react`](skills/openfdd-streamlit-to-react/SKILL.md) | Phase 1 React parity / Streamlit port (wraps modernization skill) |
 
 ---
 

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -137,14 +137,20 @@ Docs: [`MILESTONE_D_CLOSEOUT.md`](../docs/migration/MILESTONE_D_CLOSEOUT.md),
 # React / Rust modernization — Phase 1 (2026-07-31+)
 
 Program: [`tools/open-fdd-modernization/`](../tools/open-fdd-modernization/README.md) ·
+Skill bridge: [`AGENT_SKILL_BRIDGE.md`](../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md) ·
+Streamlit→React skill: [`skills/streamlit-to-react`](../tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md) ·
 Ledgers: [`docs/migration/react-rust/`](../docs/migration/react-rust/README.md) ·
 ADR: [`ADR-001`](../docs/architecture/adr-001-react-rust-modernization.md)
 
+Agents **must** follow `openfdd_agent_spec` + streamlit-to-react skills for UI PRs
+(see Cursor rule `.cursor/rules/openfdd-phase1-react-parity.mdc`).
+
 - [x] P1-M0-01 — ADR + instruction reconciliation + policy CI
 - [x] P1-M0-02 — Capability / Python-exit / API ledgers
-- [ ] P1-M1 — Fixtures / oracle exporter / Streamlit baseline
-- [ ] P1-M2 — Rust contracts + React shell + async ops
-- [ ] P1-M3 — Parity shell / widgets / navigation
+- [x] P1-M1 — Fixtures / oracle exporter / Streamlit baseline (#615)
+- [x] P1-M2 — Rust contracts + React shell + async ops (#616–#618)
+- [~] P1-M3 — Parity shell / widgets / navigation (#619 done; M3-02/03 in flight)
 - [ ] P1-M4 — Jobs/CSV/map/run vertical slice
 - [ ] P1-M5 — Domain families
 - [ ] P1-M6 — No-Python RC qualification
+- [x] Agent skill bridge — `AGENT_SKILL_BRIDGE.md` + `openfdd-streamlit-to-react` skill + Cursor rule

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,14 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-07-31 — Agent skill bridge (Phase 1)
+
+- Added `tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md` linking agent_spec ↔ modernization.
+- Rewrote modernization `AGENTS.md` for Open-FDD (Rust/central; no FastAPI template).
+- Added `openfdd_agent_spec/skills/openfdd-streamlit-to-react` wrapper + Cursor rule.
+- Prompt 0 / AGENT_EXECUTION_SYSTEM require streamlit-to-react before UI edits.
+- BUILD_CHECKPOINTS Phase 1 status refreshed through M2 / M3 partial.
+
 ## 2026-07-31 — Phase 1 pause (M1 WIP on branch)
 
 - M0 complete on master (#613/#614).

--- a/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: openfdd-streamlit-to-react
+description: >-
+  Open-FDD Phase 1 Streamlit→React parity work. Use when porting services/ui to
+  frontend/web, shell/widgets/routing, visual or interaction parity, Jobs/CSV/FDD
+  vertical slices, or diagnosing React vs Streamlit mismatches. Always pair with
+  tools/open-fdd-modernization/skills/streamlit-to-react and Rust/central contracts.
+---
+
+# Open-FDD Streamlit → React
+
+## Goal
+
+Reproduce Streamlit UX in `frontend/web` while keeping authority on **central
+Rust + DataFusion**. Python is oracle-only. No FastAPI sidecar.
+
+## Read first (required)
+
+1. [`../../AGENTS.md`](../../AGENTS.md) (openfdd_agent_spec)
+2. [`../../../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md`](../../../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md)
+3. **Canonical skill:**
+   [`../../../tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md`](../../../tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md)
+4. Open-FDD overlay:
+   [`../../../tools/open-fdd-modernization/AGENTS.md`](../../../tools/open-fdd-modernization/AGENTS.md)
+
+Then selectively:
+
+- [component-mapping.md](../../../tools/open-fdd-modernization/skills/streamlit-to-react/references/component-mapping.md)
+- [parity-verification.md](../../../tools/open-fdd-modernization/skills/streamlit-to-react/references/parity-verification.md)
+- [sidecar-architecture.md](../../../tools/open-fdd-modernization/skills/streamlit-to-react/references/sidecar-architecture.md)
+  — **map FastAPI → central Rust** for this repo
+
+## Open-FDD hard rules
+
+- Browser → React → `/api` on central only.
+- Do not move FDD/analytics math into TypeScript.
+- Do not add a Python API service for the React app.
+- Update `docs/migration/react-rust/` ledgers in the same PR.
+- One `P1-M?-??` milestone ID per PR; follow
+  [`../openfdd-milestone-a-pr/SKILL.md`](../openfdd-milestone-a-pr/SKILL.md) spirit
+  (inventory → characterize → contract → implement → parity → docs).
+- Update [`../../BUILD_CHECKPOINTS.md`](../../BUILD_CHECKPOINTS.md) when Phase 1
+  status changes.
+
+## Workflow
+
+Follow the numbered workflow in the canonical streamlit-to-react `SKILL.md`
+exactly, with Open-FDD paths:
+
+| Generic skill concept | Open-FDD path |
+| --- | --- |
+| Streamlit app | `services/ui/streamlit_app.py`, `services/ui/app/` |
+| React app | `frontend/web/` |
+| API | `services/central/` `/api/*` |
+| Oracle | `open_fdd.*`, `tools/react_parity/`, cookbooks |
+| Evidence | `docs/migration/react-rust/` |
+
+## Done when
+
+Parity classes for the slice are recorded (not UNKNOWN when claiming DONE),
+tests/CI green, and ledgers + BUILD_CHECKPOINTS reflect the merge.

--- a/tools/open-fdd-modernization/AGENTS.md
+++ b/tools/open-fdd-modernization/AGENTS.md
@@ -1,297 +1,170 @@
-# Streamlit → React Parity Guide
+# Open-FDD Streamlit → React agent guide
 
 ## Mission
 
-Preserve the existing Streamlit app as the behavioral and visual reference while
-building a React client that a normal user cannot distinguish from it. Keep
-domain-specific Python calculations in a separate FastAPI service. Treat parity
-as a measured engineering requirement, not a redesign exercise.
+Preserve Streamlit (`services/ui`) as the behavioral and visual reference while
+building `frontend/web` so a user cannot tell them apart on graded workflows.
+Domain authority stays on **central Rust + DataFusion SQL**. Python is
+oracle/characterization only during Phase 1. **No FastAPI sidecar.**
 
-For porting or synchronization work, also use
-`skills/streamlit-to-react/SKILL.md`.
+This file is the modernization-kit `AGENTS.md`. It does **not** replace
+[`openfdd_agent_spec/AGENTS.md`](../../openfdd_agent_spec/AGENTS.md) or the repo
+root [`AGENTS.md`](../../AGENTS.md).
 
-## Repository map
+## Mandatory skill + OS bootstrap (every Phase 1 PR)
+
+Before editing React/Streamlit/parity code, **read and follow** in order:
+
+1. Repo root [`AGENTS.md`](../../AGENTS.md)
+2. [`openfdd_agent_spec/AGENTS.md`](../../openfdd_agent_spec/AGENTS.md) — product law,
+   ownership, PR protocol, Milestone skills
+3. This file
+4. [`AGENT_SKILL_BRIDGE.md`](AGENT_SKILL_BRIDGE.md) — which skill for which work
+5. **[`skills/streamlit-to-react/SKILL.md`](skills/streamlit-to-react/SKILL.md)** and
+   the relevant reference under `skills/streamlit-to-react/references/`
+6. [`AGENT_EXECUTION_SYSTEM.md`](AGENT_EXECUTION_SYSTEM.md)
+7. Current phase doc + [`docs/migration/react-rust/`](../../docs/migration/react-rust/)
+   ledgers
+8. Matching skill from `openfdd_agent_spec/skills/` when the PR touches SQL FDD,
+   cookbooks, GHCR, ECM, or architecture ownership
+
+Do not invent a React redesign. Port measurable Streamlit behavior.
+
+## Open-FDD repository map
 
 ```text
-app.py                         Streamlit reference
-requirements.txt               Streamlit dependencies
-backend/main.py                FastAPI and HVAC calculations
-backend/requirements.txt       API dependencies
-backend/Dockerfile             API container
-frontend/src/App.jsx           React composition and behavior
-frontend/src/styles.css        Visual parity styling
-frontend/package.json          React/Vite dependencies
-frontend/Dockerfile            UI container
-docker-compose.yml             Two-sidecar deployment
+services/ui/streamlit_app.py     Streamlit reference (default product UI)
+services/ui/app/                 Streamlit modules
+services/central/                Rust browser API + jobs + FDD orchestration
+sql_rules/ + crates/fdd_*        DataFusion FDD / analytics
+frontend/web/                    React SPA (Phase 1, flag-gated)
+docs/migration/react-rust/       Durable ledgers
+tools/open-fdd-modernization/    This program kit
+openfdd_agent_spec/              Engineering agent OS + Milestone skills
+open_fdd/                        PyPI oracle / ECM (not production FDD runtime)
 ```
-
-Do not move authoritative calculations into React merely to make a widget
-update easier. Do not delete or redesign `app.py` unless explicitly requested.
 
 ## Source-of-truth hierarchy
 
-Use evidence in this order:
-
-1. Running Streamlit app at the target viewport and state.
-2. Streamlit source, CSS, theme configuration, and assets.
+1. Running Streamlit at the target viewport and state.
+2. Streamlit source, assets, and `dashboard_contract.py` section order.
 3. Browser measurements and same-viewport screenshots.
-4. Defaults from the installed Streamlit version.
-5. Visual inference.
+4. Installed Streamlit defaults when no theme is checked in.
+5. Visual inference last — document uncertainty.
 
 Prefer the running reference when evidence conflicts. Document intentional
-differences instead of silently accepting them.
+differences (for example React Jobs routes ahead of Streamlit Jobs wiring).
 
-## Required architecture
+## Required architecture (Open-FDD)
 
 ```text
 Streamlit reference ── visual/behavioral specification
 
-React client ── HTTP/JSON ── FastAPI ── Python domain functions
+React SPA ── same-origin /api ── central Rust ── DataFusion SQL
+                                      │
+                                      ├── jobs / mappings / artifacts
+                                      └── fieldbus/MQTTS (unchanged)
+
+Python ── oracle / characterization only (Phase 1)
 ```
 
 ### React owns
 
-- Layout, components, tabs, responsive behavior, and visible UI state.
-- Form state, selections, open/closed state, and transient feedback.
+- Layout, components, tabs, responsive behavior, visible UI state.
+- Form drafts, selections, open/closed panels, transient feedback.
 - Loading, empty, disconnected, validation, and error presentation.
 - Client downloads when no server authority is needed.
 
-### FastAPI owns
+### central Rust owns
 
-- HVAC and other domain calculations.
-- Input validation, data access, file parsing, and durable project state.
-- Report generation that depends on Python libraries.
-- Stable JSON contracts usable by multiple clients.
+- APIs, authz, validation, durable jobs, persistence, orchestration.
+- Ingestion, package/ZIP defenses, exports, error envelopes.
+- Stable JSON contracts consumed by React (and Streamlit clients).
+
+### DataFusion / sql_rules owns
+
+- Deterministic telemetry analytics and FDD rule execution.
+- Never silently fall back to pandas in production paths.
 
 ### Streamlit owns
 
-- The reference workflow until React parity is accepted.
-- A runnable comparison target.
-- No new duplicated business logic.
+- Reference workflow until React parity is accepted and Phase 2 cuts over.
+- Runnable comparison target.
+- No new duplicated business logic during Phase 1.
 
-Prefer extracting calculation functions into importable Python modules used by
-both Streamlit and FastAPI. Avoid copying formulas between `app.py`,
-`backend/main.py`, and TypeScript.
+### Python oracle owns
 
-## Migration workflow
+- Characterization fixtures, cookbook parity, optional ECM honesty checks.
+- Never a browser-facing FastAPI or production UI dependency for React.
 
-### 1. Establish a baseline
+## Streamlit-to-React skill law
 
-- Run Streamlit without changing it.
-- Record Streamlit/Python versions, viewport, theme, dataset, and scenario.
-- Verify the baseline has no visible exceptions.
-- List every page, tab, sidebar section, expander, dialog, and download.
-- Save representative inputs and outputs.
+Follow [`skills/streamlit-to-react/SKILL.md`](skills/streamlit-to-react/SKILL.md):
 
-If the reference does not run, fix or document that failure before porting.
+1. Inspect before editing (inventory widgets, session keys, branches).
+2. Build a parity contract before pixel chasing.
+3. Measure the reference when browser tools exist.
+4. Separate domain logic into Rust/SQL — not TypeScript formulas.
+5. Translate `st.session_state` into explicit React/URL/server state
+   ([P1-M3-03](MILESTONE_PR_MATRIX.md)).
+6. Verify with [`references/parity-verification.md`](skills/streamlit-to-react/references/parity-verification.md).
+7. Map widgets via [`references/component-mapping.md`](skills/streamlit-to-react/references/component-mapping.md).
 
-### 2. Inventory the app
+When [`references/sidecar-architecture.md`](skills/streamlit-to-react/references/sidecar-architecture.md)
+mentions FastAPI, **substitute central Rust** for Open-FDD. Do not add a Python
+API sidecar.
 
-Cover:
+## Migration workflow (bounded PRs)
 
-- Navigation and page hierarchy.
-- Sidebar controls and ordering.
-- Labels, defaults, min/max/step, formats, help, and disabled conditions.
-- `st.session_state` keys, callbacks, forms, fragments, and rerun behavior.
-- Metrics, tables, charts, maps, alerts, status, and progress elements.
-- Uploads, downloads, caching, custom components, and custom HTML/CSS.
-- Every branch that adds, removes, or reorders UI.
-
-Map each element to a React component and identify its state/data owner.
-
-### 3. Capture a visual specification
-
-For each important state, record:
-
-- Viewport dimensions and device scale.
-- Sidebar width, content max-width, gutters, gaps, and vertical rhythm.
-- Rectangles for hero, tabs, metrics, charts, tables, and controls.
-- Computed font family, size, weight, and line height.
-- Backgrounds, borders, radii, shadows, and state colors.
-- Hover, focus, active, disabled, selected, loading, and error states.
-
-Measure the DOM when possible. Use screenshots for comparison, not as the only
-source for measurable properties.
-
-Omit Streamlit product chrome unless requested: deploy button, runner menu,
-connection status, and framework decorations.
-
-### 4. Define API contracts
-
-- Add golden tests before refactoring calculations.
-- Define Pydantic models with bounds matching Streamlit widgets.
-- Return structured, display-neutral values rather than HTML.
-- Provide `/api/health`.
-- Use narrow development and production CORS origins.
-- Keep units and raw versus rounded values explicit.
-- Return field-specific validation errors.
-- Use jobs/polling for work too long for a normal request.
-
-### 5. Build the static React shell
-
-Implement in this order:
-
-1. Font and page background.
-2. Sidebar.
-3. Main max-width and gutters.
-4. Hero/header.
-5. Tabs and active indicator.
-6. Content grids and vertical rhythm.
-7. Metrics, chart/table frames, buttons, and controls.
-8. Footer and transient feedback.
-
-Match the canonical desktop viewport before adding responsive rules.
-
-### 6. Implement interaction parity
-
-Preserve:
-
-- Default values and option order.
-- Slider range, step, value label, and formatting.
-- Immediate versus submitted updates.
-- State persistence across tabs.
-- Conditional visibility.
-- Button loading and disabled behavior.
-- Alert/toast text, timing, and location.
-- Download filename, MIME type, headers, and column order.
-- Keyboard focus and tab order.
-
-Streamlit reruns top-to-bottom after most interactions. Reproduce the intended
-result of that rerun, not unnecessary full-page work.
-
-### 7. Connect FastAPI
-
-- Debounce continuous controls and cancel stale requests.
-- Keep the last valid result during short refreshes when appropriate.
-- Show explicit API failure and recovery states.
-- Do not silently substitute fake results in production.
-- Permit local JS fallback calculations only for labeled demos.
-- Configure the API URL through environment or same-origin `/api`.
-
-### 8. Verify
-
-Run:
-
-- Python compile/lint/tests.
-- FastAPI nominal, boundary, and invalid contract tests.
-- React production build and lint/type checks.
-- HTTP checks for HTML, assets, health, API requests, and CORS.
-- Browser console checks.
-- Interaction tests for all tabs and control families.
-- Same-viewport visual comparison.
-
-Fix runtime errors before pixel differences. Fix global fonts and geometry
-before tuning individual controls.
-
-## Visual parity rules
-
-- Reuse the same font files when licensing permits.
-- Centralize measured values as CSS custom properties.
-- Preserve content order, wording, capitalization, punctuation, and formatting.
-- Match empty space as carefully as visible components.
-- Match table headers, cells, borders, scrolling, and formatting.
-- Match chart domains, ticks, lines, fills, annotations, margins, and legends.
-- Do not add cards, icons, animation, copy, or decoration absent from reference.
-- Use semantic, accessible HTML while matching visible output.
-- Responsive work must not alter the graded desktop layout.
+1. Establish baseline (Streamlit runs; record viewport/fixture).
+2. Inventory navigation, controls, session keys, downloads.
+3. Capture visual/geometry specs (`LAYOUT_GEOMETRY.md` and ledgers).
+4. Define/version Rust contracts before coupling React.
+5. Implement React presentation only; reuse widgets from `frontend/web`.
+6. Compare (exact / numeric / temporal / interaction / visual / artifact /
+   security classes). UNKNOWN blocks DONE.
+7. Update ledgers + `openfdd_agent_spec/SESSION_LOG.md` /
+   `BUILD_CHECKPOINTS.md` when Phase 1 status changes.
+8. One milestone ID per PR; CodeRabbit; green CI; squash-merge; prune.
 
 ## State translation
 
 | Streamlit state | Destination |
 |---|---|
-| Current tab, select, open panel | React local or URL state |
-| Cross-panel temporary selection | Lifted state/context/store |
-| Shareable filters | URL search parameters |
-| Calculation input | React form state → API request |
-| Calculation result | Query/cache state |
-| Durable project configuration | Authoritative backend persistence |
-| Authentication/authorization | Server-side validation/session |
+| Current tab / section | URL + React router (`main_section`) |
+| Select / open panel | React local or URL state |
+| Shareable job/equipment/site | URL search params |
+| Calculation input | React form → Rust API |
+| Calculation result | Query/cache from `/api/*` |
+| Durable config / mapping | Rust jobs + FDD session-config |
+| Auth | Server-side JWT / session validation |
 
-Keep state close to its consumers; do not create one global store for every
-`st.session_state` key.
+Do not store authoritative job/mapping state only in `localStorage`.
 
 ## Calculation rules
 
-- Follow the repository's declared target backend. Python is authoritative only
-  when the product intends to retain it.
-- For a Python-retirement program, freeze Python as a characterization oracle
-  and implement the new runtime in the target backend (for Open-FDD: Rust plus
-  DataFusion SQL). Do not add a FastAPI bridge.
-- Extract or characterize pure behavior before adding replacement routes.
-- Preserve representative golden inputs/outputs.
-- Validate on the server even when React validates.
+- No pandas logic in TypeScript.
+- No FastAPI bridge.
+- No silent SQL → pandas fallback.
+- Preserve BACnet write safety; React never touches BACnet wire.
 - Distinguish raw values from presentation rounding.
-- Never silently fall back from the target computation engine to the oracle.
-- Never claim engineering validity for intentionally illustrative calculations.
 
 ## Minimum test coverage
 
-- Health and nominal calculation.
-- Minimum, maximum, and invalid calculation inputs.
-- Initial React render with API available.
-- Explicit React error state with API unavailable.
-- Every primary tab.
-- Representative select, slider, checkbox, and action button.
-- Download filename and headers.
-- Project/scenario changes updating visible context.
-- No uncaught browser errors.
+- Contract/health and typed client compile.
+- Widget/component interaction tests for new primitives.
+- Route refresh/back/deep-link for session translation.
+- Slice e2e for Jobs → upload → map → run (M4+) without Python UI container.
+- Parity evidence rows updated in the same PR.
 
-Add screenshot baselines at the canonical desktop size for high-fidelity work.
-Mask only genuinely nondeterministic content.
+## Definition of done (shell / slice)
 
-## Service and container rules
+- Inventoried workflow migrated or explicitly waived in ledgers.
+- React talks only to central `/api`.
+- Production React build + affected CI green.
+- Reference vs React compared at identical viewport/state when visual class applies.
+- Intentional differences documented in `DECISIONS.md`.
 
-- Keep frontend and backend dependency files and Dockerfiles independent.
-- Test a production static build, not only Vite HMR.
-- Inject the browser-reachable API URL or reverse proxy `/api`.
-- Never put secrets in frontend build variables.
-- Add API health checks and document ports.
-- Remember: Docker service names are not browser-resolvable by default.
+## Related program docs
 
-## Common failures
-
-- **Blank React page:** check HTML/JS responses, browser errors, root element,
-  `createRoot`, hooks, module factories, asset paths, and production build.
-- **No calculations:** test API health, CORS, URL, payload, and response shape.
-- **Visibly close but wrong:** measure font, sidebar, main padding, and primary
-  color before adjusting individual components.
-- **Too many requests:** debounce sliders and abort stale requests.
-- **State resets:** lift only the state that must survive unmounting.
-- **Docker UI cannot call API:** use a host-reachable or proxied URL.
-- **Dev works, production blank:** check build variables, base path, and assets.
-
-## Definition of done
-
-Do not call the port complete until:
-
-- Every inventoried workflow is migrated or explicitly waived.
-- React and the authoritative backend run independently.
-- Production React build and API tests pass.
-- Reference and React are compared at identical viewport/state.
-- Critical interactions and downloads work.
-- No uncaught browser errors remain.
-- Intentional differences and verification limits are documented.
-- Local and container run instructions are current.
-
-## Open-FDD modernization program
-
-When working on the Open-FDD Streamlit-to-React and Python-exit program, also
-read these files in order:
-
-1. `docs/open-fdd-modernization/README.md`
-2. the current phase document
-3. `docs/open-fdd-modernization/TEST_PARITY_AND_ACCEPTANCE.md`
-4. `docs/open-fdd-modernization/AGENT_EXECUTION_SYSTEM.md`
-5. the matching prompt pack when starting a bounded PR
-
-For that program:
-
-- React owns presentation and browser interaction state.
-- `services/central` and the Rust workspace own APIs, jobs, persistence,
-  ingestion, exports, and orchestration.
-- `crates/fdd_sql`, `crates/fdd_rules`, and `sql_rules/` own deterministic
-  telemetry analytics and FDD.
-- Python/Streamlit is a Phase 1 oracle/fallback, not the new backend.
-- Phase 2 removes production Python only after parity, canary, rollback, and
-  deletion gates.
-- Phase 3 edge/BACnet/MQTTS work is planning-only until separately authorized.
+See [`README.md`](README.md) and [`AGENT_SKILL_BRIDGE.md`](AGENT_SKILL_BRIDGE.md).

--- a/tools/open-fdd-modernization/AGENT_EXECUTION_SYSTEM.md
+++ b/tools/open-fdd-modernization/AGENT_EXECUTION_SYSTEM.md
@@ -9,21 +9,28 @@ and never overrides, the nearest repository `AGENTS.md`.
 ## Bootstrap order for every new session
 
 1. Resolve the repository root with `git rev-parse --show-toplevel`.
-2. Read every applicable `AGENTS.md` from root to the files in scope.
-3. Read the modernization `README.md`, current phase, test strategy, and this file.
-4. Read the latest:
+2. Read every applicable `AGENTS.md` from root to the files in scope, including
+   `openfdd_agent_spec/AGENTS.md` and `tools/open-fdd-modernization/AGENTS.md`.
+3. Read [`AGENT_SKILL_BRIDGE.md`](AGENT_SKILL_BRIDGE.md) and load the matching
+   skills — for any UI port, **read
+   [`skills/streamlit-to-react/SKILL.md`](skills/streamlit-to-react/SKILL.md)**
+   (and Open-FDD wrapper
+   `openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md`) before editing.
+4. Read the modernization `README.md`, current phase, test strategy, and this file.
+5. Read the latest ledgers under `docs/migration/react-rust/`:
    - `DECISIONS.md`;
    - `CAPABILITY_MATRIX.md`;
    - `PYTHON_EXIT_MATRIX.md`;
    - `API_CONTRACT_MATRIX.md`;
    - `PARITY_EVIDENCE.md`;
    - `SESSION_LOG.md`;
-   - relevant existing architecture/migration docs.
-5. Inspect `git status`, current branch, recent commits, and open PR context.
-6. Revalidate referenced code paths. Treat docs as claims until code confirms them.
-7. Select exactly one bounded milestone/PR objective.
+   - plus `openfdd_agent_spec/BUILD_CHECKPOINTS.md` / `SESSION_LOG.md` when status changes.
+6. Inspect `git status`, current branch, recent commits, and open PR context.
+7. Revalidate referenced code paths. Treat docs as claims until code confirms them.
+8. Select exactly one bounded milestone/PR objective (`P1-M?-??`).
 
 Never begin by rewriting architecture from memory.
+Never skip the streamlit-to-react skill for shell/widget/parity/slice UI work.
 
 ## Authority and safety
 

--- a/tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md
+++ b/tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md
@@ -1,0 +1,61 @@
+# Agent skill bridge — Phase 1 React/Rust
+
+Agents executing Open-FDD Phase 1 must treat **both** trees as law:
+
+| Tree | Role |
+| --- | --- |
+| [`openfdd_agent_spec/`](../../openfdd_agent_spec/) | Product/engineering OS: ownership, Milestone A/B/C skills, PR protocol, checkpoints |
+| [`tools/open-fdd-modernization/`](./) | React/Rust Phase 1–3 program: milestones, prompts, parity tests, **streamlit-to-react skill** |
+| [`docs/migration/react-rust/`](../../docs/migration/react-rust/) | Durable ledgers updated in every Phase 1 PR |
+
+They are complementary, not alternatives. Milestone A skills still apply when a
+Phase 1 PR touches SQL FDD, cookbooks, GHCR, ECM, or packaging.
+
+## Required read order (new session)
+
+1. Root [`AGENTS.md`](../../AGENTS.md)
+2. [`openfdd_agent_spec/AGENTS.md`](../../openfdd_agent_spec/AGENTS.md)
+3. [`openfdd_agent_spec/PR_PROTOCOL.md`](../../openfdd_agent_spec/PR_PROTOCOL.md) (bounded PRs)
+4. [`AGENTS.md`](AGENTS.md) (this kit — Open-FDD Streamlit→React)
+5. This bridge
+6. [`skills/streamlit-to-react/SKILL.md`](skills/streamlit-to-react/SKILL.md) **before any UI port**
+7. [`AGENT_EXECUTION_SYSTEM.md`](AGENT_EXECUTION_SYSTEM.md)
+8. Phase doc + ledgers for the selected `P1-M?-??`
+
+## Skill router
+
+| Work | Skill |
+| --- | --- |
+| Any Streamlit→React port, widget/shell/parity UI | [`skills/streamlit-to-react/SKILL.md`](skills/streamlit-to-react/SKILL.md) (+ references) |
+| Same, from agent_spec skill index | [`openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md`](../../openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md) |
+| Ownership / forbidden imports | [`openfdd-architecture`](../../openfdd_agent_spec/skills/openfdd-architecture/SKILL.md) |
+| DataFusion / `sql_rules/` / no pandas in central | [`openfdd-sql-fdd`](../../openfdd_agent_spec/skills/openfdd-sql-fdd/SKILL.md) |
+| Pandas oracle / PyPI extras | [`openfdd-pypi-oracle`](../../openfdd_agent_spec/skills/openfdd-pypi-oracle/SKILL.md) |
+| Cookbook dual expression / parity CI | [`openfdd-cookbook-parity`](../../openfdd_agent_spec/skills/openfdd-cookbook-parity/SKILL.md) |
+| ECM calculators | [`openfdd-ecm-engineering`](../../openfdd_agent_spec/skills/openfdd-ecm-engineering/SKILL.md) |
+| Nightly GHCR stack | [`openfdd-stack-ghcr`](../../openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md) |
+| Inventory→parity→cutover→delete twin | [`openfdd-milestone-a-pr`](../../openfdd_agent_spec/skills/openfdd-milestone-a-pr/SKILL.md) |
+| Phase 1 loop prompts | [`prompts/PHASE_1_LOOP_PROMPTS.md`](prompts/PHASE_1_LOOP_PROMPTS.md) |
+
+## Open-FDD override for generic FastAPI text
+
+The upstream streamlit-to-react skill mentions FastAPI as one possible backend.
+For this repository:
+
+- **Backend = `services/central` (Rust).**
+- **Compute = DataFusion / `sql_rules/`.**
+- **Do not introduce FastAPI or any Python browser API.**
+- Python remains oracle-only until a separate Phase 2 deletion decision.
+
+## Checkpoint / session hygiene
+
+When Phase 1 milestone status changes, update **both**:
+
+- [`docs/migration/react-rust/SESSION_LOG.md`](../../docs/migration/react-rust/SESSION_LOG.md)
+- [`openfdd_agent_spec/BUILD_CHECKPOINTS.md`](../../openfdd_agent_spec/BUILD_CHECKPOINTS.md) (React/Rust section)
+- [`openfdd_agent_spec/SESSION_LOG.md`](../../openfdd_agent_spec/SESSION_LOG.md) for non-trivial agent sessions
+
+## Cursor rule
+
+Project rule: [`.cursor/rules/openfdd-phase1-react-parity.mdc`](../../.cursor/rules/openfdd-phase1-react-parity.mdc)
+auto-applies when editing React, Streamlit UI, migration ledgers, or this kit.

--- a/tools/open-fdd-modernization/README.md
+++ b/tools/open-fdd-modernization/README.md
@@ -83,6 +83,9 @@ MQTT behavior during Phases 1 or 2.
 
 | Document | Use |
 | --- | --- |
+| [AGENTS.md](AGENTS.md) | Open-FDD Streamlit→React agent law (Rust/central; no FastAPI) |
+| [AGENT_SKILL_BRIDGE.md](AGENT_SKILL_BRIDGE.md) | Bridges `openfdd_agent_spec` skills ↔ this kit + streamlit-to-react |
+| [skills/streamlit-to-react/SKILL.md](skills/streamlit-to-react/SKILL.md) | **Required** skill for every UI parity/port PR |
 | [PHASE_1_PREP_AND_REACT_PARITY.md](PHASE_1_PREP_AND_REACT_PARITY.md) | Detailed Phase 1 milestones, PRs, tests, and exit gate |
 | [PHASE_2_CUTOVER_AND_PYTHON_EXIT.md](PHASE_2_CUTOVER_AND_PYTHON_EXIT.md) | Detailed Phase 2 cutover, deletion, rollback, and qualification |
 | [PHASE_3_EDGE_STREAMING_OUTLOOK.md](PHASE_3_EDGE_STREAMING_OUTLOOK.md) | Later BACnet/MQTTS/live-data architecture and prerequisites |
@@ -92,6 +95,7 @@ MQTT behavior during Phases 1 or 2.
 | [AGENT_EXECUTION_SYSTEM.md](AGENT_EXECUTION_SYSTEM.md) | Rules for autonomous agents, bounded PR protocol, state files, and stop conditions |
 | [prompts/PHASE_1_LOOP_PROMPTS.md](prompts/PHASE_1_LOOP_PROMPTS.md) | Ready-to-paste Phase 1 execution prompts |
 | [prompts/PHASE_2_LOOP_PROMPTS.md](prompts/PHASE_2_LOOP_PROMPTS.md) | Ready-to-paste Phase 2 execution, review, recovery, and deletion prompts |
+| [`openfdd_agent_spec/`](../../openfdd_agent_spec/) | Product agent OS, PR protocol, Milestone skills, BUILD_CHECKPOINTS |
 
 ## Non-negotiable architecture
 

--- a/tools/open-fdd-modernization/prompts/PHASE_1_LOOP_PROMPTS.md
+++ b/tools/open-fdd-modernization/prompts/PHASE_1_LOOP_PROMPTS.md
@@ -16,19 +16,26 @@ Selected milestone/PR: [P1-M?-??]
 User scenario/capability IDs: [IDS]
 
 Before changing code:
-1. Resolve repo root and read the complete applicable AGENTS.md hierarchy.
-2. Read:
+1. Resolve repo root and read the complete applicable AGENTS.md hierarchy:
+   root AGENTS.md, openfdd_agent_spec/AGENTS.md, tools/open-fdd-modernization/AGENTS.md.
+2. Read tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md and load skills:
+   - ALWAYS for UI/parity work: skills/streamlit-to-react/SKILL.md
+     (+ openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md)
+   - Plus any openfdd_agent_spec/skills/* matching SQL/cookbook/GHCR/ECM/ownership.
+3. Read:
    - docs/migration/react-rust/README.md
    - PHASE_1_PREP_AND_REACT_PARITY.md
    - TEST_PARITY_AND_ACCEPTANCE.md
    - AGENT_EXECUTION_SYSTEM.md
    - DECISIONS.md, CAPABILITY_MATRIX.md, PYTHON_EXIT_MATRIX.md,
      API_CONTRACT_MATRIX.md, PARITY_EVIDENCE.md, SESSION_LOG.md
-3. Inspect git status/branch/recent history. Preserve unrelated user changes.
-4. Inspect code truth for the selected capability: Streamlit render path,
+   - openfdd_agent_spec/BUILD_CHECKPOINTS.md (React/Rust section)
+4. Inspect git status/branch/recent history. Preserve unrelated user changes.
+5. Inspect code truth for the selected capability: Streamlit render path,
    session keys, Python call graph, current Rust routes/crates, SQL, storage,
-   tests, scripts, images, docs, and consumers.
-5. Restate the bounded objective, observable acceptance criteria, files likely
+   tests, scripts, images, docs, and consumers — following the streamlit-to-react
+   inventory workflow.
+6. Restate the bounded objective, observable acceptance criteria, files likely
    in scope, risks, and tests. Split the work if it combines architecture, API,
    SQL, React, persistence, topology, cutover, or deletion beyond one coherent
    vertical slice.

--- a/tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md
+++ b/tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md
@@ -21,6 +21,20 @@ Select the backend target from the repository's product goal:
 Never introduce a Python sidecar into a product whose stated goal is a
 Python-free runtime.
 
+### Open-FDD binding (this monorepo)
+
+For `bbartling/open-fdd` Phase 1+, **always** use the Rust retirement path:
+
+- Backend = `services/central` `/api/*` (not FastAPI).
+- Compute = DataFusion / `sql_rules/`.
+- Agent OS = `openfdd_agent_spec/` +
+  `tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md`.
+- Wrapper skill =
+  `openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md`.
+
+When references mention FastAPI persistence or sidecars, substitute central
+Rust jobs/routes.
+
 ## Read references selectively
 
 - Read [component-mapping.md](references/component-mapping.md) when inventorying

--- a/tools/open-fdd-modernization/skills/streamlit-to-react/agents/openai.yaml
+++ b/tools/open-fdd-modernization/skills/streamlit-to-react/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Streamlit to React"
   short_description: "Port Streamlit apps to pixel-matched React"
-  default_prompt: "Use $streamlit-to-react to port this Streamlit app into a visually faithful React client with a Python API sidecar."
+  default_prompt: "Use $streamlit-to-react to port this Streamlit app into a visually faithful React client. For Open-FDD, backend is Rust central /api (no FastAPI sidecar); follow openfdd_agent_spec and AGENT_SKILL_BRIDGE."


### PR DESCRIPTION
## Summary
- Wire `openfdd_agent_spec` into the Phase 1 modernization kit via `AGENT_SKILL_BRIDGE.md`.
- Rewrite modernization `AGENTS.md` for Open-FDD (central Rust / DataFusion; **no FastAPI**).
- Make `skills/streamlit-to-react` mandatory in Prompt 0, AGENT_EXECUTION_SYSTEM, and a Cursor rule.
- Add `openfdd_agent_spec/skills/openfdd-streamlit-to-react` wrapper; refresh BUILD_CHECKPOINTS.

## Test plan
- [ ] Docs-guard / Stack Security Guards green
- [ ] Skim bridge + Cursor rule paths resolve in GitHub UI
- [ ] CodeRabbit (docs)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the Phase 1 React modernization workflow, including architecture boundaries, migration steps, and required references.
  * Documented the agent skill bridge, Streamlit-to-React parity requirements, and updated project decision and session records.
  * Clarified that the central Rust backend is the production authority, with Python used for validation during migration.

* **Chores**
  * Updated progress checkpoints, bootstrap instructions, prompts, and modernization tooling documentation to support consistent execution and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->