### PR TITLE
feat(p2-m6): remove Streamlit from product compose and CI gates

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -47,14 +47,14 @@ jobs:
         run: trivy fs --exit-code 1 --severity HIGH,CRITICAL .
 
   dashboard-audit:
-    name: Streamlit UI requirements present
+    name: React product UI present (Streamlit archived)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Guard Streamlit UI (no React)
+      - name: Guard product UI path
         run: |
-          test -f services/ui/requirements.txt
-          grep -qi streamlit services/ui/requirements.txt
+          test -f frontend/web/package.json
+          test -f services/ui/ARCHIVED.md
           ! test -f workspace/dashboard/package.json
 
   dockerfile-lint:
@@ -68,10 +68,16 @@ jobs:
           dockerfile: services/central/Dockerfile
           failure-threshold: error
           ignore: DL3008
-      - name: Hadolint UI (Streamlit)
+      - name: Hadolint UI (archived Streamlit)
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: services/ui/Dockerfile
+          failure-threshold: error
+          ignore: DL3008
+      - name: Hadolint web (React)
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: frontend/web/Dockerfile
           failure-threshold: error
           ignore: DL3008
       - name: Hadolint fieldbus

--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -48,11 +48,11 @@ jobs:
       - name: Stack crate tests
         run: cargo test -p openfdd-central -p openfdd-fieldbus -p openfdd_mqtt
 
-      - name: Streamlit UI syntax check
+      - name: Product UI archive marker
         run: |
-          python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py
-          test -f services/ui/Dockerfile
-          test -f services/ui/requirements.txt
+          test -f services/ui/ARCHIVED.md
+          test -f frontend/web/package.json
+          test -f docker/compose.react.yml
 
       - name: Compose config check (all recipes)
         env:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -57,7 +57,7 @@ jobs:
           grep -q 'auth.env.local' .gitignore || grep -q '/workspace' .gitignore
 
   frontend:
-    name: Streamlit UI checks
+    name: Product UI guards (React) + archive marker
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -65,31 +65,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Streamlit UI syntax + layout guards
+      - name: React product UI + Streamlit archive
         run: |
-          test -f services/ui/Dockerfile
-          test -f services/ui/streamlit_app.py
-          test -f services/ui/requirements.txt
-          test -f services/ui/app/central_client.py
-          python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py services/ui/app/agent_api.py services/ui/app/job_store.py services/ui/app/ui_jobs.py
-          grep -q "Rule tuning" services/ui/streamlit_app.py
-          grep -q "Delete…" services/ui/streamlit_app.py || grep -q "Delete site" services/ui/streamlit_app.py
-          grep -q "Active site" services/ui/streamlit_app.py
-          grep -q "def _run_rule_list" services/ui/streamlit_app.py
-          grep -q "DataFusion" services/ui/streamlit_app.py || grep -q "run_fdd" services/ui/app/central_client.py
-          grep -q "Authorization" services/ui/app/central_client.py
-          grep -q "confirm_seconds" services/ui/app/central_client.py
-          grep -q "Jobs (persistent)" services/ui/app/ui_jobs.py
-          grep -q "WattLab" services/ui/app/dashboard_contract.py
-          grep -q "render_wattlab_section" services/ui/app/ui_wattlab_studio.py
+          test -f frontend/web/package.json
+          test -f frontend/web/Dockerfile
+          test -f docker/compose.react.yml
+          test -f services/ui/ARCHIVED.md
+          grep -q "streamlit-legacy" docker/compose.central.yml
           ! test -d workspace/dashboard/src
           ! test -f workspace/dashboard/package.json
-          pip install -q pytest requests pandas pyyaml
-          (cd services/ui && PYTHONPATH=. python3 -m pytest app/test_central_client_normalize.py app/test_job_store.py app/test_jobs_central_client.py app/test_ui_analytics.py app/test_ui_ecm_job.py -q)
+
       - name: BACnet NIC helper guards
         run: |
           test -x scripts/openfdd_bacnet_nic_setup.sh

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -82,9 +82,10 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --all-targets
       - run: |
-          python3 -m py_compile services/ui/streamlit_app.py services/ui/app/central_client.py
-          test -f services/ui/Dockerfile
-          test -f services/ui/requirements.txt
+          test -f services/ui/ARCHIVED.md
+          test -f frontend/web/package.json
+          test -f frontend/web/Dockerfile
+          test -f docker/compose.react.yml
       - run: |
           export OPENFDD_SITE_ID=local
           export OPENFDD_EDGE_ID=fieldbus-1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,28 +42,27 @@ jobs:
           test -f Cargo.toml
           test -f docker/compose.standalone.yml
           test -f docker/compose.csv.yml
+          test -f docker/compose.react.yml
           test -f services/central/Dockerfile
-          test -f services/ui/Dockerfile
-          test -f services/ui/streamlit_app.py
+          test -f frontend/web/package.json
+          test -f frontend/web/Dockerfile
+          test -f services/ui/ARCHIVED.md
           test -f Dockerfile.mcp
           test -f .env.example
           test -d edge
           test -d services/central
-          test -d services/ui
+          test -d frontend/web
           test -d workspace
           test ! -f Dockerfile
           test ! -f docker/compose.edge.rust.yml
           test ! -d workspace/dashboard/src
 
-      - name: No abandoned dashboard SPA; React only via ADR-001 path
+      - name: React is sole production UI (Streamlit archived)
         run: |
-          # Legacy workspace dashboard must stay deleted.
           ! test -f workspace/dashboard/package.json
-          # Streamlit remains the shipping default UI.
-          grep -q "streamlit" services/ui/requirements.txt
-          grep -q "Rule tuning" services/ui/streamlit_app.py
-          # Phase 1 React is authorized (ADR-001); package.json may appear under
-          # frontend/ or web/ in later milestones. Policy script rejects Python backends.
+          test -f services/ui/ARCHIVED.md
+          grep -q "ARCHIVED" services/ui/ARCHIVED.md
+          grep -q "streamlit-legacy" docker/compose.central.yml
           test -f docs/architecture/adr-001-react-rust-modernization.md
           python3 scripts/architecture_react_policy_check.py
           python3 scripts/phase2_computation_policy_check.py

--- a/docker/compose.central.yml
+++ b/docker/compose.central.yml
@@ -33,8 +33,9 @@ services:
       OPENFDD_PARQUET_ROOT: /workspace/.cache/parquet
       OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:-}
       OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
-      # Rollback / Streamlit stack: keep generation default on Streamlit.
-      OPENFDD_UI_GENERATION_DEFAULT: ${OPENFDD_UI_GENERATION_DEFAULT:-streamlit}
+      OPENFDD_REACT_UI: "1"
+      # P2-M6: React is the product default even on this compose file.
+      OPENFDD_UI_GENERATION_DEFAULT: ${OPENFDD_UI_GENERATION_DEFAULT:-react}
     ports:
       - "${OPENFDD_CENTRAL_BIND:-0.0.0.0}:8080:8080"
     volumes:
@@ -44,7 +45,9 @@ services:
       - mqtt
     restart: unless-stopped
 
+  # P2-M6: Streamlit is not the product UI. Enable only for emergency recovery.
   ui:
+    profiles: ["streamlit-legacy"]
     image: ${OPENFDD_UI_IMAGE:-ghcr.io/bbartling/openfdd-ui:nightly}
     build:
       context: ../services/ui

--- a/docker/compose.csv.yml
+++ b/docker/compose.csv.yml
@@ -22,6 +22,7 @@ services:
     restart: unless-stopped
 
   ui:
+    profiles: ["streamlit-legacy"]
     image: ${OPENFDD_UI_IMAGE:-ghcr.io/bbartling/openfdd-ui:nightly}
     build:
       context: ../services/ui

--- a/docker/compose.standalone.yml
+++ b/docker/compose.standalone.yml
@@ -47,6 +47,7 @@ services:
     restart: unless-stopped
 
   ui:
+    profiles: ["streamlit-legacy"]
     image: ${OPENFDD_UI_IMAGE:-ghcr.io/bbartling/openfdd-ui:nightly}
     build:
       context: ../services/ui

--- a/docs/migration/react-rust/CUTOVER_LOG.md
+++ b/docs/migration/react-rust/CUTOVER_LOG.md
@@ -2,6 +2,12 @@
 
 Phase 2 operational record. Newest first.
 
+## 2026-08-01 — P2-M6 Streamlit product removal
+
+- Product path no longer starts Streamlit by default.
+- Recovery: `ARCHIVED.md` + `--profile streamlit-legacy` + historical GHCR digests.
+- Next: Prompt 8 final no-Python qualification.
+
 ## 2026-08-01 — P2-M5 fallback observation closed
 
 - Streamlit is emergency rollback only. Leaf twin deletion deferred to Prompt 7 vehicle.

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,7 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-08-01 | P2-M6: Streamlit removed from product compose/CI; source archived in-tree; recovery via profile/GHCR | Accepted |
 | 2026-08-01 | P2-M4: production UI generation default is React; Streamlit via cookie/header or compose.central env | Accepted |
 | 2026-08-01 | P2-M3 canary: PROMOTE to 100% with Streamlit fallback; default flip deferred to P2-M4 | Accepted |
 | 2026-08-01 | Production rule statuses: proven_building_100→PROVEN; ported_from_cookbook→PROVISIONAL; skipped_missing_roles→DISABLED. Ported ≠ PROVEN | Accepted |

--- a/docs/migration/react-rust/PYTHON_EXIT_MATRIX.md
+++ b/docs/migration/react-rust/PYTHON_EXIT_MATRIX.md
@@ -6,7 +6,7 @@ ORACLE-ONLY / ARCHIVE-DECISION / KEEP-AS-LIB / REPLACE. Deletion is Phase 2 only
 
 | path | purpose | production consumers | oracle value | target owner | disposition | evidence required | deletion blocker |
 |---|---|---|---|---|---|---|---|
-| services/ui/streamlit_app.py | Product Streamlit entry | openfdd-ui image | behavioral reference | React SPA (Phase 2 delete) | DELETE-P2 | React path M4–M5; no-Python compose M6-02 | Streamlit fallback until P2 cutover |
+| services/ui/streamlit_app.py | Product Streamlit entry | openfdd-ui image | behavioral reference | React SPA | DELETED | P2-M6 product path; source archived `services/ui/ARCHIVED.md` | use compose `--profile streamlit-legacy` or GHCR digests |
 | services/ui/requirements.txt | Streamlit deps | openfdd-ui | — | web image without Streamlit | DELETE-P2 | React path M4–M5; no-Python compose M6-02 | Streamlit fallback until P2 cutover |
 | services/ui/app/agent_api.py | Local/agent helpers around UI workflows | services/ui | MAYBE | Rust/DataFusion or React presentation | DELETE-P2 | React path M4–M5; no-Python compose M6-02 | Streamlit fallback until P2 cutover |
 | services/ui/app/agent_prerun.py | Pre-run checks before FDD | services/ui | MAYBE | Rust/DataFusion or React presentation | DELETE-P2 | React path M4–M5; no-Python compose M6-02 | Streamlit fallback until P2 cutover |

--- a/docs/migration/react-rust/ROLLBACK_DRILL.md
+++ b/docs/migration/react-rust/ROLLBACK_DRILL.md
@@ -20,8 +20,9 @@ Target RTO: **≤ 15 minutes** (operator + compose).
    ```
 4. Start Streamlit fallback topology (same workspace volume):
    ```bash
-   docker compose -f docker/compose.central.yml up -d
+   docker compose -f docker/compose.central.yml --profile streamlit-legacy up -d
    ```
+   (P2-M6: `ui` is profile-gated; without the profile, compose.central is central+mqtt only.)
 5. Verify Streamlit UI on `:3000` and central `:8080/api/health`.
 6. Optional: clear React sticky cookie / set generation streamlit:
    ```bash

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,12 @@
 
 Newest first.
 
+## 2026-08-01 — P2-M6 Streamlit product removal
+
+- `STREAMLIT_PRODUCT_REMOVAL.md` + `services/ui/ARCHIVED.md`.
+- Compose `ui` → `streamlit-legacy` profile; CI product gates → React.
+- Next: P2 final no-Python qualification (Prompt 8).
+
 ## 2026-08-01 — P2-M5 fallback closeout
 
 - `FALLBACK_CLOSEOUT.md`: fallback window closed; leaf deletes bundled into Prompt 7.

--- a/docs/migration/react-rust/STREAMLIT_PRODUCT_REMOVAL.md
+++ b/docs/migration/react-rust/STREAMLIT_PRODUCT_REMOVAL.md
@@ -1,0 +1,28 @@
+# P2-M6 — Streamlit product removal
+
+## Removed from product path
+
+| surface | change |
+|---|---|
+| Default compose | `compose.central.yml` `ui` service → `profiles: [streamlit-legacy]` |
+| Generation default on central compose | `OPENFDD_UI_GENERATION_DEFAULT=react` |
+| Required CI product gates | Streamlit syntax/pytest greps removed; React + `ARCHIVED.md` required |
+| AppSec dashboard guard | React package.json + archive marker |
+| Release/GHCR validate | Archive marker instead of py_compile streamlit_app |
+
+## Retained for recovery / oracle
+
+- `services/ui/**` source + Dockerfile (historical GHCR `openfdd-ui` builds may continue for archive)
+- `open_fdd/{rules,analytics,reporting,ecm_engineering}`
+- `tools/react_parity/**`
+
+## Last Streamlit product recovery
+
+- Marker: `services/ui/ARCHIVED.md`
+- Compose: `docker compose -f docker/compose.central.yml --profile streamlit-legacy up -d`
+- Prefer pinning an immutable `ghcr.io/bbartling/openfdd-ui@sha256:…` from pre-removal retention
+
+## Matrix updates
+
+Product Streamlit entry disposition → **DELETED** from shipping topology (source archived in-tree).
+Leaf twins (P2-DEL-01…06) remain in archive tree; not imported by product compose.

--- a/services/ui/ARCHIVED.md
+++ b/services/ui/ARCHIVED.md
@@ -1,0 +1,19 @@
+# Streamlit UI — ARCHIVED (P2-M6 / Prompt 7)
+
+**Status:** Not a production product UI. React (`frontend/web` + `docker/compose.react.yml`) is the sole shipping UI.
+
+**Last product commit before archive:** `99ccdd9` (P2-M5) / React default flip `e28e156` (P2-M4).
+
+**Recovery (immutable release, not active twin):**
+
+```bash
+# Historical GHCR image (pin digest from your registry retention)
+docker pull ghcr.io/bbartling/openfdd-ui:nightly
+
+# Optional legacy compose profile (not default):
+docker compose -f docker/compose.central.yml --profile streamlit-legacy up -d
+```
+
+**Retained in-tree:** source under `services/ui/` for oracle/characterization and emergency recovery reference. Do not wire into default product compose or required CI product gates.
+
+**Preserved separately:** `open_fdd/{rules,analytics,reporting,ecm_engineering}`, `tools/react_parity/**`.


### PR DESCRIPTION
## Summary
- `ui` services profile-gated (`streamlit-legacy`)
- CI/AppSec/release validate React + `ARCHIVED.md` (no Streamlit product greps)
- Recovery documented in `STREAMLIT_PRODUCT_REMOVAL.md`

## Test plan
- [x] compose config OK for central/standalone/csv/react
- [x] policy scripts OK
- [ ] required Actions green → squash-merge

Made with [Cursor](https://cursor.com)