### PR TITLE
Wire dataset delete for feather/package sites

### DIFF
--- a/frontend/web/src/api/datasetsApi.test.ts
+++ b/frontend/web/src/api/datasetsApi.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deleteDataset } from "./datasetsApi";
+
+describe("deleteDataset", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("DELETEs /api/datasets?id=", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ ok: true, action_id: "act-1" }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const body = await deleteDataset("BUILDING_100");
+    expect(body).toEqual({ ok: true, action_id: "act-1" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/datasets?id=BUILDING_100");
+    expect(init.method).toBe("DELETE");
+  });
+});

--- a/frontend/web/src/api/datasetsApi.test.ts
+++ b/frontend/web/src/api/datasetsApi.test.ts
@@ -19,7 +19,10 @@ describe("deleteDataset", () => {
     const body = await deleteDataset("BUILDING_100");
     expect(body).toEqual({ ok: true, action_id: "act-1" });
     expect(fetchMock).toHaveBeenCalledOnce();
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const url = String(call?.[0] ?? "");
+    const init = (call?.[1] ?? {}) as RequestInit;
     expect(url).toContain("/api/datasets?id=BUILDING_100");
     expect(init.method).toBe("DELETE");
   });

--- a/frontend/web/src/api/datasetsApi.test.ts
+++ b/frontend/web/src/api/datasetsApi.test.ts
@@ -7,23 +7,27 @@ describe("deleteDataset", () => {
   });
 
   it("DELETEs /api/datasets?id=", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ ok: true, action_id: "act-1" }),
-      text: async () => "",
-    }));
+    let seenUrl = "";
+    let seenMethod = "";
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        seenUrl = String(input);
+        seenMethod = String(init?.method ?? "GET");
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ ok: true, action_id: "act-1" }),
+          text: async () => "",
+        };
+      },
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const body = await deleteDataset("BUILDING_100");
     expect(body).toEqual({ ok: true, action_id: "act-1" });
     expect(fetchMock).toHaveBeenCalledOnce();
-    const call = fetchMock.mock.calls[0];
-    expect(call).toBeDefined();
-    const url = String(call?.[0] ?? "");
-    const init = (call?.[1] ?? {}) as RequestInit;
-    expect(url).toContain("/api/datasets?id=BUILDING_100");
-    expect(init.method).toBe("DELETE");
+    expect(seenUrl).toContain("/api/datasets?id=BUILDING_100");
+    expect(seenMethod).toBe("DELETE");
   });
 });

--- a/frontend/web/src/api/datasetsApi.ts
+++ b/frontend/web/src/api/datasetsApi.ts
@@ -1,0 +1,21 @@
+import { apiFetch } from "./client";
+
+export interface DeleteDatasetResponse {
+  ok: boolean;
+  error?: string;
+  action_id?: string;
+}
+
+/** Purge registry + csv_buildings + feather package/csv + parquet + rule_results. */
+export async function deleteDataset(
+  datasetId: string,
+): Promise<DeleteDatasetResponse> {
+  const id = datasetId.trim();
+  if (!id) {
+    throw new Error("dataset id required");
+  }
+  return apiFetch<DeleteDatasetResponse>(
+    `/api/datasets?id=${encodeURIComponent(id)}`,
+    { method: "DELETE" },
+  );
+}

--- a/frontend/web/src/components/OracleSidebar.tsx
+++ b/frontend/web/src/components/OracleSidebar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { useSessionQuery } from "../session";
 import { listPackageBuildings } from "../api/mappingApi";
+import { deleteDataset } from "../api/datasetsApi";
 import { uploadPackage } from "../api/uploadApi";
 import { ApiClientError } from "../api/client";
 import { RuleTuningPanel } from "./RuleTuningPanel";
@@ -224,6 +225,49 @@ export function OracleSidebar({ collapsed }: { collapsed: boolean }) {
     }
   };
 
+  const onDeleteActiveSite = async () => {
+    if (!confirmDelete) {
+      setError("Check Confirm delete Active site first.");
+      return;
+    }
+    const id = activeSite.trim();
+    if (!id) {
+      setError("Select an Active site before deleting.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setStatus(`Deleting ${id} (feather + parquet + rule results)…`);
+    try {
+      const body = await deleteDataset(id);
+      if (!body.ok) {
+        throw new Error(body.error || "Delete failed");
+      }
+      setConfirmDelete(false);
+      setQuery({ siteId: "" }, true);
+      await refreshSites();
+      setStatus(`Deleted dataset \`${id}\`. Re-import a package to restore.`);
+      try {
+        window.dispatchEvent(
+          new CustomEvent("openfdd:package-deleted", {
+            detail: { buildingId: id },
+          }),
+        );
+      } catch {
+        /* ignore */
+      }
+    } catch (err: unknown) {
+      setStatus("");
+      if (err instanceof ApiClientError) {
+        setError(`${err.code}: ${err.message}`);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
   if (collapsed) {
     return (
       <div className="oracle-sidebar oracle-sidebar--collapsed" data-testid="oracle-sidebar">
@@ -327,15 +371,9 @@ export function OracleSidebar({ collapsed }: { collapsed: boolean }) {
           <button
             type="button"
             className="oracle-sidebar__btn"
-            disabled={!confirmDelete}
+            disabled={!confirmDelete || !activeSite || loading}
             title="Purge Feathers + FDD results for the Active site (requires confirm)."
-            onClick={() =>
-              setError(
-                confirmDelete
-                  ? "Delete via central Hive is available from Jobs/API — confirm wired in next pass."
-                  : "Check Confirm delete Active site first.",
-              )
-            }
+            onClick={() => void onDeleteActiveSite()}
             data-testid="sidebar-delete-site"
           >
             Delete…

--- a/frontend/web/src/pages/MappingPage.tsx
+++ b/frontend/web/src/pages/MappingPage.tsx
@@ -22,6 +22,7 @@ import {
   type PackageMappingResponse,
   type SessionConfig,
 } from "../api/mappingApi";
+import { deleteDataset } from "../api/datasetsApi";
 
 type ColumnRow = {
   column: string;
@@ -52,6 +53,8 @@ export function MappingPage() {
   const [notice, setNotice] = useState<string | null>(null);
   const [showUnmappedOnly, setShowUnmappedOnly] = useState(false);
   const [cookbookRoles, setCookbookRoles] = useState<string[]>([]);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDeleteBuilding, setConfirmDeleteBuilding] = useState(false);
 
   const selectedEq: MappingEquipment | null = useMemo(() => {
     const list = inventory?.equipment ?? [];
@@ -176,6 +179,39 @@ export function MappingPage() {
     URL.revokeObjectURL(url);
   };
 
+  const onDeleteBuilding = async () => {
+    if (!buildingId) {
+      setError("Select a building first");
+      return;
+    }
+    if (!confirmDeleteBuilding) {
+      setError("Confirm delete building before purging feather stores.");
+      return;
+    }
+    if (dirty && !window.confirm("Discard unsaved mapping edits and delete this building?")) {
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const body = await deleteDataset(buildingId);
+      if (!body.ok) {
+        throw new Error(body.error || "Delete failed");
+      }
+      setConfirmDeleteBuilding(false);
+      setDirty(false);
+      setInventory(null);
+      setNotice(`Deleted dataset ${buildingId} (feather, parquet, rule results).`);
+      setQuery({ siteId: "", equipment: "" }, true);
+      await refreshBuildings();
+    } catch (err) {
+      setError(formatErr(err));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   const tableRows: ColumnRow[] = useMemo(() => {
     const cols = selectedEq?.columns ?? [];
     return cols
@@ -262,6 +298,22 @@ export function MappingPage() {
             checked={showUnmappedOnly}
             onChange={setShowUnmappedOnly}
             testId="map-unmapped-only"
+          />
+          <Toggle
+            id="map-confirm-delete"
+            label="Confirm delete building"
+            checked={confirmDeleteBuilding}
+            onChange={setConfirmDeleteBuilding}
+            testId="map-confirm-delete"
+            disabled={!buildingId}
+          />
+          <Button
+            id="map-delete-building"
+            label={deleting ? "Deleting…" : "Delete building dataset"}
+            variant="danger"
+            onClick={() => void onDeleteBuilding()}
+            disabled={!buildingId || !confirmDeleteBuilding || deleting}
+            testId="map-delete-building"
           />
         </div>
 

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1262,10 +1262,10 @@ pub async fn csv_delete_dataset(
         Ok(()) => (true, None),
         Err(e) => (false, Some(e.clone())),
     };
-    if let Some(aid) = action_id {
+    if let Some(ref aid) = action_id {
         let status = if ok { "ok" } else { "fail" };
         let _ = actions::finish_action(
-            &aid,
+            aid,
             status,
             Some(json!({
                 "ok": ok,

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1077,11 +1077,34 @@ pub async fn csv_preview(headers: HeaderMap, body: Bytes) -> Json<Value> {
 /// `openfdd_package_v1` zip upload (#514): multipart, JSON base64, or raw zip body.
 pub async fn csv_import_package(headers: HeaderMap, body: Bytes) -> Json<Value> {
     let ct = content_type(&headers);
-    let result = tokio::task::spawn_blocking(move || {
+    let action_id = actions::start_action(
+        "package_import",
+        "Package import",
+        Some(json!({ "content_type": ct.clone() })),
+    )
+    .ok();
+    let mut result = tokio::task::spawn_blocking(move || {
         open_fdd_edge_prototype::csv_ingest::package::import_package_handler(&ct, &body)
     })
     .await
     .unwrap_or_else(|e| json!({"ok": false, "error": format!("package import task: {e}")}));
+    if let Some(aid) = action_id {
+        let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+        let status = if ok { "ok" } else { "fail" };
+        let building_id = result.get("building_id").cloned().unwrap_or(Value::Null);
+        let detail = json!({
+            "ok": ok,
+            "building_id": building_id,
+            "equipment_written": result.get("equipment_written"),
+            "total_rows": result.get("total_rows"),
+            "total_ms": result.get("total_ms"),
+            "error": result.get("error"),
+        });
+        let _ = actions::finish_action(&aid, status, Some(detail));
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("action_id".into(), json!(aid));
+        }
+    }
     Json(result)
 }
 
@@ -1213,15 +1236,44 @@ pub struct DatasetIdQuery {
 pub async fn csv_delete_dataset(
     Query(q): Query<DatasetIdQuery>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let Some(id) = q.id.as_deref().filter(|s| !s.is_empty()) else {
+    let Some(id) = q.id.as_deref().filter(|s| !s.is_empty()).map(str::to_string) else {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({"ok": false, "error": "id query required"})),
         ));
     };
-    match open_fdd_edge_prototype::csv_ingest::delete_dataset(id) {
-        Ok(()) => Ok(Json(json!({"ok": true}))),
-        Err(e) => Ok(Json(json!({"ok": false, "error": e}))),
+    let action_id = actions::start_action(
+        "dataset_delete",
+        &format!("Delete dataset · {id}"),
+        Some(json!({ "building_id": id, "dataset_id": id })),
+    )
+    .ok();
+    let id_for_task = id.clone();
+    let outcome = tokio::task::spawn_blocking(move || {
+        open_fdd_edge_prototype::csv_ingest::delete_dataset(&id_for_task)
+    })
+    .await
+    .unwrap_or_else(|e| Err(format!("dataset delete task failed: {e}")));
+    let (ok, error) = match &outcome {
+        Ok(()) => (true, None),
+        Err(e) => (false, Some(e.clone())),
+    };
+    if let Some(aid) = action_id {
+        let status = if ok { "ok" } else { "fail" };
+        let _ = actions::finish_action(
+            &aid,
+            status,
+            Some(json!({
+                "ok": ok,
+                "building_id": id,
+                "dataset_id": id,
+                "error": error,
+            })),
+        );
+    }
+    match outcome {
+        Ok(()) => Ok(Json(json!({ "ok": true, "action_id": action_id }))),
+        Err(e) => Ok(Json(json!({ "ok": false, "error": e, "action_id": action_id }))),
     }
 }
 

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1236,7 +1236,11 @@ pub struct DatasetIdQuery {
 pub async fn csv_delete_dataset(
     Query(q): Query<DatasetIdQuery>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let Some(id) = q.id.as_deref().filter(|s| !s.is_empty()).map(str::to_string) else {
+    let Some(id) =
+        q.id.as_deref()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    else {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({"ok": false, "error": "id query required"})),
@@ -1273,7 +1277,9 @@ pub async fn csv_delete_dataset(
     }
     match outcome {
         Ok(()) => Ok(Json(json!({ "ok": true, "action_id": action_id }))),
-        Err(e) => Ok(Json(json!({ "ok": false, "error": e, "action_id": action_id }))),
+        Err(e) => Ok(Json(
+            json!({ "ok": false, "error": e, "action_id": action_id }),
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary
- Wire Oracle sidebar + Mapping delete to `DELETE /api/datasets?id=` (full feather/parquet/registry purge).
- Log `dataset_delete` and `package_import` on the durable Actions JSONL.
- Add FE `deleteDataset` client + unit test.

## Test plan
- [ ] Confirm delete Active site in sidebar purges and clears `?site=`
- [ ] Mapping “Delete building dataset” same path
- [ ] Actions shows `dataset_delete` / `package_import` ok/fail
- [ ] Vitest `datasetsApi.test.ts` passes; CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dataset deletion from the Oracle sidebar and mapping page.
  * Added confirmation safeguards, loading states, and clear success or error feedback.
  * Deletion now refreshes building/site lists and clears related selections.
  * CSV imports and dataset deletions now provide action tracking IDs and status details.

* **Bug Fixes**
  * Improved handling of deletion failures and unsaved mapping changes.

* **Tests**
  * Added coverage for dataset deletion requests, validation, encoding, and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->