### PR TITLE
Full Plotly vibe19 parity: Overview, FDD, RCx presets

### DIFF
--- a/frontend/web/src/api/analyticsApi.ts
+++ b/frontend/web/src/api/analyticsApi.ts
@@ -164,6 +164,12 @@ export async function postBasVsWebOat(
   return postAnalytics("/api/analytics/bas-vs-web-oat", body);
 }
 
+export async function postInspect(
+  body: AnalyticsRequest & { series?: { columns?: string[] } },
+): Promise<AnalyticsEnvelope> {
+  return postAnalytics("/api/analytics/inspect", body);
+}
+
 export async function postEconomizer(
   body: AnalyticsRequest,
 ): Promise<AnalyticsEnvelope> {

--- a/frontend/web/src/api/analyticsApi.ts
+++ b/frontend/web/src/api/analyticsApi.ts
@@ -200,6 +200,35 @@ export async function postRcxBoiler(
   return postAnalytics("/api/analytics/rcx/boiler", body);
 }
 
+export async function postRcxPreset(
+  body: AnalyticsRequest & { series?: { preset_id?: string } },
+): Promise<AnalyticsEnvelope> {
+  return postAnalytics("/api/analytics/rcx/preset", body);
+}
+
+export async function listRcxPresets(): Promise<
+  Array<{
+    id: string;
+    title: string;
+    family: string;
+    chart: string;
+    role_col?: string;
+  }>
+> {
+  const body = await apiFetch<{
+    ok?: boolean;
+    presets?: Array<Record<string, unknown>>;
+  }>("/api/analytics/rcx/presets");
+  const raw = Array.isArray(body.presets) ? body.presets : [];
+  return raw.map((p) => ({
+    id: String(p.id ?? ""),
+    title: String(p.title ?? p.id ?? ""),
+    family: String(p.family ?? ""),
+    chart: String(p.chart ?? "timeseries"),
+    role_col: p.role_col != null ? String(p.role_col) : undefined,
+  }));
+}
+
 export async function listFddEquipment(
   buildingId?: string,
 ): Promise<FddEquipmentItem[]> {

--- a/frontend/web/src/api/centralOverview.test.ts
+++ b/frontend/web/src/api/centralOverview.test.ts
@@ -150,32 +150,24 @@ vi.mock("./analyticsApi", () => ({
     })),
     skipped: [],
   })),
-  postSchedule: vi.fn(async () => ({
+  postBasVsWebOat: vi.fn(async () => ({
     schema_version: "1",
-    query_version: "schedule-v1",
+    query_version: "bas-vs-web-oat-v2",
     generated_at: "",
     engine: "datafusion",
     warnings: [],
     rows: [
-      {
-        equipment_id: "AHU_1",
-        occupied_hours: 40,
-        unoccupied_hours: 8,
-      },
+      { kind: "delta_hist", bin_lo_f: -1, bin_hi_f: 0, count: 10 },
+      { kind: "delta_hist", bin_lo_f: 0, bin_hi_f: 1, count: 20 },
     ],
     equipment: [],
-    points: [],
-    skipped: [],
-  })),
-  postBasVsWebOat: vi.fn(async () => ({
-    schema_version: "1",
-    query_version: "bas-vs-web-oat-v1",
-    generated_at: "",
-    engine: "datafusion",
-    warnings: ["BAS vs web OAT unavailable"],
-    rows: [],
-    equipment: [],
-    points: [],
+    points: Array.from({ length: 12 }, (_, i) => ({
+      timestamp_utc: `2026-07-01T0${i}:00:00Z`,
+      equipment_id: "site",
+      bas_oat_f: 70 + i * 0.2,
+      web_oat_f: 68 + i * 0.2,
+      delta_f: 2,
+    })),
     skipped: [],
   })),
 }));
@@ -209,10 +201,35 @@ describe("fetchCentralOverview", () => {
     expect(out.economizer_free_cooling.temps_overlay?.layout?.title).toMatch(
       /Free-cooling temps/i,
     );
+    expect(out.bas_vs_web_oat.overlay?.data?.length).toBeGreaterThan(0);
     expect(out.devices_by_type).toEqual([
       { type: "AHU", count: 1 },
       { type: "VAV", count: 1 },
     ]);
+  });
+
+  it("does not substitute count bars when econ scatter is empty", async () => {
+    const { postEconomizer } = await import("./analyticsApi");
+    vi.mocked(postEconomizer).mockResolvedValueOnce({
+      schema_version: "1",
+      query_version: "economizer-diagnostics-v1",
+      generated_at: "",
+      engine: "datafusion",
+      warnings: [],
+      rows: [{ equipment_id: "AHU_1", n_fan_on_samples: 100, n_identifiable: 2 }],
+      equipment: [],
+      points: [
+        {
+          equipment_id: "AHU_1",
+          identifiable: false,
+          delta_or_f: -1,
+          delta_mr_f: -2,
+        },
+      ],
+      skipped: [],
+    } as never);
+    const out = await fetchCentralOverview({ building_id: "BUILDING_100" });
+    expect(out.economizer_free_cooling.delta_scatter).toBeNull();
   });
 
   it("renders per-AHU weekly bars + OAT y2 + bare-min line (vibe19 parity)", async () => {

--- a/frontend/web/src/api/centralOverview.ts
+++ b/frontend/web/src/api/centralOverview.ts
@@ -8,7 +8,6 @@ import {
   postEconomizer,
   postMechanicalCooling,
   postRuntime,
-  postSchedule,
   type AnalyticsEnvelope,
 } from "./analyticsApi";
 import {
@@ -403,13 +402,23 @@ function econDeltaScatter(
     byEq.set(eq, list);
   }
   for (const [eq, rows] of byEq) {
+    const hasDamper = rows.some((r) => num(r.damper_fb_pct) != null);
     data.push({
       type: "scatter",
       mode: "markers",
       name: eq,
       x: rows.map((r) => num(r.delta_or_f) as number),
       y: rows.map((r) => num(r.delta_mr_f)),
-      marker: { size: 6, opacity: 0.7 },
+      marker: hasDamper
+        ? {
+            size: 7,
+            opacity: 0.75,
+            color: rows.map((r) => num(r.damper_fb_pct)),
+            colorscale: "Viridis",
+            showscale: true,
+            colorbar: { title: "OA damper %", thickness: 12 },
+          }
+        : { size: 6, opacity: 0.7 },
     });
   }
 
@@ -541,42 +550,6 @@ function econTempsOverlay(
   };
 }
 
-/** Fallback bars when historian has counts but not yet plot points (old central). */
-function econCountsFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null {
-  const usable = rows.filter(
-    (r) => num(r.n_fan_on_samples) != null || num(r.n_identifiable) != null,
-  );
-  if (!usable.length) return null;
-  return rowsToBarFigure(usable, {
-    xKey: "equipment_id",
-    yKeys: ["n_fan_on_samples", "n_identifiable"],
-    title: "Economizer — fan-on / identifiable samples",
-    yAxisTitle: "samples",
-    sortBy: "n_fan_on_samples",
-    sortDesc: true,
-    maxBars: 40,
-    provenance: "POST /api/analytics/economizer (DataFusion)",
-  });
-}
-
-function scheduleFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null {
-  const usable = rows.filter(
-    (r) => num(r.occupied_hours) != null || num(r.unoccupied_hours) != null,
-  );
-  if (!usable.length) return null;
-  return rowsToBarFigure(usable, {
-    xKey: "equipment_id",
-    yKeys: ["occupied_hours", "unoccupied_hours"],
-    title: "Schedule — occupied / unoccupied hours",
-    yAxisTitle: "hours",
-    sortBy: "occupied_hours",
-    sortDesc: true,
-    maxBars: 40,
-    barmode: "stack",
-    provenance: "POST /api/analytics/schedule (DataFusion)",
-  });
-}
-
 /** vibe19 bas_vs_web_oat_overlay with ±oat_err band. */
 function basOverlay(
   points: Array<Record<string, unknown>>,
@@ -682,11 +655,10 @@ export async function fetchCentralOverview(opts: {
   const dtMin = opts.dt_min_f ?? 10;
   const body = { building_id, max_points: 4000, dt_min_f: dtMin };
 
-  const [runtime, mech, econ, schedule, bas] = await Promise.all([
+  const [runtime, mech, econ, bas] = await Promise.all([
     postRuntime(body),
     postMechanicalCooling(body),
     postEconomizer(body),
-    postSchedule(body),
     postBasVsWebOat(body),
   ]);
 
@@ -695,7 +667,6 @@ export async function fetchCentralOverview(opts: {
     runtime.equipment?.length ? runtime.equipment : runtimeRows;
   const mechRows = mech.rows?.length ? mech.rows : mech.equipment;
   const econRows = econ.rows?.length ? econ.rows : econ.equipment;
-  const scheduleRows = schedule.rows?.length ? schedule.rows : schedule.equipment;
   const econPoints = econ.points ?? [];
 
   const equipmentIds = [
@@ -749,7 +720,6 @@ export async function fetchCentralOverview(opts: {
     econPoints,
     opts.econ_overlay_equipment_id ?? null,
   );
-  const schedFig = scheduleFigure(scheduleRows);
   const basPoints = bas.points ?? [];
   const basOverlayFig = basOverlay(basPoints, oatErr);
   const basHistFig = basHist(bas.rows ?? []);
@@ -812,14 +782,17 @@ export async function fetchCentralOverview(opts: {
     economizer_free_cooling: {
       caption: warnCaption(
         econ,
-        econPoints.length
+        deltaScatter
           ? "Economizer free-cooling plots from DataFusion historian points"
-          : "Economizer sample counts from DataFusion (plot points unavailable)",
+          : econPoints.length
+            ? "Economizer points present but fewer than 5 identifiable |OAT−RAT| samples for scatter"
+            : "Economizer plot points unavailable (need fan-on + OAT/RAT/MAT)",
       ),
       metrics: econRows.slice(0, 200),
-      delta_scatter: deltaScatter ?? econCountsFigure(econRows),
+      // Never substitute count bars or schedule bars for missing econ figures.
+      delta_scatter: deltaScatter,
       mat_residual: matResidual,
-      temps_overlay: tempsOverlay ?? schedFig,
+      temps_overlay: tempsOverlay,
       overlay_equipment_id: overlayEq,
       skipped: [],
       dt_min_f: dtMin,
@@ -828,7 +801,7 @@ export async function fetchCentralOverview(opts: {
       caption: warnCaption(
         bas,
         basOverlayFig
-          ? "BAS vs web OAT from DataFusion historian"
+          ? "BAS vs web OAT from DataFusion historian (site-broadcast join)"
           : "BAS vs web OAT unavailable (need both oa_t and web OAT columns)",
       ),
       overlay: basOverlayFig,

--- a/frontend/web/src/api/inspectChart.ts
+++ b/frontend/web/src/api/inspectChart.ts
@@ -1,0 +1,88 @@
+/**
+ * vibe19 equipment_inspection_chart — stacked subplots of raw historian columns.
+ */
+import { fingerprintJson, type PlotlyFigure, type PlotlyTrace } from "./plotDataset";
+import { rainbowColor } from "./plotlyTheme";
+
+export function equipmentInspectionChart(
+  points: Array<Record<string, unknown>>,
+  opts: {
+    equipmentId: string;
+    columns: string[];
+    rowHeight?: number;
+    maxHeight?: number;
+  },
+): PlotlyFigure | null {
+  if (!points.length || !opts.columns.length) return null;
+  const x = points.map((p) => String(p.timestamp_utc ?? ""));
+  const cols = opts.columns.filter((c) =>
+    points.some((p) => {
+      const v = p[c];
+      if (v == null || v === "") return false;
+      const n = typeof v === "number" ? v : Number(v);
+      return Number.isFinite(n) || typeof v === "boolean";
+    }),
+  );
+  if (!cols.length) return null;
+
+  const n = cols.length;
+  const rowH = opts.rowHeight ?? 140;
+  const height = Math.min(opts.maxHeight ?? 2400, Math.max(420, rowH * n + 80));
+  const data: PlotlyTrace[] = [];
+  const layout: Record<string, unknown> = {
+    title: `Inspection — ${opts.equipmentId}`,
+    height,
+    showlegend: false,
+    paper_bgcolor: "white",
+    plot_bgcolor: "white",
+    margin: { t: 48, r: 24, b: 40, l: 56 },
+    uirevision: `inspect:${opts.equipmentId}:${fingerprintJson(cols)}`,
+  };
+
+  cols.forEach((col, i) => {
+    const axis = i === 0 ? "y" : `y${i + 1}`;
+    const xaxis = i === 0 ? "x" : `x${i + 1}`;
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: col,
+      x,
+      y: points.map((p) => {
+        const v = p[col];
+        if (typeof v === "boolean") return v ? 1 : 0;
+        if (v == null || v === "") return null;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      xaxis,
+      yaxis: axis,
+      line: { width: 1.4, color: rainbowColor(i) },
+    });
+    const domainH = 1 / n;
+    const y0 = 1 - (i + 1) * domainH + 0.02;
+    const y1 = 1 - i * domainH - 0.01;
+    layout[axis === "y" ? "yaxis" : `yaxis${i + 1}`] = {
+      title: col,
+      domain: [Math.max(0, y0), Math.min(1, y1)],
+      autorange: true,
+      showgrid: true,
+    };
+    layout[xaxis === "x" ? "xaxis" : `xaxis${i + 1}`] = {
+      anchor: axis,
+      domain: [0, 1],
+      showticklabels: i === n - 1,
+      matches: i === 0 ? undefined : "x",
+      autorange: true,
+    };
+  });
+
+  return {
+    data,
+    layout,
+    meta: {
+      equipment_id: opts.equipmentId,
+      point_count: points.length,
+      provenance: "POST /api/analytics/inspect",
+    },
+  };
+}

--- a/frontend/web/src/api/plotDataset.ts
+++ b/frontend/web/src/api/plotDataset.ts
@@ -3,9 +3,10 @@
  */
 
 export type PlotlyTrace = {
-  x: Array<string | number>;
-  y: Array<number | null>;
-  name: string;
+  x?: Array<string | number | null>;
+  y?: Array<number | null | string>;
+  z?: Array<Array<number | null>>;
+  name?: string;
   mode?: string;
   type?: string;
   marker?: Record<string, unknown>;
@@ -182,8 +183,9 @@ export function plantFamily(equipmentId: string): "air" | "heating" | "cooling" 
 export function missingSegmentCount(trace: PlotlyTrace): number {
   let segments = 0;
   let inGap = false;
-  for (const y of trace.y) {
-    const missing = y == null || !Number.isFinite(y);
+  for (const y of trace.y ?? []) {
+    const missing =
+      y == null || (typeof y === "number" && !Number.isFinite(y));
     if (missing && !inGap) {
       segments += 1;
       inGap = true;

--- a/frontend/web/src/api/vibeCharts.test.ts
+++ b/frontend/web/src/api/vibeCharts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  multiEquipmentBox,
+  rankingBars,
+  ruleResultChart,
+  sensorHealthHeatmap,
+} from "./vibeCharts";
+
+describe("vibeCharts", () => {
+  it("ruleResultChart adds confirmed_fault swim lane", () => {
+    const fig = ruleResultChart(
+      [
+        { timestamp_utc: "t0", zone_t: 70, confirmed_fault: 0 },
+        { timestamp_utc: "t1", zone_t: 78, confirmed_fault: 1 },
+      ],
+      {
+        equipmentId: "VAV_1",
+        ruleId: "VAV-1",
+        roles: ["zone_t"],
+        confirmedFault: [0, 1],
+      },
+    );
+    expect(fig?.data.some((t) => t.name === "confirmed_fault")).toBe(true);
+    expect(fig?.layout?.yaxis2).toBeTruthy();
+  });
+
+  it("rankingBars sorts by fail pct", () => {
+    const fig = rankingBars(
+      [
+        { equipment_id: "VAV_2", value_f: 10 },
+        { equipment_id: "VAV_1", value_f: 40 },
+      ],
+      { title: "rank" },
+    );
+    expect(fig?.data[0]?.x?.[0]).toBe("VAV_1");
+  });
+
+  it("multiEquipmentBox groups by equipment", () => {
+    const fig = multiEquipmentBox(
+      [
+        { equipment_id: "AHU_1", value_f: 1.2 },
+        { equipment_id: "AHU_1", value_f: 1.4 },
+        { equipment_id: "AHU_2", value_f: 0.9 },
+      ],
+      { title: "box" },
+    );
+    expect(fig?.data).toHaveLength(2);
+    expect(fig?.data[0]?.type).toBe("box");
+  });
+
+  it("sensorHealthHeatmap builds coverage grid", () => {
+    const fig = sensorHealthHeatmap([
+      { equipment_id: "AHU_1", role: "sat", coverage_pct: 90 },
+      { equipment_id: "AHU_1", role: "mat", coverage_pct: 80 },
+    ]);
+    expect(fig?.data[0]?.type).toBe("heatmap");
+  });
+});

--- a/frontend/web/src/api/vibeCharts.ts
+++ b/frontend/web/src/api/vibeCharts.ts
@@ -1,0 +1,428 @@
+/**
+ * vibe19-style multi-equipment Plotly builders for RCx / Overview / FDD.
+ */
+import {
+  fingerprintJson,
+  type PlotlyFigure,
+  type PlotlyTrace,
+} from "./plotDataset";
+import { overviewChartLayout, rainbowColor } from "./plotlyTheme";
+
+export function multiEquipmentTimeseries(
+  points: Array<Record<string, unknown>>,
+  opts: { title: string; yTitle?: string },
+): PlotlyFigure | null {
+  if (!points.length) return null;
+  const byKey = new Map<string, Array<Record<string, unknown>>>();
+  for (const p of points) {
+    const eq = String(p.equipment_id ?? "eq");
+    const series = String(p.series ?? "primary");
+    const name =
+      series === "primary"
+        ? eq
+        : series === "overlay"
+          ? `${eq} · setpoint`
+          : series === "return"
+            ? `${eq} · return`
+            : series === "delta_t"
+              ? `${eq} · ΔT`
+              : `${eq} · ${series}`;
+    const list = byKey.get(name) ?? [];
+    list.push(p);
+    byKey.set(name, list);
+  }
+  const data: PlotlyTrace[] = [];
+  let i = 0;
+  for (const [name, rows] of [...byKey.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name,
+      x: rows.map((r) => String(r.timestamp_utc ?? "")),
+      y: rows.map((r) => {
+        const v = r.value_f;
+        if (v == null || v === "") return null;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      line: { width: 1.4, color: rainbowColor(i) },
+    });
+    i += 1;
+  }
+  return {
+    data,
+    layout: overviewChartLayout({
+      xTitle: "time",
+      yTitle: opts.yTitle ?? "value",
+      height: Math.max(380, 40 + 14 * Math.min(byKey.size, 16)),
+      tickangle: -30,
+      uirevision: `rcx-ts:${fingerprintJson(points.slice(0, 50))}`,
+      extra: { title: opts.title },
+    }),
+    meta: {
+      point_count: points.length,
+      provenance: "POST /api/analytics/rcx/preset",
+    },
+  };
+}
+
+export function oatScatter(
+  points: Array<Record<string, unknown>>,
+  opts: { title: string; yTitle: string },
+): PlotlyFigure | null {
+  if (!points.length) return null;
+  const byEq = new Map<string, Array<Record<string, unknown>>>();
+  for (const p of points) {
+    const eq = String(p.equipment_id ?? "eq");
+    const list = byEq.get(eq) ?? [];
+    list.push(p);
+    byEq.set(eq, list);
+  }
+  const data: PlotlyTrace[] = [];
+  let i = 0;
+  for (const [eq, rows] of [...byEq.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    data.push({
+      type: "scatter",
+      mode: "markers",
+      name: eq,
+      x: rows.map((r) => {
+        const v = r.oat_f;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      y: rows.map((r) => {
+        const v = r.y_f;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      marker: { size: 6, opacity: 0.65, color: rainbowColor(i) },
+    });
+    i += 1;
+  }
+  const hasDry = points.some((p) => p.dry_bulb_f != null);
+  if (hasDry) {
+    data.push({
+      type: "scatter",
+      mode: "markers",
+      name: "dry-bulb ref (x)",
+      x: points.map((r) => {
+        const v = r.dry_bulb_f;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      y: points.map((r) => {
+        const v = r.y_f;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      marker: { size: 5, opacity: 0.35, symbol: "x", color: "#64748b" },
+    });
+  }
+  return {
+    data,
+    layout: overviewChartLayout({
+      xTitle: "OAT °F",
+      yTitle: opts.yTitle,
+      height: 420,
+      tickangle: 0,
+      uirevision: `rcx-oat:${fingerprintJson(points.slice(0, 50))}`,
+      extra: { title: opts.title },
+    }),
+    meta: {
+      point_count: points.length,
+      provenance: "POST /api/analytics/rcx/preset",
+    },
+  };
+}
+
+export function multiEquipmentBox(
+  points: Array<Record<string, unknown>>,
+  opts: { title: string; yTitle?: string },
+): PlotlyFigure | null {
+  if (!points.length) return null;
+  const byEq = new Map<string, number[]>();
+  for (const p of points) {
+    const eq = String(p.equipment_id ?? "eq");
+    const v = p.value_f;
+    const n = typeof v === "number" ? v : Number(v);
+    if (!Number.isFinite(n)) continue;
+    const list = byEq.get(eq) ?? [];
+    list.push(n);
+    byEq.set(eq, list);
+  }
+  if (!byEq.size) return null;
+  const data: PlotlyTrace[] = [];
+  let i = 0;
+  for (const [eq, ys] of [...byEq.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    data.push({
+      type: "box",
+      name: eq,
+      y: ys,
+      marker: { color: rainbowColor(i) },
+      boxpoints: false,
+    } as PlotlyTrace);
+    i += 1;
+  }
+  return {
+    data,
+    layout: overviewChartLayout({
+      xTitle: "equipment",
+      yTitle: opts.yTitle ?? "value",
+      height: 420,
+      tickangle: -20,
+      uirevision: `rcx-box:${fingerprintJson([...byEq.keys()])}`,
+      extra: { title: opts.title, boxmode: "group" },
+    }),
+    meta: {
+      point_count: points.length,
+      provenance: "POST /api/analytics/rcx/preset",
+    },
+  };
+}
+
+export function rankingBars(
+  points: Array<Record<string, unknown>>,
+  opts: { title: string; yTitle?: string },
+): PlotlyFigure | null {
+  if (!points.length) return null;
+  const sorted = [...points].sort((a, b) => {
+    const av = Number(a.value_f ?? a.fail_pct ?? 0);
+    const bv = Number(b.value_f ?? b.fail_pct ?? 0);
+    return bv - av;
+  });
+  return {
+    data: [
+      {
+        type: "bar",
+        name: "fail %",
+        x: sorted.map((r) => String(r.equipment_id ?? "")),
+        y: sorted.map((r) => {
+          const v = r.value_f ?? r.fail_pct;
+          const n = typeof v === "number" ? v : Number(v);
+          return Number.isFinite(n) ? n : null;
+        }),
+        marker: { color: sorted.map((_, i) => rainbowColor(i)) },
+      },
+    ],
+    layout: overviewChartLayout({
+      xTitle: "equipment",
+      yTitle: opts.yTitle ?? "comfort fail %",
+      height: Math.max(360, 28 * Math.min(sorted.length, 24)),
+      tickangle: -35,
+      uirevision: `rcx-rank:${fingerprintJson(sorted.slice(0, 20))}`,
+      extra: { title: opts.title },
+    }),
+    meta: {
+      point_count: points.length,
+      provenance: "POST /api/analytics/rcx/preset",
+    },
+  };
+}
+
+export function meteringCharts(
+  points: Array<Record<string, unknown>>,
+  opts: { title: string; ddLabel?: string },
+): PlotlyFigure | null {
+  if (!points.length) return null;
+  const byEq = new Map<string, Array<Record<string, unknown>>>();
+  for (const p of points) {
+    const eq = String(p.equipment_id ?? "eq");
+    const list = byEq.get(eq) ?? [];
+    list.push(p);
+    byEq.set(eq, list);
+  }
+  const barData: PlotlyTrace[] = [];
+  const scatterData: PlotlyTrace[] = [];
+  let i = 0;
+  for (const [eq, rows] of [...byEq.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    const color = rainbowColor(i);
+    barData.push({
+      type: "bar",
+      name: `${eq} · energy`,
+      x: rows.map((r) => String(r.month ?? "")),
+      y: rows.map((r) => {
+        const v = r.energy ?? r.value_f;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      marker: { color },
+      xaxis: "x",
+      yaxis: "y",
+    });
+    scatterData.push({
+      type: "scatter",
+      mode: "markers",
+      name: `${eq} · vs DD`,
+      x: rows.map((r) => {
+        const v = r.degree_days ?? r.oat_f;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      y: rows.map((r) => {
+        const v = r.energy ?? r.y_f;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      marker: { size: 8, color, opacity: 0.75 },
+      xaxis: "x2",
+      yaxis: "y2",
+    });
+    i += 1;
+  }
+  return {
+    data: [...barData, ...scatterData],
+    layout: {
+      title: opts.title,
+      grid: { rows: 1, columns: 2, pattern: "independent" },
+      xaxis: { title: "month", domain: [0, 0.45] },
+      yaxis: { title: "energy" },
+      xaxis2: { title: opts.ddLabel ?? "degree-days", domain: [0.55, 1] },
+      yaxis2: { title: "energy", anchor: "x2" },
+      height: 420,
+      legend: { orientation: "h" },
+      paper_bgcolor: "white",
+      plot_bgcolor: "white",
+      uirevision: `rcx-meter:${fingerprintJson(points.slice(0, 30))}`,
+    },
+    meta: {
+      point_count: points.length,
+      provenance: "POST /api/analytics/rcx/preset",
+    },
+  };
+}
+
+/** FDD rule_result_chart with optional confirmed_fault swim lane. */
+export function ruleResultChart(
+  rows: Array<Record<string, unknown>>,
+  opts: {
+    equipmentId: string;
+    ruleId: string;
+    roles: string[];
+    confirmedFault?: Array<boolean | number | null>;
+  },
+): PlotlyFigure | null {
+  if (!rows.length || !opts.roles.length) return null;
+  const x = rows.map((r) => String(r.timestamp_utc ?? r.timestamp ?? ""));
+  const data: PlotlyTrace[] = opts.roles.map((role, i) => ({
+    type: "scatter",
+    mode: "lines",
+    name: role,
+    x,
+    y: rows.map((r) => {
+      const v = r[role];
+      if (v == null || v === "") return null;
+      const n = typeof v === "number" ? v : Number(v);
+      return Number.isFinite(n) ? n : null;
+    }),
+    yaxis: "y",
+    line: { width: 1.5, color: rainbowColor(i) },
+  }));
+
+  const fault = opts.confirmedFault;
+  if (fault && fault.length === rows.length) {
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: "confirmed_fault",
+      x,
+      y: fault.map((v) => (v === true || v === 1 ? 1 : 0)),
+      yaxis: "y2",
+      line: { width: 1.2, color: "#dc2626" },
+      fill: "tozeroy",
+      fillcolor: "rgba(220,38,38,0.25)",
+    });
+  }
+
+  return {
+    data,
+    layout: {
+      title: `${opts.ruleId} · ${opts.equipmentId}`,
+      xaxis: { title: "timestamp_utc", autorange: true },
+      yaxis: {
+        title: "value",
+        autorange: true,
+        domain: fault ? [0.22, 1] : [0, 1],
+      },
+      ...(fault
+        ? {
+            yaxis2: {
+              title: "fault",
+              domain: [0, 0.18],
+              range: [-0.05, 1.05],
+              showgrid: false,
+              tickvals: [0, 1],
+              ticktext: ["ok", "fault"],
+            },
+          }
+        : {}),
+      legend: { orientation: "h" },
+      height: fault ? 480 : 380,
+      paper_bgcolor: "white",
+      plot_bgcolor: "white",
+      uirevision: `fdd:${opts.ruleId}:${opts.equipmentId}`,
+    },
+    meta: {
+      equipment_id: opts.equipmentId,
+      rule_id: opts.ruleId,
+      roles: opts.roles,
+      point_count: rows.length,
+      provenance: "GET /api/fdd/series",
+    },
+  };
+}
+
+/** Sensor health coverage matrix as a Plotly heatmap (equipment × role). */
+export function sensorHealthHeatmap(
+  rows: Array<Record<string, unknown>>,
+  opts?: { title?: string },
+): PlotlyFigure | null {
+  if (!rows.length) return null;
+  const eqs = [...new Set(rows.map((r) => String(r.equipment_id ?? "")))].sort();
+  const roles = [...new Set(rows.map((r) => String(r.role ?? "")))].sort();
+  if (!eqs.length || !roles.length) return null;
+  const z = eqs.map((eq) =>
+    roles.map((role) => {
+      const hit = rows.find(
+        (r) =>
+          String(r.equipment_id ?? "") === eq && String(r.role ?? "") === role,
+      );
+      if (!hit) return null;
+      const cov = Number(hit.coverage_pct);
+      return Number.isFinite(cov) ? cov : null;
+    }),
+  );
+  return {
+    data: [
+      {
+        type: "heatmap",
+        x: roles,
+        y: eqs,
+        z,
+        colorscale: "YlGnBu",
+        colorbar: { title: "coverage %" },
+        hoverongaps: false,
+      } as PlotlyTrace,
+    ],
+    layout: {
+      title: opts?.title ?? "Sensor health — coverage %",
+      xaxis: { title: "role", tickangle: -30 },
+      yaxis: { title: "equipment", autorange: "reversed" },
+      height: Math.max(360, 18 * Math.min(eqs.length, 40)),
+      paper_bgcolor: "white",
+      plot_bgcolor: "white",
+      uirevision: `sensor-health:${fingerprintJson(eqs.slice(0, 20))}`,
+    },
+    meta: {
+      point_count: rows.length,
+      provenance: "POST /api/analytics/sensor-health",
+    },
+  };
+}

--- a/frontend/web/src/components/OverviewPopulated.tsx
+++ b/frontend/web/src/components/OverviewPopulated.tsx
@@ -15,7 +15,6 @@ import {
   getFddStatus,
   listFddRules,
   getFddResults,
-  getFddSeries,
   runFdd,
 } from "../api/fddApi";
 import {
@@ -27,8 +26,9 @@ import {
 import { downloadRowsCsv } from "../api/overviewOracleApi";
 import type { OverviewVibe19Response } from "../api/overviewOracleApi";
 import { fetchCentralOverview } from "../api/centralOverview";
-import type { FddEquipmentItem } from "../api/analyticsApi";
-import { seriesRowsToFigure, type PlotlyFigure } from "../api/plotDataset";
+import { postInspect, type FddEquipmentItem } from "../api/analyticsApi";
+import { equipmentInspectionChart } from "../api/inspectChart";
+import type { PlotlyFigure } from "../api/plotDataset";
 import { RULES_UPDATED_EVENT } from "./RuleTuningPanel";
 
 const DAYS = [
@@ -169,6 +169,9 @@ export function OverviewPopulated({
   const [tz, setTz] = useState(() => loadStoredSchedule().tz);
   const [schedOpen, setSchedOpen] = useState(true);
   const [motorTableOpen, setMotorTableOpen] = useState(false);
+  const [mechBinsOpen, setMechBinsOpen] = useState(false);
+  const [mechCoverageOpen, setMechCoverageOpen] = useState(false);
+  const [econMetricsOpen, setEconMetricsOpen] = useState(false);
   const [basHistOpen, setBasHistOpen] = useState(false);
   const [econOverlayOpen, setEconOverlayOpen] = useState(false);
   const [econSkippedOpen, setEconSkippedOpen] = useState(false);
@@ -282,54 +285,55 @@ export function OverviewPopulated({
     setInspectBusy(true);
     setInspectErr(null);
     try {
-      const map = await getPackageMapping(buildingId, inspectPick).catch(
-        () => null,
-      );
-      const eq =
-        map?.equipment?.find((e) => e.equipment_id === inspectPick) ??
-        map?.equipment?.[0];
-      const cols =
-        eq?.columns
-          ?.map((c) => String(c.column || c.role || ""))
-          .filter(Boolean) ?? [];
-      setInspectCols(cols);
-      setInspectSelectedCols((prev) => (prev.length ? prev : cols.slice(0, 6)));
-      if (eq?.sampling?.row_count != null) setRowCount(eq.sampling.row_count);
-      if (eq?.sampling?.first_timestamp) setFirstTs(eq.sampling.first_timestamp);
-      if (eq?.sampling?.last_timestamp) setLastTs(eq.sampling.last_timestamp);
-      setInspectMeta({
-        row_count: eq?.sampling?.row_count ?? 0,
-        span:
-          eq?.sampling?.first_timestamp && eq?.sampling?.last_timestamp
-            ? `${eq.sampling.first_timestamp} → ${eq.sampling.last_timestamp}`
-            : "—",
+      const env = await postInspect({
+        building_id: buildingId,
+        equipment_ids: [inspectPick],
+        max_points: 2000,
+        series: {
+          columns:
+            inspectSelectedCols.length > 0 ? inspectSelectedCols : undefined,
+        },
       });
-
-      const results = await getFddResults(buildingId).catch(() => []);
-      const hit = results.find(
-        (r) => String(r.equipment_id) === inspectPick && r.rule_id,
+      const cov = (env.coverage ?? {}) as Record<string, unknown>;
+      const plottable = Array.isArray(cov.plottable_columns)
+        ? (cov.plottable_columns as string[])
+        : [];
+      const plotted = Array.isArray(cov.columns_plotted)
+        ? (cov.columns_plotted as string[])
+        : [];
+      setInspectCols(plottable.length ? plottable : plotted);
+      setInspectSelectedCols((prev) =>
+        prev.length ? prev.filter((c) => plottable.includes(c) || plotted.includes(c)) : plotted.slice(0, 6),
       );
-      if (!hit?.rule_id) {
+      const rowCountN = Number(cov.row_count ?? env.points?.length ?? 0);
+      if (Number.isFinite(rowCountN)) setRowCount(rowCountN);
+      const first = cov.first_timestamp != null ? String(cov.first_timestamp) : null;
+      const last = cov.last_timestamp != null ? String(cov.last_timestamp) : null;
+      if (first) setFirstTs(first);
+      if (last) setLastTs(last);
+      setInspectMeta({
+        row_count: rowCountN,
+        span: first && last ? `${first} → ${last}` : "—",
+      });
+      if (env.warnings?.length && !env.points?.length) {
         setInspectFig(null);
-        setInspectErr(
-          "No FDD result series for this equipment yet — Run all rules first, then re-open inspection.",
-        );
+        setInspectErr(env.warnings[0] ?? "Inspection unavailable");
         return;
       }
-      const series = await getFddSeries(inspectPick, String(hit.rule_id));
-      const roles =
-        inspectSelectedCols.length > 0
-          ? inspectSelectedCols
-          : (series.roles ?? cols).slice(0, 6);
-      const fig = seriesRowsToFigure(series.rows ?? [], {
+      const cols =
+        (inspectSelectedCols.length ? inspectSelectedCols : plotted).filter(
+          (c) => plottable.includes(c) || plotted.includes(c) || !plottable.length,
+        );
+      const fig = equipmentInspectionChart(env.points ?? [], {
         equipmentId: inspectPick,
-        ruleId: String(hit.rule_id),
-        roles,
-        downsampled: series.downsampled,
-        maxPoints: series.max_points,
+        columns: cols.length ? cols : plotted,
       });
       setInspectFig(fig);
-      setInspectErr(null);
+      setInspectErr(
+        fig
+          ? null
+          : "No plottable numeric columns for this equipment in historian Parquet.",
+      );
     } catch (err) {
       setInspectErr(formatErr(err));
       setInspectFig(null);
@@ -877,7 +881,13 @@ export function OverviewPopulated({
           testId="overview-mech-plot"
         />
         {overview?.mech_cooling.bins?.length ? (
-          <>
+          <Expander
+            id="mech-bins-exp"
+            label="Mech cooling OAT bins table"
+            expanded={mechBinsOpen}
+            onChange={setMechBinsOpen}
+            testId="overview-mech-bins-exp"
+          >
             <DataTable
               id="mech-bins"
               label="Mech cooling OAT bins"
@@ -904,16 +914,20 @@ export function OverviewPopulated({
               }
               testId="overview-dl-mech-bins"
             />
-          </>
+          </Expander>
         ) : null}
         {overview?.mech_cooling.coverage?.length ? (
-          <>
-            <h4>
-              Mechanical cooling devices
-              {overview.mech_cooling.n_included != null
+          <Expander
+            id="mech-coverage-exp"
+            label={`Mechanical cooling devices${
+              overview.mech_cooling.n_included != null
                 ? ` — ${overview.mech_cooling.n_included} included, ${overview.mech_cooling.n_excluded ?? 0} excluded`
-                : ""}
-            </h4>
+                : ""
+            }`}
+            expanded={mechCoverageOpen}
+            onChange={setMechCoverageOpen}
+            testId="overview-mech-coverage-exp"
+          >
             <DataTable
               id="mech-coverage"
               label="Cooling coverage"
@@ -939,7 +953,7 @@ export function OverviewPopulated({
               }
               testId="overview-dl-mech-cov"
             />
-          </>
+          </Expander>
         ) : null}
       </section>
 
@@ -993,7 +1007,13 @@ export function OverviewPopulated({
             "G36 mixing plots while supply fan is running."}
         </p>
         {overview?.economizer_free_cooling.metrics?.length ? (
-          <>
+          <Expander
+            id="econ-metrics-exp"
+            label="Economizer free-cooling diagnostics table"
+            expanded={econMetricsOpen}
+            onChange={setEconMetricsOpen}
+            testId="overview-econ-metrics-exp"
+          >
             <DataTable
               id="econ-metrics"
               label="Economizer diagnostic metrics"
@@ -1019,7 +1039,7 @@ export function OverviewPopulated({
               }
               testId="overview-dl-econ-metrics"
             />
-          </>
+          </Expander>
         ) : null}
         <PlotlyHost
           id="econ-delta"

--- a/frontend/web/src/pages/RcxPage.tsx
+++ b/frontend/web/src/pages/RcxPage.tsx
@@ -1,43 +1,42 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AppShell } from "../components/AppShell";
 import {
   InlineAlert,
   Select,
   Button,
   DataTable,
-  RadioGroup,
 } from "../components/widgets";
 import { PlotlyHost } from "../components/widgets/PlotlyHost";
 import { useSessionQuery } from "../session";
 import { listPackageBuildings } from "../api/mappingApi";
 import {
-  listFddEquipment,
-  postRcxAhu,
-  postRcxVav,
-  postRcxChiller,
-  postRcxBoiler,
+  listRcxPresets,
+  postRcxPreset,
   type AnalyticsEnvelope,
 } from "../api/analyticsApi";
-import { rowsToBarFigure, type PlotlyFigure } from "../api/plotDataset";
-
-const PRESETS = [
-  { value: "ahu", label: "AHU — SAT reset / DAT / MAT / RAT / dampers / fans" },
-  { value: "vav", label: "Zones — comfort / space temps / VAV airflow" },
-  { value: "chiller", label: "Chiller / tower — leave temp vs OAT, CHW/CW temps" },
-  { value: "boiler", label: "Boiler / HW — leave temp vs OAT" },
-] as const;
+import {
+  meteringCharts,
+  multiEquipmentBox,
+  multiEquipmentTimeseries,
+  oatScatter,
+  rankingBars,
+} from "../api/vibeCharts";
+import type { PlotlyFigure } from "../api/plotDataset";
 
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** Streamlit RCx Plots tab — central rcx/{ahu,vav,chiller,boiler}. */
+/** vibe19 RCx Plots — preset picker + DataFusion historian series. */
 export function RcxPage() {
   const { query, setQuery } = useSessionQuery();
   const buildingId = query.siteId ?? "";
   const [buildings, setBuildings] = useState<string[]>([]);
-  const [equipment, setEquipment] = useState<string[]>([]);
-  const [preset, setPreset] = useState<string>("ahu");
+  const [presets, setPresets] = useState<
+    Array<{ id: string; title: string; family: string; chart: string }>
+  >([]);
+  const [family, setFamily] = useState("");
+  const [presetId, setPresetId] = useState("");
   const [env, setEnv] = useState<AnalyticsEnvelope | null>(null);
   const [figure, setFigure] = useState<PlotlyFigure | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -47,62 +46,80 @@ export function RcxPage() {
     void listPackageBuildings()
       .then(setBuildings)
       .catch(() => setBuildings([]));
+    void listRcxPresets()
+      .then((p) => {
+        const ok = p.filter((x) => x.id);
+        setPresets(ok);
+        setFamily((prev) => prev || ok[0]?.family || "");
+        setPresetId((prev) => prev || ok[0]?.id || "");
+      })
+      .catch(() => setPresets([]));
   }, []);
 
-  useEffect(() => {
-    if (!buildingId) {
-      setEquipment([]);
-      return;
-    }
-    void listFddEquipment(buildingId)
-      .then((eq) => setEquipment(eq.map((e) => String(e.equipment_id))))
-      .catch(() => setEquipment([]));
-  }, [buildingId]);
+  const families = useMemo(
+    () => [...new Set(presets.map((p) => p.family))].sort(),
+    [presets],
+  );
+  const familyPresets = useMemo(
+    () => presets.filter((p) => !family || p.family === family),
+    [presets, family],
+  );
 
   const run = async () => {
-    if (!buildingId) return;
+    if (!buildingId || !presetId) return;
     setLoading(true);
     setError(null);
     try {
-      const body = {
+      const res = await postRcxPreset({
         building_id: buildingId,
-        equipment_ids: equipment.slice(0, 20),
-        max_points: 5000,
-      };
-      let res: AnalyticsEnvelope;
-      switch (preset) {
-        case "vav":
-          res = await postRcxVav(body);
-          break;
-        case "chiller":
-          res = await postRcxChiller(body);
-          break;
-        case "boiler":
-          res = await postRcxBoiler(body);
-          break;
-        default:
-          res = await postRcxAhu(body);
-      }
+        max_points: 8000,
+        series: { preset_id: presetId },
+      });
       setEnv(res);
-      if (res.rows?.length) {
-        const keys = Object.keys(res.rows[0] ?? {}).filter(
-          (k) => k !== "equipment_id" && k !== "timestamp",
-        );
-        const xKey =
-          res.rows[0]?.equipment_id != null ? "equipment_id" : keys[0] ?? "x";
-        setFigure(
-          rowsToBarFigure(res.rows, {
-            xKey,
-            yKeys: keys.filter((k) => k !== xKey).slice(0, 6),
-            title: `RCx · ${preset}`,
-            provenance: `engine=${res.engine} · ${res.query_version}`,
-          }),
-        );
-      } else {
+      const title =
+        String(res.coverage?.title ?? presetId) ||
+        familyPresets.find((p) => p.id === presetId)?.title ||
+        presetId;
+      const kind = String(
+        res.coverage?.chart_kind ??
+          familyPresets.find((p) => p.id === presetId)?.chart ??
+          "",
+      );
+      const points = res.points ?? [];
+      if (!points.length) {
         setFigure(null);
+        if (res.warnings?.length) setError(res.warnings[0] ?? "No points");
+        return;
       }
+      let fig: PlotlyFigure | null = null;
+      if (kind === "scatter_oat") {
+        fig = oatScatter(points, {
+          title,
+          yTitle: String(res.coverage?.y_col ?? "value"),
+        });
+      } else if (kind === "box") {
+        fig = multiEquipmentBox(points, {
+          title,
+          yTitle: String(res.coverage?.role_col ?? "value"),
+        });
+      } else if (kind === "ranking") {
+        fig = rankingBars(points, { title });
+      } else if (kind === "metering") {
+        fig = meteringCharts(points, {
+          title,
+          ddLabel:
+            String(res.coverage?.meter_kind ?? "") === "gas" ? "HDD" : "CDD",
+        });
+      } else {
+        fig = multiEquipmentTimeseries(points, {
+          title,
+          yTitle: String(res.coverage?.role_col ?? "value"),
+        });
+      }
+      setFigure(fig);
     } catch (err) {
       setError(formatErr(err));
+      setFigure(null);
     } finally {
       setLoading(false);
     }
@@ -111,7 +128,7 @@ export function RcxPage() {
   return (
     <AppShell
       title="RCx Plots"
-      caption="Retro-commissioning analytics — vibe19 RCx family presets via central DataFusion (rcx/ahu|vav|chiller|boiler). Full timeseries/scatter/box presets land as historian points grow."
+      caption="Retro-commissioning presets via central DataFusion historian (vibe19 chart kinds)."
       activeSectionId="rcx-plots"
     >
       <div className="page-stack" data-testid="rcx-page">
@@ -126,19 +143,37 @@ export function RcxPage() {
           onChange={(v) => setQuery({ siteId: v || undefined }, true)}
           testId="rcx-building"
         />
-        <RadioGroup
+        <Select
+          id="rcx-family"
+          label="Family"
+          value={family}
+          options={[
+            { value: "", label: "— all —" },
+            ...families.map((f) => ({ value: f, label: f })),
+          ]}
+          onChange={(v) => {
+            setFamily(v);
+            const next = presets.find((p) => !v || p.family === v);
+            if (next) setPresetId(next.id);
+          }}
+          testId="rcx-family"
+        />
+        <Select
           id="rcx-preset"
-          label="Equipment family"
-          value={preset}
-          options={[...PRESETS]}
-          onChange={setPreset}
+          label="Preset"
+          value={presetId}
+          options={familyPresets.map((p) => ({
+            value: p.id,
+            label: `${p.title} [${p.chart}]`,
+          }))}
+          onChange={setPresetId}
           testId="rcx-preset"
         />
         <Button
           id="rcx-run"
-          label={loading ? "Running…" : "Run RCx analytics"}
+          label={loading ? "Running…" : "Run RCx preset"}
           onClick={() => void run()}
-          disabled={!buildingId || loading}
+          disabled={!buildingId || !presetId || loading}
           testId="rcx-run"
         />
         {error ? (
@@ -148,8 +183,9 @@ export function RcxPage() {
         ) : null}
         {env ? (
           <p className="oracle-sidebar__caption" data-testid="rcx-provenance">
-            analytics provenance · engine={env.engine} · query_version=
-            {env.query_version} · rows={env.rows?.length ?? 0}
+            engine={env.engine} · {env.query_version} · points=
+            {env.points?.length ?? 0}
+            {env.warnings?.[0] ? ` · ${env.warnings[0]}` : ""}
           </p>
         ) : null}
         <PlotlyHost
@@ -157,26 +193,36 @@ export function RcxPage() {
           label="RCx chart"
           figure={figure}
           loading={loading}
-          height={320}
+          height={420}
           testId="rcx-plot"
         />
         {env?.rows?.length ? (
           <DataTable
-            id="rcx-table"
-            label="RCx rows"
+            id="rcx-rows"
+            label="RCx stats"
             columns={Object.keys(env.rows[0] ?? {}).map((k) => ({
               key: k,
               header: k,
             }))}
-            rows={env.rows as Array<Record<string, string | number>>}
-            testId="rcx-table"
+            rows={
+              env.rows.slice(0, 80) as Array<Record<string, string | number>>
+            }
+            testId="rcx-rows-table"
+          />
+        ) : env?.points?.length ? (
+          <DataTable
+            id="rcx-points"
+            label="RCx points (sample)"
+            columns={Object.keys(env.points[0] ?? {}).map((k) => ({
+              key: k,
+              header: k,
+            }))}
+            rows={
+              env.points.slice(0, 80) as Array<Record<string, string | number>>
+            }
+            testId="rcx-points-table"
           />
         ) : null}
-        <p className="oracle-sidebar__caption">
-          Detailed free-cooling / mixing diagnostics: AHU economizer preset.
-          Fan-on / Fan-off tabs map to central coverage filters when present in
-          the envelope.
-        </p>
       </div>
     </AppShell>
   );

--- a/frontend/web/src/pages/ReportsPage.test.tsx
+++ b/frontend/web/src/pages/ReportsPage.test.tsx
@@ -40,6 +40,27 @@ vi.mock("../api/analyticsApi", () => ({
   listFddEquipment: vi.fn(async () => [
     { equipment_id: "VAV_1", equipment_type: "VAV" },
   ]),
+  postSensorHealth: vi.fn(async () => ({
+    schema_version: "analytics-envelope-v1",
+    query_version: "sensor-health-v1",
+    generated_at: "",
+    engine: "datafusion",
+    warnings: [],
+    rows: [
+      {
+        equipment_id: "VAV_1",
+        role: "zone_t",
+        coverage_pct: 100,
+        missingness: 0,
+        flatline_flag: false,
+        n: 10,
+        n_finite: 10,
+      },
+    ],
+    equipment: [],
+    points: [],
+    skipped: [],
+  })),
 }));
 
 vi.mock("../api/uploadApi", () => ({ uploadPackage: vi.fn() }));

--- a/frontend/web/src/pages/ReportsPage.tsx
+++ b/frontend/web/src/pages/ReportsPage.tsx
@@ -4,6 +4,7 @@ import { AppShell } from "../components/AppShell";
 import {
   Button,
   DataTable,
+  Expander,
   InlineAlert,
   PlotlyHost,
   RadioGroup,
@@ -12,11 +13,12 @@ import {
 import { useSessionQuery } from "../session";
 import { listPackageBuildings } from "../api/mappingApi";
 import { getFddResults, getFddSeries, listFddRules } from "../api/fddApi";
+import { postSensorHealth } from "../api/analyticsApi";
 import {
   missingSegmentCount,
-  seriesRowsToFigure,
   type PlotlyFigure,
 } from "../api/plotDataset";
+import { ruleResultChart, sensorHealthHeatmap } from "../api/vibeCharts";
 import {
   createReportDraft,
   getEngineeringFindingsReport,
@@ -55,6 +57,13 @@ export function ReportsPage() {
   const [figure, setFigure] = useState<PlotlyFigure | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sensorRows, setSensorRows] = useState<
+    Array<Record<string, string | number | boolean>>
+  >([]);
+  const [sensorFigure, setSensorFigure] = useState<PlotlyFigure | null>(null);
+  const [sensorLoading, setSensorLoading] = useState(false);
+  const [sensorError, setSensorError] = useState<string | null>(null);
+  const [sensorOpen, setSensorOpen] = useState(false);
 
   const [reports, setReports] = useState<ReportRecord[]>([]);
   const [artifactsNotice, setArtifactsNotice] = useState<string | null>(null);
@@ -126,13 +135,19 @@ export function ReportsPage() {
       const series = await getFddSeries(equipmentId, ruleId);
       const roles = series.roles ?? [];
       const rows = (series.rows ?? []) as Array<Record<string, unknown>>;
+      const fault = rows.map((r) => {
+        const v = r.confirmed_fault ?? r.fault;
+        if (v === true || v === 1 || v === "1" || v === "true") return 1;
+        if (v === false || v === 0 || v === "0" || v === "false") return 0;
+        return null;
+      });
+      const hasFault = fault.some((v) => v != null);
       setFigure(
-        seriesRowsToFigure(rows, {
+        ruleResultChart(rows, {
           equipmentId: series.equipment_id ?? equipmentId,
           ruleId: series.rule_id ?? ruleId,
           roles,
-          downsampled: series.downsampled,
-          maxPoints: series.max_points,
+          confirmedFault: hasFault ? fault : undefined,
         }),
       );
     } catch (err) {
@@ -142,6 +157,50 @@ export function ReportsPage() {
       setLoading(false);
     }
   }, [equipmentId, ruleId]);
+
+  const loadSensorHealth = useCallback(async () => {
+    if (!buildingId) {
+      setSensorError("Select a building");
+      return;
+    }
+    setSensorLoading(true);
+    setSensorError(null);
+    try {
+      const env = await postSensorHealth({
+        building_id: buildingId,
+        equipment_ids: equipmentId ? [equipmentId] : undefined,
+      });
+      const rows = (env.rows?.length ? env.rows : env.equipment) ?? [];
+      const normalized = rows.map((r) => ({
+        equipment_id: String(r.equipment_id ?? ""),
+        role: String(r.role ?? ""),
+        n: Number(r.n ?? 0),
+        n_finite: Number(r.n_finite ?? 0),
+        coverage_pct: Number(r.coverage_pct ?? 0),
+        missingness: Number(r.missingness ?? 0),
+        flatline_flag: Boolean(r.flatline_flag),
+        min: r.min != null ? Number(r.min) : "",
+        max: r.max != null ? Number(r.max) : "",
+        mean: r.mean != null ? Number(r.mean) : "",
+        std: r.std != null ? Number(r.std) : "",
+      }));
+      setSensorRows(normalized);
+      setSensorFigure(
+        sensorHealthHeatmap(normalized as Array<Record<string, unknown>>, {
+          title: `Sensor health — ${buildingId}`,
+        }),
+      );
+      if (!normalized.length && env.warnings?.[0]) {
+        setSensorError(env.warnings[0]);
+      }
+    } catch (err) {
+      setSensorRows([]);
+      setSensorFigure(null);
+      setSensorError(formatErr(err));
+    } finally {
+      setSensorLoading(false);
+    }
+  }, [buildingId, equipmentId]);
 
   const onCreateDraft = async () => {
     setArtifactsNotice(null);
@@ -311,6 +370,56 @@ export function ReportsPage() {
                 testId="plots-preview-table"
               />
             ) : null}
+
+            <Expander
+              id="sensor-health"
+              label="Sensor health — coverage / flatline (DataFusion)"
+              expanded={sensorOpen}
+              onChange={setSensorOpen}
+              testId="sensor-health-expander"
+            >
+              <p>
+                Loads <code>POST /api/analytics/sensor-health</code> for the
+                selected building (optionally scoped to equipment).
+              </p>
+              <Button
+                id="sensor-health-load"
+                label={sensorLoading ? "Loading…" : "Load sensor health"}
+                onClick={() => void loadSensorHealth()}
+                disabled={sensorLoading || !buildingId}
+                testId="sensor-health-load"
+              />
+              {sensorError ? (
+                <InlineAlert id="sensor-health-error" variant="danger">
+                  {sensorError}
+                </InlineAlert>
+              ) : null}
+              <PlotlyHost
+                id="sensor-health-chart"
+                label="Coverage heatmap"
+                figure={sensorFigure}
+                loading={sensorLoading}
+                testId="sensor-health-chart"
+              />
+              {sensorRows.length ? (
+                <DataTable
+                  id="sensor-health-table"
+                  label="Sensor health matrix"
+                  columns={[
+                    { key: "equipment_id", header: "equipment" },
+                    { key: "role", header: "role" },
+                    { key: "coverage_pct", header: "coverage %" },
+                    { key: "missingness", header: "missingness" },
+                    { key: "flatline_flag", header: "flatline" },
+                    { key: "n_finite", header: "n_finite" },
+                    { key: "mean", header: "mean" },
+                    { key: "std", header: "std" },
+                  ]}
+                  rows={sensorRows}
+                  testId="sensor-health-table"
+                />
+              ) : null}
+            </Expander>
           </div>
         ) : (
           <div data-testid="reports-artifacts">

--- a/frontend/web/src/pages/ReportsPage.tsx
+++ b/frontend/web/src/pages/ReportsPage.tsx
@@ -240,13 +240,16 @@ export function ReportsPage() {
 
   const previewRows = useMemo(() => {
     if (!figure?.data[0]) return [];
-    const n = Math.min(8, figure.data[0].x.length);
+    const x0 = figure.data[0].x ?? [];
+    const n = Math.min(8, x0.length);
     return Array.from({ length: n }, (_, i) => {
       const row: Record<string, string> = {
-        timestamp: String(figure.data[0].x[i] ?? ""),
+        timestamp: String(x0[i] ?? ""),
       };
       for (const t of figure.data) {
-        row[t.name] = t.y[i] == null ? "" : String(t.y[i]);
+        const name = t.name ?? "series";
+        const y = t.y ?? [];
+        row[name] = y[i] == null ? "" : String(y[i]);
       }
       return row;
     });

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1541,16 +1541,12 @@ LIMIT {limit}
         .and_then(|p| p.get("timestamp_utc").and_then(|v| v.as_str()))
         .map(str::to_string);
     let warnings = vec![
-        "equipment inspection points from historian DataFusion (raw columns; no FDD rule)"
-            .into(),
+        "equipment inspection points from historian DataFusion (raw columns; no FDD rule)".into(),
     ];
     let query = AnalyticsQuery::default();
     let mut env = envelope_with_engine("equipment-inspect-v1", &query, warnings, DF_ENGINE);
     env.points = points;
-    env.rows = selected
-        .iter()
-        .map(|c| json!({ "column": c }))
-        .collect();
+    env.rows = selected.iter().map(|c| json!({ "column": c })).collect();
     env.coverage = Some(json!({
         "equipment_id": eq,
         "row_count": n,
@@ -1954,9 +1950,8 @@ ORDER BY (CAST(SUM(CASE WHEN zone_t < {comfort_low_f} OR zone_t > {comfort_high_
             "series": "fail_pct",
         }));
     }
-    let warnings = vec![
-        "RCx zone comfort ranking from historian DataFusion (default band 70–75°F)".into(),
-    ];
+    let warnings =
+        vec!["RCx zone comfort ranking from historian DataFusion (default band 70–75°F)".into()];
     let query = AnalyticsQuery::default();
     let mut env = envelope_with_engine("rcx-ranking-v1", &query, warnings, DF_ENGINE);
     env.points = points;
@@ -2678,11 +2673,7 @@ mod tests {
 
         let ahu = building.join("AHU_1");
         std::fs::create_dir_all(&ahu).unwrap();
-        std::fs::write(
-            ahu.join("columns.csv"),
-            "col,point_role\noa_t,oa_t\n",
-        )
-        .unwrap();
+        std::fs::write(ahu.join("columns.csv"), "col,point_role\noa_t,oa_t\n").unwrap();
         let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
         writeln!(f, "timestamp_utc,oa_t").unwrap();
         writeln!(f, "2026-07-01T00:00:00Z,70").unwrap();
@@ -2713,7 +2704,10 @@ mod tests {
         std::env::remove_var("OPENFDD_PARQUET_ROOT");
 
         assert!(!env.points.is_empty());
-        assert_eq!(env.coverage.as_ref().unwrap()["oat_join"], "site_broadcast_by_ts");
+        assert_eq!(
+            env.coverage.as_ref().unwrap()["oat_join"],
+            "site_broadcast_by_ts"
+        );
         assert!(env.rows.iter().any(|r| r["kind"] == "delta_hist"));
     }
 

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1086,7 +1086,12 @@ SELECT
 FROM base
 WHERE fan_on
   AND oat_f IS NOT NULL AND rat_f IS NOT NULL AND mat_f IS NOT NULL
-ORDER BY timestamp_utc
+ORDER BY
+  CASE
+    WHEN oat_f IS NOT NULL AND rat_f IS NOT NULL AND ABS(oat_f - rat_f) >= {dt_min}
+    THEN 0 ELSE 1
+  END,
+  timestamp_utc
 LIMIT {limit}
 "#
     );
@@ -1331,6 +1336,8 @@ ORDER BY series_kind, equipment_id, bin_lo
 }
 
 /// BAS oa_t vs web OAT overlay samples + deviation histogram rows.
+/// Site-broadcasts BAS and web OAT by timestamp so Liberty works when `oa_t`
+/// lives on AHU rows and `web_oa_t` on weather (not co-located on one row).
 pub async fn bas_vs_web_from_history(
     equipment_filter: Option<&[String]>,
     max_points: usize,
@@ -1356,20 +1363,31 @@ pub async fn bas_vs_web_from_history(
         // Only one OAT column — cannot compare BAS vs web.
         return Ok(None);
     }
-    let eq_filter = equipment_filter_sql(equipment_filter);
+    let _eq_filter = equipment_filter_sql(equipment_filter);
     let limit = max_points.clamp(100, 5000);
     let sql = format!(
         r#"
+WITH bas_by_ts AS (
+  SELECT {ts_col} AS ts, AVG({bas}) AS bas_oat_f
+  FROM history
+  WHERE {bas} IS NOT NULL
+  GROUP BY {ts_col}
+),
+web_by_ts AS (
+  SELECT {ts_col} AS ts, AVG({web}) AS web_oat_f
+  FROM history
+  WHERE {web} IS NOT NULL
+  GROUP BY {ts_col}
+)
 SELECT
-  CAST({ts_col} AS VARCHAR) AS timestamp_utc,
-  equipment_id,
-  {bas} AS bas_oat_f,
-  {web} AS web_oat_f,
-  ({bas} - {web}) AS delta_f
-FROM history
-WHERE equipment_id IS NOT NULL
-  AND {bas} IS NOT NULL AND {web} IS NOT NULL{eq_filter}
-ORDER BY {ts_col}
+  CAST(b.ts AS VARCHAR) AS timestamp_utc,
+  'site' AS equipment_id,
+  b.bas_oat_f,
+  w.web_oat_f,
+  (b.bas_oat_f - w.web_oat_f) AS delta_f
+FROM bas_by_ts b
+INNER JOIN web_by_ts w ON b.ts = w.ts
+ORDER BY b.ts
 LIMIT {limit}
 "#
     );
@@ -1402,9 +1420,12 @@ LIMIT {limit}
             })
         })
         .collect();
-    let warnings = vec!["BAS vs web OAT from historian DataFusion (oa_t vs web OAT column)".into()];
+    let warnings = vec![
+        "BAS vs web OAT from historian DataFusion (site-broadcast oa_t × web OAT by timestamp)"
+            .into(),
+    ];
     let query = AnalyticsQuery::default();
-    let mut env = envelope_with_engine("bas-vs-web-oat-v1", &query, warnings, DF_ENGINE);
+    let mut env = envelope_with_engine("bas-vs-web-oat-v2", &query, warnings, DF_ENGINE);
     env.points = points;
     env.rows = rows;
     env.coverage = Some(json!({
@@ -1413,6 +1434,119 @@ LIMIT {limit}
         "history_rows": n,
         "bas_column": bas,
         "web_column": web,
+        "oat_join": "site_broadcast_by_ts",
+        "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
+    }));
+    Ok(Some(env))
+}
+
+/// Raw equipment history for Overview data inspection (vibe19 equipment_inspection_chart).
+/// Returns plottable numeric columns + downsampled wide points — no FDD rule required.
+pub async fn inspect_from_history(
+    building_id: Option<&str>,
+    equipment_id: &str,
+    columns: Option<&[String]>,
+    max_points: usize,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let eq = equipment_id.trim();
+    if eq.is_empty() {
+        return Ok(None);
+    }
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let Some(ts_col) = pick_ts_col(&cols) else {
+        return Ok(None);
+    };
+    let skip = HashSet::from([
+        "equipment_id".to_string(),
+        "building".to_string(),
+        "building_id".to_string(),
+        ts_col.to_string(),
+        "timestamp_utc".to_string(),
+        "timestamp".to_string(),
+        "ts".to_string(),
+    ]);
+    let mut plottable: Vec<String> = cols
+        .iter()
+        .filter(|c| !skip.contains(c.as_str()))
+        .cloned()
+        .collect();
+    plottable.sort();
+    if plottable.is_empty() {
+        return Ok(None);
+    }
+    let selected: Vec<String> = match columns {
+        Some(want) if !want.is_empty() => want
+            .iter()
+            .filter(|c| plottable.iter().any(|p| p == *c))
+            .cloned()
+            .collect(),
+        _ => plottable.iter().take(8).cloned().collect(),
+    };
+    if selected.is_empty() {
+        return Ok(None);
+    }
+    let limit = max_points.clamp(50, 8000);
+    let proj = selected
+        .iter()
+        .map(|c| format!("{c}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let eq_lit = eq.replace('\'', "''");
+    let sql = format!(
+        r#"
+SELECT
+  CAST({ts_col} AS VARCHAR) AS timestamp_utc,
+  {proj}
+FROM history
+WHERE equipment_id = '{eq_lit}'
+ORDER BY {ts_col}
+LIMIT {limit}
+"#
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    let mut points = Vec::with_capacity(result.rows.len());
+    for r in &result.rows {
+        let mut row = json!({
+            "timestamp_utc": r.get("timestamp_utc").cloned().unwrap_or(json!("")),
+            "equipment_id": eq,
+        });
+        if let Some(obj) = row.as_object_mut() {
+            for c in &selected {
+                obj.insert(c.clone(), r.get(c).cloned().unwrap_or(Value::Null));
+            }
+        }
+        points.push(row);
+    }
+    let first = points
+        .first()
+        .and_then(|p| p.get("timestamp_utc").and_then(|v| v.as_str()))
+        .map(str::to_string);
+    let last = points
+        .last()
+        .and_then(|p| p.get("timestamp_utc").and_then(|v| v.as_str()))
+        .map(str::to_string);
+    let warnings = vec![
+        "equipment inspection points from historian DataFusion (raw columns; no FDD rule)"
+            .into(),
+    ];
+    let query = AnalyticsQuery::default();
+    let mut env = envelope_with_engine("equipment-inspect-v1", &query, warnings, DF_ENGINE);
+    env.points = points;
+    env.rows = selected
+        .iter()
+        .map(|c| json!({ "column": c }))
+        .collect();
+    env.coverage = Some(json!({
+        "equipment_id": eq,
+        "row_count": n,
+        "point_count": env.points.len(),
+        "plottable_columns": plottable,
+        "columns_plotted": selected,
+        "first_timestamp": first,
+        "last_timestamp": last,
         "source": "historian_parquet",
         "building_id": safe_building_segment(building_id),
     }));
@@ -1994,6 +2128,92 @@ mod tests {
         assert!(weekly.iter().all(|r| r.get("label").is_some()));
         // Must not emit folded plant totals as the product rows.
         assert!(env.rows.iter().all(|r| r["kind"] != "weekly_plant"));
+    }
+
+    #[tokio::test]
+    async fn bas_vs_web_joins_site_oat_across_equipment() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_BAS");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+
+        let ahu = building.join("AHU_1");
+        std::fs::create_dir_all(&ahu).unwrap();
+        std::fs::write(
+            ahu.join("columns.csv"),
+            "col,point_role\noa_t,oa_t\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,oa_t").unwrap();
+        writeln!(f, "2026-07-01T00:00:00Z,70").unwrap();
+        writeln!(f, "2026-07-01T00:05:00Z,71").unwrap();
+        writeln!(f, "2026-07-01T00:10:00Z,72").unwrap();
+
+        let wx = building.join("weather");
+        std::fs::create_dir_all(&wx).unwrap();
+        std::fs::write(
+            wx.join("columns.csv"),
+            "col,point_role\nweb_oa_t,web_oa_t\n",
+        )
+        .unwrap();
+        let mut wf = std::fs::File::create(wx.join("history_wide.csv")).unwrap();
+        writeln!(wf, "timestamp_utc,web_oa_t").unwrap();
+        writeln!(wf, "2026-07-01T00:00:00Z,68").unwrap();
+        writeln!(wf, "2026-07-01T00:05:00Z,69").unwrap();
+        writeln!(wf, "2026-07-01T00:10:00Z,70").unwrap();
+
+        let parquet = tmp.path().join("parquet_bas");
+        fdd_store::ingest_building(tmp.path(), "BUILDING_BAS", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let env = bas_vs_web_from_history(None, 500, Some("BUILDING_BAS"))
+            .await
+            .unwrap()
+            .expect("site BAS×web join should produce overlay points");
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+
+        assert!(!env.points.is_empty());
+        assert_eq!(env.coverage.as_ref().unwrap()["oat_join"], "site_broadcast_by_ts");
+        assert!(env.rows.iter().any(|r| r["kind"] == "delta_hist"));
+    }
+
+    #[tokio::test]
+    async fn inspect_from_history_returns_raw_columns() {
+        let _guard = ENV_LOCK.lock().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_INSP");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let ahu = building.join("AHU_1");
+        std::fs::create_dir_all(&ahu).unwrap();
+        std::fs::write(
+            ahu.join("columns.csv"),
+            "col,point_role\nfan_status,fan_status\noa_t,oa_t\n",
+        )
+        .unwrap();
+        let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
+        writeln!(f, "timestamp_utc,fan_status,oa_t").unwrap();
+        writeln!(f, "2026-07-01T00:00:00Z,1,55").unwrap();
+        writeln!(f, "2026-07-01T00:05:00Z,1,56").unwrap();
+
+        let parquet = tmp.path().join("parquet_insp");
+        fdd_store::ingest_building(tmp.path(), "BUILDING_INSP", &parquet).unwrap();
+        std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
+
+        let env = inspect_from_history(Some("BUILDING_INSP"), "AHU_1", None, 500)
+            .await
+            .unwrap()
+            .expect("inspect envelope");
+        std::env::remove_var("OPENFDD_PARQUET_ROOT");
+
+        assert!(!env.points.is_empty());
+        let plotted = env.coverage.as_ref().unwrap()["columns_plotted"]
+            .as_array()
+            .unwrap();
+        assert!(!plotted.is_empty());
+        assert!(env.points[0].get("timestamp_utc").is_some());
     }
 
     #[test]

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1503,7 +1503,7 @@ pub async fn inspect_from_history(
     let limit = max_points.clamp(50, 8000);
     let proj = selected
         .iter()
-        .map(|c| format!("{c}"))
+        .map(|c| c.to_string())
         .collect::<Vec<_>>()
         .join(", ");
     let eq_lit = eq.replace('\'', "''");

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -18,22 +18,33 @@ use super::{
 /// handled separately by the schedule path.
 const NUMERIC_ROLE_COLS: &[&str] = &[
     "oa_t",
+    "web_oa_t",
+    "web_wb_t",
     "rat",
     "mat",
     "sat",
     "zone_t",
+    "zone_flow",
     "fan_cmd",
     "fan_status",
     "oa_damper_pct",
     "clg_valve_pct",
     "htg_valve_pct",
+    "damper_pct",
+    "reheat_valve_pct",
     "sat_sp",
     "duct_static",
     "duct_static_sp",
     "chw_supply_t",
     "chw_return_t",
+    "cw_supply_t",
+    "cw_return_t",
     "hw_supply_t",
     "hw_return_t",
+    "elec_power",
+    "gas_flow",
+    "chiller_power",
+    "chiller_amps",
     "oa_h",
     "return_fan",
 ];
@@ -746,8 +757,9 @@ fn as_u64(v: Option<&serde_json::Value>) -> u64 {
 /// `engine=datafusion` only when the aggregate SQL actually runs.
 pub async fn sensor_health_from_history(
     equipment_filter: Option<&[String]>,
+    building_id: Option<&str>,
 ) -> Result<Option<AnalyticsEnvelope>> {
-    let Some((ctx, cols, n)) = open_history().await? else {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
         return Ok(None);
     };
 
@@ -1553,6 +1565,532 @@ LIMIT {limit}
     Ok(Some(env))
 }
 
+fn rcx_eq_filter(kinds: &[&str]) -> String {
+    if kinds.is_empty() {
+        return String::new();
+    }
+    let mut parts = Vec::new();
+    for k in kinds {
+        let ku = k.to_ascii_uppercase();
+        if ku == "VAV" {
+            parts.push(
+                "(UPPER(equipment_id) LIKE 'VAV%' OR UPPER(equipment_id) LIKE '%/VAV%' \
+                 OR UPPER(equipment_id) LIKE '%VAVH%' OR UPPER(equipment_id) LIKE '%VAVFC%')"
+                    .to_string(),
+            );
+        } else if ku == "CHW" || ku == "CHW_PLANT" {
+            parts.push(
+                "(UPPER(equipment_id) LIKE '%CHILLER%' OR UPPER(equipment_id) LIKE 'CHW%' \
+                 OR UPPER(equipment_id) LIKE '%CHW_PLANT%')"
+                    .to_string(),
+            );
+        } else if ku == "BOILER" {
+            parts.push(
+                "(UPPER(equipment_id) LIKE 'BOILER%' OR UPPER(equipment_id) LIKE '%/BOILER%' \
+                 OR UPPER(equipment_id) LIKE '%BOILERS%')"
+                    .to_string(),
+            );
+        } else if ku == "TOWER" || ku == "CT" || ku == "COOLING_TOWER" {
+            parts.push(
+                "(UPPER(equipment_id) LIKE '%TOWER%' OR UPPER(equipment_id) LIKE 'CT%' \
+                 OR UPPER(equipment_id) LIKE '%COOLING_TOWER%')"
+                    .to_string(),
+            );
+        } else if ku == "METER" {
+            parts.push(
+                "(UPPER(equipment_id) LIKE 'METER%' OR UPPER(equipment_id) LIKE '%/METER%' \
+                 OR UPPER(equipment_id) LIKE '%_METER%')"
+                    .to_string(),
+            );
+        } else {
+            parts.push(format!(
+                "(UPPER(equipment_id) LIKE '{ku}%' OR UPPER(equipment_id) LIKE '%/{ku}%')"
+            ));
+        }
+    }
+    format!(" AND ({})", parts.join(" OR "))
+}
+
+/// Multi-equipment role timeseries for RCx presets (vibe19 multi_equipment_timeseries).
+pub async fn rcx_timeseries_from_history(
+    building_id: Option<&str>,
+    role_col: &str,
+    overlay_col: Option<&str>,
+    pair_return_col: Option<&str>,
+    eq_kinds: &[&str],
+    filter_fan_on: bool,
+    max_points: usize,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let Some(ts_col) = pick_ts_col(&cols) else {
+        return Ok(None);
+    };
+    if !cols.contains(role_col) {
+        return Ok(None);
+    }
+    let eq_filter = rcx_eq_filter(eq_kinds);
+    let fan_filter = if filter_fan_on {
+        match on_expr(&cols) {
+            Some(expr) => format!(" AND ({expr})"),
+            None => String::new(),
+        }
+    } else {
+        String::new()
+    };
+    let limit = max_points.clamp(200, 20000);
+    let overlay_sel = overlay_col
+        .filter(|c| cols.contains(*c))
+        .map(|c| format!(", {c} AS overlay_f"))
+        .unwrap_or_else(|| ", CAST(NULL AS FLOAT) AS overlay_f".into());
+    let return_sel = pair_return_col
+        .filter(|c| cols.contains(*c))
+        .map(|c| format!(", {c} AS return_f"))
+        .unwrap_or_else(|| ", CAST(NULL AS FLOAT) AS return_f".into());
+    let sql = format!(
+        r#"
+SELECT
+  CAST({ts_col} AS VARCHAR) AS timestamp_utc,
+  equipment_id,
+  {role_col} AS value_f
+  {overlay_sel}
+  {return_sel}
+FROM history
+WHERE equipment_id IS NOT NULL AND {role_col} IS NOT NULL{eq_filter}{fan_filter}
+ORDER BY {ts_col}, equipment_id
+LIMIT {limit}
+"#
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    if result.rows.is_empty() {
+        return Ok(None);
+    }
+    let mut points = Vec::with_capacity(result.rows.len());
+    for r in &result.rows {
+        let row = json!({
+            "timestamp_utc": r.get("timestamp_utc").cloned().unwrap_or(json!("")),
+            "equipment_id": r.get("equipment_id").cloned().unwrap_or(json!("")),
+            "value_f": as_f64(r.get("value_f")),
+            "series": "primary",
+        });
+        points.push(row.clone());
+        if let Some(ov) = as_f64(r.get("overlay_f")) {
+            let mut o = row.clone();
+            if let Some(obj) = o.as_object_mut() {
+                obj.insert("value_f".into(), json!(ov));
+                obj.insert("series".into(), json!("overlay"));
+            }
+            points.push(o);
+        }
+        if let Some(ret) = as_f64(r.get("return_f")) {
+            let mut rr = row.clone();
+            if let Some(obj) = rr.as_object_mut() {
+                obj.insert("value_f".into(), json!(ret));
+                obj.insert("series".into(), json!("return"));
+            }
+            points.push(rr);
+            if let Some(sup) = as_f64(r.get("value_f")) {
+                let mut d = row;
+                if let Some(obj) = d.as_object_mut() {
+                    obj.insert("value_f".into(), json!(round2(ret - sup)));
+                    obj.insert("series".into(), json!("delta_t"));
+                }
+                points.push(d);
+            }
+        }
+    }
+    let warnings = vec!["RCx role timeseries from historian DataFusion".into()];
+    let query = AnalyticsQuery::default();
+    let mut env = envelope_with_engine("rcx-timeseries-v1", &query, warnings, DF_ENGINE);
+    env.points = points;
+    env.coverage = Some(json!({
+        "history_rows": n,
+        "point_count": env.points.len(),
+        "role_col": role_col,
+        "chart_kind": "timeseries",
+        "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
+    }));
+    Ok(Some(env))
+}
+
+/// OAT scatter for RCx reset charts (vibe19 oat_scatter) with site-broadcast OAT.
+pub async fn rcx_oat_scatter_from_history(
+    building_id: Option<&str>,
+    y_col: &str,
+    eq_kinds: &[&str],
+    prefer_wetbulb: bool,
+    max_points: usize,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let Some(ts_col) = pick_ts_col(&cols) else {
+        return Ok(None);
+    };
+    if !cols.contains(y_col) {
+        return Ok(None);
+    }
+    let oat = if prefer_wetbulb {
+        ["web_wb_t", "oa_wb_t", "wetbulb_t"]
+            .into_iter()
+            .find(|&c| cols.contains(c))
+            .or_else(|| mech_oat_col(&cols))
+    } else {
+        mech_oat_col(&cols)
+    };
+    let Some(oat) = oat else {
+        return Ok(None);
+    };
+    let dry_ref = if prefer_wetbulb {
+        mech_oat_col(&cols).filter(|c| *c != oat)
+    } else {
+        None
+    };
+    let eq_filter = rcx_eq_filter(eq_kinds);
+    // Prefixed for JOIN aliases (history AS h).
+    let eq_filter_h = eq_filter.replace("equipment_id", "h.equipment_id");
+    let limit = max_points.clamp(200, 12000);
+    let dry_sel = if dry_ref.is_some() {
+        ", d.dry_f AS dry_bulb_f".to_string()
+    } else {
+        ", CAST(NULL AS FLOAT) AS dry_bulb_f".into()
+    };
+    let dry_cte = dry_ref
+        .map(|c| {
+            format!(
+                ", dry_by_ts AS (\n  SELECT {ts_col} AS ts, AVG({c}) AS dry_f\n  FROM history\n  WHERE {c} IS NOT NULL\n  GROUP BY {ts_col}\n)"
+            )
+        })
+        .unwrap_or_default();
+    let dry_join = if dry_ref.is_some() {
+        "LEFT JOIN dry_by_ts d ON h.{ts_col} = d.ts".replace("{ts_col}", ts_col)
+    } else {
+        String::new()
+    };
+    let sql = format!(
+        r#"
+WITH oat_by_ts AS (
+  SELECT {ts_col} AS ts, AVG({oat}) AS oat_f
+  FROM history
+  WHERE {oat} IS NOT NULL
+  GROUP BY {ts_col}
+){dry_cte}
+SELECT
+  CAST(h.{ts_col} AS VARCHAR) AS timestamp_utc,
+  h.equipment_id,
+  o.oat_f,
+  h.{y_col} AS y_f
+  {dry_sel}
+FROM history h
+LEFT JOIN oat_by_ts o ON h.{ts_col} = o.ts
+{dry_join}
+WHERE h.equipment_id IS NOT NULL
+  AND h.{y_col} IS NOT NULL
+  AND o.oat_f IS NOT NULL{eq_filter_h}
+ORDER BY h.{ts_col}, h.equipment_id
+LIMIT {limit}
+"#
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    if result.rows.is_empty() {
+        return Ok(None);
+    }
+    let mut points = Vec::with_capacity(result.rows.len());
+    for r in &result.rows {
+        let mut row = json!({
+            "timestamp_utc": r.get("timestamp_utc").cloned().unwrap_or(json!("")),
+            "equipment_id": r.get("equipment_id").cloned().unwrap_or(json!("")),
+            "oat_f": as_f64(r.get("oat_f")),
+            "y_f": as_f64(r.get("y_f")),
+        });
+        if let Some(d) = as_f64(r.get("dry_bulb_f")) {
+            if let Some(obj) = row.as_object_mut() {
+                obj.insert("dry_bulb_f".into(), json!(d));
+            }
+        }
+        points.push(row);
+    }
+    let warnings = vec!["RCx OAT scatter from historian DataFusion (site-broadcast OAT)".into()];
+    let query = AnalyticsQuery::default();
+    let mut env = envelope_with_engine("rcx-oat-scatter-v1", &query, warnings, DF_ENGINE);
+    env.points = points;
+    env.coverage = Some(json!({
+        "history_rows": n,
+        "point_count": env.points.len(),
+        "y_col": y_col,
+        "oat_column": oat,
+        "prefer_wetbulb": prefer_wetbulb,
+        "chart_kind": "scatter_oat",
+        "oat_join": "site_broadcast_by_ts",
+        "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
+    }));
+    Ok(Some(env))
+}
+
+/// Multi-equipment box-plot samples (vibe19 multi_equipment_box).
+pub async fn rcx_box_from_history(
+    building_id: Option<&str>,
+    role_col: &str,
+    eq_kinds: &[&str],
+    filter_fan_on: bool,
+    max_points: usize,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    if !cols.contains(role_col) {
+        return Ok(None);
+    }
+    let eq_filter = rcx_eq_filter(eq_kinds);
+    let fan_filter = if filter_fan_on {
+        match on_expr(&cols) {
+            Some(expr) => format!(" AND ({expr})"),
+            None => String::new(),
+        }
+    } else {
+        String::new()
+    };
+    let limit = max_points.clamp(200, 20000);
+    let sql = format!(
+        r#"
+SELECT equipment_id, {role_col} AS value_f
+FROM history
+WHERE equipment_id IS NOT NULL AND {role_col} IS NOT NULL{eq_filter}{fan_filter}
+LIMIT {limit}
+"#
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    if result.rows.is_empty() {
+        return Ok(None);
+    }
+    let mut points = Vec::with_capacity(result.rows.len());
+    for r in &result.rows {
+        points.push(json!({
+            "equipment_id": r.get("equipment_id").cloned().unwrap_or(json!("")),
+            "value_f": as_f64(r.get("value_f")),
+        }));
+    }
+    let warnings = vec!["RCx box samples from historian DataFusion".into()];
+    let query = AnalyticsQuery::default();
+    let mut env = envelope_with_engine("rcx-box-v1", &query, warnings, DF_ENGINE);
+    env.points = points;
+    env.coverage = Some(json!({
+        "history_rows": n,
+        "point_count": env.points.len(),
+        "role_col": role_col,
+        "chart_kind": "box",
+        "filter_fan_on": filter_fan_on,
+        "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
+    }));
+    Ok(Some(env))
+}
+
+/// Zone comfort fail ranking (vibe19 zone_comfort_fail_ranking) — % of samples
+/// outside [low, high] band per VAV. Uses occ_mode when present on the row.
+pub async fn rcx_zone_comfort_rank_from_history(
+    building_id: Option<&str>,
+    eq_kinds: &[&str],
+    comfort_low_f: f64,
+    comfort_high_f: f64,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    if !cols.contains("zone_t") {
+        return Ok(None);
+    }
+    let eq_filter = rcx_eq_filter(eq_kinds);
+    let occ_filter = if cols.contains("occ_mode") {
+        " AND (occ_mode IS NULL OR UPPER(CAST(occ_mode AS VARCHAR)) IN \
+          ('OCC','OCCUPIED','TRUE','YES','1','ON'))"
+            .to_string()
+    } else {
+        String::new()
+    };
+    let sql = format!(
+        r#"
+SELECT
+  equipment_id,
+  COUNT(*) AS n_samples,
+  SUM(CASE WHEN zone_t < {comfort_low_f} OR zone_t > {comfort_high_f} THEN 1 ELSE 0 END) AS n_fail
+FROM history
+WHERE equipment_id IS NOT NULL AND zone_t IS NOT NULL{eq_filter}{occ_filter}
+GROUP BY equipment_id
+ORDER BY (CAST(SUM(CASE WHEN zone_t < {comfort_low_f} OR zone_t > {comfort_high_f} THEN 1 ELSE 0 END) AS FLOAT)
+          / CAST(COUNT(*) AS FLOAT)) DESC
+"#
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    if result.rows.is_empty() {
+        return Ok(None);
+    }
+    let mut points = Vec::with_capacity(result.rows.len());
+    let mut rows = Vec::with_capacity(result.rows.len());
+    for r in &result.rows {
+        let n_samples = as_u64(r.get("n_samples")) as f64;
+        let n_fail = as_u64(r.get("n_fail")) as f64;
+        let fail_pct = if n_samples > 0.0 {
+            round2(100.0 * n_fail / n_samples)
+        } else {
+            0.0
+        };
+        let eq = r.get("equipment_id").cloned().unwrap_or(json!(""));
+        let row = json!({
+            "equipment_id": eq.clone(),
+            "n_samples": n_samples as u64,
+            "n_fail": n_fail as u64,
+            "fail_pct": fail_pct,
+            "comfort_low_f": comfort_low_f,
+            "comfort_high_f": comfort_high_f,
+        });
+        rows.push(row.clone());
+        points.push(json!({
+            "equipment_id": eq,
+            "value_f": fail_pct,
+            "series": "fail_pct",
+        }));
+    }
+    let warnings = vec![
+        "RCx zone comfort ranking from historian DataFusion (default band 70–75°F)".into(),
+    ];
+    let query = AnalyticsQuery::default();
+    let mut env = envelope_with_engine("rcx-ranking-v1", &query, warnings, DF_ENGINE);
+    env.points = points;
+    env.rows = rows;
+    env.coverage = Some(json!({
+        "history_rows": n,
+        "point_count": env.points.len(),
+        "chart_kind": "ranking",
+        "comfort_low_f": comfort_low_f,
+        "comfort_high_f": comfort_high_f,
+        "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
+    }));
+    Ok(Some(env))
+}
+
+/// Monthly metering vs degree-days (vibe19 metering presets) — average power ×
+/// hours as kWh proxy; CDD/HDD from site-broadcast monthly mean OAT (65°F base).
+pub async fn rcx_metering_from_history(
+    building_id: Option<&str>,
+    role_col: &str,
+    eq_kinds: &[&str],
+    kind: &str,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let Some(ts_col) = pick_ts_col(&cols) else {
+        return Ok(None);
+    };
+    if !cols.contains(role_col) {
+        return Ok(None);
+    }
+    let Some(oat) = mech_oat_col(&cols) else {
+        return Ok(None);
+    };
+    let eq_filter = rcx_eq_filter(eq_kinds);
+    let eq_filter_h = eq_filter.replace("equipment_id", "h.equipment_id");
+    let cooling = kind != "gas";
+    let sql = format!(
+        r#"
+WITH oat_month AS (
+  SELECT
+    substr(CAST({ts_col} AS VARCHAR), 1, 7) AS month,
+    AVG({oat}) AS avg_oat_f,
+    COUNT(*) AS oat_n
+  FROM history
+  WHERE {oat} IS NOT NULL
+  GROUP BY substr(CAST({ts_col} AS VARCHAR), 1, 7)
+),
+meter_month AS (
+  SELECT
+    h.equipment_id,
+    substr(CAST(h.{ts_col} AS VARCHAR), 1, 7) AS month,
+    AVG(h.{role_col}) AS avg_rate,
+    COUNT(*) AS n_samples
+  FROM history h
+  WHERE h.equipment_id IS NOT NULL AND h.{role_col} IS NOT NULL{eq_filter_h}
+  GROUP BY h.equipment_id, substr(CAST(h.{ts_col} AS VARCHAR), 1, 7)
+)
+SELECT
+  m.equipment_id,
+  m.month,
+  m.avg_rate,
+  m.n_samples,
+  o.avg_oat_f
+FROM meter_month m
+LEFT JOIN oat_month o ON m.month = o.month
+ORDER BY m.equipment_id, m.month
+"#
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    if result.rows.is_empty() {
+        return Ok(None);
+    }
+    let mut points = Vec::new();
+    let mut rows = Vec::new();
+    for r in &result.rows {
+        let avg_rate = as_f64(r.get("avg_rate")).unwrap_or(0.0);
+        let n_samples = as_u64(r.get("n_samples")) as f64;
+        // Assume ~5-min samples → hours ≈ n * 5/60.
+        let hours = n_samples * (5.0 / 60.0);
+        let energy = round2(avg_rate * hours);
+        let avg_oat = as_f64(r.get("avg_oat_f")).unwrap_or(65.0);
+        let days = (n_samples * 5.0 / (60.0 * 24.0)).max(1.0);
+        let dd = if cooling {
+            round2((avg_oat - 65.0).max(0.0) * days)
+        } else {
+            round2((65.0 - avg_oat).max(0.0) * days)
+        };
+        let eq = r.get("equipment_id").cloned().unwrap_or(json!(""));
+        let month = r.get("month").cloned().unwrap_or(json!(""));
+        let row = json!({
+            "equipment_id": eq.clone(),
+            "month": month.clone(),
+            "energy": energy,
+            "avg_rate": round2(avg_rate),
+            "degree_days": dd,
+            "avg_oat_f": round2(avg_oat),
+            "n_samples": n_samples as u64,
+            "kind": kind,
+        });
+        rows.push(row.clone());
+        points.push(json!({
+            "equipment_id": eq,
+            "month": month,
+            "energy": energy,
+            "degree_days": dd,
+            "oat_f": dd,
+            "y_f": energy,
+            "value_f": energy,
+        }));
+    }
+    let warnings = vec![
+        format!(
+            "RCx metering from historian DataFusion ({kind}; energy ≈ avg_rate × sample-hours; DD base 65°F)"
+        ),
+    ];
+    let query = AnalyticsQuery::default();
+    let mut env = envelope_with_engine("rcx-metering-v1", &query, warnings, DF_ENGINE);
+    env.points = points;
+    env.rows = rows;
+    env.coverage = Some(json!({
+        "history_rows": n,
+        "point_count": env.points.len(),
+        "role_col": role_col,
+        "chart_kind": "metering",
+        "meter_kind": kind,
+        "source": "historian_parquet",
+        "building_id": safe_building_segment(building_id),
+    }));
+    Ok(Some(env))
+}
+
 /// Generic descriptive per-equipment row-count evidence from historian Parquet
 /// via DataFusion. Used by families (mechanical_cooling, metering, rcx/*, plant)
 /// that do not yet have a family-specific DF metric. Honest: sets
@@ -1675,7 +2213,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let missing = tmp.path().join("no_such_parquet_sh");
         std::env::set_var("OPENFDD_PARQUET_ROOT", &missing);
-        let out = sensor_health_from_history(None).await.unwrap();
+        let out = sensor_health_from_history(None, None).await.unwrap();
         assert!(out.is_none());
         std::env::remove_var("OPENFDD_PARQUET_ROOT");
     }
@@ -1704,7 +2242,7 @@ mod tests {
         fdd_store::ingest_building(tmp.path(), "BUILDING_SH", &parquet).unwrap();
         std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
 
-        let env = sensor_health_from_history(None)
+        let env = sensor_health_from_history(None, Some("BUILDING_SH"))
             .await
             .unwrap()
             .expect("expected sensor_health historian envelope");

--- a/services/central/src/analytics/mod.rs
+++ b/services/central/src/analytics/mod.rs
@@ -10,6 +10,7 @@ pub mod mechanical_cooling;
 pub mod metering;
 pub mod plant;
 pub mod rcx;
+pub mod rcx_presets;
 pub mod runtime;
 pub mod schedule;
 pub mod sensor_health;

--- a/services/central/src/analytics/rcx_presets.rs
+++ b/services/central/src/analytics/rcx_presets.rs
@@ -409,13 +409,8 @@ pub async fn run_preset(
             .await?
         }
         "ranking" => {
-            historian::rcx_zone_comfort_rank_from_history(
-                building_id,
-                meta.eq_kinds,
-                70.0,
-                75.0,
-            )
-            .await?
+            historian::rcx_zone_comfort_rank_from_history(building_id, meta.eq_kinds, 70.0, 75.0)
+                .await?
         }
         "metering" => {
             historian::rcx_metering_from_history(
@@ -429,7 +424,10 @@ pub async fn run_preset(
         other => {
             return Ok(Some(empty_stub(
                 meta,
-                &format!("RCx preset '{}' chart kind '{other}' not yet wired in DataFusion", meta.id),
+                &format!(
+                    "RCx preset '{}' chart kind '{other}' not yet wired in DataFusion",
+                    meta.id
+                ),
             )));
         }
     };

--- a/services/central/src/analytics/rcx_presets.rs
+++ b/services/central/src/analytics/rcx_presets.rs
@@ -1,0 +1,463 @@
+//! RCx preset metadata + DataFusion series for vibe19 RCx Plots parity.
+//!
+//! Catalog mirrors `open_fdd/analytics/rcx_plots.py` PRESETS (20) including the
+//! 18 frozen `REQUIRED_RCX_PRESET_IDS` plus AHU valve extras.
+
+use anyhow::Result;
+use serde_json::{json, Value};
+
+use super::historian;
+use super::{envelope_with_engine, AnalyticsEnvelope, AnalyticsQuery, DF_ENGINE};
+
+#[derive(Clone, Copy)]
+pub struct RcxPresetMeta {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub family: &'static str,
+    pub chart: &'static str,
+    pub role_col: &'static str,
+    pub eq_kinds: &'static [&'static str],
+    pub overlay_col: Option<&'static str>,
+    pub pair_return_col: Option<&'static str>,
+    pub filter_fan_on: bool,
+    /// For scatter: use wet-bulb OAT when present (`cw_reset_scatter`).
+    pub prefer_wetbulb: bool,
+    /// Metering kind: "electric" | "gas" (chart == metering).
+    pub meter_kind: Option<&'static str>,
+}
+
+/// Full vibe19 preset catalog (frozen 18 + valve extras).
+pub const RCX_PRESETS: &[RcxPresetMeta] = &[
+    RcxPresetMeta {
+        id: "zone_comfort_rank",
+        title: "Zones — comfort fail ranking (occupied hours)",
+        family: "Zones / VAV",
+        chart: "ranking",
+        role_col: "zone_t",
+        eq_kinds: &["VAV"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "zone_temps",
+        title: "Zones — all space temps (timeseries)",
+        family: "Zones / VAV",
+        chart: "timeseries",
+        role_col: "zone_t",
+        eq_kinds: &["VAV"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "vav_flows",
+        title: "Zones — all VAV airflow (timeseries)",
+        family: "Zones / VAV",
+        chart: "timeseries",
+        role_col: "zone_flow",
+        eq_kinds: &["VAV"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "ahu_sat_reset_scatter",
+        title: "AHU — SAT vs web dry-bulb (scatter)",
+        family: "AHU / air",
+        chart: "scatter_oat",
+        role_col: "sat",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "ahu_dats",
+        title: "AHU — all DATs / SAT (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "sat",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "ahu_mats",
+        title: "AHU — all MATs (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "mat",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "ahu_rats",
+        title: "AHU — all RATs (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "rat",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "ahu_dampers",
+        title: "AHU — OA dampers (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "oa_damper_pct",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "ahu_cooling_valves",
+        title: "AHU — cooling valves (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "clg_valve_pct",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "ahu_heating_valves",
+        title: "AHU — heating valves (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "htg_valve_pct",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "fan_speeds",
+        title: "AHU — fan speeds / cmds (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "fan_cmd",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "duct_static_box",
+        title: "AHU — duct static fan-on (box)",
+        family: "AHU / air",
+        chart: "box",
+        role_col: "duct_static",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: true,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "duct_static_ts",
+        title: "AHU — duct static + setpoint (timeseries)",
+        family: "AHU / air",
+        chart: "timeseries",
+        role_col: "duct_static",
+        eq_kinds: &["AHU", "RTU", "MAU"],
+        overlay_col: Some("duct_static_sp"),
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "hw_reset_scatter",
+        title: "Boiler — HWS vs web dry-bulb (scatter)",
+        family: "Boiler / HW",
+        chart: "scatter_oat",
+        role_col: "hw_supply_t",
+        eq_kinds: &["BOILER"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "chw_reset_scatter",
+        title: "Chiller — CHWS vs web dry-bulb (scatter)",
+        family: "Chiller / CHW / tower",
+        chart: "scatter_oat",
+        role_col: "chw_supply_t",
+        eq_kinds: &["CHILLER", "CHW"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "cw_reset_scatter",
+        title: "Tower / CW — leave temp vs wet-bulb + dry-bulb ref (scatter)",
+        family: "Chiller / CHW / tower",
+        chart: "scatter_oat",
+        role_col: "cw_supply_t",
+        eq_kinds: &["CHILLER", "CHW", "TOWER", "CT"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: true,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "chw_temps_ts",
+        title: "Chiller — CHW supply/return/ΔT (timeseries)",
+        family: "Chiller / CHW / tower",
+        chart: "timeseries",
+        role_col: "chw_supply_t",
+        eq_kinds: &["CHILLER", "CHW"],
+        overlay_col: None,
+        pair_return_col: Some("chw_return_t"),
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "cw_temps_ts",
+        title: "Tower / CW — supply/return/ΔT (timeseries)",
+        family: "Chiller / CHW / tower",
+        chart: "timeseries",
+        role_col: "cw_supply_t",
+        eq_kinds: &["CHILLER", "CHW", "TOWER", "CT"],
+        overlay_col: None,
+        pair_return_col: Some("cw_return_t"),
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: None,
+    },
+    RcxPresetMeta {
+        id: "meter_elec_cdd",
+        title: "Metering — electric kWh/month vs CDD (scatter + stats)",
+        family: "Metering",
+        chart: "metering",
+        role_col: "elec_power",
+        eq_kinds: &["METER", "CHILLER", "CHW"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: Some("electric"),
+    },
+    RcxPresetMeta {
+        id: "meter_gas_hdd",
+        title: "Metering — gas/month vs HDD (scatter + stats)",
+        family: "Metering",
+        chart: "metering",
+        role_col: "gas_flow",
+        eq_kinds: &["METER", "BOILER"],
+        overlay_col: None,
+        pair_return_col: None,
+        filter_fan_on: false,
+        prefer_wetbulb: false,
+        meter_kind: Some("gas"),
+    },
+];
+
+/// Frozen catalog ids (must stay listed even when columns are absent on a site).
+pub const REQUIRED_RCX_PRESET_IDS: &[&str] = &[
+    "zone_comfort_rank",
+    "zone_temps",
+    "ahu_dats",
+    "ahu_mats",
+    "ahu_rats",
+    "ahu_dampers",
+    "duct_static_box",
+    "ahu_sat_reset_scatter",
+    "hw_reset_scatter",
+    "chw_reset_scatter",
+    "cw_reset_scatter",
+    "vav_flows",
+    "fan_speeds",
+    "meter_elec_cdd",
+    "meter_gas_hdd",
+    "duct_static_ts",
+    "chw_temps_ts",
+    "cw_temps_ts",
+];
+
+pub fn preset_by_id(id: &str) -> Option<&'static RcxPresetMeta> {
+    RCX_PRESETS.iter().find(|p| p.id == id)
+}
+
+pub fn presets_json() -> Value {
+    json!(RCX_PRESETS
+        .iter()
+        .map(|p| json!({
+            "id": p.id,
+            "title": p.title,
+            "family": p.family,
+            "chart": p.chart,
+            "role_col": p.role_col,
+            "filter_fan_on": p.filter_fan_on,
+            "frozen": REQUIRED_RCX_PRESET_IDS.contains(&p.id),
+        }))
+        .collect::<Vec<_>>())
+}
+
+fn annotate(mut env: AnalyticsEnvelope, meta: &RcxPresetMeta) -> AnalyticsEnvelope {
+    env.query_version = format!("rcx-preset-{}-v1", meta.id);
+    let mut cov = env.coverage.unwrap_or_else(|| json!({}));
+    if let Some(obj) = cov.as_object_mut() {
+        obj.insert("preset_id".into(), json!(meta.id));
+        obj.insert("chart_kind".into(), json!(meta.chart));
+        obj.insert("title".into(), json!(meta.title));
+        obj.insert("family".into(), json!(meta.family));
+        obj.insert("role_col".into(), json!(meta.role_col));
+        obj.insert("y_col".into(), json!(meta.role_col));
+    }
+    env.coverage = Some(cov);
+    env
+}
+
+fn empty_stub(meta: &RcxPresetMeta, reason: &str) -> AnalyticsEnvelope {
+    let query = AnalyticsQuery::default();
+    let mut env = envelope_with_engine(
+        &format!("rcx-preset-{}-v1", meta.id),
+        &query,
+        vec![reason.to_string()],
+        DF_ENGINE,
+    );
+    env.coverage = Some(json!({
+        "preset_id": meta.id,
+        "chart_kind": meta.chart,
+        "title": meta.title,
+        "family": meta.family,
+        "role_col": meta.role_col,
+        "y_col": meta.role_col,
+        "empty": true,
+    }));
+    env
+}
+
+/// Run a named RCx preset against historian parquet.
+pub async fn run_preset(
+    building_id: Option<&str>,
+    preset_id: &str,
+    max_points: usize,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some(meta) = preset_by_id(preset_id) else {
+        return Ok(None);
+    };
+    let out = match meta.chart {
+        "timeseries" => {
+            historian::rcx_timeseries_from_history(
+                building_id,
+                meta.role_col,
+                meta.overlay_col,
+                meta.pair_return_col,
+                meta.eq_kinds,
+                meta.filter_fan_on,
+                max_points,
+            )
+            .await?
+        }
+        "scatter_oat" => {
+            historian::rcx_oat_scatter_from_history(
+                building_id,
+                meta.role_col,
+                meta.eq_kinds,
+                meta.prefer_wetbulb,
+                max_points,
+            )
+            .await?
+        }
+        "box" => {
+            historian::rcx_box_from_history(
+                building_id,
+                meta.role_col,
+                meta.eq_kinds,
+                meta.filter_fan_on,
+                max_points,
+            )
+            .await?
+        }
+        "ranking" => {
+            historian::rcx_zone_comfort_rank_from_history(
+                building_id,
+                meta.eq_kinds,
+                70.0,
+                75.0,
+            )
+            .await?
+        }
+        "metering" => {
+            historian::rcx_metering_from_history(
+                building_id,
+                meta.role_col,
+                meta.eq_kinds,
+                meta.meter_kind.unwrap_or("electric"),
+            )
+            .await?
+        }
+        other => {
+            return Ok(Some(empty_stub(
+                meta,
+                &format!("RCx preset '{}' chart kind '{other}' not yet wired in DataFusion", meta.id),
+            )));
+        }
+    };
+    Ok(Some(match out {
+        Some(env) => annotate(env, meta),
+        None => empty_stub(
+            meta,
+            &format!(
+                "RCx preset '{}' unavailable — missing historian column '{}' or no matching equipment",
+                meta.id, meta.role_col
+            ),
+        ),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frozen_presets_all_listed() {
+        for id in REQUIRED_RCX_PRESET_IDS {
+            assert!(
+                preset_by_id(id).is_some(),
+                "frozen preset {id} missing from RCX_PRESETS"
+            );
+        }
+        assert!(RCX_PRESETS.len() >= 18);
+        assert!(presets_json().as_array().unwrap().len() >= 18);
+    }
+}

--- a/services/central/src/analytics/sensor_health.rs
+++ b/services/central/src/analytics/sensor_health.rs
@@ -166,7 +166,12 @@ pub fn handle(req: &AnalyticsRequest) -> AnalyticsEnvelope {
 /// series is provided; otherwise inline central-analytics-v1 compute.
 pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
     if req.series.is_none() {
-        match historian::sensor_health_from_history(req.query.equipment_ids.as_deref()).await {
+        match historian::sensor_health_from_history(
+            req.query.equipment_ids.as_deref(),
+            req.query.building_id.as_deref(),
+        )
+        .await
+        {
             Ok(Some(env)) => return finalize_historian(req, env, QV_SENSOR_HEALTH),
             Ok(None) => {}
             Err(e) => {

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -189,7 +189,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/analytics/rcx/chiller", post(analytics_rcx_chiller))
         .route("/api/analytics/rcx/boiler", post(analytics_rcx_boiler))
         .route("/api/analytics/rcx/preset", post(analytics_rcx_preset))
-        .route("/api/analytics/rcx/presets", get(analytics_rcx_presets_list))
+        .route(
+            "/api/analytics/rcx/presets",
+            get(analytics_rcx_presets_list),
+        )
         .route("/api/analytics/metering", post(analytics_metering))
         .merge(csv)
         // OFDD-075: analytics/FDD posts (building-scoped Overview samples) can
@@ -1761,13 +1764,11 @@ async fn analytics_inspect(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
         .map(|s| s.as_str())
         .unwrap_or("");
     let columns: Option<Vec<String>> = req.series.as_ref().and_then(|s| {
-        s.get("columns")
-            .and_then(|c| c.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect()
-            })
+        s.get("columns").and_then(|c| c.as_array()).map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
     });
     let max_points = req.query.max_points.unwrap_or(2000);
     let env = match analytics::historian::inspect_from_history(

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -182,6 +182,7 @@ pub fn router(state: Arc<AppState>) -> Router {
             "/api/analytics/bas-vs-web-oat",
             post(analytics_bas_vs_web_oat),
         )
+        .route("/api/analytics/inspect", post(analytics_inspect))
         .route("/api/analytics/economizer", post(analytics_economizer))
         .route("/api/analytics/rcx/ahu", post(analytics_rcx_ahu))
         .route("/api/analytics/rcx/vav", post(analytics_rcx_vav))
@@ -1725,11 +1726,11 @@ async fn analytics_bas_vs_web_oat(Json(req): Json<AnalyticsRequest>) -> Json<Val
     {
         Ok(Some(env)) => env,
         Ok(None) => analytics::envelope_with_engine(
-            "bas-vs-web-oat-v1",
+            "bas-vs-web-oat-v2",
             &req.query,
             vec![
                 "BAS vs web OAT unavailable — need distinct oa_t and web OAT \
-                 columns on historian Parquet"
+                 columns on historian Parquet (site-broadcast join)"
                     .into(),
             ],
             analytics::DF_ENGINE,
@@ -1737,9 +1738,57 @@ async fn analytics_bas_vs_web_oat(Json(req): Json<AnalyticsRequest>) -> Json<Val
         Err(e) => {
             tracing::warn!(error = %e, "bas-vs-web-oat historian path failed");
             analytics::envelope(
-                "bas-vs-web-oat-v1",
+                "bas-vs-web-oat-v2",
                 &req.query,
                 vec![format!("bas-vs-web-oat failed: {e}")],
+            )
+        }
+    };
+    Json(json!({
+        "ok": true,
+        "analytics": env.to_json(),
+    }))
+}
+
+async fn analytics_inspect(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    let eq = req
+        .query
+        .equipment_ids
+        .as_ref()
+        .and_then(|ids| ids.first())
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    let columns: Option<Vec<String>> = req.series.as_ref().and_then(|s| {
+        s.get("columns")
+            .and_then(|c| c.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+    });
+    let max_points = req.query.max_points.unwrap_or(2000);
+    let env = match analytics::historian::inspect_from_history(
+        req.query.building_id.as_deref(),
+        eq,
+        columns.as_deref(),
+        max_points,
+    )
+    .await
+    {
+        Ok(Some(env)) => env,
+        Ok(None) => analytics::envelope_with_engine(
+            "equipment-inspect-v1",
+            &req.query,
+            vec!["equipment inspection unavailable — need historian parquet for equipment".into()],
+            analytics::DF_ENGINE,
+        ),
+        Err(e) => {
+            tracing::warn!(error = %e, "equipment inspect historian path failed");
+            analytics::envelope(
+                "equipment-inspect-v1",
+                &req.query,
+                vec![format!("inspect failed: {e}")],
             )
         }
     };

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -188,6 +188,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/analytics/rcx/vav", post(analytics_rcx_vav))
         .route("/api/analytics/rcx/chiller", post(analytics_rcx_chiller))
         .route("/api/analytics/rcx/boiler", post(analytics_rcx_boiler))
+        .route("/api/analytics/rcx/preset", post(analytics_rcx_preset))
+        .route("/api/analytics/rcx/presets", get(analytics_rcx_presets_list))
         .route("/api/analytics/metering", post(analytics_metering))
         .merge(csv)
         // OFDD-075: analytics/FDD posts (building-scoped Overview samples) can
@@ -1830,6 +1832,57 @@ async fn analytics_rcx_boiler(Json(req): Json<AnalyticsRequest>) -> Json<Value> 
     Json(json!({
         "ok": true,
         "analytics": analytics::plant::handle_boiler_async(&req).await.to_json(),
+    }))
+}
+
+async fn analytics_rcx_presets_list() -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "presets": analytics::rcx_presets::presets_json(),
+    }))
+}
+
+async fn analytics_rcx_preset(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    let preset_id = req
+        .query
+        .query_version
+        .as_deref()
+        .or_else(|| {
+            req.series
+                .as_ref()
+                .and_then(|s| s.get("preset_id"))
+                .and_then(|v| v.as_str())
+        })
+        .unwrap_or("");
+    let max_points = req.query.max_points.unwrap_or(8000);
+    let env = match analytics::rcx_presets::run_preset(
+        req.query.building_id.as_deref(),
+        preset_id,
+        max_points,
+    )
+    .await
+    {
+        Ok(Some(env)) => env,
+        Ok(None) => analytics::envelope_with_engine(
+            "rcx-preset-v1",
+            &req.query,
+            vec![format!(
+                "RCx preset '{preset_id}' unavailable — unknown id or missing historian columns"
+            )],
+            analytics::DF_ENGINE,
+        ),
+        Err(e) => {
+            tracing::warn!(error = %e, preset = %preset_id, "rcx preset failed");
+            analytics::envelope(
+                "rcx-preset-v1",
+                &req.query,
+                vec![format!("rcx preset failed: {e}")],
+            )
+        }
+    };
+    Json(json!({
+        "ok": true,
+        "analytics": env.to_json(),
     }))
 }
 


### PR DESCRIPTION
## Summary
- Overview (slice A): economizer scatter fidelity, BAS vs web site-broadcast OAT, raw CSV inspect, collapsible metric tables
- FDD Plots: `rule_result_chart` with confirmed_fault swim lane + sensor-health coverage heatmap from DataFusion
- RCx: full frozen preset catalog (18 + valve extras) via `GET/POST /api/analytics/rcx/presets|preset` with timeseries, OAT scatter, box, ranking, and metering chart kinds

## Test plan
- [ ] FE: `npm test` vibeCharts + ReportsPage + centralOverview
- [ ] Rust CI: `openfdd-central` unit tests (rcx frozen catalog + historian)
- [ ] Bench BUILDING_100: Overview BAS/inspect; RCx presets with available columns; CW/gas presets show honest empty warnings
- [ ] FDD Plots: load series + expand sensor health
- [ ] After merge: GHCR `sha-<tip>`, recreate central+web, no stale PRs/branches


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added equipment inspection charts with flexible equipment and sensor selection.
  * Added dynamic RCx preset browsing and specialized trend, scatter, ranking, metering, and box-plot visualizations.
  * Added sensor-health heatmaps and coverage tables to Reports.
  * Improved BAS-versus-web outdoor-air-temperature comparisons with site-wide overlays and clearer provenance.
  * Expanded analytics for equipment, comfort, metering, and sensor data.

* **Bug Fixes**
  * Prevented empty economizer data from displaying misleading fallback charts.
  * Improved handling of missing, unavailable, and optional analytics data.
  * Improved chart rendering when data fields are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->