### PR TITLE
Polish Actions detail UI and analytics logging

### DIFF
--- a/frontend/web/src/pages/ActionsPage.tsx
+++ b/frontend/web/src/pages/ActionsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AppShell } from "../components/AppShell";
 import { DataTable, InlineAlert, Button } from "../components/widgets";
 import {
@@ -21,18 +21,157 @@ function elapsedMs(a: ActionEntry, now: number): number | null {
   return null;
 }
 
+function detailRecord(
+  detail: ActionEntry["detail"],
+): Record<string, unknown> {
+  if (detail && typeof detail === "object" && !Array.isArray(detail)) {
+    return detail as Record<string, unknown>;
+  }
+  return {};
+}
+
+function asNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim() && Number.isFinite(Number(v))) {
+    return Number(v);
+  }
+  return null;
+}
+
+function asString(v: unknown): string | null {
+  if (typeof v === "string" && v.trim()) return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return null;
+}
+
+function statusClass(status: string): string {
+  if (status === "running") return "actions-status actions-status--running";
+  if (status === "ok") return "actions-status actions-status--ok";
+  if (status === "fail") return "actions-status actions-status--fail";
+  return "actions-status";
+}
+
+function ActionDetailPanel({
+  action,
+  now,
+}: {
+  action: ActionEntry;
+  now: number;
+}) {
+  const detail = detailRecord(action.detail);
+  const buildingId =
+    asString(detail.building_id) ?? asString(detail.dataset_id);
+  const rulesOk = asNumber(detail.rules_succeeded);
+  const rulesFail = asNumber(detail.rules_failed);
+  const rulesSkip = asNumber(detail.rules_skipped);
+  const totalMs = asNumber(detail.total_ms) ?? action.duration_ms ?? null;
+  const err = asString(detail.error);
+  const elapsed = elapsedMs(action, now);
+  const [showRaw, setShowRaw] = useState(false);
+
+  const metricRows: Array<{ label: string; value: string }> = [];
+  if (buildingId) metricRows.push({ label: "Building", value: buildingId });
+  if (rulesOk != null)
+    metricRows.push({ label: "Rules succeeded", value: String(rulesOk) });
+  if (rulesFail != null)
+    metricRows.push({ label: "Rules failed", value: String(rulesFail) });
+  if (rulesSkip != null)
+    metricRows.push({ label: "Rules skipped", value: String(rulesSkip) });
+  if (asNumber(detail.equipment_written) != null) {
+    metricRows.push({
+      label: "Equipment written",
+      value: String(asNumber(detail.equipment_written)),
+    });
+  }
+  if (asNumber(detail.total_rows) != null) {
+    metricRows.push({
+      label: "Rows",
+      value: String(asNumber(detail.total_rows)),
+    });
+  }
+  if (totalMs != null) {
+    metricRows.push({ label: "Server time", value: formatDurationMs(totalMs) });
+  }
+
+  return (
+    <div className="actions-detail-panel" data-testid="actions-detail-panel">
+      <div className="actions-detail-panel__header">
+        <span
+          className={statusClass(action.status)}
+          data-testid="actions-detail-status"
+        >
+          {statusIndicator(action.status)} {action.status}
+        </span>
+        <strong data-testid="actions-detail-label">{action.label}</strong>
+      </div>
+      <p className="oracle-sidebar__caption" data-testid="actions-detail-kind">
+        {action.kind}
+        {action.status === "running"
+          ? ` · in progress · ${formatDurationMs(elapsed)}`
+          : ` · ${formatDurationMs(elapsed)}`}
+      </p>
+      {action.status === "running" ? (
+        <div
+          className="actions-detail-panel__pulse"
+          data-testid="actions-detail-running"
+          role="status"
+        >
+          Backend work is still running. This panel refreshes automatically.
+        </div>
+      ) : null}
+      {err ? (
+        <InlineAlert id="actions-detail-error" variant="danger">
+          {err}
+        </InlineAlert>
+      ) : null}
+      {metricRows.length ? (
+        <dl className="actions-detail-panel__metrics" data-testid="actions-detail-metrics">
+          {metricRows.map((row) => (
+            <div key={row.label} className="actions-detail-panel__metric">
+              <dt>{row.label}</dt>
+              <dd>{row.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+      <button
+        type="button"
+        className="oracle-sidebar__btn"
+        data-testid="actions-detail-toggle-raw"
+        onClick={() => setShowRaw((v) => !v)}
+      >
+        {showRaw ? "Hide technical detail" : "Show technical detail"}
+      </button>
+      {showRaw ? (
+        <pre
+          style={{ maxHeight: 240, overflow: "auto", fontSize: "0.85rem" }}
+          data-testid="actions-detail-json"
+        >
+          {JSON.stringify(action, null, 2)}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
 export function ActionsPage() {
   const [actions, setActions] = useState<ActionEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [now, setNow] = useState(() => Date.now());
-  const [selected, setSelected] = useState<ActionEntry | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
       const list = await listActions(150);
       setActions(list);
       setError(null);
+      setSelectedId((prev) => {
+        if (prev && list.some((a) => a.id === prev)) return prev;
+        const running = list.find((a) => a.status === "running");
+        if (running) return running.id;
+        return list[0]?.id ?? null;
+      });
     } catch (err) {
       setError(formatErr(err));
     } finally {
@@ -44,8 +183,12 @@ export function ActionsPage() {
     void refresh();
   }, [refresh]);
 
+  const hasRunning = useMemo(
+    () => actions.some((a) => a.status === "running"),
+    [actions],
+  );
+
   useEffect(() => {
-    const hasRunning = actions.some((a) => a.status === "running");
     const interval = window.setInterval(
       () => {
         setNow(Date.now());
@@ -54,7 +197,12 @@ export function ActionsPage() {
       hasRunning ? 1500 : 8000,
     );
     return () => window.clearInterval(interval);
-  }, [actions, refresh]);
+  }, [hasRunning, refresh]);
+
+  const selected =
+    (selectedId && actions.find((a) => a.id === selectedId)) ||
+    actions[0] ||
+    null;
 
   const rows = actions.map((a) => ({
     status: `${statusIndicator(a.status)} ${a.status}`,
@@ -73,6 +221,48 @@ export function ActionsPage() {
       activeSectionId="actions"
     >
       <div className="page-stack" data-testid="actions-page">
+        <style>{`
+          .actions-status { display: inline-flex; align-items: center; gap: 0.35rem; font-weight: 600; }
+          .actions-status--running { color: #b45309; animation: actions-pulse 1.4s ease-in-out infinite; }
+          .actions-status--ok { color: #15803d; }
+          .actions-status--fail { color: #b91c1c; }
+          @keyframes actions-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.55; } }
+          .actions-detail-panel {
+            border: 1px solid var(--border, #d8d2cc);
+            border-radius: 8px;
+            padding: 1rem 1.1rem;
+            background: var(--surface-2, #faf8f6);
+          }
+          .actions-detail-panel__header {
+            display: flex; flex-wrap: wrap; gap: 0.65rem; align-items: center;
+            margin-bottom: 0.35rem;
+          }
+          .actions-detail-panel__pulse {
+            margin: 0.6rem 0;
+            padding: 0.55rem 0.75rem;
+            border-radius: 6px;
+            background: #fff7ed;
+            border: 1px solid #fdba74;
+            color: #9a3412;
+          }
+          .actions-detail-panel__metrics {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 0.55rem 1rem;
+            margin: 0.85rem 0;
+          }
+          .actions-detail-panel__metric { margin: 0; }
+          .actions-detail-panel__metric dt {
+            font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em;
+            color: var(--muted, #6b6560); margin: 0;
+          }
+          .actions-detail-panel__metric dd {
+            margin: 0.15rem 0 0; font-weight: 600; font-variant-numeric: tabular-nums;
+          }
+          .actions-table-wrap [data-row-id="${selected?.id ?? ""}"] {
+            outline: 2px solid color-mix(in srgb, var(--color-primary, #c23b3b) 45%, transparent);
+          }
+        `}</style>
         <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
           <Button
             id="actions-refresh"
@@ -81,7 +271,9 @@ export function ActionsPage() {
             testId="actions-refresh"
           />
           <p className="oracle-sidebar__caption">
-            Polling GET /api/actions · workspace/data/actions/log.jsonl
+            Auto-refresh {hasRunning ? "every 1.5s while running" : "every 8s"}
+            {" · "}
+            GET /api/actions
           </p>
         </div>
         {error ? (
@@ -89,30 +281,30 @@ export function ActionsPage() {
             {error}
           </InlineAlert>
         ) : null}
-        <DataTable
-          id="actions-table"
-          label="Recent actions"
-          columns={[
-            { key: "status", header: "Status" },
-            { key: "started_at", header: "Started" },
-            { key: "finished_at", header: "Finished" },
-            { key: "duration", header: "Duration" },
-            { key: "kind", header: "Kind" },
-            { key: "label", header: "Label" },
-          ]}
-          rows={rows}
-          testId="actions-table"
-        />
-        {actions.length > 0 ? (
+        <div className="actions-table-wrap">
+          <DataTable
+            id="actions-table"
+            label="Recent actions"
+            columns={[
+              { key: "status", header: "Status" },
+              { key: "started_at", header: "Started" },
+              { key: "finished_at", header: "Finished" },
+              { key: "duration", header: "Duration" },
+              { key: "kind", header: "Kind" },
+              { key: "label", header: "Label" },
+            ]}
+            rows={rows}
+            testId="actions-table"
+          />
+        </div>
+        {selected ? (
           <div data-testid="actions-detail">
             <h3>Detail</h3>
             <select
               data-testid="actions-detail-pick"
-              value={selected?.id ?? actions[0]?.id ?? ""}
-              onChange={(e) => {
-                const hit = actions.find((a) => a.id === e.target.value) ?? null;
-                setSelected(hit);
-              }}
+              value={selected.id}
+              onChange={(e) => setSelectedId(e.target.value)}
+              style={{ marginBottom: "0.75rem" }}
             >
               {actions.map((a) => (
                 <option key={a.id} value={a.id}>
@@ -120,16 +312,7 @@ export function ActionsPage() {
                 </option>
               ))}
             </select>
-            <pre
-              style={{ maxHeight: 240, overflow: "auto", fontSize: "0.85rem" }}
-              data-testid="actions-detail-json"
-            >
-              {JSON.stringify(
-                selected ?? actions[0] ?? null,
-                null,
-                2,
-              )}
-            </pre>
+            <ActionDetailPanel action={selected} now={now} />
           </div>
         ) : null}
       </div>

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1992,36 +1992,82 @@ async fn analytics_rcx_preset(Json(req): Json<AnalyticsRequest>) -> Json<Value> 
                 .and_then(|s| s.get("preset_id"))
                 .and_then(|v| v.as_str())
         })
-        .unwrap_or("");
+        .unwrap_or("")
+        .to_string();
+    let building_id = req.query.building_id.clone();
     let max_points = req.query.max_points.unwrap_or(8000);
-    let env = match analytics::rcx_presets::run_preset(
-        req.query.building_id.as_deref(),
-        preset_id,
-        max_points,
-    )
-    .await
-    {
-        Ok(Some(env)) => env,
-        Ok(None) => analytics::envelope_with_engine(
-            "rcx-preset-v1",
-            &req.query,
-            vec![format!(
-                "RCx preset '{preset_id}' unavailable — unknown id or missing historian columns"
-            )],
-            analytics::DF_ENGINE,
+    let action_id = actions::start_action(
+        "analytics_rcx",
+        &format!(
+            "RCx preset · {} · {}",
+            building_id.as_deref().unwrap_or("(no building)"),
+            if preset_id.is_empty() {
+                "(none)"
+            } else {
+                &preset_id
+            }
         ),
-        Err(e) => {
-            tracing::warn!(error = %e, preset = %preset_id, "rcx preset failed");
-            analytics::envelope(
+        Some(json!({
+            "building_id": building_id.clone(),
+            "preset_id": preset_id.clone(),
+        })),
+    )
+    .ok();
+    let env =
+        match analytics::rcx_presets::run_preset(building_id.as_deref(), &preset_id, max_points)
+            .await
+        {
+            Ok(Some(env)) => env,
+            Ok(None) => analytics::envelope_with_engine(
                 "rcx-preset-v1",
                 &req.query,
-                vec![format!("rcx preset failed: {e}")],
-            )
-        }
-    };
+                vec![format!(
+                "RCx preset '{preset_id}' unavailable — unknown id or missing historian columns"
+            )],
+                analytics::DF_ENGINE,
+            ),
+            Err(e) => {
+                tracing::warn!(error = %e, preset = %preset_id, "rcx preset failed");
+                analytics::envelope(
+                    "rcx-preset-v1",
+                    &req.query,
+                    vec![format!("rcx preset failed: {e}")],
+                )
+            }
+        };
+    let analytics_json = env.to_json();
+    if let Some(aid) = action_id {
+        let warnings = analytics_json
+            .get("warnings")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        let status = if warnings > 0
+            && analytics_json
+                .get("rows")
+                .and_then(|r| r.as_array())
+                .map(|a| a.is_empty())
+                .unwrap_or(true)
+        {
+            "fail"
+        } else {
+            "ok"
+        };
+        let _ = actions::finish_action(
+            &aid,
+            status,
+            Some(json!({
+                "ok": status == "ok",
+                "building_id": building_id,
+                "preset_id": preset_id,
+                "warning_count": warnings,
+            })),
+        );
+    }
     Json(json!({
         "ok": true,
-        "analytics": env.to_json(),
+        "analytics": analytics_json,
+        "action_id": action_id,
     }))
 }
 
@@ -2033,10 +2079,42 @@ async fn analytics_metering(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
 }
 
 async fn analytics_fuel(Json(req): Json<FuelRequest>) -> Json<Value> {
+    let qv = req.query_version.clone().unwrap_or_else(|| "fuel".into());
+    let campus = req.campus_id.clone();
+    let action_id = actions::start_action(
+        "analytics_fuel",
+        &format!(
+            "Fuel analytics · {} · {}",
+            campus.as_deref().unwrap_or("(campus)"),
+            qv
+        ),
+        Some(json!({
+            "campus_id": campus,
+            "query_version": qv,
+            "building_id": req.building_id,
+        })),
+    )
+    .ok();
     let body = req;
-    let result = tokio::task::spawn_blocking(move || fuel::handle_fuel(&body))
+    let mut result = tokio::task::spawn_blocking(move || fuel::handle_fuel(&body))
         .await
         .unwrap_or_else(|e| json!({"ok": false, "error": format!("fuel analytics task: {e}")}));
+    if let Some(aid) = action_id {
+        let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(true);
+        let status = if ok { "ok" } else { "fail" };
+        let _ = actions::finish_action(
+            &aid,
+            status,
+            Some(json!({
+                "ok": ok,
+                "error": result.get("error"),
+                "query_version": result.get("query_version"),
+            })),
+        );
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("action_id".into(), json!(aid));
+        }
+    }
     Json(json!({
         "ok": result.get("ok").and_then(|v| v.as_bool()).unwrap_or(true),
         "analytics": result,

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -900,7 +900,7 @@ pub async fn fdd_run(Json(body): Json<FddRunRequest>) -> Json<Value> {
         }
     }
 
-    if let Some(aid) = action_id {
+    if let Some(ref aid) = action_id {
         let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
         let status = if ok { "ok" } else { "fail" };
         let detail = json!({
@@ -911,7 +911,7 @@ pub async fn fdd_run(Json(body): Json<FddRunRequest>) -> Json<Value> {
             "total_ms": result.get("total_ms"),
             "error": result.get("error"),
         });
-        let _ = actions::finish_action(&aid, status, Some(detail));
+        let _ = actions::finish_action(aid, status, Some(detail));
         if let Some(obj) = result.as_object_mut() {
             obj.insert("action_id".into(), json!(aid));
         }
@@ -1088,7 +1088,7 @@ pub async fn csv_import_package(headers: HeaderMap, body: Bytes) -> Json<Value> 
     })
     .await
     .unwrap_or_else(|e| json!({"ok": false, "error": format!("package import task: {e}")}));
-    if let Some(aid) = action_id {
+    if let Some(ref aid) = action_id {
         let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
         let status = if ok { "ok" } else { "fail" };
         let building_id = result.get("building_id").cloned().unwrap_or(Value::Null);
@@ -1100,7 +1100,7 @@ pub async fn csv_import_package(headers: HeaderMap, body: Bytes) -> Json<Value> 
             "total_ms": result.get("total_ms"),
             "error": result.get("error"),
         });
-        let _ = actions::finish_action(&aid, status, Some(detail));
+        let _ = actions::finish_action(aid, status, Some(detail));
         if let Some(obj) = result.as_object_mut() {
             obj.insert("action_id".into(), json!(aid));
         }
@@ -2036,7 +2036,7 @@ async fn analytics_rcx_preset(Json(req): Json<AnalyticsRequest>) -> Json<Value> 
             }
         };
     let analytics_json = env.to_json();
-    if let Some(aid) = action_id {
+    if let Some(ref aid) = action_id {
         let warnings = analytics_json
             .get("warnings")
             .and_then(|v| v.as_array())
@@ -2099,7 +2099,7 @@ async fn analytics_fuel(Json(req): Json<FuelRequest>) -> Json<Value> {
     let mut result = tokio::task::spawn_blocking(move || fuel::handle_fuel(&body))
         .await
         .unwrap_or_else(|e| json!({"ok": false, "error": format!("fuel analytics task: {e}")}));
-    if let Some(aid) = action_id {
+    if let Some(ref aid) = action_id {
         let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(true);
         let status = if ok { "ok" } else { "fail" };
         let _ = actions::finish_action(
@@ -2133,7 +2133,7 @@ pub async fn fuel_campus_import(headers: HeaderMap, body: Bytes) -> Json<Value> 
     let result = tokio::task::spawn_blocking(move || fuel::import::import_fuel_handler(&ct, &body))
         .await
         .unwrap_or_else(|e| json!({"ok": false, "error": format!("fuel import task: {e}")}));
-    if let Some(aid) = action_id {
+    if let Some(ref aid) = action_id {
         let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
         let status = if ok { "ok" } else { "fail" };
         let detail = json!({
@@ -2141,7 +2141,7 @@ pub async fn fuel_campus_import(headers: HeaderMap, body: Bytes) -> Json<Value> 
             "campus_id": result.get("campus_id"),
             "error": result.get("error"),
         });
-        let _ = actions::finish_action(&aid, status, Some(detail));
+        let _ = actions::finish_action(aid, status, Some(detail));
         let mut out = result;
         if let Some(obj) = out.as_object_mut() {
             obj.insert("action_id".into(), json!(aid));

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -2054,7 +2054,7 @@ async fn analytics_rcx_preset(Json(req): Json<AnalyticsRequest>) -> Json<Value> 
             "ok"
         };
         let _ = actions::finish_action(
-            &aid,
+            aid,
             status,
             Some(json!({
                 "ok": status == "ok",
@@ -2103,7 +2103,7 @@ async fn analytics_fuel(Json(req): Json<FuelRequest>) -> Json<Value> {
         let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(true);
         let status = if ok { "ok" } else { "fail" };
         let _ = actions::finish_action(
-            &aid,
+            aid,
             status,
             Some(json!({
                 "ok": ok,


### PR DESCRIPTION
## Summary
- Structured Actions detail panel (running pulse, metrics DL) instead of raw JSON-first.
- Selection stays stable across auto-refresh; faster poll while running.
- Log `analytics_rcx` / `analytics_fuel` on the Actions JSONL.

## Test plan
- [ ] Run FDD all → Actions flips running→ok without reselect
- [ ] RCx preset / fuel analytics appear in Actions
- [ ] CI green


Made with [Cursor](https://cursor.com)