### PR TITLE
feat: publish hardened openfdd-web image (P1-M1)

### DIFF
--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -1,4 +1,6 @@
-# Publish Open-FDD MQTT stack images to GHCR (central, ui, fieldbus, mqtt).
+# Publish Open-FDD stack images to GHCR (central, web, fieldbus, mqtt).
+# openfdd-ui (Streamlit) is published as an ARCHIVE/oracle image only — not the
+# supported product topology (compose.react / react-ot use openfdd-web).
 # Nightly on master; semver + sha tags on every push to master or version tags.
 name: Publish Open-FDD stack to GHCR
 
@@ -21,6 +23,7 @@ permissions:
 env:
   REGISTRY: ghcr.io/bbartling
   CENTRAL_IMAGE: ghcr.io/bbartling/openfdd-central
+  WEB_IMAGE: ghcr.io/bbartling/openfdd-web
   UI_IMAGE: ghcr.io/bbartling/openfdd-ui
   FIELDBUS_IMAGE: ghcr.io/bbartling/openfdd-fieldbus
   MQTT_IMAGE: ghcr.io/bbartling/openfdd-mqtt
@@ -52,7 +55,20 @@ jobs:
         run: |
           test -f services/ui/ARCHIVED.md
           test -f frontend/web/package.json
+          test -f frontend/web/package-lock.json
           test -f docker/compose.react.yml
+          grep -q '3000:8080' docker/compose.react.yml
+
+      - name: Build openfdd-web image (no push)
+        run: |
+          docker build \
+            --build-arg OPENFDD_GIT_SHA=ci-test \
+            --build-arg OPENFDD_WEB_VERSION=0.0.0-ci \
+            -t openfdd-web:ci \
+            -f frontend/web/Dockerfile \
+            frontend/web
+          docker run --rm --entrypoint cat openfdd-web:ci /usr/share/nginx/html/version.json | grep openfdd-web
+          ! docker run --rm --entrypoint sh openfdd-web:ci -c 'command -v python3 || command -v python' 2>/dev/null
 
       - name: Compose config check (all recipes)
         env:
@@ -134,7 +150,34 @@ jobs:
         if: steps.vars.outputs.nightly == 'true'
         run: docker buildx imagetools create -t "${{ env.CENTRAL_IMAGE }}:nightly" "${{ env.CENTRAL_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
 
-      - name: Build and push openfdd-ui
+      - name: Build and push openfdd-web (React product UI)
+        uses: docker/build-push-action@v6
+        timeout-minutes: 30
+        with:
+          context: frontend/web
+          file: frontend/web/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.WEB_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
+            ${{ env.WEB_IMAGE }}:${{ steps.vars.outputs.version }}
+          build-args: |
+            OPENFDD_GIT_SHA=${{ github.sha }}
+            OPENFDD_WEB_VERSION=${{ steps.vars.outputs.version }}
+          labels: |
+            org.opencontainers.image.title=Open-FDD Web (React SPA)
+            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.vars.outputs.version }}
+            org.opencontainers.image.description=Supported product UI — nginx SPA proxying /api to central
+          cache-from: type=gha,scope=openfdd-web
+          cache-to: type=gha,mode=max,scope=openfdd-web
+
+      - name: Tag openfdd-web nightly
+        if: steps.vars.outputs.nightly == 'true'
+        run: docker buildx imagetools create -t "${{ env.WEB_IMAGE }}:nightly" "${{ env.WEB_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
+
+      - name: Build and push openfdd-ui (ARCHIVED Streamlit oracle)
         uses: docker/build-push-action@v6
         timeout-minutes: 30
         with:
@@ -145,19 +188,21 @@ jobs:
           tags: |
             ${{ env.UI_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
             ${{ env.UI_IMAGE }}:${{ steps.vars.outputs.version }}
+            ${{ env.UI_IMAGE }}:archive-oracle
           build-args: |
             OPENFDD_GIT_SHA=${{ github.sha }}
             OPENFDD_IMAGE_TAG=sha-${{ steps.vars.outputs.short_sha }}
             WATTLAB_PIP_SPEC=git+https://github.com/bbartling/py-bacnet-stacks-playground.git@develop#subdirectory=vibe_code_apps_20
           labels: |
-            org.opencontainers.image.title=Open-FDD UI (Streamlit + WattLab)
+            org.opencontainers.image.title=Open-FDD UI (ARCHIVED Streamlit oracle)
             org.opencontainers.image.source=https://github.com/bbartling/open-fdd
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.vars.outputs.version }}
+            org.opencontainers.image.description=Unsupported archive/oracle image — use openfdd-web for product
           cache-from: type=gha,scope=openfdd-ui
           cache-to: type=gha,mode=max,scope=openfdd-ui
 
-      - name: Tag openfdd-ui nightly
+      - name: Tag openfdd-ui nightly (archive pointer only)
         if: steps.vars.outputs.nightly == 'true'
         run: docker buildx imagetools create -t "${{ env.UI_IMAGE }}:nightly" "${{ env.UI_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
 
@@ -210,9 +255,10 @@ jobs:
       - name: Published tags
         run: |
           set -euo pipefail
-          for img in central ui fieldbus mqtt; do
+          for img in central web ui fieldbus mqtt; do
             case "$img" in
               central) ref="${{ env.CENTRAL_IMAGE }}" ;;
+              web) ref="${{ env.WEB_IMAGE }}" ;;
               ui) ref="${{ env.UI_IMAGE }}" ;;
               fieldbus) ref="${{ env.FIELDBUS_IMAGE }}" ;;
               mqtt) ref="${{ env.MQTT_IMAGE }}" ;;

--- a/docker/compose.react.yml
+++ b/docker/compose.react.yml
@@ -53,8 +53,12 @@ services:
     build:
       context: ../frontend/web
       dockerfile: Dockerfile
+      args:
+        OPENFDD_GIT_SHA: ${OPENFDD_GIT_SHA:-unknown}
+        OPENFDD_WEB_VERSION: ${OPENFDD_WEB_VERSION:-0.1.0}
     ports:
-      - "${OPENFDD_WEB_BIND:-0.0.0.0}:3000:80"
+      # nginx-unprivileged listens on 8080 inside the image (P1-M1-A).
+      - "${OPENFDD_WEB_BIND:-0.0.0.0}:3000:8080"
     depends_on:
       - central
     restart: unless-stopped

--- a/docs/migration/react-rust/SESSION_LOG.md
+++ b/docs/migration/react-rust/SESSION_LOG.md
@@ -1,5 +1,11 @@
 # Session log — React / Rust modernization
 
+## 2026-08-02 — P1-G0 soak + P1-M1 openfdd-web GHCR
+
+- P1-G0 soak: `reports/nightly-ot-bench_20260802T141626Z/` — gates **14/15 PASS**; suite FAIL on OT/SPA/MCP (honest).
+- P1-M1: hardened `frontend/web` (npm ci, nginx-unprivileged :8080, CSP/cache headers, version.json); GHCR publishes `openfdd-web`; Streamlit UI tagged archive-oracle.
+- Smoke: `scripts/release/smoke_react_web_image.sh`.
+
 ## 2026-08-02 — P1-M0 Vibe 21 recovery foundation
 
 - Landed `tools/open-fdd-vibe21-production/` + `capabilities.yaml` + validator CI.

--- a/frontend/web/.dockerignore
+++ b/frontend/web/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+*.md
+.env
+.env.*

--- a/frontend/web/Dockerfile
+++ b/frontend/web/Dockerfile
@@ -1,14 +1,25 @@
 # syntax=docker/dockerfile:1
+# P1-M1-A: reproducible React SPA image (npm ci + non-root nginx).
 
 FROM node:20-alpine AS build
 WORKDIR /app
-COPY package.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
 COPY . .
-RUN npm run build
+ARG OPENFDD_GIT_SHA=unknown
+ARG OPENFDD_WEB_VERSION=0.1.0
+ENV VITE_OPENFDD_GIT_SHA=$OPENFDD_GIT_SHA
+ENV VITE_OPENFDD_WEB_VERSION=$OPENFDD_WEB_VERSION
+RUN npm run build \
+  && printf '{"ok":true,"service":"openfdd-web","git_sha":"%s","version":"%s"}\n' \
+       "$OPENFDD_GIT_SHA" "$OPENFDD_WEB_VERSION" > /app/dist/version.json
 
-FROM nginx:alpine
+# Non-root nginx (listens on 8080).
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+# Read-only rootfs friendly: html owned by nginx user (UID 101).
+USER root
+RUN chown -R 101:0 /usr/share/nginx/html
+USER 101
+EXPOSE 8080

--- a/frontend/web/README.md
+++ b/frontend/web/README.md
@@ -1,75 +1,51 @@
-# Open-FDD React Web UI
+# Open-FDD React Web UI (`openfdd-web`)
 
-Minimal Vite + React + TypeScript SPA for the Open-FDD Phase 1 React parity program (P1-M2-02).
+Supported **product** UI after Phase 2 exit / Vibe 21 P1 recovery. Built as a
+non-root Nginx image that proxies same-origin `/api` to central.
+
+Streamlit (`openfdd-ui`) is **archived oracle only** — not this image.
 
 ## Development
 
 ```bash
-npm install
+npm ci
 npm run dev
 ```
 
-Vite dev server runs on port 5173 by default. Proxy `/api` to central in `vite.config.ts` when needed, or run central on the same origin.
+Vite defaults to `:5173`. Proxy `/api` to central via `vite.config.ts` or set
+`VITE_API_BASE`.
+
+## Production image (P1-M1)
+
+```bash
+docker build \
+  --build-arg OPENFDD_GIT_SHA="$(git rev-parse HEAD)" \
+  --build-arg OPENFDD_WEB_VERSION=0.1.0 \
+  -t openfdd-web:local \
+  -f frontend/web/Dockerfile \
+  frontend/web
+
+OPENFDD_WEB_IMAGE=openfdd-web:local ./scripts/release/smoke_react_web_image.sh
+```
+
+Compose recipe `react` / `react-ot` maps host `:3000` → container `:8080`
+(nginx-unprivileged). Exposes `/version.json` (no-cache) and immutable `/assets/*`.
+
+GHCR publishes `ghcr.io/bbartling/openfdd-web:sha-<7>` and `:nightly` from the
+stack workflow.
 
 ## Environment
 
 | Variable | Purpose |
 | --- | --- |
-| `VITE_API_BASE` | Optional API origin prefix. Default `''` (same-origin). Set to e.g. `http://localhost:8080` when the API runs on a different host during local dev. |
-| `OPENFDD_REACT_UI` | **Server-side** (central). Set to `1` to advertise `capabilities.react_ui: true` on `GET /api/capabilities`. Default off — Streamlit remains the default Phase 1 UI. |
-
-### Same-origin `/api`
-
-In production, central (or compose) serves the built static assets and routes `/api/*` to the Rust backend on the same host. The React client uses relative paths (`/api/capabilities`, `/api/jobs`, …) so no CORS configuration is required when `VITE_API_BASE` is unset.
-
-When developing with Vite on `:5173` and central on `:8080`, either:
-
-- set `VITE_API_BASE=http://localhost:8080`, or
-- add a Vite dev proxy for `/api`.
+| `VITE_API_BASE` | Optional API origin for Vite-only dev. Default same-origin. |
+| `OPENFDD_REACT_UI` | Central capability flag (compose sets `1` for react recipes). |
 
 ## Scripts
 
-| Script | Description |
+| Script | Purpose |
 | --- | --- |
-| `npm run dev` | Vite dev server |
-| `npm run build` | Typecheck + production bundle → `dist/` |
-| `npm run preview` | Serve production build locally |
-| `npm run test` | Vitest unit tests |
+| `npm run build` | `tsc -b && vite build` |
+| `npm run test` | Vitest |
 | `npm run typecheck` | `tsc -b --noEmit` |
-| `npm run lint` | Placeholder (no ESLint config yet) |
-
-## Docker
-
-Build a static nginx image:
-
-```bash
-docker build -t openfdd-web .
-docker run --rm -p 8081:80 openfdd-web
-```
-
-The container serves SPA assets only. Wire `/api` through central or a reverse proxy in compose.
-
-## Contract
-
-API types in `src/api/contract.ts` mirror `openfdd.api.contract.v1` (see `services/central/src/contract.rs`). Error responses use the envelope:
-
-```json
-{
-  "error": {
-    "code": "...",
-    "message": "...",
-    "retryable": false,
-    "request_id": "..."
-  }
-}
-```
-
-The fetch client in `src/api/client.ts` sends `x-request-id` on every request and parses this envelope on failure.
-
-## Copy into open-fdd
-
-This scaffold is intended to land at `frontend/web/` in the open-fdd repository:
-
-```bash
-rsync -av --exclude node_modules /tmp/openfdd-web/ ~/open-fdd/frontend/web/
-```
+| `npm run lint` | Placeholder until P1-M2-A ESLint |

--- a/frontend/web/nginx.conf
+++ b/frontend/web/nginx.conf
@@ -1,17 +1,45 @@
+# P1-M1-A: SPA + same-origin /api proxy with security + cache headers.
 server {
-    listen 80;
+    listen 8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
 
-    # Same-origin /api → central (compose.react.yml sets upstream via envsubst optional).
-    # Default upstream hostname for docker network.
+    # Security headers (Unity WebGL later needs frame-ancestors adjusted carefully).
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    # CSP: allow same-origin API + Wasm/blob for future Unity; no remote script CDNs.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-src 'self' blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'" always;
+
+    # Same-origin /api → central (compose network hostname).
+    # Do not fall through to SPA for /api — proxy errors stay API errors.
     location /api/ {
         proxy_pass http://central:8080/api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Request-Id $http_x_request_id;
         proxy_set_header Authorization $http_authorization;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_intercept_errors off;
+    }
+
+    location = /version.json {
+        add_header Cache-Control "no-store" always;
+        try_files $uri =404;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache" always;
+        try_files $uri =404;
+    }
+
+    # Hashed Vite assets — immutable.
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
     }
 
     location / {

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -185,5 +185,7 @@ tracks the recovery program evidence gates.
 - [x] P1-M0-A — `capabilities.yaml` + `scripts/validate_capabilities_ledger.py` + CI
 - [x] P1-M0-B — openfdd_agent_spec / AGENTS authority reconciliation
 - [x] Nightly honesty gates 14–15 (ledger + product-truth greps)
-- [ ] P1-G0 soak — human/agent nightly retest after merge (STOP before P1-M1)
-- [ ] P1-M1+ — React image topology / GHCR `openfdd-web` publish (not started)
+- [x] P1-G0 soak — `reports/nightly-ot-bench_20260802T141626Z/` (14/15 PASS; OT LAN honest FAIL)
+- [x] P1-M1-A/B — hardened `openfdd-web` Dockerfile + GHCR publish in stack workflow
+- [x] P1-M1-C — `scripts/release/smoke_react_web_image.sh` (no-Python inspect)
+- [ ] P1-M2+ — ESLint/Playwright and product slices (not started)

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,11 @@
 # Session log
 
+## 2026-08-02 — P1-G0 soak + P1-M1 openfdd-web GHCR
+
+- P1-G0 soak: `reports/nightly-ot-bench_20260802T141626Z/` — gates **14/15 PASS**; suite FAIL on OT/SPA/MCP (honest).
+- P1-M1: hardened `frontend/web` (npm ci, nginx-unprivileged :8080, CSP/cache headers, version.json); GHCR publishes `openfdd-web`; Streamlit UI tagged archive-oracle.
+- Smoke: `scripts/release/smoke_react_web_image.sh`.
+
 Newest first. Append after non-trivial agent work.
 
 ---

--- a/scripts/openfdd_stack_lib.sh
+++ b/scripts/openfdd_stack_lib.sh
@@ -68,10 +68,12 @@ openfdd_stack_compose_args() {
 openfdd_stack_images() {
   local tag="${OPENFDD_IMAGE_TAG:-nightly}"
   echo "ghcr.io/bbartling/openfdd-central:${tag}"
-  echo "ghcr.io/bbartling/openfdd-ui:${tag}"
+  echo "ghcr.io/bbartling/openfdd-web:${tag}"
   echo "ghcr.io/bbartling/openfdd-fieldbus:${tag}"
   echo "ghcr.io/bbartling/openfdd-mqtt:${tag}"
   echo "ghcr.io/bbartling/openfdd-mcp:${tag}"
+  # Archive/oracle only — not required for react / react-ot product topology.
+  echo "ghcr.io/bbartling/openfdd-ui:${tag}"
 }
 
 openfdd_stack_export_image_env() {

--- a/scripts/release/smoke_react_web_image.sh
+++ b/scripts/release/smoke_react_web_image.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# P1-M1-C: inspect openfdd-web (+ optional central) for no Python runtime and
+# required SPA/version evidence. Does not require a clean VM — local docker is OK.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TAG="${OPENFDD_IMAGE_TAG:-nightly}"
+WEB_IMAGE="${OPENFDD_WEB_IMAGE:-ghcr.io/bbartling/openfdd-web:${TAG}}"
+CENTRAL_IMAGE="${OPENFDD_CENTRAL_IMAGE:-ghcr.io/bbartling/openfdd-central:${TAG}}"
+OUT_DIR="${1:-reports/p1_m1_web_smoke}"
+mkdir -p "$OUT_DIR"
+
+echo "== P1-M1 web image smoke =="
+echo "web=$WEB_IMAGE"
+echo "central=$CENTRAL_IMAGE"
+
+if ! docker image inspect "$WEB_IMAGE" >/dev/null 2>&1; then
+  docker pull "$WEB_IMAGE"
+fi
+docker image inspect "$WEB_IMAGE" >"$OUT_DIR/web_inspect.json"
+digest="$(docker image inspect "$WEB_IMAGE" --format '{{index .RepoDigests 0}}' 2>/dev/null || true)"
+echo "web_digest=${digest:-unknown}" | tee "$OUT_DIR/web_digest.txt"
+
+# No Python interpreter in the web image.
+if docker run --rm --entrypoint sh "$WEB_IMAGE" -c 'command -v python3 || command -v python || command -v python3.12' 2>/dev/null; then
+  echo "FAIL: python found in openfdd-web image" >&2
+  exit 1
+fi
+echo "OK: no python binary in openfdd-web"
+
+# version.json present
+ver="$(docker run --rm --entrypoint cat "$WEB_IMAGE" /usr/share/nginx/html/version.json)"
+echo "$ver" | tee "$OUT_DIR/version.json"
+echo "$ver" | grep -q '"service":"openfdd-web"'
+echo "OK: version.json present"
+
+# Optional: central has no python either (Rust binary image).
+if docker pull "$CENTRAL_IMAGE" >/dev/null 2>&1; then
+  if docker run --rm --entrypoint sh "$CENTRAL_IMAGE" -c 'command -v python3 || command -v python' 2>/dev/null; then
+    echo "FAIL: python found in openfdd-central" >&2
+    exit 1
+  fi
+  echo "OK: no python binary in openfdd-central"
+  docker image inspect "$CENTRAL_IMAGE" >"$OUT_DIR/central_inspect.json"
+fi
+
+# Local compose-build path when GHCR web tag missing (dev):
+# docker build -t openfdd-web:local frontend/web && OPENFDD_WEB_IMAGE=openfdd-web:local …
+
+cat >"$OUT_DIR/SUMMARY.md" <<EOF
+# P1-M1-C web image smoke
+
+- web: \`$WEB_IMAGE\`
+- digest: \`${digest:-unknown}\`
+- no python in web: PASS
+- version.json: present
+
+Recreate:
+\`\`\`bash
+OPENFDD_IMAGE_TAG=$TAG ./scripts/release/smoke_react_web_image.sh
+\`\`\`
+EOF
+
+echo "Report: $OUT_DIR/SUMMARY.md"


### PR DESCRIPTION
## Summary
- **P1-M1-A:** `frontend/web` Dockerfile uses `npm ci`, non-root nginx (8080), security/CSP headers, immutable `/assets`, `/version.json`.
- **P1-M1-B:** Stack GHCR workflow publishes `openfdd-web:sha-*` / `:nightly`; Streamlit `openfdd-ui` labeled + tagged `archive-oracle`.
- **P1-M1-C:** `scripts/release/smoke_react_web_image.sh` asserts no Python + version.json.
- **P1-G0:** soak `reports/nightly-ot-bench_20260802T141626Z/` — gates 14/15 PASS (suite still FAIL on OT/SPA/MCP honestly).

## Test plan
- [ ] CI builds `openfdd-web:ci` in stack publish test job
- [ ] After merge: tip publishes `openfdd-web:sha-*`; prune branch; 0 open PRs
- [ ] Optional: `OPENFDD_WEB_IMAGE=... ./scripts/release/smoke_react_web_image.sh`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production React web image publishing alongside stack services.
  * Added build version metadata and configurable Git SHA visibility.
  * Added release smoke tests for image integrity, metadata, and runtime contents.
* **Security & Reliability**
  * Added restrictive content security and security headers.
  * Improved caching for application assets and version information.
  * Web container now runs as an unprivileged service on port 8080.
* **Documentation**
  * Updated deployment, development, image, and migration documentation.
  * Clarified the archived status of the Streamlit UI image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->