### PR TITLE
Overview Plotly parity vs vibe19 (air weekly + mech OAT)

### DIFF
--- a/frontend/web/src/api/centralOverview.test.ts
+++ b/frontend/web/src/api/centralOverview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fetchCentralOverview } from "./centralOverview";
+import { AIR_BARE_MIN_OCC_HOURS_WEEK, RAINBOW_PALETTE } from "./plotlyTheme";
 
 vi.mock("./analyticsApi", () => ({
   postRuntime: vi.fn(async () => ({
@@ -9,11 +10,46 @@ vi.mock("./analyticsApi", () => ({
     engine: "datafusion",
     warnings: ["from historian"],
     rows: [
-      { equipment_id: "AHU_1", run_hours: 12.5, coverage_pct: 40 },
-      { equipment_id: "VAV_1", run_hours: 3, coverage_pct: 10 },
+      {
+        kind: "weekly_equipment",
+        plant_group: "air",
+        equipment_id: "AHU_1",
+        label: "AHU_1 · fan-status",
+        week_label: "2026-03-23",
+        run_hours: 80,
+        avg_oat_f: 45,
+      },
+      {
+        kind: "weekly_equipment",
+        plant_group: "air",
+        equipment_id: "AHU_2",
+        label: "AHU_2 · fan-status",
+        week_label: "2026-03-23",
+        run_hours: 70,
+        avg_oat_f: 46,
+      },
+      {
+        kind: "weekly_equipment",
+        plant_group: "air",
+        equipment_id: "AHU_1",
+        label: "AHU_1 · fan-status",
+        week_label: "2026-03-30",
+        run_hours: 90,
+        avg_oat_f: 50,
+      },
+      {
+        kind: "weekly_equipment",
+        plant_group: "air",
+        equipment_id: "AHU_2",
+        label: "AHU_2 · fan-status",
+        week_label: "2026-03-30",
+        run_hours: 85,
+        avg_oat_f: 51,
+      },
     ],
     equipment: [
-      { equipment_id: "AHU_1", run_hours: 12.5, coverage_pct: 40 },
+      { equipment_id: "AHU_1", run_hours: 170, coverage_pct: 40, plant_group: "air" },
+      { equipment_id: "AHU_2", run_hours: 155, coverage_pct: 38, plant_group: "air" },
       { equipment_id: "VAV_1", run_hours: 3, coverage_pct: 10 },
     ],
     points: [],
@@ -25,7 +61,62 @@ vi.mock("./analyticsApi", () => ({
     generated_at: "",
     engine: "datafusion",
     warnings: [],
-    rows: [{ equipment_id: "CHILLER_1", history_rows: 500 }],
+    rows: [
+      {
+        kind: "oat_bin",
+        series_kind: "individual_device",
+        equipment_id: "CHILLER_2",
+        bin_lo_f: 65,
+        bin_hi_f: 70,
+        bin_label: "65-70",
+        hours: 120,
+      },
+      {
+        kind: "oat_bin",
+        series_kind: "individual_device",
+        equipment_id: "CHILLER_2",
+        bin_lo_f: 70,
+        bin_hi_f: 75,
+        bin_label: "70-75",
+        hours: 100,
+      },
+      {
+        kind: "oat_bin",
+        series_kind: "aggregate_device_hours",
+        equipment_id: "ALL",
+        bin_lo_f: 65,
+        bin_hi_f: 70,
+        bin_label: "65-70",
+        hours: 120,
+      },
+      {
+        kind: "oat_bin",
+        series_kind: "aggregate_device_hours",
+        equipment_id: "ALL",
+        bin_lo_f: 70,
+        bin_hi_f: 75,
+        bin_label: "70-75",
+        hours: 100,
+      },
+      {
+        kind: "oat_bin",
+        series_kind: "aggregate_active_hours",
+        equipment_id: "ANY",
+        bin_lo_f: 65,
+        bin_hi_f: 70,
+        bin_label: "65-70",
+        hours: 120,
+      },
+      {
+        kind: "oat_bin",
+        series_kind: "aggregate_active_hours",
+        equipment_id: "ANY",
+        bin_lo_f: 70,
+        bin_hi_f: 75,
+        bin_label: "70-75",
+        hours: 100,
+      },
+    ],
     equipment: [],
     points: [],
     skipped: [],
@@ -122,5 +213,65 @@ describe("fetchCentralOverview", () => {
       { type: "AHU", count: 1 },
       { type: "VAV", count: 1 },
     ]);
+  });
+
+  it("renders per-AHU weekly bars + OAT y2 + bare-min line (vibe19 parity)", async () => {
+    const out = await fetchCentralOverview({ building_id: "BUILDING_100" });
+    const air = out.motor_weekly.plants.find((p) => p.plant_group === "air");
+    expect(air).toBeTruthy();
+    const bars = (air!.figure?.data ?? []).filter((t) => t.type === "bar");
+    expect(bars.length).toBeGreaterThanOrEqual(2);
+    expect(bars.map((t) => t.name)).toEqual(
+      expect.arrayContaining(["AHU_1 · fan-status", "AHU_2 · fan-status"]),
+    );
+    expect(bars[0]?.marker?.color).toBe(RAINBOW_PALETTE[0]);
+    const oat = (air!.figure?.data ?? []).find((t) =>
+      String(t.name).includes("Avg OAT"),
+    );
+    expect(oat?.yaxis).toBe("y2");
+    expect(oat?.line).toMatchObject({ dash: "dot", color: "#333333" });
+    const shapes = air!.figure?.layout?.shapes as Array<Record<string, unknown>>;
+    expect(shapes?.[0]?.y0).toBe(AIR_BARE_MIN_OCC_HOURS_WEEK);
+    // Section owns the title — figure should not duplicate plant H2.
+    expect(air!.figure?.layout?.title).toBeUndefined();
+  });
+
+  it("stacks mech OAT bins per device and does not promote history_rows", async () => {
+    const out = await fetchCentralOverview({ building_id: "BUILDING_100" });
+    const fig = out.mech_cooling.figure!;
+    const bar = fig.data.find((t) => t.type === "bar" && t.name === "CHILLER_2");
+    expect(bar).toBeTruthy();
+    expect(fig.data.some((t) => t.name === "Total compressor device-hours")).toBe(
+      true,
+    );
+    expect(fig.data.some((t) => t.name === "Any compressor active")).toBe(true);
+    expect(out.mech_cooling.callout).toMatch(/Only CHILLER_2/);
+    expect(fig.layout?.barmode).toBe("stack");
+  });
+});
+
+describe("mechFigure history_rows honesty", () => {
+  it("returns null figure when only descriptive history_rows are present", async () => {
+    const { postMechanicalCooling } = await import("./analyticsApi");
+    vi.mocked(postMechanicalCooling).mockResolvedValueOnce({
+      schema_version: "1",
+      query_version: "mechanical-cooling-v1",
+      generated_at: "",
+      engine: "datafusion",
+      warnings: ["descriptive"],
+      rows: [
+        { equipment_id: "AHU_1", history_rows: 1000 },
+        { equipment_id: "VAV_1", history_rows: 500 },
+      ],
+      equipment: [],
+      points: [],
+      skipped: [],
+    } as never);
+
+    const out = await fetchCentralOverview({ building_id: "BUILDING_100" });
+    expect(out.mech_cooling.figure).toBeNull();
+    expect(out.mech_cooling.bins).toEqual([]);
+    expect(out.mech_cooling.coverage.length).toBeGreaterThan(0);
+    expect(out.mech_cooling.caption).toMatch(/No compressor×OAT|descriptive/i);
   });
 });

--- a/frontend/web/src/api/centralOverview.ts
+++ b/frontend/web/src/api/centralOverview.ts
@@ -21,6 +21,11 @@ import type {
   OverviewPlantFig,
   OverviewVibe19Response,
 } from "./overviewOracleApi";
+import {
+  AIR_BARE_MIN_OCC_HOURS_WEEK,
+  overviewChartLayout,
+  rainbowColor,
+} from "./plotlyTheme";
 
 function num(v: unknown): number | null {
   if (v == null || v === "") return null;
@@ -60,7 +65,9 @@ function motorFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null 
 function weeklyPlantFigures(
   rows: Array<Record<string, unknown>>,
 ): OverviewPlantFig[] {
-  const weekly = rows.filter((r) => r.kind === "weekly_plant");
+  const weekly = rows.filter(
+    (r) => r.kind === "weekly_equipment" || r.kind === "weekly_plant",
+  );
   if (!weekly.length) return [];
   const byPlant = new Map<string, Array<Record<string, unknown>>>();
   for (const r of weekly) {
@@ -77,56 +84,121 @@ function weeklyPlantFigures(
   return [...byPlant.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([plant_group, plantRows]) => {
-      const sorted = [...plantRows].sort((a, b) =>
-        String(a.week_label).localeCompare(String(b.week_label)),
-      );
-      const x = sorted.map((r) => String(r.week_label ?? ""));
-      const hours = sorted.map((r) => num(r.run_hours));
-      const oat = sorted.map((r) => num(r.avg_oat_f));
-      const hasOat = oat.some((v) => v != null);
-      const data: PlotlyTrace[] = [
-        {
+      const sorted = [...plantRows].sort((a, b) => {
+        const w = String(a.week_label).localeCompare(String(b.week_label));
+        if (w !== 0) return w;
+        const la = String(a.label ?? a.equipment_id ?? "");
+        const lb = String(b.label ?? b.equipment_id ?? "");
+        return la.localeCompare(lb);
+      });
+      const weeks = [
+        ...new Set(sorted.map((r) => String(r.week_label ?? ""))),
+      ].sort((a, b) => a.localeCompare(b));
+
+      const perEq = new Map<string, Array<Record<string, unknown>>>();
+      for (const r of sorted) {
+        const lab = String(r.label ?? r.equipment_id ?? "run hours");
+        const list = perEq.get(lab) ?? [];
+        list.push(r);
+        perEq.set(lab, list);
+      }
+
+      const data: PlotlyTrace[] = [];
+      let colorIdx = 0;
+      // Prefer multi-series equipment labels; fall back to single plant total.
+      const labels = [...perEq.keys()].sort((a, b) => a.localeCompare(b));
+      for (const lab of labels) {
+        const eqRows = perEq.get(lab) ?? [];
+        const byWeek = new Map(
+          eqRows.map((r) => [String(r.week_label ?? ""), num(r.run_hours)]),
+        );
+        data.push({
           type: "bar",
-          name: "run hours",
-          x,
-          y: hours,
-        },
-      ];
+          name: lab,
+          x: weeks,
+          y: weeks.map((w) => byWeek.get(w) ?? null),
+          marker: { color: rainbowColor(colorIdx) },
+        });
+        colorIdx += 1;
+      }
+
+      // Avg OAT while on: mean across equipment that reported OAT that week.
+      const oatByWeek = new Map<string, { sum: number; n: number }>();
+      for (const r of sorted) {
+        const o = num(r.avg_oat_f);
+        if (o == null) continue;
+        const w = String(r.week_label ?? "");
+        const e = oatByWeek.get(w) ?? { sum: 0, n: 0 };
+        e.sum += o;
+        e.n += 1;
+        oatByWeek.set(w, e);
+      }
+      const oat = weeks.map((w) => {
+        const e = oatByWeek.get(w);
+        return e && e.n > 0 ? e.sum / e.n : null;
+      });
+      const hasOat = oat.some((v) => v != null);
       if (hasOat) {
         data.push({
           type: "scatter",
           mode: "lines+markers",
-          name: "avg OAT",
-          x,
+          name: "Avg OAT °F (while on)",
+          x: weeks,
           y: oat,
           yaxis: "y2",
-          line: { width: 2 },
+          line: { width: 2, color: "#333333", dash: "dot" },
+          marker: { size: 7, color: "#333333" },
         });
       }
+
+      const isAir = plant_group === "air";
+      const shapes = isAir
+        ? [
+            {
+              type: "line",
+              xref: "paper",
+              x0: 0,
+              x1: 1,
+              yref: "y",
+              y0: AIR_BARE_MIN_OCC_HOURS_WEEK,
+              y1: AIR_BARE_MIN_OCC_HOURS_WEEK,
+              line: { color: "#c45c26", width: 1.5, dash: "dash" },
+            },
+          ]
+        : undefined;
+      const annotations = isAir
+        ? [
+            {
+              xref: "paper",
+              x: 1,
+              y: AIR_BARE_MIN_OCC_HOURS_WEEK,
+              yref: "y",
+              text: `Bare-min occupied hours/week (${AIR_BARE_MIN_OCC_HOURS_WEEK}h)`,
+              showarrow: false,
+              xanchor: "right",
+              yanchor: "bottom",
+              font: { size: 10, color: "#c45c26" },
+            },
+          ]
+        : undefined;
+
       const figure: PlotlyFigure = {
         data,
-        layout: {
-          title: `${titles[plant_group] ?? plant_group} — weekly run hours`,
-          barmode: "group",
-          showlegend: true,
-          xaxis: { title: "week", tickangle: -35, autorange: true },
-          yaxis: { title: "run hours", autorange: true },
-          ...(hasOat
-            ? {
-                yaxis2: {
-                  title: "avg OAT °F",
-                  overlaying: "y",
-                  side: "right",
-                  autorange: true,
-                },
-              }
-            : {}),
-          margin: { t: 48, r: hasOat ? 56 : 24, b: 96, l: 56 },
+        layout: overviewChartLayout({
+          xTitle: "Week starting (Mon)",
+          yTitle: "Run hours",
+          rightAxis: hasOat,
+          height: Math.max(420, 60 + 18 * Math.min(labels.length, 12)),
           uirevision: `weekly:${plant_group}:${fingerprintJson(sorted)}`,
-        },
+          extra: {
+            barmode: "group",
+            ...(shapes ? { shapes } : {}),
+            ...(annotations ? { annotations } : {}),
+          },
+        }),
         meta: {
           point_count: sorted.length,
-          provenance: "POST /api/analytics/runtime (runtime-weekly-v1)",
+          provenance: "POST /api/analytics/runtime (runtime-weekly-v2)",
         },
       };
       return {
@@ -142,9 +214,96 @@ function weeklyPlantFigures(
 function mechFigure(rows: Array<Record<string, unknown>>): {
   figure: PlotlyFigure | null;
   bins: Array<Record<string, unknown>>;
+  callout: string | null;
 } {
   const oatBins = rows.filter((r) => r.kind === "oat_bin");
-  if (oatBins.length) {
+  if (!oatBins.length) {
+    // Never promote historian row-counts as the primary mech product chart.
+    return { figure: null, bins: [], callout: null };
+  }
+
+  const individuals = oatBins.filter(
+    (r) =>
+      !r.series_kind ||
+      r.series_kind === "individual_device" ||
+      (r.series_kind !== "aggregate_device_hours" &&
+        r.series_kind !== "aggregate_active_hours"),
+  );
+  const totals = oatBins.filter(
+    (r) => r.series_kind === "aggregate_device_hours",
+  );
+  const anyActive = oatBins.filter(
+    (r) => r.series_kind === "aggregate_active_hours",
+  );
+
+  const binOrder = [
+    ...new Set(
+      oatBins
+        .map((r) => ({
+          label: String(r.bin_label ?? ""),
+          lo: num(r.bin_lo_f) ?? 0,
+        }))
+        .sort((a, b) => a.lo - b.lo)
+        .map((b) => b.label),
+    ),
+  ];
+
+  const byEq = new Map<string, Array<Record<string, unknown>>>();
+  for (const r of individuals) {
+    const eq = String(r.equipment_id ?? "device");
+    if (eq === "ALL" || eq === "ANY") continue;
+    const list = byEq.get(eq) ?? [];
+    list.push(r);
+    byEq.set(eq, list);
+  }
+  const devices = [...byEq.keys()].sort((a, b) => a.localeCompare(b));
+
+  const data: PlotlyTrace[] = [];
+  devices.forEach((eq, i) => {
+    const eqRows = byEq.get(eq) ?? [];
+    const byBin = new Map(
+      eqRows.map((r) => [String(r.bin_label ?? ""), num(r.hours)]),
+    );
+    data.push({
+      type: "bar",
+      name: eq,
+      x: binOrder,
+      y: binOrder.map((b) => byBin.get(b) ?? null),
+      marker: { color: rainbowColor(i) },
+    });
+  });
+
+  if (totals.length) {
+    const byBin = new Map(
+      totals.map((r) => [String(r.bin_label ?? ""), num(r.hours)]),
+    );
+    data.push({
+      type: "scatter",
+      mode: "lines+markers",
+      name: "Total compressor device-hours",
+      x: binOrder,
+      y: binOrder.map((b) => byBin.get(b) ?? null),
+      line: { width: 2.2, color: "#111827" },
+      marker: { size: 7, color: "#111827" },
+    });
+  }
+  if (anyActive.length) {
+    const byBin = new Map(
+      anyActive.map((r) => [String(r.bin_label ?? ""), num(r.hours)]),
+    );
+    data.push({
+      type: "scatter",
+      mode: "lines+markers",
+      name: "Any compressor active",
+      x: binOrder,
+      y: binOrder.map((b) => byBin.get(b) ?? null),
+      line: { width: 2.2, color: "#6b7280", dash: "dash" },
+      marker: { size: 7, color: "#6b7280", symbol: "circle-open" },
+    });
+  }
+
+  // Fallback: legacy single-series oat_bin without series_kind / equipment_id.
+  if (!data.length) {
     const sorted = [...oatBins].sort(
       (a, b) => (num(a.bin_lo_f) ?? 0) - (num(b.bin_lo_f) ?? 0),
     );
@@ -153,28 +312,44 @@ function mechFigure(rows: Array<Record<string, unknown>>): {
         xKey: "bin_label",
         yKeys: ["hours"],
         title: "Mechanical cooling run hours by outdoor-air temperature (5°F bins)",
-        yAxisTitle: "hours",
+        yAxisTitle: "Run hours",
         maxBars: 40,
         provenance: "POST /api/analytics/mechanical-cooling (OAT bins)",
       }),
       bins: sorted,
+      callout: null,
     };
   }
-  const usable = rows.filter((r) => num(r.history_rows) != null);
-  if (!usable.length) return { figure: null, bins: [] };
-  return {
-    figure: rowsToBarFigure(usable, {
-      xKey: "equipment_id",
-      yKeys: ["history_rows"],
-      title: "Mechanical cooling — historian row counts",
-      yAxisTitle: "rows",
-      sortBy: "history_rows",
-      sortDesc: true,
-      maxBars: 40,
-      provenance: "POST /api/analytics/mechanical-cooling (DataFusion)",
+
+  let callout: string | null = null;
+  if (devices.length === 1) {
+    callout = `Only ${devices[0]} had observed compressor runtime during this period. Total compressor device-hours therefore equal ${devices[0]} runtime.`;
+  }
+
+  const figure: PlotlyFigure = {
+    data,
+    layout: overviewChartLayout({
+      xTitle: "OAT bin °F",
+      yTitle: "Run hours",
+      height: 420,
+      tickangle: 0,
+      uirevision: `mech-oat:${fingerprintJson(oatBins)}`,
+      extra: {
+        barmode: "stack",
+        xaxis: {
+          title: "OAT bin °F",
+          categoryorder: "array",
+          categoryarray: binOrder,
+          autorange: true,
+        },
+      },
     }),
-    bins: [],
+    meta: {
+      point_count: oatBins.length,
+      provenance: "POST /api/analytics/mechanical-cooling (OAT bins v2)",
+    },
   };
+  return { figure, bins: oatBins, callout };
 }
 
 /** vibe19 economizer_delta_scatter: (MAT−RAT) vs (OAT−RAT) + OA-fraction refs. */
@@ -544,7 +719,9 @@ export async function fetchCentralOverview(opts: {
 
   const weeklyPlants = weeklyPlantFigures(runtimeRows);
   const motorFig = motorFigure(
-    equipmentTotals.filter((r) => r.kind !== "weekly_plant"),
+    equipmentTotals.filter(
+      (r) => r.kind !== "weekly_plant" && r.kind !== "weekly_equipment",
+    ),
   );
   const plants: OverviewPlantFig[] =
     weeklyPlants.length > 0
@@ -561,7 +738,11 @@ export async function fetchCentralOverview(opts: {
           ]
         : [];
 
-  const { figure: mechFig, bins: mechBins } = mechFigure(mechRows);
+  const {
+    figure: mechFig,
+    bins: mechBins,
+    callout: mechCallout,
+  } = mechFigure(mechRows);
   const deltaScatter = econDeltaScatter(econPoints, dtMin);
   const matResidual = econMatResidual(econPoints);
   const { figure: tempsOverlay, equipmentId: overlayEq } = econTempsOverlay(
@@ -603,13 +784,25 @@ export async function fetchCentralOverview(opts: {
         mech,
         mechBins.length
           ? "Mechanical cooling OAT bin hours from DataFusion"
-          : "Mechanical cooling evidence from DataFusion",
+          : mechFig
+            ? "Mechanical cooling evidence from DataFusion"
+            : "No compressor×OAT intervals in historian (need chiller proof + site OAT)",
       ),
       figure: mechFig,
       bins: mechBins,
-      coverage: mechRows.filter((r) => r.kind !== "oat_bin").slice(0, 200),
-      n_included: mechBins.length || mechRows.length,
+      coverage: mechRows
+        .filter((r) => r.kind !== "oat_bin" && num(r.history_rows) != null)
+        .slice(0, 200),
+      n_included: mechBins.filter((r) => r.series_kind === "individual_device")
+        .length
+        ? new Set(
+            mechBins
+              .filter((r) => r.series_kind === "individual_device")
+              .map((r) => String(r.equipment_id)),
+          ).size
+        : mechBins.length || null,
       n_excluded: 0,
+      callout: mechCallout,
     },
     economizer_weather: {
       caption:

--- a/frontend/web/src/api/overviewOracleApi.ts
+++ b/frontend/web/src/api/overviewOracleApi.ts
@@ -34,6 +34,8 @@ export interface OverviewVibe19Response {
     coverage: Array<Record<string, unknown>>;
     n_included: number | null;
     n_excluded: number | null;
+    /** Single-device runtime note (vibe19 parity). */
+    callout?: string | null;
   };
   economizer_weather: {
     caption: string;

--- a/frontend/web/src/api/plotlyTheme.ts
+++ b/frontend/web/src/api/plotlyTheme.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared Plotly presentation constants — port of vibe19 / open_fdd.analytics.charts
+ * RAINBOW_PALETTE + Overview layout defaults.
+ */
+
+export const RAINBOW_PALETTE: string[] = [
+  "#e11d48", // rose
+  "#ea580c", // orange
+  "#ca8a04", // gold
+  "#16a34a", // green
+  "#0d9488", // teal
+  "#2563eb", // blue
+  "#7c3aed", // violet
+  "#db2777", // pink
+  "#0891b2", // cyan
+  "#65a30d", // lime
+  "#9333ea", // purple
+  "#dc2626", // red
+];
+
+/** Bare-min occupied hours/week for air-side weekly chart (BUILDING_100 parity). */
+export const AIR_BARE_MIN_OCC_HOURS_WEEK = 60;
+
+export function rainbowColor(index: number): string {
+  return RAINBOW_PALETTE[index % RAINBOW_PALETTE.length];
+}
+
+/** Horizontal legend + white-template margins used by vibe19 Overview charts. */
+export function overviewChartLayout(opts: {
+  xTitle: string;
+  yTitle: string;
+  height?: number;
+  rightAxis?: boolean;
+  tickangle?: number;
+  uirevision?: string;
+  extra?: Record<string, unknown>;
+}): Record<string, unknown> {
+  const right = Boolean(opts.rightAxis);
+  return {
+    showlegend: true,
+    legend: { orientation: "h", y: 1.14, font: { size: 10 } },
+    xaxis: {
+      title: opts.xTitle,
+      tickangle: opts.tickangle ?? -45,
+      autorange: true,
+    },
+    yaxis: { title: opts.yTitle, autorange: true },
+    ...(right
+      ? {
+          yaxis2: {
+            title: "Avg OAT °F",
+            overlaying: "y",
+            side: "right",
+            showgrid: false,
+            autorange: true,
+          },
+        }
+      : {}),
+    margin: { l: 50, r: right ? 60 : 20, t: 60, b: 80 },
+    paper_bgcolor: "white",
+    plot_bgcolor: "white",
+    height: opts.height ?? 420,
+    ...(opts.uirevision ? { uirevision: opts.uirevision } : {}),
+    ...(opts.extra ?? {}),
+  };
+}

--- a/frontend/web/src/components/OverviewPopulated.tsx
+++ b/frontend/web/src/components/OverviewPopulated.tsx
@@ -802,7 +802,6 @@ export function OverviewPopulated({
         {(overview?.motor_weekly.plants ?? []).map((plant) => (
           <div key={plant.plant_group} data-testid={`overview-motor-${plant.plant_group}`}>
             <h4>{plant.title}</h4>
-            <p className="oracle-sidebar__caption">{plant.caption}</p>
             {plant.empty || !plant.figure ? (
               <p className="oracle-sidebar__caption">
                 No series for {plant.title.split("—")[0]?.trim().toLowerCase()}.
@@ -856,6 +855,19 @@ export function OverviewPopulated({
           {overview?.mech_cooling.caption ??
             "Chillers / DX / VRF compressor-proof; never CHW valves."}
         </p>
+        {overview?.mech_cooling.callout ? (
+          <p
+            className="oracle-sidebar__caption"
+            data-testid="overview-mech-callout"
+            style={{
+              background: "rgba(59, 130, 246, 0.12)",
+              borderRadius: 8,
+              padding: "10px 12px",
+            }}
+          >
+            {overview.mech_cooling.callout}
+          </p>
+        ) : null}
         <PlotlyHost
           id="mech-cooling"
           label="Mechanical cooling by OAT"

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1638,10 +1638,7 @@ mod tests {
         assert!(!env.rows.is_empty());
         assert_eq!(env.rows[0]["history_rows"].as_u64().unwrap(), 2);
         assert!(env.warnings.iter().any(|w| w.contains("not fabricated")));
-        assert_eq!(
-            env.coverage.as_ref().unwrap()["building_id"],
-            "BUILDING_DC"
-        );
+        assert_eq!(env.coverage.as_ref().unwrap()["building_id"], "BUILDING_DC");
     }
 
     #[tokio::test]
@@ -1886,10 +1883,7 @@ mod tests {
             .rows
             .iter()
             .any(|r| r["series_kind"] == "aggregate_device_hours"));
-        assert!(env
-            .rows
-            .iter()
-            .any(|r| r["equipment_id"] == "CHILLER_1"));
+        assert!(env.rows.iter().any(|r| r["equipment_id"] == "CHILLER_1"));
     }
 
     #[tokio::test]
@@ -1957,10 +1951,7 @@ mod tests {
         std::fs::create_dir_all(&building).unwrap();
         std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
 
-        for (eq, fan_vals) in [
-            ("AHU_1", [1, 1, 1]),
-            ("AHU_2", [1, 0, 1]),
-        ] {
+        for (eq, fan_vals) in [("AHU_1", [1, 1, 1]), ("AHU_2", [1, 0, 1])] {
             let dir = building.join(eq);
             std::fs::create_dir_all(&dir).unwrap();
             std::fs::write(

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -307,20 +307,30 @@ fn mech_oat_col(cols: &HashSet<String>) -> Option<&'static str> {
     })
 }
 
-fn oat_col(cols: &HashSet<String>) -> Option<&'static str> {
-    if cols.contains("oa_t") {
-        Some("oa_t")
-    } else if cols.contains("web_oa_t") {
-        Some("web_oa_t")
-    } else {
-        None
-    }
-}
-
 fn web_oat_col(cols: &HashSet<String>) -> Option<&'static str> {
     ["web_oa_t", "oa_t_web", "oat_meteo", "oa_t_meteo"]
         .into_iter()
         .find(|&c| cols.contains(c))
+}
+
+/// Prefer web/meteo OAT for weekly plant avg-while-on (vibe19 `prefer_web_oat`).
+fn weekly_oat_col(cols: &HashSet<String>) -> Option<&'static str> {
+    mech_oat_col(cols)
+}
+
+/// Short signal label for weekly chart series names (schema-level best effort).
+fn plant_signal_label(cols: &HashSet<String>) -> &'static str {
+    if cols.contains("fan_status") {
+        "fan-status"
+    } else if cols.contains("fan_cmd") {
+        "fan-cmd"
+    } else if cols.contains("chiller_status") {
+        "chiller-status"
+    } else if cols.contains("boiler_status") {
+        "boiler-status"
+    } else {
+        "status"
+    }
 }
 
 fn equipment_filter_sql(equipment_filter: Option<&[String]>) -> String {
@@ -493,9 +503,10 @@ ORDER BY i.equipment_id
                         &ctx,
                         ts_col,
                         &on_sql,
-                        oat_col(&cols),
+                        weekly_oat_col(&cols),
                         max_gap,
                         &eq_filter,
+                        plant_signal_label(&cols),
                     )
                     .await
                     .unwrap_or_else(|e| {
@@ -504,7 +515,8 @@ ORDER BY i.equipment_id
                     });
                     if !weekly_rows.is_empty() {
                         warnings.push(
-                            "rows include weekly plant_group bins (runtime-weekly-v1)".into(),
+                            "rows include weekly per-equipment plant bins (runtime-weekly-v2)"
+                                .into(),
                         );
                     }
                     let mut env = envelope_with_engine(QV_RUNTIME, &query, warnings, DF_ENGINE);
@@ -548,7 +560,11 @@ ORDER BY i.equipment_id
     Ok(Some(env))
 }
 
-/// Weekly plant-group run hours (Mon-start week labels) for Overview motor charts.
+/// Weekly per-equipment run hours (Mon-start week labels) for Overview motor charts.
+/// Emits `kind=weekly_equipment` rows (one series per AHU/chiller/boiler), matching
+/// vibe19 `motor_run_hours_weekly` — does **not** fold equipment into plant totals.
+/// Site OAT is broadcast by timestamp so avg-while-on works when OAT lives on
+/// weather/web rows rather than on the motor equipment itself.
 async fn runtime_weekly_plant_rows(
     ctx: &SessionContext,
     ts_col: &str,
@@ -556,21 +572,49 @@ async fn runtime_weekly_plant_rows(
     oat: Option<&str>,
     max_gap: f64,
     eq_filter: &str,
+    signal_label: &str,
 ) -> Result<Vec<Value>> {
-    let oat_sel = oat
-        .map(|c| format!("{c} AS oat_f,"))
-        .unwrap_or_else(|| "CAST(NULL AS FLOAT) AS oat_f,".into());
+    let oat_by_ts_cte = match oat {
+        Some(c) => format!(
+            r#"
+oat_by_ts AS (
+  SELECT {ts_col} AS ts, AVG({c}) AS oat_f
+  FROM history
+  WHERE {c} IS NOT NULL
+  GROUP BY {ts_col}
+),"#
+        ),
+        None => String::new(),
+    };
+    let oat_join = if oat.is_some() {
+        "LEFT JOIN oat_by_ts o ON h.ts = o.ts"
+    } else {
+        ""
+    };
+    let oat_sel = if oat.is_some() {
+        "o.oat_f AS oat_f,"
+    } else {
+        "CAST(NULL AS FLOAT) AS oat_f,"
+    };
     let sql = format!(
         r#"
-WITH ordered AS (
+WITH {oat_by_ts_cte}
+ordered AS (
   SELECT
-    equipment_id,
-    {ts_col} AS ts,
-    {on_sql} AS is_on,
+    h.equipment_id,
+    h.ts,
+    h.is_on,
     {oat_sel}
-    LEAD({ts_col}) OVER (PARTITION BY equipment_id ORDER BY {ts_col}) AS next_ts
-  FROM history
-  WHERE equipment_id IS NOT NULL{eq_filter}
+    LEAD(h.ts) OVER (PARTITION BY h.equipment_id ORDER BY h.ts) AS next_ts
+  FROM (
+    SELECT
+      equipment_id,
+      {ts_col} AS ts,
+      {on_sql} AS is_on
+    FROM history
+    WHERE equipment_id IS NOT NULL{eq_filter}
+  ) h
+  {oat_join}
 ),
 raw_intervals AS (
   SELECT
@@ -606,8 +650,7 @@ ORDER BY week_start, equipment_id
 "#
     );
     let result = run_sql(ctx, &sql).await?;
-    // Aggregate equipment → plant_group per week.
-    let mut agg: BTreeMap<(String, String), (f64, f64, u64)> = BTreeMap::new();
+    let mut out = Vec::new();
     for row in &result.rows {
         let eq = row
             .get("equipment_id")
@@ -627,24 +670,20 @@ ORDER BY week_start, equipment_id
             continue;
         }
         let hours = row.get("run_hours").and_then(|v| v.as_f64()).unwrap_or(0.0);
-        let oat_v = row.get("avg_oat_f").and_then(|v| v.as_f64());
-        let key = (plant.to_string(), week);
-        let e = agg.entry(key).or_insert((0.0, 0.0, 0));
-        e.0 += hours;
-        if let Some(o) = oat_v {
-            e.1 += o;
-            e.2 += 1;
+        if hours <= 0.0 {
+            continue;
         }
-    }
-    let mut out = Vec::new();
-    for ((plant, week), (hours, oat_sum, oat_n)) in agg {
+        let oat_v = row.get("avg_oat_f").and_then(|v| v.as_f64());
+        let label = format!("{eq} · {signal_label}");
         out.push(json!({
-            "kind": "weekly_plant",
-            "query_version": "runtime-weekly-v1",
+            "kind": "weekly_equipment",
+            "query_version": "runtime-weekly-v2",
+            "equipment_id": eq,
+            "label": label,
             "plant_group": plant,
             "week_label": week,
             "run_hours": round2(hours),
-            "avg_oat_f": if oat_n > 0 { Some(round2(oat_sum / oat_n as f64)) } else { None::<f64> },
+            "avg_oat_f": oat_v.map(round2),
         }));
     }
     out.sort_by(|a, b| {
@@ -653,7 +692,11 @@ ORDER BY week_start, equipment_id
         wa.cmp(wb).then_with(|| {
             let pa = a.get("plant_group").and_then(|v| v.as_str()).unwrap_or("");
             let pb = b.get("plant_group").and_then(|v| v.as_str()).unwrap_or("");
-            pa.cmp(pb)
+            pa.cmp(pb).then_with(|| {
+                let ea = a.get("equipment_id").and_then(|v| v.as_str()).unwrap_or("");
+                let eb = b.get("equipment_id").and_then(|v| v.as_str()).unwrap_or("");
+                ea.cmp(eb)
+            })
         })
     });
     Ok(out)
@@ -1123,17 +1166,33 @@ pub async fn mech_oat_bins_from_history(
     let max_gap = max_gap_seconds.max(0.0);
     let eq_filter = equipment_filter_sql(equipment_filter);
     let chiller_filter = chiller_like_equipment_sql();
+    // Site OAT broadcast by timestamp (Liberty chillers often lack inline OAT).
     let sql = format!(
         r#"
-WITH ordered AS (
+WITH oat_by_ts AS (
+  SELECT {ts_col} AS ts, AVG({oat}) AS oat_f
+  FROM history
+  WHERE {oat} IS NOT NULL AND {oat} >= 40.0 AND {oat} <= 110.0
+  GROUP BY {ts_col}
+),
+chiller_samp AS (
+  SELECT
+    h.equipment_id,
+    h.{ts_col} AS ts,
+    {on_sql} AS is_on,
+    o.oat_f
+  FROM history h
+  LEFT JOIN oat_by_ts o ON h.{ts_col} = o.ts
+  WHERE h.equipment_id IS NOT NULL{eq_filter}{chiller_filter}
+),
+ordered AS (
   SELECT
     equipment_id,
-    {ts_col} AS ts,
-    {on_sql} AS is_on,
-    {oat} AS oat_f,
-    LEAD({ts_col}) OVER (PARTITION BY equipment_id ORDER BY {ts_col}) AS next_ts
-  FROM history
-  WHERE equipment_id IS NOT NULL AND {oat} IS NOT NULL{eq_filter}{chiller_filter}
+    ts,
+    is_on,
+    oat_f,
+    LEAD(ts) OVER (PARTITION BY equipment_id ORDER BY ts) AS next_ts
+  FROM chiller_samp
 ),
 intervals AS (
   SELECT
@@ -1146,24 +1205,104 @@ intervals AS (
       ELSE (CAST(next_ts AS BIGINT) - CAST(ts AS BIGINT)) / 1000000000.0
     END AS dt_sec
   FROM ordered
-  WHERE next_ts IS NOT NULL AND is_on
+  WHERE next_ts IS NOT NULL AND is_on AND oat_f IS NOT NULL
+),
+device_bins AS (
+  SELECT
+    equipment_id,
+    FLOOR(oat_f / 5.0) * 5.0 AS bin_lo,
+    SUM(dt_sec) / 3600.0 AS hours
+  FROM intervals
+  GROUP BY equipment_id, FLOOR(oat_f / 5.0) * 5.0
+),
+any_by_ts AS (
+  SELECT
+    ts,
+    BOOL_OR(is_on) AS any_on,
+    MAX(oat_f) AS oat_f
+  FROM chiller_samp
+  WHERE oat_f IS NOT NULL
+  GROUP BY ts
+),
+any_ordered AS (
+  SELECT
+    ts,
+    any_on,
+    oat_f,
+    LEAD(ts) OVER (ORDER BY ts) AS next_ts
+  FROM any_by_ts
+),
+any_intervals AS (
+  SELECT
+    oat_f,
+    CASE
+      WHEN (CAST(next_ts AS BIGINT) - CAST(ts AS BIGINT)) / 1000000000.0 < 0.0 THEN 0.0
+      WHEN (CAST(next_ts AS BIGINT) - CAST(ts AS BIGINT)) / 1000000000.0 > {max_gap} THEN {max_gap}
+      ELSE (CAST(next_ts AS BIGINT) - CAST(ts AS BIGINT)) / 1000000000.0
+    END AS dt_sec
+  FROM any_ordered
+  WHERE next_ts IS NOT NULL AND any_on AND oat_f IS NOT NULL
+),
+any_bins AS (
+  SELECT
+    FLOOR(oat_f / 5.0) * 5.0 AS bin_lo,
+    SUM(dt_sec) / 3600.0 AS hours
+  FROM any_intervals
+  GROUP BY FLOOR(oat_f / 5.0) * 5.0
 )
 SELECT
-  FLOOR(oat_f / 5.0) * 5.0 AS bin_lo,
-  SUM(dt_sec) / 3600.0 AS hours
-FROM intervals
-GROUP BY FLOOR(oat_f / 5.0) * 5.0
-ORDER BY bin_lo
+  equipment_id,
+  'individual_device' AS series_kind,
+  bin_lo,
+  hours
+FROM device_bins
+UNION ALL
+SELECT
+  'ALL' AS equipment_id,
+  'aggregate_device_hours' AS series_kind,
+  bin_lo,
+  SUM(hours) AS hours
+FROM device_bins
+GROUP BY bin_lo
+UNION ALL
+SELECT
+  'ANY' AS equipment_id,
+  'aggregate_active_hours' AS series_kind,
+  bin_lo,
+  hours
+FROM any_bins
+ORDER BY series_kind, equipment_id, bin_lo
 "#
     );
-    let result = run_sql(&ctx, &sql).await?;
+    let result = match run_sql(&ctx, &sql).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "mech oat bin SQL failed");
+            return Ok(None);
+        }
+    };
     let mut rows = Vec::new();
     for r in &result.rows {
         let lo = as_f64(r.get("bin_lo")).unwrap_or(0.0);
         let hours = as_f64(r.get("hours")).unwrap_or(0.0);
+        if hours <= 0.0 {
+            continue;
+        }
+        let eq = r
+            .get("equipment_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let series_kind = r
+            .get("series_kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("individual_device")
+            .to_string();
         rows.push(json!({
             "kind": "oat_bin",
-            "query_version": "mechanical-cooling-oat-bins-v1",
+            "query_version": "mechanical-cooling-oat-bins-v2",
+            "series_kind": series_kind,
+            "equipment_id": eq,
             "bin_lo_f": round2(lo),
             "bin_hi_f": round2(lo + 5.0),
             "bin_label": format!("{:.0}-{:.0}", lo, lo + 5.0),
@@ -1174,7 +1313,7 @@ ORDER BY bin_lo
         return Ok(None);
     }
     let warnings = vec!["mechanical cooling OAT bins from historian DataFusion \
-         (compressor/chiller proof × preferred web OAT; chiller-like equipment only)"
+         (compressor/chiller proof × site-broadcast preferred web OAT; per-device + aggregates)"
         .into()];
     let query = AnalyticsQuery::default();
     let mut env = envelope_with_engine(QV_MECHANICAL_COOLING, &query, warnings, DF_ENGINE);
@@ -1186,6 +1325,7 @@ ORDER BY bin_lo
         "source": "historian_parquet",
         "building_id": safe_building_segment(building_id),
         "oat_column": oat,
+        "oat_join": "site_broadcast_by_ts",
     }));
     Ok(Some(env))
 }
@@ -1288,8 +1428,9 @@ pub async fn descriptive_counts_from_history(
     query_version: &str,
     equipment_filter: Option<&[String]>,
     note: &str,
+    building_id: Option<&str>,
 ) -> Result<Option<AnalyticsEnvelope>> {
-    let Some((ctx, _cols, n)) = open_history().await? else {
+    let Some((ctx, _cols, n)) = open_history_scoped(building_id).await? else {
         return Ok(None);
     };
     let eq_filter = equipment_filter_sql(equipment_filter);
@@ -1320,6 +1461,7 @@ pub async fn descriptive_counts_from_history(
         "equipment_count": env.equipment.len(),
         "history_rows": n,
         "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
     }));
     Ok(Some(env))
 }
@@ -1484,6 +1626,7 @@ mod tests {
             crate::analytics::QV_METERING,
             None,
             "metering test note",
+            Some("BUILDING_DC"),
         )
         .await
         .unwrap()
@@ -1495,6 +1638,10 @@ mod tests {
         assert!(!env.rows.is_empty());
         assert_eq!(env.rows[0]["history_rows"].as_u64().unwrap(), 2);
         assert!(env.warnings.iter().any(|w| w.contains("not fabricated")));
+        assert_eq!(
+            env.coverage.as_ref().unwrap()["building_id"],
+            "BUILDING_DC"
+        );
     }
 
     #[tokio::test]
@@ -1724,13 +1871,138 @@ mod tests {
         assert!(!env.rows.is_empty());
         assert_eq!(env.rows[0]["kind"], "oat_bin");
         assert!(env.coverage.as_ref().unwrap()["oat_column"] == "web_oa_t");
-        let hours: f64 = env
+        let device_hours: f64 = env
             .rows
             .iter()
+            .filter(|r| r["series_kind"] == "individual_device")
             .map(|r| r["hours"].as_f64().unwrap_or(0.0))
             .sum();
         // Two on intervals of 300s (t0→t1 and t1→t2 while status stays 1) → 600s
-        assert!((hours - (600.0 / 3600.0)).abs() < 0.02, "hours={hours}");
+        assert!(
+            (device_hours - (600.0 / 3600.0)).abs() < 0.02,
+            "device_hours={device_hours}"
+        );
+        assert!(env
+            .rows
+            .iter()
+            .any(|r| r["series_kind"] == "aggregate_device_hours"));
+        assert!(env
+            .rows
+            .iter()
+            .any(|r| r["equipment_id"] == "CHILLER_1"));
+    }
+
+    #[tokio::test]
+    async fn mech_oat_bins_joins_site_oat_from_weather_equipment() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SPLIT");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+
+        let ch = building.join("CHILLER_2");
+        std::fs::create_dir_all(&ch).unwrap();
+        std::fs::write(
+            ch.join("columns.csv"),
+            "col,point_role\nchiller_status,chiller_status\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ch.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,chiller_status").unwrap();
+        writeln!(f, "2026-07-01T00:00:00Z,1").unwrap();
+        writeln!(f, "2026-07-01T00:05:00Z,1").unwrap();
+        writeln!(f, "2026-07-01T00:10:00Z,0").unwrap();
+
+        let wx = building.join("weather");
+        std::fs::create_dir_all(&wx).unwrap();
+        std::fs::write(
+            wx.join("columns.csv"),
+            "col,point_role\nweb_oa_t,web_oa_t\n",
+        )
+        .unwrap();
+        let mut wf = std::fs::File::create(wx.join("history_wide.csv")).unwrap();
+        writeln!(wf, "timestamp_utc,web_oa_t").unwrap();
+        writeln!(wf, "2026-07-01T00:00:00Z,72").unwrap();
+        writeln!(wf, "2026-07-01T00:05:00Z,73").unwrap();
+        writeln!(wf, "2026-07-01T00:10:00Z,74").unwrap();
+
+        let parquet = tmp.path().join("parquet_split");
+        fdd_store::ingest_building(tmp.path(), "BUILDING_SPLIT", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let env = mech_oat_bins_from_history(None, 900.0, Some("BUILDING_SPLIT"))
+            .await
+            .unwrap()
+            .expect("site OAT join should produce oat bins without inline chiller OAT");
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+
+        let device: Vec<_> = env
+            .rows
+            .iter()
+            .filter(|r| r["series_kind"] == "individual_device")
+            .collect();
+        assert!(!device.is_empty());
+        assert_eq!(device[0]["equipment_id"], "CHILLER_2");
+        assert!(device.iter().any(|r| {
+            let lo = r["bin_lo_f"].as_f64().unwrap_or(-1.0);
+            (70.0..75.0).contains(&lo)
+        }));
+    }
+
+    #[tokio::test]
+    async fn runtime_weekly_emits_per_equipment_not_plant_sum() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_AIR");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+
+        for (eq, fan_vals) in [
+            ("AHU_1", [1, 1, 1]),
+            ("AHU_2", [1, 0, 1]),
+        ] {
+            let dir = building.join(eq);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("columns.csv"),
+                "col,point_role\nfan_status,fan_status\nweb_oa_t,web_oa_t\n",
+            )
+            .unwrap();
+            let mut f = std::fs::File::create(dir.join("history_wide.csv")).unwrap();
+            writeln!(f, "timestamp_utc,fan_status,web_oa_t").unwrap();
+            writeln!(f, "2026-03-23T00:00:00Z,{},55", fan_vals[0]).unwrap();
+            writeln!(f, "2026-03-23T00:05:00Z,{},56", fan_vals[1]).unwrap();
+            writeln!(f, "2026-03-23T00:10:00Z,{},57", fan_vals[2]).unwrap();
+        }
+
+        let parquet = tmp.path().join("parquet_air");
+        fdd_store::ingest_building(tmp.path(), "BUILDING_AIR", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let env = runtime_from_history(None, 900.0, Some("BUILDING_AIR"))
+            .await
+            .unwrap()
+            .expect("runtime envelope");
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+
+        let weekly: Vec<_> = env
+            .rows
+            .iter()
+            .filter(|r| r["kind"] == "weekly_equipment")
+            .collect();
+        assert!(
+            weekly.len() >= 2,
+            "expected per-AHU weekly rows, got {weekly:?}"
+        );
+        let eqs: HashSet<_> = weekly
+            .iter()
+            .filter_map(|r| r["equipment_id"].as_str())
+            .collect();
+        assert!(eqs.contains("AHU_1"));
+        assert!(eqs.contains("AHU_2"));
+        assert!(weekly.iter().all(|r| r.get("label").is_some()));
+        // Must not emit folded plant totals as the product rows.
+        assert!(env.rows.iter().all(|r| r["kind"] != "weekly_plant"));
     }
 
     #[test]

--- a/services/central/src/analytics/mechanical_cooling.rs
+++ b/services/central/src/analytics/mechanical_cooling.rs
@@ -195,6 +195,7 @@ pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
             QV_MECHANICAL_COOLING,
             req.query.equipment_ids.as_deref(),
             "mechanical_cooling: compressor/chiller evidence gate requires inline series",
+            req.query.building_id.as_deref(),
         )
         .await
         {

--- a/services/central/src/analytics/metering.rs
+++ b/services/central/src/analytics/metering.rs
@@ -92,6 +92,7 @@ pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
             QV_METERING,
             req.query.equipment_ids.as_deref(),
             "metering: monthly kWh aggregation requires inline {period,kwh} rows",
+            req.query.building_id.as_deref(),
         )
         .await
         {

--- a/services/central/src/analytics/plant.rs
+++ b/services/central/src/analytics/plant.rs
@@ -55,6 +55,7 @@ async fn plant_from_history(
         expected_qv,
         req.query.equipment_ids.as_deref(),
         &note,
+        req.query.building_id.as_deref(),
     )
     .await
     {

--- a/services/central/src/analytics/rcx.rs
+++ b/services/central/src/analytics/rcx.rs
@@ -261,6 +261,7 @@ pub async fn handle_ahu_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
             QV_RCX_AHU,
             req.query.equipment_ids.as_deref(),
             "rcx/ahu: reset-evidence coverage requires inline series",
+            req.query.building_id.as_deref(),
         )
         .await
         {
@@ -282,6 +283,7 @@ pub async fn handle_vav_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
             QV_RCX_VAV,
             req.query.equipment_ids.as_deref(),
             "rcx/vav: zone-comfort ranking requires inline zone_temp/setpoint series",
+            req.query.building_id.as_deref(),
         )
         .await
         {


### PR DESCRIPTION
## Summary
- Central runtime emits per-equipment `weekly_equipment` rows (AHU_1 / AHU_2) with site-broadcast OAT while-on instead of folding into one plant total.
- Mech cooling joins site/web OAT onto chiller intervals, emits per-device OAT bins plus Total / Any-active aggregates, and scopes descriptive counts by `building_id`.
- React Overview uses vibe19 rainbow palette, grouped/stacked bars, dotted Avg OAT, 60h bare-min line, and no longer promotes historian row-counts as the primary mech chart.

## Test plan
- [x] Vitest `centralOverview.test.ts` (per-AHU bars, mech stack, history_rows honesty)
- [x] `cargo test -p openfdd-central historian` (16 tests incl. site OAT join + weekly per-eq)
- [ ] GH Actions green
- [ ] Pull `sha-<tip>` central+web on bensbench; hard-refresh BUILDING_100 Overview vs vibe19 :8502


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Central overview charts now show weekly runtime by individual equipment.
  - Added outdoor-air-temperature overlays and bare-minimum occupancy reference lines.
  - Mechanical-cooling charts now display individual devices, aggregate totals, active compressors, coverage metrics, and optional callouts.
  - Added clearer stacked outdoor-temperature cooling-bin visualizations.
- **Bug Fixes**
  - Improved chart accuracy by filtering invalid temperature data and excluding descriptive-only history rows.
  - Building-specific analytics now use the selected building scope consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->