### PR TITLE
fix: RCx timeseries downsample for DataFusion 43 (MOD→%)

### DIFF
--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1732,6 +1732,7 @@ pub async fn rcx_timeseries_from_history(
         .unwrap_or_else(|| ", CAST(NULL AS FLOAT) AS return_f".into());
     // Span-preserving downsample (vibe19): keep first/last + evenly spaced rows
     // across the full historian range instead of LIMIT taking only the earliest.
+    // DataFusion 43 has no SQL `MOD()` UDF — use the `%` remainder operator.
     let sql = format!(
         r#"
 SELECT timestamp_utc, equipment_id, value_f, overlay_f, return_f
@@ -1749,7 +1750,7 @@ FROM (
 )
 WHERE _rn = 1
    OR _rn = _cnt
-   OR MOD(_rn, GREATEST(CAST((_cnt + {limit} - 1) / {limit} AS BIGINT), 1)) = 0
+   OR (_rn % GREATEST(CAST((_cnt + {limit} - 1) / {limit} AS BIGINT), 1)) = 0
 ORDER BY timestamp_utc, equipment_id
 LIMIT {limit}
 "#


### PR DESCRIPTION
## Summary
- RCx span-preserving downsample used SQL `MOD()`, which DataFusion 43 rejects → empty timeseries presets (zone temps, AHU DATs, dampers/valves, etc.).
- Switch to the `%` remainder operator so BUILDING_100 / vibe19-style plots return points again.
- Scatter / box / ranking / metering paths were already OK; this unblocks the timeseries family.

## Test plan
- [ ] Rust Stack CI green on this PR
- [ ] After merge: GHCR publishes `openfdd-central:sha-<tip>` (+ nightly)
- [ ] On bensbench: `docker pull` central only (no local build) and recreate
- [ ] `POST /api/analytics/rcx/preset` with `ahu_dats` / `zone_temps` on `BUILDING_100` returns points (no `Invalid function 'mod'`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue affecting RCx time-series queries.
  * Preserved existing span-preserving downsampling behavior while improving query compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->