### PR TITLE
RCx full-span plots and role-gated Selects

### DIFF
--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -405,6 +405,37 @@ pub fn series_response(equipment_id: &str, rule_id: &str) -> Value {
         if let Err(e) = register_parquet_tree(&ctx, &root).await {
             return json!({"ok": false, "error": e.to_string()});
         }
+        // Preflight required roles against history schema (no SchemaError banners).
+        let history_columns: std::collections::HashSet<String> = match ctx.table("history").await {
+            Ok(df) => df
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().to_ascii_lowercase())
+                .collect(),
+            Err(_) => std::collections::HashSet::new(),
+        };
+        if !history_columns.is_empty() {
+            let missing: Vec<String> = columns
+                .iter()
+                .map(|c| (*c).to_string())
+                .filter(|role| !history_columns.contains(&role.to_ascii_lowercase()))
+                .collect();
+            if !missing.is_empty() {
+                return json!({
+                    "ok": false,
+                    "error": format!(
+                        "missing roles for rule {}: {}",
+                        rule.rule_id,
+                        missing.join(", ")
+                    ),
+                    "missing_roles": missing,
+                    "equipment_id": equipment_id,
+                    "rule_id": rule.rule_id,
+                    "rows": [],
+                });
+            }
+        }
         match run_sql(&ctx, &sql).await {
             Ok(mut result) => {
                 // Overlay confirmed_fault from last registry run when present so
@@ -436,7 +467,22 @@ pub fn series_response(equipment_id: &str, rule_id: &str) -> Value {
                     "has_confirmed_fault": !fault_by_ts.is_empty(),
                 })
             }
-            Err(e) => json!({"ok": false, "error": e.to_string()}),
+            Err(e) => {
+                let msg = e.to_string();
+                let lower = msg.to_ascii_lowercase();
+                if lower.contains("no field named") || lower.contains("schema error") {
+                    json!({
+                        "ok": false,
+                        "error": format!("missing roles for rule {}: {msg}", rule.rule_id),
+                        "missing_roles": rule.required_roles,
+                        "equipment_id": equipment_id,
+                        "rule_id": rule.rule_id,
+                        "rows": [],
+                    })
+                } else {
+                    json!({"ok": false, "error": msg})
+                }
+            }
         }
     })
 }

--- a/frontend/web/src/api/fddApi.ts
+++ b/frontend/web/src/api/fddApi.ts
@@ -96,6 +96,8 @@ export interface FddSeriesResponse {
   rows?: Array<Record<string, unknown>>;
   downsampled?: boolean;
   max_points?: number;
+  has_confirmed_fault?: boolean;
+  missing_roles?: string[];
   error?: string;
 }
 
@@ -171,7 +173,14 @@ export async function getFddSeries(
     buildFddSeriesPath(equipmentId, ruleId),
   );
   if (!body.ok) {
-    throw new Error(body.error || "Failed to load FDD series");
+    const missing = Array.isArray(body.missing_roles)
+      ? body.missing_roles.filter(Boolean).join(", ")
+      : "";
+    throw new Error(
+      missing
+        ? `Rule unavailable — unmapped roles: ${missing}`
+        : body.error || "Failed to load FDD series",
+    );
   }
   return body;
 }

--- a/frontend/web/src/api/vibeCharts.ts
+++ b/frontend/web/src/api/vibeCharts.ts
@@ -60,7 +60,15 @@ export function multiEquipmentTimeseries(
       height: Math.max(380, 40 + 14 * Math.min(byKey.size, 16)),
       tickangle: -30,
       uirevision: `rcx-ts:${fingerprintJson(points.slice(0, 50))}`,
-      extra: { title: opts.title },
+      extra: {
+        title: opts.title,
+        xaxis: {
+          title: "time",
+          type: "date",
+          autorange: true,
+          tickangle: -30,
+        },
+      },
     }),
     meta: {
       point_count: points.length,

--- a/frontend/web/src/components/widgets/Select.tsx
+++ b/frontend/web/src/components/widgets/Select.tsx
@@ -4,6 +4,7 @@ import { widgetTestId } from "./types";
 export interface SelectOption {
   value: string;
   label: string;
+  disabled?: boolean;
 }
 
 export interface SelectProps extends WidgetBaseProps {
@@ -55,7 +56,7 @@ export function Select({
         onChange={(e) => onChange(e.target.value)}
       >
         {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
+          <option key={opt.value} value={opt.value} disabled={opt.disabled}>
             {opt.label}
           </option>
         ))}
@@ -111,7 +112,7 @@ export function MultiSelect({
         }
       >
         {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
+          <option key={opt.value} value={opt.value} disabled={opt.disabled}>
             {opt.label}
           </option>
         ))}

--- a/frontend/web/src/pages/RcxPage.tsx
+++ b/frontend/web/src/pages/RcxPage.tsx
@@ -9,7 +9,7 @@ import {
 } from "../components/widgets";
 import { PlotlyHost } from "../components/widgets/PlotlyHost";
 import { useSessionQuery } from "../session";
-import { listPackageBuildings } from "../api/mappingApi";
+import { getPackageMapping, listPackageBuildings } from "../api/mappingApi";
 import {
   listRcxPresets,
   postRcxPreset,
@@ -33,12 +33,14 @@ export function RcxPage() {
   const { query, setQuery } = useSessionQuery();
   const buildingId = query.siteId ?? "";
   const [buildings, setBuildings] = useState<string[]>([]);
+  const [mappedRoles, setMappedRoles] = useState<Set<string>>(new Set());
   const [presets, setPresets] = useState<
     Array<{
       id: string;
       title: string;
       family: string;
       chart: string;
+      role_col?: string;
       frozen?: boolean;
     }>
   >([]);
@@ -64,6 +66,27 @@ export function RcxPage() {
       .catch(() => setPresets([]));
   }, []);
 
+  useEffect(() => {
+    if (!buildingId) {
+      setMappedRoles(new Set());
+      return;
+    }
+    void getPackageMapping(buildingId)
+      .then((inv) => {
+        const roles = new Set<string>();
+        for (const eq of inv.equipment ?? []) {
+          for (const role of Object.values(eq.roles ?? {})) {
+            if (role) roles.add(String(role));
+          }
+          for (const col of eq.columns ?? []) {
+            if (col.role) roles.add(String(col.role));
+          }
+        }
+        setMappedRoles(roles);
+      })
+      .catch(() => setMappedRoles(new Set()));
+  }, [buildingId]);
+
   const families = useMemo(
     () => [...new Set(presets.map((p) => p.family))].sort(),
     [presets],
@@ -71,6 +94,26 @@ export function RcxPage() {
   const familyPresets = useMemo(
     () => presets.filter((p) => !family || p.family === family),
     [presets, family],
+  );
+
+  const presetOptions = useMemo(
+    () =>
+      familyPresets.map((p) => {
+        const role = p.role_col?.trim();
+        const missing =
+          Boolean(buildingId) &&
+          Boolean(role) &&
+          mappedRoles.size > 0 &&
+          !mappedRoles.has(role!);
+        return {
+          value: p.id,
+          label: missing
+            ? `${p.title} [${p.chart}] — unavailable (unmapped ${role})`
+            : `${p.title} [${p.chart}]`,
+          disabled: missing,
+        };
+      }),
+    [familyPresets, buildingId, mappedRoles],
   );
 
   const coverageRows = useMemo(() => {
@@ -231,10 +274,7 @@ export function RcxPage() {
           id="rcx-preset"
           label="Preset"
           value={presetId}
-          options={familyPresets.map((p) => ({
-            value: p.id,
-            label: `${p.title} [${p.chart}]`,
-          }))}
+          options={presetOptions}
           onChange={setPresetId}
           testId="rcx-preset"
         />

--- a/frontend/web/src/pages/ReportsPage.test.tsx
+++ b/frontend/web/src/pages/ReportsPage.test.tsx
@@ -5,6 +5,19 @@ import { ReportsPage } from "./ReportsPage";
 
 vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => ["B1"]),
+  getPackageMapping: vi.fn(async () => ({
+    ok: true,
+    building_id: "B1",
+    equipment: [
+      {
+        equipment_id: "VAV_1",
+        equipment_type: "VAV",
+        ok: true,
+        roles: { zone_t: "zone_t" },
+        columns: [{ column: "zone_air_temp", role: "zone_t", status: "mapped" }],
+      },
+    ],
+  })),
   getSessionConfig: vi.fn(async () => ({ ok: true, config: {} })),
   putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));

--- a/frontend/web/src/pages/ReportsPage.tsx
+++ b/frontend/web/src/pages/ReportsPage.tsx
@@ -11,8 +11,8 @@ import {
   Select,
 } from "../components/widgets";
 import { useSessionQuery } from "../session";
-import { listPackageBuildings } from "../api/mappingApi";
-import { getFddResults, getFddSeries, listFddRules } from "../api/fddApi";
+import { listPackageBuildings, getPackageMapping } from "../api/mappingApi";
+import { getFddResults, getFddSeries, listFddRules, type FddRuleSummary } from "../api/fddApi";
 import { postInspect, postSensorHealth } from "../api/analyticsApi";
 import {
   missingSegmentCount,
@@ -51,8 +51,10 @@ export function ReportsPage() {
 
   const [buildings, setBuildings] = useState<string[]>([]);
   const [ruleId, setRuleId] = useState("");
+  const [rules, setRules] = useState<FddRuleSummary[]>([]);
+  const [mappedRoles, setMappedRoles] = useState<Set<string>>(new Set());
   const [ruleOptions, setRuleOptions] = useState<
-    Array<{ value: string; label: string }>
+    Array<{ value: string; label: string; disabled?: boolean }>
   >([{ value: "", label: "— rule —" }]);
   const [equipmentOptions, setEquipmentOptions] = useState<
     Array<{ value: string; label: string }>
@@ -82,18 +84,55 @@ export function ReportsPage() {
       .then(setBuildings)
       .catch(() => setBuildings([]));
     void listFddRules()
-      .then((rules) => {
-        setRuleOptions([
-          { value: "", label: "— rule —" },
-          ...rules.map((r) => ({
-            value: r.rule_id,
-            label: `${r.rule_id} — ${r.description ?? ""}`,
-          })),
-        ]);
-        if (!ruleId && rules[0]) setRuleId(rules[0].rule_id);
+      .then((list) => {
+        setRules(list);
+        if (!ruleId && list[0]) setRuleId(list[0].rule_id);
       })
       .catch(() => undefined);
   }, [ruleId]);
+
+  useEffect(() => {
+    if (!buildingId || !equipmentId) {
+      setMappedRoles(new Set());
+      return;
+    }
+    void getPackageMapping(buildingId, equipmentId)
+      .then((inv) => {
+        const roles = new Set<string>();
+        const eq =
+          inv.equipment?.find((e) => e.equipment_id === equipmentId) ??
+          inv.equipment?.[0];
+        for (const role of Object.values(eq?.roles ?? {})) {
+          if (role) roles.add(String(role));
+        }
+        for (const col of eq?.columns ?? []) {
+          if (col.role) roles.add(String(col.role));
+        }
+        setMappedRoles(roles);
+      })
+      .catch(() => setMappedRoles(new Set()));
+  }, [buildingId, equipmentId]);
+
+  useEffect(() => {
+    setRuleOptions([
+      { value: "", label: "— rule —" },
+      ...rules.map((r) => {
+        const required = (r.required_roles ?? []).filter(Boolean);
+        const missing =
+          mappedRoles.size > 0
+            ? required.filter((role) => !mappedRoles.has(role))
+            : [];
+        const blocked = missing.length > 0;
+        return {
+          value: r.rule_id,
+          label: blocked
+            ? `${r.rule_id} — unavailable (missing ${missing.join(", ")})`
+            : `${r.rule_id} — ${r.description ?? ""}`,
+          disabled: blocked,
+        };
+      }),
+    ]);
+  }, [rules, mappedRoles]);
 
   useEffect(() => {
     if (!buildingId) {

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1730,17 +1730,27 @@ pub async fn rcx_timeseries_from_history(
         .filter(|c| cols.contains(*c))
         .map(|c| format!(", {c} AS return_f"))
         .unwrap_or_else(|| ", CAST(NULL AS FLOAT) AS return_f".into());
+    // Span-preserving downsample (vibe19): keep first/last + evenly spaced rows
+    // across the full historian range instead of LIMIT taking only the earliest.
     let sql = format!(
         r#"
-SELECT
-  CAST({ts_col} AS VARCHAR) AS timestamp_utc,
-  equipment_id,
-  {role_col} AS value_f
-  {overlay_sel}
-  {return_sel}
-FROM history
-WHERE equipment_id IS NOT NULL AND {role_col} IS NOT NULL{eq_filter}{fan_filter}
-ORDER BY {ts_col}, equipment_id
+SELECT timestamp_utc, equipment_id, value_f, overlay_f, return_f
+FROM (
+  SELECT
+    CAST({ts_col} AS VARCHAR) AS timestamp_utc,
+    equipment_id,
+    {role_col} AS value_f
+    {overlay_sel}
+    {return_sel},
+    ROW_NUMBER() OVER (ORDER BY {ts_col}, equipment_id) AS _rn,
+    COUNT(*) OVER () AS _cnt
+  FROM history
+  WHERE equipment_id IS NOT NULL AND {role_col} IS NOT NULL{eq_filter}{fan_filter}
+)
+WHERE _rn = 1
+   OR _rn = _cnt
+   OR MOD(_rn, GREATEST(CAST((_cnt + {limit} - 1) / {limit} AS BIGINT), 1)) = 0
+ORDER BY timestamp_utc, equipment_id
 LIMIT {limit}
 "#
     );


### PR DESCRIPTION
## Summary
- Span-preserving downsample for RCx historian timeseries (not earliest-only LIMIT).
- Plotly date x-axis for RCx multi-equipment charts.
- Disable RCx/FDD Selects when roles are unmapped; FDD series preflight returns `missing_roles`.

## Test plan
- [ ] RCx AHU SAT spans full history with date autorange
- [ ] Unmapped heating-valve preset greyed out
- [ ] FDD rule missing roles disabled / friendly error
- [ ] CI green

**Base:** `feature/actions-polish` (#678) — merge after #678.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - RCx presets and report rules now indicate when required equipment roles are unavailable and disable unsupported selections.
  - Dropdown options can be marked unavailable with explanatory labels.
  - Missing equipment roles are reported clearly when FDD data cannot be loaded.

- **Bug Fixes**
  - Historian charts now represent the full selected time range instead of favoring only the earliest readings.
  - Improved time-axis formatting and automatic chart scaling for equipment trends.
  - FDD requests now return clearer results when required roles are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->