### PR TITLE
Make Metering a vibe20 Fuel dashboard via DataFusion

### DIFF
--- a/frontend/web/src/components/FuelDashboard.tsx
+++ b/frontend/web/src/components/FuelDashboard.tsx
@@ -73,7 +73,12 @@ function coolSeasonFromWeather(
   return out;
 }
 
-export function FuelDashboard() {
+export type FuelDashboardProps = {
+  /** When this value changes, re-fetch the campus list (e.g. after import). */
+  reloadToken?: number;
+};
+
+export function FuelDashboard({ reloadToken }: FuelDashboardProps = {}) {
   const [campuses, setCampuses] = useState<FuelCampusMeta[]>([]);
   const [campusId, setCampusId] = useState("");
   const [tab, setTab] = useState<string>(TAB_IDS.overview);
@@ -107,7 +112,7 @@ export function FuelDashboard() {
 
   useEffect(() => {
     void refreshCampuses();
-  }, [refreshCampuses]);
+  }, [refreshCampuses, reloadToken]);
 
   useEffect(() => {
     if (!campusId) {

--- a/frontend/web/src/pages/MeteringPage.test.tsx
+++ b/frontend/web/src/pages/MeteringPage.test.tsx
@@ -3,81 +3,24 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { MeteringPage } from "./MeteringPage";
 
-vi.mock("../api/mappingApi", () => ({
-  listPackageBuildings: vi.fn(async () => ["B1"]),
+vi.mock("../api/fuelApi", () => ({
+  importFuelCampus: vi.fn(async () => ({
+    ok: true,
+    campus_id: "campus-100-50",
+  })),
 }));
 
-vi.mock("../api/analyticsApi", async () => {
-  const actual = await vi.importActual<typeof import("../api/analyticsApi")>(
-    "../api/analyticsApi",
-  );
-  return {
-    ...actual,
-    postMetering: vi.fn(async () => ({
-      schema_version: "analytics-envelope-v1",
-      query_version: "metering-v1",
-      generated_at: "2024-01-01T00:00:00Z",
-      engine: "central-analytics-v1",
-      warnings: ["metering: monthly kWh sum only"],
-      rows: [
-        { period: "2024-01", kwh: 150.5, n_rows: 2 },
-        { period: "2024-02", kwh: 200, n_rows: 1 },
-        { period: "2024-03", kwh: 175.25, n_rows: 1 },
-      ],
-      equipment: [],
-      points: [],
-      skipped: [],
-      coverage: { total_kwh: 525.75, period_count: 3 },
-    })),
-    postRcxPreset: vi.fn(async () => ({
-      schema_version: "analytics-envelope-v1",
-      query_version: "rcx-preset-meter_elec_cdd-v1",
-      generated_at: "2024-01-01T00:00:00Z",
-      engine: "central-analytics-v1",
-      warnings: [],
-      rows: [],
-      equipment: [],
-      points: [
-        {
-          equipment_id: "M_ELEC",
-          month: "2024-01",
-          energy: 100,
-          degree_days: 12,
-        },
-        {
-          equipment_id: "M_ELEC",
-          month: "2024-02",
-          energy: 120,
-          degree_days: 18,
-        },
-      ],
-      skipped: [],
-      coverage: {
-        title: "Electric × CDD",
-        chart_kind: "metering",
-        meter_kind: "electric",
-      },
-    })),
-  };
-});
+vi.mock("../components/FuelDashboard", () => ({
+  FuelDashboard: ({ reloadToken }: { reloadToken?: number }) => (
+    <div data-testid="fuel-dashboard" data-reload-token={String(reloadToken ?? 0)}>
+      FuelDashboard stub
+    </div>
+  ),
+}));
 
-vi.mock("../api/vibeCharts", async () => {
-  const actual = await vi.importActual<typeof import("../api/vibeCharts")>(
-    "../api/vibeCharts",
-  );
-  return {
-    ...actual,
-    meteringCharts: vi.fn(() => ({
-      data: [{ type: "bar", name: "stub", x: ["2024-01"], y: [1] }],
-      layout: {},
-      meta: { point_count: 1, provenance: "test" },
-    })),
-  };
-});
+import { importFuelCampus } from "../api/fuelApi";
 
-import { postMetering, postRcxPreset } from "../api/analyticsApi";
-
-function renderPage(entry = "/metering?site=B1") {
+function renderPage(entry = "/metering") {
   return render(
     <MemoryRouter initialEntries={[entry]}>
       <MeteringPage />
@@ -87,31 +30,57 @@ function renderPage(entry = "/metering?site=B1") {
 
 describe("MeteringPage", () => {
   beforeEach(() => {
-    vi.mocked(postMetering).mockClear();
-    vi.mocked(postRcxPreset).mockClear();
+    vi.mocked(importFuelCampus).mockClear();
   });
 
-  it("runs metering and shows parity PASS", async () => {
+  it("renders Fuel dashboard shell and import control", async () => {
     renderPage();
-    await waitFor(() => screen.getByTestId("metering-run"));
-    fireEvent.click(screen.getByTestId("metering-run").querySelector("button")!);
+    await waitFor(() => screen.getByTestId("metering-page"));
+    expect(screen.getByTestId("metering-fuel-upload")).toBeTruthy();
+    expect(screen.getByTestId("fuel-dashboard")).toBeTruthy();
+    expect(screen.queryByTestId("metering-preset-run")).toBeNull();
+    expect(screen.queryByTestId("metering-series")).toBeNull();
+  });
+
+  it("imports fuel campus zip and shows campus_id", async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId("metering-fuel-zip-input"));
+
+    const file = new File(["zip-bytes"], "Buidling_100_50_fuel_use.zip", {
+      type: "application/zip",
+    });
+    fireEvent.change(screen.getByTestId("metering-fuel-zip-input"), {
+      target: { files: [file] },
+    });
+
     await waitFor(() => {
-      expect(postMetering).toHaveBeenCalled();
-      expect(screen.getByTestId("metering-parity").textContent).toContain("PASS");
-      expect(screen.getByTestId("metering-table")).toBeTruthy();
-      expect(screen.getByTestId("metering-plot")).toBeTruthy();
+      expect(importFuelCampus).toHaveBeenCalledWith(file);
+      expect(screen.getByTestId("metering-fuel-campus-id").textContent).toContain(
+        "campus-100-50",
+      );
+      expect(screen.getByTestId("fuel-dashboard").getAttribute("data-reload-token")).toBe(
+        "1",
+      );
     });
   });
 
-  it("runs RCx metering preset", async () => {
-    renderPage();
-    await waitFor(() => screen.getByTestId("metering-preset-run"));
-    fireEvent.click(
-      screen.getByTestId("metering-preset-run").querySelector("button")!,
+  it("shows import errors", async () => {
+    vi.mocked(importFuelCampus).mockRejectedValueOnce(
+      new Error("Fuel campus import failed"),
     );
+    renderPage();
+    await waitFor(() => screen.getByTestId("metering-fuel-zip-input"));
+
+    const file = new File(["bad"], "bad.zip", { type: "application/zip" });
+    fireEvent.change(screen.getByTestId("metering-fuel-zip-input"), {
+      target: { files: [file] },
+    });
+
     await waitFor(() => {
-      expect(postRcxPreset).toHaveBeenCalled();
-      expect(screen.getByTestId("metering-plot")).toBeTruthy();
+      expect(screen.getByTestId("metering-error").textContent).toContain(
+        "Fuel campus import failed",
+      );
+      expect(screen.queryByTestId("metering-fuel-campus-id")).toBeNull();
     });
   });
 });

--- a/frontend/web/src/pages/MeteringPage.tsx
+++ b/frontend/web/src/pages/MeteringPage.tsx
@@ -1,352 +1,86 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router";
+import { useRef, useState } from "react";
 import { AppShell } from "../components/AppShell";
-import {
-  Button,
-  DataTable,
-  InlineAlert,
-  Metric,
-  Select,
-} from "../components/widgets";
-import { PlotlyHost } from "../components/widgets/PlotlyHost";
-import { useSessionQuery } from "../session";
-import { listPackageBuildings } from "../api/mappingApi";
-import {
-  monthlySumClient,
-  postMetering,
-  postRcxPreset,
-  type AnalyticsEnvelope,
-  type MeterRow,
-  type MonthlySumRow,
-} from "../api/analyticsApi";
-import { meteringCharts } from "../api/vibeCharts";
-import type { PlotlyFigure } from "../api/plotDataset";
+import { FuelDashboard } from "../components/FuelDashboard";
+import { Button, InlineAlert } from "../components/widgets";
+import { importFuelCampus } from "../api/fuelApi";
 
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-type SumTableRow = {
-  period: string;
-  kwh: string;
-  n_rows: string;
-  meter_id: string;
-};
-
-const METER_PRESETS = [
-  {
-    id: "meter_elec_cdd",
-    label: "Electric × CDD (RCx metering preset)",
-  },
-  {
-    id: "meter_gas_hdd",
-    label: "Gas × HDD (RCx metering preset)",
-  },
-] as const;
-
 export function MeteringPage() {
-  const { query, setQuery } = useSessionQuery();
-  const buildingId = query.siteId ?? "";
-
-  const [buildings, setBuildings] = useState<string[]>([]);
-  const [seriesJson, setSeriesJson] = useState(
-    () => JSON.stringify({ rows: SAMPLE_METER_ROWS_DEFAULT }, null, 2),
-  );
-  const [presetId, setPresetId] = useState<string>(METER_PRESETS[0].id);
-  const [envelope, setEnvelope] = useState<AnalyticsEnvelope | null>(null);
-  const [clientSums, setClientSums] = useState<MonthlySumRow[]>([]);
-  const [figure, setFigure] = useState<PlotlyFigure | null>(null);
-  const [loading, setLoading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [campusId, setCampusId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
-  useEffect(() => {
-    let cancelled = false;
-    listPackageBuildings()
-      .then((b) => {
-        if (!cancelled) setBuildings(b);
-      })
-      .catch(() => {
-        if (!cancelled) setBuildings([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const runMetering = useCallback(async () => {
-    setLoading(true);
+  const onFuelZipSelected = async (file: File | undefined) => {
+    if (!file) return;
+    setUploading(true);
     setError(null);
     try {
-      let parsed: { rows?: MeterRow[] } | MeterRow[];
-      try {
-        parsed = JSON.parse(seriesJson) as { rows?: MeterRow[] } | MeterRow[];
-      } catch {
-        throw new Error("Series JSON is invalid");
-      }
-      const rows = Array.isArray(parsed)
-        ? parsed
-        : Array.isArray(parsed.rows)
-          ? parsed.rows
-          : [];
-      if (rows.length === 0) {
-        throw new Error("Provide at least one {period,kwh} row");
-      }
-      setClientSums(monthlySumClient(rows));
-      const env = await postMetering({
-        building_id: buildingId || undefined,
-        series: { rows },
-        query_version: "metering-v1",
-      });
-      setEnvelope(env);
-
-      // Build Plotly from monthly sums (bars) — vibe19 meteringCharts shape.
-      const points = (env.rows?.length ? env.rows : monthlySumClient(rows)).map(
-        (r) => ({
-          equipment_id: String(r.meter_id ?? (buildingId || "meter")),
-          month: String(r.period ?? ""),
-          energy: Number(r.kwh),
-          value_f: Number(r.kwh),
-          degree_days: null,
-        }),
-      );
-      setFigure(
-        meteringCharts(points, {
-          title: "Monthly energy (inline series)",
-          ddLabel: "DD",
-        }),
-      );
+      const res = await importFuelCampus(file);
+      const id = res.campus_id ?? res.campus?.campus_id ?? null;
+      setCampusId(id);
+      setReloadToken((n) => n + 1);
     } catch (err) {
-      setEnvelope(null);
-      setFigure(null);
+      setCampusId(null);
       setError(formatErr(err));
     } finally {
-      setLoading(false);
+      setUploading(false);
+      if (fileRef.current) fileRef.current.value = "";
     }
-  }, [buildingId, seriesJson]);
-
-  const runMeterPreset = useCallback(async () => {
-    if (!buildingId) {
-      setError("Select a building for RCx metering presets");
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const env = await postRcxPreset({
-        building_id: buildingId,
-        max_points: 8000,
-        series: { preset_id: presetId },
-      });
-      setEnvelope(env);
-      setClientSums([]);
-      const title = String(
-        env.coverage?.title ??
-          METER_PRESETS.find((p) => p.id === presetId)?.label ??
-          presetId,
-      );
-      const ddLabel =
-        String(env.coverage?.meter_kind ?? "") === "gas" ||
-        presetId.includes("gas")
-          ? "HDD"
-          : "CDD";
-      const points = env.points ?? [];
-      if (!points.length) {
-        setFigure(null);
-        if (env.warnings?.length) setError(env.warnings[0] ?? "No points");
-        return;
-      }
-      setFigure(meteringCharts(points, { title, ddLabel }));
-    } catch (err) {
-      setEnvelope(null);
-      setFigure(null);
-      setError(formatErr(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [buildingId, presetId]);
-
-  const tableRows: SumTableRow[] = useMemo(() => {
-    if (envelope?.points?.length) {
-      return envelope.points.slice(0, 120).map((r) => ({
-        period: String(r.month ?? r.period ?? ""),
-        kwh: String(r.energy ?? r.value_f ?? r.kwh ?? ""),
-        n_rows: String(r.n_rows ?? ""),
-        meter_id: String(r.equipment_id ?? r.meter_id ?? ""),
-      }));
-    }
-    const src =
-      envelope?.rows?.length && envelope.rows.length > 0
-        ? envelope.rows
-        : clientSums;
-    return src.map((r) => ({
-      period: String(r.period ?? ""),
-      kwh: String(r.kwh ?? ""),
-      n_rows: String(r.n_rows ?? ""),
-      meter_id: String(r.meter_id ?? ""),
-    }));
-  }, [envelope, clientSums]);
-
-  const totalKwh =
-    (envelope?.coverage?.total_kwh as number | undefined) ??
-    clientSums.reduce((a, r) => a + r.kwh, 0);
-
-  const parityOk =
-    envelope != null &&
-    clientSums.length > 0 &&
-    envelope.rows.length === clientSums.length &&
-    envelope.rows.every((r, i) => {
-      const c = clientSums[i];
-      return (
-        c &&
-        String(r.period) === c.period &&
-        Math.abs(Number(r.kwh) - c.kwh) < 1e-6
-      );
-    });
+  };
 
   return (
     <AppShell
       title="Metering"
-      caption="Monthly energy + degree-day charts via metering analytics / RCx presets"
+      caption="Campus fuel metering via DataFusion — import ZIP, then explore Portfolio / Monthly / Weather / Demand / DQ"
       activeSectionId="metering"
     >
       <div className="page-stack" data-testid="metering-page">
         <InlineAlert id="metering-scope" variant="info">
-          Prefer Plotly from RCx metering presets (
-          <code>meter_elec_cdd</code> / <code>meter_gas_hdd</code>) or run the
-          inline monthly kWh sum. JSON remains an advanced input, not the
-          primary UX.
+          Import a fuel campus ZIP (<code>campus.json</code> + bill CSVs) via{" "}
+          <code>POST /api/fuel/campus/import</code>, then use the shared Fuel
+          dashboard charts.
         </InlineAlert>
 
-        <div className="form-row">
-          <Select
-            id="metering-building"
-            label="Building"
-            value={buildingId}
-            options={[
-              { value: "", label: "— building —" },
-              ...buildings.map((b) => ({ value: b, label: b })),
-            ]}
-            onChange={(v) => setQuery({ siteId: v || undefined }, true)}
-            testId="metering-building"
-          />
-          <Select
-            id="metering-preset"
-            label="Metering preset"
-            value={presetId}
-            options={METER_PRESETS.map((p) => ({
-              value: p.id,
-              label: p.label,
-            }))}
-            onChange={setPresetId}
-            testId="metering-preset"
-          />
-        </div>
-
         <div className="form-row" style={{ gap: "0.5rem", display: "flex" }}>
-          <Button
-            id="metering-preset-run"
-            label={loading ? "Running…" : "Run metering preset"}
-            onClick={() => void runMeterPreset()}
-            disabled={loading || !buildingId}
-            testId="metering-preset-run"
+          <input
+            ref={fileRef}
+            id="metering-fuel-zip"
+            type="file"
+            accept=".zip,application/zip"
+            hidden
+            data-testid="metering-fuel-zip-input"
+            onChange={(e) =>
+              void onFuelZipSelected(e.target.files?.[0] ?? undefined)
+            }
           />
           <Button
-            id="metering-run"
-            label={loading ? "Running…" : "Run inline monthly sum"}
-            variant="secondary"
-            onClick={() => void runMetering()}
-            disabled={loading}
-            testId="metering-run"
+            id="metering-fuel-upload"
+            label={uploading ? "Importing fuel…" : "Import fuel campus ZIP"}
+            onClick={() => fileRef.current?.click()}
+            disabled={uploading}
+            testId="metering-fuel-upload"
           />
-          <Link to="/rcx">RCx Plots</Link>
         </div>
 
-        <details data-testid="metering-series-advanced">
-          <summary>Advanced: inline series JSON</summary>
-          <label htmlFor="metering-series">
-            Series JSON
-            <textarea
-              id="metering-series"
-              data-testid="metering-series"
-              rows={8}
-              value={seriesJson}
-              onChange={(e) => setSeriesJson(e.target.value)}
-              style={{ width: "100%", fontFamily: "monospace" }}
-            />
-          </label>
-        </details>
+        {campusId ? (
+          <p data-testid="metering-fuel-campus-id">
+            Imported campus_id: <strong>{campusId}</strong>
+          </p>
+        ) : null}
 
-        {error && (
-          <InlineAlert id="metering-error" variant="danger">
+        {error ? (
+          <InlineAlert id="metering-error" variant="danger" testId="metering-error">
             {error}
-          </InlineAlert>
-        )}
-
-        <div
-          className="metric-row"
-          style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}
-        >
-          <Metric
-            id="metering-total"
-            label="Total kWh"
-            value={Number.isFinite(totalKwh) ? totalKwh.toFixed(2) : "—"}
-            testId="metering-total"
-          />
-          <Metric
-            id="metering-periods"
-            label="Periods"
-            value={String(tableRows.length)}
-            testId="metering-periods"
-          />
-          <Metric
-            id="metering-engine"
-            label="Engine"
-            value={envelope?.engine ?? "—"}
-            testId="metering-engine"
-          />
-          <Metric
-            id="metering-parity"
-            label="Client↔API parity"
-            value={parityOk ? "PASS" : envelope ? "CHECK" : "—"}
-            testId="metering-parity"
-          />
-        </div>
-
-        {envelope?.warnings?.length ? (
-          <InlineAlert id="metering-warn" variant="warning">
-            {envelope.warnings.join(" · ")}
           </InlineAlert>
         ) : null}
 
-        <PlotlyHost
-          id="metering-plot"
-          label="Metering chart"
-          figure={figure}
-          loading={loading}
-          height={420}
-          testId="metering-plot"
-        />
-
-        <DataTable
-          id="metering-table"
-          label="Monthly energy"
-          columns={[
-            { key: "period", header: "Period" },
-            { key: "kwh", header: "kWh / energy" },
-            { key: "n_rows", header: "n_rows" },
-            { key: "meter_id", header: "meter / equipment" },
-          ]}
-          rows={tableRows}
-          testId="metering-table"
-        />
+        <FuelDashboard reloadToken={reloadToken} />
       </div>
     </AppShell>
   );
 }
-
-const SAMPLE_METER_ROWS_DEFAULT = [
-  { period: "2024-01", kwh: 100.25, meter_id: "M1" },
-  { period: "2024-01", kwh: 50.25, meter_id: "M1" },
-  { period: "2024-02", kwh: 200, meter_id: "M1" },
-  { period: "2024-03", kwh: 175.25, meter_id: "M1" },
-];


### PR DESCRIPTION
## Summary
- Metering tab imports fuel campus ZIP and renders shared `FuelDashboard` (Portfolio/Monthly/Weather/Demand/DQ).
- `FuelDashboard` accepts `reloadToken` so import refreshes campus list.
- Removes RCx-preset-only Metering stub UX.

## Test plan
- [ ] Import `/home/ben/Buidling_100_50_fuel_use.zip` on Metering
- [ ] Campus appears; site EUI ~66.9; Plotly tabs render
- [ ] WattLab Fuel still works
- [ ] CI green

**Base:** `feature/strip-reports-artifacts` (#680).


Made with [Cursor](https://cursor.com)