### PR TITLE
FDD: sensor_fault_chart for plan Slice C parity

### DIFF
--- a/frontend/web/src/api/vibeCharts.test.ts
+++ b/frontend/web/src/api/vibeCharts.test.ts
@@ -3,6 +3,7 @@ import {
   multiEquipmentBox,
   rankingBars,
   ruleResultChart,
+  sensorFaultChart,
   sensorHealthHeatmap,
 } from "./vibeCharts";
 
@@ -54,5 +55,19 @@ describe("vibeCharts", () => {
       { equipment_id: "AHU_1", role: "mat", coverage_pct: 80 },
     ]);
     expect(fig?.data[0]?.type).toBe("heatmap");
+  });
+
+  it("sensorFaultChart adds fault swim lanes", () => {
+    const points = Array.from({ length: 24 }, (_, i) => ({
+      timestamp_utc: `t${i}`,
+      value_f: 55,
+    }));
+    const fig = sensorFaultChart(points, { sensorName: "AHU_1 · sat" });
+    expect(fig?.data[0]?.name).toBe("AHU_1 · sat");
+    expect(
+      fig?.data.some((t: { name?: string }) =>
+        String(t.name).includes("FLATLINE"),
+      ),
+    ).toBe(true);
   });
 });

--- a/frontend/web/src/api/vibeCharts.ts
+++ b/frontend/web/src/api/vibeCharts.ts
@@ -403,6 +403,7 @@ export function sensorHealthHeatmap(
     data: [
       {
         type: "heatmap",
+        name: "coverage",
         x: roles,
         y: eqs,
         z,
@@ -423,6 +424,164 @@ export function sensorHealthHeatmap(
     meta: {
       point_count: rows.length,
       provenance: "POST /api/analytics/sensor-health",
+    },
+  };
+}
+
+const FAULT_LANE_COLORS: Record<string, { line: string; fill: string }> = {
+  "SV-FLATLINE": { line: "#2563eb", fill: "rgba(59,130,246,0.25)" },
+  "SV-SPIKE": { line: "#ca8a04", fill: "rgba(234,179,8,0.25)" },
+  "SV-RANGE": { line: "#dc2626", fill: "rgba(220,38,38,0.25)" },
+  "SV-STALE": { line: "#a855f7", fill: "rgba(168,85,247,0.25)" },
+  "SV-RATE": { line: "#059669", fill: "rgba(16,185,129,0.25)" },
+};
+
+function finiteNums(ys: Array<number | null>): number[] {
+  return ys.filter((v): v is number => v != null && Number.isFinite(v));
+}
+
+/** Derive vibe19-style sensor fault masks from a raw numeric series. */
+export function deriveSensorFaultMasks(
+  values: Array<number | null>,
+  opts?: { flatlineWindow?: number; spikeZ?: number; rangeZ?: number },
+): Record<string, Array<0 | 1>> {
+  const win = opts?.flatlineWindow ?? 12;
+  const spikeZ = opts?.spikeZ ?? 4;
+  const rangeZ = opts?.rangeZ ?? 3;
+  const finite = finiteNums(values);
+  const mean =
+    finite.length > 0
+      ? finite.reduce((a, b) => a + b, 0) / finite.length
+      : 0;
+  const variance =
+    finite.length > 1
+      ? finite.reduce((a, v) => a + (v - mean) ** 2, 0) / finite.length
+      : 0;
+  const std = Math.sqrt(variance);
+  const flatline: Array<0 | 1> = values.map(() => 0);
+  const spike: Array<0 | 1> = values.map(() => 0);
+  const range: Array<0 | 1> = values.map(() => 0);
+
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (v == null || !Number.isFinite(v)) continue;
+    if (std > 0 && Math.abs(v - mean) > rangeZ * std) range[i] = 1;
+    if (std > 0 && Math.abs(v - mean) > spikeZ * std) spike[i] = 1;
+    if (i + 1 >= win) {
+      const slice = values.slice(i + 1 - win, i + 1);
+      const nums = finiteNums(slice);
+      if (nums.length >= Math.max(5, Math.floor(win * 0.6))) {
+        const m = nums.reduce((a, b) => a + b, 0) / nums.length;
+        const s = Math.sqrt(
+          nums.reduce((a, x) => a + (x - m) ** 2, 0) / nums.length,
+        );
+        if (s <= 1e-9) {
+          for (let j = i + 1 - win; j <= i; j++) flatline[j] = 1;
+        }
+      }
+    }
+  }
+  return {
+    "SV-FLATLINE": flatline,
+    "SV-SPIKE": spike,
+    "SV-RANGE": range,
+  };
+}
+
+/**
+ * vibe19 `sensor_fault_chart` — sensor timeseries + optional fault swim lanes.
+ */
+export function sensorFaultChart(
+  points: Array<Record<string, unknown>>,
+  opts: {
+    sensorName: string;
+    valueKey?: string;
+    ruleMasks?: Record<string, Array<boolean | number | null>>;
+    yTitle?: string;
+  },
+): PlotlyFigure | null {
+  if (!points.length) return null;
+  const key = opts.valueKey ?? "value_f";
+  const x = points.map((p) => String(p.timestamp_utc ?? p.timestamp ?? ""));
+  const y = points.map((p) => {
+    const v = p[key] ?? p.value ?? p.value_f;
+    if (v == null || v === "") return null;
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) ? n : null;
+  });
+  if (!y.some((v) => v != null)) return null;
+
+  const masks =
+    opts.ruleMasks && Object.keys(opts.ruleMasks).length
+      ? opts.ruleMasks
+      : deriveSensorFaultMasks(y);
+
+  const data: PlotlyTrace[] = [
+    {
+      type: "scatter",
+      mode: "lines",
+      name: opts.sensorName,
+      x,
+      y,
+      line: { width: 1.4, color: rainbowColor(0) },
+      yaxis: "y",
+    },
+  ];
+
+  let laneCount = 0;
+  for (const [rid, mask] of Object.entries(masks)) {
+    if (!mask || mask.length !== y.length) continue;
+    const flags = mask.map((v) => (v === true || v === 1 ? 1 : 0));
+    if (!flags.some((f) => f === 1)) continue;
+    const colors = FAULT_LANE_COLORS[rid] ?? {
+      line: "#ef4444",
+      fill: "rgba(239,68,68,0.3)",
+    };
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: `${rid} fault`,
+      x,
+      y: flags,
+      yaxis: "y2",
+      line: { width: 0.8, color: colors.line, shape: "hv" },
+      fill: "tozeroy",
+      fillcolor: colors.fill,
+    });
+    laneCount += 1;
+  }
+
+  return {
+    data,
+    layout: {
+      title: `Sensor health — ${opts.sensorName}`,
+      xaxis: { title: "timestamp_utc", autorange: true },
+      yaxis: {
+        title: opts.yTitle ?? opts.sensorName,
+        autorange: true,
+        domain: laneCount ? [0.28, 1] : [0, 1],
+      },
+      ...(laneCount
+        ? {
+            yaxis2: {
+              title: "fault",
+              domain: [0, 0.22],
+              range: [-0.05, 1.05],
+              showgrid: false,
+              tickvals: [0, 1],
+              ticktext: ["ok", "fault"],
+            },
+          }
+        : {}),
+      legend: { orientation: "h" },
+      height: 420,
+      paper_bgcolor: "white",
+      plot_bgcolor: "white",
+      uirevision: `sensor-fault:${opts.sensorName}`,
+    },
+    meta: {
+      point_count: points.length,
+      provenance: "POST /api/analytics/inspect + sensor_fault_chart",
     },
   };
 }

--- a/frontend/web/src/pages/ReportsPage.tsx
+++ b/frontend/web/src/pages/ReportsPage.tsx
@@ -13,12 +13,16 @@ import {
 import { useSessionQuery } from "../session";
 import { listPackageBuildings } from "../api/mappingApi";
 import { getFddResults, getFddSeries, listFddRules } from "../api/fddApi";
-import { postSensorHealth } from "../api/analyticsApi";
+import { postInspect, postSensorHealth } from "../api/analyticsApi";
 import {
   missingSegmentCount,
   type PlotlyFigure,
 } from "../api/plotDataset";
-import { ruleResultChart, sensorHealthHeatmap } from "../api/vibeCharts";
+import {
+  ruleResultChart,
+  sensorFaultChart,
+  sensorHealthHeatmap,
+} from "../api/vibeCharts";
 import {
   createReportDraft,
   getEngineeringFindingsReport,
@@ -61,7 +65,11 @@ export function ReportsPage() {
     Array<Record<string, string | number | boolean>>
   >([]);
   const [sensorFigure, setSensorFigure] = useState<PlotlyFigure | null>(null);
+  const [sensorFaultFigure, setSensorFaultFigure] =
+    useState<PlotlyFigure | null>(null);
+  const [sensorKey, setSensorKey] = useState("");
   const [sensorLoading, setSensorLoading] = useState(false);
+  const [sensorFaultLoading, setSensorFaultLoading] = useState(false);
   const [sensorError, setSensorError] = useState<string | null>(null);
   const [sensorOpen, setSensorOpen] = useState(false);
 
@@ -190,6 +198,10 @@ export function ReportsPage() {
           title: `Sensor health — ${buildingId}`,
         }),
       );
+      setSensorKey((prev) => {
+        if (prev || !normalized[0]) return prev;
+        return `${normalized[0].equipment_id}::${normalized[0].role}`;
+      });
       if (!normalized.length && env.warnings?.[0]) {
         setSensorError(env.warnings[0]);
       }
@@ -201,6 +213,55 @@ export function ReportsPage() {
       setSensorLoading(false);
     }
   }, [buildingId, equipmentId]);
+
+  const loadSensorFaultChart = useCallback(async () => {
+    if (!buildingId || !sensorKey.includes("::")) {
+      setSensorError("Load sensor health and pick a sensor first");
+      return;
+    }
+    const [eq, role] = sensorKey.split("::");
+    if (!eq || !role) return;
+    setSensorFaultLoading(true);
+    setSensorError(null);
+    try {
+      const env = await postInspect({
+        building_id: buildingId,
+        equipment_ids: [eq],
+        max_points: 4000,
+        series: { columns: [role] },
+      });
+      const points = (env.points ?? []).map((p) => ({
+        timestamp_utc: p.timestamp_utc,
+        value_f: p[role] ?? p.value_f,
+      }));
+      const fig = sensorFaultChart(points, {
+        sensorName: `${eq} · ${role}`,
+        valueKey: "value_f",
+        yTitle: role,
+      });
+      setSensorFaultFigure(fig);
+      if (!fig) {
+        setSensorError(
+          env.warnings?.[0] ?? `No inspect points for ${eq}/${role}`,
+        );
+      }
+    } catch (err) {
+      setSensorFaultFigure(null);
+      setSensorError(formatErr(err));
+    } finally {
+      setSensorFaultLoading(false);
+    }
+  }, [buildingId, sensorKey]);
+
+  const sensorKeyOptions = useMemo(() => {
+    const opts = sensorRows.map((r) => ({
+      value: `${r.equipment_id}::${r.role}`,
+      label: `${r.equipment_id} · ${r.role}${
+        r.flatline_flag ? " (flatline)" : ""
+      }`,
+    }));
+    return [{ value: "", label: "— sensor —" }, ...opts];
+  }, [sensorRows]);
 
   const onCreateDraft = async () => {
     setArtifactsNotice(null);
@@ -422,6 +483,33 @@ export function ReportsPage() {
                   testId="sensor-health-table"
                 />
               ) : null}
+
+              <Select
+                id="sensor-fault-pick"
+                label="Sensor for fault chart"
+                value={sensorKey}
+                options={sensorKeyOptions}
+                onChange={setSensorKey}
+                testId="sensor-fault-pick"
+              />
+              <Button
+                id="sensor-fault-load"
+                label={
+                  sensorFaultLoading ? "Loading…" : "Load sensor fault chart"
+                }
+                onClick={() => void loadSensorFaultChart()}
+                disabled={
+                  sensorFaultLoading || !buildingId || !sensorKey.includes("::")
+                }
+                testId="sensor-fault-load"
+              />
+              <PlotlyHost
+                id="sensor-fault-chart"
+                label="Sensor fault chart"
+                figure={sensorFaultFigure}
+                loading={sensorFaultLoading}
+                testId="sensor-fault-chart"
+              />
             </Expander>
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- Completes plan Slice C: `sensor_fault_chart` (timeseries + SV-FLATLINE/SPIKE/RANGE lanes) on FDD Plots sensor health expander
- Uses inspect historian series for the selected equipment/role

## Test plan
- [ ] `npm run typecheck` + vibeCharts/ReportsPage tests
- [ ] Bench: FDD Plots → Sensor health → pick sensor → Load sensor fault chart


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sensor fault visualization to Reports, including sensor readings and fault indicators for flatlines, spikes, and out-of-range values.
  * Added sensor selection controls and loading, empty-data, and error states.
  * Improved chart metadata and labeling for sensor health coverage.

* **Tests**
  * Added coverage for detecting and displaying flatline sensor faults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->