### PR TITLE
P1-M3: Playwright product workflows + nightly gate 16

### DIFF
--- a/frontend/web/.gitignore
+++ b/frontend/web/.gitignore
@@ -4,3 +4,6 @@ dist
 .DS_Store
 node_modules/
 dist/
+test-results/
+playwright-report/
+blob-report/

--- a/frontend/web/README.md
+++ b/frontend/web/README.md
@@ -15,7 +15,18 @@ npm run dev
 Vite defaults to `:5173`. Proxy `/api` to central via `vite.config.ts` or set
 `VITE_API_BASE`.
 
-## Production image (P1-M1)
+## Real-stack Playwright (P1-M3)
+
+```bash
+# SPA must be up on :3000 (react-ot). Hard-fail mode:
+OPENFDD_PLAYWRIGHT_REQUIRE_STACK=1 npm run test:e2e -- e2e/product.spec.ts
+# Nightly:
+./scripts/nightly-ot-bench/16_playwright_web.sh
+```
+
+`e2e/smoke.spec.ts` soft-skips when SPA is down (CI without stack).
+`e2e/product.spec.ts` covers Overview / Auth / Jobs / Upload→WattLab markers.
+
 
 ```bash
 docker build \

--- a/frontend/web/e2e/product.spec.ts
+++ b/frontend/web/e2e/product.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * P1-M3 real-stack product markers — no route/network mocks.
+ * Nightly gate 16 sets OPENFDD_PLAYWRIGHT_REQUIRE_STACK=1 so SPA-down is a hard fail.
+ * CI without a stack may omit that env and soft-skip like smoke.spec.ts.
+ */
+const base = process.env.OPENFDD_PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000";
+const requireStack = process.env.OPENFDD_PLAYWRIGHT_REQUIRE_STACK === "1";
+
+test.describe("react product workflows (real stack)", () => {
+  test.beforeAll(async ({ request }) => {
+    if (process.env.OPENFDD_PLAYWRIGHT_SKIP === "1") {
+      test.skip(true, "OPENFDD_PLAYWRIGHT_SKIP=1");
+    }
+    try {
+      const res = await request.get(base, { timeout: 5_000 });
+      if (!res.ok()) {
+        if (requireStack) {
+          throw new Error(`SPA not healthy at ${base} (HTTP ${res.status()})`);
+        }
+        test.skip(true, `SPA not healthy at ${base} (HTTP ${res.status()})`);
+      }
+    } catch (err) {
+      if (requireStack) {
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+      test.skip(true, `SPA unreachable at ${base}`);
+    }
+  });
+
+  test("overview loads capabilities and generation markers", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(String(err)));
+
+    await page.goto("/");
+    await expect(page.getByTestId("overview-page")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId("home-loading")).toHaveCount(0, { timeout: 20_000 });
+    await expect(page.getByTestId("overview-react-ui")).toContainText(/on|off|—/);
+    await expect(page.getByTestId("overview-ui-generation")).toBeVisible();
+    await expect(page.getByTestId("contract-version")).toBeVisible();
+    expect(errors, `page errors: ${errors.join(" | ")}`).toEqual([]);
+  });
+
+  test("auth page login mints or refreshes session", async ({ page }) => {
+    await page.goto("/auth");
+    await expect(page.getByTestId("auth-page")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("auth-required")).toBeVisible();
+
+    const password = process.env.OPENFDD_ADMIN_PASSWORD ?? "";
+    await page.getByTestId("auth-username").fill("admin");
+    if (password) {
+      await page.getByTestId("auth-password").fill(password);
+    }
+    await page.getByTestId("auth-login").click();
+    await expect(page.getByTestId("auth-notice")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("auth-notice")).toContainText(/Logged in/i);
+  });
+
+  test("jobs page shell and create section", async ({ page }) => {
+    await page.goto("/jobs");
+    await expect(page.getByTestId("jobs-page")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("jobs-create-section")).toBeVisible();
+    await expect(page.getByTestId("jobs-create-name")).toBeVisible();
+  });
+
+  test("primary product routes expose page markers", async ({ page }) => {
+    const routes: { path: string; testId: string }[] = [
+      { path: "/upload", testId: "upload-page" },
+      { path: "/mapping", testId: "mapping-page" },
+      { path: "/rules", testId: "rules-page" },
+      { path: "/findings", testId: "findings-page" },
+      { path: "/reports", testId: "reports-page" },
+      { path: "/metering", testId: "metering-page" },
+      { path: "/wattlab", testId: "wattlab-page" },
+    ];
+    for (const { path, testId } of routes) {
+      await page.goto(path);
+      await expect(page.getByTestId(testId), `${path} → ${testId}`).toBeVisible({
+        timeout: 15_000,
+      });
+    }
+  });
+});

--- a/frontend/web/e2e/smoke.spec.ts
+++ b/frontend/web/e2e/smoke.spec.ts
@@ -29,10 +29,7 @@ test.describe("react product smoke (real stack)", () => {
 
     await page.goto("/");
     await expect(page.locator("#root")).toBeVisible({ timeout: 15_000 });
-    // Product overview marker when HomePage mounts
-    await expect(
-      page.getByTestId("overview-page").or(page.locator("#root")),
-    ).toBeVisible();
+    await expect(page.getByTestId("overview-page")).toBeVisible({ timeout: 15_000 });
 
     expect(errors, `console/page errors: ${errors.join(" | ")}`).toEqual([]);
   });

--- a/frontend/web/src/pages/JobsPage.tsx
+++ b/frontend/web/src/pages/JobsPage.tsx
@@ -279,7 +279,7 @@ export function JobsPage() {
       title="Jobs"
       caption="Create, select, and manage engineering jobs. Selection is URL-backed (?job=)."
     >
-      <div className="page-placeholder">
+      <div className="page-placeholder" data-testid="jobs-page">
         <h2>Jobs</h2>
         <p>Presentation-only UI — durable job state lives in central Rust.</p>
 

--- a/frontend/web/src/pages/UploadPage.tsx
+++ b/frontend/web/src/pages/UploadPage.tsx
@@ -67,7 +67,7 @@ export function UploadPage() {
       title="Upload"
       caption="Package ZIP → central Rust ingest (hostile paths rejected)."
     >
-      <div className="page-placeholder">
+      <div className="page-placeholder" data-testid="upload-page">
         <h2>Upload</h2>
         <p>
           Posts to <code>POST /api/csv/import/package</code>. Selection via{" "}

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -191,6 +191,7 @@ tracks the recovery program evidence gates.
 - [x] P1-M2-A — ESLint (real) + Playwright real-stack smoke harness (self-skip if SPA down)
 - [ ] P1-M2-B — unified error/loading/recovery matrix
 - [ ] P1-M2-C — accessibility/responsive shell (axe/keyboard)
-- [ ] P1-M3-* — PlotlyHost replacement; remove demo/stub product controls; browser-qualify workflows
+- [x] P1-M3 partial — Playwright product markers (Overview/Auth/Jobs/…/WattLab) + nightly gate 16; PlotlyHost/demo strip still open
+- [ ] P1-M3-* — PlotlyHost replacement; remove demo/stub product controls; full browser-qualify workflows
 - [ ] P1-M4-* — SQL oracle closure by family; RCx/metering real algorithms; report no-Python
 - [ ] P1-M5-* — independent qualification pack + Streamlit retirement guard

--- a/scripts/nightly-ot-bench/10_react_spa.sh
+++ b/scripts/nightly-ot-bench/10_react_spa.sh
@@ -31,7 +31,7 @@ else
 fi
 
 # --- SPA HTML shell ----------------------------------------------------------
-HTML="$(curl -fsS --max-time 15 "$UI_BASE/" || true)"
+HTML="$(curl_body_retry --max-time 15 "$UI_BASE/" || true)"
 echo "$HTML" | head -c 500 >"$ART/spa_index_snip.html"
 if grep -qiE '<div id="root"|/assets/.*\.js' <<<"$HTML"; then
   ok "SPA index has #root / asset script"
@@ -48,7 +48,7 @@ fi
 # --- Product routes (SPA may return index.html for all; HTTP 200 is enough) ---
 ROUTES=(/ /auth /jobs /upload /mapping /rules /findings /reports /metering /wattlab)
 for path in "${ROUTES[@]}"; do
-  code="$(http_code --max-time 10 "$UI_BASE$path")"
+  code="$(http_code_retry --max-time 10 "$UI_BASE$path")"
   if [[ "$code" == "200" || "$code" == "301" || "$code" == "302" ]]; then
     ok "SPA $path → HTTP $code"
   elif [[ "$code" == "000" ]]; then
@@ -59,7 +59,7 @@ for path in "${ROUTES[@]}"; do
 done
 
 # Streamlit Lab path must not be the product surface
-lab_code="$(http_code --max-time 10 "$UI_BASE/lab")"
+lab_code="$(http_code_retry --max-time 10 "$UI_BASE/lab")"
 if [[ "$lab_code" == "000" ]]; then
   bad "SPA host unreachable (HTTP 000) — cannot assess /lab"
 elif [[ "$lab_code" == "200" ]]; then

--- a/scripts/nightly-ot-bench/16_playwright_web.sh
+++ b/scripts/nightly-ot-bench/16_playwright_web.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Gate 16 — Playwright real-stack product workflows (P1-M3).
+# Requires live SPA on UI_BASE. Fails hard when stack is up but e2e fails.
+# Prefers host Playwright; falls back to mcr.microsoft.com/playwright when
+# host OS libs (e.g. libatk) are missing (common on minimal CI/lab hosts).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+
+hdr "Playwright product workflows (real stack)"
+
+if [[ "${OPENFDD_PLAYWRIGHT_SKIP:-0}" == "1" ]]; then
+  skip "OPENFDD_PLAYWRIGHT_SKIP=1"
+  summary
+  exit 0
+fi
+
+spa_code="$(http_code_retry --max-time 10 "$UI_BASE/")"
+if [[ "$spa_code" != "200" && "$spa_code" != "301" && "$spa_code" != "302" ]]; then
+  bad "SPA unreachable at $UI_BASE (HTTP $spa_code) — gate 16 requires live stack"
+  summary
+  exit 1
+fi
+ok "SPA $UI_BASE → HTTP $spa_code"
+
+WEB="$ROOT/frontend/web"
+if [[ ! -f "$WEB/package.json" ]]; then
+  bad "missing $WEB/package.json"
+  summary
+  exit 1
+fi
+
+export OPENFDD_PLAYWRIGHT_BASE_URL="${OPENFDD_PLAYWRIGHT_BASE_URL:-$UI_BASE}"
+export OPENFDD_PLAYWRIGHT_REQUIRE_STACK=1
+if [[ -z "${OPENFDD_ADMIN_PASSWORD:-}" && -f "$ROOT/.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT/.env"
+  set +a
+fi
+
+# Pin Playwright image to package.json version when possible.
+PW_VER="$(node -p "require('$WEB/package.json').devDependencies['@playwright/test'].replace(/^[^\d]*/, '')" 2>/dev/null || echo "1.62.1")"
+PW_IMAGE="${OPENFDD_PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v${PW_VER}-jammy}"
+
+host_playwright_ok() {
+  pushd "$WEB" >/dev/null
+  [[ -d node_modules ]] || npm ci >/dev/null
+  npx playwright install chromium >/dev/null 2>&1 || true
+  # Probe launch (shared libs)
+  if node -e "
+const { chromium } = require('playwright');
+(async () => {
+  const b = await chromium.launch({ headless: true });
+  await b.close();
+})().catch((e) => { console.error(e); process.exit(1); });
+" >/dev/null 2>&1; then
+    popd >/dev/null
+    return 0
+  fi
+  popd >/dev/null
+  return 1
+}
+
+run_host() {
+  pushd "$WEB" >/dev/null
+  npx playwright test e2e/product.spec.ts e2e/smoke.spec.ts --reporter=list
+  local rc=$?
+  popd >/dev/null
+  return "$rc"
+}
+
+run_docker() {
+  echo "${DIM}using Playwright image $PW_IMAGE (host libs missing)${RST}"
+  docker pull "$PW_IMAGE" >/dev/null
+  # Map host loopback SPA into the container via host networking.
+  docker run --rm --network host \
+    -e OPENFDD_PLAYWRIGHT_BASE_URL="$OPENFDD_PLAYWRIGHT_BASE_URL" \
+    -e OPENFDD_PLAYWRIGHT_REQUIRE_STACK=1 \
+    -e OPENFDD_ADMIN_PASSWORD="${OPENFDD_ADMIN_PASSWORD:-}" \
+    -e CI=1 \
+    -v "$WEB:/work" -w /work \
+    "$PW_IMAGE" \
+    bash -lc 'npm ci --silent && npx playwright test e2e/product.spec.ts e2e/smoke.spec.ts --reporter=list'
+}
+
+LOG="$ART/16_playwright_web.log"
+set +e
+if [[ "${OPENFDD_PLAYWRIGHT_FORCE_DOCKER:-0}" == "1" ]] || ! host_playwright_ok; then
+  run_docker 2>&1 | tee "$LOG"
+  rc=${PIPESTATUS[0]}
+else
+  ok "host Playwright launch probe passed"
+  run_host 2>&1 | tee "$LOG"
+  rc=${PIPESTATUS[0]}
+fi
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  ok "Playwright product + smoke suites passed"
+else
+  bad "Playwright failed (exit $rc) — see $LOG"
+fi
+
+summary
+exit "$rc"

--- a/scripts/nightly-ot-bench/lib.sh
+++ b/scripts/nightly-ot-bench/lib.sh
@@ -149,6 +149,38 @@ http_code() {
   echo "${code:0:3}"
 }
 
+# Retry transient SPA/proxy failures (HTTP 000 / connection reset) a few times.
+http_code_retry() {
+  local attempts="${HTTP_CODE_RETRIES:-5}"
+  local sleep_s="${HTTP_CODE_RETRY_SLEEP:-2}"
+  local code="000" i
+  for ((i = 1; i <= attempts; i++)); do
+    code="$(http_code "$@")"
+    if [[ "$code" != "000" ]]; then
+      echo "$code"
+      return 0
+    fi
+    sleep "$sleep_s"
+  done
+  echo "000"
+}
+
+curl_body_retry() {
+  # curl_body_retry [curl args…] — print body; retry on empty/fail.
+  local attempts="${HTTP_CODE_RETRIES:-5}"
+  local sleep_s="${HTTP_CODE_RETRY_SLEEP:-2}"
+  local body="" i
+  for ((i = 1; i <= attempts; i++)); do
+    body="$(curl -fsS --max-time "${CURL_TIMEOUT:-20}" "$@" 2>/dev/null || true)"
+    if [[ -n "$body" ]]; then
+      printf '%s' "$body"
+      return 0
+    fi
+    sleep "$sleep_s"
+  done
+  return 1
+}
+
 http_code_to() {
   # http_code_to OUTFILE [curl args…] — body to OUTFILE, print status code.
   local out="$1"

--- a/scripts/nightly-ot-bench/run_all.sh
+++ b/scripts/nightly-ot-bench/run_all.sh
@@ -117,4 +117,7 @@ run_phase 13_mcp_accuracy.sh "13 MCP accuracy vs central" || OVERALL=1
 run_phase 14_capability_ledger.sh "14 capability ledger (P1-M0)" || OVERALL=1
 run_phase 15_product_truth_honesty.sh "15 product-truth honesty (P1)" || OVERALL=1
 
+# P1-M3 real-stack Playwright — requires live SPA (hard fail if up-but-broken).
+run_phase 16_playwright_web.sh "16 Playwright product workflows" || OVERALL=1
+
 finish_report


### PR DESCRIPTION
## Summary
- Extend real-stack Playwright with `e2e/product.spec.ts` (Overview/Auth/Jobs + product route markers).
- Add nightly `16_playwright_web.sh` (hard-fail when SPA up; Docker Playwright fallback).
- Harden gate 10 SPA curls with retries; add `jobs-page` / `upload-page` testids.

## Test plan
- [x] `./scripts/nightly-ot-bench/10_react_spa.sh` PASS
- [x] `OPENFDD_PLAYWRIGHT_FORCE_DOCKER=1 ./scripts/nightly-ot-bench/16_playwright_web.sh` PASS (6/6)
- [ ] Tip GHCR publish after squash-merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser-based coverage for core product workflows, including authentication, overview, jobs creation, uploads, and primary navigation routes.
  - Added a strict nightly browser validation gate with clear pass/fail reporting.

- **Bug Fixes**
  - Improved nightly benchmark reliability by retrying transient page and network requests.
  - Strengthened smoke checks to confirm the overview page loads correctly.

- **Documentation**
  - Added guidance for running real-stack browser tests, nightly benchmarks, and configurable skip or failure behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->