### PR TITLE
feat(p2-m4): flip production UI generation default to React

### DIFF
--- a/docker/compose.central.yml
+++ b/docker/compose.central.yml
@@ -33,6 +33,8 @@ services:
       OPENFDD_PARQUET_ROOT: /workspace/.cache/parquet
       OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:-}
       OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
+      # Rollback / Streamlit stack: keep generation default on Streamlit.
+      OPENFDD_UI_GENERATION_DEFAULT: ${OPENFDD_UI_GENERATION_DEFAULT:-streamlit}
     ports:
       - "${OPENFDD_CENTRAL_BIND:-0.0.0.0}:8080:8080"
     volumes:

--- a/docker/compose.react.yml
+++ b/docker/compose.react.yml
@@ -37,6 +37,8 @@ services:
       OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:-}
       OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
       OPENFDD_REACT_UI: "1"
+      # P2-M4: React is the production default UI generation.
+      OPENFDD_UI_GENERATION_DEFAULT: react
     ports:
       - "${OPENFDD_CENTRAL_BIND:-0.0.0.0}:8080:8080"
     volumes:

--- a/docs/migration/react-rust/CUTOVER_LOG.md
+++ b/docs/migration/react-rust/CUTOVER_LOG.md
@@ -2,6 +2,12 @@
 
 Phase 2 operational record. Newest first.
 
+## 2026-08-01 — P2-M4 React default flip
+
+- Time: 2026-08-01 (turnkey auth). Config: `OPENFDD_UI_GENERATION_DEFAULT` default → `react`.
+- `production_default_flipped: true`. Streamlit fallback still available (cookie / compose.central).
+- Observation: migration metrics + fallback_click. Next: P2-M5 leaf twin deletion after observation note.
+
 ## 2026-08-01 — P2-M3 canary PROMOTE
 
 - Decision record: `CANARY_DECISIONS.md` — PROMOTE to 100% with Streamlit fallback.

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,7 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-08-01 | P2-M4: production UI generation default is React; Streamlit via cookie/header or compose.central env | Accepted |
 | 2026-08-01 | P2-M3 canary: PROMOTE to 100% with Streamlit fallback; default flip deferred to P2-M4 | Accepted |
 | 2026-08-01 | Production rule statuses: proven_building_100→PROVEN; ported_from_cookbook→PROVISIONAL; skipped_missing_roles→DISABLED. Ported ≠ PROVEN | Accepted |
 | 2026-08-01 | React/no-Python product path has no production Python computation; Streamlit twins + gated pandas remain until deletion window | Accepted |

--- a/docs/migration/react-rust/ROLLBACK_DRILL.md
+++ b/docs/migration/react-rust/ROLLBACK_DRILL.md
@@ -32,3 +32,9 @@ Target RTO: **≤ 15 minutes** (operator + compose).
 7. Record end UTC; attach durations to CUTOVER_LOG.
 
 **Does not** rewrite jobs, findings, or artifacts. Rollback changes routing/compose only.
+
+## Post P2-M4 note
+
+Production default generation is **React**. `compose.central.yml` pins
+`OPENFDD_UI_GENERATION_DEFAULT=streamlit` so the Streamlit stack remains an
+explicit rollback path without rebuilding images.

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,12 @@
 
 Newest first.
 
+## 2026-08-01 — P2-M4-01 React production default flip
+
+- `default_generation()` → React; `production_default_flipped=true`.
+- `compose.react.yml` sets `OPENFDD_UI_GENERATION_DEFAULT=react`; `compose.central.yml` keeps streamlit for rollback.
+- Routing/config only. Streamlit frozen for fallback until Prompt 7. Next: twin deletion (P2-M5).
+
 ## 2026-08-01 — P2-M3 canary decisions
 
 - `CANARY_DECISIONS.md`: **PROMOTE** through 100% with Streamlit fallback.

--- a/frontend/web/src/api/cutoverApi.test.ts
+++ b/frontend/web/src/api/cutoverApi.test.ts
@@ -12,32 +12,32 @@ describe("cutoverApi", () => {
     vi.mocked(apiFetch).mockReset();
   });
 
-  it("gets generation status", async () => {
-    vi.mocked(apiFetch).mockResolvedValue({
-      ok: true,
-      generation: "streamlit",
-      source: "default",
-      default_generation: "streamlit",
-      production_default_flipped: false,
-      sticky_cookie: "openfdd_ui_generation",
-    });
-    const st = await getUiGeneration();
-    expect(st.production_default_flipped).toBe(false);
-    expect(st.generation).toBe("streamlit");
-  });
-
-  it("puts generation without flipping production default", async () => {
+  it("gets generation status after P2-M4 React default", async () => {
     vi.mocked(apiFetch).mockResolvedValue({
       ok: true,
       generation: "react",
-      production_default_flipped: false,
+      source: "default",
+      default_generation: "react",
+      production_default_flipped: true,
+      sticky_cookie: "openfdd_ui_generation",
     });
-    const out = await setUiGeneration("react", "canary cohort");
+    const st = await getUiGeneration();
+    expect(st.production_default_flipped).toBe(true);
+    expect(st.generation).toBe("react");
+  });
+
+  it("puts generation while production default remains flipped", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: true,
+      generation: "streamlit",
+      production_default_flipped: true,
+    });
+    const out = await setUiGeneration("streamlit", "rollback cohort");
     expect(apiFetch).toHaveBeenCalledWith(
       "/api/ui/generation",
       expect.objectContaining({ method: "PUT" }),
     );
-    expect(out.production_default_flipped).toBe(false);
+    expect(out.production_default_flipped).toBe(true);
   });
 
   it("posts migration events", async () => {

--- a/services/central/src/cutover.rs
+++ b/services/central/src/cutover.rs
@@ -1,7 +1,7 @@
-//! UI generation cutover control plane (P2-M0-01).
+//! UI generation cutover control plane (P2-M0-01 / P2-M4-01).
 //!
-//! Default remains Streamlit. React is opt-in via cookie/header/env — never a
-//! silent production default flip in this module.
+//! P2-M4: production default is React. Streamlit remains available via sticky
+//! cookie/header or `OPENFDD_UI_GENERATION_DEFAULT=streamlit` (rollback stack).
 
 use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
 use axum::response::IntoResponse;
@@ -48,12 +48,17 @@ impl UiGeneration {
     }
 }
 
-/// Safe default when config is absent/invalid: Streamlit.
+/// Safe default when config is absent/invalid: React (P2-M4).
 pub fn default_generation() -> UiGeneration {
     match std::env::var(ENV_DEFAULT) {
-        Ok(v) => UiGeneration::parse(&v).unwrap_or(UiGeneration::Streamlit),
-        Err(_) => UiGeneration::Streamlit,
+        Ok(v) => UiGeneration::parse(&v).unwrap_or(UiGeneration::React),
+        Err(_) => UiGeneration::React,
     }
+}
+
+/// True after the authorized P2-M4 production default flip.
+pub fn production_default_flipped() -> bool {
+    true
 }
 
 pub fn resolve_generation(headers: &HeaderMap) -> (UiGeneration, &'static str) {
@@ -146,8 +151,7 @@ async fn get_generation(headers: HeaderMap) -> Json<GenerationStatus> {
         generation,
         source: source.into(),
         default_generation: default_generation(),
-        // P2-M0-01 never flips the production default.
-        production_default_flipped: false,
+        production_default_flipped: production_default_flipped(),
         sticky_cookie: COOKIE_NAME.into(),
     })
 }
@@ -174,7 +178,7 @@ async fn put_generation(
         "from_source": prev_source,
         "to": generation.as_str(),
         "reason": body.reason,
-        "production_default_flipped": false,
+        "production_default_flipped": production_default_flipped(),
     });
     if let Err(e) = append_audit(&entry) {
         tracing::warn!(error = %e, "cutover audit write failed");
@@ -189,7 +193,7 @@ async fn put_generation(
         "generation": generation.as_str(),
         "source": "cookie",
         "audit": entry,
-        "production_default_flipped": false,
+        "production_default_flipped": production_default_flipped(),
     }))
     .into_response();
     if let Ok(val) = HeaderValue::from_str(&cookie) {
@@ -243,10 +247,12 @@ mod tests {
     use axum::http::HeaderValue;
 
     #[test]
-    fn invalid_env_defaults_to_streamlit() {
+    fn invalid_env_defaults_to_react() {
         std::env::set_var(ENV_DEFAULT, "bogus");
-        assert_eq!(default_generation(), UiGeneration::Streamlit);
+        assert_eq!(default_generation(), UiGeneration::React);
         std::env::remove_var(ENV_DEFAULT);
+        assert_eq!(default_generation(), UiGeneration::React);
+        assert!(production_default_flipped());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Default UI generation → React; `production_default_flipped=true`
- compose.react pins react; compose.central pins streamlit for rollback
- Routing/config only (turnkey authorized after canary PROMOTE)

## Test plan
- [x] cutoverApi vitest
- [ ] required Actions green → squash-merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * React is now the default UI generation option in production.
  * Added visibility into whether the production default has switched to React.
  * Streamlit remains available as an explicit fallback or rollback option.

* **Documentation**
  * Updated migration, rollout, and rollback records to document the React default transition.

* **Tests**
  * Updated cutover tests to verify React defaults, status reporting, and Streamlit fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->