### PR TITLE
Overview button-only analytics + Open-Meteo fuel weather

### DIFF
--- a/frontend/web/src/api/fuelApi.ts
+++ b/frontend/web/src/api/fuelApi.ts
@@ -17,6 +17,7 @@ function buildUrl(path: string): string {
 
 export const FUEL_CAMPUS_IMPORT_PATH = "/api/fuel/campus/import";
 export const FUEL_CAMPUS_LIST_PATH = "/api/fuel/campus";
+export const FUEL_WEATHER_FETCH_PATH = "/api/fuel/campus/weather/fetch";
 export const FUEL_ANALYTICS_PATH = "/api/analytics/fuel";
 
 export const FUEL_QUERY_VERSIONS = [
@@ -231,4 +232,31 @@ export async function postFuelAnalytics(
     }
   }
   return env;
+}
+
+export interface FuelOpenMeteoFetchResponse {
+  ok: boolean;
+  campus_id?: string;
+  source?: string;
+  path?: string;
+  months?: number;
+  start_date?: string;
+  end_date?: string;
+  downloaded_at_utc?: string;
+  lat?: number;
+  lon?: number;
+  hint?: string;
+  error?: string;
+  action_id?: string;
+}
+
+/** vibe20 “Fetch Open-Meteo” — archive HDD/CDD for fuel weather baseline. */
+export async function fetchFuelOpenMeteo(
+  campusId: string,
+): Promise<FuelOpenMeteoFetchResponse> {
+  return apiFetch<FuelOpenMeteoFetchResponse>(FUEL_WEATHER_FETCH_PATH, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ campus_id: campusId }),
+  });
 }

--- a/frontend/web/src/components/FuelDashboard.tsx
+++ b/frontend/web/src/components/FuelDashboard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FUEL_QUERY_VERSIONS,
+  fetchFuelOpenMeteo,
   listFuelCampuses,
   postFuelAnalytics,
   type FuelAnalyticsEnvelope,
@@ -22,6 +23,7 @@ import {
   weatherScatter,
 } from "../api/fuelCharts";
 import {
+  Button,
   DataTable,
   InlineAlert,
   Metric,
@@ -85,8 +87,10 @@ export function FuelDashboard({ reloadToken }: FuelDashboardProps = {}) {
   const [bundle, setBundle] = useState<FuelBundle>({});
   const [loadingCampuses, setLoadingCampuses] = useState(true);
   const [loadingAnalytics, setLoadingAnalytics] = useState(false);
+  const [fetchingWeather, setFetchingWeather] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [warnings, setWarnings] = useState<string[]>([]);
+  const [weatherNotice, setWeatherNotice] = useState<string | null>(null);
 
   const refreshCampuses = useCallback(async () => {
     setLoadingCampuses(true);
@@ -159,6 +163,41 @@ export function FuelDashboard({ reloadToken }: FuelDashboardProps = {}) {
       cancelled = true;
     };
   }, [campusId]);
+
+  const reloadWeatherAnalytics = useCallback(async () => {
+    if (!campusId) return;
+    const env = await postFuelAnalytics({
+      query_version: "fuel-weather-v1",
+      campus_id: campusId,
+      allocation: "area_weighted",
+    });
+    setBundle((prev) => ({ ...prev, "fuel-weather-v1": env }));
+    setWarnings((prev) => {
+      const rest = prev.filter((w) => !w.startsWith("fuel-weather-v1:"));
+      return [...rest, ...(env.warnings ?? []).map((w) => `fuel-weather-v1: ${w}`)];
+    });
+  }, [campusId]);
+
+  const onFetchOpenMeteo = async () => {
+    if (!campusId) return;
+    setFetchingWeather(true);
+    setError(null);
+    setWeatherNotice(null);
+    try {
+      const res = await fetchFuelOpenMeteo(campusId);
+      if (!res.ok) {
+        throw new Error(res.error || "Open-Meteo fetch failed");
+      }
+      setWeatherNotice(
+        `Open-Meteo cached ${res.months ?? "?"} months (${res.start_date} → ${res.end_date}). Reloading weather analytics…`,
+      );
+      await reloadWeatherAnalytics();
+    } catch (err) {
+      setError(formatErr(err));
+    } finally {
+      setFetchingWeather(false);
+    }
+  };
 
   const summary = bundle["fuel-summary-v1"];
   const monthly = bundle["fuel-monthly-v1"];
@@ -484,11 +523,39 @@ export function FuelDashboard({ reloadToken }: FuelDashboardProps = {}) {
             label: "Weather & Baseline",
             content: (
               <div data-testid="fuel-tab-weather-baseline" className="page-stack">
+                <div className="form-row">
+                  <Button
+                    id="fuel-fetch-open-meteo"
+                    label={
+                      fetchingWeather
+                        ? "Fetching Open-Meteo…"
+                        : "Fetch Open-Meteo"
+                    }
+                    loading={fetchingWeather}
+                    disabled={!campusId || fetchingWeather}
+                    onClick={() => void onFetchOpenMeteo()}
+                    testId="fuel-fetch-open-meteo"
+                  />
+                  <p className="oracle-sidebar__caption">
+                    vibe20 parity: archive dry-bulb → monthly HDD/CDD (base 65°F).
+                    Requires campus lat/lon. Falls back to synthetic sine OA until
+                    fetched.
+                  </p>
+                </div>
+                {weatherNotice ? (
+                  <InlineAlert
+                    id="fuel-weather-notice"
+                    variant="success"
+                    testId="fuel-weather-notice"
+                  >
+                    {weatherNotice}
+                  </InlineAlert>
+                ) : null}
                 <PlotlyHost
                   id="fuel-weather"
                   label="Weather vs usage"
                   figure={weatherFig}
-                  loading={loadingAnalytics}
+                  loading={loadingAnalytics || fetchingWeather}
                   height={420}
                   testId="fuel-chart-weather"
                 />

--- a/frontend/web/src/components/OverviewPopulated.tsx
+++ b/frontend/web/src/components/OverviewPopulated.tsx
@@ -360,17 +360,18 @@ export function OverviewPopulated({
     void refreshMeta();
   }, [refreshMeta]);
 
+  // Clear analytics when site/equipment context changes — do not auto-fire
+  // DataFusion POSTs (button-only; vibe19 Streamlit auto-recompute felt wonky).
   useEffect(() => {
-    void refreshOverview();
-  }, [refreshOverview]);
+    setOverview(null);
+    setOverviewErr(null);
+    setInspectFig(null);
+    setInspectErr(null);
+  }, [buildingId, econOverlayEq]);
 
   useEffect(() => {
     if (equipmentId && !inspectPick) setInspectPick(equipmentId);
   }, [equipmentId, inspectPick]);
-
-  useEffect(() => {
-    void refreshInspect();
-  }, [refreshInspect]);
 
   useEffect(() => {
     void getSessionConfig()
@@ -588,7 +589,7 @@ export function OverviewPopulated({
             testId="overview-refresh"
           />
           <p className="oracle-sidebar__caption">
-            Central DataFusion analytics → Overview charts
+            Click to run Central DataFusion analytics (not auto on load)
           </p>
         </div>
         <div className="overview-toolbar__action">
@@ -608,7 +609,11 @@ export function OverviewPopulated({
             {overview.elapsed_s}s · {overview.equipment_count} equip ·{" "}
             {overview.source}
           </span>
-        ) : null}
+        ) : (
+          <span className="oracle-sidebar__caption" data-testid="overview-idle-hint">
+            Charts idle — press Update analytics to load.
+          </span>
+        )}
       </div>
 
       {overviewErr ? (
@@ -620,9 +625,9 @@ export function OverviewPopulated({
 
       <p className="oracle-sidebar__caption" data-testid="overview-dual-catalog">
         Two actions, one engine family: <strong>Update analytics</strong>{" "}
-        refreshes Overview charts; <strong>Run all rules</strong> runs the FDD
-        SQL registry. Sidebar <strong>Update this rule</strong> re-runs one
-        rule.
+        runs Overview charts on demand (no auto-fetch);{" "}
+        <strong>Run all rules</strong> runs the FDD SQL registry. Sidebar{" "}
+        <strong>Update this rule</strong> re-runs one rule.
       </p>
 
       <div className="form-row">

--- a/services/central/Cargo.toml
+++ b/services/central/Cargo.toml
@@ -41,6 +41,7 @@ dashmap = "6"
 # aws_lc_rs avoids transitive `rsa` (RUSTSEC-2023-0071); we only mint/verify HS256.
 jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs"] }
 rumqttc = { version = "0.24", default-features = false, features = ["use-native-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [dev-dependencies]
 base64 = "0.22"

--- a/services/central/src/fuel/analytics.rs
+++ b/services/central/src/fuel/analytics.rs
@@ -21,7 +21,7 @@ pub const QV_DEMAND: &str = "fuel-demand-v1";
 pub const QV_QUALITY: &str = "fuel-quality-v1";
 pub const QV_WEATHER: &str = "fuel-weather-v1";
 
-const DD_BASE_F: f64 = 65.0;
+pub(crate) const DD_BASE_F: f64 = 65.0;
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct FuelRequest {
@@ -547,10 +547,39 @@ fn fuel_weather(campus: &Campus, warnings: &mut Vec<String>) -> Value {
         return env;
     }
 
-    let dd = synthetic_monthly_degree_days(&months, campus.lat);
-    warnings.push(
-        "fuel-weather-v1: synthetic sine OA (vibe20 _synthetic_hourly); no Open-Meteo in v1".into(),
-    );
+    let (dd, dd_source) = match crate::fuel::open_meteo::load_cached_degree_days(&campus.campus_id)
+    {
+        Some(cache) => {
+            let map = crate::fuel::open_meteo::cache_to_dd_map(&cache);
+            let covered = months.iter().filter(|m| map.contains_key(*m)).count();
+            if covered == 0 {
+                warnings.push(
+                    "fuel-weather-v1: Open-Meteo cache present but no months overlap bills; using synthetic sine OA"
+                        .into(),
+                );
+                (synthetic_monthly_degree_days(&months, campus.lat), "synthetic_sine_oa")
+            } else {
+                if covered < months.len() {
+                    warnings.push(format!(
+                        "fuel-weather-v1: Open-Meteo covers {covered}/{} bill months (partial)",
+                        months.len()
+                    ));
+                }
+                warnings.push(format!(
+                    "fuel-weather-v1: Open-Meteo archive HDD/CDD (downloaded {})",
+                    cache.downloaded_at_utc
+                ));
+                (map, "open-meteo-archive")
+            }
+        }
+        None => {
+            warnings.push(
+                "fuel-weather-v1: synthetic sine OA — click Fetch Open-Meteo on Weather tab for live HDD/CDD (vibe20 parity)"
+                    .into(),
+            );
+            (synthetic_monthly_degree_days(&months, campus.lat), "synthetic_sine_oa")
+        }
+    };
 
     let mut gas_x = Vec::new();
     let mut gas_y = Vec::new();
@@ -653,7 +682,7 @@ fn fuel_weather(campus: &Campus, warnings: &mut Vec<String>) -> Value {
         "n_fits": fits.len(),
         "degree_days": {
             "base_f": DD_BASE_F,
-            "source": "synthetic_sine_oa",
+            "source": dd_source,
             "method": "daily_mean_oat_then_monthly_sum",
             "convention": "vibe19_metering_DD_BASE_F",
         },

--- a/services/central/src/fuel/analytics.rs
+++ b/services/central/src/fuel/analytics.rs
@@ -557,7 +557,10 @@ fn fuel_weather(campus: &Campus, warnings: &mut Vec<String>) -> Value {
                     "fuel-weather-v1: Open-Meteo cache present but no months overlap bills; using synthetic sine OA"
                         .into(),
                 );
-                (synthetic_monthly_degree_days(&months, campus.lat), "synthetic_sine_oa")
+                (
+                    synthetic_monthly_degree_days(&months, campus.lat),
+                    "synthetic_sine_oa",
+                )
             } else {
                 if covered < months.len() {
                     warnings.push(format!(
@@ -577,7 +580,10 @@ fn fuel_weather(campus: &Campus, warnings: &mut Vec<String>) -> Value {
                 "fuel-weather-v1: synthetic sine OA — click Fetch Open-Meteo on Weather tab for live HDD/CDD (vibe20 parity)"
                     .into(),
             );
-            (synthetic_monthly_degree_days(&months, campus.lat), "synthetic_sine_oa")
+            (
+                synthetic_monthly_degree_days(&months, campus.lat),
+                "synthetic_sine_oa",
+            )
         }
     };
 

--- a/services/central/src/fuel/mod.rs
+++ b/services/central/src/fuel/mod.rs
@@ -7,6 +7,7 @@ pub mod bills;
 pub mod campus;
 pub mod eui;
 pub mod import;
+pub mod open_meteo;
 
 #[allow(unused_imports)]
 pub use analytics::{handle_fuel, FuelRequest};
@@ -16,3 +17,5 @@ pub use campus::{annual_summary, load_campus, Campus, KBTU_PER_KWH, KBTU_PER_MCF
 pub use eui::compare_eui;
 #[allow(unused_imports)]
 pub use import::{fuel_root, import_fuel_zip, list_campuses};
+#[allow(unused_imports)]
+pub use open_meteo::fetch_open_meteo_handler;

--- a/services/central/src/fuel/open_meteo.rs
+++ b/services/central/src/fuel/open_meteo.rs
@@ -1,0 +1,342 @@
+//! Open-Meteo Archive download for fuel HDD/CDD (vibe20 `wattlab.weather.open_meteo`).
+//!
+//! Fetches hourly dry-bulb °F from `archive-api.open-meteo.com/v1/archive`, aggregates
+//! to monthly HDD/CDD (base 65°F), and caches under
+//! `$OPENFDD_WORKSPACE/data/fuel/<campus_id>/weather/open_meteo_dd.json`.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{Datelike, NaiveDate};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::analytics::DD_BASE_F;
+use super::campus::Campus;
+use super::import::fuel_root;
+
+pub const ARCHIVE_URL: &str = "https://archive-api.open-meteo.com/v1/archive";
+pub const SOURCE_NAME: &str = "open-meteo-archive";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonthlyDegreeDays {
+    pub hdd: f64,
+    pub cdd: f64,
+    pub mean_oat_f: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenMeteoDdCache {
+    pub source: String,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub start_date: String,
+    pub end_date: String,
+    pub downloaded_at_utc: String,
+    pub base_f: f64,
+    /// month `YYYY-MM` → degree days
+    pub months: BTreeMap<String, MonthlyDegreeDays>,
+}
+
+pub type Opener = Box<dyn Fn(&str) -> Result<Vec<u8>> + Send>;
+
+fn default_opener(url: &str) -> Result<Vec<u8>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(90))
+        .build()
+        .context("reqwest client")?;
+    let resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("Open-Meteo GET {url}"))?;
+    if !resp.status().is_success() {
+        return Err(anyhow!(
+            "Open-Meteo HTTP {}: {}",
+            resp.status(),
+            resp.text().unwrap_or_default()
+        ));
+    }
+    Ok(resp.bytes()?.to_vec())
+}
+
+pub fn weather_cache_path(campus_id: &str) -> PathBuf {
+    fuel_root()
+        .join(campus_id)
+        .join("weather")
+        .join("open_meteo_dd.json")
+}
+
+pub fn load_cached_degree_days(campus_id: &str) -> Option<OpenMeteoDdCache> {
+    let path = weather_cache_path(campus_id);
+    let raw = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        serde_json::to_writer_pretty(&mut f, value)?;
+        f.write_all(b"\n")?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+pub fn build_archive_url(lat: f64, lon: f64, start: &str, end: &str) -> String {
+    format!(
+        "{ARCHIVE_URL}?latitude={lat}&longitude={lon}&start_date={start}&end_date={end}\
+         &hourly=temperature_2m&temperature_unit=fahrenheit&timezone=UTC"
+    )
+}
+
+/// Daily-mean OA → monthly HDD/CDD (same convention as vibe19 metering / fuel synthetic).
+pub fn monthly_degree_days_from_hourly(
+    times: &[String],
+    temps_f: &[Option<f64>],
+) -> BTreeMap<String, MonthlyDegreeDays> {
+    let mut daily: HashMap<NaiveDate, (f64, u32)> = HashMap::new();
+    for (ts, temp) in times.iter().zip(temps_f.iter()) {
+        let Some(t) = temp.filter(|v| v.is_finite()) else {
+            continue;
+        };
+        let day = NaiveDate::parse_from_str(&ts[..10.min(ts.len())], "%Y-%m-%d").ok();
+        let Some(day) = day else { continue };
+        let e = daily.entry(day).or_insert((0.0, 0));
+        e.0 += t;
+        e.1 += 1;
+    }
+    let mut monthly_acc: BTreeMap<String, (f64, f64, f64, u32)> = BTreeMap::new();
+    for (day, (sum, n)) in daily {
+        if n == 0 {
+            continue;
+        }
+        let mean = sum / n as f64;
+        let hdd = (DD_BASE_F - mean).max(0.0);
+        let cdd = (mean - DD_BASE_F).max(0.0);
+        let key = format!("{:04}-{:02}", day.year(), day.month());
+        let e = monthly_acc.entry(key).or_insert((0.0, 0.0, 0.0, 0));
+        e.0 += hdd;
+        e.1 += cdd;
+        e.2 += mean;
+        e.3 += 1;
+    }
+    monthly_acc
+        .into_iter()
+        .map(|(month, (hdd, cdd, mean_sum, n))| {
+            (
+                month,
+                MonthlyDegreeDays {
+                    hdd,
+                    cdd,
+                    mean_oat_f: if n > 0 { mean_sum / n as f64 } else { 0.0 },
+                },
+            )
+        })
+        .collect()
+}
+
+fn parse_archive_payload(bytes: &[u8]) -> Result<(Vec<String>, Vec<Option<f64>>)> {
+    let v: Value = serde_json::from_slice(bytes).context("Open-Meteo JSON")?;
+    let hourly = v
+        .get("hourly")
+        .ok_or_else(|| anyhow!("Open-Meteo response missing hourly"))?;
+    let times: Vec<String> = hourly
+        .get("time")
+        .and_then(|t| t.as_array())
+        .ok_or_else(|| anyhow!("Open-Meteo hourly.time missing"))?
+        .iter()
+        .filter_map(|x| x.as_str().map(|s| s.to_string()))
+        .collect();
+    let temps: Vec<Option<f64>> = hourly
+        .get("temperature_2m")
+        .and_then(|t| t.as_array())
+        .ok_or_else(|| anyhow!("Open-Meteo hourly.temperature_2m missing"))?
+        .iter()
+        .map(|x| x.as_f64())
+        .collect();
+    if times.is_empty() || times.len() != temps.len() {
+        return Err(anyhow!(
+            "Open-Meteo time/temp length mismatch ({} vs {})",
+            times.len(),
+            temps.len()
+        ));
+    }
+    Ok((times, temps))
+}
+
+/// Bill month span → archive start/end (first day of first month → last day of last month).
+pub fn month_span_to_dates(months: &[String]) -> Result<(String, String)> {
+    let start = months
+        .first()
+        .ok_or_else(|| anyhow!("no months"))?;
+    let end = months.last().ok_or_else(|| anyhow!("no months"))?;
+    let sy: i32 = start[..4].parse()?;
+    let sm: u32 = start[5..7].parse()?;
+    let ey: i32 = end[..4].parse()?;
+    let em: u32 = end[5..7].parse()?;
+    let start_date = NaiveDate::from_ymd_opt(sy, sm, 1).ok_or_else(|| anyhow!("bad start"))?;
+    let end_month_start = NaiveDate::from_ymd_opt(ey, em, 1).ok_or_else(|| anyhow!("bad end"))?;
+    let end_date = if em == 12 {
+        NaiveDate::from_ymd_opt(ey + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(ey, em + 1, 1)
+    }
+    .and_then(|d| d.pred_opt())
+    .unwrap_or(end_month_start);
+    Ok((
+        start_date.format("%Y-%m-%d").to_string(),
+        end_date.format("%Y-%m-%d").to_string(),
+    ))
+}
+
+pub fn fetch_and_cache_degree_days(
+    campus: &Campus,
+    months: &[String],
+    opener: Option<Opener>,
+) -> Result<OpenMeteoDdCache> {
+    let lat = campus
+        .lat
+        .ok_or_else(|| anyhow!("campus lat required for Open-Meteo"))?;
+    let lon = campus
+        .lon
+        .ok_or_else(|| anyhow!("campus lon required for Open-Meteo"))?;
+    if months.is_empty() {
+        return Err(anyhow!("no bill months for Open-Meteo span"));
+    }
+    if std::env::var("OPENFDD_FUEL_WEATHER_OFFLINE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return Err(anyhow!(
+            "OPENFDD_FUEL_WEATHER_OFFLINE set — refusing network Open-Meteo fetch"
+        ));
+    }
+    let (start, end) = month_span_to_dates(months)?;
+    let url = build_archive_url(lat, lon, &start, &end);
+    let open = opener.unwrap_or_else(|| Box::new(|u| default_opener(u)));
+    let bytes = open(&url)?;
+    let (times, temps) = parse_archive_payload(&bytes)?;
+    let months_dd = monthly_degree_days_from_hourly(&times, &temps);
+    let cache = OpenMeteoDdCache {
+        source: SOURCE_NAME.into(),
+        latitude: lat,
+        longitude: lon,
+        start_date: start,
+        end_date: end,
+        downloaded_at_utc: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        base_f: DD_BASE_F,
+        months: months_dd,
+    };
+    let path = weather_cache_path(&campus.campus_id);
+    atomic_write_json(&path, &serde_json::to_value(&cache)?)?;
+    Ok(cache)
+}
+
+/// API handler: fetch Open-Meteo for a campus and persist DD cache.
+pub fn fetch_open_meteo_handler(campus_id: &str) -> Value {
+    let root = fuel_root().join(campus_id);
+    let campus = match super::campus::load_campus(&root) {
+        Ok(c) => c,
+        Err(e) => {
+            return json!({"ok": false, "error": format!("load campus: {e}")});
+        }
+    };
+    let months: Vec<String> = {
+        let mut set = std::collections::BTreeSet::new();
+        for m in &campus.meters {
+            set.extend(m.months());
+        }
+        set.into_iter().collect()
+    };
+    match fetch_and_cache_degree_days(&campus, &months, None) {
+        Ok(cache) => json!({
+            "ok": true,
+            "campus_id": campus.campus_id,
+            "source": cache.source,
+            "path": weather_cache_path(&campus.campus_id).display().to_string(),
+            "months": cache.months.len(),
+            "start_date": cache.start_date,
+            "end_date": cache.end_date,
+            "downloaded_at_utc": cache.downloaded_at_utc,
+            "lat": cache.latitude,
+            "lon": cache.longitude,
+            "hint": "Re-run fuel-weather-v1 analytics to plot Open-Meteo HDD/CDD.",
+        }),
+        Err(e) => json!({"ok": false, "error": e.to_string(), "campus_id": campus_id}),
+    }
+}
+
+/// Convert cache → map used by fuel_weather (month → hdd,cdd,mean).
+pub fn cache_to_dd_map(cache: &OpenMeteoDdCache) -> BTreeMap<String, (f64, f64, f64)> {
+    cache
+        .months
+        .iter()
+        .map(|(k, v)| (k.clone(), (v.hdd, v.cdd, v.mean_oat_f)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fuel::campus::Campus;
+
+    #[test]
+    fn monthly_dd_from_hourly_fixture() {
+        let times = vec![
+            "2023-01-01T00:00".into(),
+            "2023-01-01T01:00".into(),
+            "2023-07-01T00:00".into(),
+            "2023-07-01T01:00".into(),
+        ];
+        let temps = vec![Some(20.0), Some(20.0), Some(80.0), Some(80.0)];
+        let dd = monthly_degree_days_from_hourly(&times, &temps);
+        let jan = dd.get("2023-01").unwrap();
+        let jul = dd.get("2023-07").unwrap();
+        assert!((jan.hdd - 45.0).abs() < 1e-6); // 65-20
+        assert!((jan.cdd - 0.0).abs() < 1e-6);
+        assert!((jul.cdd - 15.0).abs() < 1e-6); // 80-65
+        assert!((jul.hdd - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fetch_with_injected_opener_writes_cache() {
+        let _lock = crate::jobs::WORKSPACE_ENV_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("OPENFDD_WORKSPACE", dir.path());
+        let campus = Campus {
+            campus_id: "test_campus".into(),
+            label: "Test".into(),
+            buildings: vec![],
+            meters: vec![],
+            notes: String::new(),
+            source: dir.path().to_path_buf(),
+            lat: Some(42.5),
+            lon: Some(-83.1),
+            site_ref: None,
+        };
+        let months = vec!["2023-01".into()];
+        let opener: Opener = Box::new(|_url| {
+            Ok(br#"{
+              "hourly": {
+                "time": ["2023-01-01T00:00","2023-01-01T01:00"],
+                "temperature_2m": [30.0, 30.0]
+              }
+            }"#
+            .to_vec())
+        });
+        let cache = fetch_and_cache_degree_days(&campus, &months, Some(opener)).unwrap();
+        assert_eq!(cache.source, SOURCE_NAME);
+        assert!(weather_cache_path("test_campus").is_file());
+        let jan = cache.months.get("2023-01").unwrap();
+        assert!((jan.hdd - 35.0).abs() < 1e-6);
+        std::env::remove_var("OPENFDD_WORKSPACE");
+    }
+}

--- a/services/central/src/fuel/open_meteo.rs
+++ b/services/central/src/fuel/open_meteo.rs
@@ -219,8 +219,10 @@ pub fn fetch_and_cache_degree_days(
     }
     let (start, end) = month_span_to_dates(months)?;
     let url = build_archive_url(lat, lon, &start, &end);
-    let open = opener.unwrap_or_else(|| Box::new(|u| default_opener(u)));
-    let bytes = open(&url)?;
+    let bytes = match opener {
+        Some(open) => open(&url)?,
+        None => default_opener(&url)?,
+    };
     let (times, temps) = parse_archive_payload(&bytes)?;
     let months_dd = monthly_degree_days_from_hourly(&times, &temps);
     let cache = OpenMeteoDdCache {

--- a/services/central/src/fuel/open_meteo.rs
+++ b/services/central/src/fuel/open_meteo.rs
@@ -174,9 +174,7 @@ fn parse_archive_payload(bytes: &[u8]) -> Result<(Vec<String>, Vec<Option<f64>>)
 
 /// Bill month span → archive start/end (first day of first month → last day of last month).
 pub fn month_span_to_dates(months: &[String]) -> Result<(String, String)> {
-    let start = months
-        .first()
-        .ok_or_else(|| anyhow!("no months"))?;
+    let start = months.first().ok_or_else(|| anyhow!("no months"))?;
     let end = months.last().ok_or_else(|| anyhow!("no months"))?;
     let sy: i32 = start[..4].parse()?;
     let sm: u32 = start[5..7].parse()?;

--- a/services/central/src/openapi.rs
+++ b/services/central/src/openapi.rs
@@ -99,6 +99,15 @@ mod live_routes {
     pub fn jobs_queue_eplus_run() {}
 
     #[utoipa::path(
+        post, path = "/api/fuel/campus/weather/fetch", tag = "fuel",
+        request_body = serde_json::Value,
+        responses(
+            (status = 200, description = "Fetch Open-Meteo archive HDD/CDD for a fuel campus", body = serde_json::Value)
+        )
+    )]
+    pub fn fuel_weather_fetch() {}
+
+    #[utoipa::path(
         get, path = "/api/datasets", tag = "datasets",
         responses((status = 200, description = "List ingested datasets / sites", body = serde_json::Value))
     )]
@@ -224,6 +233,7 @@ mod live_routes {
         live_routes::jobs_queue_eplus_run,
         live_routes::datasets_list,
         live_routes::datasets_delete,
+        live_routes::fuel_weather_fetch,
         live_routes::fdd_results,
         live_routes::fdd_equipment,
         live_routes::analytics_runtime,

--- a/services/central/src/openapi.rs
+++ b/services/central/src/openapi.rs
@@ -287,6 +287,7 @@ mod live_routes {
         (name = "jobs", description = "Persistent analysis Jobs + WattLab / EnergyPlus handoff"),
         (name = "analytics", description = "Typed analytics envelopes (historian DataFusion / inline)"),
         (name = "datasets", description = "Ingested site datasets (Delete site)"),
+        (name = "fuel", description = "Campus fuel ZIP analytics + Open-Meteo weather"),
         (name = "fdd", description = "Site-scoped FDD rule results / equipment"),
         (name = "reports", description = "Report artifacts, templates, and drafts")
     )

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -204,6 +204,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/analytics/fuel", post(analytics_fuel))
         .route("/api/fuel/campus/import", post(fuel_campus_import))
         .route("/api/fuel/campus", get(fuel_campus_list))
+        .route(
+            "/api/fuel/campus/weather/fetch",
+            post(fuel_campus_weather_fetch),
+        )
         .merge(csv)
         // OFDD-075: analytics/FDD posts (building-scoped Overview samples) can
         // exceed Axum's ~2 MiB default and 413 before reaching the handler.
@@ -2083,6 +2087,47 @@ pub async fn fuel_campus_list(Query(q): Query<FuelCampusQuery>) -> Json<Value> {
     })
     .await
     .unwrap_or_else(|e| json!({"ok": false, "error": format!("fuel campus list task: {e}")}));
+    Json(result)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FuelWeatherFetchBody {
+    pub campus_id: String,
+}
+
+/// Fetch Open-Meteo archive weather and cache monthly HDD/CDD (vibe20 Fuel dashboard parity).
+pub async fn fuel_campus_weather_fetch(Json(body): Json<FuelWeatherFetchBody>) -> Json<Value> {
+    let campus_id = body.campus_id.trim().to_string();
+    if campus_id.is_empty() {
+        return Json(json!({"ok": false, "error": "campus_id required"}));
+    }
+    let action_id = actions::start_action(
+        "fuel_open_meteo",
+        &format!("Open-Meteo fetch · {campus_id}"),
+        Some(json!({ "campus_id": campus_id.clone() })),
+    )
+    .ok();
+    let result = tokio::task::spawn_blocking(move || fuel::fetch_open_meteo_handler(&campus_id))
+        .await
+        .unwrap_or_else(|e| json!({"ok": false, "error": format!("open-meteo task: {e}")}));
+    if let Some(ref aid) = action_id {
+        let ok = result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+        let status = if ok { "ok" } else { "fail" };
+        let _ = actions::finish_action(
+            aid,
+            status,
+            Some(json!({
+                "ok": ok,
+                "error": result.get("error"),
+                "months": result.get("months"),
+            })),
+        );
+        let mut out = result;
+        if let Some(obj) = out.as_object_mut() {
+            obj.insert("action_id".into(), json!(aid));
+        }
+        return Json(out);
+    }
     Json(result)
 }
 


### PR DESCRIPTION
## Summary
- Overview no longer auto-triggers analytics/inspect on load — **Update analytics** only (Streamlit-style auto-recompute felt wonky).
- Fuel weather: `POST /api/fuel/campus/weather/fetch` downloads Open-Meteo archive dry-bulb → monthly HDD/CDD (vibe20 parity); Weather tab **Fetch Open-Meteo** button; `fuel-weather-v1` prefers cache over synthetic sine OA.
- Plotly RCx/FDD parity wave (#686) already merged; this closes the fuel Open-Meteo gap called out in validation.

## Test plan
- [ ] Overview: open site → charts idle until Update analytics
- [ ] Metering/WattLab Weather tab → Fetch Open-Meteo (campus with lat/lon) → weather chart uses open-meteo source in coverage
- [ ] Vitest + Rust CI green; CodeRabbit feedback addressed


Made with [Cursor](https://cursor.com)