### PR TITLE
feat(p2-m1-01): computation closure ledger and no-Python policy

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -66,3 +66,4 @@ jobs:
           # frontend/ or web/ in later milestones. Policy script rejects Python backends.
           test -f docs/architecture/adr-001-react-rust-modernization.md
           python3 scripts/architecture_react_policy_check.py
+          python3 scripts/phase2_computation_policy_check.py

--- a/docs/migration/react-rust/COMPUTATION_CLOSURE.md
+++ b/docs/migration/react-rust/COMPUTATION_CLOSURE.md
@@ -1,0 +1,63 @@
+# P2-M1 — Computation closure ledger
+
+Prompt 2 inventory against code truth (commit of this PR). Production React
+callers already use Rust/DataFusion; remaining Python is Streamlit-local,
+explicitly gated oracle, or deferred product.
+
+Status values: `CLOSED` | `CUTOVER-NEEDED` | `ORACLE` | `DEFER` | `PROVISIONAL`
+
+| family | React caller | central owner | Streamlit twin | prod Python on React path | status | notes |
+|---|---|---|---|---|---|---|
+| FDD registry run | `fddApi` → `POST /api/fdd/run` | `fdd_rules` + DataFusion SQL | `agent_api` / gated `rules/runner` | No | CLOSED | Pandas only if `OPENFDD_ALLOW_PANDAS_FDD=1` (oracle) |
+| FDD results/series | Rules / Reports | `/api/fdd/results`, `/api/fdd/series` | charts / rule_card | No | CLOSED | |
+| Analytics metering (inline) | `analyticsApi` / MeteringPage | `analytics/metering.rs` monthly sum | `metering.py` rate→monthly prep | No | CLOSED | React posts `{period,kwh}`; no pandas |
+| Analytics metering (historian rate→kWh) | — | descriptive counts only | `metering.py` integrate_rate | N/A | PROVISIONAL | Historian invents no energy; rate integrate stays twin until M1 follow-on or delete |
+| Analytics runtime / RCx / sensor / schedule / econ | MeteringPage / Overview | `analytics/*.rs` + historian DF | `ui_analytics`, `ui_rcx_tab`, `runtime_intervals` | No | CLOSED / PROVISIONAL | Descriptive historian rows where full formula not yet proven |
+| Jobs / findings / dispositions | FindingsPage / JobsPage | `jobs.rs` | `eng_findings`, `ui_jobs` | No | CLOSED | |
+| Reports artifacts | ReportsPage | `/api/reports*` | `reports.py`, downloads | No | CLOSED | PDF/DOCX = ORACLE |
+| WattLab handoff | WattLabPage | jobs wattlab handoffs | `ui_wattlab_*`, dump | No | CLOSED | |
+| Upload / mapping / package | UploadPage / MappingPage | csv_ingest / package.rs | package_io, mapping_wizard | No | CLOSED | Streamlit twins ORACLE until delete |
+| Weather acquisition | — | — | open_meteo / weather_* | — | ORACLE / DEFER | CAP-WEATHER NOT_STARTED; ORACLE-ONLY |
+| ECM workbooks | — | — | ui_ecm_job | — | DEFER | KEEP-AS-LIB `open_fdd/ecm_engineering` |
+| Site delete FS | — | — | site_model | — | DEFER | CAP-SITE NOT_STARTED |
+
+## Remaining Python call sites (must stay unreachable on React/no-Python stack)
+
+| path | gate | disposition |
+|---|---|---|
+| `services/ui/app/metering.py` | Streamlit Metering/RCx only | DELETE-P2 after canary (`P2-DEL-01`) |
+| `services/ui/app/rules/**` + `OPENFDD_ALLOW_PANDAS_FDD` | explicit env | ORACLE-ONLY (`P2-DEL-08` prod image) |
+| `OPENFDD_ANALYTICS_ORACLE=1` branches | explicit env | ORACLE-ONLY |
+| `open_fdd/analytics` | PyPI / Streamlit shims | REPLACE → delete after observation |
+| `open_fdd/rules` | oracle / emergency | ORACLE-ONLY |
+
+## Registry production status honesty
+
+`sql_rules/registry.yaml` (63 rules):
+
+| raw `parity_status` | count | production meaning |
+|---|---|---|
+| `proven_building_100` | 24 | **PROVEN** |
+| `ported_from_cookbook` | 38 | **PROVISIONAL** (visible limitation; not silently “done”) |
+| `skipped_missing_roles` | 1 | **DISABLED** until roles exist |
+
+“Ported ≠ PROVEN.” Canary/default flip may ship PROVISIONAL rules with documented limits.
+
+## Policy proof (this PR)
+
+`scripts/phase2_computation_policy_check.py`:
+
+1. `docker/compose.react.yml` has no Streamlit `ui` / `openfdd-ui` service.
+2. Product React compose must not set `OPENFDD_ALLOW_PANDAS_FDD` or `OPENFDD_ANALYTICS_ORACLE`.
+3. `services/central/src` (non-test) has no `python`/`pandas`/`pip`/`streamlit` spawn strings.
+4. This ledger file exists.
+
+## Follow-on PRs (not this PR)
+
+| PR | scope |
+|---|---|
+| P2-M2-01/02 | Shadow harness + soak evidence |
+| P2-M3-* | Canary promotion decisions |
+| P2-M4-01 | React production default flip (authorized separately / turnkey) |
+| P2-M5 / DEL-* | Leaf twin deletion per `PHASE_2_DELETION_CANDIDATES.md` |
+| P2-M6 / Prompt 7–8 | Streamlit product removal + final no-Python qual |

--- a/docs/migration/react-rust/CUTOVER_LOG.md
+++ b/docs/migration/react-rust/CUTOVER_LOG.md
@@ -2,6 +2,12 @@
 
 Phase 2 operational record. Newest first.
 
+## 2026-08-01 — P2-M1-01 computation closure
+
+- Ledger: `COMPUTATION_CLOSURE.md`. Policy: `scripts/phase2_computation_policy_check.py`.
+- Production React path: no Python computation. Turnkey auth to continue Prompts 2–8.
+- Next: P2-M2 shadow/soak → M3 canary → M4 default flip → twin deletion.
+
 ## 2026-07-31 — P2-M0-02 / P2-M0-03 telemetry + rollback
 
 - Migration metrics: `GET /api/ui/migration-metrics` + `POST /api/ui/migration-event` (fallback_click / ui_error / datafusion_skip).

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,8 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-08-01 | Production rule statuses: proven_building_100→PROVEN; ported_from_cookbook→PROVISIONAL; skipped_missing_roles→DISABLED. Ported ≠ PROVEN | Accepted |
+| 2026-08-01 | React/no-Python product path has no production Python computation; Streamlit twins + gated pandas remain until deletion window | Accepted |
 | 2026-07-31 | P2-M0 schema policy is expand-only during rollback window; Streamlit/React share Rust job store | Accepted |
 | 2026-07-31 | P1-M6-02 no-Python topology is `docker/compose.react.yml` (web+central+mqtt); Streamlit remains in compose.central for rollback | Accepted |
 | 2026-07-31 | P1-M6-01 closes Python exit matrix with DELETE-P2 / ORACLE-ONLY / KEEP-AS-LIB / REPLACE only; Phase 2 deletions enumerated but not executed | Accepted |

--- a/docs/migration/react-rust/PYTHON_EXIT_MATRIX.md
+++ b/docs/migration/react-rust/PYTHON_EXIT_MATRIX.md
@@ -74,5 +74,5 @@ ORACLE-ONLY / ARCHIVE-DECISION / KEEP-AS-LIB / REPLACE. Deletion is Phase 2 only
 | services/ui/app/weather_resolver.py | Weather series resolve | services/ui | MAYBE | Rust/DataFusion or React presentation | ORACLE-ONLY | characterization; no silent prod fallback | oracle tooling retained |
 | open_fdd/ecm_engineering | ECM workbooks (PyPI) | ui_ecm_job, Jobs/MCP docs | YES (engineering) | keep PyPI; React consumes API/export | KEEP-AS-LIB | packaging tests | customer ECM path |
 | open_fdd/rules | Pandas oracle | UI cookbook / emergency FDD / PyPI | YES | ORACLE-ONLY in prod images | ORACLE-ONLY | characterization; no silent prod fallback | oracle tooling retained |
-| open_fdd/analytics | Pandas analytics libs | UI analytics shims / PyPI | YES | DataFusion analytics API | REPLACE | DataFusion analytics + MeteringPage | none after P2 caller cutover |
+| open_fdd/analytics | Pandas analytics libs | UI analytics shims / PyPI | YES | DataFusion analytics API | REPLACE | DataFusion analytics + MeteringPage (P2-M1-01 CLOSED on React path; twin delete after canary) | observation window + P2-DEL-01 |
 | open_fdd/reporting | Findings reporting libs | eng findings / PyPI | YES | Rust reports or ORACLE | ORACLE-ONLY | characterization; no silent prod fallback | oracle tooling retained |

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,13 @@
 
 Newest first.
 
+## 2026-08-01 — P2-M1-01 computation closure ledger
+
+- Added `COMPUTATION_CLOSURE.md` + `scripts/phase2_computation_policy_check.py` (wired in security.yml).
+- React/central FDD + analytics callers CLOSED; metering historian rate→kWh PROVISIONAL; weather/ECM/site DEFER/ORACLE.
+- Registry honesty: 24 PROVEN / 38 PROVISIONAL / 1 DISABLED. Human auth granted to continue Prompts 2–8 turnkey.
+- Next: P2-M2 shadow/soak.
+
 ## 2026-07-31 — P2-M0-02 / P2-M0-03
 
 - Migration telemetry counters + event ingest; rollback drill + schema expand-only note.

--- a/scripts/phase2_computation_policy_check.py
+++ b/scripts/phase2_computation_policy_check.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""P2-M1 computation / no-Python product policy gates.
+
+Fails if the React no-Python product path still ships a Streamlit UI service,
+enables pandas FDD/oracle flags on that compose file, or if central production
+sources spawn/import python/pandas runtimes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_REACT = ROOT / "docker" / "compose.react.yml"
+CLOSURE = ROOT / "docs" / "migration" / "react-rust" / "COMPUTATION_CLOSURE.md"
+CENTRAL_SRC = ROOT / "services" / "central" / "src"
+
+FORBIDDEN_ENV = (
+    "OPENFDD_ALLOW_PANDAS_FDD",
+    "OPENFDD_ANALYTICS_ORACLE",
+)
+
+# Actual runtime invocation / dependency markers (not cutover enum labels).
+FORBIDDEN_CENTRAL = (
+    re.compile(r"\bpandas\b", re.I),
+    re.compile(r"""Command::new\(\s*["'](?:python3?|pip3?|streamlit)["']""", re.I),
+    re.compile(r"""["'](?:python3?|pip3?)\s+-[cm]""", re.I),
+    re.compile(r"std::process::Command", re.I),
+)
+
+
+def _strip_yaml_comments(text: str) -> str:
+    lines = []
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        # Inline comment: keep code before unquoted #
+        if "#" in line:
+            code, _, _ = line.partition("#")
+            lines.append(code)
+        else:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def check_compose_react(errors: list[str]) -> None:
+    if not COMPOSE_REACT.is_file():
+        errors.append(f"missing {COMPOSE_REACT.relative_to(ROOT)}")
+        return
+    raw = COMPOSE_REACT.read_text(encoding="utf-8")
+    text = _strip_yaml_comments(raw)
+    if re.search(r"(?m)^  ui:\s*$", text):
+        errors.append("compose.react.yml must not define a Streamlit `ui` service")
+    if re.search(r"image:\s*.*openfdd-ui", text, re.I):
+        errors.append("compose.react.yml must not pull openfdd-ui image")
+    if re.search(r"\bstreamlit_app\b", text, re.I):
+        errors.append("compose.react.yml must not reference streamlit_app")
+    for env in FORBIDDEN_ENV:
+        if env in text:
+            errors.append(f"compose.react.yml must not set {env}")
+
+
+def check_closure_ledger(errors: list[str]) -> None:
+    if not CLOSURE.is_file():
+        errors.append(f"missing {CLOSURE.relative_to(ROOT)}")
+        return
+    text = CLOSURE.read_text(encoding="utf-8")
+    for needle in ("CLOSED", "ORACLE", "PROVISIONAL", "ported_from_cookbook"):
+        if needle not in text:
+            errors.append(f"COMPUTATION_CLOSURE.md missing required marker {needle!r}")
+
+
+def check_central_src(errors: list[str]) -> None:
+    if not CENTRAL_SRC.is_dir():
+        errors.append("missing services/central/src")
+        return
+    for path in CENTRAL_SRC.rglob("*.rs"):
+        rel = str(path.relative_to(ROOT)).replace("\\", "/")
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            errors.append(f"unreadable {rel}: {exc}")
+            continue
+        for pat in FORBIDDEN_CENTRAL:
+            for i, line in enumerate(text.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("//"):
+                    continue
+                if not pat.search(line):
+                    continue
+                if re.search(
+                    r"\b(forbid|forbidden|ban|banned|never|not|reject|must not|policy|deny)\b",
+                    line,
+                    re.I,
+                ):
+                    continue
+                errors.append(
+                    f"{rel}:{i} matches forbidden runtime marker {pat.pattern!r}: {stripped}"
+                )
+
+
+def main() -> int:
+    errors: list[str] = []
+    check_compose_react(errors)
+    check_closure_ledger(errors)
+    check_central_src(errors)
+    if errors:
+        print("phase2_computation_policy_check FAILED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print("phase2_computation_policy_check OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `COMPUTATION_CLOSURE.md` inventory (CLOSED / PROVISIONAL / ORACLE / DEFER)
- `scripts/phase2_computation_policy_check.py` wired into security.yml
- Registry honesty + turnkey continuation of Prompts 2–8

## Test plan
- [x] `python3 scripts/phase2_computation_policy_check.py`
- [ ] required Actions green → squash-merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to verify the React-based production path remains free of prohibited legacy computation dependencies.
  * Added migration tracking for computation ownership, rule status, cutover progress, and remaining transition stages.

* **Documentation**
  * Documented computation-closure classifications, migration decisions, exit criteria, and upcoming shadow, canary, and deletion phases.
  * Updated migration evidence to reflect completed React-path closure and pending observation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->