### PR TITLE
Fix historian rustfmt for GHCR publish

### DIFF
--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,12 +1,11 @@
 # Session log
 
-## 2026-08-06 — DF parity, no-Python central image, docs refresh
+## 2026-08-06 — DF parity, no-Python central image, docs refresh (#671)
 
-- Overview: economizer points SQL + inspect flash fix (prior local); MAT/temps/BAS Plotly colors match vibe19 rainbow.
-- RCx OAT scatter: alias `ts_utc` to avoid DataFusion timestamp ambiguity.
-- Central Dockerfile: debian-slim + Rust only (removed Python/pip/wattlab from product image); WattLab dump gated on `OPENFDD_WATTLAB_PYTHON_EXPORT=1`.
-- Removed SPA overview-oracle client; Overview types in `overviewTypes.ts`.
-- Agent/product docs rewritten present-tense React+DataFusion + PyPI/cookbooks; `openfdd-react-spa` skill replaces streamlit skill.
+- Merged `77cf8d7` — Overview economizer SQL + inspect flash; MAT/temps/BAS Plotly colors; RCx OAT scatter `ts_utc` alias; Liberty `web_*` inspect prefs.
+- Central Dockerfile: debian-slim + Rust only; WattLab dump gated `OPENFDD_WATTLAB_PYTHON_EXPORT=1`.
+- SPA overview-oracle client removed; ownership/README/docs present-tense React+DataFusion; CI checkers require React operator UI.
+- GHCR: dispatched Publish stack (+ MCP) on tip during Actions major outage; bensbench pin `sha-77cf8d7` after publish green.
 
 ## 2026-08-05 — Login page internet hygiene
 

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -2773,7 +2773,11 @@ mod tests {
 
         let wx = building.join("weather");
         std::fs::create_dir_all(&wx).unwrap();
-        std::fs::write(wx.join("columns.csv"), "col,point_role\nweb_oa_t,web_oa_t\n").unwrap();
+        std::fs::write(
+            wx.join("columns.csv"),
+            "col,point_role\nweb_oa_t,web_oa_t\n",
+        )
+        .unwrap();
         let mut wf = std::fs::File::create(wx.join("history_wide.csv")).unwrap();
         writeln!(wf, "timestamp_utc,web_oa_t").unwrap();
         writeln!(wf, "2026-07-01T00:00:00Z,60").unwrap();
@@ -2784,16 +2788,10 @@ mod tests {
         fdd_store::ingest_building(tmp.path(), "BUILDING_OATSC", &parquet).unwrap();
         std::env::set_var("OPENFDD_PARQUET_ROOT", &parquet);
 
-        let env = rcx_oat_scatter_from_history(
-            Some("BUILDING_OATSC"),
-            "sat",
-            &["AHU"],
-            false,
-            500,
-        )
-        .await
-        .unwrap()
-        .expect("oat scatter envelope");
+        let env = rcx_oat_scatter_from_history(Some("BUILDING_OATSC"), "sat", &["AHU"], false, 500)
+            .await
+            .unwrap()
+            .expect("oat scatter envelope");
         std::env::remove_var("OPENFDD_PARQUET_ROOT");
 
         assert!(!env.points.is_empty());


### PR DESCRIPTION
## Summary
- Apply rustfmt to `historian.rs` so `Publish Open-FDD stack to GHCR` format check passes on tip.
- SESSION_LOG refresh for #671 merge.

## Test plan
- [x] `cargo fmt --all -- --check`
- [ ] GHCR publish green after merge; pull `sha-*` on bensbench


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the session log with recent platform updates, publishing activity, and documentation changes.
* **Refactor**
  * Refined internal analytics test and fixture formatting without changing functionality or behavior.
* **Maintenance**
  * Recorded recent updates related to data visualization, image handling, export controls, and removal of the overview client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->