### PR TITLE
Fix Overview DataFusion charts (Plotly zoom, building scope, mech cooling proof)

### DIFF
--- a/frontend/web/src/api/centralOverview.test.ts
+++ b/frontend/web/src/api/centralOverview.test.ts
@@ -44,7 +44,19 @@ vi.mock("./analyticsApi", () => ({
       },
     ],
     equipment: [],
-    points: [],
+    points: Array.from({ length: 8 }, (_, i) => ({
+      equipment_id: "AHU_1",
+      timestamp_utc: `2026-07-01T0${i}:00:00Z`,
+      oat_f: 55 + i,
+      rat_f: 72,
+      mat_f: 65 + i * 0.5,
+      damper_fb_pct: 40,
+      delta_or_f: 55 + i - 72,
+      delta_mr_f: 65 + i * 0.5 - 72,
+      mat_resid_f: -1.5,
+      identifiable: true,
+      fan_on: true,
+    })),
     skipped: [],
   })),
   postSchedule: vi.fn(async () => ({
@@ -96,6 +108,15 @@ describe("fetchCentralOverview", () => {
     expect(out.mech_cooling.figure?.data?.length).toBeGreaterThan(0);
     expect(out.economizer_free_cooling.delta_scatter?.meta?.provenance).toMatch(
       /DataFusion/,
+    );
+    expect(out.economizer_free_cooling.delta_scatter?.layout?.title).toMatch(
+      /delta scatter/i,
+    );
+    expect(out.economizer_free_cooling.mat_residual?.data?.length).toBeGreaterThan(
+      0,
+    );
+    expect(out.economizer_free_cooling.temps_overlay?.layout?.title).toMatch(
+      /Free-cooling temps/i,
     );
     expect(out.devices_by_type).toEqual([
       { type: "AHU", count: 1 },

--- a/frontend/web/src/api/centralOverview.ts
+++ b/frontend/web/src/api/centralOverview.ts
@@ -1,6 +1,7 @@
 /**
  * Assemble Overview dashboard payload from central Rust `/api/analytics/*`
- * (DataFusion) + client-side Plotly figures — no Python overview-oracle.
+ * (DataFusion) + client-side Plotly figures — vibe19 Overview chart parity,
+ * no Python/pandas.
  */
 import {
   postBasVsWebOat,
@@ -10,7 +11,12 @@ import {
   postSchedule,
   type AnalyticsEnvelope,
 } from "./analyticsApi";
-import { rowsToBarFigure, type PlotlyFigure } from "./plotDataset";
+import {
+  fingerprintJson,
+  rowsToBarFigure,
+  type PlotlyFigure,
+  type PlotlyTrace,
+} from "./plotDataset";
 import type {
   OverviewPlantFig,
   OverviewVibe19Response,
@@ -50,6 +56,7 @@ function motorFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null 
   });
 }
 
+/** Weekly plant bars + optional avg OAT on y2 (vibe19 motor_weekly_runtime_chart). */
 function weeklyPlantFigures(
   rows: Array<Record<string, unknown>>,
 ): OverviewPlantFig[] {
@@ -63,9 +70,9 @@ function weeklyPlantFigures(
     byPlant.set(g, list);
   }
   const titles: Record<string, string> = {
-    air: "Air handlers / RTUs",
-    boiler: "Boiler plant",
-    chiller: "Chiller / tower plant",
+    air: "Air side — supply fans",
+    boiler: "Boiler plant — HW pumps",
+    chiller: "Chiller plant — chillers, CHW/CW pumps, towers",
   };
   return [...byPlant.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
@@ -73,20 +80,61 @@ function weeklyPlantFigures(
       const sorted = [...plantRows].sort((a, b) =>
         String(a.week_label).localeCompare(String(b.week_label)),
       );
-      const figure = rowsToBarFigure(sorted, {
-        xKey: "week_label",
-        yKeys: ["run_hours"],
-        title: `${titles[plant_group] ?? plant_group} — weekly run hours`,
-        yAxisTitle: "run hours",
-        maxBars: 52,
-        provenance: "POST /api/analytics/runtime (runtime-weekly-v1)",
-      });
+      const x = sorted.map((r) => String(r.week_label ?? ""));
+      const hours = sorted.map((r) => num(r.run_hours));
+      const oat = sorted.map((r) => num(r.avg_oat_f));
+      const hasOat = oat.some((v) => v != null);
+      const data: PlotlyTrace[] = [
+        {
+          type: "bar",
+          name: "run hours",
+          x,
+          y: hours,
+        },
+      ];
+      if (hasOat) {
+        data.push({
+          type: "scatter",
+          mode: "lines+markers",
+          name: "avg OAT",
+          x,
+          y: oat,
+          yaxis: "y2",
+          line: { width: 2 },
+        });
+      }
+      const figure: PlotlyFigure = {
+        data,
+        layout: {
+          title: `${titles[plant_group] ?? plant_group} — weekly run hours`,
+          barmode: "group",
+          showlegend: true,
+          xaxis: { title: "week", tickangle: -35, autorange: true },
+          yaxis: { title: "run hours", autorange: true },
+          ...(hasOat
+            ? {
+                yaxis2: {
+                  title: "avg OAT °F",
+                  overlaying: "y",
+                  side: "right",
+                  autorange: true,
+                },
+              }
+            : {}),
+          margin: { t: 48, r: hasOat ? 56 : 24, b: 96, l: 56 },
+          uirevision: `weekly:${plant_group}:${fingerprintJson(sorted)}`,
+        },
+        meta: {
+          point_count: sorted.length,
+          provenance: "POST /api/analytics/runtime (runtime-weekly-v1)",
+        },
+      };
       return {
         plant_group,
         title: titles[plant_group] ?? plant_group,
         caption: "Central weekly plant bins (DataFusion)",
         figure,
-        empty: !figure,
+        empty: !sorted.length,
       };
     });
 }
@@ -104,7 +152,7 @@ function mechFigure(rows: Array<Record<string, unknown>>): {
       figure: rowsToBarFigure(sorted, {
         xKey: "bin_label",
         yKeys: ["hours"],
-        title: "Mechanical cooling — hours by OAT bin",
+        title: "Mechanical cooling run hours by outdoor-air temperature (5°F bins)",
         yAxisTitle: "hours",
         maxBars: 40,
         provenance: "POST /api/analytics/mechanical-cooling (OAT bins)",
@@ -129,7 +177,197 @@ function mechFigure(rows: Array<Record<string, unknown>>): {
   };
 }
 
-function econFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null {
+/** vibe19 economizer_delta_scatter: (MAT−RAT) vs (OAT−RAT) + OA-fraction refs. */
+function econDeltaScatter(
+  points: Array<Record<string, unknown>>,
+  dtMinF: number,
+): PlotlyFigure | null {
+  const usable = points.filter(
+    (p) =>
+      (p.identifiable === true || p.identifiable === "true") &&
+      num(p.delta_or_f) != null &&
+      num(p.delta_mr_f) != null,
+  );
+  if (usable.length < 5) return null;
+
+  const xs = usable.map((p) => num(p.delta_or_f) as number);
+  const xLo = Math.min(...xs);
+  const xHi = Math.max(...xs);
+  const lo = Number.isFinite(xLo) ? xLo : -20;
+  const hi = Number.isFinite(xHi) ? xHi : 20;
+  const span = hi === lo ? 20 : hi - lo;
+  const refX: number[] = [];
+  for (let i = 0; i <= 40; i++) {
+    refX.push(lo + (span * i) / 40);
+  }
+  const data: PlotlyTrace[] = [];
+  for (const [frac, label] of [
+    [0, "0% OA"],
+    [0.25, "25%"],
+    [0.5, "50%"],
+    [0.75, "75%"],
+    [1, "100% OA"],
+  ] as const) {
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: label,
+      x: refX,
+      y: refX.map((x) => frac * x),
+      line: { width: 1, dash: "dot", color: "#94a3b8" },
+      hoverinfo: "skip",
+      showlegend: true,
+    });
+  }
+
+  const byEq = new Map<string, Array<Record<string, unknown>>>();
+  for (const p of usable) {
+    const eq = String(p.equipment_id || "AHU");
+    const list = byEq.get(eq) ?? [];
+    list.push(p);
+    byEq.set(eq, list);
+  }
+  for (const [eq, rows] of byEq) {
+    data.push({
+      type: "scatter",
+      mode: "markers",
+      name: eq,
+      x: rows.map((r) => num(r.delta_or_f) as number),
+      y: rows.map((r) => num(r.delta_mr_f)),
+      marker: { size: 6, opacity: 0.7 },
+    });
+  }
+
+  return {
+    data,
+    layout: {
+      title: `Economizer free-cooling delta scatter (fan on, |OAT−RAT|≥${dtMinF.toFixed(0)}°F)`,
+      xaxis: { title: "OAT − RAT (°F)", autorange: true },
+      yaxis: { title: "MAT − RAT (°F)", autorange: true },
+      legend: { orientation: "h" },
+      height: 420,
+      uirevision: `econ-delta:${fingerprintJson(usable.slice(0, 200))}`,
+    },
+    meta: {
+      point_count: usable.length,
+      provenance: "POST /api/analytics/economizer (DataFusion points)",
+    },
+  };
+}
+
+/** vibe19 economizer_mat_residual_chart. */
+function econMatResidual(
+  points: Array<Record<string, unknown>>,
+): PlotlyFigure | null {
+  const usable = points.filter(
+    (p) =>
+      (p.identifiable === true || p.identifiable === "true") &&
+      num(p.mat_resid_f) != null,
+  );
+  if (usable.length < 5) return null;
+  const byEq = new Map<string, Array<Record<string, unknown>>>();
+  for (const p of usable) {
+    const eq = String(p.equipment_id || "AHU");
+    const list = byEq.get(eq) ?? [];
+    list.push(p);
+    byEq.set(eq, list);
+  }
+  const data: PlotlyTrace[] = [];
+  for (const [eq, rows] of byEq) {
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: eq,
+      x: rows.map((r) => String(r.timestamp_utc ?? "")),
+      y: rows.map((r) => num(r.mat_resid_f)),
+    });
+  }
+  return {
+    data,
+    layout: {
+      title: "MAT residual (meas − mixing model from OA damper) — fan on, identifiable",
+      xaxis: { title: "time", autorange: true },
+      yaxis: { title: "MAT residual °F", autorange: true },
+      legend: { orientation: "h" },
+      height: 320,
+      uirevision: `econ-mat:${fingerprintJson(usable.slice(0, 200))}`,
+    },
+    meta: {
+      point_count: usable.length,
+      provenance: "POST /api/analytics/economizer (DataFusion points)",
+    },
+  };
+}
+
+/** vibe19 economizer_temps_overlay for one AHU. */
+function econTempsOverlay(
+  points: Array<Record<string, unknown>>,
+  equipmentId: string | null,
+): { figure: PlotlyFigure | null; equipmentId: string | null } {
+  if (!points.length) return { figure: null, equipmentId: null };
+  const eq =
+    equipmentId &&
+    points.some((p) => String(p.equipment_id) === equipmentId)
+      ? equipmentId
+      : String(points[0].equipment_id ?? "");
+  if (!eq) return { figure: null, equipmentId: null };
+  const rows = points.filter((p) => String(p.equipment_id) === eq);
+  if (rows.length < 3) return { figure: null, equipmentId: eq };
+  const x = rows.map((r) => String(r.timestamp_utc ?? ""));
+  const data: PlotlyTrace[] = [
+    { type: "scatter", mode: "lines", name: "OAT", x, y: rows.map((r) => num(r.oat_f)) },
+    { type: "scatter", mode: "lines", name: "RAT", x, y: rows.map((r) => num(r.rat_f)) },
+    { type: "scatter", mode: "lines", name: "MAT", x, y: rows.map((r) => num(r.mat_f)) },
+  ];
+  if (rows.some((r) => num(r.sat_f) != null)) {
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: "SAT",
+      x,
+      y: rows.map((r) => num(r.sat_f)),
+    });
+  }
+  if (rows.some((r) => num(r.damper_fb_pct) != null)) {
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: "OA damper %",
+      x,
+      y: rows.map((r) => num(r.damper_fb_pct)),
+      yaxis: "y2",
+    });
+  }
+  return {
+    equipmentId: eq,
+    figure: {
+      data,
+      layout: {
+        title: `Free-cooling temps + OA damper (fan on) — ${eq}`,
+        xaxis: { title: "time", autorange: true },
+        yaxis: { title: "°F", autorange: true },
+        yaxis2: {
+          title: "damper %",
+          overlaying: "y",
+          side: "right",
+          range: [0, 100],
+          autorange: false,
+        },
+        legend: { orientation: "h" },
+        height: 360,
+        uirevision: `econ-temps:${eq}:${fingerprintJson(rows.slice(0, 100))}`,
+      },
+      meta: {
+        equipment_id: eq,
+        point_count: rows.length,
+        provenance: "POST /api/analytics/economizer (DataFusion points)",
+      },
+    },
+  };
+}
+
+/** Fallback bars when historian has counts but not yet plot points (old central). */
+function econCountsFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null {
   const usable = rows.filter(
     (r) => num(r.n_fan_on_samples) != null || num(r.n_identifiable) != null,
   );
@@ -164,35 +402,67 @@ function scheduleFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | nu
   });
 }
 
-function basOverlay(points: Array<Record<string, unknown>>): PlotlyFigure | null {
+/** vibe19 bas_vs_web_oat_overlay with ±oat_err band. */
+function basOverlay(
+  points: Array<Record<string, unknown>>,
+  oatErr: number,
+): PlotlyFigure | null {
   if (!points.length) return null;
   const x = points.map((p) => String(p.timestamp_utc ?? ""));
   const bas = points.map((p) => num(p.bas_oat_f));
   const web = points.map((p) => num(p.web_oat_f));
-  return {
-    data: [
-      {
-        type: "scatter",
-        mode: "lines",
-        name: "BAS oa_t",
-        x,
-        y: bas,
-      },
-      {
-        type: "scatter",
-        mode: "lines",
-        name: "Web OAT",
-        x,
-        y: web,
-      },
-    ],
-    layout: {
-      title: "BAS vs web OAT",
-      xaxis: { title: "time" },
-      yaxis: { title: "°F" },
-      legend: { orientation: "h" },
+  const hi = web.map((v) => (v == null ? null : v + oatErr));
+  const lo = web.map((v) => (v == null ? null : v - oatErr));
+  const data: PlotlyTrace[] = [
+    {
+      type: "scatter",
+      mode: "lines",
+      name: `web +${oatErr}°F`,
+      x,
+      y: hi,
+      line: { width: 0 },
+      showlegend: false,
     },
-    meta: { provenance: "POST /api/analytics/bas-vs-web-oat" },
+    {
+      type: "scatter",
+      mode: "lines",
+      name: `±${oatErr}°F band`,
+      x,
+      y: lo,
+      fill: "tonexty",
+      fillcolor: "rgba(148, 163, 184, 0.25)",
+      line: { width: 0 },
+    },
+    {
+      type: "scatter",
+      mode: "lines",
+      name: "Web OAT",
+      x,
+      y: web,
+      line: { width: 2 },
+    },
+    {
+      type: "scatter",
+      mode: "lines",
+      name: "BAS oa_t",
+      x,
+      y: bas,
+      line: { width: 2 },
+    },
+  ];
+  return {
+    data,
+    layout: {
+      title: `BAS vs web outdoor-air temperature (±${oatErr}°F band)`,
+      xaxis: { title: "time", autorange: true },
+      yaxis: { title: "°F", autorange: true },
+      legend: { orientation: "h" },
+      uirevision: `bas-overlay:${fingerprintJson(points.slice(0, 100))}`,
+    },
+    meta: {
+      point_count: points.length,
+      provenance: "POST /api/analytics/bas-vs-web-oat",
+    },
   };
 }
 
@@ -210,7 +480,7 @@ function basHist(rows: Array<Record<string, unknown>>): PlotlyFigure | null {
     {
       xKey: "bin_label",
       yKeys: ["count"],
-      title: "BAS − web OAT (°F) histogram",
+      title: "BAS vs web outdoor-air temperature deviation (°F)",
       yAxisTitle: "count",
       maxBars: 60,
       provenance: "POST /api/analytics/bas-vs-web-oat",
@@ -227,10 +497,15 @@ function warnCaption(env: AnalyticsEnvelope, fallback: string): string {
 export async function fetchCentralOverview(opts: {
   building_id: string;
   equipment?: Array<{ equipment_id: string; equipment_type?: string }>;
+  econ_overlay_equipment_id?: string | null;
+  oat_err?: number;
+  dt_min_f?: number;
 }): Promise<OverviewVibe19Response> {
   const t0 = performance.now();
   const building_id = opts.building_id;
-  const body = { building_id };
+  const oatErr = opts.oat_err ?? 5;
+  const dtMin = opts.dt_min_f ?? 10;
+  const body = { building_id, max_points: 4000, dt_min_f: dtMin };
 
   const [runtime, mech, econ, schedule, bas] = await Promise.all([
     postRuntime(body),
@@ -246,6 +521,7 @@ export async function fetchCentralOverview(opts: {
   const mechRows = mech.rows?.length ? mech.rows : mech.equipment;
   const econRows = econ.rows?.length ? econ.rows : econ.equipment;
   const scheduleRows = schedule.rows?.length ? schedule.rows : schedule.equipment;
+  const econPoints = econ.points ?? [];
 
   const equipmentIds = [
     ...new Set(
@@ -286,10 +562,15 @@ export async function fetchCentralOverview(opts: {
         : [];
 
   const { figure: mechFig, bins: mechBins } = mechFigure(mechRows);
-  const econFig = econFigure(econRows);
+  const deltaScatter = econDeltaScatter(econPoints, dtMin);
+  const matResidual = econMatResidual(econPoints);
+  const { figure: tempsOverlay, equipmentId: overlayEq } = econTempsOverlay(
+    econPoints,
+    opts.econ_overlay_equipment_id ?? null,
+  );
   const schedFig = scheduleFigure(scheduleRows);
   const basPoints = bas.points ?? [];
-  const basOverlayFig = basOverlay(basPoints);
+  const basOverlayFig = basOverlay(basPoints, oatErr);
   const basHistFig = basHist(bas.rows ?? []);
 
   const elapsed_s = Math.round(((performance.now() - t0) / 1000) * 10) / 10;
@@ -332,20 +613,23 @@ export async function fetchCentralOverview(opts: {
     },
     economizer_weather: {
       caption:
-        "Economizer weather-opportunity table is not in central yet — free-cooling sample counts below.",
+        "Economizer weather-opportunity (dewpoint hours) needs web dewpoint on historian — not yet wired in central DataFusion.",
       table: [],
     },
     economizer_free_cooling: {
       caption: warnCaption(
         econ,
-        "Economizer diagnostics from DataFusion (MAT residual / scatter need richer series)",
+        econPoints.length
+          ? "Economizer free-cooling plots from DataFusion historian points"
+          : "Economizer sample counts from DataFusion (plot points unavailable)",
       ),
       metrics: econRows.slice(0, 200),
-      delta_scatter: econFig,
-      mat_residual: null,
-      temps_overlay: schedFig,
-      overlay_equipment_id: null,
+      delta_scatter: deltaScatter ?? econCountsFigure(econRows),
+      mat_residual: matResidual,
+      temps_overlay: tempsOverlay ?? schedFig,
+      overlay_equipment_id: overlayEq,
       skipped: [],
+      dt_min_f: dtMin,
     },
     bas_vs_web_oat: {
       caption: warnCaption(
@@ -356,7 +640,7 @@ export async function fetchCentralOverview(opts: {
       ),
       overlay: basOverlayFig,
       histogram: basHistFig,
-      oat_err: 5,
+      oat_err: oatErr,
     },
     devices_by_type: devices,
   };

--- a/frontend/web/src/api/plotDataset.ts
+++ b/frontend/web/src/api/plotDataset.ts
@@ -130,13 +130,24 @@ export function rowsToBarFigure(
       xaxis: { title: opts.xKey, tickangle: -35, autorange: true },
       yaxis: { title: opts.yAxisTitle ?? "hours", autorange: true },
       margin: { t: 48, r: 24, b: 96, l: 56 },
-      uirevision: `${opts.title}:${opts.xKey}:${sorted.length}`,
+      uirevision: `${opts.title}:${opts.xKey}:${fingerprintJson(sorted)}`,
     },
     meta: {
       point_count: sorted.length,
       provenance: opts.provenance,
     },
   };
+}
+
+/** Short FNV-1a of JSON so Plotly `uirevision` resets when values change. */
+export function fingerprintJson(value: unknown): string {
+  const s = JSON.stringify(value) ?? "";
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h.toString(36);
 }
 
 /** Filter runtime rows into plant families (vibe19 Air / Heating / Cooling). */

--- a/frontend/web/src/api/plotDataset.ts
+++ b/frontend/web/src/api/plotDataset.ts
@@ -127,9 +127,10 @@ export function rowsToBarFigure(
       title: opts.title,
       barmode: opts.barmode ?? "group",
       showlegend: opts.yKeys.length > 1,
-      xaxis: { title: opts.xKey, tickangle: -35 },
-      yaxis: { title: opts.yAxisTitle ?? "hours" },
+      xaxis: { title: opts.xKey, tickangle: -35, autorange: true },
+      yaxis: { title: opts.yAxisTitle ?? "hours", autorange: true },
       margin: { t: 48, r: 24, b: 96, l: 56 },
+      uirevision: `${opts.title}:${opts.xKey}:${sorted.length}`,
     },
     meta: {
       point_count: sorted.length,

--- a/frontend/web/src/components/OverviewPopulated.tsx
+++ b/frontend/web/src/components/OverviewPopulated.tsx
@@ -254,6 +254,7 @@ export function OverviewPopulated({
       const body = await fetchCentralOverview({
         building_id: buildingId,
         equipment,
+        econ_overlay_equipment_id: econOverlayEq || null,
       });
       if (!body.ok) {
         throw new Error(body.error || "Central analytics failed");
@@ -274,7 +275,7 @@ export function OverviewPopulated({
       setLoadingOverview(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [buildingId, equipment]);
+  }, [buildingId, equipment, econOverlayEq]);
 
   const refreshInspect = useCallback(async () => {
     if (!buildingId || !inspectPick || inspectPick === "(weather)") return;

--- a/frontend/web/src/components/widgets/PlotlyHost.test.tsx
+++ b/frontend/web/src/components/widgets/PlotlyHost.test.tsx
@@ -75,10 +75,46 @@ describe("PlotlyHost", () => {
     });
     const call = (react.mock.calls[0] ?? newPlot.mock.calls[0]) as unknown[];
     expect(call[1]).toEqual(figure.data);
-    expect((call[2] as { template?: unknown }).template).toBeUndefined();
+    const layout = call[2] as {
+      template?: unknown;
+      uirevision?: string;
+      xaxis?: { autorange?: boolean };
+      yaxis?: { autorange?: boolean };
+    };
+    expect(layout.template).toBeUndefined();
+    expect(layout.xaxis?.autorange).toBe(true);
+    expect(layout.yaxis?.autorange).toBe(true);
+    expect(layout.uirevision).toBeTruthy();
     await waitFor(() => {
       expect(getByTestId("plotly-meta-motor").textContent).toMatch(/rendered/);
     });
+
+    // Second figure must bump uirevision so sticky zoom resets.
+    react.mockClear();
+    newPlot.mockClear();
+    rerender(
+      <PlotlyHost
+        id="motor"
+        label="Motor"
+        figure={{
+          ...figure,
+          data: [{ x: ["2026-01-08"], y: [42], type: "bar", name: "AHU" }],
+          meta: { provenance: "runtime-v2", point_count: 1 },
+        }}
+        loading={false}
+        height={300}
+        testId="overview-motor-air-plot"
+      />,
+    );
+    await waitFor(() => {
+      expect(react.mock.calls.length + newPlot.mock.calls.length).toBeGreaterThan(
+        0,
+      );
+    });
+    const call2 = (react.mock.calls[0] ?? newPlot.mock.calls[0]) as unknown[];
+    const layout2 = call2[2] as { uirevision?: string };
+    expect(layout2.uirevision).toBeTruthy();
+    expect(layout2.uirevision).not.toEqual(layout.uirevision);
   });
 
   it("cancels Plotly wait timers on unmount so vitest teardown stays clean", async () => {

--- a/frontend/web/src/components/widgets/PlotlyHost.test.tsx
+++ b/frontend/web/src/components/widgets/PlotlyHost.test.tsx
@@ -89,7 +89,7 @@ describe("PlotlyHost", () => {
       expect(getByTestId("plotly-meta-motor").textContent).toMatch(/rendered/);
     });
 
-    // Second figure must bump uirevision so sticky zoom resets.
+    // Same cardinality / provenance, different values — must bump uirevision.
     react.mockClear();
     newPlot.mockClear();
     rerender(
@@ -98,8 +98,8 @@ describe("PlotlyHost", () => {
         label="Motor"
         figure={{
           ...figure,
-          data: [{ x: ["2026-01-08"], y: [42], type: "bar", name: "AHU" }],
-          meta: { provenance: "runtime-v2", point_count: 1 },
+          data: [{ x: ["2026-01-01"], y: [99], type: "bar", name: "AHU" }],
+          meta: { provenance: "runtime-v1", point_count: 1 },
         }}
         loading={false}
         height={300}

--- a/frontend/web/src/components/widgets/PlotlyHost.tsx
+++ b/frontend/web/src/components/widgets/PlotlyHost.tsx
@@ -139,12 +139,27 @@ export function PlotlyHost({
         }
         return;
       }
+      const baseLayout = (clean.layout as Record<string, unknown> | undefined) ?? {};
+      const axisPatch = (key: string) => {
+        const prev = (baseLayout[key] as Record<string, unknown> | undefined) ?? {};
+        return { ...prev, autorange: true };
+      };
+      // Fingerprint figure so Plotly.react resets sticky zoom after Update analytics.
+      const uirevision =
+        (baseLayout.uirevision as string | undefined) ??
+        `${figureId ?? id}:${JSON.stringify(clean.data).length}:${clean.meta?.provenance ?? ""}:${clean.meta?.point_count ?? clean.data.length}`;
       const layout: Record<string, unknown> = {
         paper_bgcolor: "rgba(0,0,0,0)",
         plot_bgcolor: "rgba(0,0,0,0)",
         font: { family: "Source Sans 3, Source Sans, sans-serif", size: 12 },
-        ...(clean.layout as object),
-        height: (clean.layout as { height?: number } | undefined)?.height ?? height,
+        ...baseLayout,
+        xaxis: axisPatch("xaxis"),
+        yaxis: axisPatch("yaxis"),
+        ...(baseLayout.yaxis2 != null || clean.data.some((t) => t.yaxis === "y2")
+          ? { yaxis2: axisPatch("yaxis2") }
+          : {}),
+        uirevision,
+        height: (baseLayout.height as number | undefined) ?? height,
         autosize: true,
       };
       delete layout.template;

--- a/frontend/web/src/components/widgets/PlotlyHost.tsx
+++ b/frontend/web/src/components/widgets/PlotlyHost.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { WidgetBaseProps } from "./types";
 import { widgetTestId } from "./types";
 import type { PlotlyFigure } from "../../api/plotDataset";
+import { fingerprintJson } from "../../api/plotDataset";
 import { sanitizePlotlyFigure } from "../../api/plotlySanitize";
 
 export interface PlotlyHostProps extends Omit<WidgetBaseProps, "label"> {
@@ -147,7 +148,7 @@ export function PlotlyHost({
       // Fingerprint figure so Plotly.react resets sticky zoom after Update analytics.
       const uirevision =
         (baseLayout.uirevision as string | undefined) ??
-        `${figureId ?? id}:${JSON.stringify(clean.data).length}:${clean.meta?.provenance ?? ""}:${clean.meta?.point_count ?? clean.data.length}`;
+        `${figureId ?? id}:${fingerprintJson(clean.data)}:${clean.meta?.provenance ?? ""}`;
       const layout: Record<string, unknown> = {
         paper_bgcolor: "rgba(0,0,0,0)",
         plot_bgcolor: "rgba(0,0,0,0)",

--- a/frontend/web/src/pages/AuthPage.test.tsx
+++ b/frontend/web/src/pages/AuthPage.test.tsx
@@ -4,7 +4,6 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { AuthPage } from "./AuthPage";
 
 vi.mock("../api/authApi", () => ({
-  getAuthStatus: vi.fn(async () => ({ ok: true, auth_required: true })),
   getAuthMe: vi.fn(async () => {
     throw new Error("unauthorized");
   }),
@@ -27,7 +26,7 @@ describe("AuthPage", () => {
     vi.mocked(getAuthMe).mockRejectedValue(new Error("unauthorized"));
   });
 
-  it("renders oracle sign-in and navigates home after login", async () => {
+  it("renders a clean sign-in form and navigates home after login", async () => {
     render(
       <MemoryRouter initialEntries={["/auth"]}>
         <Routes>
@@ -37,11 +36,14 @@ describe("AuthPage", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("auth-required").textContent).toContain("true");
-      expect(screen.getByTestId("auth-user").textContent).toContain("—");
-    });
+    expect(screen.getByTestId("auth-page")).toBeTruthy();
+    expect(screen.queryByText(/bootstrap_credentials/i)).toBeNull();
+    expect(screen.queryByText(/Auth required/i)).toBeNull();
+    expect(screen.queryByText(/Bench password/i)).toBeNull();
 
+    fireEvent.change(screen.getByTestId("auth-username"), {
+      target: { value: "admin" },
+    });
     fireEvent.change(screen.getByTestId("auth-password"), {
       target: { value: "secret" },
     });

--- a/frontend/web/src/pages/AuthPage.tsx
+++ b/frontend/web/src/pages/AuthPage.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useEffect, useId, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
-import {
-  getAuthMe,
-  getAuthStatus,
-  login,
-  logout,
-  type AuthMe,
-  type AuthStatus,
-} from "../api/authApi";
+import { getAuthMe, login, logout, type AuthMe } from "../api/authApi";
 
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -20,8 +13,11 @@ function safeReturnPath(raw: string | null): string {
 }
 
 /**
- * Dedicated sign-in surface (Streamlit-oracle chrome) — not the app shell.
+ * Dedicated sign-in surface — not the app shell.
  * AuthGate sends unauthenticated users here when central requires JWT.
+ *
+ * Internet-facing rule: no bench credential paths, no auth-config dumps,
+ * no operator handoff hints on this page.
  */
 export function AuthPage() {
   const navigate = useNavigate();
@@ -29,29 +25,19 @@ export function AuthPage() {
   const returnTo = safeReturnPath(searchParams.get("from"));
   const formId = useId();
 
-  const [status, setStatus] = useState<AuthStatus | null>(null);
   const [me, setMe] = useState<AuthMe | null>(null);
-  const [username, setUsername] = useState("admin");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [ready, setReady] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
     try {
-      const st = await getAuthStatus();
-      setStatus(st);
-      try {
-        setMe(await getAuthMe());
-      } catch {
-        setMe(null);
-      }
-    } catch (err) {
-      setError(formatErr(err));
-    } finally {
-      setReady(true);
+      setMe(await getAuthMe());
+    } catch {
+      setMe(null);
     }
   }, []);
 
@@ -95,52 +81,41 @@ export function AuthPage() {
         </h1>
         <p className="auth-screen__lede">
           {signedIn
-            ? "You already have an active central session on this browser."
-            : status?.auth_required
-              ? "Central requires a password before package import and analytics."
-              : "Optional local session token for API calls on this browser."}
+            ? "You have an active session on this browser."
+            : "Enter your username and password to continue."}
         </p>
 
-        <dl className="auth-screen__meta" aria-live="polite">
-          <div>
-            <dt>Auth required</dt>
-            <dd data-testid="auth-required">
-              {!ready || status == null
-                ? "…"
-                : status.auth_required
-                  ? "true"
-                  : "false"}
-            </dd>
-          </div>
-          <div>
-            <dt>User</dt>
-            <dd data-testid="auth-user">{me?.username ?? "—"}</dd>
-          </div>
-          <div>
-            <dt>Role</dt>
-            <dd data-testid="auth-role">{me?.role ?? "—"}</dd>
-          </div>
-        </dl>
-
         {signedIn ? (
-          <div className="auth-screen__actions">
-            <button
-              type="button"
-              className="auth-screen__btn auth-screen__btn--primary"
-              data-testid="auth-continue"
-              onClick={() => navigate(returnTo, { replace: true })}
-            >
-              Continue to app
-            </button>
-            <button
-              type="button"
-              className="auth-screen__btn auth-screen__btn--ghost"
-              data-testid="auth-logout"
-              onClick={onLogout}
-            >
-              Sign out
-            </button>
-          </div>
+          <>
+            <dl className="auth-screen__meta" aria-live="polite">
+              <div>
+                <dt>User</dt>
+                <dd data-testid="auth-user">{me?.username ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Role</dt>
+                <dd data-testid="auth-role">{me?.role ?? "—"}</dd>
+              </div>
+            </dl>
+            <div className="auth-screen__actions">
+              <button
+                type="button"
+                className="auth-screen__btn auth-screen__btn--primary"
+                data-testid="auth-continue"
+                onClick={() => navigate(returnTo, { replace: true })}
+              >
+                Continue to app
+              </button>
+              <button
+                type="button"
+                className="auth-screen__btn auth-screen__btn--ghost"
+                data-testid="auth-logout"
+                onClick={onLogout}
+              >
+                Sign out
+              </button>
+            </div>
+          </>
         ) : (
           <form
             className="auth-screen__form"
@@ -175,38 +150,34 @@ export function AuthPage() {
                 type="submit"
                 className="auth-screen__btn auth-screen__btn--primary"
                 data-testid="auth-login"
-                disabled={busy || !password}
+                disabled={busy || !username.trim() || !password}
               >
                 {busy ? "Signing in…" : "Sign in"}
-              </button>
-              <button
-                type="button"
-                className="auth-screen__btn auth-screen__btn--ghost"
-                data-testid="auth-refresh"
-                onClick={() => void refresh()}
-              >
-                Refresh status
               </button>
             </div>
           </form>
         )}
 
         {error ? (
-          <p className="auth-screen__alert auth-screen__alert--danger" role="alert" data-testid="auth-error">
+          <p
+            className="auth-screen__alert auth-screen__alert--danger"
+            role="alert"
+            data-testid="auth-error"
+          >
             {error}
           </p>
         ) : null}
         {notice ? (
-          <p className="auth-screen__alert auth-screen__alert--ok" data-testid="auth-notice">
+          <p
+            className="auth-screen__alert auth-screen__alert--ok"
+            data-testid="auth-notice"
+          >
             {notice}
           </p>
         ) : null}
 
         <p className="auth-screen__footnote">
-          Bench password handoff:{" "}
-          <code>workspace/bootstrap_credentials.once.txt</code>
-          {" · "}
-          <Link to="/">Overview</Link>
+          <Link to="/">Back to Overview</Link>
         </p>
       </main>
     </div>

--- a/frontend/web/src/pages/RcxPage.tsx
+++ b/frontend/web/src/pages/RcxPage.tsx
@@ -21,10 +21,10 @@ import {
 import { rowsToBarFigure, type PlotlyFigure } from "../api/plotDataset";
 
 const PRESETS = [
-  { value: "ahu", label: "AHU" },
-  { value: "vav", label: "VAV" },
-  { value: "chiller", label: "Chiller" },
-  { value: "boiler", label: "Boiler" },
+  { value: "ahu", label: "AHU — SAT reset / DAT / MAT / RAT / dampers / fans" },
+  { value: "vav", label: "Zones — comfort / space temps / VAV airflow" },
+  { value: "chiller", label: "Chiller / tower — leave temp vs OAT, CHW/CW temps" },
+  { value: "boiler", label: "Boiler / HW — leave temp vs OAT" },
 ] as const;
 
 function formatErr(err: unknown): string {
@@ -111,7 +111,7 @@ export function RcxPage() {
   return (
     <AppShell
       title="RCx Plots"
-      caption="Retro-commissioning analytics — AHU / VAV / chiller / boiler presets"
+      caption="Retro-commissioning analytics — vibe19 RCx family presets via central DataFusion (rcx/ahu|vav|chiller|boiler). Full timeseries/scatter/box presets land as historian points grow."
       activeSectionId="rcx-plots"
     >
       <div className="page-stack" data-testid="rcx-page">

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -49,25 +49,26 @@ Do **not** rename `open_fdd.rules` → `open_fdd.oracle` without an explicit pro
 2. Pandas oracle stays forever — cookbooks + vibe19 + PyPI `rules`/`analytics`. Never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
 4. **Product UI:** React SPA (`frontend/web` → `openfdd-web`, `compose.react.yml`) is the **sole production UI** ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md); turnkey cutover). **Do not** reintroduce Streamlit / `openfdd-ui` / overview-oracle as product surfaces. Overview analytics = central `/api/analytics/*` (DataFusion) + client Plotly. Browser → central Rust `/api` only — **no FastAPI / Python product runtime**.
-5. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`), but **pin/run `sha-*`** per [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md). OT stress: [`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md) (`react-ot`).
-6. Playground images: `ghcr.io/bbartling/vibe19:develop`, `vibe20:develop`.
-7. `edge/` and `os/` are future concepts — never delete.
-8. Bounded PRs only — see [`PR_PROTOCOL.md`](PR_PROTOCOL.md).
-9. Migration pattern: inventory → characterization → shared impl → parity → cutover → **delete twin** → regression → docs.
-10. Do not copy code into Open-FDD and leave both implementations active.
-11. Vibe 19 may keep Streamlit UX, custom `CUSTOM-*` rules, demos as **external** companions — not Open-FDD product UI and not canonical rule/analytics twins.
-12. Vibe 20 owns EnergyPlus — keep IDF/sim/orchestration; delete only **generic** ECM twins after parity.
-13. Prefer exact wheel install tests over editable-only validation for packaging PRs.
-14. Never trust a moving GHCR tag alone — resolve/pull immutable `sha-*`, recreate containers, then record the digest.
-15. Append [`SESSION_LOG.md`](SESSION_LOG.md) after non-trivial work.
-16. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) whenever Milestone A **or React/Rust modernization** status changes (not only after merge).
-17. CodeRabbit: fix actionable defects; reject suggestions that violate architecture.
-18. Do not retire playground GHCR without an open-fdd capability parity matrix.
-19. vibe21 = separate plan — not Milestone A.
-20. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
-21. Bound each PR to its declared scope — docs-only PRs do not require cross-repo pin bumps or GHCR refreshes.
-22. **Active program:** [`tools/open-fdd-vibe21-production/`](../tools/open-fdd-vibe21-production/README.md) Master Loop. Modernization Phase 1+2 “exit” is architecture direction only — not P1-G0 of the recovery program. Keep [`capabilities.yaml`](../docs/migration/react-rust/capabilities.yaml) honest; never claim QUALIFIED without evidence.
-23. For `frontend/web` work: follow [`openfdd-streamlit-to-react`](skills/openfdd-streamlit-to-react/SKILL.md) (React-only product maintenance) **and** vibe21 Master Loop / ledger. Forbid unqualified “Phase complete” claims. Keep this `openfdd_agent_spec/` tree honest whenever product truth changes.
+5. **Internet-facing auth/UI hygiene:** Treat `frontend/web` as a product that will be on the public internet. Never put bench/dev secrets, credential file paths (`workspace/bootstrap_credentials.once.txt`), default passwords, JWT/auth-config dumps, or “auth_required=true” operator diagnostics on login or other product surfaces. Ops handoff lives in docs/scripts only — not in the SPA. Generic login errors only (no username enumeration). Do not pre-fill privileged usernames in shipping UI.
+6. Test open-fdd containers on **`OPENFDD_IMAGE_TAG=nightly`** (master retargets `:nightly`), but **pin/run `sha-*`** per [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md). OT stress: [`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md) (`react-ot`).
+7. Playground images: `ghcr.io/bbartling/vibe19:develop`, `vibe20:develop`.
+8. `edge/` and `os/` are future concepts — never delete.
+9. Bounded PRs only — see [`PR_PROTOCOL.md`](PR_PROTOCOL.md).
+10. Migration pattern: inventory → characterization → shared impl → parity → cutover → **delete twin** → regression → docs.
+11. Do not copy code into Open-FDD and leave both implementations active.
+12. Vibe 19 may keep Streamlit UX, custom `CUSTOM-*` rules, demos as **external** companions — not Open-FDD product UI and not canonical rule/analytics twins.
+13. Vibe 20 owns EnergyPlus — keep IDF/sim/orchestration; delete only **generic** ECM twins after parity.
+14. Prefer exact wheel install tests over editable-only validation for packaging PRs.
+15. Never trust a moving GHCR tag alone — resolve/pull immutable `sha-*`, recreate containers, then record the digest.
+16. Append [`SESSION_LOG.md`](SESSION_LOG.md) after non-trivial work.
+17. Update [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md) whenever Milestone A **or React/Rust modernization** status changes (not only after merge).
+18. CodeRabbit: fix actionable defects; reject suggestions that violate architecture.
+19. Do not retire playground GHCR without an open-fdd capability parity matrix.
+20. vibe21 = separate plan — not Milestone A.
+21. When blocked (secrets, permissions, private data), finish non-blocked work and record the exact error.
+22. Bound each PR to its declared scope — docs-only PRs do not require cross-repo pin bumps or GHCR refreshes.
+23. **Active program:** [`tools/open-fdd-vibe21-production/`](../tools/open-fdd-vibe21-production/README.md) Master Loop. Modernization Phase 1+2 “exit” is architecture direction only — not P1-G0 of the recovery program. Keep [`capabilities.yaml`](../docs/migration/react-rust/capabilities.yaml) honest; never claim QUALIFIED without evidence.
+24. For `frontend/web` work: follow [`openfdd-streamlit-to-react`](skills/openfdd-streamlit-to-react/SKILL.md) (React-only product maintenance) **and** vibe21 Master Loop / ledger. Forbid unqualified “Phase complete” claims. Keep this `openfdd_agent_spec/` tree honest whenever product truth changes.
 
 ---
 

--- a/openfdd_agent_spec/ARCHITECTURE.md
+++ b/openfdd_agent_spec/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Update this file when code truth changes.
 | Surface | Role | Must not |
 | --- | --- | --- |
 | **Open-FDD production** (GHCR stack) | Rust central, Arrow/Feather, DataFusion SQL FDD, JWT REST, React SPA (`openfdd-web`) sole product UI; Overview via `/api/analytics/*` | Silent pandas FDD fallback; reintroduce Streamlit/`openfdd-ui`/overview-oracle as product; claim Vibe 21 Phase 1 complete without `capabilities.yaml` evidence |
-| **React SPA** | Sole production UI → central `/api` only ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)) | FastAPI/Python product sidecar; FDD math in TypeScript; BACnet wire ownership |
+| **React SPA** | Sole production UI → central `/api` only ([ADR-001](../docs/architecture/adr-001-react-rust-modernization.md)); internet-facing hygiene (no bench credential hints on login) | FastAPI/Python product sidecar; FDD math in TypeScript; BACnet wire ownership; secret/path handoffs in product UI |
 | **Streamlit product UI** | **Removed / cutover in progress** — not a shipping surface; WattLab exporter relocates before tree delete | Be reintroduced as product default without a new ADR |
 | **Vibe 21 program kit** | [`tools/open-fdd-vibe21-production/`](../tools/open-fdd-vibe21-production/) — recovery → twin → Unity ZIP import | Skip Master Loop gates; Unity Editor in production; BAS writes without authority |
 | **Open-FDD PyPI** (`open-fdd`) | Reusable libs: `ecm_engineering`, `rules`, `analytics`, `reporting` | Be the production FDD runtime |

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,11 @@
 # Session log
 
+## 2026-08-05 — Login page internet hygiene
+
+- Removed bench credential path / `auth_required` dumps from `AuthPage`.
+- Agent law: AGENTS.md + React skill — product UI treated as internet-facing;
+  ops handoff only in docs/scripts, never SPA.
+
 ## 2026-08-04 — Streamlit delete + WattLab relocate (cutover)
 
 - Relocated cookbook WattLab exporter → `tools/wattlab_export/`; central shells it (no `services/ui`).

--- a/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-streamlit-to-react/SKILL.md
@@ -47,6 +47,9 @@ modernization Phase 2/3 or Vibe 21 Phase 1 recovery.
 - Do not move FDD/analytics math into TypeScript.
 - Do not add a Python API service for the React app.
 - Do not resurrect Streamlit/`openfdd-ui` as product UI.
+- **Internet-facing:** never render bench credential paths, default passwords,
+  JWT/auth dumps, or `auth_required` diagnostics on login/product surfaces.
+  Ops handoff stays in docs/scripts only.
 - Update `capabilities.yaml` statuses honestly in the same PR; never mark
   `QUALIFIED` without evidence paths.
 - Forbid “Phase complete” claims without a qualification manifest / ledger proof.

--- a/services/central/src/analytics/economizer.rs
+++ b/services/central/src/analytics/economizer.rs
@@ -270,10 +270,11 @@ pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
         let dt_min = req.dt_min_f.unwrap_or(DEFAULT_DT_MIN_F);
         // OFDD-070: scope the historian read to the site when building_id is set
         // so an Overview economizer for one building never mixes in another's parquet.
-        match historian::economizer_from_history(
+        match historian::economizer_from_history_with_limit(
             req.query.equipment_ids.as_deref(),
             dt_min,
             req.query.building_id.as_deref(),
+            req.query.max_points.unwrap_or(4000),
         )
         .await
         {

--- a/services/central/src/analytics/economizer.rs
+++ b/services/central/src/analytics/economizer.rs
@@ -270,7 +270,7 @@ pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
         let dt_min = req.dt_min_f.unwrap_or(DEFAULT_DT_MIN_F);
         // OFDD-070: scope the historian read to the site when building_id is set
         // so an Overview economizer for one building never mixes in another's parquet.
-        match historian::economizer_from_history_with_limit(
+        match historian::economizer_from_history(
             req.query.equipment_ids.as_deref(),
             dt_min,
             req.query.building_id.as_deref(),

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -902,16 +902,25 @@ ORDER BY equipment_id
     Ok(Some(env))
 }
 
-/// Economizer descriptive diagnostics from historian Parquet via DataFusion.
+/// Economizer diagnostics from historian Parquet via DataFusion.
 ///
 /// Requires an OAT column (`oa_t` or Liberty `web_oa_t`), plus `rat` and `mat`,
-/// and a fan on-expression. Computes per-equipment fan-on and identifiable
-/// (`|OAT−RAT| >= dt_min`) sample counts. Never invents MAT residuals; those
-/// remain the inline central path only.
+/// and a fan on-expression. Returns per-equipment fan-on / identifiable counts
+/// plus downsampled fan-on points for Overview Plotly (delta scatter, MAT
+/// residual, temps+damper overlay) — vibe19 chart parity without pandas.
 pub async fn economizer_from_history(
     equipment_filter: Option<&[String]>,
     dt_min_f: f64,
     building_id: Option<&str>,
+) -> Result<Option<AnalyticsEnvelope>> {
+    economizer_from_history_with_limit(equipment_filter, dt_min_f, building_id, 4000).await
+}
+
+pub async fn economizer_from_history_with_limit(
+    equipment_filter: Option<&[String]>,
+    dt_min_f: f64,
+    building_id: Option<&str>,
+    max_points: usize,
 ) -> Result<Option<AnalyticsEnvelope>> {
     let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
         return Ok(None);
@@ -945,14 +954,20 @@ pub async fn economizer_from_history(
     let Some(on_sql) = on_expr(&cols) else {
         return Ok(None);
     };
+    let Some(ts_col) = pick_ts_col(&cols) else {
+        return Ok(None);
+    };
     let dt_min = dt_min_f.max(0.0);
     let eq_filter = equipment_filter_sql(equipment_filter);
-    // OFDD-070b: project damper into the CTE — COUNT(oa_damper_pct) from `base`
-    // fails when the column exists on `history` but was never selected into `base`.
     let damper_proj = if cols.contains("oa_damper_pct") {
         "oa_damper_pct"
     } else {
         "CAST(NULL AS DOUBLE) AS oa_damper_pct"
+    };
+    let sat_proj = if cols.contains("sat") {
+        "sat"
+    } else {
+        "CAST(NULL AS DOUBLE) AS sat"
     };
 
     let sql = format!(
@@ -964,7 +979,8 @@ WITH base AS (
     {rat_col} AS rat,
     {mat_col} AS mat,
     {on_sql} AS fan_on,
-    {damper_proj}
+    {damper_proj},
+    {sat_proj}
   FROM history
   WHERE equipment_id IS NOT NULL{eq_filter}
 )
@@ -997,20 +1013,92 @@ ORDER BY equipment_id
         }));
     }
 
-    let warnings = vec![
-        "economizer fan-on / identifiable sample counts from historian Parquet via \
-         DataFusion; MAT residual (median/MAE) requires the inline central path and \
-         is not fabricated here"
+    let limit = max_points.clamp(100, 8000);
+    let points_sql = format!(
+        r#"
+WITH base AS (
+  SELECT
+    equipment_id,
+    CAST({ts_col} AS VARCHAR) AS timestamp_utc,
+    {oat_col} AS oat_f,
+    {rat_col} AS rat_f,
+    {mat_col} AS mat_f,
+    {sat_proj},
+    {damper_proj},
+    {on_sql} AS fan_on
+  FROM history
+  WHERE equipment_id IS NOT NULL{eq_filter}
+)
+SELECT
+  equipment_id,
+  timestamp_utc,
+  oat_f,
+  rat_f,
+  mat_f,
+  sat AS sat_f,
+  oa_damper_pct AS damper_fb_pct,
+  (oat_f - rat_f) AS delta_or_f,
+  (mat_f - rat_f) AS delta_mr_f,
+  CASE
+    WHEN oa_damper_pct IS NOT NULL AND oat_f IS NOT NULL AND rat_f IS NOT NULL THEN
+      mat_f - (rat_f + (oa_damper_pct / 100.0) * (oat_f - rat_f))
+    ELSE NULL
+  END AS mat_resid_f,
+  CASE
+    WHEN oat_f IS NOT NULL AND rat_f IS NOT NULL AND ABS(oat_f - rat_f) >= {dt_min}
+    THEN true ELSE false
+  END AS identifiable
+FROM base
+WHERE fan_on
+  AND oat_f IS NOT NULL AND rat_f IS NOT NULL AND mat_f IS NOT NULL
+ORDER BY timestamp_utc
+LIMIT {limit}
+"#
+    );
+    let mut points = Vec::new();
+    match run_sql(&ctx, &points_sql).await {
+        Ok(pres) => {
+            for r in &pres.rows {
+                points.push(json!({
+                    "equipment_id": r.get("equipment_id").cloned().unwrap_or(json!("")),
+                    "timestamp_utc": r.get("timestamp_utc").cloned().unwrap_or(json!("")),
+                    "oat_f": as_f64(r.get("oat_f")),
+                    "rat_f": as_f64(r.get("rat_f")),
+                    "mat_f": as_f64(r.get("mat_f")),
+                    "sat_f": as_f64(r.get("sat_f")),
+                    "damper_fb_pct": as_f64(r.get("damper_fb_pct")),
+                    "delta_or_f": as_f64(r.get("delta_or_f")),
+                    "delta_mr_f": as_f64(r.get("delta_mr_f")),
+                    "mat_resid_f": as_f64(r.get("mat_resid_f")),
+                    "identifiable": r.get("identifiable").and_then(|v| v.as_bool()).unwrap_or(false),
+                    "fan_on": true,
+                }));
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "economizer plot points SQL failed; counts only");
+        }
+    }
+
+    let mut warnings = vec![
+        "economizer fan-on counts + free-cooling plot points from historian DataFusion \
+         (vibe19 Overview chart parity)"
             .into(),
     ];
+    if points.is_empty() {
+        warnings.push("no fan-on economizer points available for scatter/MAT/temps plots".into());
+    }
     let query = AnalyticsQuery::default();
     let mut env = envelope_with_engine(QV_ECONOMIZER, &query, warnings, DF_ENGINE);
     env.equipment = equipment.clone();
     env.rows = equipment;
+    env.points = points;
     env.coverage = Some(json!({
         "equipment_count": env.equipment.len(),
+        "point_count": env.points.len(),
         "history_rows": n,
         "dt_min_f": dt_min,
+        "max_points": limit,
         "source": "historian_parquet",
         "building_id": safe_building_segment(building_id),
         "oat_column": oat_col,

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -912,14 +912,6 @@ pub async fn economizer_from_history(
     equipment_filter: Option<&[String]>,
     dt_min_f: f64,
     building_id: Option<&str>,
-) -> Result<Option<AnalyticsEnvelope>> {
-    economizer_from_history_with_limit(equipment_filter, dt_min_f, building_id, 4000).await
-}
-
-pub async fn economizer_from_history_with_limit(
-    equipment_filter: Option<&[String]>,
-    dt_min_f: f64,
-    building_id: Option<&str>,
     max_points: usize,
 ) -> Result<Option<AnalyticsEnvelope>> {
     let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
@@ -1531,7 +1523,7 @@ mod tests {
         }
         std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
 
-        let b50 = economizer_from_history(None, 10.0, Some("BUILDING_50"))
+        let b50 = economizer_from_history(None, 10.0, Some("BUILDING_50"), 4000)
             .await
             .unwrap()
             .expect("B50 economizer envelope");

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1649,8 +1649,8 @@ mod tests {
             .iter()
             .map(|r| r["hours"].as_f64().unwrap_or(0.0))
             .sum();
-        // One on interval of 300s → 300/3600 h
-        assert!((hours - (300.0 / 3600.0)).abs() < 0.02, "hours={hours}");
+        // Two on intervals of 300s (t0→t1 and t1→t2 while status stays 1) → 600s
+        assert!((hours - (600.0 / 3600.0)).abs() < 0.02, "hours={hours}");
     }
 
     #[test]

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1527,7 +1527,7 @@ mod tests {
             .await
             .unwrap()
             .expect("B50 economizer envelope");
-        let b100 = economizer_from_history(None, 10.0, Some("BUILDING_100"))
+        let b100 = economizer_from_history(None, 10.0, Some("BUILDING_100"), 4000)
             .await
             .unwrap()
             .expect("B100 economizer envelope");
@@ -1575,7 +1575,7 @@ mod tests {
         fdd_store::ingest_building(tmp.path(), "BUILDING_50", &parquet).unwrap();
         std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
 
-        let env = economizer_from_history(None, 10.0, Some("BUILDING_50"))
+        let env = economizer_from_history(None, 10.0, Some("BUILDING_50"), 4000)
             .await
             .unwrap()
             .expect("economizer with damper");
@@ -1613,7 +1613,7 @@ mod tests {
 
         // Requesting a site that was never ingested must not fall back to the
         // whole tree (that would leak BUILDING_50 into a BUILDING_999 scope).
-        let out = economizer_from_history(None, 10.0, Some("BUILDING_999"))
+        let out = economizer_from_history(None, 10.0, Some("BUILDING_999"), 4000)
             .await
             .unwrap();
         std::env::remove_var("OPENFDD_PARQUET_ROOT");

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -61,12 +61,6 @@ pub fn parquet_root() -> PathBuf {
     PathBuf::from(".cache/parquet")
 }
 
-/// Register `history` from parquet_root when the tree exists and has data.
-/// Returns `Ok(true)` on success, `Ok(false)` when missing/empty/unusable.
-pub async fn try_register_history(ctx: &SessionContext) -> Result<bool> {
-    try_register_history_scoped(ctx, None).await
-}
-
 /// Sanitize a `building_id` for use as a Hive path segment. Rejects any value
 /// with path separators or `..` so a query field can never escape the parquet
 /// root; returns `None` for empty/unsafe ids (caller falls back to whole tree).
@@ -344,13 +338,13 @@ fn equipment_filter_sql(equipment_filter: Option<&[String]>) -> String {
 }
 
 /// SQL fragment restricting to chiller/DX/tower-like equipment ids.
+/// Kept aligned with [`plant_group_for`] (no bare `CT%` — that matches CTRL_*).
 fn chiller_like_equipment_sql() -> &'static str {
     " AND (\
         UPPER(equipment_id) LIKE '%CHILLER%' \
         OR UPPER(equipment_id) LIKE '%TOWER%' \
         OR UPPER(equipment_id) LIKE 'CT_%' \
-        OR UPPER(equipment_id) LIKE '%/CT%' \
-        OR UPPER(equipment_id) LIKE 'CT%' \
+        OR UPPER(equipment_id) LIKE '%/CT_%' \
         OR UPPER(equipment_id) LIKE '%_DX%' \
         OR UPPER(equipment_id) LIKE 'DX%' \
         OR UPPER(equipment_id) LIKE 'HP_%' \

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -168,6 +168,92 @@ fn on_expr(cols: &HashSet<String>) -> Option<String> {
     }
 }
 
+/// Threshold on-expression for a single numeric status/amp column.
+fn col_on_gt(col: &str, threshold: f64) -> String {
+    format!(
+        "CASE WHEN {col} IS NOT NULL AND {col} > {threshold} THEN true ELSE false END"
+    )
+}
+
+/// Mechanical-cooling proof (never fan). Prefers chiller/compressor status, then amps.
+fn cooling_on_expr(cols: &HashSet<String>) -> Option<String> {
+    let status_names = [
+        "chiller_status",
+        "compressor_status",
+        "comp_status",
+        "comp_1_status",
+        "comp_2_status",
+        "dx_status",
+    ];
+    let mut parts: Vec<String> = Vec::new();
+    for name in status_names {
+        if cols.contains(name) {
+            parts.push(col_on_gt(name, 0.05));
+        }
+    }
+    // Any remaining column name that clearly looks like chiller/compressor status.
+    for c in cols {
+        let u = c.to_ascii_lowercase();
+        if parts.iter().any(|p| p.contains(c.as_str())) {
+            continue;
+        }
+        if (u.contains("chiller") && u.contains("status"))
+            || (u.contains("comp") && u.contains("status") && !u.contains("occup"))
+            || (u.contains("dx") && u.contains("status"))
+        {
+            parts.push(col_on_gt(c, 0.05));
+        }
+    }
+    for name in ["chiller_amps", "comp_amps", "compressor_amps", "amps"] {
+        if cols.contains(name) {
+            parts.push(col_on_gt(name, 2.0));
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    if parts.len() == 1 {
+        return Some(parts.remove(0));
+    }
+    Some(format!("({})", parts.join(" OR ")))
+}
+
+/// Plant weekly / equipment runtime on-proof: fan OR chiller/boiler/pump status.
+fn plant_runtime_on_expr(cols: &HashSet<String>) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(fan) = on_expr(cols) {
+        parts.push(format!("({fan})"));
+    }
+    if let Some(cool) = cooling_on_expr(cols) {
+        parts.push(format!("({cool})"));
+    }
+    for name in ["boiler_status", "boiler_cmd", "hwp_status", "hw_pump_status", "cwp_status"] {
+        if cols.contains(name) {
+            parts.push(format!("({})", col_on_gt(name, 0.05)));
+        }
+    }
+    for c in cols {
+        let u = c.to_ascii_lowercase();
+        if (u.contains("boiler") && u.contains("status"))
+            || (u.contains("hwp") && (u.contains("status") || u.contains("_s")))
+            || (u.contains("cwp") && u.contains("status"))
+            || (u.contains("pump") && u.contains("status"))
+        {
+            let expr = col_on_gt(c, 0.05);
+            if !parts.iter().any(|p| p.contains(c.as_str())) {
+                parts.push(format!("({expr})"));
+            }
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    if parts.len() == 1 {
+        return Some(parts.remove(0));
+    }
+    Some(parts.join(" OR "))
+}
+
 fn round2(x: f64) -> f64 {
     (x * 100.0).round() / 100.0
 }
@@ -179,29 +265,44 @@ pub fn plant_group_for(equipment_id: &str) -> Option<&'static str> {
     if eq.contains("/VAV") || eq.starts_with("VAV") || eq.contains("VAVFC") || eq.contains("VAVH") {
         return None;
     }
-    if eq.starts_with("AHU") || eq.contains("/AHU") || eq.contains("RTU") {
+    if eq.starts_with("AHU") || eq.contains("/AHU") || eq.contains("RTU") || eq.contains("MAU") || eq.contains("DOAS")
+    {
         return Some("air");
     }
     if eq.contains("TOWER")
         || eq.starts_with("CT_")
+        || eq.contains("/CT")
+        || (eq.starts_with("CT") && eq.chars().nth(2).is_some_and(|c| c.is_ascii_digit()))
         || eq.contains("CHILLER")
         || eq.starts_with("CHW")
         || eq.contains("CWP")
+        || eq.contains("_DX")
+        || eq.starts_with("DX")
+        || eq.starts_with("HP_")
         || (eq.contains("PUMP") && (eq.contains("CHW") || eq.contains("CW")))
     {
         return Some("chiller");
     }
     if eq.contains("BOILER")
         || eq.contains("HWP")
-        || (eq.contains("PUMP") && !eq.contains("HEAT") && !eq.contains("CHW"))
+        || (eq.contains("PUMP") && eq.contains("HW") && !eq.contains("CHW"))
         || eq.contains("BOILERS")
     {
         return Some("boiler");
     }
-    if eq.contains("FAN") || eq.contains("SUPPLY") {
-        return Some("air");
-    }
+    // Do not catch bare FAN/SUPPLY — too broad (exhaust/return/etc.).
     None
+}
+
+/// OAT for mech-cooling bins: prefer web/meteo OAT (pandas Overview default).
+fn mech_oat_col(cols: &HashSet<String>) -> Option<&'static str> {
+    web_oat_col(cols).or_else(|| {
+        if cols.contains("oa_t") {
+            Some("oa_t")
+        } else {
+            None
+        }
+    })
 }
 
 fn oat_col(cols: &HashSet<String>) -> Option<&'static str> {
@@ -234,18 +335,37 @@ fn equipment_filter_sql(equipment_filter: Option<&[String]>) -> String {
     }
 }
 
+/// SQL fragment restricting to chiller/DX/tower-like equipment ids.
+fn chiller_like_equipment_sql() -> &'static str {
+    " AND (\
+        UPPER(equipment_id) LIKE '%CHILLER%' \
+        OR UPPER(equipment_id) LIKE '%TOWER%' \
+        OR UPPER(equipment_id) LIKE 'CT_%' \
+        OR UPPER(equipment_id) LIKE '%/CT%' \
+        OR UPPER(equipment_id) LIKE 'CT%' \
+        OR UPPER(equipment_id) LIKE '%_DX%' \
+        OR UPPER(equipment_id) LIKE 'DX%' \
+        OR UPPER(equipment_id) LIKE 'HP_%' \
+        OR UPPER(equipment_id) LIKE '%CWP%' \
+        OR UPPER(equipment_id) LIKE 'CHW%' \
+     )"
+}
+
 /// Load runtime hours from historian Parquet via DataFusion.
 ///
 /// Returns `Ok(None)` when parquet is missing/empty. When columns support Δt
-/// integration (`equipment_id`, timestamp, fan_status/fan_cmd), computes real
+/// integration (`equipment_id`, timestamp, fan/status/pump proofs), computes real
 /// forward-interval run hours with gap clipping. Otherwise returns a count-based
 /// envelope with `engine=datafusion` and a warning that column-mapped runtime is next.
+///
+/// When `building_id` is set, scopes the Parquet read like economizer (OFDD-070).
 pub async fn runtime_from_history(
     equipment_filter: Option<&[String]>,
     max_gap_seconds: f64,
+    building_id: Option<&str>,
 ) -> Result<Option<AnalyticsEnvelope>> {
     let ctx = SessionContext::new();
-    if !try_register_history(&ctx).await? {
+    if !try_register_history_scoped(&ctx, building_id).await? {
         return Ok(None);
     }
 
@@ -266,7 +386,8 @@ pub async fn runtime_from_history(
     let eq_filter = equipment_filter_sql(equipment_filter);
 
     if cols.contains("equipment_id") {
-        if let (Some(ts_col), Some(on_sql)) = (pick_ts_col(&cols), on_expr(&cols)) {
+        // Fan for air handlers; chiller/boiler/pump status for plant motors.
+        if let (Some(ts_col), Some(on_sql)) = (pick_ts_col(&cols), plant_runtime_on_expr(&cols)) {
             let sql = format!(
                 r#"
 WITH ordered AS (
@@ -397,6 +518,7 @@ ORDER BY i.equipment_id
                         "history_rows": n,
                         "max_gap_seconds": max_gap,
                         "source": "historian_parquet",
+                        "building_id": safe_building_segment(building_id),
                         "query_versions": ["runtime-v1", "runtime-weekly-v1"],
                     }));
                     return Ok(Some(env));
@@ -411,7 +533,7 @@ ORDER BY i.equipment_id
     // Minimum bridge: registered history with rows, engine honesty for DataFusion.
     let warnings = vec![
         "historian Parquet registered via DataFusion; column-mapped runtime Δt SQL is next \
-         (need equipment_id + timestamp_utc + fan_status/fan_cmd)"
+         (need equipment_id + timestamp_utc + fan/chiller/boiler/pump on-proof)"
             .into(),
     ];
     let mut env = envelope_with_engine(QV_RUNTIME, &query, warnings, DF_ENGINE);
@@ -419,6 +541,7 @@ ORDER BY i.equipment_id
         "history_rows": n,
         "max_gap_seconds": max_gap,
         "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
     }));
     Ok(Some(env))
 }
@@ -895,26 +1018,29 @@ ORDER BY equipment_id
     Ok(Some(env))
 }
 
-/// Mechanical-cooling OAT bin hours (5°F bins) from historian when OAT + on-proof exist.
+/// Mechanical-cooling OAT bin hours (5°F bins) from historian when OAT + cooling
+/// proof exist. Never uses AHU fan as mechanical cooling.
 pub async fn mech_oat_bins_from_history(
     equipment_filter: Option<&[String]>,
     max_gap_seconds: f64,
+    building_id: Option<&str>,
 ) -> Result<Option<AnalyticsEnvelope>> {
-    let Some((ctx, cols, n)) = open_history().await? else {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
         return Ok(None);
     };
     let Some(ts_col) = pick_ts_col(&cols) else {
         return Ok(None);
     };
-    let Some(oat) = oat_col(&cols) else {
+    let Some(oat) = mech_oat_col(&cols) else {
         return Ok(None);
     };
-    let Some(on_sql) = on_expr(&cols) else {
+    // Require compressor/chiller proof — never fan_status/fan_cmd.
+    let Some(on_sql) = cooling_on_expr(&cols) else {
         return Ok(None);
     };
     let max_gap = max_gap_seconds.max(0.0);
     let eq_filter = equipment_filter_sql(equipment_filter);
-    // Restrict to chiller/tower-like equipment via SQL filter on id patterns when possible.
+    let chiller_filter = chiller_like_equipment_sql();
     let sql = format!(
         r#"
 WITH ordered AS (
@@ -925,7 +1051,7 @@ WITH ordered AS (
     {oat} AS oat_f,
     LEAD({ts_col}) OVER (PARTITION BY equipment_id ORDER BY {ts_col}) AS next_ts
   FROM history
-  WHERE equipment_id IS NOT NULL AND {oat} IS NOT NULL{eq_filter}
+  WHERE equipment_id IS NOT NULL AND {oat} IS NOT NULL{eq_filter}{chiller_filter}
 ),
 intervals AS (
   SELECT
@@ -966,8 +1092,8 @@ ORDER BY bin_lo
         return Ok(None);
     }
     let warnings = vec![
-        "mechanical cooling OAT bins from historian DataFusion (fan/status on × oa_t; \
-         compressor-specific evidence still inline-only)"
+        "mechanical cooling OAT bins from historian DataFusion \
+         (compressor/chiller proof × preferred web OAT; chiller-like equipment only)"
             .into(),
     ];
     let query = AnalyticsQuery::default();
@@ -978,6 +1104,7 @@ ORDER BY bin_lo
         "bin_count": env.rows.len(),
         "history_rows": n,
         "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
         "oat_column": oat,
     }));
     Ok(Some(env))
@@ -987,8 +1114,9 @@ ORDER BY bin_lo
 pub async fn bas_vs_web_from_history(
     equipment_filter: Option<&[String]>,
     max_points: usize,
+    building_id: Option<&str>,
 ) -> Result<Option<AnalyticsEnvelope>> {
-    let Some((ctx, cols, n)) = open_history().await? else {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
         return Ok(None);
     };
     let Some(ts_col) = pick_ts_col(&cols) else {
@@ -1066,6 +1194,7 @@ LIMIT {limit}
         "bas_column": bas,
         "web_column": web,
         "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
     }));
     Ok(Some(env))
 }
@@ -1139,7 +1268,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let missing = tmp.path().join("no_such_parquet");
         std::env::set_var("OPENFDD_PARQUET_ROOT", &missing);
-        let out = runtime_from_history(None, 900.0).await.unwrap();
+        let out = runtime_from_history(None, 900.0, None).await.unwrap();
         assert!(out.is_none());
         std::env::remove_var("OPENFDD_PARQUET_ROOT");
     }
@@ -1168,7 +1297,7 @@ mod tests {
         fdd_store::ingest_building(tmp.path(), "BUILDING_TEST", &parquet).unwrap();
         std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
 
-        let env = runtime_from_history(None, 900.0)
+        let env = runtime_from_history(None, 900.0, None)
             .await
             .unwrap()
             .expect("expected historian envelope");
@@ -1415,10 +1544,110 @@ mod tests {
     fn plant_group_for_maps_common_ids() {
         assert_eq!(plant_group_for("AHU_1"), Some("air"));
         assert_eq!(plant_group_for("RTU_WEST"), Some("air"));
+        assert_eq!(plant_group_for("MAU_1"), Some("air"));
         assert_eq!(plant_group_for("CHILLER_1"), Some("chiller"));
+        assert_eq!(plant_group_for("CT_1"), Some("chiller"));
+        assert_eq!(plant_group_for("HP_3"), Some("chiller"));
         assert_eq!(plant_group_for("BOILER_1"), Some("boiler"));
         assert_eq!(plant_group_for("VAV_101"), None);
         assert_eq!(plant_group_for("BUILDING/VAVFC_2"), None);
+        // Bare FAN/SUPPLY must not swallow unrelated motors.
+        assert_eq!(plant_group_for("EXHAUST_FAN_1"), None);
+        assert_eq!(plant_group_for("SUPPLY_METER"), None);
+    }
+
+    #[test]
+    fn cooling_on_expr_ignores_fan_only() {
+        let mut cols = HashSet::new();
+        cols.insert("fan_status".into());
+        cols.insert("fan_cmd".into());
+        cols.insert("oa_t".into());
+        assert!(cooling_on_expr(&cols).is_none());
+        assert!(on_expr(&cols).is_some());
+    }
+
+    #[test]
+    fn cooling_on_expr_uses_chiller_status() {
+        let mut cols = HashSet::new();
+        cols.insert("chiller_status".into());
+        cols.insert("web_oa_t".into());
+        let expr = cooling_on_expr(&cols).expect("cooling proof");
+        assert!(expr.contains("chiller_status"));
+        assert!(!expr.contains("fan_"));
+    }
+
+    #[tokio::test]
+    async fn mech_oat_bins_none_for_fan_only_fixture() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_FAN");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let ahu = building.join("AHU_1");
+        std::fs::create_dir_all(&ahu).unwrap();
+        std::fs::write(
+            ahu.join("columns.csv"),
+            "col,point_role\nfan_speed_pct,fan_cmd\noa_temp_f,oa_t\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,fan_speed_pct,oa_temp_f").unwrap();
+        writeln!(f, "2026-07-01T00:00:00Z,100,85").unwrap();
+        writeln!(f, "2026-07-01T00:05:00Z,100,86").unwrap();
+        writeln!(f, "2026-07-01T00:10:00Z,100,87").unwrap();
+
+        let parquet = tmp.path().join("parquet_fan");
+        fdd_store::ingest_building(tmp.path(), "BUILDING_FAN", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let out = mech_oat_bins_from_history(None, 900.0, Some("BUILDING_FAN"))
+            .await
+            .unwrap();
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+        assert!(out.is_none(), "fan-only history must not produce mech oat bins");
+    }
+
+    #[tokio::test]
+    async fn mech_oat_bins_from_chiller_status_fixture() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_CH");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let ch = building.join("CHILLER_1");
+        std::fs::create_dir_all(&ch).unwrap();
+        std::fs::write(
+            ch.join("columns.csv"),
+            "col,point_role\nchiller_status,chiller_status\nweb_oa_t,web_oa_t\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ch.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,chiller_status,web_oa_t").unwrap();
+        writeln!(f, "2026-07-01T00:00:00Z,1,82").unwrap();
+        writeln!(f, "2026-07-01T00:05:00Z,1,83").unwrap();
+        writeln!(f, "2026-07-01T00:10:00Z,0,84").unwrap();
+
+        let parquet = tmp.path().join("parquet_ch");
+        fdd_store::ingest_building(tmp.path(), "BUILDING_CH", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let env = mech_oat_bins_from_history(None, 900.0, Some("BUILDING_CH"))
+            .await
+            .unwrap()
+            .expect("chiller_status fixture should produce oat bins");
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+
+        assert_eq!(env.engine, DF_ENGINE);
+        assert!(!env.rows.is_empty());
+        assert_eq!(env.rows[0]["kind"], "oat_bin");
+        assert!(env.coverage.as_ref().unwrap()["oat_column"] == "web_oa_t");
+        let hours: f64 = env
+            .rows
+            .iter()
+            .map(|r| r["hours"].as_f64().unwrap_or(0.0))
+            .sum();
+        // One on interval of 300s → 300/3600 h
+        assert!((hours - (300.0 / 3600.0)).abs() < 0.02, "hours={hours}");
     }
 
     #[test]

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -170,9 +170,7 @@ fn on_expr(cols: &HashSet<String>) -> Option<String> {
 
 /// Threshold on-expression for a single numeric status/amp column.
 fn col_on_gt(col: &str, threshold: f64) -> String {
-    format!(
-        "CASE WHEN {col} IS NOT NULL AND {col} > {threshold} THEN true ELSE false END"
-    )
+    format!("CASE WHEN {col} IS NOT NULL AND {col} > {threshold} THEN true ELSE false END")
 }
 
 /// Mechanical-cooling proof (never fan). Prefers chiller/compressor status, then amps.
@@ -227,7 +225,13 @@ fn plant_runtime_on_expr(cols: &HashSet<String>) -> Option<String> {
     if let Some(cool) = cooling_on_expr(cols) {
         parts.push(format!("({cool})"));
     }
-    for name in ["boiler_status", "boiler_cmd", "hwp_status", "hw_pump_status", "cwp_status"] {
+    for name in [
+        "boiler_status",
+        "boiler_cmd",
+        "hwp_status",
+        "hw_pump_status",
+        "cwp_status",
+    ] {
         if cols.contains(name) {
             parts.push(format!("({})", col_on_gt(name, 0.05)));
         }
@@ -265,7 +269,11 @@ pub fn plant_group_for(equipment_id: &str) -> Option<&'static str> {
     if eq.contains("/VAV") || eq.starts_with("VAV") || eq.contains("VAVFC") || eq.contains("VAVH") {
         return None;
     }
-    if eq.starts_with("AHU") || eq.contains("/AHU") || eq.contains("RTU") || eq.contains("MAU") || eq.contains("DOAS")
+    if eq.starts_with("AHU")
+        || eq.contains("/AHU")
+        || eq.contains("RTU")
+        || eq.contains("MAU")
+        || eq.contains("DOAS")
     {
         return Some("air");
     }
@@ -1091,11 +1099,9 @@ ORDER BY bin_lo
     if rows.is_empty() {
         return Ok(None);
     }
-    let warnings = vec![
-        "mechanical cooling OAT bins from historian DataFusion \
+    let warnings = vec!["mechanical cooling OAT bins from historian DataFusion \
          (compressor/chiller proof × preferred web OAT; chiller-like equipment only)"
-            .into(),
-    ];
+        .into()];
     let query = AnalyticsQuery::default();
     let mut env = envelope_with_engine(QV_MECHANICAL_COOLING, &query, warnings, DF_ENGINE);
     env.rows = rows.clone();
@@ -1604,7 +1610,10 @@ mod tests {
             .await
             .unwrap();
         std::env::remove_var("OPENFDD_PARQUET_ROOT");
-        assert!(out.is_none(), "fan-only history must not produce mech oat bins");
+        assert!(
+            out.is_none(),
+            "fan-only history must not produce mech oat bins"
+        );
     }
 
     #[tokio::test]

--- a/services/central/src/analytics/mechanical_cooling.rs
+++ b/services/central/src/analytics/mechanical_cooling.rs
@@ -178,8 +178,12 @@ pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
 pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     if req.series.is_none() {
         let max_gap = req.max_gap_seconds.unwrap_or(900.0);
-        match historian::mech_oat_bins_from_history(req.query.equipment_ids.as_deref(), max_gap)
-            .await
+        match historian::mech_oat_bins_from_history(
+            req.query.equipment_ids.as_deref(),
+            max_gap,
+            req.query.building_id.as_deref(),
+        )
+        .await
         {
             Ok(Some(env)) => return finalize_historian(req, env, QV_MECHANICAL_COOLING),
             Ok(None) => {}

--- a/services/central/src/analytics/runtime.rs
+++ b/services/central/src/analytics/runtime.rs
@@ -168,7 +168,9 @@ pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     if !has_inline {
         let max_gap = req.max_gap_seconds.unwrap_or(900.0);
         let filter = req.query.equipment_ids.as_deref();
-        match historian::runtime_from_history(filter, max_gap).await {
+        match historian::runtime_from_history(filter, max_gap, req.query.building_id.as_deref())
+            .await
+        {
             Ok(Some(mut env)) => {
                 let (qv, mut warnings) = resolve_query_version(req, QV_RUNTIME);
                 env.query_version = qv;

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1719,6 +1719,7 @@ async fn analytics_bas_vs_web_oat(Json(req): Json<AnalyticsRequest>) -> Json<Val
     let env = match analytics::historian::bas_vs_web_from_history(
         req.query.equipment_ids.as_deref(),
         max_points,
+        req.query.building_id.as_deref(),
     )
     .await
     {


### PR DESCRIPTION
## Summary
- Force Plotly `autorange` + `uirevision` on Overview redraw so Update analytics re-fits axes instead of sticky zoom
- Scope runtime / mech OAT / BAS-vs-web historian paths to `building_id` (same OFDD-070 pattern as economizer)
- Mechanical cooling OAT bins use compressor/chiller proof + preferred web OAT on chiller-like equipment only (never AHU fan); weekly plant on-proof includes chiller/boiler/pump status

## Test plan
- [ ] Vitest: `PlotlyHost` autorange/uirevision assertions
- [ ] Central unit tests: fan-only fixture → no mech oat bins; `chiller_status` fixture → bins; `plant_group_for` no bare FAN/SUPPLY
- [ ] GH Actions green on this PR
- [ ] After image refresh (not in this PR): Overview Update analytics re-zooms; mech OAT bins track chillers; AHU runtime scoped to selected building


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Charts now automatically autorange axes when underlying data changes.
  * Updated Plotly rendering resets zoom appropriately when figures update, preventing stale views.
  * Mechanical cooling analytics better distinguish active cooling from fan-only operation.

* **New Features**
  * Analytics now support building-scoped filtering and improved equipment coverage and classification.
  * Central Overview adds economizer and OAT visualizations, configurable thresholds, and error bands.
  * RCx preset labels and sidebar descriptions are clearer.
  * Economizer equipment selection now updates the overview charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->