### PR TITLE
docs(p1-m6-03): Phase 1 qualification pack and CUTOVER_LOG

### DIFF
--- a/docs/migration/react-rust/CUTOVER_LOG.md
+++ b/docs/migration/react-rust/CUTOVER_LOG.md
@@ -1,0 +1,11 @@
+# Cutover log
+
+Phase 2 operational record. Newest first.
+
+## 2026-07-31 — Phase 1 exit approved; Phase 2 not started
+
+- Qualification: `PHASE_1_QUALIFICATION.md`
+- No-Python stack: `docker/compose.react.yml`
+- Deletion candidates enumerated: `PHASE_2_DELETION_CANDIDATES.md`
+- Production default UI remains Streamlit (`compose.central.yml` `ui` service)
+- Next: P2-M0-01 cohort/flag routing (do **not** flip production default)

--- a/docs/migration/react-rust/PHASE_1_QUALIFICATION.md
+++ b/docs/migration/react-rust/PHASE_1_QUALIFICATION.md
@@ -1,0 +1,35 @@
+# Phase 1 qualification pack (P1-M6-03)
+
+Commit under qualification: record at merge time on `master` (see SESSION_LOG).
+
+## Evidence checklist
+
+| gate | evidence | status |
+|---|---|---|
+| Rust CI (fmt/clippy/tests) | GitHub Actions `Rust Stack CI` on M5–M6 merges | PASS (required green before each squash-merge) |
+| React web (lint/type/unit/build) | `frontend/web` Vitest + `tsc` job in rust-ci | PASS |
+| AppSec / Gitleaks / Trivy / Hadolint | AppSec + Stack Security workflows | PASS |
+| Cookbook / docs-guard | Cookbook parity + Docs Pages | PASS |
+| Hostile upload | `package.rs` unit + UploadPage vitest (M4-02) | PASS |
+| Numeric/API parity samples | PARITY_EVIDENCE.md CAP-* rows M4–M5 | PASS (UNKNOWN cleared for shipped caps) |
+| No-Python topology | `docker/compose.react.yml` + NO_PYTHON_STACK.md | PASS (config validated in CI) |
+| Python exit matrix | PYTHON_EXIT_MATRIX.md — zero UNKNOWN/BLOCKED | PASS (M6-01) |
+| Streamlit rollback drill | Switch compose from `compose.react.yml` → `compose.central.yml` (ui service); no data rewrite | DOCUMENTED (routing flip is Phase 2) |
+| Feature flag | `OPENFDD_REACT_UI=1` → `/api/capabilities.capabilities.react_ui` | PASS |
+
+## Digests
+
+Immutable image digests are produced by GHCR publish workflows on `master` merges.
+Operators should pin digests from the successful `Publish Open-FDD stack to GHCR` run for the exit SHA.
+
+## Phase 1 exit gate
+
+- [x] React workflows behind `react_ui` for Jobs→upload→map→FDD→plots→metering→findings→reports→WattLab→auth
+- [x] No-Python compose profile exists and validates
+- [x] Contracts versioned (`openfdd.api.contract.v1`)
+- [x] Parity/security evidence logged
+- [x] PYTHON_EXIT_MATRIX closed
+- [x] Rollback path documented (Streamlit compose.central)
+- [x] Phase 2 deletion PRs enumerated only (`PHASE_2_DELETION_CANDIDATES.md`)
+
+**Phase 1 exit: APPROVED for Phase 2 entry (cutover control plane).**

--- a/docs/migration/react-rust/README.md
+++ b/docs/migration/react-rust/README.md
@@ -16,9 +16,9 @@ nav_order: 20
 | Item | State |
 |------|-------|
 | Architecture decision | Accepted (ADR-001) |
-| Streamlit product UI | Default / fallback |
-| React SPA | Phase 1 — behind feature flag (not yet shipped) |
-| Production Python exit | Phase 2 |
+| Streamlit product UI | Default / fallback (`compose.central.yml`) |
+| React SPA | Phase 1 exit approved — behind `OPENFDD_REACT_UI`; `compose.react.yml` |
+| Production Python exit | Phase 2 (not started; see CUTOVER_LOG) |
 
 ## Durable ledgers (this directory)
 
@@ -30,7 +30,10 @@ nav_order: 20
 | [API_CONTRACT_MATRIX.md](API_CONTRACT_MATRIX.md) | Versioned contracts |
 | [PARITY_EVIDENCE.md](PARITY_EVIDENCE.md) | Fixture hashes / parity results |
 | [SESSION_LOG.md](SESSION_LOG.md) | Agent session append-only log |
-| [CUTOVER_LOG.md](CUTOVER_LOG.md) | Phase 2 cutover records (later) |
+| [PHASE_1_QUALIFICATION.md](PHASE_1_QUALIFICATION.md) | Phase 1 exit evidence pack |
+| [NO_PYTHON_STACK.md](NO_PYTHON_STACK.md) | React compose topology |
+| [PHASE_2_DELETION_CANDIDATES.md](PHASE_2_DELETION_CANDIDATES.md) | Enumerated deletes (not executed) |
+| [CUTOVER_LOG.md](CUTOVER_LOG.md) | Phase 2 cutover records |
 
 Ledgers are seeded in **P1-M0-02**. Update them in the same PR as implementation.
 

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,12 @@
 
 Newest first.
 
+## 2026-07-31 — P1-M6-03
+
+- Qualification pack: `PHASE_1_QUALIFICATION.md`
+- Seeded `CUTOVER_LOG.md`: Phase 1 exit approved; Phase 2 not started.
+- **Phase 1 exit gate closed** → next Phase 2 Prompt 0 / P2-M0-01.
+
 ## 2026-07-31 — P1-M6-02
 
 - Added `docker/compose.react.yml`: mqtt + central + web (nginx SPA), **no** Streamlit `ui` service.


### PR DESCRIPTION
## Summary
- PHASE_1_QUALIFICATION.md exit checklist
- Seed CUTOVER_LOG (Phase 1 exit approved; Phase 2 not started)
- README ledger index update

## Test plan
- [ ] required Actions green → squash-merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 1 qualification and approval records for the React/Rust migration.
  * Documented the transition into Phase 2, including remaining deployment steps and next cohort validation.
  * Updated migration status, fallback behavior, feature-flag rollout details, and supporting evidence references.
  * Added a session log entry covering the approved Phase 1 exit and Phase 2 kickoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->