### PR TITLE
Fix overview 401 console noise + redact offline model card paths

### DIFF
--- a/frontend/web/src/pages/HomePage.test.tsx
+++ b/frontend/web/src/pages/HomePage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { HomePage } from "./HomePage";
@@ -18,18 +18,32 @@ vi.mock("../api/analyticsApi", () => ({
   ]),
 }));
 
+vi.mock("../api/cutoverApi", () => ({
+  getUiGeneration: vi.fn(async () => ({ generation: "react" })),
+}));
+
 import { apiFetch } from "../api/client";
+import { listPackageBuildings } from "../api/mappingApi";
+import { listFddEquipment } from "../api/analyticsApi";
 
 describe("HomePage overview", () => {
   beforeEach(() => {
+    sessionStorage.clear();
     vi.mocked(apiFetch).mockResolvedValue({
       ok: true,
       contract: { contract_version: "1.0.0-test" },
       capabilities: { react_ui: true },
     });
+    vi.mocked(listPackageBuildings).mockClear();
+    vi.mocked(listFddEquipment).mockClear();
   });
 
-  it("shows equipment inventory metrics", async () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("shows equipment inventory metrics when authenticated", async () => {
+    sessionStorage.setItem("openfdd.auth.token", "test-token");
     render(
       <MemoryRouter>
         <HomePage />
@@ -42,5 +56,23 @@ describe("HomePage overview", () => {
         "1.0.0-test",
       );
     });
+    expect(listPackageBuildings).toHaveBeenCalled();
+    expect(listFddEquipment).toHaveBeenCalled();
+  });
+
+  it("skips JWT-gated inventory fetches when anonymous", async () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("contract-version").textContent).toContain(
+        "1.0.0-test",
+      );
+    });
+    expect(listPackageBuildings).not.toHaveBeenCalled();
+    expect(listFddEquipment).not.toHaveBeenCalled();
+    expect(screen.getByTestId("overview-eq-count").textContent).toContain("0");
   });
 });

--- a/frontend/web/src/pages/HomePage.tsx
+++ b/frontend/web/src/pages/HomePage.tsx
@@ -27,6 +27,15 @@ function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** Avoid unauthenticated calls to JWT-gated routes (browser logs them as console errors). */
+function hasAuthToken(): boolean {
+  try {
+    return Boolean(sessionStorage.getItem("openfdd.auth.token"));
+  } catch {
+    return false;
+  }
+}
+
 export function HomePage() {
   const { query, setQuery } = useSessionQuery();
   const buildingId = query.siteId ?? "";
@@ -44,13 +53,18 @@ export function HomePage() {
     setLoading(true);
     setError(null);
     try {
+      const authed = hasAuthToken();
       const [caps, gen, blds, eq] = await Promise.all([
         apiFetch<CapabilitiesResponse>("/api/capabilities"),
         getUiGeneration().catch(() => null),
-        listPackageBuildings().catch(() => [] as string[]),
-        listFddEquipment(buildingId || undefined).catch(
-          () => [] as FddEquipmentItem[],
-        ),
+        authed
+          ? listPackageBuildings().catch(() => [] as string[])
+          : Promise.resolve([] as string[]),
+        authed
+          ? listFddEquipment(buildingId || undefined).catch(
+              () => [] as FddEquipmentItem[],
+            )
+          : Promise.resolve([] as FddEquipmentItem[]),
       ]);
       setContractVersion(caps.contract.contract_version);
       setReactUi(Boolean(caps.capabilities?.react_ui));

--- a/services/central/src/vibe21.rs
+++ b/services/central/src/vibe21.rs
@@ -193,6 +193,29 @@ async fn v1_health() -> Json<Value> {
     }))
 }
 
+/// Redact offline oracle paths (joblib / Windows absolute) from online model cards.
+fn redact_offline_model_card(mut card: Value) -> Value {
+    let Some(obj) = card.as_object_mut() else {
+        return card;
+    };
+    if let Some(art) = obj.get("artifact").and_then(|v| v.as_str()) {
+        let lower = art.to_ascii_lowercase();
+        if lower.contains("joblib")
+            || lower.ends_with(".pkl")
+            || lower.ends_with(".pickle")
+            || art.contains(":\\")
+            || art.contains(":/")
+        {
+            obj.insert(
+                "artifact".into(),
+                json!("[redacted offline oracle path — use model_release.zip]"),
+            );
+            obj.insert("artifact_offline_redacted".into(), json!(true));
+        }
+    }
+    card
+}
+
 async fn v1_models() -> Json<Value> {
     let Some(bundle) = load_bundle() else {
         return Json(json!({"ok": false, "error": "no runtime_bundle"}));
@@ -212,6 +235,7 @@ async fn v1_models() -> Json<Value> {
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or(json!({}));
+    let card = redact_offline_model_card(card);
     Json(json!({
         "ok": true,
         "champion": release.get("champion").or_else(|| card.get("champion")),
@@ -222,6 +246,8 @@ async fn v1_models() -> Json<Value> {
         ],
         "model_release": release,
         "card": card,
+        "inference": "portable_or_conformance",
+        "note": "Online runtime never loads joblib; knobs require portable feature compiler",
     }))
 }
 


### PR DESCRIPTION
## Summary
- Overview no longer calls JWT-gated `/api/csv/import/package/buildings` or `/api/fdd/equipment` when there is no session token (was flooding the browser console with 401s and failing smoke).
- `/api/v1/models` redacts offline joblib/Windows oracle `artifact` paths from the model card JSON.

## Test plan
- [ ] Anonymous `GET /` → no 401 console errors; capabilities still load
- [ ] After login, overview building/equipment lists populate again
- [ ] `GET /api/v1/models` has no `.joblib` / `C:\\` artifact string
- [ ] Gate 16 Playwright product + smoke green on tip GHCR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unauthenticated requests from loading building and equipment data.
  - Improved model metadata safety by removing sensitive file paths and implementation details.
  - Clarified whether inference is portable or conformance-based, including online runtime requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->