### PR TITLE
Honor OPENFDD_IMAGE_TAG over sticky GHCR image env

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -153,6 +153,8 @@ jobs:
           bash -n scripts/openfdd_stack_up.sh
           bash -n scripts/openfdd_caddy_smoke.sh
           bash -n scripts/release/smoke_standalone_mqtts.sh
+          bash -n scripts/test_openfdd_stack_image_tag.sh
+          bash scripts/test_openfdd_stack_image_tag.sh
           test -f docker/compose.wattlab.yml
           test -f docker/compose.caddy.yml
           test -f docs/mcp-agents/companion-wattlab-energyplus.md
@@ -171,5 +173,7 @@ jobs:
           bash -n scripts/openfdd_caddy_smoke.sh
           bash -n scripts/openfdd_csv_import_sidecar.sh
           bash -n scripts/openfdd_csv_export_sidecar.sh
+          bash -n scripts/test_openfdd_stack_image_tag.sh
+          bash scripts/test_openfdd_stack_image_tag.sh
           test -f docker/compose.wattlab.yml
           test -f docs/mcp-agents/companion-wattlab-energyplus.md

--- a/scripts/openfdd_stack_lib.sh
+++ b/scripts/openfdd_stack_lib.sh
@@ -76,14 +76,35 @@ openfdd_stack_images() {
   echo "ghcr.io/bbartling/openfdd-ui:${tag}"
 }
 
+# Apply OPENFDD_IMAGE_TAG to default GHCR image vars.
+# Explicit custom registries (non-bbartling openfdd-*) are left alone.
+# When IMAGE_TAG is set, sticky OPENFDD_*_IMAGE from a prior shell that still
+# point at ghcr.io/bbartling/openfdd-* are rewritten so the tip pin wins.
+openfdd_stack_apply_image_tag() {
+  local var="$1"
+  local name="$2"
+  local tag="$3"
+  local desired="ghcr.io/bbartling/openfdd-${name}:${tag}"
+  local cur="${!var:-}"
+  if [[ -z "$cur" ]]; then
+    export "$var=$desired"
+    return 0
+  fi
+  if [[ -n "${OPENFDD_IMAGE_TAG:-}" && "$cur" == ghcr.io/bbartling/openfdd-"${name}":* ]]; then
+    export "$var=$desired"
+    return 0
+  fi
+  # Keep caller override (custom registry / digest pin / archive image).
+}
+
 openfdd_stack_export_image_env() {
   local tag="${OPENFDD_IMAGE_TAG:-nightly}"
-  export OPENFDD_CENTRAL_IMAGE="${OPENFDD_CENTRAL_IMAGE:-ghcr.io/bbartling/openfdd-central:${tag}}"
-  export OPENFDD_UI_IMAGE="${OPENFDD_UI_IMAGE:-ghcr.io/bbartling/openfdd-ui:${tag}}"
-  export OPENFDD_WEB_IMAGE="${OPENFDD_WEB_IMAGE:-ghcr.io/bbartling/openfdd-web:${tag}}"
-  export OPENFDD_FIELDBUS_IMAGE="${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:${tag}}"
-  export OPENFDD_MQTT_IMAGE="${OPENFDD_MQTT_IMAGE:-ghcr.io/bbartling/openfdd-mqtt:${tag}}"
-  export OPENFDD_MCP_IMAGE="${OPENFDD_MCP_IMAGE:-ghcr.io/bbartling/openfdd-mcp:${tag}}"
+  openfdd_stack_apply_image_tag OPENFDD_CENTRAL_IMAGE central "$tag"
+  openfdd_stack_apply_image_tag OPENFDD_UI_IMAGE ui "$tag"
+  openfdd_stack_apply_image_tag OPENFDD_WEB_IMAGE web "$tag"
+  openfdd_stack_apply_image_tag OPENFDD_FIELDBUS_IMAGE fieldbus "$tag"
+  openfdd_stack_apply_image_tag OPENFDD_MQTT_IMAGE mqtt "$tag"
+  openfdd_stack_apply_image_tag OPENFDD_MCP_IMAGE mcp "$tag"
 }
 
 openfdd_stack_wait_health() {

--- a/scripts/test_openfdd_stack_image_tag.sh
+++ b/scripts/test_openfdd_stack_image_tag.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Regression: OPENFDD_IMAGE_TAG must win over sticky OPENFDD_*_IMAGE nightlies.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/openfdd_stack_lib.sh
+source "$ROOT/scripts/openfdd_stack_lib.sh"
+
+# Stale shell leftovers from a prior nightly pull.
+export OPENFDD_CENTRAL_IMAGE=ghcr.io/bbartling/openfdd-central:nightly
+export OPENFDD_WEB_IMAGE=ghcr.io/bbartling/openfdd-web:nightly
+export OPENFDD_MQTT_IMAGE=ghcr.io/bbartling/openfdd-mqtt:nightly
+export OPENFDD_FIELDBUS_IMAGE=ghcr.io/bbartling/openfdd-fieldbus:nightly
+export OPENFDD_MCP_IMAGE=ghcr.io/bbartling/openfdd-mcp:nightly
+export OPENFDD_UI_IMAGE=ghcr.io/bbartling/openfdd-ui:nightly
+
+export OPENFDD_IMAGE_TAG=sha-deadbeef
+openfdd_stack_export_image_env
+
+[[ "$OPENFDD_CENTRAL_IMAGE" == "ghcr.io/bbartling/openfdd-central:sha-deadbeef" ]]
+[[ "$OPENFDD_WEB_IMAGE" == "ghcr.io/bbartling/openfdd-web:sha-deadbeef" ]]
+[[ "$OPENFDD_MQTT_IMAGE" == "ghcr.io/bbartling/openfdd-mqtt:sha-deadbeef" ]]
+[[ "$OPENFDD_FIELDBUS_IMAGE" == "ghcr.io/bbartling/openfdd-fieldbus:sha-deadbeef" ]]
+[[ "$OPENFDD_MCP_IMAGE" == "ghcr.io/bbartling/openfdd-mcp:sha-deadbeef" ]]
+[[ "$OPENFDD_UI_IMAGE" == "ghcr.io/bbartling/openfdd-ui:sha-deadbeef" ]]
+
+# Custom non-GHCR override preserved when IMAGE_TAG set.
+export OPENFDD_CENTRAL_IMAGE=registry.example/openfdd-central:dev
+export OPENFDD_IMAGE_TAG=sha-cafe
+openfdd_stack_export_image_env
+[[ "$OPENFDD_CENTRAL_IMAGE" == "registry.example/openfdd-central:dev" ]]
+[[ "$OPENFDD_WEB_IMAGE" == "ghcr.io/bbartling/openfdd-web:sha-cafe" ]]
+
+# Without IMAGE_TAG, unset vars default to nightly; sticky custom stays.
+unset OPENFDD_IMAGE_TAG
+unset OPENFDD_MQTT_IMAGE
+export OPENFDD_CENTRAL_IMAGE=registry.example/openfdd-central:dev
+openfdd_stack_export_image_env
+[[ "$OPENFDD_CENTRAL_IMAGE" == "registry.example/openfdd-central:dev" ]]
+[[ "$OPENFDD_MQTT_IMAGE" == "ghcr.io/bbartling/openfdd-mqtt:nightly" ]]
+
+echo "PASS openfdd_stack_export_image_env tip pin + custom override"

--- a/scripts/vibe21_turnkey_openfdd.sh
+++ b/scripts/vibe21_turnkey_openfdd.sh
@@ -8,6 +8,11 @@ export VIBE21_ORACLE="${VIBE21_ORACLE:-/home/ben/py-bacnet-stacks-playground/vib
 export OPENFDD_JOB_ROOT="${OPENFDD_JOB_ROOT:-$ROOT/workspace/vibe21_jobs}"
 JOB_ID="${JOB_ID:-b100-ops11}"
 
+HANDOFF="$ROOT/workspace/bootstrap_credentials.once.txt"
+if [[ -f "$HANDOFF" ]]; then
+  echo "WARN: $HANDOFF still present — delete after saving the admin password (BUG-002 lab hygiene)" >&2
+fi
+
 echo "==> master_build (reuse-champion unless MASTER_BUILD_FORCE=1)"
 if [[ "${MASTER_BUILD_FORCE:-0}" == "1" ]]; then
   ./scripts/vibe21_master_build.sh --job-id "$JOB_ID" --profile pilot
@@ -20,6 +25,9 @@ python3 ./scripts/vibe21_export_champion_portable.py \
 if [[ "${SKIP_PULL:-0}" != "1" ]]; then
   TIP="$(git rev-parse --short=7 HEAD)"
   export OPENFDD_IMAGE_TAG="${OPENFDD_IMAGE_TAG:-sha-$TIP}"
+  # Drop sticky per-image overrides so IMAGE_TAG tip pin wins (see openfdd_stack_lib).
+  unset OPENFDD_CENTRAL_IMAGE OPENFDD_UI_IMAGE OPENFDD_WEB_IMAGE \
+    OPENFDD_FIELDBUS_IMAGE OPENFDD_MQTT_IMAGE OPENFDD_MCP_IMAGE
   echo "==> pull/up react-ot pin=$OPENFDD_IMAGE_TAG"
   ./scripts/openfdd_stack_pull.sh react-ot || true
   OPENFDD_REACT_UI=1 OPENFDD_UI_GENERATION_DEFAULT=react \


### PR DESCRIPTION
## Summary
- `openfdd_stack_export_image_env` rewrites sticky `ghcr.io/bbartling/openfdd-*` image vars when `OPENFDD_IMAGE_TAG` is set so tip pins (`sha-*`) actually win.
- Custom registries stay untouched.
- Turnkey unsets sticky image env before pull/up and warns if `workspace/bootstrap_credentials.once.txt` is still on disk (BUG-002).
- Adds `scripts/test_openfdd_stack_image_tag.sh` regression.

## Test plan
- [x] `scripts/test_openfdd_stack_image_tag.sh`
- [ ] Stack script syntax CI green
- [ ] After merge: `OPENFDD_CENTRAL_IMAGE=…:nightly OPENFDD_IMAGE_TAG=sha-<tip> ./scripts/openfdd_stack_pull.sh react-ot` pulls tip sha
- [ ] Turnkey prints bootstrap hygiene WARN when handoff file present


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stack image tag handling so specified tags consistently select the intended images.
  * Preserved custom registries, digest-pinned images, and archive image configurations.
  * Added warnings for leftover bootstrap credential handoff files.
  * Ensured stale image overrides do not interfere with computed image selections.

* **Tests**
  * Added regression coverage for image tag overrides, custom image settings, and default behavior.
  * Integrated image-tag validation into automated workflow checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->