### PR TITLE
feat(p2-m0-02/03): migration telemetry and rollback drill

### DIFF
--- a/docs/migration/react-rust/CUTOVER_LOG.md
+++ b/docs/migration/react-rust/CUTOVER_LOG.md
@@ -2,6 +2,12 @@
 
 Phase 2 operational record. Newest first.
 
+## 2026-07-31 — P2-M0-02 / P2-M0-03 telemetry + rollback
+
+- Migration metrics: `GET /api/ui/migration-metrics` + `POST /api/ui/migration-event` (fallback_click / ui_error / datafusion_skip).
+- Rollback drill doc: `ROLLBACK_DRILL.md` (compose.react → compose.central, expand-only schema).
+- **Stop for human** before Prompt 2+ (computation closure / canary / deletion).
+
 ## 2026-07-31 — P2-M0-01 cohort routing
 
 - Added `/api/ui/generation` (cookie + header + env default).

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,7 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-07-31 | P2-M0 schema policy is expand-only during rollback window; Streamlit/React share Rust job store | Accepted |
 | 2026-07-31 | P1-M6-02 no-Python topology is `docker/compose.react.yml` (web+central+mqtt); Streamlit remains in compose.central for rollback | Accepted |
 | 2026-07-31 | P1-M6-01 closes Python exit matrix with DELETE-P2 / ORACLE-ONLY / KEEP-AS-LIB / REPLACE only; Phase 2 deletions enumerated but not executed | Accepted |
 | 2026-07-31 | M5-B plot datasets use SVG PlotlyHost stand-in (no plotly npm); figure JSON shape reserved for Plotly.react | Accepted |

--- a/docs/migration/react-rust/ROLLBACK_DRILL.md
+++ b/docs/migration/react-rust/ROLLBACK_DRILL.md
@@ -1,0 +1,34 @@
+# P2-M0-03 — Schema compatibility + timed Streamlit rollback drill
+
+## Schema / data compatibility
+
+- Job/meta/findings/dispositions writes remain **expand-only** during Phase 2:
+  new optional fields may appear; Streamlit fallback must ignore unknowns.
+- React and Streamlit share the same Rust job store (`OPENFDD_WORKSPACE/jobs`).
+- No destructive schema contraction in the same release as a UI flip.
+- Optimistic concurrency (`meta_revision`, findings_revision) works from both UIs.
+
+## Timed rollback drill (config only)
+
+Target RTO: **≤ 15 minutes** (operator + compose).
+
+1. Record start UTC time.
+2. Confirm React cohort path healthy: `curl -sf http://localhost:8080/api/capabilities` and `/api/ui/generation`.
+3. Stop React topology:
+   ```bash
+   docker compose -f docker/compose.react.yml down
+   ```
+4. Start Streamlit fallback topology (same workspace volume):
+   ```bash
+   docker compose -f docker/compose.central.yml up -d
+   ```
+5. Verify Streamlit UI on `:3000` and central `:8080/api/health`.
+6. Optional: clear React sticky cookie / set generation streamlit:
+   ```bash
+   curl -sf -X PUT http://localhost:8080/api/ui/generation \
+     -H 'content-type: application/json' \
+     -d '{"generation":"streamlit","reason":"rollback_drill"}'
+   ```
+7. Record end UTC; attach durations to CUTOVER_LOG.
+
+**Does not** rewrite jobs, findings, or artifacts. Rollback changes routing/compose only.

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,11 @@
 
 Newest first.
 
+## 2026-07-31 — P2-M0-02 / P2-M0-03
+
+- Migration telemetry counters + event ingest; rollback drill + schema expand-only note.
+- Phase 2 M0 control plane complete. **Await human auth before Prompts 2–8.**
+
 ## 2026-07-31 — P2-M0-01
 
 - Phase 1 exit verified (CUTOVER_LOG / PHASE_1_QUALIFICATION).

--- a/frontend/web/src/api/cutoverApi.test.ts
+++ b/frontend/web/src/api/cutoverApi.test.ts
@@ -39,4 +39,14 @@ describe("cutoverApi", () => {
     );
     expect(out.production_default_flipped).toBe(false);
   });
+
+  it("posts migration events", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({ ok: true });
+    const { postMigrationEvent } = await import("./cutoverApi");
+    await postMigrationEvent("fallback_click", "user_opt_out", "react");
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/ui/migration-event",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
 });

--- a/frontend/web/src/api/cutoverApi.ts
+++ b/frontend/web/src/api/cutoverApi.ts
@@ -25,3 +25,23 @@ export async function setUiGeneration(
     body: JSON.stringify({ generation, reason }),
   });
 }
+
+export async function getMigrationMetrics(): Promise<Record<string, unknown>> {
+  return apiFetch("/api/ui/migration-metrics");
+}
+
+export async function postMigrationEvent(
+  event: string,
+  reasonCode?: string,
+  uiGeneration?: UiGeneration,
+): Promise<Record<string, unknown>> {
+  return apiFetch("/api/ui/migration-event", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      event,
+      reason_code: reasonCode,
+      ui_generation: uiGeneration,
+    }),
+  });
+}

--- a/services/central/src/cutover.rs
+++ b/services/central/src/cutover.rs
@@ -12,10 +12,17 @@ use serde_json::{json, Value};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 pub const COOKIE_NAME: &str = "openfdd_ui_generation";
 pub const HEADER_NAME: &str = "x-openfdd-ui-generation";
 pub const ENV_DEFAULT: &str = "OPENFDD_UI_GENERATION_DEFAULT";
+
+static GEN_GETS: AtomicU64 = AtomicU64::new(0);
+static GEN_PUTS: AtomicU64 = AtomicU64::new(0);
+static FALLBACK_CLICKS: AtomicU64 = AtomicU64::new(0);
+static UI_ERRORS: AtomicU64 = AtomicU64::new(0);
+static DF_SKIPS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -106,14 +113,33 @@ pub struct SetGenerationBody {
     pub reason: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct MigrationEventBody {
+    pub event: String,
+    #[serde(default)]
+    pub reason_code: Option<String>,
+    #[serde(default)]
+    pub ui_generation: Option<String>,
+}
+
 pub fn router() -> Router {
-    Router::new().route(
-        "/api/ui/generation",
-        axum::routing::get(get_generation).put(put_generation),
-    )
+    Router::new()
+        .route(
+            "/api/ui/generation",
+            axum::routing::get(get_generation).put(put_generation),
+        )
+        .route(
+            "/api/ui/migration-metrics",
+            axum::routing::get(migration_metrics),
+        )
+        .route(
+            "/api/ui/migration-event",
+            axum::routing::post(migration_event),
+        )
 }
 
 async fn get_generation(headers: HeaderMap) -> Json<GenerationStatus> {
+    GEN_GETS.fetch_add(1, Ordering::Relaxed);
     let (generation, source) = resolve_generation(&headers);
     Json(GenerationStatus {
         ok: true,
@@ -139,6 +165,7 @@ async fn put_generation(
             })),
         ));
     };
+    GEN_PUTS.fetch_add(1, Ordering::Relaxed);
     let (prev, prev_source) = resolve_generation(&headers);
     let entry = json!({
         "ts": Utc::now().to_rfc3339(),
@@ -169,6 +196,45 @@ async fn put_generation(
         response.headers_mut().append(header::SET_COOKIE, val);
     }
     Ok(response)
+}
+
+async fn migration_metrics() -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "generation_gets": GEN_GETS.load(Ordering::Relaxed),
+        "generation_puts": GEN_PUTS.load(Ordering::Relaxed),
+        "fallback_clicks": FALLBACK_CLICKS.load(Ordering::Relaxed),
+        "ui_errors": UI_ERRORS.load(Ordering::Relaxed),
+        "datafusion_skips": DF_SKIPS.load(Ordering::Relaxed),
+        "notes": [
+            "Counters are process-local (reset on restart).",
+            "Do not log tokens or sensitive payloads here.",
+            "Alert hooks: React uncaught <0.5%; core success not worse than Streamlit by >1pp (budgets in PHASE_2 doc)."
+        ]
+    }))
+}
+
+async fn migration_event(Json(body): Json<MigrationEventBody>) -> Json<Value> {
+    match body.event.as_str() {
+        "fallback_click" => {
+            FALLBACK_CLICKS.fetch_add(1, Ordering::Relaxed);
+        }
+        "ui_error" => {
+            UI_ERRORS.fetch_add(1, Ordering::Relaxed);
+        }
+        "datafusion_skip" => {
+            DF_SKIPS.fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    }
+    let entry = json!({
+        "ts": Utc::now().to_rfc3339(),
+        "event": body.event,
+        "reason_code": body.reason_code,
+        "ui_generation": body.ui_generation,
+    });
+    let _ = append_audit(&entry);
+    Json(json!({"ok": true}))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `GET /api/ui/migration-metrics` + `POST /api/ui/migration-event`
- `ROLLBACK_DRILL.md` (compose.react → compose.central)
- Expand-only schema decision; stop before Prompt 2+

## Test plan
- [x] cutoverApi vitest
- [ ] required Actions green → squash-merge

Made with [Cursor](https://cursor.com)