### PR TITLE
feat(p1-m5-f): thin AuthPage against /api/auth

### DIFF
--- a/docs/migration/react-rust/CAPABILITY_MATRIX.md
+++ b/docs/migration/react-rust/CAPABILITY_MATRIX.md
@@ -6,7 +6,7 @@ Columns: capability_id | user scenario | Streamlit/Python owner | current API/st
 
 | capability_id | user scenario | Streamlit/Python owner | current API/storage | target React | target Rust | target SQL | parity class | fixtures | flag | status | deletion blocker |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| CAP-AUTH | Login / JWT session | services/ui/streamlit_app.py + central_client | /api/auth/* | AuthPage | auth.rs | NONE | EXACT | UNKNOWN | react_ui | NOT_STARTED | Streamlit default |
+| CAP-AUTH | Login / JWT session | services/ui/streamlit_app.py + central_client | /api/auth/* | AuthPage | auth.rs | NONE | EXACT | authApi + AuthPage vitest | react_ui | IN_PROGRESS | Thin AuthPage + Bearer sessionStorage (M5-F); Streamlit still default |
 | CAP-UPLOAD | Upload CSV/ZIP package + hostile validation | package_io, multi_zip, data_loader | /api/csv/import/* | UploadPage | routes csv_import + edge package.rs | NONE | SECURITY+EXACT | hostile_zip + package.rs tests | react_ui | IN_PROGRESS | Rust ingest + React upload (M4-02); Streamlit still default |
 | CAP-SITE | Building/site selection + delete site data | site_model, streamlit_app | datasets + workspace paths | SitesPage | UNKNOWN | NONE | EXACT | UNKNOWN | react_ui | NOT_STARTED | Filesystem side effects |
 | CAP-JOBS | Jobs CRUD archive/restore/duplicate | ui_jobs, job_store | /api/jobs* | JobsPage | jobs.rs | NONE | EXACT | UNKNOWN | react_ui | IN_PROGRESS | React JobsPage CRUD (M4-01); Streamlit still default |

--- a/docs/migration/react-rust/PARITY_EVIDENCE.md
+++ b/docs/migration/react-rust/PARITY_EVIDENCE.md
@@ -2,6 +2,7 @@
 
 | date | capability_id | fixture hash | source commit | engine versions | result | mismatch class | PR |
 |------|---------------|--------------|---------------|-----------------|--------|----------------|-----|
+| 2026-07-31 | CAP-AUTH | authApi + AuthPage vitest | branch `feat/p1-m5-f-auth-thin` | Vitest | status/me/login; Bearer in sessionStorage | EXACT+INTERACTION | P1-M5-F |
 | 2026-07-31 | CAP-REPORTS / CAP-WATTLAB | reportsApi + WattLabPage vitest | branch `feat/p1-m5-e-reports-wattlab` | Vitest | Reports list/draft; WattLab handoff POST | ARTIFACT+INTERACTION | P1-M5-E |
 | 2026-07-31 | CAP-FINDINGS | findingsApi upsert + FindingsPage vitest | branch `feat/p1-m5-d-findings-dispositions` | Vitest | Job findings load; disposition PUT by correlation_key | EXACT+INTERACTION | P1-M5-D |
 | 2026-07-31 | CAP-METER / CAP-RCX / CAP-OVERVIEW | `analyticsApi` monthlySum + MeteringPage/HomePage vitest | branch `feat/p1-m5-c-analytics-metering` | Vitest | Client↔API kWh parity; RCx AHU stub; equipment overview | NUMERIC+INTERACTION | P1-M5-C |

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,11 @@
 
 Newest first.
 
+## 2026-07-31 — P1-M5-F
+
+- Thin `AuthPage` + `authApi` for `/api/auth/status|me|login`; Bearer token in sessionStorage; `apiFetch` attaches Authorization.
+- Next: P1-M6-01 Python exit matrix closure.
+
 ## 2026-07-31 — P1-M5-E
 
 - ReportsPage: plots + Artifacts mode (`/api/reports` list/draft/engineering-findings). PDF/DOCX noted ORACLE.

--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -8,12 +8,14 @@ import { FindingsPage } from "./pages/FindingsPage";
 import { ReportsPage } from "./pages/ReportsPage";
 import { MeteringPage } from "./pages/MeteringPage";
 import { WattLabPage } from "./pages/WattLabPage";
+import { AuthPage } from "./pages/AuthPage";
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/auth" element={<AuthPage />} />
         <Route path="/jobs" element={<JobsPage />} />
         <Route path="/upload" element={<UploadPage />} />
         <Route path="/mapping" element={<MappingPage />} />

--- a/frontend/web/src/api/authApi.test.ts
+++ b/frontend/web/src/api/authApi.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { login, setStoredToken, getStoredToken } from "./authApi";
+
+vi.mock("./client", () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from "./client";
+
+describe("authApi", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    setStoredToken(null);
+  });
+
+  it("stores token on login", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: true,
+      token: "t1",
+      access_token: "t1",
+      token_type: "Bearer",
+      role: "admin",
+      subject: "u1",
+    });
+    await login("u1", "pw");
+    expect(getStoredToken()).toBe("t1");
+  });
+});

--- a/frontend/web/src/api/authApi.ts
+++ b/frontend/web/src/api/authApi.ts
@@ -1,0 +1,68 @@
+import { apiFetch } from "./client";
+
+const TOKEN_KEY = "openfdd.auth.token";
+
+export interface AuthStatus {
+  ok: boolean;
+  auth_required: boolean;
+}
+
+export interface AuthMe {
+  ok: boolean;
+  username: string;
+  role: string;
+  auth_required: boolean;
+}
+
+export interface AuthLoginResponse {
+  ok: boolean;
+  token: string;
+  access_token: string;
+  token_type: string;
+  role: string;
+  subject: string;
+  error?: string | null;
+}
+
+export function getStoredToken(): string | null {
+  try {
+    return sessionStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredToken(token: string | null): void {
+  try {
+    if (!token) sessionStorage.removeItem(TOKEN_KEY);
+    else sessionStorage.setItem(TOKEN_KEY, token);
+  } catch {
+    // ignore
+  }
+}
+
+export async function getAuthStatus(): Promise<AuthStatus> {
+  return apiFetch<AuthStatus>("/api/auth/status");
+}
+
+export async function getAuthMe(): Promise<AuthMe> {
+  return apiFetch<AuthMe>("/api/auth/me");
+}
+
+export async function login(
+  username: string,
+  password: string,
+): Promise<AuthLoginResponse> {
+  const body = await apiFetch<AuthLoginResponse>("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const token = body.access_token || body.token;
+  if (body.ok && token) setStoredToken(token);
+  return body;
+}
+
+export function logout(): void {
+  setStoredToken(null);
+}

--- a/frontend/web/src/api/client.ts
+++ b/frontend/web/src/api/client.ts
@@ -62,11 +62,19 @@ export async function apiFetch<T>(
   init?: RequestInit,
 ): Promise<T> {
   const requestId = newRequestId();
+  let authHeader: Record<string, string> = {};
+  try {
+    const token = sessionStorage.getItem("openfdd.auth.token");
+    if (token) authHeader = { Authorization: `Bearer ${token}` };
+  } catch {
+    // ignore
+  }
   const res = await fetch(buildUrl(path), {
     ...init,
     headers: {
       Accept: "application/json",
       [REQUEST_ID_HEADER]: requestId,
+      ...authHeader,
       ...(init?.headers ?? {}),
     },
   });

--- a/frontend/web/src/nav/sections.ts
+++ b/frontend/web/src/nav/sections.ts
@@ -13,6 +13,7 @@ export const MAIN_SECTIONS = [
 /** Primary React routes (Jobs vertical slice ahead of Streamlit wiring). */
 export const SIDEBAR_NAV = [
   { to: "/", label: "Home", short: "H", testId: "nav-home" },
+  { to: "/auth", label: "Auth", short: "A", testId: "nav-auth" },
   { to: "/jobs", label: "Jobs", short: "J", testId: "nav-jobs" },
   { to: "/upload", label: "Upload", short: "U", testId: "nav-upload" },
   { to: "/mapping", label: "Mapping", short: "M", testId: "nav-mapping" },

--- a/frontend/web/src/pages/AuthPage.test.tsx
+++ b/frontend/web/src/pages/AuthPage.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { AuthPage } from "./AuthPage";
+
+vi.mock("../api/authApi", () => ({
+  getAuthStatus: vi.fn(async () => ({ ok: true, auth_required: false })),
+  getAuthMe: vi.fn(async () => ({
+    ok: true,
+    username: "dev",
+    role: "admin",
+    auth_required: false,
+  })),
+  login: vi.fn(async () => ({
+    ok: true,
+    token: "open",
+    access_token: "open",
+    token_type: "Bearer",
+    role: "admin",
+    subject: "dev",
+  })),
+  logout: vi.fn(),
+}));
+
+import { login } from "../api/authApi";
+
+describe("AuthPage", () => {
+  beforeEach(() => {
+    vi.mocked(login).mockClear();
+  });
+
+  it("shows status and logs in", async () => {
+    render(
+      <MemoryRouter>
+        <AuthPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-required").textContent).toContain("false");
+      expect(screen.getByTestId("auth-user").textContent).toContain("dev");
+    });
+    fireEvent.click(screen.getByTestId("auth-login").querySelector("button")!);
+    await waitFor(() => {
+      expect(login).toHaveBeenCalled();
+      expect(screen.getByTestId("auth-notice").textContent).toMatch(/Logged in/);
+    });
+  });
+});

--- a/frontend/web/src/pages/AuthPage.tsx
+++ b/frontend/web/src/pages/AuthPage.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from "react";
+import { AppShell } from "../components/AppShell";
+import { Button, InlineAlert, Metric } from "../components/widgets";
+import {
+  getAuthMe,
+  getAuthStatus,
+  login,
+  logout,
+  type AuthMe,
+  type AuthStatus,
+} from "../api/authApi";
+
+function formatErr(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function AuthPage() {
+  const [status, setStatus] = useState<AuthStatus | null>(null);
+  const [me, setMe] = useState<AuthMe | null>(null);
+  const [username, setUsername] = useState("admin");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const st = await getAuthStatus();
+      setStatus(st);
+      try {
+        setMe(await getAuthMe());
+      } catch {
+        setMe(null);
+      }
+    } catch (err) {
+      setError(formatErr(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onLogin = async () => {
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await login(username, password);
+      setNotice(`Logged in as ${res.subject} (${res.role})`);
+      await refresh();
+    } catch (err) {
+      setError(formatErr(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onLogout = () => {
+    logout();
+    setMe(null);
+    setNotice("Cleared session token");
+  };
+
+  return (
+    <AppShell
+      title="Auth"
+      caption="Thin login against /api/auth/* (P1-M5-F)"
+      activeSectionId="overview"
+    >
+      <div className="page-stack" data-testid="auth-page">
+        <InlineAlert id="auth-hint" variant="info">
+          When auth is not required, login mints a placeholder Bearer token for
+          local session storage.
+        </InlineAlert>
+
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+          <Metric
+            id="auth-required"
+            label="auth_required"
+            value={
+              status == null ? "—" : status.auth_required ? "true" : "false"
+            }
+            testId="auth-required"
+          />
+          <Metric
+            id="auth-user"
+            label="username"
+            value={me?.username ?? "—"}
+            testId="auth-user"
+          />
+          <Metric
+            id="auth-role"
+            label="role"
+            value={me?.role ?? "—"}
+            testId="auth-role"
+          />
+        </div>
+
+        <label htmlFor="auth-username">
+          username
+          <input
+            id="auth-username"
+            data-testid="auth-username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </label>
+        <label htmlFor="auth-password">
+          password
+          <input
+            id="auth-password"
+            data-testid="auth-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          <Button
+            id="auth-login"
+            label={busy ? "…" : "Login"}
+            onClick={() => void onLogin()}
+            disabled={busy}
+            testId="auth-login"
+          />
+          <Button
+            id="auth-logout"
+            label="Logout"
+            variant="secondary"
+            onClick={onLogout}
+            testId="auth-logout"
+          />
+          <Button
+            id="auth-refresh"
+            label="Refresh"
+            variant="secondary"
+            onClick={() => void refresh()}
+            testId="auth-refresh"
+          />
+        </div>
+
+        {error ? (
+          <InlineAlert id="auth-error" variant="danger" testId="auth-error">
+            {error}
+          </InlineAlert>
+        ) : null}
+        {notice ? (
+          <InlineAlert id="auth-notice" variant="success" testId="auth-notice">
+            {notice}
+          </InlineAlert>
+        ) : null}
+      </div>
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Summary
- AuthPage + authApi for `/api/auth/status|me|login`
- Bearer token in sessionStorage; apiFetch attaches Authorization
- CAP-AUTH ledger update

## Test plan
- [x] frontend vitest + typecheck
- [ ] required Actions green → squash-merge

Made with [Cursor](https://cursor.com)