### PR TITLE
fix: wait for GHCR tip pin in nightly OT bench

### DIFF
--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -2,6 +2,13 @@
 
 Newest first.
 
+## 2026-08-01 — Nightly OT bench GHCR tip-race recovery
+
+- FAIL root cause (`reports/nightly-ot-bench_20260801T205013Z`): phase 00 pinned
+  git tip `sha-37b8b43` before GHCR publish finished → cascade.
+- Fix: wait/retry tip pull + nightly OCI revision fallback; abort suite on 00
+  FAIL; fail-closed HTTP status helper (no `000000` false PASS).
+
 ## 2026-08-01 — Nightly OT bench modernized (react-ot)
 
 - Committed `scripts/nightly-ot-bench/` for post–Phase-2: pull `sha-*`, assert

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -21,6 +21,20 @@ OT LAN benches need fieldbus too — use recipe **`react-ot`**
 (`compose.react.yml` + `compose.react.fieldbus.yml`). Full stress suite:
 [`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md).
 
+Post-merge soak: **wait for** `Publish Open-FDD stack to GHCR` (+ MCP) **success**
+on the tip SHA before pulling `sha-<7>`. Tip git SHA can exist minutes before
+GHCR tags. Prefer the harness wait/fallback:
+
+```bash
+# Turnkey (waits for tip publish, falls back to nightly OCI revision if needed)
+cd ~/open-fdd
+./scripts/nightly-ot-bench/00_pull_ghcr_up.sh
+# or full suite:
+# WEATHER_SOAK_SECS=120 ./scripts/nightly-ot-bench/run_all.sh
+```
+
+Manual pin path (only after GHCR Actions are green for that SHA):
+
 ```bash
 # 1) Discover tip SHA after merge (or use known short SHA)
 SHORT=$(git -C ~/open-fdd rev-parse --short=7 origin/master)

--- a/scripts/nightly-ot-bench/00_pull_ghcr_up.sh
+++ b/scripts/nightly-ot-bench/00_pull_ghcr_up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Pull immutable GHCR tip images, assert nightly↔sha digests, bring up react-ot.
-# Builds openfdd-web locally when GHCR does not publish it yet.
+# Pull immutable GHCR tip images (wait for publish), assert nightly↔sha digests,
+# bring up react-ot. Builds openfdd-web locally when GHCR does not publish it yet.
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
@@ -14,18 +14,25 @@ export ARTIFACT_DIR="$ART"
 
 hdr "GHCR pull + pin + react-ot up"
 
-PIN="$(resolve_tip_sha_tag)"
-export OPENFDD_IMAGE_TAG="$PIN"
-# Re-export image refs against the pin (ignore stale nightly overrides from env).
+# Resolve a *published* pin (wait/retry tip, else nightly OCI revision fallback).
+if ! resolve_published_image_tag; then
+  bad "could not resolve a published GHCR image pin"
+  summary
+  exit 1
+fi
+
+# Re-export image refs against the pin (ignore stale overrides from env).
 unset OPENFDD_CENTRAL_IMAGE OPENFDD_FIELDBUS_IMAGE OPENFDD_MQTT_IMAGE OPENFDD_MCP_IMAGE OPENFDD_WEB_IMAGE
-# Keep OPENFDD_UI_IMAGE unset for product path — Streamlit is archive-only.
 unset OPENFDD_UI_IMAGE || true
 openfdd_stack_export_image_env
 
-echo "${DIM}pin=$OPENFDD_IMAGE_TAG site/edge=${OPENFDD_SITE_ID}/${OPENFDD_EDGE_ID}${RST}"
-echo "$OPENFDD_IMAGE_TAG" >"$ART/image_tag.txt"
+echo "${DIM}pin=$OPENFDD_IMAGE_TAG source=${PIN_SOURCE:-?} site/edge=${OPENFDD_SITE_ID}/${OPENFDD_EDGE_ID}${RST}"
+{
+  echo "$OPENFDD_IMAGE_TAG"
+  echo "pin_source=${PIN_SOURCE:-unknown}"
+} >"$ART/image_tag.txt"
 
-# Pull sha tags for published stack images + MCP
+# Images already pulled by resolve_published_image_tag; refresh refs for digest assert.
 PULL_IMGS=(
   "$OPENFDD_CENTRAL_IMAGE"
   "$OPENFDD_FIELDBUS_IMAGE"
@@ -33,14 +40,15 @@ PULL_IMGS=(
   "$OPENFDD_MCP_IMAGE"
 )
 for img in "${PULL_IMGS[@]}"; do
-  echo "${DIM}pull $img${RST}"
-  docker pull "$img"
+  echo "${DIM}ensure $img${RST}"
+  docker pull "$img" >/dev/null
 done
 
 # Assert nightly currently points at the same digests (CHANNEL check)
 hdr "nightly ↔ sha digest equality"
 DIGESTS_FILE="$ART/digests.txt"
 : >"$DIGESTS_FILE"
+DIGEST_FAIL=0
 for name in openfdd-central openfdd-fieldbus openfdd-mqtt openfdd-mcp; do
   sha_ref="ghcr.io/bbartling/${name}:${OPENFDD_IMAGE_TAG}"
   night_ref="ghcr.io/bbartling/${name}:nightly"
@@ -52,13 +60,18 @@ for name in openfdd-central openfdd-fieldbus openfdd-mqtt openfdd-mcp; do
     ok "$name nightly matches $OPENFDD_IMAGE_TAG"
   else
     bad "$name nightly≠sha (sha=$d_sha nightly=$d_night)"
+    DIGEST_FAIL=1
   fi
 done
+if [[ "$DIGEST_FAIL" -ne 0 ]]; then
+  summary
+  exit 1
+fi
 
 # openfdd-web: pull if published, else mark for local build
 if docker pull "$OPENFDD_WEB_IMAGE" 2>/dev/null; then
   ok "pulled $OPENFDD_WEB_IMAGE"
-  echo "web=pulled" >>"$ART/web_source.txt"
+  echo "web=pulled" >"$ART/web_source.txt"
 else
   skip "openfdd-web not in GHCR — will compose-build from frontend/web"
   echo "web=build-local" >"$ART/web_source.txt"
@@ -79,6 +92,7 @@ mkdir -p "$ROOT/workspace" "$ROOT/deploy/mqtt/certs" "$ROOT/deploy/mqtt/kits"
 export OPENFDD_SITE_ID OPENFDD_EDGE_ID
 export OPENFDD_REACT_UI=1
 export OPENFDD_UI_GENERATION_DEFAULT=react
+export OPENFDD_IMAGE_TAG
 
 # Bring up via stack helper (builds web when missing)
 "$ROOT/scripts/openfdd_stack_up.sh" react-ot --no-pull

--- a/scripts/nightly-ot-bench/01_health_gates.sh
+++ b/scripts/nightly-ot-bench/01_health_gates.sh
@@ -68,9 +68,11 @@ else
 fi
 
 # React SPA (nginx on :3000)
-code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$UI_BASE/" || true)"
+code="$(http_code --max-time 10 "$UI_BASE/")"
 if [[ "$code" == "200" || "$code" == "301" || "$code" == "302" ]]; then
   ok "SPA $UI_BASE → HTTP $code"
+elif [[ "$code" == "000" ]]; then
+  bad "SPA $UI_BASE unreachable (HTTP 000)"
 else
   bad "SPA $UI_BASE → HTTP $code (expect React web, not Streamlit)"
 fi

--- a/scripts/nightly-ot-bench/10_react_spa.sh
+++ b/scripts/nightly-ot-bench/10_react_spa.sh
@@ -48,17 +48,21 @@ fi
 # --- Product routes (SPA may return index.html for all; HTTP 200 is enough) ---
 ROUTES=(/ /auth /jobs /upload /mapping /rules /findings /reports /metering /wattlab)
 for path in "${ROUTES[@]}"; do
-  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$UI_BASE$path" || echo 000)"
+  code="$(http_code --max-time 10 "$UI_BASE$path")"
   if [[ "$code" == "200" || "$code" == "301" || "$code" == "302" ]]; then
     ok "SPA $path → HTTP $code"
+  elif [[ "$code" == "000" ]]; then
+    bad "SPA $path unreachable (HTTP 000)"
   else
     bad "SPA $path → HTTP $code"
   fi
 done
 
 # Streamlit Lab path must not be the product surface
-lab_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$UI_BASE/lab" || echo 000)"
-if [[ "$lab_code" == "200" ]]; then
+lab_code="$(http_code --max-time 10 "$UI_BASE/lab")"
+if [[ "$lab_code" == "000" ]]; then
+  bad "SPA host unreachable (HTTP 000) — cannot assess /lab"
+elif [[ "$lab_code" == "200" ]]; then
   # React may still serve index for unknown routes — ensure no LabShell in assets
   skip "HTTP 200 on /lab (SPA fallback) — checking assets for LabShell absence"
 else

--- a/scripts/nightly-ot-bench/11_dashboard_apis_549.sh
+++ b/scripts/nightly-ot-bench/11_dashboard_apis_549.sh
@@ -60,11 +60,14 @@ PATHS=(
   /api/dashboard/summary
 )
 for path in "${PATHS[@]}"; do
-  code="$(curl -sS -o "$ART/http$(echo "$path" | tr '/' '_').body" -w '%{http_code}' --max-time 20 \
-    "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" "$CENTRAL_BASE$path" || echo 000)"
-  if [[ "$code" == "404" ]]; then
+  body="$ART/http$(echo "$path" | tr '/' '_').body"
+  code="$(http_code_to "$body" --max-time 20 \
+    "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" "$CENTRAL_BASE$path")"
+  if [[ "$code" == "000" ]]; then
+    bad "GET $path unreachable (HTTP 000)"
+  elif [[ "$code" == "404" ]]; then
     bad "GET $path → 404"
-  elif [[ "$code" =~ ^[02345] ]]; then
+  elif [[ "$code" =~ ^[2345][0-9][0-9]$ ]]; then
     ok "GET $path → HTTP $code (≠404)"
   else
     bad "GET $path → HTTP $code"
@@ -73,12 +76,14 @@ done
 
 # Explicit draft endpoint exists (POST) — React must not invent drafts via quiet GETs
 hdr "Reports — draft POST exists; list GET is quiet"
-DRAFT_CODE="$(curl -sS -o "$ART/reports_draft_post.json" -w '%{http_code}' --max-time 20 \
+DRAFT_CODE="$(http_code_to "$ART/reports_draft_post.json" --max-time 20 \
   -X POST "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" \
   -H 'Content-Type: application/json' \
   -d '{"title":"bench-smoke-draft","template_id":"blank"}' \
-  "$CENTRAL_BASE/api/reports/draft" || echo 000)"
-if [[ "$DRAFT_CODE" == "404" ]]; then
+  "$CENTRAL_BASE/api/reports/draft")"
+if [[ "$DRAFT_CODE" == "000" ]]; then
+  bad "POST /api/reports/draft unreachable (HTTP 000)"
+elif [[ "$DRAFT_CODE" == "404" ]]; then
   bad "POST /api/reports/draft → 404"
 else
   ok "POST /api/reports/draft reachable (HTTP $DRAFT_CODE) for explicit create"

--- a/scripts/nightly-ot-bench/README.md
+++ b/scripts/nightly-ot-bench/README.md
@@ -4,8 +4,11 @@ Expert-tester scripts for **immutable GHCR tip** images on the BACnet OT LAN,
 with the **React** product UI (`compose.react.yml` + fieldbus overlay).
 
 Source tree is for compose/config/analysis only — **do not build Rust runtime
-images from local src**. Phase `00` pulls `sha-<7>`, asserts digests match
-`:nightly`, and compose-builds `openfdd-web` only when GHCR has no web image.
+images from local src**. Phase `00` **waits** for tip `sha-<7>` on GHCR
+(merge→publish race), falls back to the OCI revision on `:nightly` if needed,
+asserts digests match `:nightly`, and compose-builds `openfdd-web` only when
+GHCR has no web image. If pull/up fails, `run_all.sh` **aborts** (no cascade)
+unless `ABORT_ON_PULL_FAIL=0`.
 
 ## Topology
 
@@ -68,7 +71,18 @@ Optional:
 BENCH_ALLOW_WRITES=1 ./scripts/nightly-ot-bench/09_rest_ot.sh   # REST write clamp
 RUN_CLOUD_SIM=1 ./scripts/nightly-ot-bench/run_all.sh
 SKIP_PULL=1 ./scripts/nightly-ot-bench/run_all.sh               # reuse running stack
+ABORT_ON_PULL_FAIL=0 ./scripts/nightly-ot-bench/run_all.sh      # forensic cascade after 00 FAIL
+GHCR_WAIT_SECS=900 GHCR_POLL_SECS=30 ./scripts/nightly-ot-bench/00_pull_ghcr_up.sh
 ```
+
+### GHCR pin knobs
+
+| Env | Default | Meaning |
+|-----|---------|---------|
+| `GHCR_WAIT_SECS` | 900 | Max wait for tip `sha-*` images after merge |
+| `GHCR_POLL_SECS` | 30 | Poll interval while waiting |
+| `ABORT_ON_PULL_FAIL` | 1 | Abort suite after phase 00 FAIL |
+| `OPENFDD_IMAGE_TAG` | tip `sha-<7>` | Explicit pin skips git tip resolution |
 
 ## Success definition
 

--- a/scripts/nightly-ot-bench/bench.env.example
+++ b/scripts/nightly-ot-bench/bench.env.example
@@ -5,10 +5,13 @@
 # --- Compose / GHCR (react-ot) ---
 OPENFDD_SITE_ID=lab
 OPENFDD_EDGE_ID=fieldbus-1
-# Prefer immutable tip pin (phase 00 resolves origin/master if unset):
+# Prefer immutable tip pin (phase 00 waits for GHCR publish if unset):
 # OPENFDD_IMAGE_TAG=sha-<7>
-# Floating channel (00 still asserts nightly↔sha digests):
+# Floating channel (00 waits for tip, else nightly OCI revision fallback):
 # OPENFDD_IMAGE_TAG=nightly
+# GHCR_WAIT_SECS=900
+# GHCR_POLL_SECS=30
+# ABORT_ON_PULL_FAIL=1
 
 # Optional overrides (defaults follow OPENFDD_IMAGE_TAG):
 # OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:sha-…

--- a/scripts/nightly-ot-bench/lib.sh
+++ b/scripts/nightly-ot-bench/lib.sh
@@ -136,6 +136,121 @@ resolve_tip_sha_tag() {
   echo "$tag"
 }
 
+# HTTP status from curl -w; never concatenates with || echo 000 → 000000.
+# Prints a 3-digit code (or 000 on total failure). Does not exit non-zero.
+http_code() {
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time "${CURL_TIMEOUT:-20}" "$@" 2>/dev/null || true)"
+  if [[ -z "$code" || "$code" == "000" ]]; then
+    echo "000"
+    return 0
+  fi
+  # Collapse accidental double-write (legacy callers) to first 3 digits.
+  echo "${code:0:3}"
+}
+
+http_code_to() {
+  # http_code_to OUTFILE [curl args…] — body to OUTFILE, print status code.
+  local out="$1"
+  shift
+  local code
+  code="$(curl -sS -o "$out" -w '%{http_code}' --max-time "${CURL_TIMEOUT:-20}" "$@" 2>/dev/null || true)"
+  if [[ -z "$code" || "$code" == "000" ]]; then
+    echo "000"
+    return 0
+  fi
+  echo "${code:0:3}"
+}
+
+ghcr_image_pullable() {
+  # True if docker pull succeeds for $1 (quiet).
+  docker pull "$1" >/dev/null 2>&1
+}
+
+nightly_revision_sha_tag() {
+  # Pull openfdd-central:nightly and return sha-<7> from OCI revision label.
+  local night_ref="ghcr.io/bbartling/openfdd-central:nightly"
+  docker pull "$night_ref" >/dev/null
+  local rev short
+  rev="$(docker image inspect "$night_ref" \
+    --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)"
+  if [[ -z "$rev" || "$rev" == "<no value>" ]]; then
+    return 1
+  fi
+  short="$(printf '%s' "$rev" | cut -c1-7)"
+  echo "sha-${short}"
+}
+
+# Wait for candidate sha tag on GHCR; fallback to nightly revision label.
+# Sets globals: OPENFDD_IMAGE_TAG, PIN_SOURCE (tip|nightly-label|explicit).
+# Writes pin metadata lines to stdout for logging.
+resolve_published_image_tag() {
+  local wait_secs="${GHCR_WAIT_SECS:-900}"
+  local poll_secs="${GHCR_POLL_SECS:-30}"
+  local candidate pin_source
+  local explicit="${OPENFDD_IMAGE_TAG:-}"
+
+  if [[ "$explicit" == sha-* ]]; then
+    candidate="$explicit"
+    pin_source="explicit"
+  else
+    candidate="$(resolve_tip_sha_tag)"
+    if [[ "$explicit" == "nightly" || -z "$explicit" ]]; then
+      pin_source="tip"
+    else
+      pin_source="explicit"
+    fi
+  fi
+
+  local central="ghcr.io/bbartling/openfdd-central:${candidate}"
+  local deadline=$((SECONDS + wait_secs))
+  local attempt=0
+  echo "${DIM}GHCR wait: candidate=${candidate} wait=${wait_secs}s poll=${poll_secs}s${RST}" >&2
+
+  while ((SECONDS < deadline)); do
+    attempt=$((attempt + 1))
+    echo "${DIM}GHCR pull attempt ${attempt}: ${central}${RST}" >&2
+    if ghcr_image_pullable "$central"; then
+      # Also require fieldbus/mqtt/mcp for the same pin before declaring ready.
+      local ok_all=1 name
+      for name in openfdd-fieldbus openfdd-mqtt openfdd-mcp; do
+        if ! ghcr_image_pullable "ghcr.io/bbartling/${name}:${candidate}"; then
+          ok_all=0
+          echo "${DIM}  missing ${name}:${candidate}${RST}" >&2
+          break
+        fi
+      done
+      if [[ "$ok_all" -eq 1 ]]; then
+        OPENFDD_IMAGE_TAG="$candidate"
+        PIN_SOURCE="$pin_source"
+        export OPENFDD_IMAGE_TAG PIN_SOURCE
+        echo "${DIM}GHCR pin ready: ${OPENFDD_IMAGE_TAG} (source=${PIN_SOURCE})${RST}" >&2
+        return 0
+      fi
+    fi
+    sleep "$poll_secs"
+  done
+
+  echo "${YELLOW}WARN${RST} tip pin ${candidate} not fully published after ${wait_secs}s — trying nightly revision fallback" >&2
+  local fallback
+  if ! fallback="$(nightly_revision_sha_tag)"; then
+    echo "${RED}ERROR${RST} could not read org.opencontainers.image.revision from openfdd-central:nightly" >&2
+    return 1
+  fi
+  echo "${DIM}fallback candidate=${fallback}${RST}" >&2
+  for name in openfdd-central openfdd-fieldbus openfdd-mqtt openfdd-mcp; do
+    if ! ghcr_image_pullable "ghcr.io/bbartling/${name}:${fallback}"; then
+      echo "${RED}ERROR${RST} fallback image missing: ${name}:${fallback}" >&2
+      return 1
+    fi
+  done
+  OPENFDD_IMAGE_TAG="$fallback"
+  PIN_SOURCE="nightly-label"
+  export OPENFDD_IMAGE_TAG PIN_SOURCE
+  echo "${DIM}GHCR pin ready: ${OPENFDD_IMAGE_TAG} (source=${PIN_SOURCE})${RST}" >&2
+  return 0
+}
+
 summary() {
   echo
   echo "${BOLD}Summary: ${GREEN}${PASS} passed${RST}, ${RED}${FAIL} failed${RST}, ${YELLOW}${SKIP} skipped${RST}"

--- a/scripts/nightly-ot-bench/run_all.sh
+++ b/scripts/nightly-ot-bench/run_all.sh
@@ -44,8 +44,39 @@ run_phase() {
 }
 
 OVERALL=0
+ABORT_ON_PULL_FAIL="${ABORT_ON_PULL_FAIL:-1}"
+
+finish_report() {
+  {
+    echo
+    echo "## Verdict"
+    if [[ "$OVERALL" -eq 0 ]]; then
+      echo "**PASS** — tip GHCR + React SPA + fieldbus OT through gates 00–13."
+    else
+      echo "**FAIL** — see phase logs in this directory."
+    fi
+    echo
+    echo "## Recreate"
+    echo '```bash'
+    echo "cd $ROOT"
+    echo "./scripts/nightly-ot-bench/run_all.sh"
+    echo "# optional: RUN_CLOUD_SIM=1 BENCH_ALLOW_WRITES=1 SKIP_PULL=1 ABORT_ON_PULL_FAIL=0"
+    echo '```'
+  } >>"$REPORT"
+  echo
+  echo "${BOLD}Report: $REPORT${RST}"
+  cat "$REPORT"
+  exit "$OVERALL"
+}
+
 if [[ "$SKIP_PULL" != "1" ]]; then
-  run_phase 00_pull_ghcr_up.sh "00 pull GHCR + up" || OVERALL=1
+  if ! run_phase 00_pull_ghcr_up.sh "00 pull GHCR + up"; then
+    OVERALL=1
+    if [[ "$ABORT_ON_PULL_FAIL" != "0" ]]; then
+      echo "- **ABORTED:** pull/up failed (set ABORT_ON_PULL_FAIL=0 to continue cascade)" >>"$REPORT"
+      finish_report
+    fi
+  fi
 else
   echo "- **00 pull:** SKIPPED (SKIP_PULL=1)" >>"$REPORT"
   skip "pull/up skipped (SKIP_PULL=1)"
@@ -79,24 +110,4 @@ run_phase 11_dashboard_apis_549.sh "11 dashboard APIs (#549)" || OVERALL=1
 run_phase 12_parity_honesty_550.sh "12 parity honesty (#550 KEEP OPEN)" || OVERALL=1
 run_phase 13_mcp_accuracy.sh "13 MCP accuracy vs central" || OVERALL=1
 
-{
-  echo
-  echo "## Verdict"
-  if [[ "$OVERALL" -eq 0 ]]; then
-    echo "**PASS** — tip GHCR + React SPA + fieldbus OT through gates 00–13."
-  else
-    echo "**FAIL** — see phase logs in this directory."
-  fi
-  echo
-  echo "## Recreate"
-  echo '```bash'
-  echo "cd $ROOT"
-  echo "./scripts/nightly-ot-bench/run_all.sh"
-  echo "# optional: RUN_CLOUD_SIM=1 BENCH_ALLOW_WRITES=1 SKIP_PULL=1"
-  echo '```'
-} >>"$REPORT"
-
-echo
-echo "${BOLD}Report: $REPORT${RST}"
-cat "$REPORT"
-exit "$OVERALL"
+finish_report


### PR DESCRIPTION
## Summary
- Phase 00 waits/retries tip `sha-*` on GHCR; falls back to `:nightly` OCI revision label.
- `run_all` aborts on pull/up FAIL (`ABORT_ON_PULL_FAIL=0` for forensic cascade).
- Fail-closed `http_code` helper — dead central cannot PASS ≠404 via `000000`.

## Test plan
- [x] `bash -n` on updated harness scripts
- [ ] CI green
- [ ] Post-merge: `WEATHER_SOAK_SECS=120 ./scripts/nightly-ot-bench/run_all.sh`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nightly benchmark image retrieval with retries, fallback handling, digest validation, and clearer failure reporting.
  - Strengthened health checks to distinguish unreachable services from invalid HTTP responses.
  - Improved API and product-route validation, including explicit handling for unavailable hosts and draft request failures.
  - Added configurable behavior for continuing or aborting after image-pull failures.

- **Documentation**
  - Added guidance for verifying published images, configuring polling and fallback behavior, and rerunning failed benchmark setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->