### PR TITLE
Remove Reports artifacts/PDF; keep FDD Plots

### DIFF
--- a/frontend/web/src/nav/sections.ts
+++ b/frontend/web/src/nav/sections.ts
@@ -21,7 +21,7 @@ export const SIDEBAR_NAV = [
   { to: "/rules", label: "Rules", short: "R", testId: "nav-rules" },
   { to: "/actions", label: "Actions", short: "X", testId: "nav-actions" },
   { to: "/findings", label: "Findings", short: "F", testId: "nav-findings" },
-  { to: "/reports", label: "Reports", short: "P", testId: "nav-reports" },
+  { to: "/reports", label: "FDD Plots", short: "P", testId: "nav-reports" },
   { to: "/metering", label: "Metering", short: "E", testId: "nav-metering" },
   { to: "/wattlab", label: "WattLab", short: "W", testId: "nav-wattlab" },
   { to: "/twin", label: "Twin", short: "T", testId: "nav-twin" },

--- a/frontend/web/src/pages/HomePage.test.tsx
+++ b/frontend/web/src/pages/HomePage.test.tsx
@@ -114,12 +114,6 @@ vi.mock("../api/fddApi", () => ({
   })),
 }));
 
-vi.mock("../api/reportsApi", () => ({
-  listReports: vi.fn(async () => []),
-  createReportDraft: vi.fn(async () => ({ ok: true })),
-  getEngineeringFindingsReport: vi.fn(async () => ({})),
-}));
-
 vi.mock("../api/cutoverApi", () => ({
   getUiGeneration: vi.fn(async () => ({ generation: "react" })),
 }));

--- a/frontend/web/src/pages/ReportsPage.test.tsx
+++ b/frontend/web/src/pages/ReportsPage.test.tsx
@@ -7,7 +7,6 @@ vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => ["B1"]),
   getPackageMapping: vi.fn(async () => ({
     ok: true,
-<<<<<<< HEAD
     building_id: "B1",
     equipment: [
       {
@@ -16,13 +15,6 @@ vi.mock("../api/mappingApi", () => ({
         ok: true,
         roles: { zone_t: "zone_t" },
         columns: [{ column: "zone_air_temp", role: "zone_t", status: "mapped" }],
-=======
-    equipment: [
-      {
-        equipment_id: "VAV_1",
-        roles: { zone_t: "zone_t" },
-        columns: [{ column: "zone_t", role: "zone_t" }],
->>>>>>> 897f08e (Remove Reports artifacts/PDF surface; keep FDD Plots.)
       },
     ],
   })),

--- a/frontend/web/src/pages/ReportsPage.test.tsx
+++ b/frontend/web/src/pages/ReportsPage.test.tsx
@@ -7,6 +7,7 @@ vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => ["B1"]),
   getPackageMapping: vi.fn(async () => ({
     ok: true,
+<<<<<<< HEAD
     building_id: "B1",
     equipment: [
       {
@@ -15,6 +16,13 @@ vi.mock("../api/mappingApi", () => ({
         ok: true,
         roles: { zone_t: "zone_t" },
         columns: [{ column: "zone_air_temp", role: "zone_t", status: "mapped" }],
+=======
+    equipment: [
+      {
+        equipment_id: "VAV_1",
+        roles: { zone_t: "zone_t" },
+        columns: [{ column: "zone_t", role: "zone_t" }],
+>>>>>>> 897f08e (Remove Reports artifacts/PDF surface; keep FDD Plots.)
       },
     ],
   })),
@@ -74,16 +82,13 @@ vi.mock("../api/analyticsApi", () => ({
     points: [],
     skipped: [],
   })),
+  postInspect: vi.fn(async () => ({
+    points: [],
+    warnings: [],
+  })),
 }));
 
 vi.mock("../api/uploadApi", () => ({ uploadPackage: vi.fn() }));
-
-vi.mock("../api/reportsApi", () => ({
-  listReports: vi.fn(async () => []),
-  createReportDraft: vi.fn(async () => ({ report_id: "d1" })),
-  getEngineeringFindingsReport: vi.fn(async () => ({ ok: false })),
-  createWattlabHandoff: vi.fn(),
-}));
 
 import { getFddSeries } from "../api/fddApi";
 
@@ -95,9 +100,19 @@ function renderPlots(entry = "/reports?site=B1&eq=VAV_1") {
   );
 }
 
-describe("ReportsPage plots", () => {
+describe("ReportsPage FDD Plots", () => {
   beforeEach(() => {
     vi.mocked(getFddSeries).mockClear();
+  });
+
+  it("shows FDD Plots title without artifacts mode", async () => {
+    renderPlots();
+    await waitFor(() => {
+      expect(screen.getByTestId("plots-page")).toBeTruthy();
+    });
+    expect(screen.getByRole("heading", { level: 1, name: "FDD Plots" })).toBeTruthy();
+    expect(screen.queryByTestId("reports-mode")).toBeNull();
+    expect(screen.queryByTestId("reports-artifacts")).toBeNull();
   });
 
   it("loads series and renders chart + preview", async () => {

--- a/frontend/web/src/pages/ReportsPage.tsx
+++ b/frontend/web/src/pages/ReportsPage.tsx
@@ -7,7 +7,6 @@ import {
   Expander,
   InlineAlert,
   PlotlyHost,
-  RadioGroup,
   Select,
 } from "../components/widgets";
 import { useSessionQuery } from "../session";
@@ -23,31 +22,15 @@ import {
   sensorFaultChart,
   sensorHealthHeatmap,
 } from "../api/vibeCharts";
-import {
-  createReportDraft,
-  getEngineeringFindingsReport,
-  listReports,
-  type ReportRecord,
-} from "../api/reportsApi";
 
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-type ReportRow = {
-  report_id: string;
-  report_type: string;
-  title: string;
-};
-
 export function ReportsPage() {
   const { query, setQuery } = useSessionQuery();
   const buildingId = query.siteId ?? "";
   const equipmentId = query.equipment ?? "";
-  const mode =
-    query.section === "artifacts" || query.section === "metering"
-      ? "artifacts"
-      : "plots";
 
   const [buildings, setBuildings] = useState<string[]>([]);
   const [ruleId, setRuleId] = useState("");
@@ -74,10 +57,6 @@ export function ReportsPage() {
   const [sensorFaultLoading, setSensorFaultLoading] = useState(false);
   const [sensorError, setSensorError] = useState<string | null>(null);
   const [sensorOpen, setSensorOpen] = useState(false);
-
-  const [reports, setReports] = useState<ReportRecord[]>([]);
-  const [artifactsNotice, setArtifactsNotice] = useState<string | null>(null);
-  const [engFindings, setEngFindings] = useState("");
 
   useEffect(() => {
     void listPackageBuildings()
@@ -154,22 +133,6 @@ export function ReportsPage() {
         setEquipmentOptions([{ value: "", label: "— equipment —" }]);
       });
   }, [buildingId, equipmentId, setQuery]);
-
-  const refreshReports = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setReports(await listReports());
-    } catch (err) {
-      setError(formatErr(err));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (mode === "artifacts") void refreshReports();
-  }, [mode, refreshReports]);
 
   const loadSeries = useCallback(async () => {
     if (!equipmentId || !ruleId) {
@@ -302,35 +265,6 @@ export function ReportsPage() {
     return [{ value: "", label: "— sensor —" }, ...opts];
   }, [sensorRows]);
 
-  const onCreateDraft = async () => {
-    setArtifactsNotice(null);
-    setError(null);
-    try {
-      const out = await createReportDraft({
-        template_id: "summary",
-        title: "React draft (P1-M5-E)",
-        note: "DOCX/PDF render may remain ORACLE until Rust owns them",
-      });
-      setArtifactsNotice(
-        `Draft created: ${String(out.report_id ?? JSON.stringify(out))}`,
-      );
-      await refreshReports();
-    } catch (err) {
-      setError(formatErr(err));
-    }
-  };
-
-  const onLoadEngFindings = async () => {
-    setError(null);
-    try {
-      const body = await getEngineeringFindingsReport();
-      setEngFindings(JSON.stringify(body, null, 2));
-    } catch (err) {
-      setEngFindings("");
-      setError(formatErr(err));
-    }
-  };
-
   const gapSummary = useMemo(() => {
     if (!figure) return "";
     return figure.data
@@ -367,245 +301,166 @@ export function ReportsPage() {
     return Object.keys(previewRows[0]).map((k) => ({ key: k, header: k }));
   }, [previewRows]);
 
-  const reportRows: ReportRow[] = reports.map((r) => ({
-    report_id: String(r.report_id ?? ""),
-    report_type: String(r.report_type ?? r.template_id ?? r.kind ?? ""),
-    title: String(r.title ?? ""),
-  }));
-
   return (
     <AppShell
-      title="Reports"
-      caption="FDD plots + /api/reports artifacts (P1-M5-E). PDF/DOCX may be ORACLE."
-      activeSectionId={mode === "artifacts" ? "metering" : "fdd-plots"}
+      title="FDD Plots"
+      caption="FDD series plots and sensor health."
+      activeSectionId="fdd-plots"
     >
       <div className="page-stack" data-testid="reports-page">
-        <RadioGroup
-          id="reports-mode"
-          label="Reports view"
-          value={mode}
-          options={[
-            { value: "plots", label: "FDD plots" },
-            { value: "artifacts", label: "Artifacts (/api/reports)" },
-          ]}
-          onChange={(v) =>
-            setQuery(
-              { section: v === "artifacts" ? "artifacts" : "fdd-plots" },
-              true,
-            )
-          }
-          testId="reports-mode"
-        />
-
         {error ? (
           <InlineAlert id="reports-error" variant="danger" testId="plots-error">
             {error}
           </InlineAlert>
         ) : null}
 
-        {mode === "plots" ? (
-          <div data-testid="plots-page">
-            <h2>FDD plot datasets</h2>
-            <p>
-              Loads <code>GET /api/fdd/series</code>. Run FDD via{" "}
-              <Link to="/rules">Rules</Link> first.
-            </p>
+        <div data-testid="plots-page">
+          <h2>FDD plot datasets</h2>
+          <p>
+            Loads <code>GET /api/fdd/series</code>. Run FDD via{" "}
+            <Link to="/rules">Rules</Link> first.
+          </p>
 
-            <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem" }}>
-              <Select
-                id="plots-building"
-                label="Building"
-                value={buildingId}
-                options={buildingOptions}
-                onChange={(value) => setQuery({ siteId: value }, true)}
-                testId="plots-building-select"
-              />
-              <Select
-                id="plots-equipment"
-                label="Equipment"
-                value={equipmentId}
-                options={equipmentOptions}
-                onChange={(value) => setQuery({ equipment: value }, true)}
-                testId="plots-equipment-select"
-              />
-              <Select
-                id="plots-rule"
-                label="Rule"
-                value={ruleId}
-                options={ruleOptions}
-                onChange={setRuleId}
-                testId="plots-rule-select"
-              />
-            </div>
-
-            <div style={{ margin: "0.75rem 0" }}>
-              <Button
-                id="plots-load"
-                label={loading ? "Loading…" : "Load series"}
-                onClick={() => void loadSeries()}
-                disabled={loading || !equipmentId || !ruleId}
-                testId="plots-load"
-              />
-            </div>
-
-            <PlotlyHost
-              id="fdd-series"
-              label={figure?.layout?.title ?? "FDD series"}
-              figure={figure}
-              loading={loading}
-              testId="plots-chart"
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem" }}>
+            <Select
+              id="plots-building"
+              label="Building"
+              value={buildingId}
+              options={buildingOptions}
+              onChange={(value) => setQuery({ siteId: value }, true)}
+              testId="plots-building-select"
             />
-
-            {figure ? (
-              <p data-testid="plots-gap-summary">
-                Missing segments by role: {gapSummary || "none"}
-              </p>
-            ) : null}
-
-            {previewRows.length ? (
-              <DataTable
-                id="plots-preview"
-                label="Series preview (first rows)"
-                columns={
-                  previewColumns as Array<{ key: string; header: string }>
-                }
-                rows={previewRows}
-                testId="plots-preview-table"
-              />
-            ) : null}
-
-            <Expander
-              id="sensor-health"
-              label="Sensor health — coverage / flatline (DataFusion)"
-              expanded={sensorOpen}
-              onChange={setSensorOpen}
-              testId="sensor-health-expander"
-            >
-              <p>
-                Loads <code>POST /api/analytics/sensor-health</code> for the
-                selected building (optionally scoped to equipment).
-              </p>
-              <Button
-                id="sensor-health-load"
-                label={sensorLoading ? "Loading…" : "Load sensor health"}
-                onClick={() => void loadSensorHealth()}
-                disabled={sensorLoading || !buildingId}
-                testId="sensor-health-load"
-              />
-              {sensorError ? (
-                <InlineAlert id="sensor-health-error" variant="danger">
-                  {sensorError}
-                </InlineAlert>
-              ) : null}
-              <PlotlyHost
-                id="sensor-health-chart"
-                label="Coverage heatmap"
-                figure={sensorFigure}
-                loading={sensorLoading}
-                testId="sensor-health-chart"
-              />
-              {sensorRows.length ? (
-                <DataTable
-                  id="sensor-health-table"
-                  label="Sensor health matrix"
-                  columns={[
-                    { key: "equipment_id", header: "equipment" },
-                    { key: "role", header: "role" },
-                    { key: "coverage_pct", header: "coverage %" },
-                    { key: "missingness", header: "missingness" },
-                    { key: "flatline_flag", header: "flatline" },
-                    { key: "n_finite", header: "n_finite" },
-                    { key: "mean", header: "mean" },
-                    { key: "std", header: "std" },
-                  ]}
-                  rows={sensorRows}
-                  testId="sensor-health-table"
-                />
-              ) : null}
-
-              <Select
-                id="sensor-fault-pick"
-                label="Sensor for fault chart"
-                value={sensorKey}
-                options={sensorKeyOptions}
-                onChange={setSensorKey}
-                testId="sensor-fault-pick"
-              />
-              <Button
-                id="sensor-fault-load"
-                label={
-                  sensorFaultLoading ? "Loading…" : "Load sensor fault chart"
-                }
-                onClick={() => void loadSensorFaultChart()}
-                disabled={
-                  sensorFaultLoading || !buildingId || !sensorKey.includes("::")
-                }
-                testId="sensor-fault-load"
-              />
-              <PlotlyHost
-                id="sensor-fault-chart"
-                label="Sensor fault chart"
-                figure={sensorFaultFigure}
-                loading={sensorFaultLoading}
-                testId="sensor-fault-chart"
-              />
-            </Expander>
+            <Select
+              id="plots-equipment"
+              label="Equipment"
+              value={equipmentId}
+              options={equipmentOptions}
+              onChange={(value) => setQuery({ equipment: value }, true)}
+              testId="plots-equipment-select"
+            />
+            <Select
+              id="plots-rule"
+              label="Rule"
+              value={ruleId}
+              options={ruleOptions}
+              onChange={setRuleId}
+              testId="plots-rule-select"
+            />
           </div>
-        ) : (
-          <div data-testid="reports-artifacts">
-            <h2>Report artifacts</h2>
-            <InlineAlert id="reports-oracle" variant="info">
-              List/draft/engineering-findings via Rust. PDF/DOCX render may stay
-              ORACLE-ONLY until deletion gates (see PYTHON_EXIT_MATRIX).
-            </InlineAlert>
-            <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
-              <Button
-                id="reports-refresh"
-                label="Refresh list"
-                onClick={() => void refreshReports()}
-                testId="reports-refresh"
-              />
-              <Button
-                id="reports-draft"
-                label="Create draft"
-                variant="secondary"
-                onClick={() => void onCreateDraft()}
-                testId="reports-draft"
-              />
-              <Button
-                id="reports-eng"
-                label="Load engineering-findings"
-                variant="secondary"
-                onClick={() => void onLoadEngFindings()}
-                testId="reports-eng"
-              />
-            </div>
-            {artifactsNotice ? (
-              <InlineAlert
-                id="reports-notice"
-                variant="success"
-                testId="reports-notice"
-              >
-                {artifactsNotice}
+
+          <div style={{ margin: "0.75rem 0" }}>
+            <Button
+              id="plots-load"
+              label={loading ? "Loading…" : "Load series"}
+              onClick={() => void loadSeries()}
+              disabled={loading || !equipmentId || !ruleId}
+              testId="plots-load"
+            />
+          </div>
+
+          <PlotlyHost
+            id="fdd-series"
+            label={figure?.layout?.title ?? "FDD series"}
+            figure={figure}
+            loading={loading}
+            testId="plots-chart"
+          />
+
+          {figure ? (
+            <p data-testid="plots-gap-summary">
+              Missing segments by role: {gapSummary || "none"}
+            </p>
+          ) : null}
+
+          {previewRows.length ? (
+            <DataTable
+              id="plots-preview"
+              label="Series preview (first rows)"
+              columns={
+                previewColumns as Array<{ key: string; header: string }>
+              }
+              rows={previewRows}
+              testId="plots-preview-table"
+            />
+          ) : null}
+
+          <Expander
+            id="sensor-health"
+            label="Sensor health — coverage / flatline (DataFusion)"
+            expanded={sensorOpen}
+            onChange={setSensorOpen}
+            testId="sensor-health-expander"
+          >
+            <p>
+              Loads <code>POST /api/analytics/sensor-health</code> for the
+              selected building (optionally scoped to equipment).
+            </p>
+            <Button
+              id="sensor-health-load"
+              label={sensorLoading ? "Loading…" : "Load sensor health"}
+              onClick={() => void loadSensorHealth()}
+              disabled={sensorLoading || !buildingId}
+              testId="sensor-health-load"
+            />
+            {sensorError ? (
+              <InlineAlert id="sensor-health-error" variant="danger">
+                {sensorError}
               </InlineAlert>
             ) : null}
-            <DataTable
-              id="reports-table"
-              label="Reports"
-              columns={[
-                { key: "report_id", header: "report_id" },
-                { key: "report_type", header: "type" },
-                { key: "title", header: "title" },
-              ]}
-              rows={reportRows}
-              loading={loading}
-              testId="reports-table"
+            <PlotlyHost
+              id="sensor-health-chart"
+              label="Coverage heatmap"
+              figure={sensorFigure}
+              loading={sensorLoading}
+              testId="sensor-health-chart"
             />
-            {engFindings ? (
-              <pre data-testid="reports-eng-json">{engFindings}</pre>
+            {sensorRows.length ? (
+              <DataTable
+                id="sensor-health-table"
+                label="Sensor health matrix"
+                columns={[
+                  { key: "equipment_id", header: "equipment" },
+                  { key: "role", header: "role" },
+                  { key: "coverage_pct", header: "coverage %" },
+                  { key: "missingness", header: "missingness" },
+                  { key: "flatline_flag", header: "flatline" },
+                  { key: "n_finite", header: "n_finite" },
+                  { key: "mean", header: "mean" },
+                  { key: "std", header: "std" },
+                ]}
+                rows={sensorRows}
+                testId="sensor-health-table"
+              />
             ) : null}
-          </div>
-        )}
+
+            <Select
+              id="sensor-fault-pick"
+              label="Sensor for fault chart"
+              value={sensorKey}
+              options={sensorKeyOptions}
+              onChange={setSensorKey}
+              testId="sensor-fault-pick"
+            />
+            <Button
+              id="sensor-fault-load"
+              label={
+                sensorFaultLoading ? "Loading…" : "Load sensor fault chart"
+              }
+              onClick={() => void loadSensorFaultChart()}
+              disabled={
+                sensorFaultLoading || !buildingId || !sensorKey.includes("::")
+              }
+              testId="sensor-fault-load"
+            />
+            <PlotlyHost
+              id="sensor-fault-chart"
+              label="Sensor fault chart"
+              figure={sensorFaultFigure}
+              loading={sensorFaultLoading}
+              testId="sensor-fault-chart"
+            />
+          </Expander>
+        </div>
       </div>
     </AppShell>
   );

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1346,8 +1346,7 @@ pub async fn fdd_rules_list() -> Json<Value> {
     }
 }
 
-const REPORTS_ARTIFACTS_GONE: &str =
-    "reports artifacts removed; use FDD Plots and WattLab dumps";
+const REPORTS_ARTIFACTS_GONE: &str = "reports artifacts removed; use FDD Plots and WattLab dumps";
 
 fn reports_artifacts_gone() -> (StatusCode, Json<Value>) {
     (
@@ -1392,9 +1391,7 @@ pub async fn reports_render_pdf(Path(_report_id): Path<String>) -> (StatusCode, 
     reports_artifacts_gone()
 }
 
-pub async fn reports_download_pdf(
-    Path(_report_id): Path<String>,
-) -> (StatusCode, Json<Value>) {
+pub async fn reports_download_pdf(Path(_report_id): Path<String>) -> (StatusCode, Json<Value>) {
     reports_artifacts_gone()
 }
 

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1346,143 +1346,56 @@ pub async fn fdd_rules_list() -> Json<Value> {
     }
 }
 
-pub async fn reports_list() -> Json<Value> {
-    Json(open_fdd_edge_prototype::reports::list_reports())
-}
+const REPORTS_ARTIFACTS_GONE: &str =
+    "reports artifacts removed; use FDD Plots and WattLab dumps";
 
-/// OFDD-069: dedicated Eng Findings lookup used by Liberty soak / HITL clients.
-///
-/// Returns the most recent report whose `report_type` / `template_id` / `kind`
-/// matches `engineering_findings`, or `{ok:false, error:"report not found"}`.
-pub async fn reports_engineering_findings() -> (StatusCode, Json<Value>) {
-    let listed = open_fdd_edge_prototype::reports::list_reports();
-    let records = listed
-        .get("records")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-    let match_type = |v: &Value| -> bool {
-        let t = v
-            .get("report_type")
-            .or_else(|| v.get("template_id"))
-            .or_else(|| v.get("kind"))
-            .and_then(|x| x.as_str())
-            .unwrap_or("")
-            .to_ascii_lowercase();
-        t == "engineering_findings"
-            || t == "engineering-findings"
-            || t.contains("engineering_finding")
-    };
-    if let Some(best) = records.into_iter().find(|r| match_type(r)) {
-        let report_id = best.get("report_id").and_then(|v| v.as_str()).unwrap_or("");
-        if !report_id.is_empty() {
-            let full = open_fdd_edge_prototype::reports::get_report(report_id);
-            if full.get("ok") == Some(&json!(true)) || full.get("report_id").is_some() {
-                return (StatusCode::OK, Json(full));
-            }
-        }
-        return (StatusCode::OK, Json(json!({"ok": true, "report": best})));
-    }
+fn reports_artifacts_gone() -> (StatusCode, Json<Value>) {
     (
-        StatusCode::NOT_FOUND,
-        Json(json!({"ok": false, "error": "report not found"})),
+        StatusCode::GONE,
+        Json(json!({"ok": false, "error": REPORTS_ARTIFACTS_GONE})),
     )
 }
 
-pub async fn reports_templates() -> Json<Value> {
-    Json(open_fdd_edge_prototype::reports::templates())
+/// Reports list/draft/PDF surface removed; keep route so clients get 410 not 404.
+pub async fn reports_list() -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
 }
 
-pub async fn reports_draft(Json(body): Json<Value>) -> Json<Value> {
-    let result =
-        tokio::task::spawn_blocking(move || open_fdd_edge_prototype::reports::create_draft(&body))
-            .await
-            .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports draft task: {e}")}));
-    Json(result)
+pub async fn reports_engineering_findings() -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
 }
 
-pub async fn reports_get(Path(report_id): Path<String>) -> Json<Value> {
-    Json(open_fdd_edge_prototype::reports::get_report(&report_id))
+pub async fn reports_templates() -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
 }
 
-pub async fn reports_patch(Path(report_id): Path<String>, Json(body): Json<Value>) -> Json<Value> {
-    let result = tokio::task::spawn_blocking(move || {
-        open_fdd_edge_prototype::reports::patch_report(&report_id, &body)
-    })
-    .await
-    .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports patch task: {e}")}));
-    Json(result)
+pub async fn reports_draft(Json(_body): Json<Value>) -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
 }
 
-pub async fn reports_delete(Path(report_id): Path<String>) -> Json<Value> {
-    let result = tokio::task::spawn_blocking(move || {
-        open_fdd_edge_prototype::reports::delete_report(&report_id)
-    })
-    .await
-    .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports delete task: {e}")}));
-    Json(result)
+pub async fn reports_get(Path(_report_id): Path<String>) -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
 }
 
-pub async fn reports_render_pdf(Path(report_id): Path<String>) -> Json<Value> {
-    let result = tokio::task::spawn_blocking(move || {
-        open_fdd_edge_prototype::reports::render_pdf_bundle(&report_id)
-    })
-    .await
-    .unwrap_or_else(|e| json!({"ok": false, "error": format!("reports render task: {e}")}));
-    Json(result)
+pub async fn reports_patch(
+    Path(_report_id): Path<String>,
+    Json(_body): Json<Value>,
+) -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
+}
+
+pub async fn reports_delete(Path(_report_id): Path<String>) -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
+}
+
+pub async fn reports_render_pdf(Path(_report_id): Path<String>) -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
 }
 
 pub async fn reports_download_pdf(
-    Path(report_id): Path<String>,
-) -> Result<(StatusCode, HeaderMap, Vec<u8>), (StatusCode, Json<Value>)> {
-    let safe_id: String = report_id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    if safe_id.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(json!({"ok": false, "error": "invalid report_id"})),
-        ));
-    }
-    let report_id_for_io = report_id.clone();
-    let bytes = tokio::task::spawn_blocking(move || {
-        let path = open_fdd_edge_prototype::reports::download_path(&report_id_for_io, "pdf")
-            .ok_or_else(|| "pdf not found — render first".to_string())?;
-        std::fs::read(path).map_err(|e| e.to_string())
-    })
-    .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"ok": false, "error": format!("reports download task: {e}")})),
-        )
-    })?
-    .map_err(|e| {
-        let status = if e.contains("not found") {
-            StatusCode::NOT_FOUND
-        } else {
-            StatusCode::INTERNAL_SERVER_ERROR
-        };
-        (status, Json(json!({"ok": false, "error": e})))
-    })?;
-    let mut headers = HeaderMap::new();
-    headers.insert(header::CONTENT_TYPE, "application/pdf".parse().unwrap());
-    let disposition = format!("attachment; filename=\"report-{safe_id}.pdf\"");
-    let disposition_value = disposition.parse().map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"ok": false, "error": "invalid report_id for Content-Disposition"})),
-        )
-    })?;
-    headers.insert(header::CONTENT_DISPOSITION, disposition_value);
-    Ok((StatusCode::OK, headers, bytes))
+    Path(_report_id): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    reports_artifacts_gone()
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary
- Reports page is FDD Plots only (no draft/PDF artifacts UI).
- Sidebar label → FDD Plots.
- Central `/api/reports*` returns 410 Gone with a clear message.

## Test plan
- [ ] `/reports` shows Plotly FDD only
- [ ] No Artifacts radio / report table
- [ ] `GET /api/reports` → 410
- [ ] CI green

**Base:** `feature/plot-span-role-gates` (#679).


Made with [Cursor](https://cursor.com)