### PR TITLE
Fix blank /login + default Caddy for React LAN

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -157,6 +157,8 @@ jobs:
           bash scripts/test_openfdd_stack_image_tag.sh
           test -f docker/compose.wattlab.yml
           test -f docker/compose.caddy.yml
+          test -f docker/compose.caddy.react.yml
+          test -f docker/caddy/Caddyfile.react.http
           test -f docs/mcp-agents/companion-wattlab-energyplus.md
           test -f docs/mcp-agents/dual-site-mcp-it.md
 

--- a/docker/caddy/Caddyfile.react.http
+++ b/docker/caddy/Caddyfile.react.http
@@ -1,0 +1,52 @@
+# HTTP edge for React SPA — hit http://<machine-ip>/ → web nginx (lab / LAN).
+# Same-origin /api* + /twins* → central. Default for react / react-ot recipes.
+#
+#   OPENFDD_CADDY=1 ./scripts/openfdd_stack_up.sh react-ot
+#   (react recipes default Caddy on unless OPENFDD_CADDY=0)
+
+{
+	admin off
+	auto_https off
+}
+
+:80 {
+	encode gzip zstd
+
+	header {
+		-Server
+		X-Content-Type-Options nosniff
+		Referrer-Policy strict-origin-when-cross-origin
+		X-Frame-Options SAMEORIGIN
+		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+	}
+
+	@blocked path /.env /.git /.git/* /wp-admin /wp-admin/* /xmlrpc.php
+	respond @blocked 404
+
+	# Bookmark alias (belt-and-suspenders with SPA Navigate + web nginx 302).
+	redir /login /auth 302
+
+	handle /api* {
+		reverse_proxy {$OPENFDD_CADDY_API_UPSTREAM:central:8080} {
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	handle /twins* {
+		reverse_proxy {$OPENFDD_CADDY_API_UPSTREAM:central:8080} {
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Real-IP {remote_host}
+			flush_interval -1
+		}
+	}
+
+	# Default: React SPA nginx (already proxies /api + /twins when hit on :3000)
+	handle {
+		reverse_proxy {$OPENFDD_CADDY_UI_UPSTREAM:web:8080} {
+			header_up Host {host}
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+}

--- a/docker/compose.caddy.react.yml
+++ b/docker/compose.caddy.react.yml
@@ -1,0 +1,30 @@
+# Caddy edge for React recipes (web SPA, not Streamlit ui).
+#
+#   OPENFDD_CADDY=1 ./scripts/openfdd_stack_up.sh react-ot
+#   (enabled by default for react / react-ot unless OPENFDD_CADDY=0)
+
+services:
+  caddy:
+    image: ${OPENFDD_CADDY_IMAGE:-caddy:2.8-alpine}
+    restart: unless-stopped
+    ports:
+      - "${OPENFDD_CADDY_HTTP_BIND:-0.0.0.0}:80:80"
+    volumes:
+      - ${OPENFDD_CADDYFILE:-./caddy/Caddyfile.react.http}:/etc/caddy/Caddyfile:ro
+    environment:
+      OPENFDD_CADDY_UI_UPSTREAM: ${OPENFDD_CADDY_UI_UPSTREAM:-web:8080}
+      OPENFDD_CADDY_API_UPSTREAM: ${OPENFDD_CADDY_API_UPSTREAM:-central:8080}
+    depends_on:
+      - web
+      - central
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /config
+      - /data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE

--- a/docker/compose.standalone.yml
+++ b/docker/compose.standalone.yml
@@ -33,7 +33,8 @@ services:
       OPENFDD_WORKSPACE: /workspace
       OPENFDD_PARQUET_ROOT: /workspace/.cache/parquet
       # Remote UI login (optional). When JWT secret is set, also set OPENFDD_ADMIN_PASSWORD
-      # and sign in as admin/operator/viewer with that password from http://<host>:3000/login
+      # and sign in as admin/operator/viewer with that password from http://<host>/auth
+# (Caddy :80) or http://<host>:3000/auth — /login redirects to /auth.
       OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:-}
       OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
     ports:

--- a/frontend/web/e2e/lanHttp.ts
+++ b/frontend/web/e2e/lanHttp.ts
@@ -1,0 +1,34 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Simulate LAN HTTP secure-context rules inside Playwright.
+ * `http://127.0.0.1` keeps `crypto.randomUUID`; `http://192.168.x.x` does not.
+ * Gate/CI on loopback would miss that bug without this stub.
+ */
+export async function simulateLanHttpCrypto(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const real = globalThis.crypto;
+    if (!real) return;
+    const getRandomValues = real.getRandomValues.bind(real);
+    const subtle = real.subtle;
+    // Replace the whole crypto object — randomUUID is non-configurable on Chromium.
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      enumerable: true,
+      value: {
+        getRandomValues,
+        subtle,
+        // intentionally no randomUUID
+      } as Crypto,
+    });
+  });
+}
+
+export function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(String(err)));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  return errors;
+}

--- a/frontend/web/e2e/product.spec.ts
+++ b/frontend/web/e2e/product.spec.ts
@@ -57,6 +57,19 @@ test.describe("react product workflows (real stack)", () => {
     await expect(page.getByTestId("auth-notice")).toContainText(/Logged in/i);
   });
 
+  test("/login bookmark is not a blank page (redirects to /auth)", async ({ page }) => {
+    // Regression: SPA had no /login route → empty #root for remote bookmarks.
+    const response = await page.goto("/login", { waitUntil: "networkidle" });
+    // nginx may 302 before SPA Navigate; either path must land on auth UI.
+    const status = response?.status() ?? 0;
+    expect([200, 302, 301]).toContain(status);
+    await expect(page).toHaveURL(/\/auth\/?$/);
+    await expect(page.getByTestId("auth-page")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("auth-username")).toBeVisible();
+    await expect(page.getByTestId("auth-login")).toBeVisible();
+    const rootHtml = await page.locator("#root").innerHTML();
+    expect(rootHtml.length, "blank #root after /login").toBeGreaterThan(0);
+  });
   test("jobs page shell and create section", async ({ page }) => {
     await page.goto("/jobs");
     await expect(page.getByTestId("jobs-page")).toBeVisible({ timeout: 15_000 });

--- a/frontend/web/e2e/product.spec.ts
+++ b/frontend/web/e2e/product.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { collectPageErrors, simulateLanHttpCrypto } from "./lanHttp";
 
 /**
  * P1-M3 real-stack product markers — no route/network mocks.
@@ -57,8 +58,36 @@ test.describe("react product workflows (real stack)", () => {
     await expect(page.getByTestId("auth-notice")).toContainText(/Logged in/i);
   });
 
+  test("auth login works without crypto.randomUUID (LAN HTTP)", async ({ page }) => {
+    // Loopback Playwright is a secure context — strip randomUUID so we catch
+    // the http://192.168.x.x failure mode that blanked remote login.
+    await simulateLanHttpCrypto(page);
+    const errors = collectPageErrors(page);
+
+    await page.goto("/auth");
+    await expect(page.getByTestId("auth-page")).toBeVisible({ timeout: 15_000 });
+
+    const hasUuid = await page.evaluate(
+      () => typeof globalThis.crypto?.randomUUID === "function",
+    );
+    expect(hasUuid, "simulateLanHttpCrypto must remove randomUUID").toBe(false);
+
+    const password = process.env.OPENFDD_ADMIN_PASSWORD ?? "";
+    await page.getByTestId("auth-username").fill("admin");
+    if (password) {
+      await page.getByTestId("auth-password").fill(password);
+    }
+    await page.getByTestId("auth-login").click();
+    await expect(page.getByTestId("auth-notice")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("auth-notice")).toContainText(/Logged in/i);
+
+    const uuidErrors = errors.filter((e) => /randomUUID/i.test(e));
+    expect(uuidErrors, `LAN crypto errors: ${uuidErrors.join(" | ")}`).toEqual([]);
+  });
+
   test("/login bookmark is not a blank page (redirects to /auth)", async ({ page }) => {
     // Regression: SPA had no /login route → empty #root for remote bookmarks.
+    const errors = collectPageErrors(page);
     const response = await page.goto("/login", { waitUntil: "networkidle" });
     // nginx may 302 before SPA Navigate; either path must land on auth UI.
     const status = response?.status() ?? 0;
@@ -69,7 +98,12 @@ test.describe("react product workflows (real stack)", () => {
     await expect(page.getByTestId("auth-login")).toBeVisible();
     const rootHtml = await page.locator("#root").innerHTML();
     expect(rootHtml.length, "blank #root after /login").toBeGreaterThan(0);
+    expect(
+      errors.filter((e) => /randomUUID/i.test(e)),
+      `page errors: ${errors.join(" | ")}`,
+    ).toEqual([]);
   });
+
   test("jobs page shell and create section", async ({ page }) => {
     await page.goto("/jobs");
     await expect(page.getByTestId("jobs-page")).toBeVisible({ timeout: 15_000 });

--- a/frontend/web/nginx.conf
+++ b/frontend/web/nginx.conf
@@ -4,6 +4,8 @@ server {
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+    # Host publishes web as :3000→8080; absolute redirects would send users to :8080.
+    absolute_redirect off;
 
     # Security headers (Unity WebGL later needs frame-ancestors adjusted carefully).
     add_header X-Content-Type-Options nosniff always;
@@ -34,6 +36,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_buffering off;
+    }
+
+    # Bookmark alias — do not SPA-fallback /login to a blank React tree.
+    location = /login {
+        return 302 /auth;
     }
 
     location = /version.json {

--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { HomePage } from "./pages/HomePage";
 import { JobsPage } from "./pages/JobsPage";
 import { UploadPage } from "./pages/UploadPage";
@@ -17,6 +17,8 @@ export default function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/auth" element={<AuthPage />} />
+        {/* Canonical auth is /auth; /login is the common remote bookmark (was blank). */}
+        <Route path="/login" element={<Navigate to="/auth" replace />} />
         <Route path="/jobs" element={<JobsPage />} />
         <Route path="/upload" element={<UploadPage />} />
         <Route path="/mapping" element={<MappingPage />} />

--- a/frontend/web/src/api/client.ts
+++ b/frontend/web/src/api/client.ts
@@ -1,10 +1,7 @@
 import type { ApiErrorEnvelope } from "./contract";
+import { newRequestId } from "./requestId";
 
 const REQUEST_ID_HEADER = "x-request-id";
-
-function newRequestId(): string {
-  return crypto.randomUUID();
-}
 
 export class ApiClientError extends Error {
   readonly code: string;

--- a/frontend/web/src/api/requestId.test.ts
+++ b/frontend/web/src/api/requestId.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { newRequestId } from "./requestId";
+
+describe("newRequestId", () => {
+  it("returns a non-empty id when randomUUID is available", () => {
+    const id = newRequestId();
+    expect(id.length).toBeGreaterThan(8);
+  });
+
+  it("falls back when randomUUID is missing (LAN HTTP)", () => {
+    const real = globalThis.crypto;
+    vi.stubGlobal("crypto", {
+      getRandomValues: real.getRandomValues.bind(real),
+      // no randomUUID — mirrors http://192.168.x.x secure-context rules
+    });
+    try {
+      const id = newRequestId();
+      expect(id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/frontend/web/src/api/requestId.ts
+++ b/frontend/web/src/api/requestId.ts
@@ -1,0 +1,19 @@
+/**
+ * Request-id helper that works on LAN HTTP (non-secure context).
+ * `crypto.randomUUID()` is only defined in secure contexts (HTTPS / localhost).
+ */
+export function newRequestId(): string {
+  const c = globalThis.crypto as Crypto | undefined;
+  if (c && typeof c.randomUUID === "function") {
+    return c.randomUUID();
+  }
+  if (c && typeof c.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    c.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+  return `req-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/frontend/web/src/api/uploadApi.ts
+++ b/frontend/web/src/api/uploadApi.ts
@@ -1,10 +1,7 @@
 import { ApiClientError, parseErrorEnvelope } from "./client";
+import { newRequestId } from "./requestId";
 
 const REQUEST_ID_HEADER = "x-request-id";
-
-function newRequestId(): string {
-  return crypto.randomUUID();
-}
 
 function apiBase(): string {
   const base = import.meta.env.VITE_API_BASE ?? "";

--- a/scripts/nightly-ot-bench/16_playwright_web.sh
+++ b/scripts/nightly-ot-bench/16_playwright_web.sh
@@ -71,14 +71,16 @@ if [[ -z "${OPENFDD_ADMIN_PASSWORD:-}" && -f "$ROOT/workspace/bootstrap_credenti
   export OPENFDD_ADMIN_PASSWORD
 fi
 
-# Curl-level Caddy /login redirect when Caddy is the Playwright base.
-if [[ "$OPENFDD_PLAYWRIGHT_BASE_URL" == "http://127.0.0.1" || "$OPENFDD_PLAYWRIGHT_BASE_URL" == "http://127.0.0.1/" ]]; then
-  if ! OPENFDD_CADDY_BASE=http://127.0.0.1 "$ROOT/scripts/openfdd_caddy_smoke.sh"; then
-    bad "Caddy smoke failed (/, /api/health, /login→/auth)"
+# Curl-level /login redirect when Playwright targets Caddy (:80), not :3000/:8080.
+_pw_base="${OPENFDD_PLAYWRIGHT_BASE_URL%/}"
+if [[ "$_pw_base" != *":3000" && "$_pw_base" != *":8080" ]]; then
+  if OPENFDD_CADDY_BASE="$_pw_base" "$ROOT/scripts/openfdd_caddy_smoke.sh"; then
+    ok "Caddy smoke (incl. /login redirect) via $_pw_base"
+  else
+    bad "Caddy smoke failed (/, /api/health, /login→/auth) via $_pw_base"
     summary
     exit 1
   fi
-  ok "Caddy smoke (incl. /login redirect)"
 fi
 
 # Pin Playwright image to package.json version when possible.

--- a/scripts/nightly-ot-bench/16_playwright_web.sh
+++ b/scripts/nightly-ot-bench/16_playwright_web.sh
@@ -29,6 +29,26 @@ if [[ "$spa_code" != "200" && "$spa_code" != "301" && "$spa_code" != "302" ]]; t
 fi
 ok "SPA $UI_BASE → HTTP $spa_code"
 
+# Prefer Caddy :80 when live — matches remote LAN bookmarks (still loopback
+# secure-context; product.spec also stubs missing randomUUID for the LAN case).
+if [[ -z "${OPENFDD_PLAYWRIGHT_BASE_URL:-}" ]]; then
+  caddy_code="$(http_code_retry --max-time 5 "http://127.0.0.1/" || true)"
+  if [[ "$caddy_code" == "200" || "$caddy_code" == "301" || "$caddy_code" == "302" ]]; then
+    export OPENFDD_PLAYWRIGHT_BASE_URL="http://127.0.0.1"
+    ok "Playwright base → Caddy $OPENFDD_PLAYWRIGHT_BASE_URL"
+  fi
+fi
+# Optional real LAN IP (non-secure context) when bench publishes one.
+if [[ -n "${OPENFDD_LAN_BASE:-}" ]]; then
+  lan_code="$(http_code_retry --max-time 5 "$OPENFDD_LAN_BASE/" || true)"
+  if [[ "$lan_code" == "200" || "$lan_code" == "301" || "$lan_code" == "302" ]]; then
+    export OPENFDD_PLAYWRIGHT_BASE_URL="$OPENFDD_LAN_BASE"
+    ok "Playwright base → LAN $OPENFDD_PLAYWRIGHT_BASE_URL (non-secure context)"
+  else
+    skip "OPENFDD_LAN_BASE=$OPENFDD_LAN_BASE unreachable (HTTP $lan_code) — keeping ${OPENFDD_PLAYWRIGHT_BASE_URL:-$UI_BASE}"
+  fi
+fi
+
 WEB="$ROOT/frontend/web"
 if [[ ! -f "$WEB/package.json" ]]; then
   bad "missing $WEB/package.json"
@@ -43,6 +63,22 @@ if [[ -z "${OPENFDD_ADMIN_PASSWORD:-}" && -f "$ROOT/.env" ]]; then
   # shellcheck source=/dev/null
   source "$ROOT/.env"
   set +a
+fi
+if [[ -z "${OPENFDD_ADMIN_PASSWORD:-}" && -f "$ROOT/workspace/bootstrap_credentials.once.txt" ]]; then
+  OPENFDD_ADMIN_PASSWORD="$(
+    awk -F': *' '/^admin:/{print $2; exit}' "$ROOT/workspace/bootstrap_credentials.once.txt" | tr -d '\r'
+  )"
+  export OPENFDD_ADMIN_PASSWORD
+fi
+
+# Curl-level Caddy /login redirect when Caddy is the Playwright base.
+if [[ "$OPENFDD_PLAYWRIGHT_BASE_URL" == "http://127.0.0.1" || "$OPENFDD_PLAYWRIGHT_BASE_URL" == "http://127.0.0.1/" ]]; then
+  if ! OPENFDD_CADDY_BASE=http://127.0.0.1 "$ROOT/scripts/openfdd_caddy_smoke.sh"; then
+    bad "Caddy smoke failed (/, /api/health, /login→/auth)"
+    summary
+    exit 1
+  fi
+  ok "Caddy smoke (incl. /login redirect)"
 fi
 
 # Pin Playwright image to package.json version when possible.

--- a/scripts/openfdd_caddy_smoke.sh
+++ b/scripts/openfdd_caddy_smoke.sh
@@ -35,4 +35,24 @@ PY
   fi
 fi
 
+# /login must not be a blank SPA — follow redirects to /auth.
+login_hdr="$tmp_dir/login.hdr"
+login_body="$tmp_dir/login.body"
+code_login="$(curl -sS -D "$login_hdr" -o "$login_body" -w '%{http_code}' --max-time 15 "$BASE/login" || echo 000)"
+if [[ "$code_login" == "301" || "$code_login" == "302" ]]; then
+  loc="$(awk 'BEGIN{IGNORECASE=1} /^location:/ {print $2}' "$login_hdr" | tr -d '\r' | tail -1)"
+  echo "OK GET /login → $code_login Location=$loc"
+  if [[ "$loc" != *"/auth"* ]]; then
+    echo "FAIL /login redirect target not /auth: $loc" >&2
+    fail=1
+  fi
+elif [[ "$code_login" == "200" ]]; then
+  # SPA Navigate path: HTML ok but must not be an empty product tree when followed in browser.
+  # Curl-level: ensure we did not get a soft 404; Playwright gate covers DOM.
+  echo "OK GET /login → 200 (SPA; Playwright asserts /auth markers)"
+else
+  echo "FAIL GET /login → HTTP $code_login (expected 302→/auth or 200)" >&2
+  fail=1
+fi
+
 exit "$fail"

--- a/scripts/openfdd_stack_up.sh
+++ b/scripts/openfdd_stack_up.sh
@@ -33,11 +33,12 @@ Recipes:
   react-ot    mqtt + central + React web + fieldbus (OT bench)
 
 Options:
-  --caddy     Also start Caddy on :80 → UI (/api* → central)
+  --caddy     Start Caddy on :80 → UI (/api* → central). Default ON for react/react-ot;
+              use OPENFDD_CADDY=0 to disable. Opt-in for Streamlit recipes.
   --wattlab   Mount WattLab /data + vibe20 PYTHONPATH (compose.wattlab.yml)
 
 Env: OPENFDD_IMAGE_TAG, OPENFDD_*_IMAGE, OPENFDD_JWT_SECRET, OPENFDD_ADMIN_PASSWORD
-     OPENFDD_CADDY=1 (same as --caddy), OPENFDD_CENTRAL_BIND=127.0.0.1 (LAN via Caddy)
+     OPENFDD_CADDY=1|0, OPENFDD_CENTRAL_BIND=127.0.0.1 (LAN via Caddy)
      OPENFDD_WATTLAB=1 (same as --wattlab), OPENFDD_WATTLAB_HOST_WORKSPACE, OPENFDD_WATTLAB_HOST_SRC
 EOF
       exit 0
@@ -47,6 +48,13 @@ EOF
     *) EXTRA+=("$1"); shift ;;
   esac
 done
+
+# React product recipes: Caddy :80 is the default LAN ingress (blank-/login class bugs).
+if [[ "$RECIPE" == "react" || "$RECIPE" == "react-ot" ]]; then
+  if [[ -z "${OPENFDD_CADDY+x}" ]]; then
+    export OPENFDD_CADDY=1
+  fi
+fi
 
 mapfile -t ARGS < <(openfdd_stack_compose_args "$RECIPE")
 [[ ${#ARGS[@]} -ge 2 ]] || { echo "ERROR: no compose files for recipe=$RECIPE" >&2; exit 1; }
@@ -60,6 +68,8 @@ fi
 if [[ "${OPENFDD_CADDY:-0}" == "1" || "${OPENFDD_CADDY:-}" == "true" ]]; then
   if [[ "$RECIPE" == "edge" ]]; then
     echo "WARN: --caddy ignored for edge recipe (no UI)" >&2
+  elif [[ "$RECIPE" == "react" || "$RECIPE" == "react-ot" ]]; then
+    ARGS+=(-f "$ROOT/docker/compose.caddy.react.yml")
   else
     ARGS+=(-f "$ROOT/docker/compose.caddy.yml")
   fi
@@ -94,7 +104,7 @@ if [[ "$RECIPE" != "edge" ]]; then
     echo "Fieldbus: http://127.0.0.1:8081"
   fi
   if [[ "${OPENFDD_CADDY:-0}" == "1" || "${OPENFDD_CADDY:-}" == "true" ]]; then
-    echo "Caddy: http://<host>/  (UI)  http://<host>/api/health  (central)"
+    echo "Caddy: http://<host>/  (UI)  http://<host>/auth  (login)  http://<host>/api/health"
   fi
   if [[ "${OPENFDD_WATTLAB:-0}" == "1" || "${OPENFDD_WATTLAB:-}" == "true" ]]; then
     echo "WattLab: WATTLAB_STUDIO_WORKSPACE=/data (host ${OPENFDD_WATTLAB_HOST_WORKSPACE:-~/wattlab_workspace})"


### PR DESCRIPTION
## Summary
- **Root cause:** `/login` was not a React route → empty `#root` for remote bookmarks; handoff docs pointed at `/login` while product auth lives at `/auth`.
- SPA `Navigate` `/login` → `/auth`; nginx `302 /auth` with `absolute_redirect off` (avoids `:3000` → `:8080` absolute Location bug).
- React/react-ot enable **Caddy on :80 by default** (`compose.caddy.react.yml` → `web:8080`); `OPENFDD_CADDY=0` to disable.
- Playwright product test + caddy smoke assert `/login` is not blank.

## Test plan
- [x] `http://<lan>/login` → `/auth` with auth UI (Playwright)
- [x] `http://<lan>:3000/login` → `/auth` (relative Location)
- [x] `OPENFDD_CADDY_BASE=http://<lan> ./scripts/openfdd_caddy_smoke.sh`
- [ ] Gate 16 + CI green after merge/GHCR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Caddy-based HTTP routing for React deployments, including API proxying, compression, security headers, and protected paths.
  * React recipes now enable Caddy by default, with an option to disable it.
  * Added dedicated UI, login, and API endpoint reporting.

* **Bug Fixes**
  * `/login` now redirects to `/auth` consistently across web and deployment configurations.
  * Improved request ID generation across supported browser environments.

* **Tests**
  * Added end-to-end and smoke-test coverage for login routing and React stack availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->