### PR TITLE
feat(p1-m6-02): no-Python React compose profile

### DIFF
--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           mkdir -p deploy/mqtt/kits/local__fieldbus-1
           export OPENFDD_EDGE_KIT_DIR="$PWD/deploy/mqtt/kits/local__fieldbus-1"
-          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml; do
+          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml; do
             docker compose -f "$f" config >/dev/null
             echo "OK config: $f"
           done

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           mkdir -p deploy/mqtt/kits/local__fieldbus-1
           export OPENFDD_EDGE_KIT_DIR="$PWD/deploy/mqtt/kits/local__fieldbus-1"
-          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml; do
+          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml; do
             test -f "$f"
             docker compose -f "$f" config >/dev/null
             echo "OK config: $f"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -91,7 +91,7 @@ jobs:
           export OPENFDD_MQTT_HOST=127.0.0.1
           mkdir -p deploy/mqtt/kits/local__fieldbus-1
           export OPENFDD_EDGE_KIT_DIR="$PWD/deploy/mqtt/kits/local__fieldbus-1"
-          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml; do
+          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml; do
             docker compose -f "$f" config >/dev/null
           done
           bash scripts/release/smoke_standalone_mqtts.sh

--- a/docker/compose.react.yml
+++ b/docker/compose.react.yml
@@ -1,0 +1,76 @@
+# Open-FDD React + central without Python Streamlit UI (P1-M6-02).
+#
+# Topology: mqtt + central (+ optional mcp) + web (nginx SPA).
+# No openfdd-ui / Streamlit image. OPENFDD_REACT_UI=1 enables capability flag.
+
+name: openfdd-react
+
+services:
+  mqtt:
+    image: ${OPENFDD_MQTT_IMAGE:-ghcr.io/bbartling/openfdd-mqtt:nightly}
+    build:
+      context: ../services/mqtt
+    ports:
+      - "8883:8883"
+    volumes:
+      - ../deploy/mqtt/certs:/mosquitto/certs:ro
+      - ../deploy/mqtt/acl:/mosquitto/config/acl:ro
+      - mqtt-data:/mosquitto/data
+    restart: unless-stopped
+
+  central:
+    image: ${OPENFDD_CENTRAL_IMAGE:-ghcr.io/bbartling/openfdd-central:nightly}
+    build:
+      context: ..
+      dockerfile: services/central/Dockerfile
+    environment:
+      OPENFDD_MQTT_ENABLED: "1"
+      OPENFDD_MQTT_HOST: mqtt
+      OPENFDD_MQTT_PORT: "8883"
+      OPENFDD_SITE_ID: ${OPENFDD_SITE_ID:-local}
+      OPENFDD_EDGE_ID: "+"
+      OPENFDD_MQTT_CA_PEM: /mqtt/ca.pem
+      OPENFDD_MQTT_CERT_PEM: /mqtt/central.cert.pem
+      OPENFDD_MQTT_KEY_PEM: /mqtt/central.key.pem
+      OPENFDD_WORKSPACE: /workspace
+      OPENFDD_PARQUET_ROOT: /workspace/.cache/parquet
+      OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:-}
+      OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
+      OPENFDD_REACT_UI: "1"
+    ports:
+      - "${OPENFDD_CENTRAL_BIND:-0.0.0.0}:8080:8080"
+    volumes:
+      - ../workspace:/workspace
+      - ../deploy/mqtt/kits/${OPENFDD_SITE_ID:-local}__central:/mqtt:ro
+    depends_on:
+      - mqtt
+    restart: unless-stopped
+
+  web:
+    image: ${OPENFDD_WEB_IMAGE:-ghcr.io/bbartling/openfdd-web:nightly}
+    build:
+      context: ../frontend/web
+      dockerfile: Dockerfile
+    ports:
+      - "${OPENFDD_WEB_BIND:-0.0.0.0}:3000:80"
+    depends_on:
+      - central
+    restart: unless-stopped
+
+  mcp:
+    profiles: ["mcp"]
+    image: ${OPENFDD_MCP_IMAGE:-ghcr.io/bbartling/openfdd-mcp:nightly}
+    build:
+      context: ..
+      dockerfile: Dockerfile.mcp
+    environment:
+      OPENFDD_API_BASE: http://central:8080
+      OPENFDD_MCP_TOKEN: ${OPENFDD_MCP_TOKEN:-}
+    depends_on:
+      - central
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+
+volumes:
+  mqtt-data:

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,7 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-07-31 | P1-M6-02 no-Python topology is `docker/compose.react.yml` (web+central+mqtt); Streamlit remains in compose.central for rollback | Accepted |
 | 2026-07-31 | P1-M6-01 closes Python exit matrix with DELETE-P2 / ORACLE-ONLY / KEEP-AS-LIB / REPLACE only; Phase 2 deletions enumerated but not executed | Accepted |
 | 2026-07-31 | M5-B plot datasets use SVG PlotlyHost stand-in (no plotly npm); figure JSON shape reserved for Plotly.react | Accepted |
 | 2026-07-31 | FDD run is synchronous at `/api/fdd/run` (no run_id poll); React cancel = fetch AbortSignal; async job substrate reserved for longer ops | Accepted |

--- a/docs/migration/react-rust/NO_PYTHON_STACK.md
+++ b/docs/migration/react-rust/NO_PYTHON_STACK.md
@@ -1,0 +1,18 @@
+# React / no-Python stack version manifest (P1-M6-02)
+
+| component | image / path | notes |
+|---|---|---|
+| SPA | `frontend/web` → `openfdd-web` (nginx) | Serves static assets; proxies `/api` to central |
+| API | `services/central` → `openfdd-central` | `OPENFDD_REACT_UI=1` |
+| Broker | `services/mqtt` → `openfdd-mqtt` | Optional for pure CSV/FDD lab |
+| Streamlit UI | **absent** | Not in `docker/compose.react.yml` |
+
+Compose file: [`docker/compose.react.yml`](../../docker/compose.react.yml)
+
+```bash
+docker compose -f docker/compose.react.yml config
+# health: GET http://localhost:8080/api/capabilities  (react_ui true when OPENFDD_REACT_UI=1)
+# SPA:    http://localhost:3000/
+```
+
+Rollback to Streamlit: use `docker/compose.central.yml` (includes `ui` service) — routing flip is Phase 2.

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,13 @@
 
 Newest first.
 
+## 2026-07-31 — P1-M6-02
+
+- Added `docker/compose.react.yml`: mqtt + central + web (nginx SPA), **no** Streamlit `ui` service.
+- SPA nginx proxies `/api` → central; `OPENFDD_REACT_UI=1` on central.
+- Documented in `NO_PYTHON_STACK.md`; CI compose config loop includes compose.react.yml.
+- Next: P1-M6-03 qualification pack + CUTOVER_LOG.
+
 ## 2026-07-31 — P1-M6-01
 
 - Closed `PYTHON_EXIT_MATRIX.md`: zero UNKNOWN / zero BLOCKED dispositions.

--- a/frontend/web/nginx.conf
+++ b/frontend/web/nginx.conf
@@ -4,10 +4,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Same-origin /api → central (compose.react.yml sets upstream via envsubst optional).
+    # Default upstream hostname for docker network.
+    location /api/ {
+        proxy_pass http://central:8080/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Request-Id $http_x_request_id;
+        proxy_set_header Authorization $http_authorization;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }
-
-    # API requests are proxied by central/compose in production;
-    # static nginx container serves SPA assets only.
 }


### PR DESCRIPTION
## Summary
- `docker/compose.react.yml` without openfdd-ui Streamlit
- nginx SPA proxies `/api` → central; `OPENFDD_REACT_UI=1`
- `NO_PYTHON_STACK.md` + CI compose config coverage

## Test plan
- [x] `docker compose -f docker/compose.react.yml config`
- [ ] required Actions green → squash-merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a React-based, no-Python deployment option with web, API, MQTT, and optional MCP services.
  * Enabled nginx to proxy frontend API requests to the central service while forwarding relevant request headers.
  * Added persistent MQTT storage and configurable deployment settings.

* **Documentation**
  * Documented the React stack, architecture decisions, health checks, validation steps, and Streamlit rollback path.

* **Chores**
  * Extended automated configuration checks to validate the React deployment across CI and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->