### PR TITLE
Plotly RCx/FDD vibe19 parity + delete UX

### DIFF
--- a/frontend/web/src/api/jobsApi.test.ts
+++ b/frontend/web/src/api/jobsApi.test.ts
@@ -96,6 +96,7 @@ import { apiFetch } from "./client";
 import {
   archiveJob,
   createJob,
+  deleteJob,
   duplicateJob,
   getJob,
   listJobs,
@@ -182,6 +183,19 @@ describe("jobsApi client calls", () => {
     expect(apiFetch).toHaveBeenCalledWith(
       `/api/jobs/${encodeURIComponent(sampleJob.job_id)}/archive`,
       { method: "POST" },
+    );
+  });
+
+  it("deleteJob DELETEs job id", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: true,
+      deleted: true,
+      job_id: sampleJob.job_id,
+    });
+    await deleteJob(sampleJob.job_id);
+    expect(apiFetch).toHaveBeenCalledWith(
+      `/api/jobs/${encodeURIComponent(sampleJob.job_id)}`,
+      { method: "DELETE" },
     );
   });
 

--- a/frontend/web/src/api/jobsApi.ts
+++ b/frontend/web/src/api/jobsApi.ts
@@ -200,6 +200,13 @@ export async function restoreJob(jobId: string): Promise<JobMeta> {
   return body.job;
 }
 
+export async function deleteJob(jobId: string): Promise<{ ok: boolean; job_id: string }> {
+  return apiFetch<{ ok: boolean; deleted?: boolean; job_id: string }>(
+    `/api/jobs/${encodeURIComponent(jobId)}`,
+    { method: "DELETE" },
+  );
+}
+
 export async function duplicateJob(jobId: string, newName?: string): Promise<JobMeta> {
   const body = await apiFetch<JobResponse>(
     `/api/jobs/${encodeURIComponent(jobId)}/duplicate`,

--- a/frontend/web/src/api/roleUnits.ts
+++ b/frontend/web/src/api/roleUnits.ts
@@ -9,8 +9,10 @@ export const DEFAULT_ROLE_UNITS: Record<string, string> = {
   web_oa_t: "°F",
   web_oa_dp: "°F",
   zone_t: "°F",
+  zone_flow: "cfm",
   chw_supply_t: "°F",
   chw_return_t: "°F",
+  cw_supply_t: "°F",
   hw_supply_t: "°F",
   hw_return_t: "°F",
   oa_damper_pct: "%",
@@ -23,6 +25,8 @@ export const DEFAULT_ROLE_UNITS: Record<string, string> = {
   occ_mode: "bool",
   duct_static: "in. w.c.",
   duct_static_sp: "in. w.c.",
+  elec_power: "kWh",
+  gas_flow: "therm",
 };
 
 const UNIT_FAMILY: Record<string, string> = {

--- a/frontend/web/src/api/vibeCharts.test.ts
+++ b/frontend/web/src/api/vibeCharts.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   multiEquipmentBox,
+  multiEquipmentTimeseries,
   rankingBars,
+  rcxFigureHasFaultLane,
   ruleResultChart,
   sensorFaultChart,
   sensorHealthHeatmap,
@@ -62,6 +64,16 @@ describe("vibeCharts", () => {
     expect(
       fig?.data.every((t) => !String(t.name).includes("undefined")),
     ).toBe(true);
+    const signal = (fig?.data ?? []).filter((t) => t.name !== "confirmed_fault");
+    expect(signal.every((t) => t.fill == null && t.fillcolor == null)).toBe(
+      true,
+    );
+    const fault = fig?.data.find((t) => t.name === "confirmed_fault");
+    expect(fault?.fill).toBe("tozeroy");
+    expect(fault?.mode).toBe("lines");
+    expect(
+      (last as { range?: number[] } | undefined)?.range,
+    ).toEqual([-0.05, 1.15]);
   });
 
   it("ruleResultChart rejects PrimitiveArray timestamp dumps", () => {
@@ -99,6 +111,39 @@ describe("vibeCharts", () => {
     );
     expect(fig?.data).toHaveLength(2);
     expect(fig?.data[0]?.type).toBe("box");
+  });
+
+  it("RCx timeseries never includes a confirmed_fault lane", () => {
+    const fig = multiEquipmentTimeseries(
+      [
+        {
+          equipment_id: "AHU_1",
+          timestamp_utc: "2026-01-01T00:00:00Z",
+          value_f: 55,
+          series: "primary",
+        },
+        {
+          equipment_id: "AHU_1",
+          timestamp_utc: "2026-01-01T00:00:00Z",
+          value_f: 1,
+          series: "motor",
+        },
+        {
+          equipment_id: "AHU_2",
+          timestamp_utc: "2026-01-01T00:00:00Z",
+          value_f: 58,
+          series: "primary",
+        },
+      ],
+      { title: "ahu_dats", yTitle: "°F" },
+    );
+    expect(rcxFigureHasFaultLane(fig)).toBe(false);
+    expect(fig?.data.some((t) => t.yaxis === "y2")).toBe(true);
+    expect(fig?.layout?.yaxis2).toBeTruthy();
+    const y2 = fig?.layout?.yaxis2 as { title?: { text?: string } };
+    expect(y2?.title?.text).toBe("motor on");
+    expect(fig?.layout?.yaxis?.title).toBe("°F");
+    expect(fig?.layout?.xaxis?.title).toBe("timestamp");
   });
 
   it("sensorHealthHeatmap builds coverage grid", () => {

--- a/frontend/web/src/api/vibeCharts.ts
+++ b/frontend/web/src/api/vibeCharts.ts
@@ -9,11 +9,69 @@ import {
 import { overviewChartLayout, rainbowColor } from "./plotlyTheme";
 import { familyOrderKeys, resolveRoleUnit, unitFamily } from "./roleUnits";
 
+/** Outlier red — vibe19 charts.py stroke for z-score outliers. */
+export const OUTLIER_RED = "#dc2626";
+
+/** Equipment ids whose primary-series mean is ≥ outlierZ σ from cohort mean. */
+export function outlierEquipmentIds(
+  points: Array<Record<string, unknown>>,
+  opts?: { outlierZ?: number; valueKey?: string; primaryOnly?: boolean },
+): Set<string> {
+  const zCut = opts?.outlierZ ?? 2.5;
+  const valueKey = opts?.valueKey ?? "value_f";
+  const primaryOnly = opts?.primaryOnly ?? true;
+  const means = new Map<string, { sum: number; n: number }>();
+  for (const p of points) {
+    if (primaryOnly) {
+      const series = String(p.series ?? "primary");
+      if (series !== "primary") continue;
+    }
+    const eq = String(p.equipment_id ?? "");
+    if (!eq) continue;
+    const raw = p[valueKey] ?? p.fail_pct;
+    const n = typeof raw === "number" ? raw : Number(raw);
+    if (!Number.isFinite(n)) continue;
+    const cur = means.get(eq) ?? { sum: 0, n: 0 };
+    cur.sum += n;
+    cur.n += 1;
+    means.set(eq, cur);
+  }
+  const vals = [...means.entries()].map(([eq, { sum, n }]) => ({
+    eq,
+    mean: sum / n,
+  }));
+  if (vals.length < 3) return new Set();
+  const mu = vals.reduce((a, v) => a + v.mean, 0) / vals.length;
+  const sd = Math.sqrt(
+    vals.reduce((a, v) => a + (v.mean - mu) ** 2, 0) / vals.length,
+  );
+  if (!(sd > 0)) return new Set();
+  const out = new Set<string>();
+  for (const v of vals) {
+    if (Math.abs(v.mean - mu) / sd >= zCut) out.add(v.eq);
+  }
+  return out;
+}
+
+/** True when an RCx figure accidentally grew an FDD fault lane. */
+export function rcxFigureHasFaultLane(fig: PlotlyFigure | null): boolean {
+  if (!fig) return false;
+  if (fig.data.some((t) => String(t.name) === "confirmed_fault")) return true;
+  for (const [k, v] of Object.entries(fig.layout ?? {})) {
+    if (!/^yaxis\d*$/.test(k) || !v || typeof v !== "object") continue;
+    const title = (v as { title?: string | { text?: string } }).title;
+    const text = typeof title === "string" ? title : title?.text;
+    if (text === "fault") return true;
+  }
+  return false;
+}
+
 export function multiEquipmentTimeseries(
   points: Array<Record<string, unknown>>,
   opts: { title: string; yTitle?: string },
 ): PlotlyFigure | null {
   if (!points.length) return null;
+  const outliers = outlierEquipmentIds(points);
   const byKey = new Map<string, Array<Record<string, unknown>>>();
   for (const p of points) {
     const eq = String(p.equipment_id ?? "eq");
@@ -27,16 +85,52 @@ export function multiEquipmentTimeseries(
             ? `${eq} · return`
             : series === "delta_t"
               ? `${eq} · ΔT`
-              : `${eq} · ${series}`;
+              : series === "motor"
+                ? `${eq} · motor on`
+                : `${eq} · ${series}`;
     const list = byKey.get(name) ?? [];
     list.push(p);
     byKey.set(name, list);
   }
   const data: PlotlyTrace[] = [];
-  let i = 0;
+  let colorI = 0;
+  const colorsByEq = new Map<string, string>();
+  const primaryNames = [...byKey.keys()]
+    .filter((n) => !n.includes(" · "))
+    .sort((a, b) => a.localeCompare(b));
+  for (const name of primaryNames) {
+    const eq = name;
+    const isOut = outliers.has(eq);
+    const color = isOut ? OUTLIER_RED : rainbowColor(colorI);
+    if (!isOut) colorI += 1;
+    colorsByEq.set(eq, color);
+    const rows = byKey.get(name) ?? [];
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name: isOut ? `${name} ★` : name,
+      x: rows.map((r) => String(r.timestamp_utc ?? "")),
+      y: rows.map((r) => {
+        const v = r.value_f;
+        if (v == null || v === "") return null;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      line: {
+        width: isOut ? 2.4 : 1.4,
+        color,
+        dash: isOut ? "dash" : "solid",
+      },
+      connectgaps: false,
+    });
+  }
+  // Non-primary overlays (setpoint / return / ΔT) stay on primary y.
   for (const [name, rows] of [...byKey.entries()].sort((a, b) =>
     a[0].localeCompare(b[0]),
   )) {
+    if (!name.includes(" · ") || name.endsWith(" · motor on")) continue;
+    const eq = name.split(" · ")[0] ?? name;
+    const color = colorsByEq.get(eq) ?? rainbowColor(colorI++);
     data.push({
       type: "scatter",
       mode: "lines",
@@ -48,27 +142,66 @@ export function multiEquipmentTimeseries(
         const n = typeof v === "number" ? v : Number(v);
         return Number.isFinite(n) ? n : null;
       }),
-      line: { width: 1.4, color: rainbowColor(i) },
+      line: { width: 1.2, color, dash: "dot" },
+      connectgaps: false,
     });
-    i += 1;
+  }
+  let hasMotor = false;
+  for (const [name, rows] of [...byKey.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    if (!name.endsWith(" · motor on")) continue;
+    const eq = name.split(" · ")[0] ?? name;
+    const color = colorsByEq.get(eq);
+    if (!color) continue;
+    hasMotor = true;
+    data.push({
+      type: "scatter",
+      mode: "lines",
+      name,
+      x: rows.map((r) => String(r.timestamp_utc ?? "")),
+      y: rows.map((r) => {
+        const v = r.value_f;
+        if (v == null || v === "") return null;
+        const n = typeof v === "number" ? v : Number(v);
+        return Number.isFinite(n) ? n : null;
+      }),
+      yaxis: "y2",
+      line: { width: 1.0, color, dash: "dot", shape: "hv" },
+      opacity: 0.7,
+      connectgaps: false,
+    } as PlotlyTrace);
+  }
+  const extra: Record<string, unknown> = {
+    title: opts.title,
+    xaxis: {
+      title: "timestamp",
+      type: "date",
+      autorange: true,
+      tickangle: -30,
+    },
+  };
+  if (hasMotor) {
+    extra.yaxis2 = {
+      overlaying: "y",
+      side: "right",
+      range: [-0.08, 1.4],
+      tickvals: [0, 1],
+      ticktext: ["off", "on"],
+      title: { text: "motor on", font: { size: 10 } },
+      showgrid: false,
+      autorange: false,
+    };
   }
   return {
     data,
     layout: overviewChartLayout({
-      xTitle: "time",
+      xTitle: "timestamp",
       yTitle: opts.yTitle ?? "value",
       height: Math.max(380, 40 + 14 * Math.min(byKey.size, 16)),
       tickangle: -30,
       uirevision: `rcx-ts:${fingerprintJson(points.slice(0, 50))}`,
-      extra: {
-        title: opts.title,
-        xaxis: {
-          title: "time",
-          type: "date",
-          autorange: true,
-          tickangle: -30,
-        },
-      },
+      extra,
     }),
     meta: {
       point_count: points.length,
@@ -79,7 +212,7 @@ export function multiEquipmentTimeseries(
 
 export function oatScatter(
   points: Array<Record<string, unknown>>,
-  opts: { title: string; yTitle: string },
+  opts: { title: string; yTitle: string; xTitle?: string },
 ): PlotlyFigure | null {
   if (!points.length) return null;
   const byEq = new Map<string, Array<Record<string, unknown>>>();
@@ -89,15 +222,22 @@ export function oatScatter(
     list.push(p);
     byEq.set(eq, list);
   }
+  const outliers = outlierEquipmentIds(points, {
+    valueKey: "y_f",
+    primaryOnly: false,
+  });
   const data: PlotlyTrace[] = [];
   let i = 0;
   for (const [eq, rows] of [...byEq.entries()].sort((a, b) =>
     a[0].localeCompare(b[0]),
   )) {
+    const isOut = outliers.has(eq);
+    const color = isOut ? OUTLIER_RED : rainbowColor(i);
+    if (!isOut) i += 1;
     data.push({
       type: "scatter",
       mode: "markers",
-      name: eq,
+      name: isOut ? `${eq} ★` : eq,
       x: rows.map((r) => {
         const v = r.oat_f;
         const n = typeof v === "number" ? v : Number(v);
@@ -108,9 +248,8 @@ export function oatScatter(
         const n = typeof v === "number" ? v : Number(v);
         return Number.isFinite(n) ? n : null;
       }),
-      marker: { size: 6, opacity: 0.65, color: rainbowColor(i) },
+      marker: { size: isOut ? 7 : 6, opacity: 0.65, color },
     });
-    i += 1;
   }
   const hasDry = points.some((p) => p.dry_bulb_f != null);
   if (hasDry) {
@@ -134,7 +273,7 @@ export function oatScatter(
   return {
     data,
     layout: overviewChartLayout({
-      xTitle: "OAT °F",
+      xTitle: opts.xTitle ?? "Web dry-bulb °F",
       yTitle: opts.yTitle,
       height: 420,
       tickangle: 0,
@@ -164,19 +303,22 @@ export function multiEquipmentBox(
     byEq.set(eq, list);
   }
   if (!byEq.size) return null;
+  const outliers = outlierEquipmentIds(points);
   const data: PlotlyTrace[] = [];
   let i = 0;
   for (const [eq, ys] of [...byEq.entries()].sort((a, b) =>
     a[0].localeCompare(b[0]),
   )) {
+    const isOut = outliers.has(eq);
+    const color = isOut ? OUTLIER_RED : rainbowColor(i);
+    if (!isOut) i += 1;
     data.push({
       type: "box",
-      name: eq,
+      name: isOut ? `${eq} ★` : eq,
       y: ys,
-      marker: { color: rainbowColor(i) },
-      boxpoints: false,
+      marker: { color },
+      boxpoints: "outliers",
     } as PlotlyTrace);
-    i += 1;
   }
   return {
     data,
@@ -205,6 +347,7 @@ export function rankingBars(
     const bv = Number(b.value_f ?? b.fail_pct ?? 0);
     return bv - av;
   });
+  const outliers = outlierEquipmentIds(sorted, { primaryOnly: false });
   return {
     data: [
       {
@@ -216,7 +359,13 @@ export function rankingBars(
           const n = typeof v === "number" ? v : Number(v);
           return Number.isFinite(n) ? n : null;
         }),
-        marker: { color: sorted.map((_, i) => rainbowColor(i)) },
+        marker: {
+          color: sorted.map((r, i) =>
+            outliers.has(String(r.equipment_id ?? ""))
+              ? OUTLIER_RED
+              : rainbowColor(i),
+          ),
+        },
       },
     ],
     layout: overviewChartLayout({
@@ -236,7 +385,7 @@ export function rankingBars(
 
 export function meteringCharts(
   points: Array<Record<string, unknown>>,
-  opts: { title: string; ddLabel?: string },
+  opts: { title: string; ddLabel?: string; energyYTitle?: string },
 ): PlotlyFigure | null {
   if (!points.length) return null;
   const byEq = new Map<string, Array<Record<string, unknown>>>();
@@ -286,15 +435,16 @@ export function meteringCharts(
     });
     i += 1;
   }
+  const energyTitle = opts.energyYTitle ?? "energy";
   return {
     data: [...barData, ...scatterData],
     layout: {
       title: opts.title,
       grid: { rows: 1, columns: 2, pattern: "independent" },
       xaxis: { title: "month", domain: [0, 0.45] },
-      yaxis: { title: "energy" },
+      yaxis: { title: energyTitle },
       xaxis2: { title: opts.ddLabel ?? "degree-days", domain: [0.55, 1] },
-      yaxis2: { title: "energy", anchor: "x2" },
+      yaxis2: { title: energyTitle, anchor: "x2" },
       height: 420,
       legend: { orientation: "h" },
       paper_bgcolor: "white",
@@ -413,6 +563,7 @@ export function ruleResultChart(
         yaxis: yname,
         line: { width: 1.6, color: rainbowColor(colorI) },
         connectgaps: false,
+        // Signal traces: lines only — fill reserved for confirmed_fault lane.
       });
       colorI += 1;
     }

--- a/frontend/web/src/components/OracleSidebar.tsx
+++ b/frontend/web/src/components/OracleSidebar.tsx
@@ -302,6 +302,10 @@ export function OracleSidebar({ collapsed }: { collapsed: boolean }) {
                 </option>
               ))}
             </select>
+            <p className="oracle-sidebar__caption" style={{ marginTop: "0.35rem" }}>
+              To remove this site’s feathers + FDD results, check confirm below and use{" "}
+              <strong>Delete dataset…</strong>
+            </p>
           </label>
         )}
       </section>
@@ -376,7 +380,7 @@ export function OracleSidebar({ collapsed }: { collapsed: boolean }) {
             onClick={() => void onDeleteActiveSite()}
             data-testid="sidebar-delete-site"
           >
-            Delete…
+            Delete dataset…
           </button>
         </div>
         <label className="oracle-sidebar__check">
@@ -386,7 +390,7 @@ export function OracleSidebar({ collapsed }: { collapsed: boolean }) {
             onChange={(e) => setConfirmDelete(e.target.checked)}
             data-testid="sidebar-confirm-delete"
           />
-          Confirm delete Active site
+          Confirm delete Active site dataset
         </label>
 
         {loading ? (

--- a/frontend/web/src/components/widgets/PlotlyHost.test.tsx
+++ b/frontend/web/src/components/widgets/PlotlyHost.test.tsx
@@ -1,7 +1,50 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
-import { PlotlyHost } from "./PlotlyHost";
+import { mergePlotlyHostLayout, PlotlyHost } from "./PlotlyHost";
 import { sanitizePlotlyFigure } from "../../api/plotlySanitize";
+
+describe("mergePlotlyHostLayout", () => {
+  it("keeps fixed range on fault y2 and does not force autorange", () => {
+    const layout = mergePlotlyHostLayout(
+      {
+        yaxis: { domain: [0.35, 1], title: { text: "°F" } },
+        yaxis2: {
+          domain: [0, 0.28],
+          title: { text: "fault" },
+          range: [-0.05, 1.15],
+          tickvals: [0, 1],
+          ticktext: ["ok", "fault"],
+        },
+      },
+      {
+        height: 400,
+        id: "fdd",
+        figureId: "fc1",
+        data: [{ yaxis: "y" }, { yaxis: "y2" }],
+      },
+    );
+    const y2 = layout.yaxis2 as { range?: number[]; autorange?: boolean };
+    expect(y2.range).toEqual([-0.05, 1.15]);
+    expect(y2.autorange).toBe(false);
+    const y1 = layout.yaxis as { autorange?: boolean };
+    expect(y1.autorange).toBe(true);
+  });
+
+  it("patches yaxis3+ from stacked ruleResultChart domains", () => {
+    const layout = mergePlotlyHostLayout(
+      {
+        yaxis: { domain: [0.7, 1] },
+        yaxis2: { domain: [0.4, 0.65] },
+        yaxis3: { domain: [0, 0.3], range: [-0.05, 1.15] },
+      },
+      { height: 480, id: "stack", data: [{ yaxis: "y3" }] },
+    );
+    const y3 = layout.yaxis3 as { range?: number[]; autorange?: boolean };
+    expect(y3.range).toEqual([-0.05, 1.15]);
+    expect(y3.autorange).toBe(false);
+  });
+});
+
 
 describe("sanitizePlotlyFigure", () => {
   it("strips template and rejects empty data", () => {

--- a/frontend/web/src/components/widgets/PlotlyHost.tsx
+++ b/frontend/web/src/components/widgets/PlotlyHost.tsx
@@ -36,6 +36,58 @@ declare global {
   }
 }
 
+/**
+ * Merge figure layout with host defaults without clobbering fixed fault ranges
+ * or stacked yaxis3+ domains from vibe19-style ruleResultChart.
+ */
+export function mergePlotlyHostLayout(
+  baseLayout: Record<string, unknown>,
+  opts: { height: number; figureId?: string; id: string; data: Array<{ yaxis?: string }> },
+): Record<string, unknown> {
+  const axisPatch = (key: string) => {
+    const prev = (baseLayout[key] as Record<string, unknown> | undefined) ?? {};
+    // Preserve fixed ranges (fault lane [-0.05, 1.15]); only autorange when unset.
+    if (prev.range != null) {
+      return { ...prev, autorange: false };
+    }
+    return { ...prev, autorange: true };
+  };
+
+  const layout: Record<string, unknown> = {
+    paper_bgcolor: "rgba(0,0,0,0)",
+    plot_bgcolor: "rgba(0,0,0,0)",
+    font: { family: "Source Sans 3, Source Sans, sans-serif", size: 12 },
+    ...baseLayout,
+  };
+
+  // Always patch primary x / y.
+  layout.xaxis = axisPatch("xaxis");
+  layout.yaxis = axisPatch("yaxis");
+
+  // Preserve every yaxisN from the figure (stacked unit families + fault).
+  for (const key of Object.keys(baseLayout)) {
+    if (/^yaxis\d+$/.test(key)) {
+      layout[key] = axisPatch(key);
+    }
+  }
+  // Ensure yaxis2 exists when traces reference it even if layout omitted it.
+  if (
+    layout.yaxis2 == null &&
+    opts.data.some((t) => t.yaxis === "y2")
+  ) {
+    layout.yaxis2 = axisPatch("yaxis2");
+  }
+
+  const uirevision =
+    (baseLayout.uirevision as string | undefined) ??
+    `${opts.figureId ?? opts.id}`;
+  layout.uirevision = uirevision;
+  layout.height = (baseLayout.height as number | undefined) ?? opts.height;
+  layout.autosize = true;
+  delete layout.template;
+  return layout;
+}
+
 function waitForPlotly(timeoutMs = 8000): {
   promise: Promise<PlotlyStatic | null>;
   cancel: () => void;
@@ -141,29 +193,19 @@ export function PlotlyHost({
         return;
       }
       const baseLayout = (clean.layout as Record<string, unknown> | undefined) ?? {};
-      const axisPatch = (key: string) => {
-        const prev = (baseLayout[key] as Record<string, unknown> | undefined) ?? {};
-        return { ...prev, autorange: true };
-      };
       // Fingerprint figure so Plotly.react resets sticky zoom after Update analytics.
       const uirevision =
         (baseLayout.uirevision as string | undefined) ??
         `${figureId ?? id}:${fingerprintJson(clean.data)}:${clean.meta?.provenance ?? ""}`;
-      const layout: Record<string, unknown> = {
-        paper_bgcolor: "rgba(0,0,0,0)",
-        plot_bgcolor: "rgba(0,0,0,0)",
-        font: { family: "Source Sans 3, Source Sans, sans-serif", size: 12 },
-        ...baseLayout,
-        xaxis: axisPatch("xaxis"),
-        yaxis: axisPatch("yaxis"),
-        ...(baseLayout.yaxis2 != null || clean.data.some((t) => t.yaxis === "y2")
-          ? { yaxis2: axisPatch("yaxis2") }
-          : {}),
-        uirevision,
-        height: (baseLayout.height as number | undefined) ?? height,
-        autosize: true,
-      };
-      delete layout.template;
+      const layout = mergePlotlyHostLayout(
+        { ...baseLayout, uirevision },
+        {
+          height,
+          figureId,
+          id,
+          data: clean.data as Array<{ yaxis?: string }>,
+        },
+      );
       const config = {
         responsive: true,
         displayModeBar: true,
@@ -199,7 +241,7 @@ export function PlotlyHost({
         /* ignore */
       }
     };
-  }, [clean, height]);
+  }, [clean, height, figureId, id]);
 
   const statusMsg = loading
     ? "Loading chart…"

--- a/frontend/web/src/pages/JobsPage.test.tsx
+++ b/frontend/web/src/pages/JobsPage.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../api/jobsApi", () => ({
   archiveJob: vi.fn(),
   restoreJob: vi.fn(),
   duplicateJob: vi.fn(),
+  deleteJob: vi.fn(),
   isJobRevisionConflict: (err: unknown) =>
     err instanceof Error && err.name === "JobRevisionConflictError",
   JobRevisionConflictError: class JobRevisionConflictError extends Error {

--- a/frontend/web/src/pages/JobsPage.tsx
+++ b/frontend/web/src/pages/JobsPage.tsx
@@ -4,6 +4,7 @@ import { ApiClientError } from "../api/client";
 import {
   archiveJob,
   createJob,
+  deleteJob,
   duplicateJob,
   getJob,
   isJobRevisionConflict,
@@ -78,6 +79,7 @@ export function JobsPage() {
   const [editDescription, setEditDescription] = useState("");
 
   const [archiveModalOpen, setArchiveModalOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
   const [duplicateName, setDuplicateName] = useState("");
 
@@ -220,6 +222,27 @@ export function JobsPage() {
       await refreshList();
       setArchiveModalOpen(false);
       setActionNotice(`Archived ${updated.job_name}.`);
+    } catch (err) {
+      setActionError(formatApiError(err));
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleDeleteConfirm() {
+    if (!selectedJob) return;
+    const id = selectedJob.job_id;
+    const name = selectedJob.job_name;
+    setActionLoading(true);
+    setActionError(null);
+    setActionNotice(null);
+    try {
+      await deleteJob(id);
+      setSelectedJob(null);
+      setQuery({ jobId: undefined }, true);
+      await refreshList();
+      setDeleteModalOpen(false);
+      setActionNotice(`Permanently deleted ${name}.`);
     } catch (err) {
       setActionError(formatApiError(err));
     } finally {
@@ -496,6 +519,14 @@ export function JobsPage() {
                     }}
                     testId="jobs-duplicate"
                   />
+                  <Button
+                    id="jobs-delete"
+                    label="Delete"
+                    variant="danger"
+                    loading={actionLoading}
+                    onClick={() => setDeleteModalOpen(true)}
+                    testId="jobs-delete"
+                  />
                 </div>
               </>
             ) : null}
@@ -516,6 +547,22 @@ export function JobsPage() {
           onConfirm={() => void handleArchiveConfirm()}
           onCancel={() => setArchiveModalOpen(false)}
           testId="jobs-archive-modal"
+        />
+
+        <ConfirmModal
+          id="jobs-delete-modal"
+          open={deleteModalOpen}
+          title="Delete job permanently"
+          message={
+            selectedJob
+              ? `Permanently delete "${selectedJob.job_name}" and its workspace files? This cannot be undone. Prefer Archive if you may need it later.`
+              : "Permanently delete this job?"
+          }
+          confirmLabel="Delete permanently"
+          loading={actionLoading}
+          onConfirm={() => void handleDeleteConfirm()}
+          onCancel={() => setDeleteModalOpen(false)}
+          testId="jobs-delete-modal"
         />
 
         <ConfirmModal

--- a/frontend/web/src/pages/RcxPage.tsx
+++ b/frontend/web/src/pages/RcxPage.tsx
@@ -21,11 +21,27 @@ import {
   multiEquipmentTimeseries,
   oatScatter,
   rankingBars,
+  rcxFigureHasFaultLane,
 } from "../api/vibeCharts";
+import { resolveRoleUnit } from "../api/roleUnits";
 import type { PlotlyFigure } from "../api/plotDataset";
 
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function rcxYTitle(roleCol: string | undefined, fallback: string): string {
+  const role = (roleCol ?? "").trim();
+  if (!role) return fallback;
+  const unit = resolveRoleUnit(role);
+  return unit || role || fallback;
+}
+
+function rcxScatterXTitle(coverage: Record<string, unknown> | undefined): string {
+  if (coverage?.prefer_wetbulb === true) return "Web wet-bulb °F";
+  const oat = String(coverage?.oat_column ?? "");
+  if (oat.includes("wb") || oat.includes("wet")) return "Web wet-bulb °F";
+  return "Web dry-bulb °F";
 }
 
 /** vibe19 RCx Plots — preset picker + DataFusion historian series. */
@@ -204,29 +220,41 @@ export function RcxPage() {
         return;
       }
       let fig: PlotlyFigure | null = null;
+      const roleCol = String(res.coverage?.role_col ?? res.coverage?.y_col ?? "");
+      const unitTitle = rcxYTitle(roleCol, "value");
       if (kind === "scatter_oat") {
         fig = oatScatter(points, {
           title,
-          yTitle: String(res.coverage?.y_col ?? "value"),
+          yTitle: unitTitle,
+          xTitle: rcxScatterXTitle(res.coverage as Record<string, unknown>),
         });
       } else if (kind === "box") {
         fig = multiEquipmentBox(points, {
           title,
-          yTitle: String(res.coverage?.role_col ?? "value"),
+          yTitle: unitTitle,
         });
       } else if (kind === "ranking") {
-        fig = rankingBars(points, { title });
+        fig = rankingBars(points, {
+          title,
+          yTitle: "comfort fail %",
+        });
       } else if (kind === "metering") {
+        const gas = String(res.coverage?.meter_kind ?? "") === "gas";
         fig = meteringCharts(points, {
           title,
-          ddLabel:
-            String(res.coverage?.meter_kind ?? "") === "gas" ? "HDD" : "CDD",
+          ddLabel: gas ? "HDD" : "CDD",
+          energyYTitle: gas ? "gas" : "kWh",
         });
       } else {
         fig = multiEquipmentTimeseries(points, {
           title,
-          yTitle: String(res.coverage?.role_col ?? "value"),
+          yTitle: unitTitle,
         });
+      }
+      if (rcxFigureHasFaultLane(fig)) {
+        setFigure(null);
+        setError("Internal: RCx figure must not include a fault lane");
+        return;
       }
       setFigure(fig);
     } catch (err) {

--- a/frontend/web/src/pages/ReportsPage.test.tsx
+++ b/frontend/web/src/pages/ReportsPage.test.tsx
@@ -41,8 +41,8 @@ vi.mock("../api/fddApi", () => ({
     rule_id: "VAV-1",
     roles: ["zone_t"],
     rows: [
-      { timestamp_utc: "2024-01-01T00:00:00Z", zone_t: 70 },
-      { timestamp_utc: "2024-01-01T00:05:00Z", zone_t: 71 },
+      { timestamp_utc: "2024-01-01T00:00:00Z", zone_t: 70, confirmed_fault: 0 },
+      { timestamp_utc: "2024-01-01T00:05:00Z", zone_t: 71, confirmed_fault: 1 },
     ],
     downsampled: false,
     max_points: 5000,

--- a/frontend/web/src/pages/ReportsPage.tsx
+++ b/frontend/web/src/pages/ReportsPage.tsx
@@ -23,6 +23,13 @@ import {
   sensorHealthHeatmap,
 } from "../api/vibeCharts";
 
+export const SQL_ANALYTICS_RULE_IDS = new Set([
+  "FAN-RUNTIME-HOURS",
+  "AVG-ZONE-TEMP",
+  "ZONE-COMFORT-PCT",
+  "FAULT-ELAPSED-HOURS",
+]);
+
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -96,6 +103,13 @@ export function ReportsPage() {
     setRuleOptions([
       { value: "", label: "— rule —" },
       ...rules.map((r) => {
+        if (SQL_ANALYTICS_RULE_IDS.has(r.rule_id)) {
+          return {
+            value: r.rule_id,
+            label: `${r.rule_id} — analytics rollup (no fault series)`,
+            disabled: true,
+          };
+        }
         const required = (r.required_roles ?? []).filter(Boolean);
         const missing =
           mappedRoles.size > 0
@@ -112,6 +126,13 @@ export function ReportsPage() {
       }),
     ]);
   }, [rules, mappedRoles]);
+
+  useEffect(() => {
+    if (ruleId && SQL_ANALYTICS_RULE_IDS.has(ruleId)) {
+      const next = rules.find((r) => !SQL_ANALYTICS_RULE_IDS.has(r.rule_id));
+      setRuleId(next?.rule_id ?? "");
+    }
+  }, [rules, ruleId]);
 
   useEffect(() => {
     if (!buildingId) {
@@ -139,6 +160,13 @@ export function ReportsPage() {
       setError("Select equipment and rule");
       return;
     }
+    if (SQL_ANALYTICS_RULE_IDS.has(ruleId)) {
+      setFigure(null);
+      setError(
+        "Analytics rollups have no per-sample fault series — pick a diagnostic rule (FC*, VAV*, ECON*, …) and Run FDD first.",
+      );
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -152,12 +180,19 @@ export function ReportsPage() {
         return null;
       });
       const hasFault = fault.some((v) => v != null);
+      if (!hasFault) {
+        setFigure(null);
+        setError(
+          "No confirmed_fault overlay on this series — Run FDD on Rules for this equipment/rule, then Load series again.",
+        );
+        return;
+      }
       setFigure(
         ruleResultChart(rows, {
           equipmentId: series.equipment_id ?? equipmentId,
           ruleId: series.rule_id ?? ruleId,
           roles,
-          confirmedFault: hasFault ? fault : undefined,
+          confirmedFault: fault,
         }),
       );
     } catch (err) {
@@ -317,8 +352,10 @@ export function ReportsPage() {
         <div data-testid="plots-page">
           <h2>FDD plot datasets</h2>
           <p>
-            Loads <code>GET /api/fdd/series</code>. Run FDD via{" "}
-            <Link to="/rules">Rules</Link> first.
+            Diagnostic rule series via <code>GET /api/fdd/series</code> with a
+            bottom <strong>confirmed_fault</strong> lane (vibe19{" "}
+            <code>rule_result_chart</code>). Analytics rollups are disabled here.
+            Run FDD on <Link to="/rules">Rules</Link> first.
           </p>
 
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem" }}>

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -1730,19 +1730,28 @@ pub async fn rcx_timeseries_from_history(
         .filter(|c| cols.contains(*c))
         .map(|c| format!(", {c} AS return_f"))
         .unwrap_or_else(|| ", CAST(NULL AS FLOAT) AS return_f".into());
+    // Optional motor/fan proof for vibe19 right-hand "motor on" y2 overlay.
+    let motor_sel = if cols.contains("fan_status") {
+        ", fan_status AS motor_f".to_string()
+    } else if cols.contains("fan_cmd") {
+        ", CASE WHEN fan_cmd > 0.05 THEN 1.0 ELSE 0.0 END AS motor_f".to_string()
+    } else {
+        ", CAST(NULL AS FLOAT) AS motor_f".into()
+    };
     // Span-preserving downsample (vibe19): keep first/last + evenly spaced rows
     // across the full historian range instead of LIMIT taking only the earliest.
     // DataFusion 43 has no SQL `MOD()` / `GREATEST()` — use `%` and CASE.
     let sql = format!(
         r#"
-SELECT timestamp_utc, equipment_id, value_f, overlay_f, return_f
+SELECT timestamp_utc, equipment_id, value_f, overlay_f, return_f, motor_f
 FROM (
   SELECT
     CAST({ts_col} AS VARCHAR) AS timestamp_utc,
     equipment_id,
     {role_col} AS value_f
     {overlay_sel}
-    {return_sel},
+    {return_sel}
+    {motor_sel},
     ROW_NUMBER() OVER (ORDER BY {ts_col}, equipment_id) AS _rn,
     COUNT(*) OVER () AS _cnt
   FROM history
@@ -1788,13 +1797,22 @@ LIMIT {limit}
             }
             points.push(rr);
             if let Some(sup) = as_f64(r.get("value_f")) {
-                let mut d = row;
+                let mut d = row.clone();
                 if let Some(obj) = d.as_object_mut() {
                     obj.insert("value_f".into(), json!(round2(ret - sup)));
                     obj.insert("series".into(), json!("delta_t"));
                 }
                 points.push(d);
             }
+        }
+        if let Some(m) = as_f64(r.get("motor_f")) {
+            let mut mo = row;
+            if let Some(obj) = mo.as_object_mut() {
+                let on = if m > 0.05 { 1.0 } else { 0.0 };
+                obj.insert("value_f".into(), json!(on));
+                obj.insert("series".into(), json!("motor"));
+            }
+            points.push(mo);
         }
     }
     let warnings = vec!["RCx role timeseries from historian DataFusion".into()];

--- a/services/central/src/analytics/rcx_presets.rs
+++ b/services/central/src/analytics/rcx_presets.rs
@@ -341,10 +341,10 @@ fn annotate(mut env: AnalyticsEnvelope, meta: &RcxPresetMeta) -> AnalyticsEnvelo
         obj.insert("family".into(), json!(meta.family));
         obj.insert("role_col".into(), json!(meta.role_col));
         obj.insert("y_col".into(), json!(meta.role_col));
-    }
-    env.coverage = Some(cov);
-    env
-}
+        obj.insert("prefer_wetbulb".into(), json!(meta.prefer_wetbulb));
+        if let Some(mk) = meta.meter_kind {
+            obj.insert("meter_kind".into(), json!(mk));
+        }
 
 fn empty_stub(meta: &RcxPresetMeta, reason: &str) -> AnalyticsEnvelope {
     let query = AnalyticsQuery::default();

--- a/services/central/src/analytics/rcx_presets.rs
+++ b/services/central/src/analytics/rcx_presets.rs
@@ -345,6 +345,10 @@ fn annotate(mut env: AnalyticsEnvelope, meta: &RcxPresetMeta) -> AnalyticsEnvelo
         if let Some(mk) = meta.meter_kind {
             obj.insert("meter_kind".into(), json!(mk));
         }
+    }
+    env.coverage = Some(cov);
+    env
+}
 
 fn empty_stub(meta: &RcxPresetMeta, reason: &str) -> AnalyticsEnvelope {
     let query = AnalyticsQuery::default();

--- a/services/central/src/jobs.rs
+++ b/services/central/src/jobs.rs
@@ -363,6 +363,17 @@ pub fn restore_job(job_id: &str) -> Result<JobMeta, JobError> {
     save_job(meta, Some(&expected))
 }
 
+/// Permanently remove a job workspace directory (hard delete — not archive).
+pub fn delete_job(job_id: &str) -> Result<(), JobError> {
+    validate_job_id(job_id)?;
+    let dir = job_dir(job_id)?;
+    if !dir.is_dir() {
+        return Err(JobError::NotFound(format!("job not found: {job_id}")));
+    }
+    fs::remove_dir_all(&dir).map_err(|e| JobError::Io(e.to_string()))?;
+    Ok(())
+}
+
 pub fn duplicate_job(job_id: &str, new_name: Option<&str>) -> Result<JobMeta, JobError> {
     let src = load_job(job_id)?;
     let src_dir = job_dir(job_id)?;
@@ -870,6 +881,19 @@ mod tests {
             assert_eq!(list_jobs(false, None, None, None).len(), 0);
             restore_job(&meta.job_id).unwrap();
             assert_eq!(list_jobs(false, None, None, None).len(), 1);
+        });
+    }
+
+    #[test]
+    fn hard_delete_removes_job_dir() {
+        with_tmp_ws(|_dir| {
+            let meta = create_job("Del", None, None, None, None, vec![], None).unwrap();
+            let id = meta.job_id.clone();
+            assert!(job_dir(&id).unwrap().is_dir());
+            delete_job(&id).unwrap();
+            assert!(!job_dir(&id).unwrap().exists());
+            assert!(matches!(load_job(&id), Err(JobError::NotFound(_))));
+            assert!(matches!(delete_job(&id), Err(JobError::NotFound(_))));
         });
     }
 

--- a/services/central/src/openapi.rs
+++ b/services/central/src/openapi.rs
@@ -49,6 +49,16 @@ mod live_routes {
     pub fn jobs_get() {}
 
     #[utoipa::path(
+        delete, path = "/api/jobs/{job_id}", tag = "jobs",
+        params(("job_id" = String, Path, description = "Job id")),
+        responses(
+            (status = 200, description = "Permanently delete an analysis job workspace", body = serde_json::Value),
+            (status = 404, description = "Job not found")
+        )
+    )]
+    pub fn jobs_delete() {}
+
+    #[utoipa::path(
         post, path = "/api/jobs/{job_id}/wattlab/handoffs", tag = "jobs",
         params(("job_id" = String, Path, description = "Job id")),
         request_body = serde_json::Value,

--- a/services/central/src/openapi.rs
+++ b/services/central/src/openapi.rs
@@ -217,6 +217,7 @@ mod live_routes {
         live_routes::jobs_list,
         live_routes::jobs_create,
         live_routes::jobs_get,
+        live_routes::jobs_delete,
         live_routes::jobs_create_wattlab_handoff,
         live_routes::jobs_create_wattlab_dump,
         live_routes::jobs_download_wattlab_dump,

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -1578,9 +1578,7 @@ async fn jobs_restore(
     Ok(Json(json!({"ok": true, "job": meta})))
 }
 
-async fn jobs_delete(
-    Path(job_id): Path<String>,
-) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+async fn jobs_delete(Path(job_id): Path<String>) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     jobs::delete_job(&job_id).map_err(job_err)?;
     Ok(Json(json!({"ok": true, "deleted": true, "job_id": job_id})))
 }

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use axum::extract::{DefaultBodyLimit, Path, Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::middleware;
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use bytes::Bytes;
 use chrono::Utc;
@@ -134,7 +134,10 @@ pub fn router(state: Arc<AppState>) -> Router {
             get(reports_download_pdf),
         )
         .route("/api/jobs", get(jobs_list).post(jobs_create))
-        .route("/api/jobs/{job_id}", get(jobs_get).patch(jobs_patch))
+        .route(
+            "/api/jobs/{job_id}",
+            get(jobs_get).patch(jobs_patch).delete(jobs_delete),
+        )
         .route("/api/jobs/{job_id}/duplicate", post(jobs_duplicate))
         .route("/api/jobs/{job_id}/archive", post(jobs_archive))
         .route("/api/jobs/{job_id}/restore", post(jobs_restore))
@@ -1573,6 +1576,13 @@ async fn jobs_restore(
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let meta = jobs::restore_job(&job_id).map_err(job_err)?;
     Ok(Json(json!({"ok": true, "job": meta})))
+}
+
+async fn jobs_delete(
+    Path(job_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    jobs::delete_job(&job_id).map_err(job_err)?;
+    Ok(Json(json!({"ok": true, "deleted": true, "job_id": job_id})))
 }
 
 async fn jobs_create_run(

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use axum::extract::{DefaultBodyLimit, Path, Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::middleware;
-use axum::routing::{delete, get, post};
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use bytes::Bytes;
 use chrono::Utc;


### PR DESCRIPTION
## Summary
- Fix `PlotlyHost` so fixed fault-lane ranges and stacked `yaxisN` domains are preserved (no autorange clobber).
- FDD Plots: grey/disable SQL analytics rollups; require `confirmed_fault` after Run FDD; signal traces stay line-only.
- RCx: unit-aware y titles, rainbow + outlier red, optional motor-on y2; assert no fault lane.
- Discoverable **Delete dataset…** in sidebar; permanent `DELETE /api/jobs/{id}` + Jobs UI (archive remains).

## Test plan
- [ ] Vitest: PlotlyHost merge, vibeCharts FDD/RCx, jobsApi delete
- [ ] CI green (central + web images)
- [ ] Visual: FC1/AHU_1 stacked + bottom fault; FAN-RUNTIME greyed; RCx `ahu_dats` no fault lane
- [ ] Sidebar Delete dataset… + Jobs Delete confirm


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Permanently delete jobs from the Jobs page with a confirmation warning.
  - Charts now highlight outlier equipment and display motor activity when available.
  - RCx, metering, and diagnostic charts provide clearer axis labels and measurement units.
  - Added support for expanded temperature, airflow, electricity, and gas units.

- **Bug Fixes**
  - Improved chart axis behavior, fault overlays, colors, and timestamp labels.
  - Prevented unsupported analytics rules or incomplete fault data from appearing in diagnostic reports.

- **Documentation**
  - Clarified deletion consequences and updated guidance for diagnostic workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->