### PR TITLE
Record #671 bensbench sha-130b1f0 closeout

### DIFF
--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -215,4 +215,5 @@ Product voice = React + DataFusion only. Track deletion / GHCR / agent_spec hone
 - [x] Delete `services/ui` + `services/overview_oracle`; scrub CI/docs/compose
 - [x] Stop publishing `openfdd-ui` to GHCR (workflow scrub; tip images after master merge)
 - [x] `openfdd_agent_spec/` updated for cutover direction (keep in sync every PR)
-- [ ] bensbench tip `sha-*` pull after master GHCR publish
+- [x] #671 DF Overview/RCx color+OAT parity; Rust-only central; present-tense docs (+ #672 rustfmt)
+- [x] bensbench tip `sha-130b1f0` pull + react-ot smoke (BUILDING_100 economizer + RCx OAT scatters; no Python in central)

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -5,7 +5,9 @@
 - Merged `77cf8d7` — Overview economizer SQL + inspect flash; MAT/temps/BAS Plotly colors; RCx OAT scatter `ts_utc` alias; Liberty `web_*` inspect prefs.
 - Central Dockerfile: debian-slim + Rust only; WattLab dump gated `OPENFDD_WATTLAB_PYTHON_EXPORT=1`.
 - SPA overview-oracle client removed; ownership/README/docs present-tense React+DataFusion; CI checkers require React operator UI.
-- GHCR: dispatched Publish stack (+ MCP) on tip during Actions major outage; bensbench pin `sha-77cf8d7` after publish green.
+- #672 rustfmt fix for GHCR format check (`130b1f0`).
+- GHCR Publish stack success on `130b1f0` (after #672 rustfmt); MCP dispatch also queued/published.
+- bensbench: `OPENFDD_IMAGE_TAG=sha-130b1f0` react-ot recreate; `/api/health` `3.3.0+130b1f0`; generation=react; central has **no** python; economizer 4000 points; RCx OAT scatters (ahu/hw/chw) 2000 pts each.
 
 ## 2026-08-05 — Login page internet hygiene
 


### PR DESCRIPTION
## Summary
- Mark BUILD_CHECKPOINTS + SESSION_LOG for tip `sha-130b1f0` react-ot smoke after GHCR publish.

## Verification already done on bensbench
- health `3.3.0+130b1f0`, generation=react, central NO_PYTHON
- economizer 4000 points; RCx ahu/hw/chw OAT scatters 2000 pts


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Rust cutover checklist to reflect completed parity checks, formatting validation, and Rust-only behavior.
  * Documented successful package publishing and React OAT smoke validation.
  * Refreshed the session log with health, version, generation, and dataset validation results for the latest release checkpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->