### PR TITLE
docs: Phase 3 readiness, skill compliance, post-P2 agent_spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,16 @@
 # Agent Guide (container stack + external agents)
 
-Open-FDD ships as a **container stack**: `openfdd-central`, `openfdd-ui`, `openfdd-fieldbus`, `openfdd-mqtt`, plus optional `openfdd-mcp`. It does **not** ship an embedded AI chatbot. External orchestrators — Codex CLI, Cursor, OpenClaw, Claude Desktop, or any MCP host — connect via **JWT REST** and optional **`openfdd-mcp` stdio**.
+Open-FDD ships as a **container stack**: `openfdd-central`, `openfdd-web` (React),
+`openfdd-fieldbus`, `openfdd-mqtt`, plus optional `openfdd-mcp` (legacy
+`openfdd-ui` Streamlit archived). It does **not** ship an embedded AI chatbot.
+External orchestrators — Codex CLI, Cursor, OpenClaw, Claude Desktop, or any MCP
+host — connect via **JWT REST** and optional **`openfdd-mcp` stdio**.
 
 | Layer | Responsibility |
 | --- | --- |
 | **central** | MQTTS ingest, Feather, FDD registry SQL, REST + JWT |
-| **ui** | Streamlit product UI (`services/ui`) — default / Phase 1 fallback; React SPA authorized per [ADR-001](docs/architecture/adr-001-react-rust-modernization.md) |
+| **web** | React product UI (`frontend/web`) — sole production UI after Phase 2 ([ADR-001](docs/architecture/adr-001-react-rust-modernization.md)) |
+| **ui (archived)** | Streamlit (`services/ui`) — recovery via `ARCHIVED.md` / `streamlit-legacy` |
 | **fieldbus** | BACnet / Modbus / Haystack OT drivers |
 | **mqtt** | Mosquitto MQTTS broker |
 | **mcp** | Optional read-first stdio tools → central (`OPENFDD_API_BASE`) |
@@ -14,7 +19,7 @@ Open-FDD ships as a **container stack**: `openfdd-central`, `openfdd-ui`, `openf
 
 **Software-engineering agent OS:** [`openfdd_agent_spec/`](openfdd_agent_spec/) — architecture locks, skills, Milestone A ([`openfdd_agent_spec/MILESTONE_A.md`](openfdd_agent_spec/MILESTONE_A.md)). Ops/edge soak prompts stay under [`docs/agent/`](docs/agent/).
 
-**React/Rust Phase 1:** [`tools/open-fdd-modernization/`](tools/open-fdd-modernization/README.md) · skill bridge [`AGENT_SKILL_BRIDGE.md`](tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md) · required UI skill [`streamlit-to-react`](tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md).
+**React/Rust modernization (Phase 1+2 exit approved; Phase 3 outlook):** [`tools/open-fdd-modernization/`](tools/open-fdd-modernization/README.md) · skill bridge [`AGENT_SKILL_BRIDGE.md`](tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md) · required UI skill [`streamlit-to-react`](tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md).
 
 **PyPI (`open-fdd` 4.1+):** ECM engineering + pandas oracle (`open_fdd.rules` / `analytics` / `reporting`) via extras. Production FDD is DataFusion/GHCR, not this wheel.
 

--- a/docs/architecture/adr-001-react-rust-modernization.md
+++ b/docs/architecture/adr-001-react-rust-modernization.md
@@ -6,9 +6,11 @@ nav_order: 2
 
 # ADR-001 — React SPA and Python exit (Phase 1)
 
-- **Status:** Accepted (2026-07-31)
+- **Status:** Accepted (2026-07-31); **Phase 2 cutover completed 2026-08-01**
+  (React sole product UI; Streamlit archived — see `PHASE_2_QUALIFICATION.md`)
 - **Program:** [`tools/open-fdd-modernization/`](../../tools/open-fdd-modernization/README.md)
 - **Tracking:** [`docs/migration/react-rust/`](../migration/react-rust/README.md)
+- **Phase 3:** outlook only ([`PHASE_3_EDGE_STREAMING_OUTLOOK.md`](../../tools/open-fdd-modernization/PHASE_3_EDGE_STREAMING_OUTLOOK.md)); not started.
 
 ## Context
 
@@ -33,9 +35,11 @@ Rust-owned APIs, with Streamlit retained as fallback until Phase 2 cutover.
    central; SPA must carry request IDs; document CSRF/CORS/CSP and safe
    artifact Content-Disposition in the contract milestone (P1-M2). Prefer
    same-origin `/api` to simplify cookies/CORS.
-6. **Streamlit:** remains the default product UI and behavioral reference during
-   Phase 1. React ships behind a reversible feature flag. Streamlit deletion is
-   Phase 2 only, after proof and a rollback window.
+6. **Streamlit:** was the default product UI and behavioral reference during
+   Phase 1. React shipped behind a reversible feature flag. **After Phase 2
+   exit (2026-08-01):** React is the sole production UI; Streamlit is archived
+   (`services/ui/ARCHIVED.md`, compose profile `streamlit-legacy`). Deletion of
+   remaining archive sources is optional follow-on, not required for Phase 2 exit.
 7. **Python during Phase 1:** frozen for product features. Allowed: oracle /
    characterization / fixtures. Disallowed: new production Python services,
    silent pandas FDD fallback, new persistence formats React must later consume.

--- a/docs/migration/react-rust/CUTOVER_LOG.md
+++ b/docs/migration/react-rust/CUTOVER_LOG.md
@@ -2,6 +2,11 @@
 
 Phase 2 operational record. Newest first.
 
+## 2026-08-01 — Phase 3 readiness (outlook only)
+
+- Evidence: `PHASE_3_READINESS.md`. No P3-M0+ implementation; no BACnet/MQTT changes.
+- Skill compliance PASS; agent_spec post–Phase-2 truth update in same pack.
+
 ## 2026-08-01 — Phase 2 exit APPROVED
 
 - Qualification: `PHASE_2_QUALIFICATION.md` **PASS**.

--- a/docs/migration/react-rust/DECISIONS.md
+++ b/docs/migration/react-rust/DECISIONS.md
@@ -4,6 +4,7 @@ Newest first. Record product/architecture calls only.
 
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-08-01 | Phase 3 remains outlook-only; readiness recorded; no BACnet/MQTT changes without separate auth | Accepted |
 | 2026-08-01 | P2-M6: Streamlit removed from product compose/CI; source archived in-tree; recovery via profile/GHCR | Accepted |
 | 2026-08-01 | P2-M4: production UI generation default is React; Streamlit via cookie/header or compose.central env | Accepted |
 | 2026-08-01 | P2-M3 canary: PROMOTE to 100% with Streamlit fallback; default flip deferred to P2-M4 | Accepted |

--- a/docs/migration/react-rust/PHASE_3_READINESS.md
+++ b/docs/migration/react-rust/PHASE_3_READINESS.md
@@ -1,0 +1,63 @@
+# Phase 3 readiness + skill compliance
+
+**Date:** 2026-08-01  
+**Modernization tip:** `7ba35fc` (Phase 2 exit) + this pack on merge.  
+**Phase 3 status:** **Outlook only** — not started. No `PHASE_3_LOOP_PROMPTS.md`.  
+**Authority:** [`tools/open-fdd-modernization/PHASE_3_EDGE_STREAMING_OUTLOOK.md`](../../tools/open-fdd-modernization/PHASE_3_EDGE_STREAMING_OUTLOOK.md)
+
+Phase 3 is architectural foresight for live edge/MQTTS → React. It is **not**
+authorization to change BACnet writes, fieldbus socket ownership, or MQTT topics.
+
+## Prerequisites (from Phase 3 outlook)
+
+| prerequisite | status | evidence |
+|---|---|---|
+| Versioned observation / job / run / finding / chart-dataset contracts | **PARTIAL** | Jobs/findings/reports/FDD series contracts exist (`API_CONTRACT_MATRIX`, `CONTRACT_CONVENTIONS` `openfdd.api.contract.v1`). **Live observation** schema (event time, sequence, quality, clock) **not** defined — blocks honest P3-M0. |
+| React treats server state as server state | **MET** | Pages load via `apiFetch` → `/api/*`; job/findings revisions; session-config for durable maps |
+| Asynchronous operation/event model | **PARTIAL** | `ASYNC_OPS.md` documents patterns; FDD run still sync `POST /api/fdd/run`; SSE/WebSocket reserved, not product |
+| Rust-only package ingest + DataFusion pipeline | **MET** | `package.rs` + `/api/csv/import/*`; FDD via DataFusion; no Python on `compose.react.yml` |
+| Centralized auth + capability discovery | **MET** | `/api/auth/*`, AuthPage; `/api/capabilities` + `react_ui` |
+| Provenance / units / quality / timestamp semantics | **PARTIAL** | Mapping/roles/units on package path; live quality/clock policies not specified |
+| Stable site/equipment/point identities | **PARTIAL** | Equipment via FDD APIs; CAP-SITE delete/selection **NOT_STARTED**; live point_id contract absent |
+| Operational metrics + immutable releases | **MET** | `/api/ui/migration-metrics`; GHCR `:nightly` + `sha-*` publish |
+
+## Blockers before P3-M0
+
+1. Define live observation contract (P3-M0 fields) without changing fieldbus wire ownership.
+2. Decide SSE vs WebSocket browser delivery; keep React off BACnet/MQTT sockets.
+3. Explicit human auth for any live BACnet write / topic redesign work.
+
+## Deferred product gaps (not Phase 3, not skill violations)
+
+From `PHASE_2_QUALIFICATION.md` accepted risks: CAP-SITE / CAP-WEATHER / CAP-ECM;
+historian metering rate→kWh PROVISIONAL; 38 rules PROVISIONAL; Streamlit source
+archived in-tree; Plotly npm not required for Phase 2 exit.
+
+---
+
+## Streamlit→React skill compliance
+
+Canonical: `tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md`  
+Wrapper: `openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md`
+
+| rule | result | notes |
+|---|---|---|
+| Browser → central `/api` only | **PASS** | `frontend/web/src/api/client.ts` relative/`VITE_API_BASE`; no FastAPI/8501 |
+| No FDD/analytics math in TypeScript | **PASS** | Clients post/get envelopes; monthlySum client mirrors API for parity only |
+| No Python product runtime | **PASS** | `compose.react.yml`; Streamlit `ARCHIVED.md` + `streamlit-legacy` profile |
+| Ledgers updated with UI work | **PASS** | `docs/migration/react-rust/` current through Phase 2 exit |
+| Comparison target | **PASS (post-P2)** | Streamlit is archive/oracle, not shipping default |
+| Policy CI | **PASS** | `architecture_react_policy_check` + `phase2_computation_policy_check` |
+
+No code skill violations found requiring a fix in this pack. Spec/docs drift
+(Streamlit-still-default in `openfdd_agent_spec`) corrected in the same PR.
+
+## Digests
+
+Record tip GHCR digests after successful `Publish Open-FDD stack to GHCR` /
+MCP publish for the readiness merge SHA (see CUTOVER_LOG update after verify).
+
+## Next
+
+Authorized Phase 3 program would start at **P3-M0 live observation contract**
+only — separate from this readiness pack.

--- a/docs/migration/react-rust/README.md
+++ b/docs/migration/react-rust/README.md
@@ -15,10 +15,11 @@ nav_order: 20
 
 | Item | State |
 |------|-------|
-| Architecture decision | Accepted (ADR-001) |
+| Architecture decision | Accepted (ADR-001); Phase 2 cutover complete |
 | Streamlit product UI | **Archived** (`ARCHIVED.md`; `--profile streamlit-legacy`) |
 | React SPA | **Sole production UI** (`compose.react.yml`; default generation React) |
 | Production Python exit | **Phase 2 exit APPROVED** (`PHASE_2_QUALIFICATION.md`) |
+| Phase 3 (edge/live) | **Outlook only** (`PHASE_3_READINESS.md` / `PHASE_3_EDGE_STREAMING_OUTLOOK.md`) |
 
 ## Durable ledgers (this directory)
 

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,12 @@
 
 Newest first.
 
+## 2026-08-01 — Phase 3 readiness + skill compliance
+
+- `PHASE_3_READINESS.md`: Phase 3 outlook-only; prerequisites MET/PARTIAL; skill matrix PASS.
+- `openfdd_agent_spec` refreshed for React default / Phase 2 exit (Milestone A phases unchanged).
+- Next: GHCR tip digest verify (same program).
+
 ## 2026-08-01 — P2 Prompt 8 final no-Python qualification
 
 - `PHASE_2_QUALIFICATION.md` **PASS** at `47ae7b5` + this pack.

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -18,12 +18,12 @@ bench, nightly retest, WSL sleep. Do not confuse those with this engineering OS.
 | Layer | Owns |
 | --- | --- |
 | `open_fdd/` | PyPI libraries: ECM + pandas oracle (`rules` / `analytics` / `reporting`) |
-| `services/` + `sql_rules/` | Production stack: central DataFusion SQL FDD, Streamlit UI (default), fieldbus, mqtt |
-| `frontend/` / React SPA | Phase 1+ flagged UI → central `/api` ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)) |
+| `services/` + `sql_rules/` | Production stack: central DataFusion SQL FDD, React SPA (`frontend/web` / `openfdd-web`), fieldbus, mqtt; Streamlit archived |
+| `frontend/` / React SPA | **Sole production UI** → central `/api` ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md); Phase 2 exit) |
 | `mcp/` | Optional read-first MCP → central |
 | `edge/`, `os/` | Future concepts — **never delete** |
 | `docs/rules/cookbook/` | Dual expression cookbooks (SQL + pandas) + parity matrix |
-| `docs/migration/react-rust/` | React/Rust Phase 1 ledgers |
+| `docs/migration/react-rust/` | React/Rust Phase 1–2 ledgers + Phase 3 readiness |
 | `tools/open-fdd-modernization/` | Modernization program kit |
 | `openfdd_agent_spec/` | Agent law, Milestone A, skills, session log |
 | Playground vibe19/20 | Educational/demo apps; consumers of PyPI; interim GHCR |
@@ -46,7 +46,7 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 1. Production FDD = **DataFusion SQL** on GHCR (`sql_rules/`). Never silent pandas fallback in central.
 2. Pandas oracle stays forever — cookbooks + vibe19 + PyPI `rules`/`analytics`. Never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
-4. **Product UI:** Streamlit (`services/ui` → `openfdd-ui`) is the **default**. React SPA is authorized for Phase 1 behind a flag ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)); browser → central Rust `/api` only — **no FastAPI sidecar**. Vite/Caddy SPA is not the default until Phase 2 cutover.
+4. **Product UI:** React SPA (`frontend/web` → `openfdd-web`, `compose.react.yml`) is the **sole production UI** after Phase 2 exit ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)). Streamlit (`services/ui`) is **archived** (`ARCHIVED.md`, compose profile `streamlit-legacy`). Browser → central Rust `/api` only — **no FastAPI sidecar**.
 5. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`).
 6. Playground images: `ghcr.io/bbartling/vibe19:develop`, `vibe20:develop`.
 7. `edge/` and `os/` are future concepts — never delete.
@@ -58,13 +58,13 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 13. Prefer exact wheel install tests over editable-only validation for packaging PRs.
 14. Never trust a moving GHCR tag alone — resolve/pull immutable `sha-*`, recreate containers, then record the digest.
 15. Append [`SESSION_LOG.md`](SESSION_LOG.md) after non-trivial work.
-16. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) whenever Milestone A **or React/Rust Phase 1** status changes (not only after merge).
+16. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) whenever Milestone A **or React/Rust modernization** status changes (not only after merge).
 17. CodeRabbit: fix actionable defects; reject suggestions that violate architecture.
 18. Do not retire playground GHCR without an open-fdd capability parity matrix.
 19. vibe21 = separate plan — not Milestone A.
 20. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
 21. Bound each PR to its declared scope — docs-only PRs do not require cross-repo pin bumps or GHCR refreshes.
-22. React/Rust Phase 1: follow [`tools/open-fdd-modernization/`](../tools/open-fdd-modernization/README.md); keep [`docs/migration/react-rust/`](../docs/migration/react-rust/README.md) ledgers current in the same PR.
+22. React/Rust program: follow [`tools/open-fdd-modernization/`](../tools/open-fdd-modernization/README.md); keep [`docs/migration/react-rust/`](../docs/migration/react-rust/README.md) ledgers current in the same PR. Phase 1+2 exits approved; Phase 3 is outlook-only until explicitly authorized.
 23. For any Streamlit→React / `frontend/web` work: read and follow [`tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md`](../tools/open-fdd-modernization/skills/streamlit-to-react/SKILL.md) and the bridge [`AGENT_SKILL_BRIDGE.md`](../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md) before editing UI.
 
 ---
@@ -109,7 +109,7 @@ Sibling-repo locations are **examples** — resolve via `git rev-parse --show-to
 | [`openfdd-cookbook-parity`](skills/openfdd-cookbook-parity/SKILL.md) | Cookbook CI, parity matrix, docs headings |
 | [`openfdd-stack-ghcr`](skills/openfdd-stack-ghcr/SKILL.md) | Nightly stack pull, labels, smoke |
 | [`openfdd-milestone-a-pr`](skills/openfdd-milestone-a-pr/SKILL.md) | Inventory → parity → cutover → delete loop |
-| [`openfdd-streamlit-to-react`](skills/openfdd-streamlit-to-react/SKILL.md) | Phase 1 React parity / Streamlit port (wraps modernization skill) |
+| [`openfdd-streamlit-to-react`](skills/openfdd-streamlit-to-react/SKILL.md) | React maintenance / residual parity (wraps modernization skill; P1+P2 done) |
 
 ---
 

--- a/openfdd_agent_spec/ARCHITECTURE.md
+++ b/openfdd_agent_spec/ARCHITECTURE.md
@@ -11,8 +11,9 @@ Update this file when code truth changes.
 
 | Surface | Role | Must not |
 | --- | --- | --- |
-| **Open-FDD production** (GHCR stack) | Rust central, Arrow/Feather, DataFusion SQL FDD, JWT REST, `openfdd-ui` Streamlit (default) | Silent pandas FDD fallback; claim Vite/Caddy SPA is the **default** UI before Phase 2 |
-| **React SPA (Phase 1+)** | Feature-flagged product UI → central `/api` only ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)) | FastAPI/Python sidecar; FDD math in TypeScript; BACnet wire ownership |
+| **Open-FDD production** (GHCR stack) | Rust central, Arrow/Feather, DataFusion SQL FDD, JWT REST, React SPA (`openfdd-web`) sole product UI | Silent pandas FDD fallback; claim Streamlit is still the shipping default after Phase 2 exit |
+| **React SPA** | Sole production UI → central `/api` only ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md); Phase 2 exit) | FastAPI/Python sidecar; FDD math in TypeScript; BACnet wire ownership |
+| **Streamlit UI (archived)** | `services/ui` oracle/recovery (`ARCHIVED.md`, `streamlit-legacy` profile) | Be reintroduced as product default without a new ADR |
 | **Open-FDD PyPI** (`open-fdd`) | Reusable libs: `ecm_engineering`, `rules`, `analytics`, `reporting` | Be the production FDD runtime |
 | **Vibe 19** (playground) | Educational pandas oracle + Streamlit demo + GHCR demo image | Remain canonical home of duplicated rule/analytics/reporting once migrated |
 | **Vibe 20** (playground) | EnergyPlus twin, calibration, ECM cross-check, Studio | Retain duplicate **generic** ECM formulas after Open-FDD parity |

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -134,7 +134,7 @@ Docs: [`MILESTONE_D_CLOSEOUT.md`](../docs/migration/MILESTONE_D_CLOSEOUT.md),
 
 ---
 
-# React / Rust modernization — Phase 1 (2026-07-31+)
+# React / Rust modernization — Phase 1+2 (2026-07-31 → 2026-08-01)
 
 Program: [`tools/open-fdd-modernization/`](../tools/open-fdd-modernization/README.md) ·
 Skill bridge: [`AGENT_SKILL_BRIDGE.md`](../tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md) ·
@@ -145,12 +145,29 @@ ADR: [`ADR-001`](../docs/architecture/adr-001-react-rust-modernization.md)
 Agents **must** follow `openfdd_agent_spec` + streamlit-to-react skills for UI PRs
 (see Cursor rule `.cursor/rules/openfdd-phase1-react-parity.mdc`).
 
+### Phase 1
+
 - [x] P1-M0-01 — ADR + instruction reconciliation + policy CI
 - [x] P1-M0-02 — Capability / Python-exit / API ledgers
 - [x] P1-M1 — Fixtures / oracle exporter / Streamlit baseline (#615)
 - [x] P1-M2 — Rust contracts + React shell + async ops (#616–#618)
-- [~] P1-M3 — Parity shell / widgets / navigation (#619 done; M3-02/03 in flight)
-- [ ] P1-M4 — Jobs/CSV/map/run vertical slice
-- [ ] P1-M5 — Domain families
-- [ ] P1-M6 — No-Python RC qualification
+- [x] P1-M3 — Parity shell / widgets / navigation (#619+)
+- [x] P1-M4 — Jobs/CSV/map/run vertical slice
+- [x] P1-M5 — Domain families (A–F) + Auth thin slice
+- [x] P1-M6 — No-Python RC qualification (exit approved)
 - [x] Agent skill bridge — `AGENT_SKILL_BRIDGE.md` + `openfdd-streamlit-to-react` skill + Cursor rule
+
+### Phase 2
+
+- [x] P2-M0 — Cutover control plane + telemetry + rollback (#636–#637)
+- [x] P2-M1 — Computation closure ledger + policy (#638)
+- [x] P2-M2 — Shadow/soak (#639)
+- [x] P2-M3 — Canary PROMOTE (#640)
+- [x] P2-M4 — React production default flip (#641)
+- [x] P2-M5 — Fallback closeout (#642)
+- [x] P2-M6 — Streamlit product path removal (#643)
+- [x] Prompt 8 — Final no-Python qualification PASS (#644)
+
+### Phase 3 (modernization edge/live) — outlook only
+
+- [ ] P3-M0+ — **Not started** (see `PHASE_3_READINESS.md`). Distinct from Milestone A Phase 3 (vibe19 oracle) above.

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -4,6 +4,13 @@ Newest first. Append after non-trivial agent work.
 
 ---
 
+## 2026-08-01 — Phase 2 exit + Phase 3 readiness (agent_spec)
+
+- Modernization Phase 1+2 exits approved; React sole product UI; Streamlit archived.
+- Updated AGENTS/ARCHITECTURE/BUILD_CHECKPOINTS + `openfdd-streamlit-to-react` for post-P2 truth.
+- Phase 3 (edge/live) remains outlook-only — `PHASE_3_READINESS.md`; no BACnet/MQTT work.
+- Milestone A Phase 2/3 checkboxes unchanged (different program).
+
 ## 2026-07-31 — Agent skill bridge (Phase 1)
 
 - Added `tools/open-fdd-modernization/AGENT_SKILL_BRIDGE.md` linking agent_spec ↔ modernization.

--- a/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
@@ -1,18 +1,31 @@
 ---
 name: openfdd-streamlit-to-react
 description: >-
-  Open-FDD Phase 1 Streamlit→React parity work. Use when porting services/ui to
-  frontend/web, shell/widgets/routing, visual or interaction parity, Jobs/CSV/FDD
-  vertical slices, or diagnosing React vs Streamlit mismatches. Always pair with
-  tools/open-fdd-modernization/skills/streamlit-to-react and Rust/central contracts.
+  Open-FDD Streamlit→React maintenance and residual parity. Use when editing
+  frontend/web, diagnosing React vs archived Streamlit mismatches, or residual
+  CAP-* work. Pair with tools/open-fdd-modernization/skills/streamlit-to-react
+  and Rust/central contracts. Phase 1+2 complete; Phase 3 edge/live is outlook-only.
 ---
 
 # Open-FDD Streamlit → React
 
 ## Goal
 
-Reproduce Streamlit UX in `frontend/web` while keeping authority on **central
-Rust + DataFusion**. Python is oracle-only. No FastAPI sidecar.
+Maintain React UX in `frontend/web` with authority on **central Rust +
+DataFusion**. Python is oracle-only. No FastAPI sidecar. Streamlit is archived
+(not the product comparison default for new features).
+
+## Program status
+
+| Phase | Status |
+| --- | --- |
+| Modernization Phase 1 | Exit approved (`PHASE_1_QUALIFICATION.md`) |
+| Modernization Phase 2 | Exit approved (`PHASE_2_QUALIFICATION.md`) |
+| Modernization Phase 3 | Outlook only (`PHASE_3_READINESS.md`) — no live BACnet/MQTT redesign without auth |
+| Skill compliance | See `docs/migration/react-rust/PHASE_3_READINESS.md` |
+
+**Do not confuse** Milestone A “Phase 2/3” (shared contracts / vibe19) with
+modernization Phase 2/3.
 
 ## Read first (required)
 
@@ -36,11 +49,11 @@ Then selectively:
 - Do not move FDD/analytics math into TypeScript.
 - Do not add a Python API service for the React app.
 - Update `docs/migration/react-rust/` ledgers in the same PR.
-- One `P1-M?-??` milestone ID per PR; follow
+- One bounded milestone ID per PR; follow
   [`../openfdd-milestone-a-pr/SKILL.md`](../openfdd-milestone-a-pr/SKILL.md) spirit
   (inventory → characterize → contract → implement → parity → docs).
-- Update [`../../BUILD_CHECKPOINTS.md`](../../BUILD_CHECKPOINTS.md) when Phase 1
-  status changes.
+- Update [`../../BUILD_CHECKPOINTS.md`](../../BUILD_CHECKPOINTS.md) when
+  modernization status changes.
 
 ## Workflow
 
@@ -49,7 +62,7 @@ exactly, with Open-FDD paths:
 
 | Generic skill concept | Open-FDD path |
 | --- | --- |
-| Streamlit app | `services/ui/streamlit_app.py`, `services/ui/app/` |
+| Streamlit app (archive) | `services/ui/streamlit_app.py`, `services/ui/app/` |
 | React app | `frontend/web/` |
 | API | `services/central/` `/api/*` |
 | Oracle | `open_fdd.*`, `tools/react_parity/`, cookbooks |

--- a/tools/open-fdd-modernization/AGENTS.md
+++ b/tools/open-fdd-modernization/AGENTS.md
@@ -2,16 +2,19 @@
 
 ## Mission
 
-Preserve Streamlit (`services/ui`) as the behavioral and visual reference while
-building `frontend/web` so a user cannot tell them apart on graded workflows.
-Domain authority stays on **central Rust + DataFusion SQL**. Python is
-oracle/characterization only during Phase 1. **No FastAPI sidecar.**
+Maintain React (`frontend/web`) as the sole production UI with domain authority
+on **central Rust + DataFusion SQL**. Streamlit (`services/ui`) is **archived**
+(behavioral oracle / emergency recovery). Python is oracle/characterization
+only. **No FastAPI sidecar.**
+
+Phase 1+2 exits are approved. Phase 3 (edge/live streaming) is outlook-only —
+see `PHASE_3_READINESS.md`. Do not redesign BACnet/MQTT without explicit auth.
 
 This file is the modernization-kit `AGENTS.md`. It does **not** replace
 [`openfdd_agent_spec/AGENTS.md`](../../openfdd_agent_spec/AGENTS.md) or the repo
 root [`AGENTS.md`](../../AGENTS.md).
 
-## Mandatory skill + OS bootstrap (every Phase 1 PR)
+## Mandatory skill + OS bootstrap (every UI / residual-parity PR)
 
 Before editing React/Streamlit/parity code, **read and follow** in order:
 


### PR DESCRIPTION
## Summary
- `PHASE_3_READINESS.md` — outlook-only; prerequisite MET/PARTIAL; skill matrix PASS
- `openfdd_agent_spec` + root/modernization AGENTS for React sole product UI
- No BACnet/MQTT/Phase 3 implementation

## Test plan
- [ ] docs/policy Actions green → squash-merge
- [ ] then GHCR tip verify + tidy

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project guidance and architecture records to identify the React web interface as the sole production UI.
  - Marked modernization Phases 1 and 2 as complete, with Phase 3 documented as an outlook rather than active work.
  - Added Phase 3 readiness, decisions, migration status, and session-log documentation.
  - Clarified that the former Streamlit interface is archived and that future BACnet/MQTT changes require separate authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->