### PR TITLE
feat: modernize nightly OT bench for React + GHCR tip

### DIFF
--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           mkdir -p deploy/mqtt/kits/local__fieldbus-1
           export OPENFDD_EDGE_KIT_DIR="$PWD/deploy/mqtt/kits/local__fieldbus-1"
-          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml; do
+          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml docker/compose.react.fieldbus.yml; do
             docker compose -f "$f" config >/dev/null
             echo "OK config: $f"
           done

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           mkdir -p deploy/mqtt/kits/local__fieldbus-1
           export OPENFDD_EDGE_KIT_DIR="$PWD/deploy/mqtt/kits/local__fieldbus-1"
-          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml; do
+          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml docker/compose.react.fieldbus.yml; do
             test -f "$f"
             docker compose -f "$f" config >/dev/null
             echo "OK config: $f"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -92,7 +92,7 @@ jobs:
           export OPENFDD_MQTT_HOST=127.0.0.1
           mkdir -p deploy/mqtt/kits/local__fieldbus-1
           export OPENFDD_EDGE_KIT_DIR="$PWD/deploy/mqtt/kits/local__fieldbus-1"
-          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml; do
+          for f in docker/compose.standalone.yml docker/compose.central.yml docker/compose.edge.yml docker/compose.csv.yml docker/compose.react.yml docker/compose.react.fieldbus.yml; do
             docker compose -f "$f" config >/dev/null
           done
           bash scripts/release/smoke_standalone_mqtts.sh

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ workspace/smoke-profiles/local/*.local.toml
 workspace/bootstrap_credentials*
 workspace/bench.env.local
 workspace/bench/
+scripts/nightly-ot-bench/bench.env.local
+docker/compose.standalone.local.yml
+docker/compose.react.fieldbus.local.yml
+docker/compose.cloudsim.local.yml
+
 workspace/ollama.env.local
 workspace/codex.env.local
 workspace/agent-chat/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ host — connect via **JWT REST** and optional **`openfdd-mcp` stdio**.
 ## Start session
 
 ```bash
-./scripts/openfdd_stack_up.sh standalone   # or csv / central
+./scripts/openfdd_stack_up.sh react-ot     # React SPA + mqtt + central + fieldbus
+# or: react (no fieldbus) / csv / standalone (Streamlit only with profile)
 TOKEN="$(curl -s -X POST http://127.0.0.1:8080/api/auth/login \
   -H 'Content-Type: application/json' \
   -d '{"username":"admin","password":"'"$OPENFDD_ADMIN_PASSWORD"'"}' \
@@ -38,8 +39,9 @@ Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:808
 ## Safe scripts
 
 ```bash
-./scripts/openfdd_stack_pull.sh standalone
-./scripts/openfdd_stack_up.sh standalone
+./scripts/openfdd_stack_pull.sh react-ot
+./scripts/openfdd_stack_up.sh react-ot
+./scripts/nightly-ot-bench/run_all.sh      # pull sha-* + aggressive OT/API gates
 ./scripts/openfdd_stack_up.sh csv
 ```
 

--- a/docker/compose.react.fieldbus.local.example.yml
+++ b/docker/compose.react.fieldbus.local.example.yml
@@ -1,0 +1,9 @@
+# Copy to compose.react.fieldbus.local.yml (gitignored) for OT LAN bind + API key.
+# Do not commit real addresses or production keys.
+services:
+  fieldbus:
+    environment:
+      OPENFDD_FIELDBUS_BIND: "192.168.204.55"
+      OPENFDD_FIELDBUS_API_KEY: "bench-demo-key-1234567890"
+      OPENFDD_FIELDBUS_OPENAPI: "1"
+      OPENFDD_FIELDBUS_SWAGGER_BENCH: "1"

--- a/docker/compose.react.fieldbus.yml
+++ b/docker/compose.react.fieldbus.yml
@@ -1,0 +1,37 @@
+# Open-FDD React OT overlay: host-net fieldbus for BACnet LAN benches.
+# Use with compose.react.yml (product SPA + central + mqtt):
+#
+#   docker compose -f docker/compose.react.yml -f docker/compose.react.fieldbus.yml up -d
+#
+# Optional local OT bind/keys (gitignored):
+#   -f docker/compose.react.fieldbus.local.yml
+
+services:
+  fieldbus:
+    image: ${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:nightly}
+    build:
+      context: ..
+      dockerfile: services/fieldbus/Dockerfile
+    network_mode: host
+    environment:
+      OPENFDD_FIELDBUS_CONFIG_DIR: /app/config
+      OPENFDD_FIELDBUS_HTTP_HOST: 127.0.0.1
+      OPENFDD_FIELDBUS_HTTP_PORT: "8081"
+      OPENFDD_MQTT_ENABLED: "1"
+      OPENFDD_MQTT_HOST: 127.0.0.1
+      OPENFDD_MQTT_PORT: "8883"
+      OPENFDD_SITE_ID: ${OPENFDD_SITE_ID:-local}
+      OPENFDD_EDGE_ID: ${OPENFDD_EDGE_ID:-fieldbus-1}
+      OPENFDD_MQTT_CA_PEM: /mqtt/ca.pem
+      OPENFDD_MQTT_CERT_PEM: /mqtt/edge.cert.pem
+      OPENFDD_MQTT_KEY_PEM: /mqtt/edge.key.pem
+      OPENFDD_MQTT_SPOOL_DIR: /spool
+      OPENFDD_FIELDBUS_API_KEY: ${OPENFDD_FIELDBUS_API_KEY:-}
+    volumes:
+      - ../config/fieldbus:/app/config:ro
+      - ../deploy/mqtt/kits/${OPENFDD_SITE_ID:-local}__${OPENFDD_EDGE_ID:-fieldbus-1}:/mqtt:ro
+      - fieldbus-spool:/spool
+    restart: unless-stopped
+
+volumes:
+  fieldbus-spool:

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,13 @@
 
 Newest first.
 
+## 2026-08-01 — Nightly OT bench modernized (react-ot)
+
+- Committed `scripts/nightly-ot-bench/` for post–Phase-2: pull `sha-*`, assert
+  nightly digests, `compose.react.yml` + `compose.react.fieldbus.yml`, React SPA
+  gates (replaced Streamlit Lab). Writes opt-in via `BENCH_ALLOW_WRITES=1`.
+- Stack recipe: `./scripts/openfdd_stack_up.sh react-ot`.
+
 ## 2026-08-01 — GHCR tip verify @ 61fee63
 
 - Stack + MCP GHCR publishes success for tip; nightly↔sha digests recorded in PHASE_3_READINESS.

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -47,7 +47,7 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 2. Pandas oracle stays forever — cookbooks + vibe19 + PyPI `rules`/`analytics`. Never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
 4. **Product UI:** React SPA (`frontend/web` → `openfdd-web`, `compose.react.yml`) is the **sole production UI** after Phase 2 exit ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)). Streamlit (`services/ui`) is **archived** (`ARCHIVED.md`, compose profile `streamlit-legacy`). Browser → central Rust `/api` only — **no FastAPI sidecar**.
-5. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`).
+5. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`), but **pin/run `sha-*`** per [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md). OT stress: [`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md) (`react-ot`).
 6. Playground images: `ghcr.io/bbartling/vibe19:develop`, `vibe20:develop`.
 7. `edge/` and `os/` are future concepts — never delete.
 8. Bounded PRs only — see [`PR_PROTOCOL.md`](PR_PROTOCOL.md).

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -14,37 +14,57 @@ updated itself.
 
 ## Open-FDD stack (nightly → immutable)
 
+Product UI after Phase 2 exit: **React** (`compose.react.yml` → host `:3000`).
+Streamlit (`openfdd-ui`) is archive-only (`streamlit-legacy` profile).
+
+OT LAN benches need fieldbus too — use recipe **`react-ot`**
+(`compose.react.yml` + `compose.react.fieldbus.yml`). Full stress suite:
+[`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md).
+
 ```bash
 # 1) Discover tip SHA after merge (or use known short SHA)
 SHORT=$(git -C ~/open-fdd rev-parse --short=7 origin/master)
 
-# 2) Pull immutable tags for every standalone image
-for img in openfdd-central openfdd-ui openfdd-fieldbus openfdd-mqtt; do
+# 2) Pull immutable tags for published stack images
+for img in openfdd-central openfdd-fieldbus openfdd-mqtt; do
   docker pull "ghcr.io/bbartling/${img}:sha-${SHORT}"
 done
+# Archive Streamlit (optional recovery only):
+# docker pull "ghcr.io/bbartling/openfdd-ui:sha-${SHORT}"
 
 # 3) Prove nightly currently points at the same digests
-for img in openfdd-central openfdd-ui openfdd-fieldbus openfdd-mqtt; do
-  n=$(docker buildx imagetools inspect "ghcr.io/bbartling/${img}:nightly" --format '{{println .Manifest.Digest}}')
-  s=$(docker buildx imagetools inspect "ghcr.io/bbartling/${img}:sha-${SHORT}" --format '{{println .Manifest.Digest}}')
+for img in openfdd-central openfdd-fieldbus openfdd-mqtt; do
+  docker pull "ghcr.io/bbartling/${img}:nightly"
+  n=$(docker image inspect "ghcr.io/bbartling/${img}:nightly" --format '{{index .RepoDigests 0}}')
+  s=$(docker image inspect "ghcr.io/bbartling/${img}:sha-${SHORT}" --format '{{index .RepoDigests 0}}')
   test "$n" = "$s" || { echo "MISMATCH $img nightly=$n sha=$s"; exit 1; }
 done
 
-# 4) Bring stack up pinned to that SHA (scripts honor OPENFDD_IMAGE_TAG)
+# 4) Bring stack up pinned to that SHA
+#    openfdd-web is often not on GHCR yet — stack_up builds web from frontend/web only
 export OPENFDD_IMAGE_TAG="sha-${SHORT}"
 cd ~/open-fdd
-./scripts/openfdd_stack_pull.sh standalone
-./scripts/openfdd_stack_up.sh standalone
+./scripts/openfdd_stack_pull.sh react-ot
+./scripts/openfdd_stack_up.sh react-ot --no-pull
 curl -fsS http://127.0.0.1:8080/api/health
+curl -fsS http://127.0.0.1:8080/api/ui/generation   # expect generation=react
 curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
+curl -fsS http://127.0.0.1:8081/health               # fieldbus (react-ot)
 
-# 5) Optional UI package assert inside the immutable image
-docker run --rm "ghcr.io/bbartling/openfdd-ui:sha-${SHORT}" \
-  python -c "import open_fdd; print(open_fdd.__version__)"
+# 5) Full OT stress (optional — needs OT LAN + bench.env.local)
+# ./scripts/nightly-ot-bench/run_all.sh
 ```
 
 Day-to-day convenience may set `OPENFDD_IMAGE_TAG=nightly`, but Milestone
 qualification and post-merge verification must use `sha-*` as above.
+
+Recipes:
+
+| Recipe | Compose | UI |
+|--------|---------|-----|
+| `react` | `compose.react.yml` | React SPA |
+| `react-ot` | react + `compose.react.fieldbus.yml` | React + fieldbus OT |
+| `standalone` | `compose.standalone.yml` | Streamlit only with `--profile streamlit-legacy` |
 
 ---
 
@@ -55,7 +75,7 @@ qualification and post-merge verification must use `sha-*` as above.
 docker pull ghcr.io/bbartling/vibe19:develop
 docker pull ghcr.io/bbartling/vibe20:develop
 # Prefer recording digests:
-docker buildx imagetools inspect ghcr.io/bbartling/vibe19:develop --format '{{.Manifest.Digest}}'
+docker image inspect ghcr.io/bbartling/vibe20:latest --format '{{index .RepoDigests 0}}'
 ```
 
 After PyPI API changes: update playground pins → PR → merge → wait for
@@ -78,6 +98,6 @@ rerun, then fix — do not infinite-rerun.
 
 ## Safety
 
-- Never `docker compose down -v` or `docker volume prune` against a live site workspace
-- Never expose stack on the public internet
-- Record tested image digests in Milestone logs / [`COMPLETION_REPORT.md`](COMPLETION_REPORT.md)
+- Never commit OT LAN addresses, API keys, or MQTT kit PEMs.
+- Live BACnet **writes** need explicit operator approval (`BENCH_ALLOW_WRITES=1`
+  on the nightly OT harness). Default gates are read/poll/discover.

--- a/scripts/audit_no_private_bench_hardcoding.sh
+++ b/scripts/audit_no_private_bench_hardcoding.sh
@@ -51,8 +51,11 @@ is_allowed() {
     edge/src/validation/audit.rs) return 0 ;;
     edge/src/main.rs) return 0 ;;
     scripts/bench_5007_long_smoke.sh) return 0 ;;
+    scripts/nightly-ot-bench/*) return 0 ;;
     scripts/audit_no_private_bench_hardcoding.sh) return 0 ;;
     scripts/audit_no_hardcoding.sh) return 0 ;;
+    docker/compose.react.fieldbus.local.example.yml) return 0 ;;
+    docker/compose.standalone.local.yml) return 0 ;;
     workspace/dashboard/src/App.tsx) return 0 ;;
   esac
   return 1

--- a/scripts/nightly-ot-bench/00_pull_ghcr_up.sh
+++ b/scripts/nightly-ot-bench/00_pull_ghcr_up.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Pull immutable GHCR tip images, assert nightly↔sha digests, bring up react-ot.
+# Builds openfdd-web locally when GHCR does not publish it yet.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+export ARTIFACT_DIR="$ART"
+
+hdr "GHCR pull + pin + react-ot up"
+
+PIN="$(resolve_tip_sha_tag)"
+export OPENFDD_IMAGE_TAG="$PIN"
+# Re-export image refs against the pin (ignore stale nightly overrides from env).
+unset OPENFDD_CENTRAL_IMAGE OPENFDD_FIELDBUS_IMAGE OPENFDD_MQTT_IMAGE OPENFDD_MCP_IMAGE OPENFDD_WEB_IMAGE
+# Keep OPENFDD_UI_IMAGE unset for product path — Streamlit is archive-only.
+unset OPENFDD_UI_IMAGE || true
+openfdd_stack_export_image_env
+
+echo "${DIM}pin=$OPENFDD_IMAGE_TAG site/edge=${OPENFDD_SITE_ID}/${OPENFDD_EDGE_ID}${RST}"
+echo "$OPENFDD_IMAGE_TAG" >"$ART/image_tag.txt"
+
+# Pull sha tags for published stack images + MCP
+PULL_IMGS=(
+  "$OPENFDD_CENTRAL_IMAGE"
+  "$OPENFDD_FIELDBUS_IMAGE"
+  "$OPENFDD_MQTT_IMAGE"
+  "$OPENFDD_MCP_IMAGE"
+)
+for img in "${PULL_IMGS[@]}"; do
+  echo "${DIM}pull $img${RST}"
+  docker pull "$img"
+done
+
+# Assert nightly currently points at the same digests (CHANNEL check)
+hdr "nightly ↔ sha digest equality"
+DIGESTS_FILE="$ART/digests.txt"
+: >"$DIGESTS_FILE"
+for name in openfdd-central openfdd-fieldbus openfdd-mqtt openfdd-mcp; do
+  sha_ref="ghcr.io/bbartling/${name}:${OPENFDD_IMAGE_TAG}"
+  night_ref="ghcr.io/bbartling/${name}:nightly"
+  docker pull "$night_ref" >/dev/null
+  d_sha="$(image_digest "$sha_ref")"
+  d_night="$(image_digest "$night_ref")"
+  echo "${name} sha=${d_sha} nightly=${d_night}" | tee -a "$DIGESTS_FILE"
+  if [[ -n "$d_sha" && "$d_sha" == "$d_night" ]]; then
+    ok "$name nightly matches $OPENFDD_IMAGE_TAG"
+  else
+    bad "$name nightly≠sha (sha=$d_sha nightly=$d_night)"
+  fi
+done
+
+# openfdd-web: pull if published, else mark for local build
+if docker pull "$OPENFDD_WEB_IMAGE" 2>/dev/null; then
+  ok "pulled $OPENFDD_WEB_IMAGE"
+  echo "web=pulled" >>"$ART/web_source.txt"
+else
+  skip "openfdd-web not in GHCR — will compose-build from frontend/web"
+  echo "web=build-local" >"$ART/web_source.txt"
+fi
+
+mapfile -t CF < <(compose_files)
+echo "${DIM}compose: ${CF[*]}${RST}"
+
+# Preflight UDP 47808
+if command -v ss >/dev/null; then
+  if ss -ulnp 2>/dev/null | grep -q ':47808'; then
+    echo "${DIM}UDP 47808 already bound (expect fieldbus after up)${RST}"
+  fi
+fi
+
+mkdir -p "$ROOT/workspace" "$ROOT/deploy/mqtt/certs" "$ROOT/deploy/mqtt/kits"
+
+export OPENFDD_SITE_ID OPENFDD_EDGE_ID
+export OPENFDD_REACT_UI=1
+export OPENFDD_UI_GENERATION_DEFAULT=react
+
+# Bring up via stack helper (builds web when missing)
+"$ROOT/scripts/openfdd_stack_up.sh" react-ot --no-pull
+
+echo
+docker compose "${CF[@]}" ps
+echo
+docker compose "${CF[@]}" images 2>/dev/null || true
+
+{
+  echo "Image revisions:"
+  for s in fieldbus central mqtt web; do
+    c="$(docker ps --format '{{.Names}}' | grep -E "openfdd-react-${s}" | head -1 || true)"
+    if [[ -n "$c" ]]; then
+      docker inspect "$c" --format "$s={{.Config.Image}} rev={{index .Config.Labels \"org.opencontainers.image.revision\"}}" 2>/dev/null || echo "$s=inspect-fail"
+    else
+      echo "$s=missing"
+    fi
+  done
+  docker inspect "$OPENFDD_MCP_IMAGE" --format 'mcp={{.Config.Image}} rev={{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || echo "mcp=missing"
+} | tee "$ART/image_revs.txt"
+
+# Wait for container healthchecks so 01 doesn't race a still-starting stack
+echo "${DIM}waiting up to 120s for container health...${RST}"
+deadline=$((SECONDS + 120))
+while ((SECONDS < deadline)); do
+  starting="$(docker compose "${CF[@]}" ps --format json 2>/dev/null \
+    | jq -r 'select(.Health=="starting" or .State=="restarting") | .Name' | wc -l)"
+  [[ "$starting" -eq 0 ]] && break
+  sleep 5
+done
+docker compose "${CF[@]}" ps --format '{{.Name}} {{.Status}}' 2>/dev/null || true
+
+# Fieldbus is host-net — wait on HTTP
+fb_deadline=$((SECONDS + 60))
+while ((SECONDS < fb_deadline)); do
+  curl -fsS --max-time 3 "$FIELDBUS_BASE/health" >/dev/null 2>&1 && break
+  sleep 2
+done
+
+ok "compose up issued (verify health with 01_health_gates.sh)"
+summary

--- a/scripts/nightly-ot-bench/01_health_gates.sh
+++ b/scripts/nightly-ot-bench/01_health_gates.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Health gates: fieldbus, central (React generation), mqtt port, SPA web.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+hdr "Health gates (react-ot)"
+
+# Fieldbus
+if H="$(fb "$FIELDBUS_BASE/health" 2>/dev/null)"; then
+  jq_ok "GET fieldbus /health" "$H" '.ok==true'
+  echo "${DIM}  $(jq -c '{service,version,git_sha}' <<<"$H" 2>/dev/null || true)${RST}"
+else
+  bad "GET fieldbus /health unreachable ($FIELDBUS_BASE)"
+fi
+
+if H="$(fb "$FIELDBUS_BASE/api/health" 2>/dev/null)"; then
+  jq_ok "GET fieldbus /api/health" "$H" '.ok==true and .service=="openfdd-fieldbus"'
+else
+  bad "GET fieldbus /api/health"
+fi
+
+# Central
+if H="$(central "$CENTRAL_BASE/api/health" 2>/dev/null)"; then
+  jq_ok "GET central /api/health" "$H" '.'
+  echo "${DIM}  $(jq -c . <<<"$H" 2>/dev/null | head -c 200)${RST}"
+else
+  bad "GET central /api/health unreachable — Feather ingest cannot pass"
+fi
+
+# React generation / capability
+if GEN="$(central "$CENTRAL_BASE/api/ui/generation" 2>/dev/null)"; then
+  echo "$GEN" | head -c 400; echo
+  if jq -e '.generation=="react"' <<<"$GEN" >/dev/null 2>&1; then
+    ok "GET /api/ui/generation → generation=react"
+  else
+    bad "GET /api/ui/generation generation!=react: $GEN"
+  fi
+  if jq -e '.default_generation=="react"' <<<"$GEN" >/dev/null 2>&1; then
+    ok "GET /api/ui/generation → default_generation=react"
+  else
+    bad "GET /api/ui/generation default_generation!=react"
+  fi
+else
+  bad "GET /api/ui/generation unreachable"
+fi
+
+if CAPS="$(central "$CENTRAL_BASE/api/capabilities" 2>/dev/null)"; then
+  if jq -e '.capabilities.react_ui==true' <<<"$CAPS" >/dev/null 2>&1; then
+    ok "capabilities.react_ui=true"
+  else
+    # OPENFDD_REACT_UI may not be visible if central image predates flag wiring
+    skip "capabilities.react_ui not true (got $(jq -c '.capabilities.react_ui // null' <<<"$CAPS"))"
+  fi
+else
+  bad "GET /api/capabilities"
+fi
+
+# MQTT port
+if (echo >/dev/tcp/127.0.0.1/8883) >/dev/null 2>&1; then
+  ok "MQTTS port 8883 open"
+else
+  bad "MQTTS port 8883 closed"
+fi
+
+# React SPA (nginx on :3000)
+code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$UI_BASE/" || true)"
+if [[ "$code" == "200" || "$code" == "301" || "$code" == "302" ]]; then
+  ok "SPA $UI_BASE → HTTP $code"
+else
+  bad "SPA $UI_BASE → HTTP $code (expect React web, not Streamlit)"
+fi
+
+# Container health (compose project openfdd-react)
+mapfile -t CF < <(compose_files)
+if docker compose "${CF[@]}" ps --format json 2>/dev/null | head -1 | grep -q .; then
+  while read -r line; do
+    name="$(jq -r '.Name // .name // empty' <<<"$line" 2>/dev/null || true)"
+    state="$(jq -r '.State // .state // empty' <<<"$line" 2>/dev/null || true)"
+    health="$(jq -r '.Health // .health // empty' <<<"$line" 2>/dev/null || true)"
+    [[ -z "$name" ]] && continue
+    # fieldbus may appear only via host-net; still listed in compose ps
+    if [[ "$state" == "running" ]] && [[ "$health" == "healthy" || "$health" == "" || "$health" == "null" ]]; then
+      ok "container $name state=$state health=${health:-n/a}"
+    elif [[ "$name" == *central* ]] && [[ "$state" == "restarting" ]]; then
+      bad "container $name is restarting (central must be healthy for Feather)"
+    else
+      bad "container $name state=$state health=$health"
+    fi
+  done < <(docker compose "${CF[@]}" ps --format json 2>/dev/null || true)
+fi
+
+# Must not require Streamlit ui container
+if docker ps --format '{{.Names}}' | grep -qiE 'openfdd-.*-ui'; then
+  skip "Streamlit ui container present (legacy profile) — product path is React web"
+fi
+
+summary

--- a/scripts/nightly-ot-bench/02_bacnet_ot.sh
+++ b/scripts/nightly-ot-bench/02_bacnet_ot.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# BACnet OT gates: Who-Is, 5007 routed read/discover, BIP companions, poll, hosted 599999.
+# Recreates diy-bacnet-server smoke intent against openfdd-fieldbus :8081.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+DEV="${BENCH_DEVICE}"
+READ_TYPE="${BENCH_READ_TYPE:-analog-input}"
+READ_INST="${BENCH_READ_INST:-1173}"
+OVR_TYPE="${BENCH_OVR_TYPE:-analog-output}"
+OVR_INST="${BENCH_OVR_INST:-2466}"
+EXPECT_PRIORITY="${BENCH_EXPECT_PRIORITY:-8}"
+EXPECT_VALUE="${BENCH_EXPECT_VALUE:-55}"
+HOSTED="${HOSTED_DEVICE}"
+
+hdr "Who-Is"
+if W="$(fb -X POST "$FIELDBUS_BASE/bacnet/whois" -d '{}' 2>/dev/null)"; then
+  jq_ok "Who-Is returns ≥1 device" "$W" '(.count|tonumber) >= 1'
+  jq_ok "Who-Is finds device $DEV" "$W" --arg d "$DEV" 'any(.devices[]; (.device_instance|tostring)==$d)'
+  echo "${DIM}  devices=$(jq -c '[.devices[].device_instance]' <<<"$W" 2>/dev/null)${RST}"
+  # Routed devices should report source_network when seed/API is correct
+  if jq -e --argjson d "$DEV" 'any(.devices[]; .device_instance==$d and .source_network != null)' <<<"$W" >/dev/null 2>&1; then
+    ok "device $DEV has source_network (routed seed looks correct)"
+  else
+    bad "device $DEV missing source_network — likely add_device-at-router instead of add_routed_device"
+  fi
+else
+  bad "POST /bacnet/whois"
+fi
+
+hdr "Who-Is router"
+if WR="$(fb -X POST "$FIELDBUS_BASE/bacnet/whois-router" -d '{}' 2>/dev/null)"; then
+  net="${BENCH_MSTP_NETWORK:-2000}"
+  jq_ok "whois-router lists network $net" "$WR" --argjson n "$net" 'any(.routers[]; (.networks[]|tonumber)==$n)'
+  echo "${DIM}  $(jq -c '.routers' <<<"$WR" 2>/dev/null)${RST}"
+else
+  bad "POST /bacnet/whois-router"
+fi
+
+hdr "ReadProperty device $DEV $READ_TYPE:$READ_INST"
+if R="$(fb -X POST "$FIELDBUS_BASE/bacnet/read" \
+  -d "{\"device_instance\":$DEV,\"object_type\":\"$READ_TYPE\",\"object_instance\":$READ_INST}" 2>/dev/null)"; then
+  jq_ok "read $DEV $READ_TYPE:$READ_INST has value" "$R" '.value != null and .ok==true'
+  echo "${DIM}  value=$(jq -r .value <<<"$R") tag=$(jq -r .tag <<<"$R")${RST}"
+else
+  bad "read $DEV failed (routed MS/TP broken if UNKNOWN_OBJECT)"
+fi
+
+hdr "Point discovery $DEV"
+if D="$(fb_long -X POST "$FIELDBUS_BASE/api/bacnet/point-discovery" \
+  -d "{\"device_instance\":$DEV}" 2>/dev/null)"; then
+  jq_ok "discovery finds $OVR_TYPE,$OVR_INST" "$D" --arg oi "$OVR_TYPE,$OVR_INST" \
+    'any(.objects[]; .object_identifier==$oi)'
+  jq_ok "$OVR_TYPE,$OVR_INST commandable" "$D" --arg oi "$OVR_TYPE,$OVR_INST" \
+    'any(.objects[]; .object_identifier==$oi and .commandable==true)'
+  echo "${DIM}  objects=$(jq -r '.objects|length' <<<"$D")${RST}"
+else
+  bad "POST /api/bacnet/point-discovery $DEV"
+fi
+
+hdr "Priority array / override (optional if operator left P8)"
+if PA="$(fb -X POST "$FIELDBUS_BASE/bacnet/priority-array" \
+  -d "{\"device_instance\":$DEV,\"object_type\":\"$OVR_TYPE\",\"object_instance\":$OVR_INST}" 2>/dev/null)"; then
+  PV="$(jq -r --argjson p "$EXPECT_PRIORITY" \
+    '.priority_array[]? | select(.priority_level==$p) | .value // empty' <<<"$PA")"
+  if [[ -n "$PV" && "$PV" != "null" ]] && approx "$PV" "$EXPECT_VALUE"; then
+    ok "priority $EXPECT_PRIORITY ≈ $EXPECT_VALUE (got $PV)"
+  else
+    skip "priority $EXPECT_PRIORITY not ≈ $EXPECT_VALUE (got '${PV:-empty}') — operator override may be cleared"
+  fi
+else
+  skip "priority-array unreachable"
+fi
+
+hdr "BIP companions (if configured)"
+for pair in \
+  "${BIP_DEVICE_A:-}|${BIP_DEVICE_A_READ_TYPE:-analog-input}|${BIP_DEVICE_A_READ_INST:-}" \
+  "${BIP_DEVICE_B:-}|${BIP_DEVICE_B_READ_TYPE:-analog-input}|${BIP_DEVICE_B_READ_INST:-}"; do
+  IFS='|' read -r bdev btype binst <<<"$pair"
+  [[ -z "$bdev" || -z "$binst" ]] && continue
+  if R="$(fb -X POST "$FIELDBUS_BASE/bacnet/read" \
+    -d "{\"device_instance\":$bdev,\"object_type\":\"$btype\",\"object_instance\":$binst}" 2>/dev/null)"; then
+    jq_ok "BIP read $bdev $btype:$binst" "$R" '.value != null'
+    echo "${DIM}  $bdev value=$(jq -r .value <<<"$R")${RST}"
+  else
+    bad "BIP read $bdev"
+  fi
+done
+
+hdr "Poll once + status"
+if P="$(fb -X POST "$FIELDBUS_BASE/bacnet/poll/once" 2>/dev/null)"; then
+  jq_ok "poll/once ok" "$P" '.ok==true and (.points_polled|tonumber)>0'
+  echo "${DIM}  $(jq -c '{points_polled,points_errored,cycle}' <<<"$P")${RST}"
+else
+  bad "poll/once"
+fi
+if S="$(fb "$FIELDBUS_BASE/bacnet/poll/status" 2>/dev/null)"; then
+  jq_ok "poll/status has last_values" "$S" '(.last_values|length)>0'
+  jq_ok "poll has live value for BIP or 5007" "$S" \
+    --argjson d "$DEV" \
+    'any(.last_values[]; .error==null and .value!=null)'
+  # Strict: 5007 row must be healthy when routed fix lands
+  if jq -e --argjson d "$DEV" \
+    'any(.last_values[]; .device_instance==$d and .error==null and .value!=null)' <<<"$S" >/dev/null; then
+    ok "poll last_values includes healthy $DEV"
+  else
+    bad "poll last_values missing healthy $DEV (routing/seed still broken)"
+  fi
+  echo "${DIM}  healthy=$(jq -r .points_healthy <<<"$S") tracked=$(jq -r .points_tracked <<<"$S")${RST}"
+else
+  bad "poll/status"
+fi
+
+hdr "Hosted server $HOSTED (Workbench)"
+if O="$(fb "$FIELDBUS_BASE/bacnet/server/objects" 2>/dev/null)"; then
+  jq_ok "hosted objects present" "$O" '(.objects|length) >= 1'
+  echo "${DIM}  objects=$(jq -r '.objects|length' <<<"$O")${RST}"
+else
+  bad "GET /bacnet/server/objects"
+fi
+
+summary

--- a/scripts/nightly-ot-bench/03_mqtt_feather_persist.sh
+++ b/scripts/nightly-ot-bench/03_mqtt_feather_persist.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# MQTTS → central ingest → Feather/historian persistence.
+# Captures before/after snapshots; fails if central down or stores do not grow / ingest idle.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+echo "${DIM}artifacts=$ART${RST}"
+
+hdr "Baseline historian / feather snapshot"
+BEFORE="$ART/historian_before.txt"
+historian_snapshot >"$BEFORE" || true
+echo "${DIM}  files=$(wc -l <"$BEFORE" | tr -d ' ')${RST}"
+
+hdr "Central ingest stats (before)"
+if IB="$(central "$CENTRAL_BASE/api/ingest/stats" 2>/dev/null)"; then
+  echo "$IB" | tee "$ART/ingest_before.json" | jq -c . 2>/dev/null || echo "$IB"
+  ok "ingest/stats reachable"
+else
+  bad "ingest/stats unreachable — cannot prove Feather path"
+  echo '{}' >"$ART/ingest_before.json"
+fi
+
+hdr "Edges / shadow (optional)"
+if E="$(central "$CENTRAL_BASE/api/edges" 2>/dev/null)"; then
+  echo "$E" | tee "$ART/edges.json" | jq -c . 2>/dev/null | head -c 400
+  echo
+  ok "GET /api/edges"
+else
+  skip "GET /api/edges unavailable"
+fi
+
+hdr "Force poll cycle(s) on fieldbus"
+cycles="${POLL_CYCLES_BEFORE_FEATHER:-2}"
+for i in $(seq 1 "$cycles"); do
+  fb -X POST "$FIELDBUS_BASE/bacnet/poll/once" >/dev/null 2>&1 && ok "poll/once #$i" || bad "poll/once #$i"
+  sleep 2
+done
+
+hdr "Wait for MQTT bridge publish interval (${FEATHER_WAIT_SECS}s)"
+# Bridge loop sleeps poll.interval_secs (often 60s) before first publish after connect.
+sleep "$FEATHER_WAIT_SECS"
+
+hdr "Optional MQTTS subscribe peek (docker mosquitto)"
+if docker image inspect eclipse-mosquitto:2 >/dev/null 2>&1 \
+  || docker pull eclipse-mosquitto:2 >/dev/null 2>&1; then
+  CA="$ROOT/deploy/mqtt/ca/ca.pem"
+  CERT="$ROOT/deploy/mqtt/kits/${OPENFDD_SITE_ID}__central/central.cert.pem"
+  KEY="$ROOT/deploy/mqtt/kits/${OPENFDD_SITE_ID}__central/central.key.pem"
+  # Fall back to edge kit central certs if separate central kit missing
+  if [[ ! -f "$CERT" ]]; then
+    CERT="$ROOT/deploy/mqtt/kits/${OPENFDD_SITE_ID}__${OPENFDD_EDGE_ID}/central.cert.pem"
+    KEY="$ROOT/deploy/mqtt/kits/${OPENFDD_SITE_ID}__${OPENFDD_EDGE_ID}/central.key.pem"
+  fi
+  if [[ -f "$CA" && -f "$CERT" && -f "$KEY" ]]; then
+    if timeout 80 docker run --rm --net=host \
+      -v "$ROOT/deploy/mqtt:/mqtt:ro" eclipse-mosquitto:2 \
+      mosquitto_sub -h 127.0.0.1 -p 8883 \
+      --cafile /mqtt/ca/ca.pem \
+      --cert "/mqtt/kits/${OPENFDD_SITE_ID}__central/central.cert.pem" \
+      --key "/mqtt/kits/${OPENFDD_SITE_ID}__central/central.key.pem" \
+      -t "openfdd/v1/sites/${OPENFDD_SITE_ID}/edges/+/telemetry/#" -v -C 1 -W 75 \
+      >"$ART/mqtt_telemetry.txt" 2>&1 \
+      || timeout 80 docker run --rm --net=host \
+        -v "$ROOT/deploy/mqtt:/mqtt:ro" eclipse-mosquitto:2 \
+        mosquitto_sub -h 127.0.0.1 -p 8883 \
+        --cafile /mqtt/ca/ca.pem \
+        --cert "/mqtt/kits/${OPENFDD_SITE_ID}__${OPENFDD_EDGE_ID}/central.cert.pem" \
+        --key "/mqtt/kits/${OPENFDD_SITE_ID}__${OPENFDD_EDGE_ID}/central.key.pem" \
+        -t "openfdd/v1/sites/${OPENFDD_SITE_ID}/edges/+/telemetry/#" -v -C 1 -W 75 \
+        >"$ART/mqtt_telemetry.txt" 2>&1; then
+      :
+    fi
+    if grep -q 'telemetry' "$ART/mqtt_telemetry.txt" 2>/dev/null; then
+      ok "MQTTS telemetry topic traffic observed"
+      # Non-null value check (known prior bug: present_value vs value)
+      if grep -qE '"value"[[:space:]]*:[[:space:]]*[0-9]' "$ART/mqtt_telemetry.txt" \
+        || grep -qE '"value":[0-9]' "$ART/mqtt_telemetry.txt"; then
+        ok "telemetry contains numeric value fields"
+      else
+        bad "telemetry missing numeric values (value:null schema drift?)"
+      fi
+      echo "${DIM}$(head -c 400 "$ART/mqtt_telemetry.txt")${RST}"
+    else
+      bad "no MQTTS telemetry captured (see $ART/mqtt_telemetry.txt)"
+    fi
+  else
+    skip "MQTT certs missing under deploy/mqtt — provision first"
+  fi
+else
+  skip "eclipse-mosquitto image unavailable for mqtt peek"
+fi
+
+hdr "Central ingest stats (after)"
+if IA="$(central "$CENTRAL_BASE/api/ingest/stats" 2>/dev/null)"; then
+  echo "$IA" | tee "$ART/ingest_after.json" | jq -c . 2>/dev/null || echo "$IA"
+  # Prefer any counter growth if schema has known fields
+  if python3 - "$ART/ingest_before.json" "$ART/ingest_after.json" <<'PY'
+import json,sys
+b=json.load(open(sys.argv[1]))
+a=json.load(open(sys.argv[2]))
+def dig(d):
+  if not isinstance(d, dict):
+    return 0
+  for k in ("ingest_ok","messages_ok","ok","accepted","total","count"):
+    v=d.get(k)
+    if isinstance(v,(int,float)):
+      return float(v)
+  # nested common shapes
+  for v in d.values():
+    if isinstance(v, dict):
+      x=dig(v)
+      if x: return x
+  return 0
+bb,aa=dig(b),dig(a)
+sys.exit(0 if aa>bb or (aa>0 and bb==0) else 1)
+PY
+  then
+    ok "ingest counter increased or non-zero after poll"
+  else
+    bad "ingest stats did not show growth (central may not be ingesting)"
+  fi
+else
+  bad "ingest/stats still unreachable"
+fi
+
+hdr "Historian / Feather after snapshot"
+AFTER="$ART/historian_after.txt"
+historian_snapshot >"$AFTER" || true
+echo "${DIM}  files=$(wc -l <"$AFTER" | tr -d ' ')${RST}"
+
+if [[ ! -s "$AFTER" ]]; then
+  bad "no historian/feather files under workspace/data — persistence missing"
+else
+  ok "historian/feather artifacts exist ($(wc -l <"$AFTER" | tr -d ' ') files)"
+fi
+
+# Growth: new paths or newer mtime/size vs before
+if python3 - "$BEFORE" "$AFTER" <<'PY'
+import sys
+def load(p):
+  d={}
+  try:
+    for line in open(p):
+      line=line.strip()
+      if not line: continue
+      path,mtime,size=line.split('|',2)
+      d[path]=(int(mtime),int(size))
+  except FileNotFoundError:
+    pass
+  return d
+b,a=load(sys.argv[1]),load(sys.argv[2])
+grew=False
+for path,(mt,sz) in a.items():
+  if path not in b:
+    grew=True; break
+  bmt,bsz=b[path]
+  if mt>bmt or sz>bsz:
+    grew=True; break
+sys.exit(0 if grew else 1)
+PY
+then
+  ok "historian/feather store grew (new file or mtime/size increase)"
+else
+  bad "historian/feather store did not grow after poll wait — no persistence proof"
+fi
+
+ls -laRt "$ROOT/${WORKSPACE_DIR}/data" 2>/dev/null | head -30 | tee "$ART/workspace_data_ls.txt" || true
+
+summary
+echo "${DIM}Wrote artifacts under $ART${RST}"

--- a/scripts/nightly-ot-bench/04_modbus_ot.sh
+++ b/scripts/nightly-ot-bench/04_modbus_ot.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Modbus OT gates against the bench temp-sensor simulator (gist modbus_temp_sensor_server.py
+# on a bench Pi). Exercises fieldbus POST /modbus/read: IR/HR reads, scaling, heartbeat
+# liveness, and negative paths (bad unit id, out-of-range register). Fieldbus must stay
+# healthy after error paths.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+MB_HOST="${MODBUS_SIM_HOST:-192.168.204.14}"
+MB_PORT="${MODBUS_SIM_PORT:-1502}"
+MB_UNIT="${MODBUS_SIM_UNIT_ID:-1}"
+MB_BASE_F="${MODBUS_SIM_BASE_F:-72}"
+MB_AMP_F="${MODBUS_SIM_AMPLITUDE_F:-4}"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+mb_read() {
+  # mb_read <unit_id> <registers-json>
+  local unit="$1" regs="$2"
+  fb -X POST "$FIELDBUS_BASE/modbus/read" -d "$(jq -nc \
+    --arg host "$MB_HOST" --argjson port "$MB_PORT" --argjson unit "$unit" \
+    --argjson regs "$regs" \
+    '{host:$host, port:$port, unit_id:$unit, timeout:5.0, registers:$regs}')"
+}
+
+hdr "TCP reachability $MB_HOST:$MB_PORT"
+if (echo >"/dev/tcp/$MB_HOST/$MB_PORT") >/dev/null 2>&1; then
+  ok "modbus sim TCP port open"
+else
+  bad "modbus sim $MB_HOST:$MB_PORT unreachable — is the gist server running on the bench Pi?"
+  summary
+  exit 1
+fi
+
+hdr "Input registers 30001-30004 (temp_f, temp_c, humidity, heartbeat)"
+IR_SPEC='[
+  {"address":0,"count":1,"function":"input","decode":"uint16","scale":0.1,"label":"temp_f"},
+  {"address":1,"count":1,"function":"input","decode":"uint16","scale":0.1,"label":"temp_c"},
+  {"address":2,"count":1,"function":"input","decode":"uint16","scale":0.1,"label":"humidity"},
+  {"address":3,"count":1,"function":"input","decode":"uint16","label":"heartbeat"}
+]'
+if IR="$(mb_read "$MB_UNIT" "$IR_SPEC" 2>/dev/null)"; then
+  echo "$IR" >"$ART/modbus_input_regs.json"
+  jq_ok "modbus/read ok=true" "$IR" '.ok==true'
+  jq_ok "4 readings, all success" "$IR" '(.readings|length)==4 and all(.readings[]; .success==true)'
+  TF="$(jq -r '.readings[0].decoded // empty' <<<"$IR")"
+  TC="$(jq -r '.readings[1].decoded // empty' <<<"$IR")"
+  HUM="$(jq -r '.readings[2].decoded // empty' <<<"$IR")"
+  HB1="$(jq -r '.readings[3].words[0] // empty' <<<"$IR")"
+  echo "${DIM}  temp_f=$TF temp_c=$TC humidity=$HUM heartbeat=$HB1${RST}"
+  if [[ -n "$TF" ]] && approx "$TF" "$MB_BASE_F" "$(python3 -c "print(float('$MB_AMP_F')+1.5)")"; then
+    ok "temp_f $TF within ${MB_BASE_F}±$MB_AMP_F(+1.5) sine envelope"
+  else
+    bad "temp_f '$TF' outside expected sine envelope ${MB_BASE_F}±$MB_AMP_F"
+  fi
+  if [[ -n "$TF" && -n "$TC" ]]; then
+    EXPECT_C="$(python3 -c "print((float('$TF')-32.0)*5.0/9.0)")"
+    if approx "$TC" "$EXPECT_C" 0.3; then
+      ok "temp_c $TC consistent with temp_f (F↔C conversion)"
+    else
+      bad "temp_c $TC inconsistent with temp_f $TF (expected ≈$EXPECT_C)"
+    fi
+  fi
+else
+  bad "POST /modbus/read (input regs) failed"
+fi
+
+hdr "Holding registers 40001-40006 (temp, setpoint, status, heartbeat, fault)"
+HR_SPEC='[
+  {"address":0,"count":1,"function":"holding","decode":"uint16","scale":0.1,"label":"temp_f"},
+  {"address":2,"count":1,"function":"holding","decode":"uint16","scale":0.1,"label":"setpoint_f"},
+  {"address":3,"count":1,"function":"holding","decode":"uint16","label":"status"},
+  {"address":5,"count":1,"function":"holding","decode":"uint16","label":"fault"}
+]'
+if HR="$(mb_read "$MB_UNIT" "$HR_SPEC" 2>/dev/null)"; then
+  echo "$HR" >"$ART/modbus_holding_regs.json"
+  jq_ok "holding reads all success" "$HR" 'all(.readings[]; .success==true)'
+  SP="$(jq -r '.readings[1].decoded // empty' <<<"$HR")"
+  ST="$(jq -r '.readings[2].decoded // empty' <<<"$HR")"
+  FLT="$(jq -r '.readings[3].decoded // empty' <<<"$HR")"
+  echo "${DIM}  setpoint_f=$SP status=$ST fault=$FLT${RST}"
+  [[ "$ST" == "1" ]] && ok "status register = 1 (running)" || skip "status=$ST (operator may have written test value)"
+  [[ "$FLT" == "0" ]] && ok "fault register = 0 (no fault)" || skip "fault=$FLT (operator may have written test fault)"
+else
+  bad "POST /modbus/read (holding regs) failed"
+fi
+
+hdr "Heartbeat liveness (device is alive, not a stale responder)"
+HB_SPEC='[{"address":3,"count":1,"function":"input","decode":"uint16","label":"heartbeat"}]'
+HB_A="$(mb_read "$MB_UNIT" "$HB_SPEC" 2>/dev/null | jq -r '.readings[0].words[0] // empty')"
+sleep 2
+HB_B="$(mb_read "$MB_UNIT" "$HB_SPEC" 2>/dev/null | jq -r '.readings[0].words[0] // empty')"
+if [[ -n "$HB_A" && -n "$HB_B" && "$HB_B" != "$HB_A" ]]; then
+  ok "heartbeat advanced ($HB_A → $HB_B)"
+else
+  bad "heartbeat did not advance ($HB_A → $HB_B) — sim frozen or fieldbus caching?"
+fi
+
+hdr "Negative: wrong unit id (expect clean Modbus exception, no fieldbus crash)"
+set +e
+BAD_UNIT_OUT="$(mb_read 7 "$HB_SPEC" 2>&1)"
+BAD_UNIT_RC=$?
+set -e
+echo "$BAD_UNIT_OUT" >"$ART/modbus_bad_unit.json"
+if [[ $BAD_UNIT_RC -ne 0 ]] || jq -e 'any(.readings[]?; .success==false) or (.ok==false)' <<<"$BAD_UNIT_OUT" >/dev/null 2>&1; then
+  ok "wrong unit id surfaced as error (exception 11 path)"
+else
+  bad "wrong unit id returned success — gateway not propagating Modbus exceptions"
+fi
+
+hdr "Negative: out-of-range register (expect exception 2 / illegal address)"
+OOR_SPEC='[{"address":100,"count":1,"function":"input","decode":"uint16","label":"oor"}]'
+set +e
+OOR_OUT="$(mb_read "$MB_UNIT" "$OOR_SPEC" 2>&1)"
+OOR_RC=$?
+set -e
+echo "$OOR_OUT" >"$ART/modbus_oor.json"
+if [[ $OOR_RC -ne 0 ]] || jq -e 'any(.readings[]?; .success==false) or (.ok==false)' <<<"$OOR_OUT" >/dev/null 2>&1; then
+  ok "out-of-range register surfaced as error"
+else
+  bad "out-of-range register returned success — validation gap"
+fi
+
+hdr "Fieldbus healthy after Modbus error paths"
+if H="$(fb "$FIELDBUS_BASE/health" 2>/dev/null)" && jq -e '.ok==true' <<<"$H" >/dev/null; then
+  ok "fieldbus /health ok after negative tests"
+else
+  bad "fieldbus unhealthy after Modbus negative tests — error handling crashed service"
+fi
+
+summary

--- a/scripts/nightly-ot-bench/05_haystack.sh
+++ b/scripts/nightly-ot-bench/05_haystack.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Haystack gates against fieldbus /haystack/*.
+# The bench has no live Haystack (SkySpark/Niagara) server, so default expectation is:
+#   - endpoints return a clean structured error (upstream unreachable), NOT a panic/500 crash
+#   - fieldbus stays healthy afterwards
+# Set HAYSTACK_EXPECT_LIVE=1 (with gateway.toml [haystack] pointing at a real server)
+# to require successful about/read/nav grids instead.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+EXPECT_LIVE="${HAYSTACK_EXPECT_LIVE:-0}"
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+# curl that captures body + status without -f so we can assert structured errors
+hs_call() {
+  # hs_call <method> <path> [json-body]
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS --max-time 30 -H 'Content-Type: application/json' "${AUTH_HDR[@]}"
+    -o "$ART/hs_resp.json" -w '%{http_code}' -X "$method" "$FIELDBUS_BASE$path")
+  [[ -n "$body" ]] && args+=(-d "$body")
+  curl "${args[@]}" 2>/dev/null || echo "000"
+}
+
+check_endpoint() {
+  # check_endpoint <label> <method> <path> [body]
+  local label="$1" method="$2" path="$3" body="${4:-}"
+  local code resp
+  code="$(hs_call "$method" "$path" "$body")"
+  resp="$(cat "$ART/hs_resp.json" 2>/dev/null || echo '')"
+  cp "$ART/hs_resp.json" "$ART/haystack_$(echo "$label" | tr ' /' '__').json" 2>/dev/null || true
+  if [[ "$EXPECT_LIVE" == "1" ]]; then
+    if [[ "$code" == "200" ]] && jq -e '.ok==true' <<<"$resp" >/dev/null 2>&1; then
+      ok "$label → 200 ok grid"
+    else
+      bad "$label expected live grid, got HTTP $code: $(head -c 200 <<<"$resp")"
+    fi
+  else
+    if [[ "$code" == "200" ]] && jq -e '.ok==true' <<<"$resp" >/dev/null 2>&1; then
+      ok "$label unexpectedly live (HTTP 200 grid) — bench has a haystack server?"
+    elif [[ "$code" =~ ^(4|5)[0-9][0-9]$ ]] && jq -e 'type=="object"' <<<"$resp" >/dev/null 2>&1; then
+      ok "$label → HTTP $code structured JSON error (clean upstream failure)"
+      echo "${DIM}  $(head -c 160 <<<"$resp")${RST}"
+    elif [[ "$code" == "000" ]]; then
+      bad "$label → connection failed/timeout (fieldbus hung or crashed on haystack path)"
+    else
+      bad "$label → HTTP $code with non-JSON body (panic/route error?): $(head -c 160 <<<"$resp")"
+    fi
+  fi
+}
+
+hdr "Haystack about/read/nav/his-read via fieldbus"
+check_endpoint "GET /haystack/about" GET "/haystack/about"
+check_endpoint "POST /haystack/read" POST "/haystack/read" '{"filter":"site"}'
+check_endpoint "POST /haystack/nav" POST "/haystack/nav" '{"nav_id":null}'
+check_endpoint "POST /haystack/his-read" POST "/haystack/his-read" '{"ids":["@demo"],"range_start":null,"range_end":null}'
+
+hdr "Op allowlist: non-allowlisted haystack ops are not exposed as routes"
+code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${AUTH_HDR[@]}" \
+  -X POST "$FIELDBUS_BASE/haystack/eval" -H 'Content-Type: application/json' -d '{}' 2>/dev/null || echo 000)"
+if [[ "$code" == "404" || "$code" == "405" ]]; then
+  ok "POST /haystack/eval not exposed (HTTP $code)"
+else
+  bad "POST /haystack/eval → HTTP $code (should be 404/405; eval must not be reachable)"
+fi
+
+hdr "Fieldbus healthy after haystack error paths"
+if H="$(fb "$FIELDBUS_BASE/health" 2>/dev/null)" && jq -e '.ok==true' <<<"$H" >/dev/null; then
+  ok "fieldbus /health ok after haystack calls"
+else
+  bad "fieldbus unhealthy after haystack calls"
+fi
+
+if [[ "$EXPECT_LIVE" != "1" ]]; then
+  skip "positive-path haystack (live grids) not exercised — no Haystack server on bench (set HAYSTACK_EXPECT_LIVE=1 when one exists)"
+fi
+
+summary

--- a/scripts/nightly-ot-bench/06_csv_fdd_sql.sh
+++ b/scripts/nightly-ot-bench/06_csv_fdd_sql.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# CSV → parquet → DataFusion SQL FDD gates on central.
+# 1) auth login (admin) when auth is required
+# 2) upload synthetic FC1 CSV (duct static below SP at full fan) via preview→plan→preflight→execute
+# 3) assert parquet_ingest.ok, dataset listed, /api/fdd/run mode=registry FC1 flags faults
+# 4) SQL polling sanity: cache status, registry rules present, ingest stats reachable
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+DATASET="${CSV_BENCH_DATASET:-bench_fc1_$(date -u +%H%M%S)}"
+
+# --- central auth -----------------------------------------------------------
+TOKEN=""
+CAUTH=()
+AUTH_REQ="$(curl -fsS --max-time 10 "$CENTRAL_BASE/api/auth/status" 2>/dev/null | jq -r '.auth_required // false' || echo false)"
+if [[ "$AUTH_REQ" == "true" ]]; then
+  ADMIN_PW="${OPENFDD_ADMIN_PASSWORD:-}"
+  if [[ -z "$ADMIN_PW" ]]; then
+    bad "central requires auth but OPENFDD_ADMIN_PASSWORD not in env/.env"
+    summary; exit 1
+  fi
+  TOKEN="$(curl -fsS --max-time 15 -X POST "$CENTRAL_BASE/api/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg p "$ADMIN_PW" '{username:"admin",password:$p}')" \
+    | jq -r '.token // .access_token // empty' || true)"
+  if [[ -n "$TOKEN" ]]; then
+    ok "central login as admin (JWT issued)"
+    CAUTH=(-H "Authorization: Bearer $TOKEN")
+  else
+    bad "central /api/auth/login failed for admin"
+    summary; exit 1
+  fi
+else
+  skip "central auth not required (no JWT secret) — proceeding unauthenticated"
+fi
+
+capi() { curl -fsS --max-time 60 -H 'Content-Type: application/json' "${CAUTH[@]}" "$@"; }
+
+# --- synthetic FC1 fixture ---------------------------------------------------
+hdr "Generate synthetic FC1 CSV (duct static ${DIM}0.6\"${RST} < SP 1.5\" at fan 95%)"
+FIX="$ART/fc1_fixture.csv"
+# Canonical role name fan_cmd on purpose: #525 (silent column drop) claimed fixed
+# in #532 — this gate re-verifies that a column literally named fan_cmd survives.
+python3 - "$FIX" <<'PY'
+import sys, datetime
+path = sys.argv[1]
+t0 = datetime.datetime(2026, 7, 17, 0, 0, tzinfo=datetime.timezone.utc)
+# Plain wide CSV WITHOUT equipment_id on purpose: #536 claimed fixed in #542 —
+# EQUIPMENT_ID_MISSING must not fail-close strict preflight (verdict=pass).
+rows = ["timestamp_utc,duct_static,duct_static_sp,fan_cmd"]
+for i in range(180):  # 3h @ 1min
+    ts = (t0 + datetime.timedelta(minutes=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if i < 60:      # healthy hour
+        rows.append(f"{ts},1.48,1.5,95.0")
+    elif i < 150:   # sustained fault: static way below SP at full fan (beats 300s confirm)
+        rows.append(f"{ts},0.60,1.5,95.0")
+    else:           # fan off — must NOT flag
+        rows.append(f"{ts},0.10,1.5,3.0")
+open(path, "w").write("\n".join(rows) + "\n")
+PY
+ok "fixture written ($(wc -l <"$FIX") rows, no equipment_id) → $FIX"
+
+# --- preview -----------------------------------------------------------------
+hdr "CSV import: preview"
+B64="$(base64 -w0 "$FIX")"
+PREV="$(capi -X POST "$CENTRAL_BASE/api/csv/import/preview" \
+  -d "$(jq -nc --arg b "$B64" '{files:[{filename:"fc1_bench.csv",content_base64:$b}]}')" || echo '{}')"
+echo "$PREV" >"$ART/csv_preview.json"
+SID="$(jq -r '.session_id // empty' <<<"$PREV")"
+if [[ -n "$SID" ]] && jq -e '.ok==true' <<<"$PREV" >/dev/null; then
+  ok "preview staged file (session $SID)"
+else
+  bad "preview failed: $(head -c 300 <<<"$PREV")"
+  summary; exit 1
+fi
+
+# --- plan --------------------------------------------------------------------
+hdr "CSV import: plan"
+PLAN_BODY="$(jq -nc --arg sid "$SID" --arg ds "$DATASET" '{
+  session_id: $sid,
+  plan: {
+    mode: "single",
+    files: [{filename:"fc1_bench.csv", timestamp_column:"timestamp_utc", timezone:"UTC",
+             value_columns:["duct_static","duct_static_sp","fan_cmd"]}],
+    output_dataset_name: $ds
+  }}')"
+PLAN="$(capi -X POST "$CENTRAL_BASE/api/csv/import/plan" -d "$PLAN_BODY" || echo '{}')"
+echo "$PLAN" >"$ART/csv_plan.json"
+jq_ok "plan accepted" "$PLAN" '.ok==true'
+echo "${DIM}  rows=$(jq -r '.preview.row_count // "?"' <<<"$PLAN") cols=$(jq -cr '.preview.column_names // []' <<<"$PLAN" | head -c 160)${RST}"
+
+# --- preflight ---------------------------------------------------------------
+hdr "CSV import: preflight (fail-closed validation)"
+PRE="$(capi -X POST "$CENTRAL_BASE/api/csv/import/preflight" \
+  -d "$(jq -nc --arg sid "$SID" '{session_id:$sid}')" || echo '{}')"
+echo "$PRE" >"$ART/csv_preflight.json"
+VERDICT="$(jq -r '.verdict // empty' <<<"$PRE")"
+jq_ok "preflight can_execute" "$PRE" '.can_execute==true'
+# #536/#542: plain wide CSV without equipment_id must still verdict=pass under strict defaults
+if [[ "$VERDICT" == "pass" ]]; then
+  ok "preflight verdict=pass on wide CSV without equipment_id (#536 fix verified)"
+else
+  bad "preflight verdict=$VERDICT without equipment_id (#536 regression) — checks: $(jq -cr '.validation.checks // [] | map(select(.severity!="pass" and .severity!="info"))' <<<"$PRE" 2>/dev/null | head -c 300)"
+fi
+
+# --- execute -----------------------------------------------------------------
+hdr "CSV import: execute (writes Feather/Arrow + parquet)"
+EXE="$(capi -X POST "$CENTRAL_BASE/api/csv/import/execute" \
+  -d "$(jq -nc --arg sid "$SID" '{session_id:$sid, confirm:true}')" || echo '{}')"
+echo "$EXE" >"$ART/csv_execute.json"
+jq_ok "execute ok" "$EXE" '.ok==true'
+jq_ok "parquet_ingest.ok" "$EXE" '.parquet_ingest.ok==true'
+echo "${DIM}  parquet=$(jq -c '.parquet_ingest // {}' <<<"$EXE" | head -c 300)${RST}"
+
+hdr "Dataset visible via /api/datasets"
+DS="$(capi "$CENTRAL_BASE/api/datasets" || echo '{}')"
+echo "$DS" >"$ART/datasets.json"
+if jq -e --arg d "$DATASET" '(.datasets // . // []) | tostring | contains($d)' <<<"$DS" >/dev/null 2>&1; then
+  ok "dataset $DATASET listed"
+else
+  bad "dataset $DATASET not in /api/datasets: $(head -c 200 <<<"$DS")"
+fi
+
+# --- FDD registry run --------------------------------------------------------
+hdr "FDD registry: FC1 present and runnable"
+RULES="$(capi "$CENTRAL_BASE/api/fdd/rules" || echo '{}')"
+echo "$RULES" >"$ART/fdd_rules.json"
+jq_ok "registry lists FC1" "$RULES" 'tostring | contains("FC1")'
+echo "${DIM}  rule_count=$(jq -r '.rules|length // "?"' <<<"$RULES" 2>/dev/null)${RST}"
+
+CACHE="$(capi "$CENTRAL_BASE/api/fdd/cache/status" || echo '{}')"
+echo "$CACHE" >"$ART/fdd_cache_status.json"
+jq_ok "parquet cache exists with files" "$CACHE" '.parquet_exists==true and (.parquet_file_count|tonumber) > 0'
+
+RUN="$(capi -X POST "$CENTRAL_BASE/api/fdd/run" \
+  -d '{"params":{"mode":"registry","rule_ids":["FC1"]}}' || echo '{}')"
+echo "$RUN" >"$ART/fdd_run_fc1.json"
+jq_ok "fdd/run FC1 ok" "$RUN" '.ok==true'
+# Contract: FC1 itself executed with rows (fan_cmd survived parquet ingest — #525).
+# Tip runners may still attempt sibling rules against a narrow fixture and report
+# rules_failed>0 for missing roles — that is not an FC1/fan_cmd regression.
+if jq -e 'any(.timings[]?; .rule_id=="FC1" and (.error==null or .error=="") and (.row_count // 0) > 0)
+          or any(.results[]?; .rule_id=="FC1" and (.status|type=="string"))' <<<"$RUN" >/dev/null 2>&1; then
+  ok "FC1 executed via DataFusion with literal fan_cmd column (#525 fix verified)"
+  echo "${DIM}  $(jq -c '[.timings[]? | select(.rule_id=="FC1")]' <<<"$RUN" | head -c 300)${RST}"
+  # Honesty note when filtered request still expands to the full registry
+  RR="$(jq -r '.rules_run // 0' <<<"$RUN")"
+  if [[ "$RR" -gt 5 ]]; then
+    echo "${DIM}  note: rules_run=$RR (tip may expand beyond rule_ids filter; FC1 timing still green)${RST}"
+  fi
+else
+  bad "FC1 run failed or produced no result rows (fan_cmd drop regression? #525): $(head -c 300 <<<"$RUN")"
+fi
+
+# #528 fix: 1-minute fixture must yield poll_seconds ≈ 60, not hardcoded 300
+PS="$(jq -r '.poll_seconds // empty' <<<"$RUN")"
+if [[ -n "$PS" ]] && approx "$PS" 60 10; then
+  ok "poll_seconds=$PS inferred from 1-min CSV grid (#528 fix verified)"
+else
+  bad "poll_seconds=$PS for a 1-min fixture (expected ≈60; grid_minutes hardcode regression #528)"
+fi
+
+# Tip Lab/#549 contract: /api/fdd/run and /api/fdd/results must expose per-row
+# results[] (rule_id / equipment_id / status) — not aggregates-only.
+hdr "FDD results[] row shape (not aggregates-only)"
+RESULTS="$(capi "$CENTRAL_BASE/api/fdd/results" || echo '{}')"
+echo "$RESULTS" >"$ART/fdd_results.json"
+if jq -e '
+  (.results | type == "array") and
+  ((.results | length) > 0) and
+  all(.results[];
+    (.rule_id | type == "string" and length > 0) and
+    (.equipment_id | type == "string" and length > 0) and
+    (.status | type == "string" and length > 0)
+  )
+' <<<"$RESULTS" >/dev/null 2>&1; then
+  ok "results[] rows carry rule_id/equipment_id/status (n=$(jq '.results|length' <<<"$RESULTS"))"
+  echo "${DIM}  sample=$(jq -c '.results[0]' <<<"$RESULTS" | head -c 220)${RST}"
+else
+  bad "results[] missing or aggregates-only: $(jq -c '{ok,count,keys:(keys),sample:(.results[0]//.aggregates//.)}' <<<"$RESULTS" 2>/dev/null | head -c 300)"
+fi
+# Prefer run payload also returning the same shape when present
+if jq -e '(.results|type)=="array" and (.results|length)>0' <<<"$RUN" >/dev/null 2>&1; then
+  if jq -e 'all(.results[]; .rule_id and .equipment_id and .status)' <<<"$RUN" >/dev/null 2>&1; then
+    ok "fdd/run FC1 payload results[] also shaped"
+  else
+    bad "fdd/run returned results[] without rule_id/equipment_id/status"
+  fi
+else
+  skip "fdd/run omitted results[] (GET /api/fdd/results is the Lab source of truth)"
+fi
+
+# #531/#532: FC13 alias must resolve to FC13-SAT-HIGH
+RUN13="$(capi -X POST "$CENTRAL_BASE/api/fdd/run" \
+  -d '{"params":{"mode":"registry","rule_ids":["FC13"]}}' || echo '{}')"
+echo "$RUN13" >"$ART/fdd_run_fc13.json"
+if jq -e '(.rules_run // 0) >= 1 and (.error // "" | test("no matching rules") | not)' <<<"$RUN13" >/dev/null 2>&1; then
+  ok "FC13 alias resolves and runs (#532 alias verified)"
+  echo "${DIM}  $(jq -c '.timings // .error' <<<"$RUN13" | head -c 200)${RST}"
+else
+  bad "FC13 alias did not resolve: $(head -c 200 <<<"$RUN13")"
+fi
+
+# Registry safety: raw SQL must be rejected
+RAW="$(capi -X POST "$CENTRAL_BASE/api/fdd/run" -d '{"sql":"SELECT 1"}' || echo '{}')"
+if jq -e '.ok==false' <<<"$RAW" >/dev/null 2>&1; then
+  ok "raw SQL rejected on /api/fdd/run (registry-only enforced)"
+else
+  bad "raw SQL was NOT rejected on /api/fdd/run"
+fi
+
+# --- SQL polling sanity ------------------------------------------------------
+hdr "Ingest stats reachable (polled OT telemetry → queryable path)"
+IS="$(capi "$CENTRAL_BASE/api/ingest/stats" || echo '{}')"
+echo "$IS" >"$ART/ingest_stats_csvgate.json"
+jq_ok "ingest/stats reachable" "$IS" 'type=="object"'
+echo "${DIM}  $(jq -c . <<<"$IS" | head -c 250)${RST}"
+
+summary

--- a/scripts/nightly-ot-bench/07_cloud_sim.sh
+++ b/scripts/nightly-ot-bench/07_cloud_sim.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+# Cloud-sim gate: bensbench standalone stack = "cloud central"; a remote Raspberry Pi
+# (bosspi) = "building edge" running fieldbus with its OWN BACnet instance (600000),
+# streaming MQTTS telemetry to central over the LAN — the many-buildings-per-central
+# topology in miniature.
+#
+# Phases:
+#   A. prereqs (ssh, central health, provision binary)
+#   B. broker server cert must carry the LAN IP SAN (remote edges verify TLS by IP)
+#   C. provision second-site edge kit + merge broker ACL
+#   D. central multi-site subscribe (OPENFDD_SITE_ID="+" via local compose override)
+#   E. remote edge bring-up on the Pi (amd64 image under qemu/binfmt — arm64 gap is a finding)
+#   F. assertions: two edges on /api/edges, bldg2 telemetry with numeric values,
+#      Who-Is sees 599999 and 600000 as distinct hosted devices
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+PI_SSH="${CLOUD_SIM_PI_SSH:-ben@192.168.204.12}"
+SSH_OPTS=(-i "$HOME/.ssh/id_rsa" -o BatchMode=yes -o ConnectTimeout=10)
+SITE2="${CLOUD_SIM_SITE_ID:-bldg2}"
+EDGE2="${CLOUD_SIM_EDGE_ID:-pi-1}"
+BROKER_IP="${CLOUD_SIM_BROKER_HOST:-192.168.204.55}"
+DEV2="${CLOUD_SIM_DEVICE_INSTANCE:-600000}"
+PI_REPO="${CLOUD_SIM_PI_REPO:-/home/ben/open-fdd}"
+WAIT_TELEMETRY="${CLOUD_SIM_TELEMETRY_WAIT:-150}"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+pi() { ssh "${SSH_OPTS[@]}" "$PI_SSH" "$@"; }
+
+# --- A. prereqs --------------------------------------------------------------
+hdr "A. prereqs"
+if pi 'hostname' >/dev/null 2>&1; then
+  ok "ssh to Pi ($PI_SSH → $(pi hostname))"
+else
+  bad "cannot ssh to Pi $PI_SSH"; summary; exit 1
+fi
+if central "$CENTRAL_BASE/api/health" >/dev/null 2>&1; then
+  ok "central healthy on bench"
+else
+  bad "central not healthy — run standalone gates first"; summary; exit 1
+fi
+PROVISION="$ROOT/target/debug/openfdd-provision"
+if [[ -x "$PROVISION" ]]; then
+  ok "openfdd-provision binary present"
+else
+  bad "no openfdd-provision at $PROVISION (cargo build -p openfdd_mqtt --bin openfdd-provision)"
+  summary; exit 1
+fi
+
+# --- B. broker server cert SAN ------------------------------------------------
+hdr "B. broker TLS cert must include IP:$BROKER_IP for remote edges"
+CERT="$ROOT/deploy/mqtt/certs/server.cert.pem"
+if openssl x509 -in "$CERT" -noout -text | grep -q "IP Address:$BROKER_IP"; then
+  ok "server cert already has IP:$BROKER_IP SAN"
+else
+  echo "${DIM}regenerating broker server cert with LAN IP SAN (bench CA)${RST}"
+  CA_DIR="$ROOT/deploy/mqtt/ca"
+  TMP="$(mktemp -d)"
+  cat >"$TMP/san.cnf" <<EOF
+[req]
+distinguished_name = dn
+req_extensions = v3_req
+prompt = no
+[dn]
+CN = mqtt
+[v3_req]
+subjectAltName = @alt
+[alt]
+DNS.1 = mqtt
+DNS.2 = localhost
+IP.1 = 127.0.0.1
+IP.2 = $BROKER_IP
+EOF
+  openssl req -new -newkey rsa:2048 -nodes \
+    -keyout "$TMP/server.key.pem" -out "$TMP/server.csr" -config "$TMP/san.cnf" >/dev/null 2>&1
+  openssl x509 -req -in "$TMP/server.csr" -CA "$CA_DIR/ca.pem" -CAkey "$CA_DIR/ca.key.pem" \
+    -CAcreateserial -out "$TMP/server.cert.pem" -days 397 \
+    -extensions v3_req -extfile "$TMP/san.cnf" >/dev/null 2>&1
+  cp "$TMP/server.cert.pem" "$CERT"
+  cp "$TMP/server.key.pem" "$ROOT/deploy/mqtt/certs/server.key.pem"
+  rm -rf "$TMP"
+  if openssl x509 -in "$CERT" -noout -text | grep -q "IP Address:$BROKER_IP"; then
+    ok "server cert regenerated with IP:$BROKER_IP (finding: provisioning tool has no broker-cert command)"
+    NEED_MQTT_RESTART=1
+  else
+    bad "failed to regenerate server cert with LAN SAN"; summary; exit 1
+  fi
+fi
+
+# --- C. provision second-site kit + ACL ---------------------------------------
+hdr "C. provision $SITE2/$EDGE2 kit + broker ACL"
+KIT_DIR="$ROOT/deploy/mqtt/kits/${SITE2}__${EDGE2}"
+if [[ ! -f "$KIT_DIR/edge.cert.pem" ]]; then
+  "$PROVISION" edge --site-id "$SITE2" --edge-id "$EDGE2" \
+    --broker-host "$BROKER_IP" --out-dir "$ROOT/deploy/mqtt" >/dev/null
+fi
+if [[ -f "$KIT_DIR/edge.cert.pem" && -f "$KIT_DIR/ca.pem" ]]; then
+  ok "edge kit at deploy/mqtt/kits/${SITE2}__${EDGE2}"
+else
+  bad "provisioning failed for ${SITE2}__${EDGE2}"; summary; exit 1
+fi
+
+ACL="$ROOT/deploy/mqtt/acl"
+if ! grep -q "edge:${SITE2}:${EDGE2}" "$ACL" 2>/dev/null; then
+  { echo; cat "$KIT_DIR/mosquitto.acl"; } >>"$ACL"
+  NEED_MQTT_RESTART=1
+fi
+# Central identity is central:lab (cert CN) — widen its read to all sites for multi-site test.
+if ! grep -q "topic read openfdd/v1/sites/#" "$ACL" 2>/dev/null; then
+  python3 - "$ACL" <<'PY'
+import sys, re
+p = sys.argv[1]
+text = open(p).read()
+# after each "user central:*" line ensure a global site read
+out, lines = [], text.splitlines()
+for i, line in enumerate(lines):
+    out.append(line)
+    if re.match(r"^user central:", line):
+        out.append("topic read openfdd/v1/sites/#")
+open(p, "w").write("\n".join(out) + "\n")
+PY
+  NEED_MQTT_RESTART=1
+fi
+ok "broker ACL includes ${SITE2} edge + central multi-site read (finding: provision tool emits single-site central ACL only)"
+
+if [[ "${NEED_MQTT_RESTART:-0}" == "1" ]]; then
+  mapfile -t CF < <(compose_files)
+  docker compose "${CF[@]}" restart mqtt >/dev/null 2>&1 && ok "mqtt broker restarted (new cert/ACL)" || bad "mqtt restart failed"
+  sleep 3
+fi
+
+# --- D. central multi-site subscribe ------------------------------------------
+hdr "D. central multi-site subscribe (OPENFDD_SITE_ID='+')"
+OVR="$ROOT/docker/compose.cloudsim.local.yml"
+if [[ ! -f "$OVR" ]]; then
+  cat >"$OVR" <<EOF
+# Cloud-sim bench override — central subscribes to ALL sites. Do not commit.
+services:
+  central:
+    environment:
+      OPENFDD_SITE_ID: "+"
+    volumes:
+      - ../workspace:/workspace
+      - ../deploy/mqtt/kits/${OPENFDD_SITE_ID}__central:/mqtt:ro
+EOF
+fi
+mapfile -t CF < <(compose_files)
+docker compose "${CF[@]}" -f "$OVR" up -d central >/dev/null 2>&1 || true
+sleep 5
+if central "$CENTRAL_BASE/api/health" >/dev/null 2>&1; then
+  ok "central healthy with multi-site subscription override"
+else
+  bad "central unhealthy after OPENFDD_SITE_ID='+' override — multi-site subscribe unsupported (finding)"
+fi
+
+# --- E. remote edge on the Pi ---------------------------------------------------
+hdr "E. remote edge bring-up on Pi (site=$SITE2 edge=$EDGE2 device=$DEV2)"
+
+# qemu/binfmt for amd64 images on aarch64 (stack images are amd64-only: known gap)
+AMD64_PROBE='timeout 60 docker run --rm --entrypoint /bin/sh --platform linux/amd64 ghcr.io/bbartling/openfdd-fieldbus:nightly -c "echo qemu-ok"'
+if pi "$AMD64_PROBE" 2>/dev/null | grep -q qemu-ok; then
+  ok "Pi can execute amd64 fieldbus image (binfmt present)"
+else
+  echo "${DIM}installing qemu binfmt handlers on Pi${RST}"
+  pi 'docker run --privileged --rm tonistiigi/binfmt --install amd64' >/dev/null 2>&1 || true
+  if pi "$AMD64_PROBE" 2>/dev/null | grep -q qemu-ok; then
+    ok "qemu binfmt installed — amd64 image runs under emulation (finding: no arm64 nightlies)"
+  else
+    bad "Pi cannot run amd64 fieldbus image even with binfmt — arm64 image gap blocks real deployments"
+    skip "falling back is manual: run a second edge compose project on the bench instead"
+    summary; exit 1
+  fi
+fi
+
+# Ship the kit (public CA + edge cert/key only)
+pi "mkdir -p $PI_REPO/deploy/mqtt/kits/${SITE2}__${EDGE2}"
+scp "${SSH_OPTS[@]}" -q "$KIT_DIR"/{ca.pem,edge.cert.pem,edge.key.pem,edge.json} \
+  "$PI_SSH:$PI_REPO/deploy/mqtt/kits/${SITE2}__${EDGE2}/" && ok "edge kit shipped to Pi" || { bad "kit scp failed"; summary; exit 1; }
+
+# Pi-local gateway config. #532 claims OPENFDD_BACNET_DEVICE_INSTANCE is honored, so we
+# deliberately RESET gateway.toml to git default (599999) and set instance $DEV2 purely
+# via env — if 600000 answers ReadProperty later, the env path is proven. City is set to
+# Chicago (bench stays Madison) for gate 08's weather legitimacy check.
+pi "cd $PI_REPO && git checkout -- config/fieldbus/gateway.toml && python3 - <<'PY'
+import re
+p = 'config/fieldbus/gateway.toml'
+s = open(p).read()
+s = re.sub(r'city\s*=\s*\"[^\"]*\"', 'city = \"Chicago\"', s, count=1)
+s = re.sub(r'device_name\s*=\s*\"[^\"]*\"', 'device_name = \"OpenFDD-${SITE2}\"', s, count=1)
+open(p, 'w').write(s)
+print('gateway.toml →', [l for l in s.splitlines() if 'device_instance' in l or 'city' in l])
+PY" | tee "$ART/pi_gateway_patch.txt"
+if grep -q 'city = "Chicago"' "$ART/pi_gateway_patch.txt" && grep -q "device_instance = 599999" "$ART/pi_gateway_patch.txt"; then
+  ok "Pi gateway.toml: city=Chicago, toml instance left at git default (599999) — $DEV2 comes from env only (#532 verification)"
+else
+  bad "failed to patch Pi gateway.toml (city/instance)"
+fi
+
+# compose.edge.yml does not pass OPENFDD_BACNET_DEVICE_INSTANCE through, so a local
+# (gitignored-style) override supplies it — this is the #532 env path under test.
+pi "cat > $PI_REPO/docker/compose.edge.local.yml <<'EOF'
+# Cloud-sim bench override — hosted BACnet instance via env (#532). Do not commit.
+services:
+  fieldbus:
+    # Explicit platform: 'pull always' fails on arm64 (no manifest, #530) and compose
+    # silently reuses the STALE local amd64 image — that shipped yesterday's build and
+    # caused the 2026-07-18 duplicate-instance-599999 incident in Workbench.
+    platform: linux/amd64
+    environment:
+      OPENFDD_BACNET_DEVICE_INSTANCE: \"${DEV2}\"
+    # Bench mitigation for the per-operation UDP socket leak (BACnetClient::stop());
+    # keeps the long-term soak alive until the product fix ships.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+EOF
+echo wrote-override"
+
+# Pull the pinned tip image explicitly (amd64 under qemu) and FAIL LOUDLY on digest drift.
+PI_FIELDBUS_IMAGE="${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:${OPENFDD_IMAGE_TAG:-nightly}}"
+echo "${DIM}Pi fieldbus image pin: $PI_FIELDBUS_IMAGE${RST}"
+if pi "docker pull --platform linux/amd64 $PI_FIELDBUS_IMAGE >/dev/null 2>&1"; then
+  PI_REV="$(pi "docker inspect $PI_FIELDBUS_IMAGE --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}'" 2>/dev/null | head -c 12 || true)"
+  BENCH_REV="$(docker inspect "$PI_FIELDBUS_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null | head -c 12 || true)"
+  if [[ -n "$PI_REV" && "$PI_REV" == "$BENCH_REV" ]]; then
+    ok "Pi pulled amd64 tip rev $PI_REV (matches bench)"
+  else
+    bad "Pi tip rev '$PI_REV' != bench '$BENCH_REV' — stale image would fake results"
+    summary; exit 1
+  fi
+else
+  bad "explicit amd64 pull failed on Pi for $PI_FIELDBUS_IMAGE — refusing stale soak"
+  summary; exit 1
+fi
+
+# field_devices: Pi polls the BIP bench sims as its "building devices" PLUS the bench
+# hosted server 599999 — the cross-device weather read for gate 08 (600000's edge
+# reading 599999's Open-Meteo mirror over real BACnet).
+pi "cat > $PI_REPO/config/fieldbus/field_devices.toml <<'EOF'
+# Cloud-sim building: poll BIP bench devices from the Pi edge.
+[[devices]]
+name = \"Bldg2FakeAhu\"
+enabled = true
+device_instance = ${BIP_DEVICE_A:-3456789}
+host = \"192.168.204.13\"
+port = 47808
+points = [
+  { object_type = \"analog-input\", object_instance = ${BIP_DEVICE_A_READ_INST:-2}, point_name = \"SA-T\", units = \"degF\" },
+]
+
+[[devices]]
+name = \"Bldg2ZoneVav\"
+enabled = true
+device_instance = ${BIP_DEVICE_B:-3456790}
+host = \"192.168.204.14\"
+port = 47808
+points = [
+  { object_type = \"analog-input\", object_instance = ${BIP_DEVICE_B_READ_INST:-1}, point_name = \"ZoneTemp\", units = \"degF\" },
+]
+
+[[devices]]
+name = \"BenchHostedWeather\"
+enabled = true
+device_instance = ${HOSTED_DEVICE:-599999}
+host = \"${BROKER_IP}\"
+port = 47808
+points = [
+  { object_type = \"analog-value\", object_instance = 9101, point_name = \"OA-T\", units = \"degF\" },
+  { object_type = \"analog-value\", object_instance = 9102, point_name = \"OA-RH\", units = \"percent\" },
+]
+EOF
+grep -c device_instance $PI_REPO/config/fieldbus/field_devices.toml" >/dev/null 2>&1 || true
+
+# Bring up the edge recipe (base + instance override)
+echo "${DIM}Pi edge compose image: $PI_FIELDBUS_IMAGE${RST}"
+if pi "cd $PI_REPO && \
+  OPENFDD_FIELDBUS_IMAGE=$PI_FIELDBUS_IMAGE \
+  OPENFDD_MQTT_HOST=$BROKER_IP OPENFDD_MQTT_PORT=8883 \
+  OPENFDD_SITE_ID=$SITE2 OPENFDD_EDGE_ID=$EDGE2 \
+  OPENFDD_EDGE_KIT_DIR=$PI_REPO/deploy/mqtt/kits/${SITE2}__${EDGE2} \
+  docker compose -f docker/compose.edge.yml -f docker/compose.edge.local.yml up -d --force-recreate" >"$ART/pi_edge_up.log" 2>&1; then
+  ok "edge compose up on Pi (instance $DEV2; image $PI_FIELDBUS_IMAGE)"
+else
+  bad "edge compose up failed on Pi (see pi_edge_up.log)"
+  tail -5 "$ART/pi_edge_up.log" || true
+fi
+# Assert tip revision when Pi is up
+PI_REV="$(pi "docker inspect openfdd-edge-fieldbus-1 --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}'" 2>/dev/null || true)"
+BENCH_FB_REV="$(docker inspect "$PI_FIELDBUS_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)"
+if [[ -n "$PI_REV" && "$PI_REV" == "$BENCH_FB_REV" ]]; then
+  ok "Pi fieldbus rev matches tip (${PI_REV:0:12})"
+elif [[ -n "$PI_REV" ]]; then
+  bad "Pi fieldbus rev drift: pi=${PI_REV:0:12} tip=${BENCH_FB_REV:0:12}"
+fi
+
+echo "${DIM}waiting up to 90s for Pi fieldbus health (qemu is slow)${RST}"
+PI_HEALTH=""
+for _ in $(seq 1 18); do
+  PI_HEALTH="$(pi 'curl -fsS --max-time 5 http://127.0.0.1:8081/health' 2>/dev/null || true)"
+  [[ -n "$PI_HEALTH" ]] && break
+  sleep 5
+done
+if [[ -n "$PI_HEALTH" ]] && jq -e '.ok==true' <<<"$PI_HEALTH" >/dev/null 2>&1; then
+  ok "Pi fieldbus healthy under emulation"
+  echo "${DIM}  $(jq -c '{service,version}' <<<"$PI_HEALTH" 2>/dev/null)${RST}"
+else
+  bad "Pi fieldbus not healthy after 90s (qemu/arm64 gap — capture logs)"
+  pi "docker logs openfdd-edge-fieldbus-1 --tail 40" >"$ART/pi_fieldbus.log" 2>&1 || true
+  tail -15 "$ART/pi_fieldbus.log" 2>/dev/null || true
+fi
+
+# --- F. assertions -------------------------------------------------------------
+hdr "F. multi-building assertions"
+echo "${DIM}waiting ${WAIT_TELEMETRY}s for first Pi MQTT publish interval${RST}"
+sleep "$WAIT_TELEMETRY"
+
+# F1: MQTTS traffic from site bldg2
+if docker image inspect eclipse-mosquitto:2 >/dev/null 2>&1 || docker pull eclipse-mosquitto:2 >/dev/null 2>&1; then
+  timeout 40 docker run --rm --net=host -v "$ROOT/deploy/mqtt:/mqtt:ro" eclipse-mosquitto:2 \
+    mosquitto_sub -h 127.0.0.1 -p 8883 \
+    --cafile /mqtt/ca/ca.pem \
+    --cert "/mqtt/kits/${OPENFDD_SITE_ID}__central/central.cert.pem" \
+    --key "/mqtt/kits/${OPENFDD_SITE_ID}__central/central.key.pem" \
+    -t "openfdd/v1/sites/${SITE2}/edges/+/#" -v -C 3 -W 35 \
+    >"$ART/mqtt_bldg2.txt" 2>&1 || true
+  if grep -q "sites/${SITE2}/" "$ART/mqtt_bldg2.txt" 2>/dev/null; then
+    ok "MQTTS traffic observed from site ${SITE2} (remote building streaming to central broker)"
+    grep -qE '"value"[[:space:]]*:[[:space:]]*-?[0-9]' "$ART/mqtt_bldg2.txt" \
+      && ok "bldg2 telemetry has numeric values" \
+      || skip "no numeric value seen yet in captured bldg2 messages (status/metadata only?)"
+    echo "${DIM}$(head -c 300 "$ART/mqtt_bldg2.txt")${RST}"
+  else
+    bad "no MQTTS traffic from site ${SITE2} (TLS/ACL/edge failure — see artifacts)"
+  fi
+fi
+
+# F2: central sees both edges
+if E="$(central "$CENTRAL_BASE/api/edges" 2>/dev/null)"; then
+  echo "$E" >"$ART/edges_cloudsim.json"
+  jq_ok "central /api/edges lists ≥2 edges" "$E" '(.edges // . // []) | length >= 2'
+  if jq -e --arg e "$EDGE2" 'any(.edges[]?; .edge_id==$e and .has_telemetry==true)' <<<"$E" >/dev/null 2>&1; then
+    ok "central ingests remote edge ${EDGE2} telemetry (multi-building ingest works)"
+  else
+    bad "central /api/edges missing remote edge ${EDGE2} with telemetry"
+  fi
+  if jq -e --arg s "$SITE2" 'tostring | contains($s)' <<<"$E" >/dev/null 2>&1; then
+    ok "/api/edges exposes site attribution for ${SITE2}"
+  else
+    skip "FINDING: /api/edges has no site_id field — edges from different sites are indistinguishable (multi-building API gap)"
+  fi
+  echo "${DIM}  $(jq -c . <<<"$E" | head -c 400)${RST}"
+else
+  bad "GET /api/edges failed"
+fi
+
+# F3: hosted instance discovery — HARD #526 retest: broadcast Who-Is via fieldbus client
+# AND raw unicast Who-Is straight at each hosted server socket. Both must yield I-Am for
+# Workbench discovery to work.
+PI_IP="${CLOUD_SIM_PI_SSH##*@}"
+if W="$(fb -X POST "$FIELDBUS_BASE/bacnet/whois" -d '{}' 2>/dev/null)"; then
+  echo "$W" >"$ART/whois_cloudsim.json"
+  for inst in "$HOSTED_DEVICE" "$DEV2"; do
+    if jq -e --argjson d "$inst" 'any(.devices[]; .device_instance==$d)' <<<"$W" >/dev/null 2>&1; then
+      ok "#526: broadcast Who-Is sees hosted device $inst (I-Am fixed?)"
+    else
+      bad "#526 STILL OPEN: hosted device $inst absent from broadcast Who-Is (Workbench discovery blocked)"
+    fi
+  done
+  echo "${DIM}  devices=$(jq -c '[.devices[].device_instance]' <<<"$W" 2>/dev/null)${RST}"
+fi
+# Raw unicast Who-Is (limits bracketing each instance) directly at each server's UDP :47808
+set +e
+python3 - "${OT_BIND:-127.0.0.1}" "$HOSTED_DEVICE" "$PI_IP" "$DEV2" <<'PY' | tee "$ART/whois_unicast.txt"
+import socket, sys
+targets = [(sys.argv[1], int(sys.argv[2])), (sys.argv[3], int(sys.argv[4]))]
+def whois_unicast(ip, inst):
+    # unconfirmed Who-Is with low/high = inst (context tags 0,1; 3-byte unsigned)
+    lim = inst.to_bytes(3, "big")
+    apdu = bytes([0x10, 0x08]) + b"\x0a" + lim + b"\x1a" + lim
+    pkt = bytes([0x81, 0x0a]) + (4 + 2 + len(apdu)).to_bytes(2, "big") + bytes([0x01, 0x04]) + apdu
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.settimeout(6)
+    try:
+        s.sendto(pkt, (ip, 47808))
+        data, _ = s.recvfrom(2048)
+        return data.hex()
+    except Exception as e:
+        return None
+    finally:
+        s.close()
+rc = 0
+for ip, inst in targets:
+    r = whois_unicast(ip, inst)
+    print(f"unicast-whois {inst}@{ip}: {'I-Am ' + r[:40] if r else 'no unicast reply to ephemeral source'}")
+    if not r:
+        rc = 1
+sys.exit(rc)
+PY
+WHOIS_UNI_RC=${PIPESTATUS[0]}
+set -e
+if [[ "$WHOIS_UNI_RC" -eq 0 ]]; then
+  ok "#526: hosted servers reply I-Am unicast to ephemeral requester"
+else
+  # 2026-07-18 evidence: server DOES emit I-Am, but as a BROADCAST to :47808 (spec-legal);
+  # a 47808-bound listener on another host captures it. The gap is the fieldbus CLIENT:
+  # whois_bind_port=0 (ephemeral) can never receive broadcast I-Ams, so /bacnet/whois
+  # misses hosted devices. Workbench (bound :47808) should discover fine.
+  skip "#526 refined: no unicast I-Am to ephemeral source (server broadcasts I-Am to :47808; fieldbus client's ephemeral whois bind misses it — client-side defect)"
+fi
+
+# F3b: directed ReadProperty proves both hosted devices are alive, DISTINCT, and that the
+# Pi genuinely hosts $DEV2 (env-only instance, #532). Error-aware on purpose: the 2026-07-18
+# duplicate-instance incident slipped through a parser that treated a BACnet Error APDU as
+# success. Now we require: dev2@Pi = ComplexAck, dev1@Pi = Error (no 599999 ghost on the Pi),
+# dev1@bench = ComplexAck, and the two names differ.
+RP_OUT="$(python3 - "$PI_IP" "$DEV2" "${OT_BIND:-127.0.0.1}" "${HOSTED_DEVICE}" <<'PY'
+import socket, sys
+pi_ip, dev2, bench_ip, dev1 = sys.argv[1], int(sys.argv[2]), sys.argv[3], int(sys.argv[4])
+def read_object_name(ip, inst):
+    # -> ("ok", name) | ("error", raw) | ("timeout", None)
+    obj = (8 << 22) | inst
+    apdu = bytes([0x00,0x05,0x01,0x0C]) + b'\x0c' + obj.to_bytes(4,'big') + b'\x19\x4d'
+    pkt = bytes([0x81,0x0a]) + (4+2+len(apdu)).to_bytes(2,'big') + bytes([0x01,0x04]) + apdu
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.settimeout(6)
+    try:
+        s.sendto(pkt, (ip, 47808)); data,_ = s.recvfrom(2048)
+    except Exception:
+        return ("timeout", None)
+    finally:
+        s.close()
+    pdu_type = data[6] >> 4
+    if pdu_type == 5:   # Error PDU (e.g. unknown-object)
+        return ("error", data[6:].hex())
+    if pdu_type == 3 and 0x75 in data:  # ComplexAck with extended charstring
+        i = data.index(0x75)
+        return ("ok", data[i+3:i+3+data[i+1]-1].decode('utf-8', 'replace'))
+    return ("error", f"unexpected pdu_type={pdu_type}")
+r2 = read_object_name(pi_ip, dev2)      # must be ok
+g2 = read_object_name(pi_ip, dev1)      # must be error (no duplicate of bench instance!)
+r1 = read_object_name(bench_ip, dev1)   # must be ok
+print(f"pi    device:{dev2} -> {r2}")
+print(f"pi    device:{dev1} -> {g2}   (must be error: duplicate-instance guard)")
+print(f"bench device:{dev1} -> {r1}")
+okall = (r2[0] == "ok" and r1[0] == "ok" and g2[0] == "error" and r2[1] != r1[1])
+sys.exit(0 if okall else 1)
+PY
+)" && RP_RC=0 || RP_RC=1
+echo "$RP_OUT" | tee "$ART/hosted_readprop.txt"
+if [[ "$RP_RC" -eq 0 ]]; then
+  ok "hosted instances distinct: Pi answers ONLY $DEV2, bench answers ${HOSTED_DEVICE} — env instance honored (#532), no duplicate device id"
+else
+  bad "hosted instance identity FAILED — duplicate/misconfigured device id (env ignored or stale image; see hosted_readprop.txt)"
+fi
+
+# F4: ingest growth attributable to second site
+if IS="$(central "$CENTRAL_BASE/api/ingest/stats" 2>/dev/null)"; then
+  echo "$IS" >"$ART/ingest_stats_cloudsim.json"
+  ok "ingest/stats captured post-cloudsim ($(jq -c . <<<"$IS" | head -c 200))"
+fi
+
+summary
+echo "${DIM}Artifacts: $ART — leave the Pi edge RUNNING for soak; tear down only by human decision.${RST}"

--- a/scripts/nightly-ot-bench/08_weather_trend.sh
+++ b/scripts/nightly-ot-bench/08_weather_trend.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# Weather trend + long-term soak gate — proves the hosted BACnet servers serve LIVE,
+# UPDATING Open-Meteo data (not the 70.0/50.0 fallback frozen values seen in Workbench
+# on 2026-07-17).
+#
+# Topology under test:
+#   599999 @ bench (Madison Wisconsin)   — standalone stack fieldbus
+#   600000 @ Pi    (Chicago)             — cloud-sim edge (gate 07 sets city=Chicago)
+#
+# Phases:
+#   A. BEFORE snapshot — /weather API + directed BACnet ReadProperty (AV:9101 temp,
+#      AV:9102 RH, CSV:9107 last-updated, BV:9106 app-fault) on BOTH devices
+#   B. Cross-device read — the Pi's 600000 edge reads 599999's weather points over
+#      real BACnet (device 599999 is in the Pi's field_devices.toml, gate 07)
+#   C. Soak — WEATHER_SOAK_SECS (default 1800) with a sample every WEATHER_SAMPLE_SECS
+#      (default 300) → trend CSV artifact for the report
+#   D. AFTER snapshot — assert weather-last-updated CHANGED on both devices and values
+#      are NOT stuck at fallback (app-fault BV inactive, from_api=true)
+#   E. Legitimacy — python fetches real Open-Meteo Chicago + Madison current temps from
+#      the host and asserts each device matches its city within ±3 °F
+#   F. Root-cause on failure — docker exec DNS/HTTPS probe to open-meteo from inside
+#      the fieldbus container(s)
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+cd "$ROOT"
+
+PI_SSH="${CLOUD_SIM_PI_SSH:-ben@192.168.204.12}"
+SSH_OPTS=(-i "$HOME/.ssh/id_rsa" -o BatchMode=yes -o ConnectTimeout=10)
+PI_IP="${PI_SSH##*@}"
+BENCH_IP="${OT_BIND:-127.0.0.1}"
+DEV1="${HOSTED_DEVICE:-599999}"
+DEV2="${CLOUD_SIM_DEVICE_INSTANCE:-600000}"
+SOAK="${WEATHER_SOAK_SECS:-1800}"
+SAMPLE_EVERY="${WEATHER_SAMPLE_SECS:-300}"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+TREND="$ART/weather_trend.csv"
+
+pi() { ssh "${SSH_OPTS[@]}" "$PI_SSH" "$@"; }
+
+PI_UP=0
+if pi 'curl -fsS --max-time 5 http://127.0.0.1:8081/health' 2>/dev/null | jq -e '.ok==true' >/dev/null 2>&1; then
+  PI_UP=1
+fi
+
+# rp <ip> <device_instance> <object_type:AV|CSV|BV> <object_instance>
+# Directed BACnet ReadProperty of present-value; prints decoded value or "ERR".
+rp() {
+  python3 - "$1" "$2" "$3" "$4" <<'PY'
+import socket, struct, sys
+ip, inst, otype, oinst = sys.argv[1], int(sys.argv[2]), sys.argv[3], int(sys.argv[4])
+OT = {"AV": 2, "CSV": 40, "BV": 5}[otype]
+obj = (OT << 22) | oinst
+# ReadProperty (service 12): ctx0 objid, ctx1 property 85 (present-value)
+apdu = bytes([0x00, 0x05, 0x01, 0x0C]) + b"\x0c" + obj.to_bytes(4, "big") + b"\x19\x55"
+pkt = bytes([0x81, 0x0a]) + (4 + 2 + len(apdu)).to_bytes(2, "big") + bytes([0x01, 0x04]) + apdu
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.settimeout(8)
+try:
+    s.sendto(pkt, (ip, 47808))
+    data, _ = s.recvfrom(2048)
+except Exception as e:
+    print("ERR"); sys.exit(1)
+finally:
+    s.close()
+# ComplexAck: value sits inside opening/closing context tag 3 (0x3e ... 0x3f)
+try:
+    i = data.index(0x3e) + 1
+    tag = data[i]
+    cls, ln = tag >> 4, tag & 0x07
+    if tag == 0x44:  # Real
+        print(round(struct.unpack(">f", data[i+1:i+5])[0], 2))
+    elif cls == 7:  # CharacterString
+        if ln == 5:  # extended length in next byte
+            length = data[i+1]; body = data[i+2:i+2+length]
+        else:
+            length = ln; body = data[i+1:i+1+length]
+        print(body[1:].decode("utf-8", "replace"))  # first byte = charset
+    elif cls == 9:  # Enumerated (BV)
+        length = ln
+        print(int.from_bytes(data[i+1:i+1+length], "big"))
+    else:
+        print(f"tag0x{tag:02x}:" + data[i:i+12].hex())
+except ValueError:
+    print("ERR"); sys.exit(1)
+PY
+}
+
+snapshot() {
+  # snapshot <label> — prints "temp|rh|stamp|fault" for dev1 and dev2 to stdout,
+  # saves a readable block to the artifact dir.
+  local label="$1" out="$ART/weather_snapshot_${1}.txt"
+  {
+    echo "== $label $(date -u +%FT%TZ) =="
+    for spec in "bench:$BENCH_IP:$DEV1" "pi:$PI_IP:$DEV2"; do
+      IFS=':' read -r name ip dev <<<"$spec"
+      if [[ "$name" == "pi" && "$PI_UP" != "1" ]]; then
+        echo "$name dev=$dev SKIPPED (pi edge not up)"
+        continue
+      fi
+      local t rh st flt
+      t="$(rp "$ip" "$dev" AV 9101 2>/dev/null || echo ERR)"
+      rh="$(rp "$ip" "$dev" AV 9102 2>/dev/null || echo ERR)"
+      st="$(rp "$ip" "$dev" CSV 9107 2>/dev/null || echo ERR)"
+      flt="$(rp "$ip" "$dev" BV 9106 2>/dev/null || echo ERR)"
+      echo "$name dev=$dev temp_f=$t rh=$rh app_fault=$flt last_updated='$st'"
+    done
+  } | tee "$out"
+}
+
+extract() {
+  # extract <snapshot-file> <bench|pi> <field: temp_f|rh|app_fault|last_updated>
+  local f="$1" who="$2" field="$3"
+  if [[ "$field" == "last_updated" ]]; then
+    grep "^$who " "$f" | sed -n "s/.*last_updated='\(.*\)'$/\1/p"
+  else
+    grep "^$who " "$f" | grep -o "${field}=[^ ]*" | cut -d= -f2
+  fi
+}
+
+# --- A0. device identity guard ---------------------------------------------------
+# Weather objects (AV/CSV/BV) answer regardless of the DEVICE instance, so before
+# trusting any read, prove each host actually hosts ITS OWN device object and NOT the
+# other one. Catches the duplicate-instance-599999 regression seen in Workbench.
+hdr "A0. device identity ($DEV1 only on bench, $DEV2 only on Pi)"
+devcheck() {
+  # devcheck <ip> <instance> -> "ok:<name>" | "error" | "timeout"
+  python3 - "$1" "$2" <<'PY'
+import socket, sys
+ip, inst = sys.argv[1], int(sys.argv[2])
+obj = (8 << 22) | inst
+apdu = bytes([0x00,0x05,0x01,0x0C]) + b'\x0c' + obj.to_bytes(4,'big') + b'\x19\x4d'
+pkt = bytes([0x81,0x0a]) + (6+len(apdu)).to_bytes(2,'big') + bytes([0x01,0x04]) + apdu
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.settimeout(6)
+try:
+    s.sendto(pkt, (ip, 47808)); d,_ = s.recvfrom(2048)
+except Exception:
+    print("timeout"); sys.exit(0)
+finally:
+    s.close()
+t = d[6] >> 4
+if t == 3 and 0x75 in d:
+    i = d.index(0x75)
+    print("ok:" + d[i+3:i+3+d[i+1]-1].decode('utf-8','replace'))
+else:
+    print("error")
+PY
+}
+ID_B1="$(devcheck "$BENCH_IP" "$DEV1")"; ID_B2="$(devcheck "$BENCH_IP" "$DEV2")"
+echo "bench device:$DEV1 -> $ID_B1 ; device:$DEV2 -> $ID_B2" | tee "$ART/device_identity.txt"
+if [[ "$ID_B1" == ok:* && "$ID_B2" == "error" ]]; then
+  ok "bench hosts ONLY device $DEV1 (${ID_B1#ok:})"
+else
+  bad "bench device identity wrong (dev$DEV1=$ID_B1 dev$DEV2=$ID_B2) — duplicate/misconfigured instance"
+fi
+if [[ "$PI_UP" == "1" ]]; then
+  ID_P2="$(devcheck "$PI_IP" "$DEV2")"; ID_P1="$(devcheck "$PI_IP" "$DEV1")"
+  echo "pi device:$DEV2 -> $ID_P2 ; device:$DEV1 -> $ID_P1" | tee -a "$ART/device_identity.txt"
+  if [[ "$ID_P2" == ok:* && "$ID_P1" == "error" ]]; then
+    ok "pi hosts ONLY device $DEV2 (${ID_P2#ok:}) — no duplicate of $DEV1 on the LAN"
+  else
+    bad "pi device identity wrong (dev$DEV2=$ID_P2 dev$DEV1=$ID_P1) — DUPLICATE INSTANCE, Workbench discovery will collide"
+  fi
+fi
+
+# --- A. BEFORE snapshot --------------------------------------------------------
+hdr "A. BEFORE snapshot (BACnet ReadProperty on $DEV1@$BENCH_IP and $DEV2@$PI_IP)"
+snapshot before >/dev/null
+BEFORE="$ART/weather_snapshot_before.txt"
+B_T1="$(extract "$BEFORE" bench temp_f || true)"; B_ST1="$(extract "$BEFORE" bench last_updated || true)"
+B_T2="$(extract "$BEFORE" pi temp_f || true)";    B_ST2="$(extract "$BEFORE" pi last_updated || true)"
+[[ "$B_T1" != "ERR" && -n "$B_T1" ]] && ok "599999 answers weather ReadProperty (temp_f=$B_T1)" \
+  || bad "599999 ReadProperty failed for AV:9101"
+if [[ "$PI_UP" == "1" ]]; then
+  [[ "$B_T2" != "ERR" && -n "$B_T2" ]] && ok "600000 answers weather ReadProperty (temp_f=$B_T2)" \
+    || bad "600000 ReadProperty failed for AV:9101"
+else
+  skip "Pi edge not up — 600000 checks skipped (run gate 07 first)"
+fi
+
+# /weather API view (from_api truthfulness) on both fieldbuses
+WB="$(fb "$FIELDBUS_BASE/weather" 2>/dev/null || echo '{}')"
+echo "$WB" >"$ART/weather_api_bench_before.json"
+echo "${DIM}  bench /weather: $(jq -c '{location,temp_f,from_api,reason}' <<<"$WB" 2>/dev/null)${RST}"
+if [[ "$PI_UP" == "1" ]]; then
+  WP="$(pi 'curl -fsS --max-time 10 http://127.0.0.1:8081/weather' 2>/dev/null || echo '{}')"
+  echo "$WP" >"$ART/weather_api_pi_before.json"
+  echo "${DIM}  pi    /weather: $(jq -c '{location,temp_f,from_api,reason}' <<<"$WP" 2>/dev/null)${RST}"
+  if jq -e '.location | test("Chicago")' <<<"$WP" >/dev/null 2>&1; then
+    ok "Pi weather city is Chicago (gate 07 config applied)"
+  else
+    bad "Pi weather location is not Chicago: $(jq -r '.location // "?"' <<<"$WP")"
+  fi
+fi
+
+# --- B. cross-device read: 600000's edge reads 599999 over real BACnet ---------
+hdr "B. cross-device read (Pi edge → 599999 weather points over BACnet)"
+if [[ "$PI_UP" == "1" ]]; then
+  XD="$(pi "curl -fsS --max-time 30 -X POST http://127.0.0.1:8081/bacnet/read \
+    -H 'Content-Type: application/json' \
+    -d '{\"device_instance\":$DEV1,\"object_type\":\"analog-value\",\"object_instance\":9101,\"property_id\":\"present-value\"}'" 2>/dev/null || echo '{}')"
+  echo "$XD" >"$ART/cross_device_read.json"
+  XDV="$(jq -r '.value // .present_value // empty' <<<"$XD")"
+  if [[ -n "$XDV" ]] && jq -e '.ok==true' <<<"$XD" >/dev/null 2>&1; then
+    ok "Pi edge read 599999 AV:9101 over BACnet: $XDV °F"
+    if [[ "$B_T1" != "ERR" ]] && approx "$XDV" "$B_T1" 1.0; then
+      ok "cross-device value agrees with direct read ($XDV ≈ $B_T1)"
+    else
+      bad "cross-device value $XDV disagrees with direct read $B_T1"
+    fi
+  else
+    bad "Pi edge could not read 599999 weather point: $(head -c 200 <<<"$XD")"
+  fi
+else
+  skip "cross-device read skipped (Pi edge not up)"
+fi
+
+# --- C. soak with trend sampling ------------------------------------------------
+hdr "C. soak ${SOAK}s, sampling every ${SAMPLE_EVERY}s → weather_trend.csv"
+# FD-leak instrumentation: BACnetClient::stop() leaks the transport UDP socket per
+# operation (vendored bacnet-client lifecycle.rs never stops the Arc'd NetworkLayer).
+# At ~4 sockets/min the fieldbus dies at the 1024-FD ulimit in ~4-5h — root cause of
+# the 2026-07-17 frozen-fallback weather in Workbench. Quantify growth over the soak.
+FB_CTR="$(docker ps --format '{{.Names}}' | grep -m1 fieldbus || true)"
+fd_count() { docker exec "$FB_CTR" sh -c 'ls /proc/1/fd | wc -l' 2>/dev/null || echo 0; }
+FD_START=0
+[[ -n "$FB_CTR" ]] && FD_START="$(fd_count)"
+echo "utc,device,temp_f,rh,app_fault,last_updated" >"$TREND"
+ELAPSED=0
+while (( ELAPSED < SOAK )); do
+  NOW="$(date -u +%FT%TZ)"
+  T1="$(rp "$BENCH_IP" "$DEV1" AV 9101 2>/dev/null || echo ERR)"
+  R1="$(rp "$BENCH_IP" "$DEV1" AV 9102 2>/dev/null || echo ERR)"
+  F1="$(rp "$BENCH_IP" "$DEV1" BV 9106 2>/dev/null || echo ERR)"
+  S1="$(rp "$BENCH_IP" "$DEV1" CSV 9107 2>/dev/null || echo ERR)"
+  echo "$NOW,$DEV1,$T1,$R1,$F1,\"$S1\"" >>"$TREND"
+  if [[ "$PI_UP" == "1" ]]; then
+    T2="$(rp "$PI_IP" "$DEV2" AV 9101 2>/dev/null || echo ERR)"
+    R2="$(rp "$PI_IP" "$DEV2" AV 9102 2>/dev/null || echo ERR)"
+    F2="$(rp "$PI_IP" "$DEV2" BV 9106 2>/dev/null || echo ERR)"
+    S2="$(rp "$PI_IP" "$DEV2" CSV 9107 2>/dev/null || echo ERR)"
+    echo "$NOW,$DEV2,$T2,$R2,$F2,\"$S2\"" >>"$TREND"
+  fi
+  PI_NOTE=""
+  [[ "$PI_UP" == "1" ]] && PI_NOTE="$DEV2=${T2:-n/a}°F"
+  echo "${DIM}  t+${ELAPSED}s  $DEV1=$T1°F  $PI_NOTE${RST}"
+  sleep "$SAMPLE_EVERY"
+  ELAPSED=$((ELAPSED + SAMPLE_EVERY))
+done
+ok "soak complete — $(( $(wc -l <"$TREND") - 1 )) trend samples in weather_trend.csv"
+
+# FD leak verdict over the soak window
+if [[ -n "$FB_CTR" ]]; then
+  FD_END="$(fd_count)"
+  FD_GROWTH=$((FD_END - FD_START))
+  echo "fd_start=$FD_START fd_end=$FD_END growth=$FD_GROWTH soak_secs=$SOAK" >"$ART/fd_leak.txt"
+  if (( FD_GROWTH > 20 )); then
+    RATE_H="$(python3 -c "print(round($FD_GROWTH * 3600 / $SOAK))")"
+    bad "FD LEAK: fieldbus fds grew $FD_START → $FD_END over ${SOAK}s (~${RATE_H}/h) — BACnetClient::stop() leaks UDP socket; service dies at 1024-fd ulimit"
+  else
+    ok "fieldbus fd count stable over soak ($FD_START → $FD_END)"
+  fi
+fi
+
+# --- D. AFTER snapshot ----------------------------------------------------------
+hdr "D. AFTER snapshot + staleness assertions"
+snapshot after >/dev/null
+AFTER="$ART/weather_snapshot_after.txt"
+A_T1="$(extract "$AFTER" bench temp_f || true)"; A_ST1="$(extract "$AFTER" bench last_updated || true)"
+A_F1="$(extract "$AFTER" bench app_fault || true)"
+A_T2="$(extract "$AFTER" pi temp_f || true)";    A_ST2="$(extract "$AFTER" pi last_updated || true)"
+A_F2="$(extract "$AFTER" pi app_fault || true)"
+
+check_device_fresh() {
+  # check_device_fresh <name> <dev> <t_before> <stamp_before> <t_after> <stamp_after> <fault_after>
+  local name="$1" dev="$2" tb="$3" sb="$4" ta="$5" sa="$6" fa="$7"
+  if [[ -z "$sa" || "$sa" == "ERR" ]]; then
+    bad "$name $dev: could not read weather-last-updated after soak"
+    return
+  fi
+  if [[ "$sa" != "$sb" ]]; then
+    ok "$name $dev: weather-last-updated CHANGED over soak — server data is live"
+    echo "${DIM}  before: $sb${RST}"
+    echo "${DIM}  after:  $sa${RST}"
+  else
+    bad "$name $dev: weather-last-updated FROZEN over ${SOAK}s soak ('$sa') — mirror loop dead?"
+  fi
+  # fallback detection: exact 70.0/50.0 pair AND app-fault active
+  if [[ "$fa" == "1" ]]; then
+    bad "$name $dev: app-fault BV:9106 ACTIVE after soak — serving fallback, Open-Meteo unreachable"
+  elif [[ "$ta" == "70.0" || "$ta" == "70" ]] && grep -q "fallback" <<<"$sa"; then
+    bad "$name $dev: values look like frozen fallback (temp=$ta, stamp mentions fallback)"
+  else
+    ok "$name $dev: live values (temp_f=$ta, app-fault inactive)"
+  fi
+}
+check_device_fresh bench "$DEV1" "$B_T1" "$B_ST1" "$A_T1" "$A_ST1" "$A_F1"
+if [[ "$PI_UP" == "1" ]]; then
+  check_device_fresh pi "$DEV2" "$B_T2" "$B_ST2" "$A_T2" "$A_ST2" "$A_F2"
+fi
+
+# --- E. legitimacy vs real Open-Meteo -------------------------------------------
+hdr "E. legitimacy: device temps vs real Open-Meteo (±3 °F)"
+LEGIT_ARGS=("Madison Wisconsin" "$A_T1")
+[[ "$PI_UP" == "1" ]] && LEGIT_ARGS+=("Chicago" "$A_T2")
+set +e
+python3 - "${LEGIT_ARGS[@]}" <<'PY' | tee "$ART/weather_legitimacy.txt"
+import json, sys, urllib.request, urllib.parse
+pairs = list(zip(sys.argv[1::2], sys.argv[2::2]))
+rc = 0
+def geocode(city):
+    # Multi-word queries ("Madison Wisconsin") return no results from the geocoding
+    # API; fall back to first token + admin1 filter, mirroring the product's logic.
+    for name in (city, city.split()[0]):
+        q = urllib.parse.urlencode({"name": name, "count": 10, "language": "en", "format": "json"})
+        geo = json.load(urllib.request.urlopen(f"https://geocoding-api.open-meteo.com/v1/search?{q}", timeout=20))
+        results = geo.get("results") or []
+        hint = " ".join(city.split()[1:]).lower()
+        for r in results:
+            if not hint or hint in r.get("admin1", "").lower():
+                return r
+        if results:
+            return results[0]
+    raise RuntimeError(f"no geocode result for {city!r}")
+
+for city, dev_val in pairs:
+    try:
+        loc = geocode(city)
+        q2 = urllib.parse.urlencode({
+            "latitude": loc["latitude"], "longitude": loc["longitude"],
+            "current": "temperature_2m", "temperature_unit": "fahrenheit"})
+        fc = json.load(urllib.request.urlopen(f"https://api.open-meteo.com/v1/forecast?{q2}", timeout=20))
+        real = fc["current"]["temperature_2m"]
+    except Exception as e:
+        print(f"{city}: host-side Open-Meteo fetch FAILED ({e}) — cannot judge legitimacy")
+        rc = 1
+        continue
+    try:
+        dv = float(dev_val)
+    except ValueError:
+        print(f"{city}: device value '{dev_val}' unreadable")
+        rc = 1
+        continue
+    delta = abs(dv - real)
+    verdict = "MATCH" if delta <= 3.0 else "MISMATCH"
+    if verdict == "MISMATCH":
+        rc = 1
+    print(f"{city}: real Open-Meteo now {real}°F, device serves {dv}°F (Δ{delta:.1f}) → {verdict}")
+sys.exit(rc)
+PY
+LEGIT_RC=${PIPESTATUS[0]}
+set -e
+if [[ "$LEGIT_RC" -eq 0 ]]; then
+  ok "device weather matches real Open-Meteo city data within ±3 °F — data is legit, not canned"
+else
+  bad "device weather does NOT match real Open-Meteo city data (see weather_legitimacy.txt)"
+fi
+
+# --- F. root-cause probe if anything served fallback -----------------------------
+if [[ "$A_F1" == "1" || ( "$PI_UP" == "1" && "${A_F2:-0}" == "1" ) ]]; then
+  hdr "F. root-cause: container egress to Open-Meteo"
+  FB_CTR="$(docker ps --format '{{.Names}}' | grep -m1 fieldbus || true)"
+  if [[ -n "$FB_CTR" && "$A_F1" == "1" ]]; then
+    docker exec "$FB_CTR" sh -c \
+      'getent hosts geocoding-api.open-meteo.com; wget -q -T 10 -O- "https://geocoding-api.open-meteo.com/v1/search?name=Madison&count=1" | head -c 200; echo' \
+      >"$ART/bench_container_egress.txt" 2>&1 || true
+    echo "${DIM}$(cat "$ART/bench_container_egress.txt")${RST}"
+    skip "bench container egress probe saved (bench_container_egress.txt) — attach to weather issue"
+  fi
+  if [[ "$PI_UP" == "1" && "${A_F2:-0}" == "1" ]]; then
+    pi 'CTR=$(docker ps --format "{{.Names}}" | grep -m1 fieldbus); docker exec "$CTR" sh -c "getent hosts geocoding-api.open-meteo.com; wget -q -T 10 -O- \"https://geocoding-api.open-meteo.com/v1/search?name=Chicago&count=1\" | head -c 200; echo"' \
+      >"$ART/pi_container_egress.txt" 2>&1 || true
+    echo "${DIM}$(cat "$ART/pi_container_egress.txt")${RST}"
+    skip "pi container egress probe saved (pi_container_egress.txt) — attach to weather issue"
+  fi
+fi
+
+summary
+echo "${DIM}Trend artifact: $TREND — both BACnet servers stay RUNNING for Workbench trending.${RST}"

--- a/scripts/nightly-ot-bench/09_rest_ot.sh
+++ b/scripts/nightly-ot-bench/09_rest_ot.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# Gate 09 — REST/JSON edge driver (#540).
+# Runs a throwaway fieldbus container against a tiny JSON sim so the long-running
+# Workbench stack (standalone on :8081 / :47808) is never interrupted.
+#
+# Asserts: GET decode+scale, JSONPath miss → structured error, bearer auth,
+# write 403 when disabled, write clamp when enabled, circuit-breaker on sim kill,
+# FD stability across ≥500 reads (no #535-style per-op leak on reqwest).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+SIM_PORT="${REST_SIM_PORT:-18765}"
+SIM_TOKEN="${REST_SIM_TOKEN:-bench-rest-sim-token-xyz}"
+FB_HTTP_PORT="${REST_GATE_HTTP_PORT:-18091}"
+FB_NAME="openfdd-rest-gate-$$"
+CFG_DIR="$ART/rest_gate_config"
+SIM_PID=""
+FB_CID=""
+
+cleanup() {
+  set +e
+  if [[ -n "$FB_CID" ]]; then docker rm -f "$FB_CID" >/dev/null 2>&1; fi
+  if [[ -n "$SIM_PID" ]] && kill -0 "$SIM_PID" 2>/dev/null; then kill "$SIM_PID" 2>/dev/null; wait "$SIM_PID" 2>/dev/null; fi
+  # leftover from a previous aborted run
+  docker rm -f openfdd-rest-gate 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- probe: does the nightly image even expose /rest/* ? ---------------------
+hdr "Probe REST driver presence on nightly fieldbus image"
+# Prefer the running react-ot fieldbus (same image) for a quick surface check; if 404,
+# the feature is not in this image and we FAIL (expected shipped per #540/#543).
+PROBE="$(curl -sS --max-time 8 -o /tmp/rest_probe.json -w '%{http_code}' \
+  -H "Authorization: Bearer ${OPENFDD_FIELDBUS_API_KEY:-bench-demo-key-1234567890}" \
+  "$FIELDBUS_BASE/rest/devices" || echo 000)"
+echo "fieldbus /rest/devices HTTP $PROBE → $(head -c 200 /tmp/rest_probe.json 2>/dev/null)"
+if [[ "$PROBE" == "404" || "$PROBE" == "000" ]]; then
+  bad "REST driver not present on this nightly (/rest/devices → $PROBE) — #540 not shipped in image"
+  summary; exit 1
+fi
+ok "REST surface present on OT fieldbus (HTTP $PROBE)"
+
+# --- start JSON sim ----------------------------------------------------------
+hdr "Start REST JSON sim on :$SIM_PORT"
+REST_SIM_HOST=127.0.0.1 REST_SIM_PORT="$SIM_PORT" REST_SIM_TOKEN="$SIM_TOKEN" \
+  python3 "$DIR/rest_sim.py" >"$ART/rest_sim.log" 2>&1 &
+SIM_PID=$!
+for i in $(seq 1 30); do
+  if curl -fsS --max-time 1 "http://127.0.0.1:$SIM_PORT/_health" >/dev/null 2>&1; then break; fi
+  sleep 0.2
+done
+if ! curl -fsS --max-time 2 "http://127.0.0.1:$SIM_PORT/_health" >/dev/null 2>&1; then
+  bad "rest_sim failed to start (see rest_sim.log)"
+  summary; exit 1
+fi
+ok "rest_sim up (pid $SIM_PID)"
+
+# --- throwaway fieldbus with test catalog ------------------------------------
+hdr "Throwaway fieldbus on :$FB_HTTP_PORT with REST catalog → sim"
+rm -rf "$CFG_DIR"
+mkdir -p "$CFG_DIR"
+# Minimal gateway: no bacnet OT bind fight — host network shared, but we do NOT
+# start a conflicting bacnet server on 47808 if possible. Use a high bacnet port.
+cat >"$CFG_DIR/gateway.toml" <<EOF
+[bacnet_server]
+device_instance = 610099
+device_name = "OpenFDD-rest-gate"
+interface = "127.0.0.1"
+port = 47899
+broadcast = "127.0.0.1"
+
+[bacnet_client]
+interface = "127.0.0.1"
+broadcast = "127.0.0.1"
+whois_bind_port = 0
+read_bind_port = 0
+
+[weather]
+city = "Madison Wisconsin"
+interval_secs = 3600
+
+[rest]
+default_timeout_secs = 5
+default_tls_verify = true
+default_poll_interval_secs = 60
+allow_write = false
+EOF
+
+# Device points at host.docker.internal / host-gateway. On --network host, 127.0.0.1 works.
+cat >"$CFG_DIR/rest_devices.toml" <<EOF
+[[devices]]
+name = "bench-sim"
+enabled = true
+base_url = "http://127.0.0.1:${SIM_PORT}"
+auth = "bearer"
+token_env = "OPENFDD_REST_TOKEN_BENCH"
+tls_verify = true
+timeout_secs = 5
+
+  [[devices.points]]
+  point_name = "CHW-ST"
+  method = "GET"
+  path = "/points/chw_supply_temp"
+  select = "\$.value"
+  units = "°F"
+  scale = 1.0
+
+  [[devices.points]]
+  point_name = "PLANT-KW"
+  method = "GET"
+  path = "/points/plant_kw"
+  select = "\$.value"
+  units = "kW"
+  scale = 2.0
+
+  [[devices.points]]
+  point_name = "MISSING"
+  method = "GET"
+  path = "/points/missing_path"
+  select = "\$.value"
+  units = "-"
+
+  [[devices.writes]]
+  name = "chw_setpoint"
+  enabled = false
+  method = "POST"
+  path = "/points/chw_setpoint"
+  body_template = '{"value": {{value}}, "priority": 8}'
+  value_min = 40.0
+  value_max = 55.0
+EOF
+
+# Empty field_devices catalog (must still parse — `devices` key required)
+printf '%s\n' '# gate 09 — no BACnet field devices' 'devices = []' >"$CFG_DIR/field_devices.toml"
+cp "$ROOT/config/fieldbus/objects.csv" "$CFG_DIR/objects.csv" 2>/dev/null || \
+  echo 'object_type,object_instance,object_name' >"$CFG_DIR/objects.csv"
+cp "$ROOT/config/fieldbus/haystack_users.toml" "$CFG_DIR/haystack_users.toml" 2>/dev/null || true
+
+docker rm -f openfdd-rest-gate >/dev/null 2>&1 || true
+# No --rm until healthy so boot failures leave inspectable logs
+FB_CID="$(docker run -d --name openfdd-rest-gate --network host \
+  -e OPENFDD_FIELDBUS_CONFIG_DIR=/app/config \
+  -e OPENFDD_FIELDBUS_HTTP_HOST=127.0.0.1 \
+  -e OPENFDD_FIELDBUS_HTTP_PORT="$FB_HTTP_PORT" \
+  -e OPENFDD_FIELDBUS_API_KEY=bench-rest-gate-key \
+  -e OPENFDD_REST_TOKEN_BENCH="$SIM_TOKEN" \
+  -v "$CFG_DIR:/app/config:ro" \
+  "${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:nightly}")"
+ok "throwaway fieldbus cid=${FB_CID:0:12}"
+
+FB="http://127.0.0.1:$FB_HTTP_PORT"
+AUTH=(-H "Authorization: Bearer bench-rest-gate-key" -H "Content-Type: application/json")
+for i in $(seq 1 40); do
+  if curl -fsS --max-time 2 "$FB/health" >/dev/null 2>&1; then break; fi
+  sleep 0.5
+done
+if ! curl -fsS --max-time 5 "$FB/health" >/dev/null 2>&1; then
+  bad "throwaway fieldbus never healthy; logs:"
+  docker logs openfdd-rest-gate 2>&1 | tee "$ART/rest_gate_boot.log" | tail -40
+  summary; exit 1
+fi
+# Now safe to mark for cleanup (trap removes by name/cid)
+ok "throwaway fieldbus healthy on :$FB_HTTP_PORT"
+
+rapi() { curl -sS --max-time 20 "${AUTH[@]}" "$@"; }
+
+# --- list devices ------------------------------------------------------------
+hdr "GET /rest/devices"
+DEV="$(rapi "$FB/rest/devices" || echo '{}')"
+echo "$DEV" | tee "$ART/rest_devices.json" | head -c 400; echo
+jq_ok "rest devices list ok" "$DEV" '.ok==true'
+if jq -e '.devices[] | select(.name=="bench-sim")' <<<"$DEV" >/dev/null 2>&1; then
+  ok "bench-sim present in catalog"
+else
+  bad "bench-sim missing from /rest/devices: $(head -c 200 <<<"$DEV")"
+fi
+
+# --- read + scale ------------------------------------------------------------
+hdr "POST /rest/read decode + scale"
+RD="$(rapi -X POST "$FB/rest/read" -d '{"device":"bench-sim","point":"CHW-ST"}' || echo '{}')"
+echo "$RD" | tee "$ART/rest_read_chw.json"
+# value should be ~44.0
+VAL="$(jq -r '.value // .present_value // empty' <<<"$RD")"
+if jq -e '.ok==true or (.value!=null)' <<<"$RD" >/dev/null 2>&1 && python3 -c "import sys; v=float('$VAL'); sys.exit(0 if abs(v-44.0)<0.01 else 1)"; then
+  ok "CHW-ST decode = $VAL (expected 44.0)"
+else
+  bad "CHW-ST decode failed: $RD"
+fi
+
+RD2="$(rapi -X POST "$FB/rest/read" -d '{"device":"bench-sim","point":"PLANT-KW"}' || echo '{}')"
+echo "$RD2" | tee "$ART/rest_read_kw.json"
+VAL2="$(jq -r '.value // .present_value // empty' <<<"$RD2")"
+# scale=2.0 → 120.5 * 2 = 241.0
+if python3 -c "import sys; v=float('$VAL2' or 'nan'); sys.exit(0 if abs(v-241.0)<0.05 else 1)"; then
+  ok "PLANT-KW scale×2 = $VAL2 (expected 241.0)"
+else
+  bad "PLANT-KW scale failed (got $VAL2): $RD2"
+fi
+
+# --- JSONPath miss -----------------------------------------------------------
+hdr "JSONPath miss → structured error"
+MISS="$(rapi -X POST "$FB/rest/read" -d '{"device":"bench-sim","point":"MISSING"}' || echo '{}')"
+echo "$MISS" | tee "$ART/rest_read_miss.json"
+# expect non-ok / 4xx body with error string
+if jq -e '(.ok==false) or (.error!=null) or (.detail!=null)' <<<"$MISS" >/dev/null 2>&1; then
+  ok "JSONPath miss returned structured error"
+else
+  # some builds return HTTP 4xx with JSON body that curl -s still captures
+  CODE="$(curl -sS -o "$ART/rest_read_miss.json" -w '%{http_code}' --max-time 20 "${AUTH[@]}" \
+    -X POST "$FB/rest/read" -d '{"device":"bench-sim","point":"MISSING"}' || echo 000)"
+  if [[ "$CODE" =~ ^4 ]]; then
+    ok "JSONPath miss HTTP $CODE (structured)"
+  else
+    bad "JSONPath miss did not error (HTTP $CODE): $(head -c 200 "$ART/rest_read_miss.json")"
+  fi
+fi
+
+# --- write 403 when disabled -------------------------------------------------
+hdr "POST /rest/write → 403 when allow_write/binding disabled"
+WCODE="$(curl -sS -o "$ART/rest_write_disabled.json" -w '%{http_code}' --max-time 20 "${AUTH[@]}" \
+  -X POST "$FB/rest/write" -d '{"device":"bench-sim","name":"chw_setpoint","value":45.0}' || echo 000)"
+echo "HTTP $WCODE → $(head -c 200 "$ART/rest_write_disabled.json")"
+if [[ "$WCODE" == "403" ]] || jq -e '(.ok==false) or (.error!=null)' "$ART/rest_write_disabled.json" >/dev/null 2>&1; then
+  ok "write blocked when disabled (HTTP $WCODE)"
+else
+  bad "write should be forbidden when disabled (HTTP $WCODE)"
+fi
+
+# --- write clamp (opt-in: BENCH_ALLOW_WRITES=1) ------------------------------
+if [[ "${BENCH_ALLOW_WRITES:-0}" == "1" ]]; then
+  hdr "Write clamp: restart throwaway with allow_write=true + binding enabled"
+  docker rm -f openfdd-rest-gate >/dev/null 2>&1 || true
+  FB_CID=""
+  python3 - "$CFG_DIR" <<'PY'
+from pathlib import Path
+import sys
+cfg = Path(sys.argv[1])
+g = (cfg/"gateway.toml").read_text().replace("allow_write = false", "allow_write = true")
+(cfg/"gateway.toml").write_text(g)
+r = (cfg/"rest_devices.toml").read_text().replace("enabled = false", "enabled = true", 1)
+(cfg/"rest_devices.toml").write_text(r)
+print("patched allow_write + binding enabled")
+PY
+  docker rm -f openfdd-rest-gate >/dev/null 2>&1 || true
+  FB_CID="$(docker run -d --name openfdd-rest-gate --network host \
+    -e OPENFDD_FIELDBUS_CONFIG_DIR=/app/config \
+    -e OPENFDD_FIELDBUS_HTTP_HOST=127.0.0.1 \
+    -e OPENFDD_FIELDBUS_HTTP_PORT="$FB_HTTP_PORT" \
+    -e OPENFDD_FIELDBUS_API_KEY=bench-rest-gate-key \
+    -e OPENFDD_REST_TOKEN_BENCH="$SIM_TOKEN" \
+    -v "$CFG_DIR:/app/config:ro" \
+    "${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:nightly}")"
+  for i in $(seq 1 40); do
+    curl -fsS --max-time 2 "$FB/health" >/dev/null 2>&1 && break
+    sleep 0.5
+  done
+  if ! curl -fsS --max-time 5 "$FB/health" >/dev/null 2>&1; then
+    bad "throwaway fieldbus (allow_write restart) never healthy"
+    docker logs openfdd-rest-gate 2>&1 | tee -a "$ART/rest_gate_boot.log" | tail -20
+    summary; exit 1
+  fi
+
+  LOW="$(curl -sS -o "$ART/rest_write_low.json" -w '%{http_code}' --max-time 20 "${AUTH[@]}" \
+    -X POST "$FB/rest/write" -d '{"device":"bench-sim","name":"chw_setpoint","value":30.0}' || echo 000)"
+  echo "low write HTTP $LOW → $(head -c 200 "$ART/rest_write_low.json")"
+  if [[ "$LOW" =~ ^4 ]] || jq -e '(.ok==false) or (.error!=null) or (.clamped==true)' "$ART/rest_write_low.json" >/dev/null 2>&1; then
+    ok "write below min rejected/clamped (HTTP $LOW)"
+  else
+    bad "write below min (30) should fail clamp (HTTP $LOW)"
+  fi
+
+  OKW="$(rapi -X POST "$FB/rest/write" -d '{"device":"bench-sim","name":"chw_setpoint","value":46.0}' || echo '{}')"
+  echo "$OKW" | tee "$ART/rest_write_ok.json"
+  if jq -e '.ok==true or (.value==46.0) or (.written==true)' <<<"$OKW" >/dev/null 2>&1; then
+    ok "in-range write 46.0 accepted"
+  else
+    CODE="$(curl -sS -o "$ART/rest_write_ok.json" -w '%{http_code}' --max-time 20 "${AUTH[@]}" \
+      -X POST "$FB/rest/write" -d '{"device":"bench-sim","name":"chw_setpoint","value":46.0}')"
+    if [[ "$CODE" == "200" ]]; then ok "in-range write HTTP 200"; else bad "in-range write failed HTTP $CODE: $(head -c 200 "$ART/rest_write_ok.json")"; fi
+  fi
+else
+  skip "REST write clamp / in-range write (set BENCH_ALLOW_WRITES=1)"
+fi
+
+# --- FD soak: 500 reads ------------------------------------------------------
+hdr "FD stability across 500 REST reads (no #535-style leak)"
+FD0="$(docker exec openfdd-rest-gate sh -c 'ls /proc/1/fd | wc -l' 2>/dev/null || echo 0)"
+echo "FD t0=$FD0"
+python3 - "$FB" <<'PY'
+import json, urllib.request, sys
+base = sys.argv[1]
+req_body = json.dumps({"device":"bench-sim","point":"CHW-ST"}).encode()
+ok = 0
+for i in range(500):
+    req = urllib.request.Request(
+        base + "/rest/read", data=req_body,
+        headers={"Authorization":"Bearer bench-rest-gate-key","Content-Type":"application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            if r.status == 200:
+                ok += 1
+    except Exception as e:
+        if i < 3 or i == 499:
+            print(f"read {i} err: {e}", file=sys.stderr)
+print(f"reads_ok={ok}/500")
+sys.exit(0 if ok >= 490 else 1)
+PY
+FD1="$(docker exec openfdd-rest-gate sh -c 'ls /proc/1/fd | wc -l' 2>/dev/null || echo 0)"
+echo "FD t500=$FD1 (delta=$((FD1 - FD0)))" | tee "$ART/rest_fd_soak.txt"
+# Allow small jitter (±20); fail if growth looks like a leak (>50)
+if python3 -c "import sys; d=int('$FD1')-int('$FD0'); sys.exit(0 if d<=50 else 1)"; then
+  ok "FD growth flat across 500 reads ($FD0 → $FD1)"
+else
+  bad "FD leaked across 500 REST reads ($FD0 → $FD1) — possible #535-style reqwest leak"
+fi
+
+# --- circuit breaker ---------------------------------------------------------
+hdr "Circuit breaker: kill sim, assert breaker opens after failures"
+curl -fsS --max-time 5 -X POST "http://127.0.0.1:$SIM_PORT/_kill" >/dev/null 2>&1 || true
+sleep 0.5
+SIM_PID=""  # already dead
+FAILS=0
+for i in $(seq 1 6); do
+  CODE="$(curl -sS -o /tmp/rest_cb.json -w '%{http_code}' --max-time 8 "${AUTH[@]}" \
+    -X POST "$FB/rest/read" -d '{"device":"bench-sim","point":"CHW-ST"}' || echo 000)"
+  echo "  attempt $i HTTP $CODE $(head -c 120 /tmp/rest_cb.json)"
+  FAILS=$((FAILS + 1))
+done
+DEV2="$(rapi "$FB/rest/devices" || echo '{}')"
+echo "$DEV2" | tee "$ART/rest_devices_after_kill.json" | head -c 500; echo
+if jq -e '.devices[] | select(.name=="bench-sim") | (.health.circuit_open==true) or ((.health.consecutive_failures//0)>=3)' <<<"$DEV2" >/dev/null 2>&1 \
+   || grep -qi 'circuit open' /tmp/rest_cb.json 2>/dev/null; then
+  ok "circuit breaker opened after sim kill"
+else
+  if jq -e '.devices[] | select(.name=="bench-sim") | ((.health.consecutive_failures//0) >= 1)' <<<"$DEV2" >/dev/null 2>&1; then
+    ok "failures recorded after sim kill (breaker telemetry present)"
+  else
+    bad "circuit breaker did not open / no failure telemetry after sim kill"
+  fi
+fi
+
+summary

--- a/scripts/nightly-ot-bench/10_react_spa.sh
+++ b/scripts/nightly-ot-bench/10_react_spa.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Gate 10 — React SPA product surface (post–Phase-2).
+# Asserts SPA routes + HTML shell + web asset markers + UI generation APIs.
+# Replaces Streamlit LabShell /lab gate (10_lab_ux_ia.sh).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+hdr "React SPA — routes + shell + generation"
+
+central_auth_setup
+
+# --- /api/ui/generation ------------------------------------------------------
+GEN="$(central "$CENTRAL_BASE/api/ui/generation" || echo '{}')"
+echo "$GEN" >"$ART/ui_generation.json"
+if jq -e '.generation=="react"' <<<"$GEN" >/dev/null 2>&1; then
+  ok "generation=react"
+else
+  bad "generation!=react: $(jq -c . <<<"$GEN")"
+fi
+if jq -e '.default_generation=="react"' <<<"$GEN" >/dev/null 2>&1; then
+  ok "default_generation=react"
+else
+  bad "default_generation!=react"
+fi
+
+# --- SPA HTML shell ----------------------------------------------------------
+HTML="$(curl -fsS --max-time 15 "$UI_BASE/" || true)"
+echo "$HTML" | head -c 500 >"$ART/spa_index_snip.html"
+if grep -qiE '<div id="root"|/assets/.*\.js' <<<"$HTML"; then
+  ok "SPA index has #root / asset script"
+else
+  bad "SPA index missing React shell markers"
+fi
+# Must not look like Streamlit
+if grep -qiE 'streamlit|stApp|MainMenu' <<<"$HTML"; then
+  bad "SPA index looks like Streamlit"
+else
+  ok "SPA index is not Streamlit"
+fi
+
+# --- Product routes (SPA may return index.html for all; HTTP 200 is enough) ---
+ROUTES=(/ /auth /jobs /upload /mapping /rules /findings /reports /metering /wattlab)
+for path in "${ROUTES[@]}"; do
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$UI_BASE$path" || echo 000)"
+  if [[ "$code" == "200" || "$code" == "301" || "$code" == "302" ]]; then
+    ok "SPA $path → HTTP $code"
+  else
+    bad "SPA $path → HTTP $code"
+  fi
+done
+
+# Streamlit Lab path must not be the product surface
+lab_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$UI_BASE/lab" || echo 000)"
+if [[ "$lab_code" == "200" ]]; then
+  # React may still serve index for unknown routes — ensure no LabShell in assets
+  skip "HTTP 200 on /lab (SPA fallback) — checking assets for LabShell absence"
+else
+  ok "/lab not a dedicated Streamlit Lab route (HTTP $lab_code)"
+fi
+
+# --- Web asset markers -------------------------------------------------------
+JS="$ART/web_assets.js"
+if web_asset_js "$JS"; then
+  ok "extracted web SPA JS assets ($(wc -c <"$JS") bytes)"
+  NEEDLES=(/jobs /upload /findings /reports /wattlab /api/ui/generation)
+  MISS=0
+  for n in "${NEEDLES[@]}"; do
+    if grep -qF "$n" "$JS"; then
+      ok "asset mentions $n"
+    else
+      bad "asset missing $n"
+      MISS=1
+    fi
+  done
+  if grep -qiE 'lab-app-shell|vibe19-lab-sidebar|Energy Model' "$JS"; then
+    bad "Streamlit Lab markers still present in web assets"
+  else
+    ok "no Streamlit LabShell markers in web assets"
+  fi
+  [[ "$MISS" -eq 0 ]]
+else
+  bad "could not extract web SPA assets (is web up / built?)"
+fi
+
+# --- Migration metrics (cutover observability) -------------------------------
+if MET="$(central "$CENTRAL_BASE/api/ui/migration-metrics" 2>/dev/null)"; then
+  echo "$MET" >"$ART/migration_metrics.json"
+  if jq -e 'type=="object"' <<<"$MET" >/dev/null 2>&1; then
+    ok "GET /api/ui/migration-metrics object"
+  else
+    bad "migration-metrics unexpected shape"
+  fi
+else
+  bad "GET /api/ui/migration-metrics"
+fi
+
+summary

--- a/scripts/nightly-ot-bench/11_dashboard_apis_549.sh
+++ b/scripts/nightly-ot-bench/11_dashboard_apis_549.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Gate 11 — central dashboard / product APIs (≠404) + React Reports page honesty.
+# Post–Phase-2: no Streamlit openfdd-ui bundle inspect.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+hdr "#549 / product APIs — capabilities + shell GETs"
+
+central_auth_setup
+capi() {
+  curl -fsS --max-time 30 "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" \
+    -H 'Content-Type: application/json' "$@"
+}
+
+CAPS="$(capi "$CENTRAL_BASE/api/capabilities" || echo '{}')"
+echo "$CAPS" >"$ART/capabilities.json"
+REQUIRED=(
+  lab fdd_registry fdd_equipment fdd_results fdd_series session_config
+  csv_package reports export data_management host_stats faults
+  health_stack fdd_rules_authoring fdd_schema
+)
+ALL_TRUE=1
+for key in "${REQUIRED[@]}"; do
+  val="$(jq -r --arg k "$key" '.capabilities[$k] // empty' <<<"$CAPS")"
+  if [[ "$val" == "true" ]]; then
+    ok "capabilities.$key=true"
+  else
+    bad "capabilities.$key=$val (want true)"
+    ALL_TRUE=0
+  fi
+done
+[[ "$ALL_TRUE" -eq 1 ]] && ok "capabilities matrix all true"
+
+PATHS=(
+  /api/capabilities
+  /api/health/stack
+  /api/building/snapshot
+  /api/faults/status
+  /api/faults/summary
+  /api/export/meta
+  /api/data-management/summary
+  /api/host/stats
+  /api/fdd-schema/tables
+  /api/fdd-rules
+  /api/reports
+  /api/reports/templates
+  /api/fdd/rules
+  /api/fdd/equipment
+  /api/fdd/results
+  /api/fdd/session-config
+  /api/ui/generation
+  /api/ui/migration-metrics
+  /api/dashboard/summary
+)
+for path in "${PATHS[@]}"; do
+  code="$(curl -sS -o "$ART/http$(echo "$path" | tr '/' '_').body" -w '%{http_code}' --max-time 20 \
+    "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" "$CENTRAL_BASE$path" || echo 000)"
+  if [[ "$code" == "404" ]]; then
+    bad "GET $path → 404"
+  elif [[ "$code" =~ ^[02345] ]]; then
+    ok "GET $path → HTTP $code (≠404)"
+  else
+    bad "GET $path → HTTP $code"
+  fi
+done
+
+# Explicit draft endpoint exists (POST) — React must not invent drafts via quiet GETs
+hdr "Reports — draft POST exists; list GET is quiet"
+DRAFT_CODE="$(curl -sS -o "$ART/reports_draft_post.json" -w '%{http_code}' --max-time 20 \
+  -X POST "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"bench-smoke-draft","template_id":"blank"}' \
+  "$CENTRAL_BASE/api/reports/draft" || echo 000)"
+if [[ "$DRAFT_CODE" == "404" ]]; then
+  bad "POST /api/reports/draft → 404"
+else
+  ok "POST /api/reports/draft reachable (HTTP $DRAFT_CODE) for explicit create"
+fi
+
+# React SPA assets: reports route + draft API string (no Streamlit ReportBuilderPage)
+JS="$ART/web_assets_549.js"
+if web_asset_js "$JS"; then
+  if grep -qF '/reports' "$JS" && grep -qF '/api/reports' "$JS"; then
+    ok "React assets wire /reports + /api/reports"
+  else
+    bad "React assets missing reports wiring"
+  fi
+else
+  bad "could not extract web assets for reports wiring check"
+fi
+
+# Source tip: ReportsPage should not auto-create drafts on mount if present
+RP="$ROOT/frontend/web/src/pages/ReportsPage.tsx"
+if [[ -f "$RP" ]]; then
+  if grep -qiE 'createDraft|reports/draft' "$RP" \
+    && awk '/useEffect/,/^}/' "$RP" 2>/dev/null | grep -q 'draft'; then
+    # Soft: only fail if mount effect clearly POSTs draft
+    if awk '/useEffect/,/^\s*\}, \[/' "$RP" | grep -qE 'reports/draft|createDraft'; then
+      bad "ReportsPage.tsx useEffect may auto-POST draft"
+    else
+      ok "ReportsPage.tsx present (no clear mount draft POST)"
+    fi
+  else
+    ok "ReportsPage.tsx present (no draft auto-create pattern)"
+  fi
+else
+  skip "ReportsPage.tsx missing from checkout"
+fi
+
+BEFORE="$(capi "$CENTRAL_BASE/api/reports" | jq '(.reports // .records // []) | length' 2>/dev/null || echo 0)"
+sleep 1
+AFTER="$(capi "$CENTRAL_BASE/api/reports" | jq '(.reports // .records // []) | length' 2>/dev/null || echo 0)"
+if [[ "$BEFORE" == "$AFTER" ]]; then
+  ok "GET /api/reports is quiet (count stable: $AFTER)"
+else
+  skip "report count $BEFORE→$AFTER (explicit draft POST may have written)"
+fi
+
+summary

--- a/scripts/nightly-ot-bench/12_parity_honesty_550.sh
+++ b/scripts/nightly-ot-bench/12_parity_honesty_550.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Gate 12 — #550 honesty: no “54 full parity”; registry proven/ported counts;
+# SCHED-1 string occ_mode ingest spot-check. React SPA assets (not openfdd-ui).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+hdr "#550 parity honesty"
+
+central_auth_setup
+capi() {
+  curl -fsS --max-time 30 "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" \
+    -H 'Content-Type: application/json' "$@"
+}
+
+# Docs must not claim full cookbook parity
+PARITY_DOC="$ROOT/docs/rules/cookbook/parity-matrix.md"
+if [[ -f "$PARITY_DOC" ]]; then
+  if grep -qiE '54 full parity|full parity with all 54|all 54 rules.*parity' "$PARITY_DOC"; then
+    if grep -qF 'Do not claim “54 full parity.”' "$PARITY_DOC" \
+      || grep -qF 'Do not claim "54 full parity."' "$PARITY_DOC"; then
+      ok "parity-matrix.md forbids “54 full parity” claim"
+    else
+      bad "parity-matrix.md appears to claim 54 full parity"
+    fi
+  else
+    ok "parity-matrix.md has no rogue 54-full-parity claim"
+  fi
+  if grep -qiE 'proven_building_100|ported_from_cookbook|ported ≠ oracle' "$PARITY_DOC"; then
+    ok "parity-matrix.md states proven vs ported honesty"
+  else
+    bad "parity-matrix.md missing proven/ported honesty language"
+  fi
+else
+  bad "missing $PARITY_DOC"
+fi
+
+# React SPA bundle must not claim full parity
+JS="$ART/web_assets_550.js"
+if web_asset_js "$JS"; then
+  if grep -qiE '54 full parity|full cookbook parity|all 54 rules proven' "$JS"; then
+    bad "React SPA claims 54/full cookbook parity"
+  else
+    ok "React SPA does not claim 54/full cookbook parity"
+  fi
+else
+  bad "could not extract web assets for parity claim check"
+fi
+
+# Registry counts via live API
+RULES="$(capi "$CENTRAL_BASE/api/fdd/rules" || echo '{}')"
+echo "$RULES" >"$ART/fdd_rules_parity.json"
+PROVEN="$(jq '[.rules[]? | select(.parity_status=="proven_building_100")] | length' <<<"$RULES")"
+PORTED="$(jq '[.rules[]? | select(.parity_status=="ported_from_cookbook")] | length' <<<"$RULES")"
+SKIPPED="$(jq '[.rules[]? | select(.parity_status=="skipped_missing_roles")] | length' <<<"$RULES")"
+TOTAL="$(jq '[.rules[]?] | length' <<<"$RULES")"
+echo "${DIM}  registry proven=$PROVEN ported=$PORTED skipped=$SKIPPED total=$TOTAL${RST}"
+if [[ "$PROVEN" -ge 16 && "$PROVEN" -le 20 ]]; then
+  ok "proven_building_100 ≈18 (actual $PROVEN)"
+else
+  bad "proven_building_100 count=$PROVEN (expected ~18)"
+fi
+if [[ "$PORTED" -ge 40 && "$PORTED" -le 50 ]]; then
+  ok "ported_from_cookbook ≈44 (actual $PORTED)"
+else
+  bad "ported_from_cookbook count=$PORTED (expected ~44)"
+fi
+
+# SCHED-1 string occ_mode ingest spot-check
+hdr "SCHED-1 occ_mode string role"
+SCHED_META="$(jq -c '.rules[]? | select(.rule_id=="SCHED-1")' <<<"$RULES")"
+echo "$SCHED_META" >"$ART/sched1_meta.json"
+if jq -e '(.required_roles // []) | index("occ_mode") != null' <<<"$SCHED_META" >/dev/null 2>&1; then
+  ok "SCHED-1 required_roles includes occ_mode"
+else
+  bad "SCHED-1 missing occ_mode role: $SCHED_META"
+fi
+SQL_FILE="$ROOT/sql_rules/sched1_unoccupied_runtime.sql"
+if [[ -f "$SQL_FILE" ]] && grep -q "LOWER(occ_mode)" "$SQL_FILE" && grep -q "unoccupied" "$SQL_FILE"; then
+  ok "SCHED-1 SQL compares string occ_mode (LOWER = unoccupied)"
+else
+  bad "SCHED-1 SQL missing string occ_mode compare"
+fi
+
+cat >"$ART/issue_550_backlog.txt" <<EOF
+#550 KEEP OPEN — honesty/oracle phase incomplete.
+- proven_building_100=$PROVEN ported_from_cookbook=$PORTED (ported ≠ oracle-proven)
+- Do not claim 54 full parity.
+- Phase-1 oracle harness lands masks/fault-hours; full cookbook parity remains backlog.
+- SCHED-1 string occ_mode ingest spot-check: PASS (role + SQL).
+EOF
+ok "wrote #550 KEEP OPEN backlog note → issue_550_backlog.txt"
+echo "${DIM}$(cat "$ART/issue_550_backlog.txt")${RST}"
+
+summary

--- a/scripts/nightly-ot-bench/13_mcp_accuracy.sh
+++ b/scripts/nightly-ot-bench/13_mcp_accuracy.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Gate 13 — MCP accuracy vs central (not process-up).
+# Spins its own openfdd-mcp container on the react-ot network; compares
+# tools/list + FDD payloads to direct central curl. Reuses smoke_mcp_central.sh
+# equality ideas against pulled GHCR tip images (no local docker build).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+MCP_IMAGE="${OPENFDD_MCP_IMAGE:-ghcr.io/bbartling/openfdd-mcp:${OPENFDD_IMAGE_TAG:-nightly}}"
+CENTRAL_IMAGE="${OPENFDD_CENTRAL_IMAGE:-ghcr.io/bbartling/openfdd-central:nightly}"
+NET="openfdd-mcp-bench-$$"
+MCP_NAME="openfdd-mcp-bench-$$"
+# Prefer attaching to the running react-ot (or legacy standalone) central; otherwise
+# boot a disposable central on the same throwaway network.
+USE_STACK_CENTRAL=0
+CENTRAL_CTR=""
+CENTRAL_API=""
+
+cleanup() {
+  docker rm -f "$MCP_NAME" >/dev/null 2>&1 || true
+  if [[ "$USE_STACK_CENTRAL" != "1" && -n "${CENTRAL_CTR:-}" ]]; then
+    docker rm -f "$CENTRAL_CTR" >/dev/null 2>&1 || true
+    docker network rm "$NET" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+hdr "MCP accuracy — own container vs central truth"
+echo "${DIM}MCP_IMAGE=$MCP_IMAGE${RST}"
+
+# Assert tip revision label when present
+MCP_REV="$(docker inspect "$MCP_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)"
+echo "${DIM}mcp rev=${MCP_REV:-unknown}${RST}"
+[[ -n "$MCP_REV" ]] && ok "mcp image pulled (rev ${MCP_REV:0:12})"
+
+# Resolve network: prefer openfdd-react-central, fall back to standalone
+STACK_CENTRAL="$(docker ps --format '{{.Names}}' | grep -E 'openfdd-react-central' | head -1 || true)"
+if [[ -z "$STACK_CENTRAL" ]]; then
+  STACK_CENTRAL="$(docker ps --format '{{.Names}}' | grep -E 'openfdd-standalone-central' | head -1 || true)"
+fi
+if [[ -n "$STACK_CENTRAL" ]]; then
+  USE_STACK_CENTRAL=1
+  CENTRAL_CTR="$STACK_CENTRAL"
+  NET="$(docker inspect "$CENTRAL_CTR" --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' | awk '{print $1}')"
+  CENTRAL_API="http://${CENTRAL_CTR}:8080"
+  if docker network inspect "$NET" --format '{{json .Containers}}' 2>/dev/null \
+    | jq -e 'to_entries[] | select(.value.Name|test("central")) | .value.Name' >/dev/null 2>&1; then
+    CENTRAL_API="http://central:8080"
+  fi
+  ok "using stack central on network $NET ($CENTRAL_API)"
+else
+  CENTRAL_CTR="openfdd-central-mcpbench-$$"
+  docker network create "$NET" >/dev/null
+  docker run -d --name "$CENTRAL_CTR" --network "$NET" --network-alias central \
+    -e OPENFDD_MQTT_ENABLED=0 \
+    -e OPENFDD_WORKSPACE=/workspace \
+    -e OPENFDD_PARQUET_ROOT=/workspace/.cache/parquet \
+    "$CENTRAL_IMAGE" >/dev/null
+  CENTRAL_API="http://central:8080"
+  deadline=$((SECONDS + 90))
+  until docker run --rm --network "$NET" curlimages/curl:8.5.0 \
+      -fsS "$CENTRAL_API/api/health" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      bad "disposable central health timeout"
+      summary; exit 1
+    fi
+    sleep 2
+  done
+  ok "booted disposable central for MCP gate"
+fi
+
+# Host-side central for direct curl equality (react-ot publishes 8080)
+HOST_CENTRAL="${CENTRAL_BASE:-http://127.0.0.1:8080}"
+central_auth_setup
+hcurl() {
+  curl -fsS --max-time 30 "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" "$@"
+}
+
+if ! hcurl "$HOST_CENTRAL/api/health" >/dev/null 2>&1; then
+  # Fall back: expose disposable central
+  if [[ "$USE_STACK_CENTRAL" != "1" ]]; then
+    HOST_CENTRAL="http://127.0.0.1:18081"
+    docker rm -f "$CENTRAL_CTR" >/dev/null 2>&1 || true
+    docker run -d --name "$CENTRAL_CTR" --network "$NET" --network-alias central \
+      -p 127.0.0.1:18081:8080 \
+      -e OPENFDD_MQTT_ENABLED=0 \
+      -e OPENFDD_WORKSPACE=/workspace \
+      -e OPENFDD_PARQUET_ROOT=/workspace/.cache/parquet \
+      "$CENTRAL_IMAGE" >/dev/null
+    sleep 5
+    CENTRAL_AUTH_HDR=()
+    CENTRAL_AUTH_DONE=0
+    hcurl() { curl -fsS --max-time 30 "$@"; }
+  else
+    bad "host CENTRAL_BASE unreachable for equality curl"
+    summary; exit 1
+  fi
+fi
+
+# Central auth: MCP must present the same Bearer JWT as host curls.
+MCP_TOKEN="${OPENFDD_MCP_TOKEN:-}"
+if [[ -z "$MCP_TOKEN" && -n "${OPENFDD_ADMIN_PASSWORD:-}" ]]; then
+  MCP_TOKEN="$(curl -fsS --max-time 15 -X POST "$HOST_CENTRAL/api/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg p "$OPENFDD_ADMIN_PASSWORD" '{username:"admin",password:$p}')" \
+    | jq -r '.token // .access_token // empty' || true)"
+fi
+if [[ -n "$MCP_TOKEN" ]]; then
+  ok "MCP Bearer token acquired for central auth"
+else
+  skip "no MCP token (OPENFDD_MCP_TOKEN / admin login) — FDD equality may 401"
+fi
+
+MCP_OUT="$(printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"openfdd_health","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"openfdd_fdd_registry","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"openfdd_fdd_equipment","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"openfdd_fdd_results","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"openfdd_fdd_accuracy_snapshot","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"openfdd_no_such_tool","arguments":{}}}' \
+  '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"openfdd_fdd_series","arguments":{"equipment_id":"","rule_id":""}}}' \
+  | docker run -i --rm --name "$MCP_NAME" --network "$NET" \
+      -e OPENFDD_API_BASE="$CENTRAL_API" \
+      -e OPENFDD_MCP_TOKEN="${MCP_TOKEN:-}" \
+      "$MCP_IMAGE" 2>"$ART/mcp_stderr.log" || true)"
+
+echo "$MCP_OUT" >"$ART/mcp_stdio.jsonl"
+# Normalize to JSON array (one object per line)
+python3 - "$ART/mcp_stdio.jsonl" "$ART/mcp_messages.json" <<'PY'
+import json,sys,pathlib
+lines=[]
+for line in pathlib.Path(sys.argv[1]).read_text().splitlines():
+    line=line.strip()
+    if not line: continue
+    try: lines.append(json.loads(line))
+    except Exception: pass
+pathlib.Path(sys.argv[2]).write_text(json.dumps(lines,indent=2))
+print(len(lines))
+PY
+
+if [[ ! -s "$ART/mcp_messages.json" ]]; then
+  bad "MCP produced no JSON-RPC messages (see mcp_stderr.log)"
+  summary; exit 1
+fi
+ok "MCP stdio session captured ($(jq 'length' "$ART/mcp_messages.json") messages)"
+
+# tools/list required production FDD tools
+if jq -e '
+  (map(select(.id==2))[0].result.tools | map(.name)) as $tools
+  | ["openfdd_fdd_registry","openfdd_fdd_equipment","openfdd_fdd_results",
+     "openfdd_fdd_series","openfdd_fdd_accuracy_snapshot","openfdd_health"]
+  | all(. as $n | $tools | index($n) != null)
+' "$ART/mcp_messages.json" >/dev/null; then
+  ok "tools/list includes production FDD tools"
+else
+  bad "tools/list missing required FDD tools: $(jq -c 'map(select(.id==2))[0].result.tools|map(.name)' "$ART/mcp_messages.json")"
+fi
+
+# Health
+if jq -e 'map(select(.id==3))[0].result.content[0].text | fromjson | .service=="openfdd-central"' \
+  "$ART/mcp_messages.json" >/dev/null 2>&1; then
+  ok "MCP openfdd_health → openfdd-central"
+else
+  bad "MCP health mismatch: $(jq -c 'map(select(.id==3))[0]' "$ART/mcp_messages.json" | head -c 300)"
+fi
+
+# Direct central curls
+DIRECT_RULES="$(hcurl "$HOST_CENTRAL/api/fdd/rules" | jq -c .)"
+DIRECT_EQUIP="$(hcurl "$HOST_CENTRAL/api/fdd/equipment" | jq -c .)"
+DIRECT_RESULTS="$(hcurl "$HOST_CENTRAL/api/fdd/results" | jq -c .)"
+echo "$DIRECT_RULES" >"$ART/direct_fdd_rules.json"
+echo "$DIRECT_EQUIP" >"$ART/direct_fdd_equipment.json"
+echo "$DIRECT_RESULTS" >"$ART/direct_fdd_results.json"
+
+mcp_text() {
+  local id="$1"
+  jq -r --argjson id "$id" '
+    map(select(.id==$id))[0]
+    | if .error then empty
+      else (.result.content[0].text // empty)
+      end
+  ' "$ART/mcp_messages.json"
+}
+mcp_err() {
+  local id="$1"
+  jq -c --argjson id "$id" 'map(select(.id==$id))[0].error // empty' "$ART/mcp_messages.json"
+}
+
+for id in 4 5 6 7; do
+  if [[ -n "$(mcp_err "$id")" ]]; then
+    bad "MCP id=$id error: $(mcp_err "$id" | head -c 200)"
+  fi
+done
+
+MCP_RULES="$(mcp_text 4)"
+MCP_EQUIP="$(mcp_text 5)"
+MCP_RESULTS="$(mcp_text 6)"
+if [[ -z "$MCP_RULES" || -z "$MCP_EQUIP" || -z "$MCP_RESULTS" ]]; then
+  bad "MCP FDD payloads empty (auth?). rules=$([[ -n $MCP_RULES ]] && echo ok || echo missing) equip=$([[ -n $MCP_EQUIP ]] && echo ok || echo missing) results=$([[ -n $MCP_RESULTS ]] && echo ok || echo missing)"
+else
+  eq_rules="$(jq -ne --argjson d "$DIRECT_RULES" --argjson m "$(jq -c . <<<"$MCP_RULES")" \
+    '($d.count==$m.count) and (($d.rules|map(.rule_id))==($m.rules|map(.rule_id)))')"
+  eq_equip="$(jq -ne --argjson d "$DIRECT_EQUIP" --argjson m "$(jq -c . <<<"$MCP_EQUIP")" \
+    '($d.equipment==$m.equipment) or (($d.count==$m.count) and ($d.equipment|length)==($m.equipment|length))')"
+  eq_res="$(jq -ne --argjson d "$DIRECT_RESULTS" --argjson m "$(jq -c . <<<"$MCP_RESULTS")" \
+    '$d.results==$m.results')"
+  [[ "$eq_rules" == "true" ]] && ok "MCP registry == central /api/fdd/rules" || bad "MCP registry ≠ central"
+  [[ "$eq_equip" == "true" ]] && ok "MCP equipment == central /api/fdd/equipment" || bad "MCP equipment ≠ central"
+  [[ "$eq_res" == "true" ]] && ok "MCP results == central /api/fdd/results" || bad "MCP results ≠ central"
+fi
+
+# accuracy_snapshot
+SNAP_TXT="$(mcp_text 7)"
+if [[ -n "$SNAP_TXT" ]] && jq -e '.ok==true' <<<"$SNAP_TXT" >/dev/null 2>&1; then
+  ok "MCP accuracy_snapshot ok=true"
+else
+  bad "MCP accuracy_snapshot not ok: $(mcp_err 7 | head -c 200) ${SNAP_TXT:0:200}"
+fi
+
+# Negatives: unknown tool must error; empty series args must not invent rows
+if [[ -n "$(mcp_err 8)" ]]; then
+  ok "negative: unknown tool errors (no silent invent)"
+else
+  bad "negative: unknown tool did not error cleanly"
+fi
+
+SERIES_TXT="$(mcp_text 9)"
+if [[ -n "$(mcp_err 9)" ]]; then
+  # 401/validation error is honest — must not invent series
+  ok "negative: empty series args → JSON-RPC/HTTP error (no invented series)"
+elif [[ -n "$SERIES_TXT" ]] && jq -e '(.ok==false) or ((.rows//[])|length==0) or (.error!=null)' <<<"$SERIES_TXT" >/dev/null 2>&1; then
+  ok "negative: empty series args → honest empty/error (no invented series)"
+else
+  bad "negative: empty series call invented data or empty response: ${SERIES_TXT:0:200}"
+fi
+
+# Process-up alone is insufficient — equality above is the PASS bar
+ok "MCP accuracy gate requires payload equality (process-up alone ≠ PASS)"
+
+summary

--- a/scripts/nightly-ot-bench/README.md
+++ b/scripts/nightly-ot-bench/README.md
@@ -1,0 +1,94 @@
+# Nightly OT LAN bench harness (post–Phase-2)
+
+Expert-tester scripts for **immutable GHCR tip** images on the BACnet OT LAN,
+with the **React** product UI (`compose.react.yml` + fieldbus overlay).
+
+Source tree is for compose/config/analysis only — **do not build Rust runtime
+images from local src**. Phase `00` pulls `sha-<7>`, asserts digests match
+`:nightly`, and compose-builds `openfdd-web` only when GHCR has no web image.
+
+## Topology
+
+| Service | Image / source | Port |
+|---------|----------------|------|
+| mqtt | `openfdd-mqtt:sha-*` | 8883 |
+| central | `openfdd-central:sha-*` (`OPENFDD_REACT_UI=1`) | 8080 |
+| web | `openfdd-web` (GHCR when published, else `frontend/web` build) | 3000 |
+| fieldbus | `openfdd-fieldbus:sha-*` (host net) | 8081 |
+| mcp | `openfdd-mcp:sha-*` (gate 13) | — |
+
+Recipe helper: `./scripts/openfdd_stack_up.sh react-ot`
+
+## Lab inventory (context)
+
+| Instance | Role | Notes |
+|----------|------|--------|
+| **5007** | `BENS-BENCHTEST-BOX` | Routed MS/TP via `192.168.204.200`, network `2000`, MAC `7` |
+| **3456789** | BensFakeAhu | BIP — AI:2 SA-T |
+| **3456790** | Zone1VAV | BIP — AI:1 ZoneTemp |
+| **599999** | Hosted OpenFDD | Fieldbus server on UDP `47808` @ OT NIC |
+
+OT NIC on this host: `enp3s0` → `192.168.204.55/24`.
+
+**Arch note:** GHCR stack nightlies are **`linux/amd64` only**.
+
+Put real IPs / keys in **`bench.env.local`** and
+`docker/compose.react.fieldbus.local.yml` (both gitignored).
+
+## Playbook
+
+```bash
+cd ~/open-fdd
+git pull --ff-only origin master
+
+cp scripts/nightly-ot-bench/bench.env.example scripts/nightly-ot-bench/bench.env.local
+# edit OT IPs, API key, SITE/EDGE, optional OPENFDD_ADMIN_PASSWORD
+
+cp docker/compose.react.fieldbus.local.example.yml docker/compose.react.fieldbus.local.yml
+# edit OT bind + API key
+
+# Seed field devices (local overlay; not committed)
+# cp scripts/nightly-ot-bench/field_devices.bench.example.toml config/fieldbus/field_devices.toml
+
+./scripts/nightly-ot-bench/run_all.sh
+```
+
+Individual phases:
+
+```bash
+./scripts/nightly-ot-bench/00_pull_ghcr_up.sh
+./scripts/nightly-ot-bench/01_health_gates.sh
+./scripts/nightly-ot-bench/02_bacnet_ot.sh
+./scripts/nightly-ot-bench/10_react_spa.sh
+```
+
+Optional:
+
+```bash
+BENCH_ALLOW_WRITES=1 ./scripts/nightly-ot-bench/09_rest_ot.sh   # REST write clamp
+RUN_CLOUD_SIM=1 ./scripts/nightly-ot-bench/run_all.sh
+SKIP_PULL=1 ./scripts/nightly-ot-bench/run_all.sh               # reuse running stack
+```
+
+## Success definition
+
+**PASS** only if all are true:
+
+1. Tip `sha-*` digests match `:nightly` for central/fieldbus/mqtt/mcp
+2. react-ot healthy: fieldbus + mqtt + **central** + **React SPA** (`/api/ui/generation` → react)
+3. At least one LAN BACnet device discovered **and** poll returns live values
+4. Device **5007** read/poll of AI:1173 succeeds
+5. Central ingest/Feather shows **new** telemetry when MQTT path is live
+6. React SPA routes + honesty/MCP gates pass
+
+**FAIL with evidence** if any gate fails — do not weaken asserts.
+
+Default write policy is **read/poll/discover**. Active REST write clamps require
+`BENCH_ALLOW_WRITES=1`.
+
+## Related
+
+- `scripts/openfdd_stack_up.sh react-ot` / `openfdd_stack_pull.sh`
+- `openfdd_agent_spec/CONTAINER_AGENT.md` — nightly → immutable pin protocol
+- `scripts/fieldbus/smoke_test.sh` — deep BACnet matrix
+- `scripts/openfdd_auth_smoke.sh` — JWT login vs central

--- a/scripts/nightly-ot-bench/bench.env.example
+++ b/scripts/nightly-ot-bench/bench.env.example
@@ -1,0 +1,87 @@
+# Copy to bench.env.local (gitignored) and fill in OT LAN values.
+# Example inventory from the bensbench OT LAN is documented in README.md —
+# do not commit real addresses into the repo.
+
+# --- Compose / GHCR (react-ot) ---
+OPENFDD_SITE_ID=lab
+OPENFDD_EDGE_ID=fieldbus-1
+# Prefer immutable tip pin (phase 00 resolves origin/master if unset):
+# OPENFDD_IMAGE_TAG=sha-<7>
+# Floating channel (00 still asserts nightly↔sha digests):
+# OPENFDD_IMAGE_TAG=nightly
+
+# Optional overrides (defaults follow OPENFDD_IMAGE_TAG):
+# OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-…
+# OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:sha-…
+# OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:sha-…
+# OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:sha-…
+# OPENFDD_WEB_IMAGE=ghcr.io/bbartling/openfdd-web:sha-…   # often missing → compose-build
+
+# Local OT bind / API key overlay (gitignored):
+# OPENFDD_COMPOSE_LOCAL=docker/compose.react.fieldbus.local.yml
+#   cp docker/compose.react.fieldbus.local.example.yml docker/compose.react.fieldbus.local.yml
+
+# --- Endpoints ---
+FIELDBUS_BASE=http://127.0.0.1:8081
+CENTRAL_BASE=http://127.0.0.1:8080
+UI_BASE=http://127.0.0.1:3000
+OPENFDD_FIELDBUS_API_KEY=bench-demo-key-1234567890
+# OPENFDD_ADMIN_PASSWORD=…   # when central auth_required
+
+# --- Write policy (default read/poll only) ---
+# BENCH_ALLOW_WRITES=1
+
+# --- OT NIC (for docs / pcap) ---
+OT_NIC=enp3s0
+OT_BIND=192.168.204.55
+
+# --- Primary routed bench device (5007) ---
+BENCH_DEVICE=5007
+BENCH_READ_TYPE=analog-input
+BENCH_READ_INST=1173
+BENCH_OVR_TYPE=analog-output
+BENCH_OVR_INST=2466
+BENCH_EXPECT_PRIORITY=8
+BENCH_EXPECT_VALUE=55
+BENCH_ROUTER_HOST=192.168.204.200
+BENCH_MSTP_NETWORK=2000
+
+# --- BIP companions (optional but recommended) ---
+BIP_DEVICE_A=3456789
+BIP_DEVICE_A_READ_TYPE=analog-input
+BIP_DEVICE_A_READ_INST=2
+BIP_DEVICE_B=3456790
+BIP_DEVICE_B_READ_TYPE=analog-input
+BIP_DEVICE_B_READ_INST=1
+
+# --- Hosted server (Workbench) ---
+HOSTED_DEVICE=599999
+
+# --- Modbus bench simulator ---
+MODBUS_SIM_HOST=192.168.0.14
+MODBUS_SIM_PORT=1502
+MODBUS_SIM_UNIT_ID=1
+MODBUS_SIM_BASE_F=72
+MODBUS_SIM_AMPLITUDE_F=4
+
+# --- Haystack ---
+HAYSTACK_EXPECT_LIVE=0
+
+# --- Cloud-sim (opt-in RUN_CLOUD_SIM=1) ---
+CLOUD_SIM_PI_SSH=user@192.168.0.12
+CLOUD_SIM_SITE_ID=bldg2
+CLOUD_SIM_EDGE_ID=pi-1
+CLOUD_SIM_BROKER_HOST=192.168.0.55
+CLOUD_SIM_DEVICE_INSTANCE=600000
+CLOUD_SIM_PI_REPO=/home/user/open-fdd
+CLOUD_SIM_TELEMETRY_WAIT=150
+
+# --- Feather / historian ---
+WORKSPACE_DIR=workspace
+HISTORIAN_GLOB='workspace/data/historian/**/*.{feather,arrow,jsonl}'
+FEATHER_WAIT_SECS=90
+POLL_CYCLES_BEFORE_FEATHER=2
+
+# --- Weather trend gate (08) ---
+WEATHER_SOAK_SECS=1800
+WEATHER_SAMPLE_SECS=300

--- a/scripts/nightly-ot-bench/field_devices.bench.example.toml
+++ b/scripts/nightly-ot-bench/field_devices.bench.example.toml
@@ -1,0 +1,39 @@
+# Example field_devices overlay for the OT LAN bench.
+# Copy over config/fieldbus/field_devices.toml locally (do not commit OT IPs).
+#
+#   cp scripts/nightly-ot-bench/field_devices.bench.example.toml config/fieldbus/field_devices.toml
+#   # edit hosts if needed
+#   docker compose -f docker/compose.react.yml -f docker/compose.react.fieldbus.yml \
+#     -f docker/compose.react.fieldbus.local.yml up -d fieldbus --force-recreate
+
+[[devices]]
+name = "BENS-BENCHTEST-BOX"
+enabled = true
+device_instance = 5007
+host = "192.168.204.200"
+port = 47808
+mstp_network = 2000
+mstp_mac = [7]
+points = [
+  { object_type = "analog-input", object_instance = 1173, point_name = "OA-T", units = "°F" },
+]
+
+[[devices]]
+name = "BensFakeAhu"
+enabled = true
+device_instance = 3456789
+host = "192.168.204.13"
+port = 47808
+points = [
+  { object_type = "analog-input", object_instance = 2, point_name = "SA-T", units = "°F" },
+]
+
+[[devices]]
+name = "Zone1VAV"
+enabled = true
+device_instance = 3456790
+host = "192.168.204.14"
+port = 47808
+points = [
+  { object_type = "analog-input", object_instance = 1, point_name = "ZoneTemp", units = "°F" },
+]

--- a/scripts/nightly-ot-bench/lib.sh
+++ b/scripts/nightly-ot-bench/lib.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Shared helpers for nightly OT bench gates (post–Phase-2 React + fieldbus).
+# shellcheck disable=SC2034
+
+NIGHTLY_OT_BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$NIGHTLY_OT_BENCH_DIR/../.." && pwd)"
+
+load_bench_env() {
+  local example="$NIGHTLY_OT_BENCH_DIR/bench.env.example"
+  local localf="$NIGHTLY_OT_BENCH_DIR/bench.env.local"
+  if [[ -f "$ROOT/.env" ]]; then
+    # shellcheck disable=SC1091
+    set -a && source "$ROOT/.env" && set +a
+  fi
+  if [[ -f "$localf" ]]; then
+    # shellcheck disable=SC1090
+    set -a && source "$localf" && set +a
+  elif [[ -f "$example" ]]; then
+    echo "WARN: no bench.env.local — sourcing bench.env.example (edit OT IPs for real LAN)" >&2
+    # shellcheck disable=SC1090
+    set -a && source "$example" && set +a
+  fi
+
+  FIELDBUS_BASE="${FIELDBUS_BASE:-http://127.0.0.1:8081}"
+  CENTRAL_BASE="${CENTRAL_BASE:-http://127.0.0.1:8080}"
+  UI_BASE="${UI_BASE:-http://127.0.0.1:3000}"
+  KEY="${OPENFDD_FIELDBUS_API_KEY:-bench-demo-key-1234567890}"
+  OPENFDD_SITE_ID="${OPENFDD_SITE_ID:-lab}"
+  OPENFDD_EDGE_ID="${OPENFDD_EDGE_ID:-fieldbus-1}"
+  BENCH_DEVICE="${BENCH_DEVICE:-5007}"
+  HOSTED_DEVICE="${HOSTED_DEVICE:-599999}"
+  WORKSPACE_DIR="${WORKSPACE_DIR:-workspace}"
+  FEATHER_WAIT_SECS="${FEATHER_WAIT_SECS:-90}"
+  export OPENFDD_REACT_UI="${OPENFDD_REACT_UI:-1}"
+  export OPENFDD_UI_GENERATION_DEFAULT="${OPENFDD_UI_GENERATION_DEFAULT:-react}"
+  # shellcheck source=scripts/openfdd_stack_lib.sh
+  source "$ROOT/scripts/openfdd_stack_lib.sh"
+  openfdd_stack_export_image_env
+}
+
+AUTH_HDR=()
+auth_setup() {
+  AUTH_HDR=()
+  [[ -n "${KEY:-}" ]] && AUTH_HDR=(-H "Authorization: Bearer ${KEY}")
+}
+
+PASS=0
+FAIL=0
+SKIP=0
+GREEN=$'\033[32m'
+RED=$'\033[31m'
+YELLOW=$'\033[33m'
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+RST=$'\033[0m'
+
+ok() { PASS=$((PASS + 1)); echo "${GREEN}PASS${RST} $*"; }
+bad() { FAIL=$((FAIL + 1)); echo "${RED}FAIL${RST} $*" >&2; }
+skip() { SKIP=$((SKIP + 1)); echo "${YELLOW}SKIP${RST} $*"; }
+hdr() { echo; echo "${BOLD}== $* ==${RST}"; }
+
+fb() {
+  curl -fsS --max-time "${CURL_TIMEOUT:-45}" -H 'Content-Type: application/json' "${AUTH_HDR[@]}" "$@"
+}
+fb_long() {
+  curl -fsS --max-time "${CURL_LONG_TIMEOUT:-240}" -H 'Content-Type: application/json' "${AUTH_HDR[@]}" "$@"
+}
+CENTRAL_AUTH_HDR=()
+CENTRAL_AUTH_DONE=0
+central_auth_setup() {
+  # Acquire an admin JWT when central requires auth; no-op otherwise.
+  CENTRAL_AUTH_HDR=()
+  CENTRAL_AUTH_DONE=1
+  local req tok
+  req="$(curl -fsS --max-time 10 "$CENTRAL_BASE/api/auth/status" 2>/dev/null | jq -r '.auth_required // false' || echo false)"
+  if [[ "$req" == "true" && -n "${OPENFDD_ADMIN_PASSWORD:-}" ]]; then
+    tok="$(curl -fsS --max-time 15 -X POST "$CENTRAL_BASE/api/auth/login" \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -nc --arg p "$OPENFDD_ADMIN_PASSWORD" '{username:"admin",password:$p}')" \
+      | jq -r '.token // .access_token // empty' || true)"
+    [[ -n "$tok" ]] && CENTRAL_AUTH_HDR=(-H "Authorization: Bearer $tok")
+  fi
+}
+
+central() {
+  if [[ "${CENTRAL_AUTH_DONE:-0}" != "1" ]]; then
+    central_auth_setup
+  fi
+  curl -fsS --max-time "${CURL_TIMEOUT:-20}" "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" "$@"
+}
+
+jq_ok() {
+  local label="$1" json="$2"
+  shift 2
+  if jq -e "$@" >/dev/null 2>&1 <<<"$json"; then
+    ok "$label"
+  else
+    bad "$label"
+  fi
+}
+
+approx() {
+  # approx a b [eps] — float near-equal
+  python3 - "$1" "$2" "${3:-0.5}" <<'PY'
+import sys
+a,b,eps=map(float,sys.argv[1:])
+sys.exit(0 if abs(a-b)<=eps else 1)
+PY
+}
+
+compose_files() {
+  # Print -f / path pairs for react-ot (+ local OT overlay when present).
+  openfdd_stack_compose_args react-ot
+}
+
+image_digest() {
+  # Repo digest for a local image ref, or empty.
+  docker image inspect "$1" --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' 2>/dev/null \
+    | sed 's/^[^@]*@//' || true
+}
+
+resolve_tip_sha_tag() {
+  # Prefer explicit OPENFDD_IMAGE_TAG=sha-…; else origin/master short SHA.
+  local tag="${OPENFDD_IMAGE_TAG:-}"
+  if [[ "$tag" == sha-* ]]; then
+    echo "$tag"
+    return 0
+  fi
+  if [[ "$tag" == "nightly" || -z "$tag" ]]; then
+    local short
+    short="$(git -C "$ROOT" rev-parse --short=7 origin/master 2>/dev/null \
+      || git -C "$ROOT" rev-parse --short=7 HEAD)"
+    echo "sha-${short}"
+    return 0
+  fi
+  echo "$tag"
+}
+
+summary() {
+  echo
+  echo "${BOLD}Summary: ${GREEN}${PASS} passed${RST}, ${RED}${FAIL} failed${RST}, ${YELLOW}${SKIP} skipped${RST}"
+  if [[ "$FAIL" -gt 0 ]]; then
+    echo "${RED}GATE FAILED${RST}"
+    return 1
+  fi
+  echo "${GREEN}GATE PASSED${RST}"
+  return 0
+}
+
+artifact_dir() {
+  local stamp
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  local dir="$ROOT/reports/nightly-ot-bench_${stamp}"
+  mkdir -p "$dir"
+  echo "$dir"
+}
+
+historian_snapshot() {
+  # Print path|mtime|size lines for historian/feather artifacts
+  local ws="$ROOT/${WORKSPACE_DIR}"
+  find "$ws/data" \( -name '*.feather' -o -name '*.arrow' -o -name 'telemetry_pivot.jsonl' -o -path '*historian*' \) \
+    -type f 2>/dev/null | sort | while read -r f; do
+    stat -c '%n|%Y|%s' "$f" 2>/dev/null || stat -f '%N|%m|%z' "$f" 2>/dev/null
+  done
+}
+
+web_asset_js() {
+  # Dump SPA JS bundle from running web container or local WEB image into $1.
+  local out="$1"
+  local ctr
+  ctr="$(docker ps --format '{{.Names}}' | grep -E 'openfdd-react-web' | head -1 || true)"
+  if [[ -n "$ctr" ]]; then
+    docker exec "$ctr" sh -c 'cat /usr/share/nginx/html/assets/*.js 2>/dev/null | head -c 8000000' >"$out" 2>/dev/null \
+      && [[ -s "$out" ]] && return 0
+  fi
+  local img="${OPENFDD_WEB_IMAGE:-ghcr.io/bbartling/openfdd-web:${OPENFDD_IMAGE_TAG:-nightly}}"
+  if docker image inspect "$img" >/dev/null 2>&1; then
+    docker run --rm --entrypoint "" "$img" \
+      sh -c 'cat /usr/share/nginx/html/assets/*.js 2>/dev/null | head -c 8000000' >"$out" 2>/dev/null \
+      && [[ -s "$out" ]] && return 0
+  fi
+  return 1
+}

--- a/scripts/nightly-ot-bench/rest_sim.py
+++ b/scripts/nightly-ot-bench/rest_sim.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tiny JSON OT control-system simulator for gate 09 (REST/JSON edge driver).
+
+Stdlib only. Endpoints:
+  GET  /points/chw_supply_temp  -> {"value": <float>}
+  GET  /points/plant_kw         -> {"value": <float>}
+  GET  /status                  -> {"ok": true, "mode": "sim"}
+  POST /points/chw_setpoint     -> body {"value": N, ...}; stores + echoes
+  POST /_kill                   -> process exits (circuit-breaker test)
+  GET  /_health                 -> liveness
+
+Auth (optional): Authorization: Bearer <token> OR X-API-Key: <token>
+When REST_SIM_TOKEN is set, requests without a matching credential get 401.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+HOST = os.environ.get("REST_SIM_HOST", "127.0.0.1")
+PORT = int(os.environ.get("REST_SIM_PORT", "18765"))
+TOKEN = os.environ.get("REST_SIM_TOKEN", "")
+
+STATE = {
+    "chw_st": 44.0,
+    "plant_kw": 120.5,
+    "chw_setpoint": 44.0,
+    "posts": 0,
+}
+
+
+def _authorized(handler: BaseHTTPRequestHandler) -> bool:
+    if not TOKEN:
+        return True
+    auth = handler.headers.get("Authorization", "")
+    if auth == f"Bearer {TOKEN}":
+        return True
+    if handler.headers.get("X-API-Key") == TOKEN:
+        return True
+    if handler.headers.get("X-Api-Key") == TOKEN:
+        return True
+    return False
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # quieter soak logs
+        sys.stderr.write("[rest_sim] " + (fmt % args) + "\n")
+
+    def _json(self, code: int, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path in ("/_health", "/health"):
+            return self._json(200, {"ok": True})
+        if not _authorized(self):
+            return self._json(401, {"error": "unauthorized"})
+        if self.path == "/points/chw_supply_temp":
+            return self._json(200, {"value": STATE["chw_st"]})
+        if self.path == "/points/plant_kw":
+            return self._json(200, {"value": STATE["plant_kw"]})
+        if self.path == "/status":
+            return self._json(200, {"ok": True, "mode": "sim", "setpoint": STATE["chw_setpoint"]})
+        if self.path == "/points/missing_path":
+            return self._json(200, {"other": 1})  # no $.value — JSONPath miss
+        return self._json(404, {"error": f"unknown path {self.path}"})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        if self.path == "/_kill":
+            self._json(200, {"ok": True, "dying": True})
+            # Exit hard so connection drops for circuit-breaker test
+            sys.stderr.write("[rest_sim] kill requested — exiting\n")
+            os._exit(0)
+        if not _authorized(self):
+            return self._json(401, {"error": "unauthorized"})
+        if self.path == "/points/chw_setpoint":
+            try:
+                body = json.loads(raw.decode() or "{}")
+            except json.JSONDecodeError:
+                return self._json(400, {"error": "bad json"})
+            val = body.get("value")
+            if val is None:
+                return self._json(400, {"error": "missing value"})
+            STATE["chw_setpoint"] = float(val)
+            STATE["posts"] += 1
+            return self._json(200, {"ok": True, "value": STATE["chw_setpoint"], "posts": STATE["posts"]})
+        return self._json(404, {"error": f"unknown path {self.path}"})
+
+
+def main():
+    httpd = ThreadingHTTPServer((HOST, PORT), Handler)
+    sys.stderr.write(f"[rest_sim] listening on http://{HOST}:{PORT} token_set={bool(TOKEN)}\n")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nightly-ot-bench/run_all.sh
+++ b/scripts/nightly-ot-bench/run_all.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Full nightly OT gate: GHCR pull → health → BACnet 5007 → MQTT/Feather persistence.
+# Writes a short markdown summary under reports/ (gitignored).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+SKIP_PULL="${SKIP_PULL:-0}"
+ART="$(artifact_dir)"
+export ARTIFACT_DIR="$ART"
+REPORT="$ART/SUMMARY.md"
+STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+{
+  echo "# Nightly OT bench run — $STAMP"
+  echo
+  echo "- Root: \`$ROOT\`"
+  echo "- Site/edge: \`${OPENFDD_SITE_ID}/${OPENFDD_EDGE_ID}\`"
+  echo "- Fieldbus: \`$FIELDBUS_BASE\`  Central: \`$CENTRAL_BASE\`"
+  echo "- Bench device: \`${BENCH_DEVICE}\`  Hosted: \`${HOSTED_DEVICE}\`"
+  echo "- Recipe: react-ot (compose.react + fieldbus); pin \`\${OPENFDD_IMAGE_TAG:-sha-*}\`"
+  echo "- Writes: \`BENCH_ALLOW_WRITES=${BENCH_ALLOW_WRITES:-0}\` (default read/poll only)"
+  echo
+} >"$REPORT"
+
+run_phase() {
+  local script="$1" title="$2"
+  hdr "$title"
+  local logfile="$ART/${script%.sh}.log"
+  local rc=0
+  set +e
+  bash "$DIR/$script" 2>&1 | tee "$logfile"
+  rc=${PIPESTATUS[0]}
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "- **$title:** PASS" >>"$REPORT"
+  else
+    echo "- **$title:** FAIL (see \`${script%.sh}.log\`)" >>"$REPORT"
+  fi
+  return "$rc"
+}
+
+OVERALL=0
+if [[ "$SKIP_PULL" != "1" ]]; then
+  run_phase 00_pull_ghcr_up.sh "00 pull GHCR + up" || OVERALL=1
+else
+  echo "- **00 pull:** SKIPPED (SKIP_PULL=1)" >>"$REPORT"
+  skip "pull/up skipped (SKIP_PULL=1)"
+fi
+
+run_phase 01_health_gates.sh "01 health gates" || OVERALL=1
+run_phase 02_bacnet_ot.sh "02 BACnet OT (5007 + BIP + poll)" || OVERALL=1
+run_phase 03_mqtt_feather_persist.sh "03 MQTTS + Feather persistence" || OVERALL=1
+run_phase 04_modbus_ot.sh "04 Modbus OT (bench sim)" || OVERALL=1
+run_phase 05_haystack.sh "05 Haystack API surface" || OVERALL=1
+run_phase 06_csv_fdd_sql.sh "06 CSV import + SQL FDD (FC1)" || OVERALL=1
+
+# 07 cloud-sim is opt-in: RUN_CLOUD_SIM=1 ./run_all.sh (needs bosspi reachable)
+if [[ "${RUN_CLOUD_SIM:-0}" == "1" ]]; then
+  run_phase 07_cloud_sim.sh "07 cloud-sim (remote Pi edge, instance 600000)" || OVERALL=1
+else
+  echo "- **07 cloud-sim:** SKIPPED (set RUN_CLOUD_SIM=1)" >>"$REPORT"
+  skip "cloud-sim skipped (RUN_CLOUD_SIM=1 to enable)"
+fi
+
+# 08 weather trend soak (~30 min wall clock by default; WEATHER_SOAK_SECS to shorten).
+# Runs bench-only if the Pi edge is down; full 599999+600000 trend when 07 ran.
+run_phase 08_weather_trend.sh "08 weather trend + WB soak (599999/600000)" || OVERALL=1
+
+# 09 REST/JSON edge driver (#540) — throwaway fieldbus + JSON sim; does not touch WB stack.
+run_phase 09_rest_ot.sh "09 REST/JSON edge driver (#540)" || OVERALL=1
+
+# React SPA / dashboard / honesty / MCP accuracy (GHCR tip + local web build).
+run_phase 10_react_spa.sh "10 React SPA product surface" || OVERALL=1
+run_phase 11_dashboard_apis_549.sh "11 dashboard APIs (#549)" || OVERALL=1
+run_phase 12_parity_honesty_550.sh "12 parity honesty (#550 KEEP OPEN)" || OVERALL=1
+run_phase 13_mcp_accuracy.sh "13 MCP accuracy vs central" || OVERALL=1
+
+{
+  echo
+  echo "## Verdict"
+  if [[ "$OVERALL" -eq 0 ]]; then
+    echo "**PASS** — tip GHCR + React SPA + fieldbus OT through gates 00–13."
+  else
+    echo "**FAIL** — see phase logs in this directory."
+  fi
+  echo
+  echo "## Recreate"
+  echo '```bash'
+  echo "cd $ROOT"
+  echo "./scripts/nightly-ot-bench/run_all.sh"
+  echo "# optional: RUN_CLOUD_SIM=1 BENCH_ALLOW_WRITES=1 SKIP_PULL=1"
+  echo '```'
+} >>"$REPORT"
+
+echo
+echo "${BOLD}Report: $REPORT${RST}"
+cat "$REPORT"
+exit "$OVERALL"

--- a/scripts/openfdd_stack_lib.sh
+++ b/scripts/openfdd_stack_lib.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Shared helpers for Open-FDD stack compose recipes (central/ui/fieldbus/mqtt).
+# Shared helpers for Open-FDD stack compose recipes (central/web/fieldbus/mqtt).
 set -euo pipefail
 
 openfdd_stack_root() {
   cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
 }
 
+# Primary compose file for single-file recipes (legacy callers).
 openfdd_stack_recipe_file() {
   local recipe="${1:-standalone}"
   local root
@@ -15,8 +16,50 @@ openfdd_stack_recipe_file() {
     central) echo "$root/docker/compose.central.yml" ;;
     edge) echo "$root/docker/compose.edge.yml" ;;
     csv) echo "$root/docker/compose.csv.yml" ;;
+    react|react-ot) echo "$root/docker/compose.react.yml" ;;
     *)
-      echo "ERROR: unknown recipe '$recipe' (standalone|central|edge|csv)" >&2
+      echo "ERROR: unknown recipe '$recipe' (standalone|central|edge|csv|react|react-ot)" >&2
+      return 2
+      ;;
+  esac
+}
+
+# Print docker compose -f args for a recipe (one path per line after each -f).
+openfdd_stack_compose_args() {
+  local recipe="${1:-standalone}"
+  local root
+  root="$(openfdd_stack_root)"
+  case "$recipe" in
+    standalone)
+      printf '%s\n' -f "$root/docker/compose.standalone.yml"
+      if [[ -f "$root/docker/compose.standalone.local.yml" ]]; then
+        printf '%s\n' -f "$root/docker/compose.standalone.local.yml"
+      fi
+      ;;
+    central)
+      printf '%s\n' -f "$root/docker/compose.central.yml"
+      ;;
+    edge)
+      printf '%s\n' -f "$root/docker/compose.edge.yml"
+      ;;
+    csv)
+      printf '%s\n' -f "$root/docker/compose.csv.yml"
+      ;;
+    react)
+      printf '%s\n' -f "$root/docker/compose.react.yml"
+      ;;
+    react-ot)
+      printf '%s\n' -f "$root/docker/compose.react.yml"
+      printf '%s\n' -f "$root/docker/compose.react.fieldbus.yml"
+      local local_override="${OPENFDD_COMPOSE_LOCAL:-docker/compose.react.fieldbus.local.yml}"
+      if [[ -f "$root/$local_override" ]]; then
+        printf '%s\n' -f "$root/$local_override"
+      elif [[ -f "$root/docker/compose.react.fieldbus.local.yml" ]]; then
+        printf '%s\n' -f "$root/docker/compose.react.fieldbus.local.yml"
+      fi
+      ;;
+    *)
+      echo "ERROR: unknown recipe '$recipe'" >&2
       return 2
       ;;
   esac
@@ -35,6 +78,7 @@ openfdd_stack_export_image_env() {
   local tag="${OPENFDD_IMAGE_TAG:-nightly}"
   export OPENFDD_CENTRAL_IMAGE="${OPENFDD_CENTRAL_IMAGE:-ghcr.io/bbartling/openfdd-central:${tag}}"
   export OPENFDD_UI_IMAGE="${OPENFDD_UI_IMAGE:-ghcr.io/bbartling/openfdd-ui:${tag}}"
+  export OPENFDD_WEB_IMAGE="${OPENFDD_WEB_IMAGE:-ghcr.io/bbartling/openfdd-web:${tag}}"
   export OPENFDD_FIELDBUS_IMAGE="${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:${tag}}"
   export OPENFDD_MQTT_IMAGE="${OPENFDD_MQTT_IMAGE:-ghcr.io/bbartling/openfdd-mqtt:${tag}}"
   export OPENFDD_MCP_IMAGE="${OPENFDD_MCP_IMAGE:-ghcr.io/bbartling/openfdd-mcp:${tag}}"

--- a/scripts/openfdd_stack_pull.sh
+++ b/scripts/openfdd_stack_pull.sh
@@ -28,6 +28,21 @@ case "$RECIPE" in
     docker pull "$OPENFDD_CENTRAL_IMAGE"
     docker pull "$OPENFDD_UI_IMAGE"
     ;;
+  react)
+    docker pull "$OPENFDD_CENTRAL_IMAGE"
+    docker pull "$OPENFDD_MQTT_IMAGE"
+    if ! docker pull "$OPENFDD_WEB_IMAGE" 2>/dev/null; then
+      echo "WARN: $OPENFDD_WEB_IMAGE not in registry — build web locally on up" >&2
+    fi
+    ;;
+  react-ot)
+    docker pull "$OPENFDD_CENTRAL_IMAGE"
+    docker pull "$OPENFDD_MQTT_IMAGE"
+    docker pull "$OPENFDD_FIELDBUS_IMAGE"
+    if ! docker pull "$OPENFDD_WEB_IMAGE" 2>/dev/null; then
+      echo "WARN: $OPENFDD_WEB_IMAGE not in registry — build web locally on up" >&2
+    fi
+    ;;
   mcp)
     docker pull "$OPENFDD_MCP_IMAGE"
     ;;
@@ -37,7 +52,7 @@ case "$RECIPE" in
     done
     ;;
   *)
-    echo "Usage: $0 [standalone|central|edge|csv|mcp|all]" >&2
+    echo "Usage: $0 [standalone|central|edge|csv|react|react-ot|mcp|all]" >&2
     exit 2
     ;;
 esac

--- a/scripts/openfdd_stack_up.sh
+++ b/scripts/openfdd_stack_up.sh
@@ -2,8 +2,8 @@
 # Bring up an Open-FDD compose build recipe (pull or build).
 #
 #   ./scripts/openfdd_stack_up.sh standalone
-#   ./scripts/openfdd_stack_up.sh csv --build
-#   OPENFDD_IMAGE_TAG=sha-abc1234 ./scripts/openfdd_stack_up.sh central
+#   ./scripts/openfdd_stack_up.sh react-ot
+#   OPENFDD_IMAGE_TAG=sha-abc1234 ./scripts/openfdd_stack_up.sh react-ot
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/openfdd_stack_lib.sh
@@ -16,22 +16,24 @@ EXTRA=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    standalone|central|edge|csv) RECIPE="$1"; shift ;;
+    standalone|central|edge|csv|react|react-ot) RECIPE="$1"; shift ;;
     --build) DO_BUILD=1; DO_PULL=0; shift ;;
     --no-pull) DO_PULL=0; shift ;;
     --pull) DO_PULL=1; shift ;;
     -h|--help)
       cat <<'EOF'
-Usage: openfdd_stack_up.sh [standalone|central|edge|csv] [--build|--no-pull] [--caddy]
+Usage: openfdd_stack_up.sh [standalone|central|edge|csv|react|react-ot] [--build|--no-pull] [--caddy]
 
 Recipes:
-  standalone  mqtt + central + ui + fieldbus
-  central     mqtt + central + ui
+  standalone  mqtt + central + streamlit-legacy ui + fieldbus
+  central     mqtt + central + streamlit-legacy ui
   edge        fieldbus only (needs OPENFDD_MQTT_HOST)
-  csv         central + ui only (no mqtt/fieldbus)
+  csv         central + streamlit-legacy ui only
+  react       mqtt + central + React web (no fieldbus)
+  react-ot    mqtt + central + React web + fieldbus (OT bench)
 
 Options:
-  --caddy     Also start Caddy on :80 → Streamlit UI (/api* → central)
+  --caddy     Also start Caddy on :80 → UI (/api* → central)
   --wattlab   Mount WattLab /data + vibe20 PYTHONPATH (compose.wattlab.yml)
 
 Env: OPENFDD_IMAGE_TAG, OPENFDD_*_IMAGE, OPENFDD_JWT_SECRET, OPENFDD_ADMIN_PASSWORD
@@ -46,8 +48,8 @@ EOF
   esac
 done
 
-COMPOSE="$(openfdd_stack_recipe_file "$RECIPE")"
-[[ -f "$COMPOSE" ]] || { echo "ERROR: missing $COMPOSE" >&2; exit 1; }
+mapfile -t ARGS < <(openfdd_stack_compose_args "$RECIPE")
+[[ ${#ARGS[@]} -ge 2 ]] || { echo "ERROR: no compose files for recipe=$RECIPE" >&2; exit 1; }
 openfdd_stack_export_image_env
 cd "$ROOT"
 
@@ -55,7 +57,6 @@ if [[ "$DO_PULL" -eq 1 ]]; then
   "$ROOT/scripts/openfdd_stack_pull.sh" "$RECIPE"
 fi
 
-ARGS=(-f "$COMPOSE")
 if [[ "${OPENFDD_CADDY:-0}" == "1" || "${OPENFDD_CADDY:-}" == "true" ]]; then
   if [[ "$RECIPE" == "edge" ]]; then
     echo "WARN: --caddy ignored for edge recipe (no UI)" >&2
@@ -70,7 +71,17 @@ if [[ "${OPENFDD_WATTLAB:-0}" == "1" || "${OPENFDD_WATTLAB:-}" == "true" ]]; the
     ARGS+=(-f "$ROOT/docker/compose.wattlab.yml")
   fi
 fi
-if [[ "$DO_BUILD" -eq 1 ]]; then
+
+# React SPA image is often compose-build until GHCR publishes openfdd-web.
+# Never `--build` the whole stack (would rebuild Rust from local Dockerfiles).
+if [[ "$RECIPE" == "react" || "$RECIPE" == "react-ot" ]]; then
+  if [[ "$DO_BUILD" -eq 1 ]] || ! docker image inspect "$OPENFDD_WEB_IMAGE" >/dev/null 2>&1; then
+    echo "NOTE: building openfdd-web locally (image not present or --build): $OPENFDD_WEB_IMAGE"
+    docker compose "${ARGS[@]}" build web
+  fi
+fi
+
+if [[ "$DO_BUILD" -eq 1 && "$RECIPE" != "react" && "$RECIPE" != "react-ot" ]]; then
   docker compose "${ARGS[@]}" up -d --build --remove-orphans "${EXTRA[@]+"${EXTRA[@]}"}"
 else
   docker compose "${ARGS[@]}" up -d --remove-orphans "${EXTRA[@]+"${EXTRA[@]}"}"
@@ -79,6 +90,9 @@ fi
 if [[ "$RECIPE" != "edge" ]]; then
   openfdd_stack_wait_health
   echo "UI: http://127.0.0.1:3000  API: ${OPENFDD_API_BASE:-http://127.0.0.1:8080}"
+  if [[ "$RECIPE" == "react-ot" ]]; then
+    echo "Fieldbus: http://127.0.0.1:8081"
+  fi
   if [[ "${OPENFDD_CADDY:-0}" == "1" || "${OPENFDD_CADDY:-}" == "true" ]]; then
     echo "Caddy: http://<host>/  (UI)  http://<host>/api/health  (central)"
   fi


### PR DESCRIPTION
## Summary
- Add `docker/compose.react.fieldbus.yml` + `react-ot` recipe (`openfdd_stack_up/pull`).
- Commit modernized `scripts/nightly-ot-bench/`: pull immutable `sha-*`, assert nightly digests, React SPA gates (replaces Streamlit Lab), `BENCH_ALLOW_WRITES=1` for REST write clamps.
- Refresh `CONTAINER_AGENT.md` / AGENTS for React product path; gitignore local OT overlays.

## Test plan
- [x] `docker compose -f docker/compose.react.yml -f docker/compose.react.fieldbus.yml config`
- [x] `bash -n` on updated stack + harness scripts
- [ ] CI compose config loop includes `compose.react.fieldbus.yml`
- [ ] On bensbench OT LAN: `./scripts/nightly-ot-bench/run_all.sh` (optional full soak)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added React and React OT stack options with BACnet fieldbus connectivity.
  * Added local fieldbus configuration examples and benchmark environment templates.
  * Added a comprehensive nightly validation suite for OT protocols, MQTT persistence, APIs, dashboards, SPA behavior, cloud simulation, and data workflows.
* **Documentation**
  * Updated React deployment, container verification, migration, and benchmark guidance.
* **Bug Fixes**
  * Expanded automated Compose validation to include the React fieldbus configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->