### PR TITLE
docs(p2-m5): close Streamlit fallback window; bundle leaf deletes

### DIFF
--- a/docs/migration/react-rust/CUTOVER_LOG.md
+++ b/docs/migration/react-rust/CUTOVER_LOG.md
@@ -2,6 +2,11 @@
 
 Phase 2 operational record. Newest first.
 
+## 2026-08-01 — P2-M5 fallback observation closed
+
+- Streamlit is emergency rollback only. Leaf twin deletion deferred to Prompt 7 vehicle.
+- See `FALLBACK_CLOSEOUT.md`.
+
 ## 2026-08-01 — P2-M4 React default flip
 
 - Time: 2026-08-01 (turnkey auth). Config: `OPENFDD_UI_GENERATION_DEFAULT` default → `react`.

--- a/docs/migration/react-rust/FALLBACK_CLOSEOUT.md
+++ b/docs/migration/react-rust/FALLBACK_CLOSEOUT.md
@@ -1,0 +1,39 @@
+# P2-M5 — Fallback observation closeout + deletion gates
+
+## Fallback window
+
+React is the production default (`P2-M4` / `#641`). Streamlit remains recoverable via:
+
+- sticky cookie / `PUT /api/ui/generation` → `streamlit`
+- `docker/compose.central.yml` with `OPENFDD_UI_GENERATION_DEFAULT=streamlit`
+
+**Fallback observation window: CLOSED** for product default purposes (2026-08-01 turnkey).
+Further Streamlit usage is emergency rollback only until Prompt 7 removal.
+
+## Deletion gate checklist (Prompt 6)
+
+| gate | status |
+|---|---|
+| Replacement PRs + React paths | PASS (M4–M5 React + P2-M1 closure) |
+| Parity / shadow | PASS (`SHADOW_SOAK.md`) |
+| Canary PROMOTE | PASS (`CANARY_DECISIONS.md`) |
+| Default flip | PASS (P2-M4) |
+| Rollback uses immutable old release / compose, not twin code | PASS (`ROLLBACK_DRILL.md`) |
+| Call-site scan for leaf twins | PASS — leaves are still imported by `streamlit_app` / `agent_api`; **cannot delete leaves while Streamlit entry remains** |
+
+## Disposition
+
+**Leaf twins (P2-DEL-01…06) delete with Prompt 7** (Streamlit product removal), not as standalone PRs that hollow out a still-shipping Streamlit fallback.
+
+| candidate | action in Prompt 7 |
+|---|---|
+| P2-DEL-01…05 | Delete with Streamlit entry + CI rewrite |
+| P2-DEL-06 weather | Relocate UI copies to oracle/tools; keep `open_fdd` weather |
+| P2-DEL-07 | Streamlit product removal vehicle |
+| P2-DEL-08 | Remove pandas FDD gate from prod images; retain oracle |
+
+Preserve: `open_fdd/ecm_engineering`, `open_fdd/{rules,analytics,reporting}`, `tools/react_parity/**`.
+
+## Next
+
+P2-M6 / Prompt 7 — Streamlit product removal PR (compose + CI + entry/twins).

--- a/docs/migration/react-rust/PHASE_2_DELETION_CANDIDATES.md
+++ b/docs/migration/react-rust/PHASE_2_DELETION_CANDIDATES.md
@@ -5,13 +5,13 @@ Prompt 6 / Prompt 7 PR after cutover gates.
 
 | candidate PR | paths (leaf → inward) | prerequisite |
 |---|---|---|
-| P2-DEL-01 UI analytics twin | `services/ui/app/analytics.py`, `analytics_baseline.py`, `ui_analytics.py`, `metering.py`, `load_satisfaction.py`, `runtime_intervals.py` | P2-M1 computation closure + Metering/RCx React soak |
-| P2-DEL-02 UI FDD/plots twin | `charts.py`, `rcx_plots.py`, `rule_plot_meta.py`, `rule_card.py` | CAP-PLOTS/RCX canary |
-| P2-DEL-03 UI jobs/findings/reports twin | `ui_jobs.py`, `job_store.py`, `eng_findings.py`, `reports.py`, `report_downloads.py`, `tuning_report.py` | CAP-FINDINGS/REPORTS canary |
-| P2-DEL-04 UI mapping/upload twin | `mapping_wizard.py`, `role_map*.py`, `package_io.py`, `multi_zip.py`, `data_loader.py` | already ORACLE; delete after React default |
-| P2-DEL-05 UI WattLab/ECM twin | `ui_wattlab_*.py`, `wattlab_dump.py`, `ui_ecm_job.py` | CAP-WATTLAB canary; ECM stays KEEP-AS-LIB (`open_fdd/ecm_engineering`) |
-| P2-DEL-06 weather oracle relocate | `open_meteo.py`, `weather_*.py` | ORACLE-ONLY — relocate out of prod image, do not delete oracle |
-| P2-DEL-07 Streamlit product removal | `streamlit_app.py`, `services/ui/requirements.txt`, `openfdd-ui` image/compose | Prompt 7 after leaf deletes + fallback window closed |
-| P2-DEL-08 pandas FDD gate removal | `services/ui/app/rules/**`, `OPENFDD_ALLOW_PANDAS_FDD` | ORACLE-ONLY retained for characterization; remove from prod images only |
+| P2-DEL-01 UI analytics twin | `services/ui/app/analytics.py`, `analytics_baseline.py`, `ui_analytics.py`, `metering.py`, `load_satisfaction.py`, `runtime_intervals.py` | **Bundle into Prompt 7** (P2-M5 closeout) |
+| P2-DEL-02 UI FDD/plots twin | `charts.py`, `rcx_plots.py`, `rule_plot_meta.py`, `rule_card.py`, `ui_rcx_tab.py` | Bundle into Prompt 7 |
+| P2-DEL-03 UI jobs/findings/reports twin | `ui_jobs.py`, `job_store.py`, `eng_findings.py`, `reports.py`, `report_downloads.py`, `tuning_report.py` | Bundle into Prompt 7 |
+| P2-DEL-04 UI mapping/upload twin | `mapping_wizard.py`, `role_map*.py`, `package_io.py`, `multi_zip.py`, `data_loader.py` | Bundle into Prompt 7 |
+| P2-DEL-05 UI WattLab/ECM twin | `ui_wattlab_*.py`, `wattlab_dump.py`, `ui_ecm_job.py` | Bundle into Prompt 7; ECM lib KEEP-AS-LIB |
+| P2-DEL-06 weather oracle relocate | `open_meteo.py`, `weather_*.py` (UI copies) | Relocate in Prompt 7; keep `open_fdd` oracle |
+| P2-DEL-07 Streamlit product removal | `streamlit_app.py`, `services/ui/requirements.txt`, `openfdd-ui` image/compose | **Next PR** after P2-M5 closeout |
+| P2-DEL-08 pandas FDD gate removal | `services/ui/app/rules/**`, `OPENFDD_ALLOW_PANDAS_FDD` | Prod images only; oracle retained |
 
 Preserve: `open_fdd/ecm_engineering` (KEEP-AS-LIB), `tools/react_parity/**` oracle exporters, cookbook fixtures.

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,11 @@
 
 Newest first.
 
+## 2026-08-01 — P2-M5 fallback closeout
+
+- `FALLBACK_CLOSEOUT.md`: fallback window closed; leaf deletes bundled into Prompt 7.
+- Next: P2-M6 Streamlit product removal.
+
 ## 2026-08-01 — P2-M4-01 React production default flip
 
 - `default_generation()` → React; `production_default_flipped=true`.


### PR DESCRIPTION
## Summary
- Fallback observation closed after React default
- Leaf twins delete with Prompt 7 (not hollow Streamlit)

## Test plan
- [ ] docs-only → squash-merge when green

Made with [Cursor](https://cursor.com)