### PR TITLE
Record sha-d38d09b bensbench smoke closeout

### DIFF
--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -7,7 +7,8 @@
 - Data Model role editors → Select from cookbook role catalog (`GET /api/fdd/cookbook-roles`).
 - RCx preset coverage diagnostics UI; Metering Plotly (not JSON stub).
 - Overview/tokens softened; Fuel Plotly 1:1 gaps (peer bullet, roll-12 EUI, ranked EUI, OLS fit/residuals, demand peaks).
-- #674 Fuel Phase A merged `cc63574` → GHCR `sha-cc63574` (bensbench pull when publish green).
+- #674 Fuel Phase A merged `cc63574`; #675 Plotly/UX parity merged `d38d09b`.
+- bensbench: `OPENFDD_IMAGE_TAG=sha-d38d09b` react-ot recreate; health `3.3.0+d38d09b`; Fuel EUI ~66.9 (7 query versions); BUILDING_100 economizer 4000 pts + RCx; Actions/cookbook-roles APIs live; fuel sidecar removed.
 
 ## 2026-08-07 — Vibe20 Fuel Phase A into Open-FDD (Rust + React)
 


### PR DESCRIPTION
## Summary
- SESSION_LOG: bensbench pulled `sha-d38d09b` after #674/#675; Fuel + BUILDING_100 smoke notes.

## Test plan
- [ ] Docs-only; CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project records with the latest release milestones and deployment status.
  - Added confirmation of health checks, data and query validation, live API availability, and fuel-related results.
  - Refreshed the recorded deployment image reference and removed an outdated reference.
  - Documented recent user experience improvements and completion of the Fuel Phase A work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->