### PR TITLE
Harden login page for internet-facing hygiene

### DIFF
--- a/frontend/web/src/pages/AuthPage.test.tsx
+++ b/frontend/web/src/pages/AuthPage.test.tsx
@@ -4,7 +4,6 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { AuthPage } from "./AuthPage";
 
 vi.mock("../api/authApi", () => ({
-  getAuthStatus: vi.fn(async () => ({ ok: true, auth_required: true })),
   getAuthMe: vi.fn(async () => {
     throw new Error("unauthorized");
   }),
@@ -27,7 +26,7 @@ describe("AuthPage", () => {
     vi.mocked(getAuthMe).mockRejectedValue(new Error("unauthorized"));
   });
 
-  it("renders oracle sign-in and navigates home after login", async () => {
+  it("renders a clean sign-in form and navigates home after login", async () => {
     render(
       <MemoryRouter initialEntries={["/auth"]}>
         <Routes>
@@ -37,11 +36,14 @@ describe("AuthPage", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("auth-required").textContent).toContain("true");
-      expect(screen.getByTestId("auth-user").textContent).toContain("—");
-    });
+    expect(screen.getByTestId("auth-page")).toBeTruthy();
+    expect(screen.queryByText(/bootstrap_credentials/i)).toBeNull();
+    expect(screen.queryByText(/Auth required/i)).toBeNull();
+    expect(screen.queryByText(/Bench password/i)).toBeNull();
 
+    fireEvent.change(screen.getByTestId("auth-username"), {
+      target: { value: "admin" },
+    });
     fireEvent.change(screen.getByTestId("auth-password"), {
       target: { value: "secret" },
     });

--- a/frontend/web/src/pages/AuthPage.tsx
+++ b/frontend/web/src/pages/AuthPage.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useEffect, useId, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
-import {
-  getAuthMe,
-  getAuthStatus,
-  login,
-  logout,
-  type AuthMe,
-  type AuthStatus,
-} from "../api/authApi";
+import { getAuthMe, login, logout, type AuthMe } from "../api/authApi";
 
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -20,8 +13,11 @@ function safeReturnPath(raw: string | null): string {
 }
 
 /**
- * Dedicated sign-in surface (Streamlit-oracle chrome) — not the app shell.
+ * Dedicated sign-in surface — not the app shell.
  * AuthGate sends unauthenticated users here when central requires JWT.
+ *
+ * Internet-facing rule: no bench credential paths, no auth-config dumps,
+ * no operator handoff hints on this page.
  */
 export function AuthPage() {
   const navigate = useNavigate();
@@ -29,29 +25,19 @@ export function AuthPage() {
   const returnTo = safeReturnPath(searchParams.get("from"));
   const formId = useId();
 
-  const [status, setStatus] = useState<AuthStatus | null>(null);
   const [me, setMe] = useState<AuthMe | null>(null);
-  const [username, setUsername] = useState("admin");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [ready, setReady] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
     try {
-      const st = await getAuthStatus();
-      setStatus(st);
-      try {
-        setMe(await getAuthMe());
-      } catch {
-        setMe(null);
-      }
-    } catch (err) {
-      setError(formatErr(err));
-    } finally {
-      setReady(true);
+      setMe(await getAuthMe());
+    } catch {
+      setMe(null);
     }
   }, []);
 
@@ -95,52 +81,41 @@ export function AuthPage() {
         </h1>
         <p className="auth-screen__lede">
           {signedIn
-            ? "You already have an active central session on this browser."
-            : status?.auth_required
-              ? "Central requires a password before package import and analytics."
-              : "Optional local session token for API calls on this browser."}
+            ? "You have an active session on this browser."
+            : "Enter your username and password to continue."}
         </p>
 
-        <dl className="auth-screen__meta" aria-live="polite">
-          <div>
-            <dt>Auth required</dt>
-            <dd data-testid="auth-required">
-              {!ready || status == null
-                ? "…"
-                : status.auth_required
-                  ? "true"
-                  : "false"}
-            </dd>
-          </div>
-          <div>
-            <dt>User</dt>
-            <dd data-testid="auth-user">{me?.username ?? "—"}</dd>
-          </div>
-          <div>
-            <dt>Role</dt>
-            <dd data-testid="auth-role">{me?.role ?? "—"}</dd>
-          </div>
-        </dl>
-
         {signedIn ? (
-          <div className="auth-screen__actions">
-            <button
-              type="button"
-              className="auth-screen__btn auth-screen__btn--primary"
-              data-testid="auth-continue"
-              onClick={() => navigate(returnTo, { replace: true })}
-            >
-              Continue to app
-            </button>
-            <button
-              type="button"
-              className="auth-screen__btn auth-screen__btn--ghost"
-              data-testid="auth-logout"
-              onClick={onLogout}
-            >
-              Sign out
-            </button>
-          </div>
+          <>
+            <dl className="auth-screen__meta" aria-live="polite">
+              <div>
+                <dt>User</dt>
+                <dd data-testid="auth-user">{me?.username ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Role</dt>
+                <dd data-testid="auth-role">{me?.role ?? "—"}</dd>
+              </div>
+            </dl>
+            <div className="auth-screen__actions">
+              <button
+                type="button"
+                className="auth-screen__btn auth-screen__btn--primary"
+                data-testid="auth-continue"
+                onClick={() => navigate(returnTo, { replace: true })}
+              >
+                Continue to app
+              </button>
+              <button
+                type="button"
+                className="auth-screen__btn auth-screen__btn--ghost"
+                data-testid="auth-logout"
+                onClick={onLogout}
+              >
+                Sign out
+              </button>
+            </div>
+          </>
         ) : (
           <form
             className="auth-screen__form"
@@ -175,38 +150,34 @@ export function AuthPage() {
                 type="submit"
                 className="auth-screen__btn auth-screen__btn--primary"
                 data-testid="auth-login"
-                disabled={busy || !password}
+                disabled={busy || !username.trim() || !password}
               >
                 {busy ? "Signing in…" : "Sign in"}
-              </button>
-              <button
-                type="button"
-                className="auth-screen__btn auth-screen__btn--ghost"
-                data-testid="auth-refresh"
-                onClick={() => void refresh()}
-              >
-                Refresh status
               </button>
             </div>
           </form>
         )}
 
         {error ? (
-          <p className="auth-screen__alert auth-screen__alert--danger" role="alert" data-testid="auth-error">
+          <p
+            className="auth-screen__alert auth-screen__alert--danger"
+            role="alert"
+            data-testid="auth-error"
+          >
             {error}
           </p>
         ) : null}
         {notice ? (
-          <p className="auth-screen__alert auth-screen__alert--ok" data-testid="auth-notice">
+          <p
+            className="auth-screen__alert auth-screen__alert--ok"
+            data-testid="auth-notice"
+          >
             {notice}
           </p>
         ) : null}
 
         <p className="auth-screen__footnote">
-          Bench password handoff:{" "}
-          <code>workspace/bootstrap_credentials.once.txt</code>
-          {" · "}
-          <Link to="/">Overview</Link>
+          <Link to="/">Back to Overview</Link>
         </p>
       </main>
     </div>

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -49,25 +49,26 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 2. Pandas oracle stays forever — cookbooks + vibe19 + PyPI `rules`/`analytics`. Never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
 4. **Product UI:** React SPA (`frontend/web` → `openfdd-web`, `compose.react.yml`) is the **sole production UI** ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md); turnkey cutover). **Do not** reintroduce Streamlit / `openfdd-ui` / overview-oracle as product surfaces. Overview analytics = central `/api/analytics/*` (DataFusion) + client Plotly. Browser → central Rust `/api` only — **no FastAPI / Python product runtime**.
-5. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`), but **pin/run `sha-*`** per [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md). OT stress: [`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md) (`react-ot`).
-6. Playground images: `ghcr.io/bbartling/vibe19:develop`, `vibe20:develop`.
-7. `edge/` and `os/` are future concepts — never delete.
-8. Bounded PRs only — see [`PR_PROTOCOL.md`](PR_PROTOCOL.md).
-9. Migration pattern: inventory → characterization → shared impl → parity → cutover → **delete twin** → regression → docs.
-10. Do not copy code into Open-FDD and leave both implementations active.
-11. Vibe 19 may keep Streamlit UX, custom `CUSTOM-*` rules, demos as **external** companions — not Open-FDD product UI and not canonical rule/analytics twins.
-12. Vibe 20 owns EnergyPlus — keep IDF/sim/orchestration; delete only **generic** ECM twins after parity.
-13. Prefer exact wheel install tests over editable-only validation for packaging PRs.
-14. Never trust a moving GHCR tag alone — resolve/pull immutable `sha-*`, recreate containers, then record the digest.
-15. Append [`SESSION_LOG.md`](SESSION_LOG.md) after non-trivial work.
-16. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) whenever Milestone A **or React/Rust modernization** status changes (not only after merge).
-17. CodeRabbit: fix actionable defects; reject suggestions that violate architecture.
-18. Do not retire playground GHCR without an open-fdd capability parity matrix.
-19. vibe21 = separate plan — not Milestone A.
-20. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
-21. Bound each PR to its declared scope — docs-only PRs do not require cross-repo pin bumps or GHCR refreshes.
-22. **Active program:** [`tools/open-fdd-vibe21-production/`](../tools/open-fdd-vibe21-production/README.md) Master Loop. Modernization Phase 1+2 “exit” is architecture direction only — not P1-G0 of the recovery program. Keep [`capabilities.yaml`](../docs/migration/react-rust/capabilities.yaml) honest; never claim QUALIFIED without evidence.
-23. For `frontend/web` work: follow [`openfdd-streamlit-to-react`](skills/openfdd-streamlit-to-react/SKILL.md) (React-only product maintenance) **and** vibe21 Master Loop / ledger. Forbid unqualified “Phase complete” claims. Keep this `openfdd_agent_spec/` tree honest whenever product truth changes.
+5. **Internet-facing auth/UI hygiene:** Treat `frontend/web` as a product that will be on the public internet. Never put bench/dev secrets, credential file paths (`workspace/bootstrap_credentials.once.txt`), default passwords, JWT/auth-config dumps, or “auth_required=true” operator diagnostics on login or other product surfaces. Ops handoff lives in docs/scripts only — not in the SPA. Generic login errors only (no username enumeration). Do not pre-fill privileged usernames in shipping UI.
+6. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`), but **pin/run `sha-*`** per [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md). OT stress: [`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md) (`react-ot`).
+7. Playground images: `ghcr.io/bbartling/vibe19:develop`, `vibe20:develop`.
+8. `edge/` and `os/` are future concepts — never delete.
+9. Bounded PRs only — see [`PR_PROTOCOL.md`](PR_PROTOCOL.md).
+10. Migration pattern: inventory → characterization → shared impl → parity → cutover → **delete twin** → regression → docs.
+11. Do not copy code into Open-FDD and leave both implementations active.
+12. Vibe 19 may keep Streamlit UX, custom `CUSTOM-*` rules, demos as **external** companions — not Open-FDD product UI and not canonical rule/analytics twins.
+13. Vibe 20 owns EnergyPlus — keep IDF/sim/orchestration; delete only **generic** ECM twins after parity.
+14. Prefer exact wheel install tests over editable-only validation for packaging PRs.
+15. Never trust a moving GHCR tag alone — resolve/pull immutable `sha-*`, recreate containers, then record the digest.
+16. Append [`SESSION_LOG.md`](SESSION_LOG.md) after non-trivial work.
+17. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) whenever Milestone A **or React/Rust modernization** status changes (not only after merge).
+18. CodeRabbit: fix actionable defects; reject suggestions that violate architecture.
+19. Do not retire playground GHCR without an open-fdd capability parity matrix.
+20. vibe21 = separate plan — not Milestone A.
+21. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
+22. Bound each PR to its declared scope — docs-only PRs do not require cross-repo pin bumps or GHCR refreshes.
+23. **Active program:** [`tools/open-fdd-vibe21-production/`](../tools/open-fdd-vibe21-production/README.md) Master Loop. Modernization Phase 1+2 “exit” is architecture direction only — not P1-G0 of the recovery program. Keep [`capabilities.yaml`](../docs/migration/react-rust/capabilities.yaml) honest; never claim QUALIFIED without evidence.
+24. For `frontend/web` work: follow [`openfdd-streamlit-to-react`](skills/openfdd-streamlit-to-react/SKILL.md) (React-only product maintenance) **and** vibe21 Master Loop / ledger. Forbid unqualified “Phase complete” claims. Keep this `openfdd_agent_spec/` tree honest whenever product truth changes.
 
 ---
 

--- a/openfdd_agent_spec/ARCHITECTURE.md
+++ b/openfdd_agent_spec/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Update this file when code truth changes.
 | Surface | Role | Must not |
 | --- | --- | --- |
 | **Open-FDD production** (GHCR stack) | Rust central, Arrow/Feather, DataFusion SQL FDD, JWT REST, React SPA (`openfdd-web`) sole product UI; Overview via `/api/analytics/*` | Silent pandas FDD fallback; reintroduce Streamlit/`openfdd-ui`/overview-oracle as product; claim Vibe 21 Phase 1 complete without `capabilities.yaml` evidence |
-| **React SPA** | Sole production UI → central `/api` only ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)) | FastAPI/Python product sidecar; FDD math in TypeScript; BACnet wire ownership |
+| **React SPA** | Sole production UI → central `/api` only ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)); internet-facing hygiene (no bench credential hints on login) | FastAPI/Python product sidecar; FDD math in TypeScript; BACnet wire ownership; secret/path handoffs in product UI |
 | **Streamlit product UI** | **Removed / cutover in progress** — not a shipping surface; WattLab exporter relocates before tree delete | Be reintroduced as product default without a new ADR |
 | **Vibe 21 program kit** | [`tools/open-fdd-vibe21-production/`](../tools/open-fdd-vibe21-production/) — recovery → twin → Unity ZIP import | Skip Master Loop gates; Unity Editor in production; BAS writes without authority |
 | **Open-FDD PyPI** (`open-fdd`) | Reusable libs: `ecm_engineering`, `rules`, `analytics`, `reporting` | Be the production FDD runtime |

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,11 @@
 # Session log
 
+## 2026-08-05 — Login page internet hygiene
+
+- Removed bench credential path / `auth_required` dumps from `AuthPage`.
+- Agent law: AGENTS.md + React skill — product UI treated as internet-facing;
+  ops handoff only in docs/scripts, never SPA.
+
 ## 2026-08-04 — Streamlit delete + WattLab relocate (cutover)
 
 - Relocated cookbook WattLab exporter → `tools/wattlab_export/`; central shells it (no `services/ui`).

--- a/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
@@ -47,6 +47,9 @@ modernization Phase 2/3 or Vibe 21 Phase 1 recovery.
 - Do not move FDD/analytics math into TypeScript.
 - Do not add a Python API service for the React app.
 - Do not resurrect Streamlit/`openfdd-ui` as product UI.
+- **Internet-facing:** never render bench credential paths, default passwords,
+  JWT/auth dumps, or `auth_required` diagnostics on login/product surfaces.
+  Ops handoff stays in docs/scripts only.
 - Update `capabilities.yaml` statuses honestly in the same PR; never mark
   `QUALIFIED` without evidence paths.
 - Forbid “Phase complete” claims without a qualification manifest / ledger proof.


### PR DESCRIPTION
## Summary
- Remove bench password handoff path, auth_required diagnostics, and privileged username prefill from `AuthPage`.
- Encode internet-facing auth/UI hygiene in `openfdd_agent_spec` (AGENTS, ARCHITECTURE, React skill, SESSION_LOG).

## Test plan
- [x] `npm test -- AuthPage.test.tsx`
- [ ] Sign in at `/auth` — no credential path / Auth required dump
- [ ] Login still works with admin credentials


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined the authentication page into a focused sign-in experience.
  * Added input validation so sign-in requires both a username and password.
  * Simplified the signed-in view with user details and clear continue/sign-out actions.
  * Added a direct link back to the overview.

* **Bug Fixes**
  * Removed internal credential hints and authentication diagnostics from the login page.
  * Updated authentication tests to reflect the streamlined sign-in flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->