### PR TITLE
feat(oracle): parity inventory v2 matrix (59/63)

### DIFF
--- a/docs/rules/cookbook/parity-matrix.md
+++ b/docs/rules/cookbook/parity-matrix.md
@@ -6,20 +6,26 @@ nav_order: 6
 
 # SQL ↔ Pandas parity matrix
 
-**Wave 0 contract:** machine-readable inventory at [`sql_rules/generated/parity_inventory.yaml`](../../../sql_rules/generated/parity_inventory.yaml).  
-**Audit:** 2026-08-07 — legacy `proven_building_100` / `ported_from_cookbook` labels removed.
+**Contract:** machine-readable inventory at [`sql_rules/generated/parity_inventory.yaml`](../../../sql_rules/generated/parity_inventory.yaml) (`parity-inventory-v2`).  
+Regenerate with `python3 scripts/generate_parity_inventory.py`. Drift fails CI via `--check`.
 
-## Product split (read this first)
+**Audit:** 2026-08-07 — legacy `proven_building_100` / `ported_from_cookbook` labels removed.  
+**Audit:** 2026-08-11 — flat `matrix[]` columns (title, roles, proof, thresholds, docs, tests, difference class).
 
-| Surface | Count | Role |
+## Why 59 versus 63 (do not pad)
+
+| Surface | Count | Source |
 |---------|------:|------|
-| DataFusion SQL registry | **63** | Production Open-FDD FDD (Rust/DataFusion) |
-| Pandas catalog | **59** | PyPI `open_fdd.rules` oracle (+ docs) |
-| SQL analytics (no pandas twin) | **4** | `FAN-RUNTIME-HOURS`, `AVG-ZONE-TEMP`, `ZONE-COMFORT-PCT`, `FAULT-ELAPSED-HOURS` |
+| Pandas diagnostics | **59** | `CookbookRule(...)` in `open_fdd/rules/cookbook_catalog.py` (`CANONICAL_RULE_COUNT`) |
+| SQL twins of those 59 | 59 | `sql_rules/registry.yaml` |
+| SQL-only analytics | **4** | `FAN-RUNTIME-HOURS`, `AVG-ZONE-TEMP`, `ZONE-COMFORT-PCT`, `FAULT-ELAPSED-HOURS` |
+| SQL registry total | **63** | 59 diagnostics + 4 analytics |
+
+Aliases are **not** extra rules: `SV-SLEW` → `SV-RATE`, `FC13` → `FC13-SAT-HIGH`, `excess_runtime` → `SCHED-1`.
+
+Building 100 `48 × 59 = 2,832` is the pandas diagnostic cartesian product, not 63.
 
 Product UI is **React** (`frontend/web`). Do not delete pandas because SQL exists. Do not put pandas on the product request path.
-
-Aliases: `FC13` → SQL `FC13-SAT-HIGH`; `SV-SLEW` → `SV-RATE`.
 
 ## Honesty first — parity levels
 

--- a/scripts/generate_parity_inventory.py
+++ b/scripts/generate_parity_inventory.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Generate sql_rules/generated/parity_inventory.{yaml,json} from registry + pandas catalog.
 
-Wave 0 contract: explains 59 diagnostic concepts + 4 SQL analytics = 63 SQL entries.
-Does not claim mask/duration parity — statuses come from registry.yaml.
+Contract: 59 pandas diagnostics + 4 SQL-only analytics = 63 SQL registry entries.
+Aliases (SV-SLEW, FC13, excess_runtime) are not extra rules.
+
+Does not claim mask/duration parity — statuses come from registry.yaml plus
+classified known differences.
 """
 
 from __future__ import annotations
@@ -24,6 +27,9 @@ REGISTRY = ROOT / "sql_rules" / "registry.yaml"
 CATALOG = ROOT / "open_fdd" / "rules" / "cookbook_catalog.py"
 OUT_DIR = ROOT / "sql_rules" / "generated"
 FIXTURE_ROOT = ROOT / "crates" / "fdd_rules" / "fixtures" / "oracle"
+TESTS_ROOT = ROOT / "tests"
+PANDAS_COOKBOOK = "docs/rules/cookbook/pandas-cookbook.md"
+SQL_COOKBOOK = "docs/rules/cookbook/datafusion-sql-cookbook.md"
 
 SQL_ANALYTICS = frozenset(
     {
@@ -34,7 +40,6 @@ SQL_ANALYTICS = frozenset(
     }
 )
 
-# Pandas FC13 ↔ SQL FC13-SAT-HIGH
 PANDAS_TO_SQL_CANONICAL = {
     "FC13": "FC13-SAT-HIGH",
 }
@@ -63,12 +68,118 @@ PARITY_LEVELS = frozenset(
     }
 )
 
+DIFFERENCE_CLASSES = (
+    "none",
+    "alias",
+    "missing_implementation",
+    "intentional_non_applicability",
+    "unsupported_datafusion_expression",
+    "documentation_error",
+    "semantic_gap",
+)
+
+# Classified from executable pandas vs SQL, not from padded counts.
+KNOWN_DIFFERENCES: dict[str, dict] = {
+    "CHW-1": {
+        "class": "semantic_gap",
+        "note": (
+            "pandas chw1() treats missing chw-pump-cmd as always-on; hydronic gate "
+            "returns ungated_no_proof_roles (all True) and does not use chiller "
+            "status/amps/power; SQL chw1_low_dt.sql only inspects chw_pump_cmd and "
+            "still scores ΔT when pump is NULL"
+        ),
+    },
+    "SCHED-247": {
+        "class": "semantic_gap",
+        "note": (
+            "pandas _sched247 ORs fan/pump/chiller status, commands, and duct "
+            "pressure; SQL sched247_always_on.sql uses fan_cmd only"
+        ),
+    },
+    "FC7": {
+        "class": "missing_implementation",
+        "note": "concept_only — SQL file is a placeholder; do not claim twin parity",
+    },
+    "FAN-RUNTIME-HOURS": {
+        "class": "intentional_non_applicability",
+        "note": "SQL analytics rollup — not a pandas diagnostic",
+    },
+    "AVG-ZONE-TEMP": {
+        "class": "intentional_non_applicability",
+        "note": "SQL analytics rollup — not a pandas diagnostic",
+    },
+    "ZONE-COMFORT-PCT": {
+        "class": "intentional_non_applicability",
+        "note": "SQL analytics rollup — not a pandas diagnostic",
+    },
+    "FAULT-ELAPSED-HOURS": {
+        "class": "intentional_non_applicability",
+        "note": "SQL analytics rollup — not a pandas diagnostic",
+    },
+}
+
+GATE_PROOF_ROLES = {
+    "fan_running": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+    ],
+    "hydronic_flow": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd",
+    ],
+    "compressor": [
+        "compressor-status",
+        "equipment-enable",
+        "fan-status",
+        "fan-cmd",
+    ],
+    "control_loop": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled",
+    ],
+    "equipment_energized": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable",
+    ],
+    "always": [],
+    "conditional": [],
+}
+
 
 def pandas_ids_from_catalog() -> list[str]:
     text = CATALOG.read_text(encoding="utf-8")
-    # Only CookbookRule("ID" ...) constructors in the RULES list region.
     ids = re.findall(r'CookbookRule\(\s*\n?\s*"([A-Z][A-Z0-9-]*)"', text)
-    # Dedupe preserving order
     seen: set[str] = set()
     out: list[str] = []
     for i in ids:
@@ -84,6 +195,18 @@ def load_registry() -> list[dict]:
     if not isinstance(rules, list):
         raise SystemExit("FAIL: sql_rules/registry.yaml missing rules list")
     return rules
+
+
+def load_pandas_objects() -> tuple[dict, dict]:
+    """Return (rules_by_id, gates) from the live package when importable."""
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    try:
+        from open_fdd.rules.cookbook_catalog import RULES_BY_ID
+        from open_fdd.rules.operational_gate import RULE_GATES
+    except ImportError:
+        return {}, {}
+    return dict(RULES_BY_ID), dict(RULE_GATES)
 
 
 def fixture_entries(rule_id: str, seed_cases: set[str] | None = None) -> list[dict]:
@@ -107,6 +230,92 @@ def fixture_entries(rule_id: str, seed_cases: set[str] | None = None) -> list[di
     return entries
 
 
+def _slug(rule_id: str) -> str:
+    return rule_id.lower()
+
+
+def _docs_link(rule_id: str, *, sql: bool = False) -> str:
+    page = SQL_COOKBOOK if sql else PANDAS_COOKBOOK
+    return f"{page}#{_slug(rule_id)}"
+
+
+def _scan_test_coverage() -> dict[str, list[str]]:
+    hits: dict[str, list[str]] = {}
+    if not TESTS_ROOT.is_dir():
+        return hits
+    for path in TESTS_ROOT.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        rel = str(path.relative_to(ROOT)).replace("\\", "/")
+        for m in re.findall(r"\b([A-Z]{2,}(?:-\d+|[A-Z0-9-]*)?)\b", text):
+            hits.setdefault(m, [])
+            if rel not in hits[m]:
+                hits[m].append(rel)
+    scripts = ROOT / "scripts"
+    for path in scripts.glob("*oracle*.py"):
+        rel = str(path.relative_to(ROOT)).replace("\\", "/")
+        text = path.read_text(encoding="utf-8")
+        for m in re.findall(r"\b([A-Z]{2,}(?:-\d+|[A-Z0-9-]*)?)\b", text):
+            hits.setdefault(m, [])
+            if rel not in hits[m]:
+                hits[m].append(rel)
+    return hits
+
+
+def _default_thresholds(rule_obj, registry_params: dict) -> dict:
+    out: dict = {}
+    if rule_obj is not None:
+        for p in getattr(rule_obj, "params", []) or []:
+            out[p.key] = {
+                "default": p.default,
+                "unit": p.unit,
+                "min": p.min,
+                "max": p.max,
+                "step": p.step,
+                "label": p.label,
+            }
+        out.setdefault(
+            "confirm_seconds",
+            {
+                "default": float(getattr(rule_obj, "confirm_seconds", 300) or 300),
+                "unit": "sec",
+            },
+        )
+        return out
+    for key, spec in (registry_params or {}).items():
+        if isinstance(spec, dict):
+            out[key] = {
+                "default": spec.get("default"),
+                "unit": spec.get("unit"),
+                "min": spec.get("min"),
+                "max": spec.get("max"),
+                "step": spec.get("step"),
+                "label": spec.get("label"),
+            }
+    return out
+
+
+def _proof_roles(rule_id: str, gates: dict) -> tuple[str | None, list[str], float | None]:
+    spec = gates.get(rule_id)
+    if spec is None:
+        return None, [], None
+    kind = getattr(spec, "kind", None)
+    delay = getattr(spec, "startup_delay_seconds", None)
+    roles = list(GATE_PROOF_ROLES.get(kind, []))
+    return kind, roles, delay
+
+
+def _difference(rule_id: str, aliases: list[str]) -> tuple[str, str]:
+    if rule_id in KNOWN_DIFFERENCES:
+        d = KNOWN_DIFFERENCES[rule_id]
+        return d["class"], d["note"]
+    if aliases:
+        return "alias", f"aliases: {', '.join(aliases)} (not independent rules)"
+    return "none", ""
+
+
 def build_inventory() -> dict:
     pandas_ids = pandas_ids_from_catalog()
     if len(pandas_ids) != 59:
@@ -124,8 +333,13 @@ def build_inventory() -> dict:
         rid = r["rule_id"]
         for a in r.get("aliases") or []:
             aliases_index[str(a)] = rid
+    # Pandas-only alias documented in cookbook_catalog
+    aliases_index.setdefault("SV-SLEW", "SV-RATE")
+    aliases_index.setdefault("excess_runtime", "SCHED-1")
 
-    # Seed cases that must exist for Wave 0 end-to-end oracle
+    pandas_objs, gates = load_pandas_objects()
+    test_hits = _scan_test_coverage()
+
     seed_map = {
         "ECON-4": {"fault"},
         "FC1": {"normal", "fault"},
@@ -133,8 +347,8 @@ def build_inventory() -> dict:
     }
 
     concepts: list[dict] = []
+    matrix: list[dict] = []
 
-    # Diagnostics: one concept per pandas id
     for pid in pandas_ids:
         sql_id = PANDAS_TO_SQL_CANONICAL.get(pid, pid)
         if sql_id not in by_sql:
@@ -145,78 +359,179 @@ def build_inventory() -> dict:
             raise SystemExit(f"FAIL: {sql_id} has invalid parity_status={level!r}")
         aliases = list(r.get("aliases") or [])
         if pid == "SV-RATE" and "SV-SLEW" not in aliases:
-            # pandas alias must be explainable even if only on pandas side
             aliases = aliases + ["SV-SLEW"]
-        concepts.append(
+        if pid == "SCHED-1" and "excess_runtime" not in aliases:
+            aliases = aliases + ["excess_runtime"]
+
+        rule_obj = pandas_objs.get(pid)
+        title = getattr(rule_obj, "title", None) or r.get("description") or pid
+        equipment = list(getattr(rule_obj, "equipment_kinds", None) or [])
+        required = list(getattr(rule_obj, "required_roles", None) or r.get("required_roles") or [])
+        optional = list(getattr(rule_obj, "optional_roles", None) or r.get("optional_roles") or [])
+        pandas_impl = None
+        if rule_obj is not None and getattr(rule_obj, "compute", None) is not None:
+            pandas_impl = getattr(rule_obj.compute, "__name__", None)
+        pandas_impl = pandas_impl or r.get("pandas_function") or pid.lower().replace("-", "_")
+        gate_kind, proof_roles, startup = _proof_roles(pid, gates)
+        if gate_kind is None:
+            gate_kind = "fan_or_occupied_when_declared"
+        diff_class, diff_note = _difference(sql_id if sql_id in KNOWN_DIFFERENCES else pid, aliases)
+        coverage = sorted(
+            set(test_hits.get(pid, []) + test_hits.get(sql_id, []) + test_hits.get("SV-SLEW", [])[:0])
+        )
+        if pid == "SV-RATE":
+            coverage = sorted(set(coverage + test_hits.get("SV-SLEW", [])))
+
+        concept = {
+            "canonical_id": sql_id,
+            "pandas_id": pid,
+            "rule_id": pid,
+            "title": title,
+            "aliases": aliases,
+            "kind": "diagnostic",
+            "equipment_types": equipment,
+            "equipment_kinds": equipment or None,
+            "required_roles": required,
+            "optional_roles": optional,
+            "operational_proof_roles": proof_roles,
+            "default_thresholds": _default_thresholds(rule_obj, r.get("parameters") or {}),
+            "pandas_implementation": pandas_impl,
+            "datafusion_sql_implementation": r.get("sql_file"),
+            "sql_file": r.get("sql_file"),
+            "documentation_link": _docs_link(pid),
+            "sql_documentation_link": _docs_link(sql_id, sql=True),
+            "test_coverage": coverage,
+            "parity_status": level,
+            "parity_level": level,
+            "difference_class": diff_class,
+            "known_semantic_differences": diff_note,
+            "operational_gate": gate_kind,
+            "startup_delay_seconds": startup,
+            "confirm_seconds": getattr(rule_obj, "confirm_seconds", None)
+            if rule_obj is not None
+            else r.get("confirm_seconds"),
+            "parameters": r.get("parameters") or {},
+            "time_semantics": "row_or_interval_per_sql_file",
+            "output_schema": list(r.get("output_columns") or []),
+            "proof_fixtures": fixture_entries(sql_id, seed_map.get(sql_id)),
+        }
+        concepts.append(concept)
+        matrix.append(
             {
-                "canonical_id": sql_id,
-                "pandas_id": pid,
-                "aliases": aliases,
-                "kind": "diagnostic",
-                "pandas_implementation": r.get("pandas_function") or pid.lower().replace("-", "_"),
-                "sql_file": r.get("sql_file"),
-                "equipment_kinds": None,  # filled from catalog when available
-                "required_roles": list(r.get("required_roles") or []),
-                "optional_roles": list(r.get("optional_roles") or []),
-                "operational_gate": "fan_or_occupied_when_declared",
-                "startup_delay_seconds": None,
-                "confirm_seconds": r.get("confirm_seconds"),
-                "parameters": r.get("parameters") or {},
-                "time_semantics": "row_or_interval_per_sql_file",
-                "output_schema": list(r.get("output_columns") or []),
-                "parity_level": level,
-                "proof_fixtures": fixture_entries(sql_id, seed_map.get(sql_id)),
+                "rule_id": pid,
+                "title": title,
+                "equipment_types": equipment,
+                "required_roles": required,
+                "optional_roles": optional,
+                "operational_proof_roles": proof_roles,
+                "default_thresholds": concept["default_thresholds"],
+                "pandas_implementation": pandas_impl,
+                "datafusion_sql_implementation": r.get("sql_file"),
+                "documentation_link": concept["documentation_link"],
+                "test_coverage": coverage,
+                "parity_status": level,
+                "known_semantic_differences": diff_note,
+                "difference_class": diff_class,
             }
         )
 
-    # SQL analytics (no pandas diagnostic)
     for aid in sorted(SQL_ANALYTICS):
         if aid not in by_sql:
             raise SystemExit(f"FAIL: missing SQL analytics {aid}")
         r = by_sql[aid]
         level = r.get("parity_status") or "concept_only"
-        concepts.append(
+        diff_class, diff_note = _difference(aid, list(r.get("aliases") or []))
+        coverage = sorted(test_hits.get(aid, []))
+        concept = {
+            "canonical_id": aid,
+            "pandas_id": None,
+            "rule_id": aid,
+            "title": r.get("description") or aid,
+            "aliases": list(r.get("aliases") or []),
+            "kind": "sql_analytics",
+            "equipment_types": [],
+            "equipment_kinds": None,
+            "required_roles": list(r.get("required_roles") or []),
+            "optional_roles": list(r.get("optional_roles") or []),
+            "operational_proof_roles": [],
+            "default_thresholds": _default_thresholds(None, r.get("parameters") or {}),
+            "pandas_implementation": None,
+            "datafusion_sql_implementation": r.get("sql_file"),
+            "sql_file": r.get("sql_file"),
+            "documentation_link": _docs_link(aid, sql=True),
+            "sql_documentation_link": _docs_link(aid, sql=True),
+            "test_coverage": coverage,
+            "parity_status": level,
+            "parity_level": level,
+            "difference_class": diff_class,
+            "known_semantic_differences": diff_note,
+            "operational_gate": None,
+            "startup_delay_seconds": None,
+            "confirm_seconds": r.get("confirm_seconds"),
+            "parameters": r.get("parameters") or {},
+            "time_semantics": "analytics_rollup",
+            "output_schema": list(r.get("output_columns") or []),
+            "proof_fixtures": [],
+        }
+        concepts.append(concept)
+        matrix.append(
             {
-                "canonical_id": aid,
-                "pandas_id": None,
-                "aliases": list(r.get("aliases") or []),
-                "kind": "sql_analytics",
+                "rule_id": aid,
+                "title": concept["title"],
+                "equipment_types": [],
+                "required_roles": concept["required_roles"],
+                "optional_roles": [],
+                "operational_proof_roles": [],
+                "default_thresholds": concept["default_thresholds"],
                 "pandas_implementation": None,
-                "sql_file": r.get("sql_file"),
-                "equipment_kinds": None,
-                "required_roles": list(r.get("required_roles") or []),
-                "optional_roles": list(r.get("optional_roles") or []),
-                "operational_gate": None,
-                "startup_delay_seconds": None,
-                "confirm_seconds": r.get("confirm_seconds"),
-                "parameters": r.get("parameters") or {},
-                "time_semantics": "analytics_rollup",
-                "output_schema": list(r.get("output_columns") or []),
-                "parity_level": level,
-                "proof_fixtures": [],
+                "datafusion_sql_implementation": r.get("sql_file"),
+                "documentation_link": concept["documentation_link"],
+                "test_coverage": coverage,
+                "parity_status": level,
+                "known_semantic_differences": diff_note,
+                "difference_class": diff_class,
             }
         )
 
-    # Orphan / duplicate checks
     sql_ids = set(by_sql)
     concept_sql = {c["canonical_id"] for c in concepts}
     orphans = sorted(sql_ids - concept_sql)
     if orphans:
         raise SystemExit(f"FAIL: orphan SQL rules not in inventory: {orphans}")
 
+    class_counts = {}
+    for row in matrix:
+        class_counts[row["difference_class"]] = class_counts.get(row["difference_class"], 0) + 1
+
     return {
-        "schema_version": "parity-inventory-v1",
+        "schema_version": "parity-inventory-v2",
         "generated_by": "scripts/generate_parity_inventory.py",
         "counts": {
             "pandas_diagnostics": 59,
             "sql_analytics": 4,
             "sql_registry": 63,
             "concepts": len(concepts),
+            "aliases": len(aliases_index),
+            "building_100_cartesian": "48 equipment × 59 diagnostics = 2832 results",
         },
+        "count_explanation": (
+            "59 is the executable pandas cookbook (CookbookRule constructors). "
+            "63 is the SQL registry: those 59 twins plus 4 SQL-only analytics. "
+            "Aliases SV-SLEW, FC13, and excess_runtime are not extra rules."
+        ),
         "parity_levels": sorted(PARITY_LEVELS),
+        "difference_classes": list(DIFFERENCE_CLASSES),
+        "difference_class_counts": class_counts,
         "aliases_index": aliases_index,
+        "matrix": matrix,
         "concepts": concepts,
     }
+
+
+def dump_inventory(inv: dict) -> tuple[str, str]:
+    yaml_text = yaml.safe_dump(inv, sort_keys=False, allow_unicode=True)
+    json_text = json.dumps(inv, indent=2, sort_keys=False) + "\n"
+    return yaml_text, json_text
 
 
 def main() -> int:
@@ -228,9 +543,7 @@ def main() -> int:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     yaml_path = OUT_DIR / "parity_inventory.yaml"
     json_path = OUT_DIR / "parity_inventory.json"
-
-    yaml_text = yaml.safe_dump(inv, sort_keys=False, allow_unicode=True)
-    json_text = json.dumps(inv, indent=2, sort_keys=False) + "\n"
+    yaml_text, json_text = dump_inventory(inv)
 
     if args.check:
         if not yaml_path.is_file() or not json_path.is_file():
@@ -249,9 +562,9 @@ def main() -> int:
     json_path.write_text(json_text, encoding="utf-8")
     print(f"Wrote {yaml_path.relative_to(ROOT)}")
     print(f"Wrote {json_path.relative_to(ROOT)}")
+    print("counts", inv["counts"])
+    print("difference_class_counts", inv["difference_class_counts"])
     print(
-        "counts",
-        inv["counts"],
         "levels",
         {
             lvl: sum(1 for c in inv["concepts"] if c["parity_level"] == lvl)

--- a/scripts/parity_inventory_check.py
+++ b/scripts/parity_inventory_check.py
@@ -57,6 +57,8 @@ def main() -> int:
     concepts = inv.get("concepts") or []
     counts = inv.get("counts") or {}
 
+    if inv.get("schema_version") != "parity-inventory-v2":
+        fail(f"schema_version={inv.get('schema_version')!r} want parity-inventory-v2")
     if counts.get("pandas_diagnostics") != 59:
         fail(f"inventory pandas_diagnostics={counts.get('pandas_diagnostics')} want 59")
     if counts.get("sql_analytics") != 4:
@@ -65,6 +67,48 @@ def main() -> int:
         fail(f"inventory sql_registry={counts.get('sql_registry')} want 63")
     if len(concepts) != 63:
         fail(f"inventory concepts={len(concepts)} want 63")
+    matrix = inv.get("matrix") or []
+    if len(matrix) != 63:
+        fail(f"inventory matrix={len(matrix)} want 63")
+    required_matrix = {
+        "rule_id",
+        "title",
+        "equipment_types",
+        "required_roles",
+        "optional_roles",
+        "operational_proof_roles",
+        "default_thresholds",
+        "pandas_implementation",
+        "datafusion_sql_implementation",
+        "documentation_link",
+        "test_coverage",
+        "parity_status",
+        "known_semantic_differences",
+        "difference_class",
+    }
+    allowed_diff = {
+        "none",
+        "alias",
+        "missing_implementation",
+        "intentional_non_applicability",
+        "unsupported_datafusion_expression",
+        "documentation_error",
+        "semantic_gap",
+    }
+    for row in matrix:
+        missing_keys = sorted(required_matrix - set(row))
+        if missing_keys:
+            fail(f"{row.get('rule_id')}: matrix missing {missing_keys}")
+        if row.get("difference_class") not in allowed_diff:
+            fail(f"{row.get('rule_id')}: bad difference_class={row.get('difference_class')}")
+    chw = next(r for r in matrix if r["rule_id"] == "CHW-1")
+    if chw.get("difference_class") != "semantic_gap":
+        fail("CHW-1 must be classified semantic_gap until gate/SQL twins match")
+    sched = next(r for r in matrix if r["rule_id"] == "SCHED-247")
+    if sched.get("difference_class") != "semantic_gap":
+        fail("SCHED-247 must be classified semantic_gap until proof ranking matches SQL")
+    if "count_explanation" not in inv:
+        fail("missing count_explanation for 59-versus-63")
 
     diag = [c for c in concepts if c.get("kind") == "diagnostic"]
     analytics = [c for c in concepts if c.get("kind") == "sql_analytics"]

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -1,12 +1,15 @@
 {
-  "schema_version": "parity-inventory-v1",
+  "schema_version": "parity-inventory-v2",
   "generated_by": "scripts/generate_parity_inventory.py",
   "counts": {
     "pandas_diagnostics": 59,
     "sql_analytics": 4,
     "sql_registry": 63,
-    "concepts": 63
+    "concepts": 63,
+    "aliases": 3,
+    "building_100_cartesian": "48 equipment \u00d7 59 diagnostics = 2832 results"
   },
+  "count_explanation": "59 is the executable pandas cookbook (CookbookRule constructors). 63 is the SQL registry: those 59 twins plus 4 SQL-only analytics. Aliases SV-SLEW, FC13, and excess_runtime are not extra rules.",
   "parity_levels": [
     "concept_only",
     "duration_parity",
@@ -15,26 +18,4317 @@
     "site_soak",
     "sql_screening"
   ],
+  "difference_classes": [
+    "none",
+    "alias",
+    "missing_implementation",
+    "intentional_non_applicability",
+    "unsupported_datafusion_expression",
+    "documentation_error",
+    "semantic_gap"
+  ],
+  "difference_class_counts": {
+    "none": 53,
+    "alias": 3,
+    "missing_implementation": 1,
+    "semantic_gap": 2,
+    "intentional_non_applicability": 4
+  },
   "aliases_index": {
     "FC13": "FC13-SAT-HIGH",
     "SV-SLEW": "SV-RATE",
     "excess_runtime": "SCHED-1"
   },
-  "concepts": [
+  "matrix": [
     {
-      "canonical_id": "SV-RANGE",
-      "pandas_id": "SV-RANGE",
-      "aliases": [],
-      "kind": "diagnostic",
-      "pandas_implementation": "sv_range",
-      "sql_file": "sv_range.sql",
-      "equipment_kinds": null,
+      "rule_id": "SV-RANGE",
+      "title": "Sensor out of hard range",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
+      "default_thresholds": {
+        "range_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Temp range scale"
+        },
+        "range_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Humidity range scale"
+        },
+        "range_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Pressure range scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_range",
+      "datafusion_sql_implementation": "sv_range.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "SV-FLATLINE",
+      "title": "Sensor flatline (stuck)",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "required_roles": [
+        "oa_t"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "flatline_tol": {
+          "default": 0.1,
+          "unit": "\u00b0F",
+          "min": 0.02,
+          "max": 1.0,
+          "step": 0.02,
+          "label": "Flatline tolerance"
+        },
+        "flatline_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
+          "label": "Flatline window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_flatline",
+      "datafusion_sql_implementation": "sv_flatline.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "SV-SPIKE",
+      "title": "Sensor rate-of-change spike",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "required_roles": [
+        "oa_t"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
+      "default_thresholds": {
+        "spike_scale": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Spike limit scale (global)"
+        },
+        "spike_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Temp spike scale"
+        },
+        "spike_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Humidity spike scale"
+        },
+        "spike_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Pressure spike scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_spike",
+      "datafusion_sql_implementation": "sv_spike.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "SV-STALE",
+      "title": "Stale data (no fresh samples)",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "required_roles": [
+        "fan_cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "stale_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.5,
+          "max": 12.0,
+          "step": 0.5,
+          "label": "Stale window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_stale",
+      "datafusion_sql_implementation": "sv_stale.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "SV-RATE",
+      "title": "Context-aware sensor rate of change",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "required_roles": [
+        "oa_t"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "persistence_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 5.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault persistence"
+        },
+        "transition_window_min": {
+          "default": 20.0,
+          "unit": "min",
+          "min": 5.0,
+          "max": 60.0,
+          "step": 5.0,
+          "label": "Transition window"
+        },
+        "max_gap_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Max sample gap"
+        },
+        "design_flow": {
+          "default": 0.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 100.0,
+          "label": "Design flow (flow profiles)"
+        },
+        "sensor_span": {
+          "default": 0.0,
+          "unit": "eng",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 10.0,
+          "label": "Sensor span (flow/pressure)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sv_rate_compute",
+      "datafusion_sql_implementation": "sv_rate.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
+      "test_coverage": [
+        "scripts/sql_pandas_oracle_check.py",
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "aliases: SV-SLEW (not independent rules)",
+      "difference_class": "alias"
+    },
+    {
+      "rule_id": "PID-HUNT-1",
+      "title": "Suspected control-output hunting",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "required_roles": [
+        "clg_valve_pct"
+      ],
+      "optional_roles": [
+        "loop-enabled"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
+      "default_thresholds": {
+        "change_deadband_pct": {
+          "default": 1.0,
+          "unit": "% out",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Ignore changes below"
+        },
+        "minimum_span_pct": {
+          "default": 20.0,
+          "unit": "% out",
+          "min": 5.0,
+          "max": 100.0,
+          "step": 5.0,
+          "label": "Minimum observed span"
+        },
+        "total_variation_fault_pct": {
+          "default": 500.0,
+          "unit": "%/h",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 50.0,
+          "label": "Total travel threshold"
+        },
+        "minimum_equivalent_cycles": {
+          "default": 2.5,
+          "unit": "cyc/h",
+          "min": 0.5,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Min equivalent cycles"
+        },
+        "minimum_reversals": {
+          "default": 4,
+          "unit": "count",
+          "min": 1,
+          "max": 40,
+          "step": 1,
+          "label": "Min direction reversals"
+        },
+        "minimum_coverage_pct": {
+          "default": 80.0,
+          "unit": "%",
+          "min": 25.0,
+          "max": 100.0,
+          "step": 5.0,
+          "label": "Minimum data coverage"
+        },
+        "confirm_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_pid_hunt_1",
+      "datafusion_sql_implementation": "pid_hunt_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC1",
+      "title": "Duct static below SP at full fan (GL36 A)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "duct-static-pressure",
+        "duct-static-pressure-sp",
+        "fan-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_dsp": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
+        },
+        "eps_vfd_spd": {
+          "default": 0.13,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
+        },
+        "duct_static_err": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Legacy duct-static error (sets \u03b5DSP)"
+        },
+        "fan_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc1",
+      "datafusion_sql_implementation": "fc1_duct_static_low.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC2",
+      "title": "MAT below OAT/RAT envelope (GL36 B)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc2",
+      "datafusion_sql_implementation": "fc2_mat_low.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc2",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC3",
+      "title": "MAT above OAT/RAT envelope (GL36 C)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc3",
+      "datafusion_sql_implementation": "fc3_mat_high.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC4",
+      "title": "PID hunting (operating-state oscillation)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-damper",
+        "cooling-valve",
+        "fan-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
+      "default_thresholds": {
+        "delta_os_max": {
+          "default": 5,
+          "unit": "count",
+          "min": 1,
+          "max": 30,
+          "step": 1,
+          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc4",
+      "datafusion_sql_implementation": "fc4_os_hunting.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC5",
+      "title": "SAT cold when heating commanded (GL36 D)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "fan-cmd",
+        "heating-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc5",
+      "datafusion_sql_implementation": "fc5_sat_cold_heating.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc5",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC6",
+      "title": "Estimated OA fraction mismatch",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "vav-total-airflow"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_airflow": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Airflow error \u03b5F (GL36 default 30%)"
+        },
+        "delta_t_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
+        },
+        "airflow_err": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy OA-fraction error (sets \u03b5F)"
+        },
+        "oat_rat_delta_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
+        },
+        "min_cfm_design": {
+          "default": 5000,
+          "unit": "cfm",
+          "min": 500,
+          "max": 20000,
+          "step": 500,
+          "label": "Design min OA CFM"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc6",
+      "datafusion_sql_implementation": "fc6_oa_frac_mismatch.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc6",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC7",
+      "title": "SAT low with full heating (GL36 E)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "fan-cmd",
+        "heating-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "htg_full_min": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Full-heating threshold (GL36 99%)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc7",
+      "datafusion_sql_implementation": "fc7_sat_low_heating.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc7",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "concept_only",
+      "known_semantic_differences": "concept_only \u2014 SQL file is a placeholder; do not claim twin parity",
+      "difference_class": "missing_implementation"
+    },
+    {
+      "rule_id": "FC8",
+      "title": "SAT/MAT mismatch in economizer (GL36 F)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc8",
+      "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc8",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC9",
+      "title": "OAT too warm for free cooling (GL36 G)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc9",
+      "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc9",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC10",
+      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "mixed-air-temp",
+        "outside-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc10",
+      "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc10",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC11",
+      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc11",
+      "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc11",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC12",
+      "title": "SAT above blend in cooling (GL36 J)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc12",
+      "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc12",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC13",
+      "title": "SAT above SP at full cooling (GL36 K)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "clg_full_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Full-cooling threshold (GL36 99%)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc13",
+      "datafusion_sql_implementation": "sat_high_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc13",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "aliases: FC13 (not independent rules)",
+      "difference_class": "alias"
+    },
+    {
+      "rule_id": "FC14",
+      "title": "CHW coil \u0394T when inactive (GL36 L)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "cooling-coil-entering-temp",
+        "cooling-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_ccet": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil entering sensor error \u03b5CCET"
+        },
+        "eps_cclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc14",
+      "datafusion_sql_implementation": "fc14_chw_coil_dt_inactive.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc14",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "FC15",
+      "title": "HW coil \u0394T when inactive (GL36 M)",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "heating-coil-entering-temp",
+        "heating-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_hcet": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil entering sensor error \u03b5HCET"
+        },
+        "eps_hclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil leaving sensor error \u03b5HCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc15",
+      "datafusion_sql_implementation": "fc15_hw_coil_dt_inactive.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc15",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "AHU-SATDEV",
+      "title": "SAT deviation from setpoint",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "discharge-air-temp-sp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "sat_dev_err": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 1.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "SAT deviation"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "ahu_sat_dev",
+      "datafusion_sql_implementation": "ahu_satdev.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "AHU-DUCTHI",
+      "title": "Duct static pressure high",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "duct-static-pressure",
+        "duct-static-pressure-sp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "duct_high_margin": {
+          "default": 0.25,
+          "unit": "in. w.c.",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.05,
+          "label": "High margin"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "in. w.c.",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "ahu_duct_high",
+      "datafusion_sql_implementation": "ahu_ducthi.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "AHU-SIMUL",
+      "title": "Heating and cooling simultaneous",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "heating-valve",
+        "cooling-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "valve_open_pct": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Valve open threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "ahu_simul_heat_cool",
+      "datafusion_sql_implementation": "ahu_simul.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "OAT-METEO",
+      "title": "BAS outdoor-air sensor vs Open-Meteo",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-temp",
+        "web-outside-air-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "oat_err": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 2.0,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Max OAT disagreement"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "oat_vs_meteo",
+      "datafusion_sql_implementation": "oat_meteo_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oat-meteo",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "ECON-1",
+      "title": "Economizer stuck closed",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "fan-cmd",
+        "outside-air-damper",
+        "outside-air-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ1_oat_min": {
+          "default": 55.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 70.0,
+          "step": 1.0,
+          "label": "Favorable OAT"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ1",
+      "datafusion_sql_implementation": "econ1_stuck_closed.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "ECON-2",
+      "title": "Economizing when outdoor unfavorable",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-temp",
+        "outside-air-damper"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ2_oat_hi": {
+          "default": 63.0,
+          "unit": "\u00b0F",
+          "min": 55.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "OAT high cutoff"
+        },
+        "econ2_damper": {
+          "default": 0.42,
+          "unit": "frac",
+          "min": 0.2,
+          "max": 0.9,
+          "step": 0.02,
+          "label": "Damper open frac"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ2",
+      "datafusion_sql_implementation": "economizer_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-2",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "ECON-3",
+      "title": "Mech cooling without integrated economizer",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ3_db_min": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 50.0,
+          "max": 68.0,
+          "step": 1.0,
+          "label": "Free-cool OA dry-bulb min"
+        },
+        "econ3_db_max": {
+          "default": 72.0,
+          "unit": "\u00b0F",
+          "min": 65.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Free-cool OA dry-bulb max"
+        },
+        "econ3_dp_max": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 68.0,
+          "step": 1.0,
+          "label": "Free-cool OA dew point max"
+        },
+        "econ3_damper_hi": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.02,
+          "label": "Integrated economizer damper"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ2",
+      "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "ECON-4",
+      "title": "Low estimated OA fraction",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "oa_min_pct": {
+          "default": 21.0,
+          "unit": "%",
+          "min": 5.0,
+          "max": 40.0,
+          "step": 1.0,
+          "label": "Min OA fraction"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ4",
+      "datafusion_sql_implementation": "econ4_low_oa_frac.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "ECON-5",
+      "title": "Preheat over-conditioning",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "preheat-leaving-temp",
+        "discharge-air-temp-sp",
+        "outside-air-temp",
+        "heating-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "preheat_over_f": {
+          "default": 2.2,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.1,
+          "label": "Preheat over \u0394T"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ5",
+      "datafusion_sql_implementation": "econ5_preheat_over.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "ECON-6",
+      "title": "Economizing in freezing weather",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-damper"
+      ],
+      "optional_roles": [
+        "web-outside-air-temp"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ6_oat_max_f": {
+          "default": 25.0,
+          "unit": "\u00b0F",
+          "min": 15.0,
+          "max": 40.0,
+          "step": 1.0,
+          "label": "Winter OAT ceiling"
+        },
+        "econ6_damper_max": {
+          "default": 0.25,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Winter min-OA damper"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ6_compute",
+      "datafusion_sql_implementation": "econ6_econ_freezing.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "ECON-7",
+      "title": "Economizer OK but not economizing",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-damper"
+      ],
+      "optional_roles": [
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity",
+        "cooling-valve",
+        "compressor-status",
+        "dx-cool-cmd"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ7_db_min": {
+          "default": 35.0,
+          "unit": "\u00b0F",
+          "min": 20.0,
+          "max": 50.0,
+          "step": 1.0,
+          "label": "Econ-OK dry-bulb floor (freeze guard)"
+        },
+        "econ7_db_max": {
+          "default": 72.0,
+          "unit": "\u00b0F",
+          "min": 65.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Econ-OK dry-bulb max"
+        },
+        "econ7_dp_max": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 68.0,
+          "step": 1.0,
+          "label": "Econ-OK dew point max"
+        },
+        "econ7_damper_min": {
+          "default": 0.5,
+          "unit": "frac",
+          "min": 0.2,
+          "max": 0.9,
+          "step": 0.02,
+          "label": "Economizing damper threshold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ7_compute",
+      "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "MECH-OAT-1",
+      "title": "Mechanical cooling below 60\u00b0F web OAT",
+      "equipment_types": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
+      "required_roles": [
+        "web_oa_t",
+        "clg_valve_pct"
+      ],
+      "optional_roles": [
+        "web-outside-air-temp",
+        "compressor-status",
+        "chiller-status",
+        "chw-pump-status",
+        "dx-cool-cmd"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "mech_oat_max_f": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 65.0,
+          "step": 1.0,
+          "label": "Mech-cool OAT ceiling"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "mech_oat1_compute",
+      "datafusion_sql_implementation": "mech_oat_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "CHW-NOLOAD-1",
+      "title": "Chiller running with no building load",
+      "equipment_types": [
+        "chiller"
+      ],
+      "required_roles": [
+        "chw_supply_t",
+        "chw_supply_sp",
+        "chw_pump_cmd"
+      ],
+      "optional_roles": [
+        "chiller-status",
+        "chw-pump-status",
+        "compressor-status",
+        "building-zone-load-satisfied",
+        "building-ahu-load-satisfied"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
+        },
+        "sat_band_f": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "AHU SAT\u2248SP band"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw_noload1_compute",
+      "datafusion_sql_implementation": "chw_noload_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VAV-1",
+      "title": "Zone comfort band",
+      "equipment_types": [
+        "vav",
+        "zone"
+      ],
+      "required_roles": [
+        "zone-air-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_lo": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 55.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone low"
+        },
+        "zone_hi": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone high"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav1",
+      "datafusion_sql_implementation": "vav1_comfort_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VAV-3",
+      "title": "Excessive reheat during warm weather",
+      "equipment_types": [
+        "vav"
+      ],
+      "required_roles": [
+        "outside-air-temp",
+        "reheat-valve"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "reheat_oat": {
+          "default": 78.0,
+          "unit": "\u00b0F",
+          "min": 65.0,
+          "max": 90.0,
+          "step": 1.0,
+          "label": "Warm OAT"
+        },
+        "reheat_pct": {
+          "default": 0.52,
+          "unit": "frac",
+          "min": 0.1,
+          "max": 1.0,
+          "step": 0.02,
+          "label": "Reheat frac"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav3",
+      "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VAV-4",
+      "title": "Damper stuck at full open",
+      "equipment_types": [
+        "vav"
+      ],
+      "required_roles": [
+        "damper"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
+      "default_thresholds": {
+        "full_open_pct": {
+          "default": 0.975,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.005,
+          "label": "Full open frac"
+        },
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav4",
+      "datafusion_sql_implementation": "vav4_damper_full_open.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VAV-5",
+      "title": "Airflow sensor bias",
+      "equipment_types": [
+        "vav"
+      ],
+      "required_roles": [
+        "zone-airflow",
+        "damper"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav5",
+      "datafusion_sql_implementation": "vav5_airflow_bias.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VAV-REHEAT",
+      "title": "Reheat valve stuck / no temp rise",
+      "equipment_types": [
+        "vav"
+      ],
+      "required_roles": [
+        "reheat-valve",
+        "vav-discharge-air-temp",
+        "vav-inlet-air-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "reheat_cmd": {
+          "default": 0.3,
+          "unit": "frac",
+          "min": 0.1,
+          "max": 1.0,
+          "step": 0.05,
+          "label": "Reheat open frac"
+        },
+        "min_rise": {
+          "default": 3.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Min temp rise"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav_reheat_stuck",
+      "datafusion_sql_implementation": "vav_reheat.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VAV-AHU-LEAVE",
+      "title": "VAV leave vs parent AHU SAT (fedBy)",
+      "equipment_types": [
+        "vav"
+      ],
+      "required_roles": [
+        "vav-discharge-air-temp",
+        "ahu-discharge-air-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "delta_f": {
+          "default": 8.0,
+          "unit": "\u00b0F",
+          "min": 2.0,
+          "max": 25.0,
+          "step": 0.5,
+          "label": "Leave \u0394 vs AHU SAT"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav_vs_ahu_leave",
+      "datafusion_sql_implementation": "vav_ahu_leave.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VAV-7",
+      "title": "Min airflow / fixed high flow",
+      "equipment_types": [
+        "vav"
+      ],
+      "required_roles": [
+        "zone-airflow"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "fixed_flow_max_std": {
+          "default": 15.0,
+          "unit": "cfm",
+          "min": 1.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Fixed-flow max std"
+        },
+        "fixed_flow_min_mean": {
+          "default": 200.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "Fixed-flow min mean"
+        },
+        "high_min_flow_sp": {
+          "default": 250.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "High min-flow SP"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav7",
+      "datafusion_sql_implementation": "vav7_min_airflow.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "CHW-1",
+      "title": "Low chilled-water \u0394T",
+      "equipment_types": [
+        "chiller"
+      ],
+      "required_roles": [
+        "chilled-water-supply-temp",
+        "chilled-water-return-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "min_dt": {
+          "default": 4.0,
+          "unit": "\u00b0F",
+          "min": 1.0,
+          "max": 12.0,
+          "step": 0.5,
+          "label": "Min \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw1",
+      "datafusion_sql_implementation": "chw1_low_dt.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-1",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "pandas chw1() treats missing chw-pump-cmd as always-on; hydronic gate returns ungated_no_proof_roles (all True) and does not use chiller status/amps/power; SQL chw1_low_dt.sql only inspects chw_pump_cmd and still scores \u0394T when pump is NULL",
+      "difference_class": "semantic_gap"
+    },
+    {
+      "rule_id": "CHW-2",
+      "title": "DP below SP at max pump speed",
+      "equipment_types": [
+        "chiller"
+      ],
+      "required_roles": [
+        "chw-diff-pressure",
+        "chw-diff-pressure-sp",
+        "chw-pump-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "dp_margin": {
+          "default": 2.2,
+          "unit": "psi",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.1,
+          "label": "DP margin"
+        },
+        "pump_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw2",
+      "datafusion_sql_implementation": "chw2_dp_low.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "CHW-3",
+      "title": "Plant supply temp outside deadband",
+      "equipment_types": [
+        "chiller"
+      ],
+      "required_roles": [
+        "chilled-water-supply-temp",
+        "chilled-water-supply-temp-sp",
+        "chw-pump-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "sp_band": {
+          "default": 2.2,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.1,
+          "label": "SP band"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw3",
+      "datafusion_sql_implementation": "chw3_supply_band.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "CHW-4",
+      "title": "Flow high at max pump",
+      "equipment_types": [
+        "chiller"
+      ],
+      "required_roles": [
+        "chw-flow",
+        "chw-pump-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "flow_hi": {
+          "default": 1100,
+          "unit": "gpm",
+          "min": 200,
+          "max": 3000,
+          "step": 50,
+          "label": "Flow high"
+        },
+        "pump_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw4",
+      "datafusion_sql_implementation": "chw4_flow_high.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "HP-1",
+      "title": "Discharge cold when heating",
+      "equipment_types": [
+        "heatpump"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "zone-air-temp",
+        "fan-cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "compressor-status",
+        "equipment-enable",
+        "fan-status",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "min_sat": {
+          "default": 85.0,
+          "unit": "\u00b0F",
+          "min": 70.0,
+          "max": 110.0,
+          "step": 1.0,
+          "label": "Min heating SAT"
+        },
+        "zone_cold": {
+          "default": 69.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone cold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "hp1",
+      "datafusion_sql_implementation": "hp1_discharge_cold.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "WX-1",
+      "title": "OA temperature spike",
+      "equipment_types": [
+        "weather"
+      ],
+      "required_roles": [
+        "outside-air-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "spike_limit": {
+          "default": 16.0,
+          "unit": "\u00b0F",
+          "min": 4.0,
+          "max": 40.0,
+          "step": 1.0,
+          "label": "Spike limit"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "wx1",
+      "datafusion_sql_implementation": "wx1_oa_spike.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "CW-OPT-1",
+      "title": "Condenser water not optimized vs wet-bulb",
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "required_roles": [
+        "condenser-water-supply-temp"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "cw_approach": {
+          "default": 7.0,
+          "unit": "\u00b0F",
+          "min": 3.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Design approach"
+        },
+        "cw_slack": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Slack below target"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cw_opt",
+      "datafusion_sql_implementation": "cw_opt_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "CW-APR-1",
+      "title": "High CW approach at full tower fan",
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "required_roles": [
+        "condenser-water-supply-temp"
+      ],
+      "optional_roles": [
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
+      ],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "approach_max_f": {
+          "default": 8.0,
+          "unit": "\u00b0F",
+          "min": 5.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Max approach at full fan"
+        },
+        "tower_fan_hi": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cw_apr",
+      "datafusion_sql_implementation": "cw_apr_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "CW-FAN-1",
+      "title": "Excess tower fan energy vs wet-bulb limit",
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "required_roles": [
+        "condenser-water-supply-temp"
+      ],
+      "optional_roles": [
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
+      ],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "cw_approach": {
+          "default": 7.0,
+          "unit": "\u00b0F",
+          "min": 3.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Design approach"
+        },
+        "excess_beyond_approach_f": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 2.0,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Excess beyond approach"
+        },
+        "tower_fan_hi": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cw_fan_excess",
+      "datafusion_sql_implementation": "cw_fan_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "TRIM-1",
+      "title": "Duct static trim advisory",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "duct-static-pressure",
+        "vav-pressure-request-sum"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "duct_hi": {
+          "default": 1.35,
+          "unit": "in. w.c.",
+          "min": 0.5,
+          "max": 3.0,
+          "step": 0.05,
+          "label": "Duct static high"
+        },
+        "request_lo": {
+          "default": 1.0,
+          "unit": "count",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "trim1",
+      "datafusion_sql_implementation": "trim1_duct_static.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "TRIM-3",
+      "title": "HWST trim advisory",
+      "equipment_types": [
+        "boiler"
+      ],
+      "required_roles": [
+        "hot-water-supply-temp",
+        "hw-reset-request-sum"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "hwst_hi": {
+          "default": 160.0,
+          "unit": "\u00b0F",
+          "min": 120.0,
+          "max": 200.0,
+          "step": 1.0,
+          "label": "HWST high"
+        },
+        "request_lo": {
+          "default": 1.0,
+          "unit": "count",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "trim3",
+      "datafusion_sql_implementation": "trim3_hwst.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "TRIM-4",
+      "title": "CHW plant reset advisory",
+      "equipment_types": [
+        "chiller"
+      ],
+      "required_roles": [
+        "chilled-water-supply-temp",
+        "chw-reset-request-sum"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "chw_lo": {
+          "default": 45.0,
+          "unit": "\u00b0F",
+          "min": 35.0,
+          "max": 55.0,
+          "step": 0.5,
+          "label": "CHWS low"
+        },
+        "request_lo": {
+          "default": 1.0,
+          "unit": "count",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "trim4",
+      "datafusion_sql_implementation": "trim4_chw_reset.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "SCHED-1",
+      "title": "Unoccupied runtime",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "occupied",
+        "fan-status"
+      ],
+      "optional_roles": [
+        "zone-air-temp"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "sched1",
+      "datafusion_sql_implementation": "sched1_unoccupied_runtime.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sched-1",
+      "test_coverage": [
+        "tests/reporting/test_findings_smoke.py",
+        "tests/rules/test_catalog_smoke.py"
+      ],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "aliases: excess_runtime (not independent rules)",
+      "difference_class": "alias"
+    },
+    {
+      "rule_id": "SCHED-247",
+      "title": "Always-on fan or pump runtime",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "required_roles": [
+        "fan_cmd"
+      ],
+      "optional_roles": [
+        "fan-status",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "chiller-status",
+        "compressor-status",
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd",
+        "duct-static-pressure",
+        "chw-diff-pressure"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "always_on_pct": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Always-on fraction"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "eng",
+          "min": 0.05,
+          "max": 2.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sched247",
+      "datafusion_sql_implementation": "sched247_always_on.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sched-247",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "pandas _sched247 ORs fan/pump/chiller status, commands, and duct pressure; SQL sched247_always_on.sql uses fan_cmd only",
+      "difference_class": "semantic_gap"
+    },
+    {
+      "rule_id": "CMD-1",
+      "title": "Fan cmd/status mismatch",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "fan-cmd",
+        "fan-status"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cmd1",
+      "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "OA-1",
+      "title": "Low OA fraction",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-status"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "min_oa_frac": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 0.4,
+          "step": 0.01,
+          "label": "Min OA fraction"
+        },
+        "oat_rat_guard": {
+          "default": 2.2,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.1,
+          "label": "Min |RAT\u2212OAT| guard"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "oa1",
+      "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "DMP-1",
+      "title": "OA damper leakage",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "leak_delta": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "dmp1",
+      "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "VLV-1",
+      "title": "Cooling valve leakage",
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "cooling-valve"
+      ],
+      "optional_roles": [
+        "mixed-air-temp",
+        "fan-status",
+        "fan-cmd"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "sat_err": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
+          "label": "SAT vs SP leak \u0394T"
+        },
+        "mat_leak_delta": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 12.0,
+          "step": 0.5,
+          "label": "SAT vs MAT leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vlv1",
+      "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "",
+      "difference_class": "none"
+    },
+    {
+      "rule_id": "AVG-ZONE-TEMP",
+      "title": "Average zone temperature per equipment",
+      "equipment_types": [],
+      "required_roles": [
+        "zone_t"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_t_lo": {
+          "default": 68.0,
+          "unit": "degF",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone comfort low (reference)"
+        },
+        "zone_t_hi": {
+          "default": 76.0,
+          "unit": "degF",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone comfort high (reference)"
+        }
+      },
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "avg_zone_temp.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#avg-zone-temp",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
+      "difference_class": "intentional_non_applicability"
+    },
+    {
+      "rule_id": "FAN-RUNTIME-HOURS",
+      "title": "Fan running hours where fan_cmd > 5% (normalized 0-1)",
+      "equipment_types": [],
+      "required_roles": [
+        "fan_cmd"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {},
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "fan_runtime_hours.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fan-runtime-hours",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
+      "difference_class": "intentional_non_applicability"
+    },
+    {
+      "rule_id": "FAULT-ELAPSED-HOURS",
+      "title": "Comfort fault sample count \u2192 hours",
+      "equipment_types": [],
+      "required_roles": [
+        "zone_t"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_t_lo": {
+          "default": 68.0,
+          "unit": "degF",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone comfort low"
+        },
+        "zone_t_hi": {
+          "default": 76.0,
+          "unit": "degF",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone comfort high"
+        }
+      },
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "fault_elapsed_hours.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fault-elapsed-hours",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
+      "difference_class": "intentional_non_applicability"
+    },
+    {
+      "rule_id": "ZONE-COMFORT-PCT",
+      "title": "Percent of samples in comfort band",
+      "equipment_types": [],
+      "required_roles": [
+        "zone_t"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_t_lo": {
+          "default": 68.0,
+          "unit": "degF",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone comfort low"
+        },
+        "zone_t_hi": {
+          "default": 76.0,
+          "unit": "degF",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone comfort high"
+        }
+      },
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "zone_comfort_pct.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#zone-comfort-pct",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
+      "difference_class": "intentional_non_applicability"
+    }
+  ],
+  "concepts": [
+    {
+      "canonical_id": "SV-RANGE",
+      "pandas_id": "SV-RANGE",
+      "rule_id": "SV-RANGE",
+      "title": "Sensor out of hard range",
+      "aliases": [],
+      "kind": "diagnostic",
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "required_roles": [
+        "oa_t"
+      ],
+      "optional_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
+      "default_thresholds": {
+        "range_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Temp range scale"
+        },
+        "range_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Humidity range scale"
+        },
+        "range_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Pressure range scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_range",
+      "datafusion_sql_implementation": "sv_range.sql",
+      "sql_file": "sv_range.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#sv-range",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "equipment_energized",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -63,7 +4357,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -140,17 +4433,75 @@
     {
       "canonical_id": "SV-FLATLINE",
       "pandas_id": "SV-FLATLINE",
+      "rule_id": "SV-FLATLINE",
+      "title": "Sensor flatline (stuck)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "sv_flatline",
-      "sql_file": "sv_flatline.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "flatline_tol": {
+          "default": 0.1,
+          "unit": "\u00b0F",
+          "min": 0.02,
+          "max": 1.0,
+          "step": 0.02,
+          "label": "Flatline tolerance"
+        },
+        "flatline_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
+          "label": "Flatline window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_flatline",
+      "datafusion_sql_implementation": "sv_flatline.sql",
+      "sql_file": "sv_flatline.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#sv-flatline",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -179,7 +4530,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -256,17 +4606,105 @@
     {
       "canonical_id": "SV-SPIKE",
       "pandas_id": "SV-SPIKE",
+      "rule_id": "SV-SPIKE",
+      "title": "Sensor rate-of-change spike",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "sv_spike",
-      "sql_file": "sv_spike.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
+      "default_thresholds": {
+        "spike_scale": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Spike limit scale (global)"
+        },
+        "spike_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Temp spike scale"
+        },
+        "spike_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Humidity spike scale"
+        },
+        "spike_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Pressure spike scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_spike",
+      "datafusion_sql_implementation": "sv_spike.sql",
+      "sql_file": "sv_spike.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#sv-spike",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "equipment_energized",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -295,7 +4733,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -372,17 +4809,67 @@
     {
       "canonical_id": "SV-STALE",
       "pandas_id": "SV-STALE",
+      "rule_id": "SV-STALE",
+      "title": "Stale data (no fresh samples)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "sv_stale",
-      "sql_file": "sv_stale.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "fan_cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "stale_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.5,
+          "max": 12.0,
+          "step": 0.5,
+          "label": "Stale window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sweep_stale",
+      "datafusion_sql_implementation": "sv_stale.sql",
+      "sql_file": "sv_stale.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#sv-stale",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -411,7 +4898,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -488,19 +4974,104 @@
     {
       "canonical_id": "SV-RATE",
       "pandas_id": "SV-RATE",
+      "rule_id": "SV-RATE",
+      "title": "Context-aware sensor rate of change",
       "aliases": [
         "SV-SLEW"
       ],
       "kind": "diagnostic",
-      "pandas_implementation": "sv_rate",
-      "sql_file": "sv_rate.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "persistence_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 5.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault persistence"
+        },
+        "transition_window_min": {
+          "default": 20.0,
+          "unit": "min",
+          "min": 5.0,
+          "max": 60.0,
+          "step": 5.0,
+          "label": "Transition window"
+        },
+        "max_gap_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Max sample gap"
+        },
+        "design_flow": {
+          "default": 0.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 100.0,
+          "label": "Design flow (flow profiles)"
+        },
+        "sensor_span": {
+          "default": 0.0,
+          "unit": "eng",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 10.0,
+          "label": "Sensor span (flow/pressure)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sv_rate_compute",
+      "datafusion_sql_implementation": "sv_rate.sql",
+      "sql_file": "sv_rate.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#sv-rate",
+      "test_coverage": [
+        "scripts/sql_pandas_oracle_check.py",
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "alias",
+      "known_semantic_differences": "aliases: SV-SLEW (not independent rules)",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -529,7 +5100,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -606,17 +5176,113 @@
     {
       "canonical_id": "PID-HUNT-1",
       "pandas_id": "PID-HUNT-1",
+      "rule_id": "PID-HUNT-1",
+      "title": "Suspected control-output hunting",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "pid_hunt_1",
-      "sql_file": "pid_hunt_1.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [
         "clg_valve_pct"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "optional_roles": [
+        "loop-enabled"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
+      "default_thresholds": {
+        "change_deadband_pct": {
+          "default": 1.0,
+          "unit": "% out",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Ignore changes below"
+        },
+        "minimum_span_pct": {
+          "default": 20.0,
+          "unit": "% out",
+          "min": 5.0,
+          "max": 100.0,
+          "step": 5.0,
+          "label": "Minimum observed span"
+        },
+        "total_variation_fault_pct": {
+          "default": 500.0,
+          "unit": "%/h",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 50.0,
+          "label": "Total travel threshold"
+        },
+        "minimum_equivalent_cycles": {
+          "default": 2.5,
+          "unit": "cyc/h",
+          "min": 0.5,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Min equivalent cycles"
+        },
+        "minimum_reversals": {
+          "default": 4,
+          "unit": "count",
+          "min": 1,
+          "max": 40,
+          "step": 1,
+          "label": "Min direction reversals"
+        },
+        "minimum_coverage_pct": {
+          "default": 80.0,
+          "unit": "%",
+          "min": 25.0,
+          "max": 100.0,
+          "step": 5.0,
+          "label": "Minimum data coverage"
+        },
+        "confirm_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_pid_hunt_1",
+      "datafusion_sql_implementation": "pid_hunt_1.sql",
+      "sql_file": "pid_hunt_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#pid-hunt-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 0,
       "parameters": {
         "confirm_seconds": {
@@ -655,7 +5321,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -732,19 +5397,96 @@
     {
       "canonical_id": "FC1",
       "pandas_id": "FC1",
+      "rule_id": "FC1",
+      "title": "Duct static below SP at full fan (GL36 A)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc1",
-      "sql_file": "fc1_duct_static_low.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp",
+        "fan-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_dsp": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
+        },
+        "eps_vfd_spd": {
+          "default": 0.13,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
+        },
+        "duct_static_err": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Legacy duct-static error (sets \u03b5DSP)"
+        },
+        "fan_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc1",
+      "datafusion_sql_implementation": "fc1_duct_static_low.sql",
+      "sql_file": "fc1_duct_static_low.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "eps_dsp": {
@@ -783,7 +5525,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -860,20 +5601,105 @@
     {
       "canonical_id": "FC2",
       "pandas_id": "FC2",
+      "rule_id": "FC2",
+      "title": "MAT below OAT/RAT envelope (GL36 B)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc2",
-      "sql_file": "fc2_mat_low.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc2",
+      "datafusion_sql_implementation": "fc2_mat_low.sql",
+      "sql_file": "fc2_mat_low.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc2",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc2",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -881,7 +5707,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -958,20 +5783,105 @@
     {
       "canonical_id": "FC3",
       "pandas_id": "FC3",
+      "rule_id": "FC3",
+      "title": "MAT above OAT/RAT envelope (GL36 C)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc3",
-      "sql_file": "fc3_mat_high.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc3",
+      "datafusion_sql_implementation": "fc3_mat_high.sql",
+      "sql_file": "fc3_mat_high.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc3",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -979,7 +5889,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1056,19 +5965,73 @@
     {
       "canonical_id": "FC4",
       "pandas_id": "FC4",
+      "rule_id": "FC4",
+      "title": "PID hunting (operating-state oscillation)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc4",
-      "sql_file": "fc4_os_hunting.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct",
-        "fan_cmd"
+        "outside-air-damper",
+        "cooling-valve",
+        "fan-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
+      "default_thresholds": {
+        "delta_os_max": {
+          "default": 5,
+          "unit": "count",
+          "min": 1,
+          "max": 30,
+          "step": 1,
+          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc4",
+      "datafusion_sql_implementation": "fc4_os_hunting.sql",
+      "sql_file": "fc4_os_hunting.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc4",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -1087,7 +6050,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1164,20 +6126,113 @@
     {
       "canonical_id": "FC5",
       "pandas_id": "FC5",
+      "rule_id": "FC5",
+      "title": "SAT cold when heating commanded (GL36 D)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc5",
-      "sql_file": "fc5_sat_cold_heating.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc5",
+      "datafusion_sql_implementation": "fc5_sat_cold_heating.sql",
+      "sql_file": "fc5_sat_cold_heating.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc5",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc5",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -1216,7 +6271,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1293,20 +6347,113 @@
     {
       "canonical_id": "FC6",
       "pandas_id": "FC6",
+      "rule_id": "FC6",
+      "title": "Estimated OA fraction mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc6",
-      "sql_file": "fc6_oa_frac_mismatch.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "vav-total-airflow"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_airflow": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Airflow error \u03b5F (GL36 default 30%)"
+        },
+        "delta_t_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
+        },
+        "airflow_err": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy OA-fraction error (sets \u03b5F)"
+        },
+        "oat_rat_delta_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
+        },
+        "min_cfm_design": {
+          "default": 5000,
+          "unit": "cfm",
+          "min": 500,
+          "max": 20000,
+          "step": 500,
+          "label": "Design min OA CFM"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc6",
+      "datafusion_sql_implementation": "fc6_oa_frac_mismatch.sql",
+      "sql_file": "fc6_oa_frac_mismatch.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc6",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc6",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -1345,7 +6492,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1422,20 +6568,99 @@
     {
       "canonical_id": "FC7",
       "pandas_id": "FC7",
+      "rule_id": "FC7",
+      "title": "SAT low with full heating (GL36 E)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc7",
-      "sql_file": "fc7_sat_low_heating.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "htg_full_min": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Full-heating threshold (GL36 99%)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc7",
+      "datafusion_sql_implementation": "fc7_sat_low_heating.sql",
+      "sql_file": "fc7_sat_low_heating.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc7",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc7",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "concept_only",
+      "parity_level": "concept_only",
+      "difference_class": "missing_implementation",
+      "known_semantic_differences": "concept_only \u2014 SQL file is a placeholder; do not claim twin parity",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -1474,7 +6699,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "concept_only",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1551,20 +6775,121 @@
     {
       "canonical_id": "FC8",
       "pandas_id": "FC8",
+      "rule_id": "FC8",
+      "title": "SAT/MAT mismatch in economizer (GL36 F)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc8",
-      "sql_file": "fc8_sat_mat_econ.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc8",
+      "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
+      "sql_file": "fc8_sat_mat_econ.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc8",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc8",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -1572,7 +6897,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1649,20 +6973,113 @@
     {
       "canonical_id": "FC9",
       "pandas_id": "FC9",
+      "rule_id": "FC9",
+      "title": "OAT too warm for free cooling (GL36 G)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc9",
-      "sql_file": "fc9_oa_sat_sp_econ.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc9",
+      "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
+      "sql_file": "fc9_oa_sat_sp_econ.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc9",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc9",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -1670,7 +7087,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1747,20 +7163,105 @@
     {
       "canonical_id": "FC10",
       "pandas_id": "FC10",
+      "rule_id": "FC10",
+      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc10",
-      "sql_file": "fc10_mat_oa_clg.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc10",
+      "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
+      "sql_file": "fc10_mat_oa_clg.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc10",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc10",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -1768,7 +7269,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1845,20 +7345,113 @@
     {
       "canonical_id": "FC11",
       "pandas_id": "FC11",
+      "rule_id": "FC11",
+      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc11",
-      "sql_file": "fc11_oa_sat_sp_clg.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc11",
+      "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
+      "sql_file": "fc11_oa_sat_sp_clg.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc11",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc11",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -1866,7 +7459,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -1943,20 +7535,129 @@
     {
       "canonical_id": "FC12",
       "pandas_id": "FC12",
+      "rule_id": "FC12",
+      "title": "SAT above blend in cooling (GL36 J)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc12",
-      "sql_file": "fc12_sat_mat_clg.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc12",
+      "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
+      "sql_file": "fc12_sat_mat_clg.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc12",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc12",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -1964,7 +7665,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2041,22 +7741,109 @@
     {
       "canonical_id": "FC13-SAT-HIGH",
       "pandas_id": "FC13",
+      "rule_id": "FC13",
+      "title": "SAT above SP at full cooling (GL36 K)",
       "aliases": [
         "FC13"
       ],
       "kind": "diagnostic",
-      "pandas_implementation": "fc13",
-      "sql_file": "sat_high_fault.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "clg_valve_pct",
-        "oa_damper_pct"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "clg_full_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Full-cooling threshold (GL36 99%)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc13",
+      "datafusion_sql_implementation": "sat_high_fault.sql",
+      "sql_file": "sat_high_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc13",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc13-sat-high",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "alias",
+      "known_semantic_differences": "aliases: FC13 (not independent rules)",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -2115,7 +7902,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2192,21 +7978,121 @@
     {
       "canonical_id": "FC14",
       "pandas_id": "FC14",
+      "rule_id": "FC14",
+      "title": "CHW coil \u0394T when inactive (GL36 L)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc14",
-      "sql_file": "fc14_chw_coil_dt_inactive.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "sat",
-        "clg_valve_pct",
-        "oa_damper_pct",
-        "fan_cmd"
+        "cooling-coil-entering-temp",
+        "cooling-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_ccet": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil entering sensor error \u03b5CCET"
+        },
+        "eps_cclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc14",
+      "datafusion_sql_implementation": "fc14_chw_coil_dt_inactive.sql",
+      "sql_file": "fc14_chw_coil_dt_inactive.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc14",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc14",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -2235,7 +8121,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2312,20 +8197,129 @@
     {
       "canonical_id": "FC15",
       "pandas_id": "FC15",
+      "rule_id": "FC15",
+      "title": "HW coil \u0394T when inactive (GL36 M)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "fc15",
-      "sql_file": "fc15_hw_coil_dt_inactive.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "sat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "heating-coil-entering-temp",
+        "heating-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_hcet": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil entering sensor error \u03b5HCET"
+        },
+        "eps_hclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil leaving sensor error \u03b5HCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "fc15",
+      "datafusion_sql_implementation": "fc15_hw_coil_dt_inactive.sql",
+      "sql_file": "fc15_hw_coil_dt_inactive.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc15",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc15",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -2354,7 +8348,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2431,18 +8424,63 @@
     {
       "canonical_id": "AHU-SATDEV",
       "pandas_id": "AHU-SATDEV",
+      "rule_id": "AHU-SATDEV",
+      "title": "SAT deviation from setpoint",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "ahu_satdev",
-      "sql_file": "ahu_satdev.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp"
+        "discharge-air-temp",
+        "discharge-air-temp-sp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "sat_dev_err": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 1.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "SAT deviation"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "ahu_sat_dev",
+      "datafusion_sql_implementation": "ahu_satdev.sql",
+      "sql_file": "ahu_satdev.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#ahu-satdev",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -2471,7 +8509,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2548,19 +8585,64 @@
     {
       "canonical_id": "AHU-DUCTHI",
       "pandas_id": "AHU-DUCTHI",
+      "rule_id": "AHU-DUCTHI",
+      "title": "Duct static pressure high",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "ahu_ducthi",
-      "sql_file": "ahu_ducthi.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "duct_high_margin": {
+          "default": 0.25,
+          "unit": "in. w.c.",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.05,
+          "label": "High margin"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "in. w.c.",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "ahu_duct_high",
+      "datafusion_sql_implementation": "ahu_ducthi.sql",
+      "sql_file": "ahu_ducthi.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#ahu-ducthi",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -2599,7 +8681,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2676,18 +8757,63 @@
     {
       "canonical_id": "AHU-SIMUL",
       "pandas_id": "AHU-SIMUL",
+      "rule_id": "AHU-SIMUL",
+      "title": "Heating and cooling simultaneous",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "ahu_simul",
-      "sql_file": "ahu_simul.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "htg_valve_pct",
-        "clg_valve_pct"
+        "heating-valve",
+        "cooling-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "valve_open_pct": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Valve open threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "ahu_simul_heat_cool",
+      "datafusion_sql_implementation": "ahu_simul.sql",
+      "sql_file": "ahu_simul.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#ahu-simul",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -2716,7 +8842,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2793,17 +8918,56 @@
     {
       "canonical_id": "OAT-METEO",
       "pandas_id": "OAT-METEO",
+      "rule_id": "OAT-METEO",
+      "title": "BAS outdoor-air sensor vs Open-Meteo",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "oat_vs_meteo",
-      "sql_file": "oat_meteo_fault.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp",
+        "web-outside-air-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "oat_err": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 2.0,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Max OAT disagreement"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "oat_vs_meteo",
+      "datafusion_sql_implementation": "oat_meteo_fault.sql",
+      "sql_file": "oat_meteo_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oat-meteo",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#oat-meteo",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 900,
       "parameters": {
         "oat_err": {
@@ -2833,7 +8997,6 @@
         "fault_hours",
         "fault_pct"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -2910,19 +9073,64 @@
     {
       "canonical_id": "ECON-1",
       "pandas_id": "ECON-1",
+      "rule_id": "ECON-1",
+      "title": "Economizer stuck closed",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "econ1",
-      "sql_file": "econ1_stuck_closed.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "oa_damper_pct",
-        "oa_t"
+        "fan-cmd",
+        "outside-air-damper",
+        "outside-air-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ1_oat_min": {
+          "default": 55.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 70.0,
+          "step": 1.0,
+          "label": "Favorable OAT"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ1",
+      "datafusion_sql_implementation": "econ1_stuck_closed.sql",
+      "sql_file": "econ1_stuck_closed.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#econ-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "econ1_oat_min": {
@@ -2941,7 +9149,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3018,18 +9225,71 @@
     {
       "canonical_id": "ECON-2",
       "pandas_id": "ECON-2",
+      "rule_id": "ECON-2",
+      "title": "Economizing when outdoor unfavorable",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "econ2",
-      "sql_file": "economizer_fault.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "oa_damper_pct"
+        "outside-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ2_oat_hi": {
+          "default": 63.0,
+          "unit": "\u00b0F",
+          "min": 55.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "OAT high cutoff"
+        },
+        "econ2_damper": {
+          "default": 0.42,
+          "unit": "frac",
+          "min": 0.2,
+          "max": 0.9,
+          "step": 0.02,
+          "label": "Damper open frac"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ2",
+      "datafusion_sql_implementation": "economizer_fault.sql",
+      "sql_file": "economizer_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-2",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#econ-2",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "econ2_oat_hi": {
@@ -3068,7 +9328,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3145,20 +9404,91 @@
     {
       "canonical_id": "ECON-3",
       "pandas_id": "ECON-3",
+      "rule_id": "ECON-3",
+      "title": "Mech cooling without integrated economizer",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "econ_3",
-      "sql_file": "econ3_mech_without_econ.sql",
-      "equipment_kinds": null,
-      "required_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+      "equipment_types": [
+        "ahu"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "equipment_kinds": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-damper",
+        "cooling-valve"
+      ],
+      "optional_roles": [
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ3_db_min": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 50.0,
+          "max": 68.0,
+          "step": 1.0,
+          "label": "Free-cool OA dry-bulb min"
+        },
+        "econ3_db_max": {
+          "default": 72.0,
+          "unit": "\u00b0F",
+          "min": 65.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Free-cool OA dry-bulb max"
+        },
+        "econ3_dp_max": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 68.0,
+          "step": 1.0,
+          "label": "Free-cool OA dew point max"
+        },
+        "econ3_damper_hi": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.02,
+          "label": "Integrated economizer damper"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ2",
+      "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
+      "sql_file": "econ3_mech_without_econ.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#econ-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -3217,7 +9547,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3294,20 +9623,65 @@
     {
       "canonical_id": "ECON-4",
       "pandas_id": "ECON-4",
+      "rule_id": "ECON-4",
+      "title": "Low estimated OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "econ4",
-      "sql_file": "econ4_low_oa_frac.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "oa_min_pct": {
+          "default": 21.0,
+          "unit": "%",
+          "min": 5.0,
+          "max": 40.0,
+          "step": 1.0,
+          "label": "Min OA fraction"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ4",
+      "datafusion_sql_implementation": "econ4_low_oa_frac.sql",
+      "sql_file": "econ4_low_oa_frac.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-4",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#econ-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "oa_min_pct": {
@@ -3336,7 +9710,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3413,20 +9786,65 @@
     {
       "canonical_id": "ECON-5",
       "pandas_id": "ECON-5",
+      "rule_id": "ECON-5",
+      "title": "Preheat over-conditioning",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "econ_5",
-      "sql_file": "econ5_preheat_over.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "preheat_leave_t",
-        "sat_sp",
-        "oa_t",
-        "htg_valve_pct"
+        "preheat-leaving-temp",
+        "discharge-air-temp-sp",
+        "outside-air-temp",
+        "heating-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "preheat_over_f": {
+          "default": 2.2,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.1,
+          "label": "Preheat over \u0394T"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ5",
+      "datafusion_sql_implementation": "econ5_preheat_over.sql",
+      "sql_file": "econ5_preheat_over.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#econ-5",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -3455,7 +9873,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3532,18 +9949,72 @@
     {
       "canonical_id": "ECON-6",
       "pandas_id": "ECON-6",
+      "rule_id": "ECON-6",
+      "title": "Economizing in freezing weather",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "econ_6",
-      "sql_file": "econ6_econ_freezing.sql",
-      "equipment_kinds": null,
-      "required_roles": [
-        "web_oa_t",
-        "oa_damper_pct"
+      "equipment_types": [
+        "ahu"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "equipment_kinds": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-damper"
+      ],
+      "optional_roles": [
+        "web-outside-air-temp"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ6_oat_max_f": {
+          "default": 25.0,
+          "unit": "\u00b0F",
+          "min": 15.0,
+          "max": 40.0,
+          "step": 1.0,
+          "label": "Winter OAT ceiling"
+        },
+        "econ6_damper_max": {
+          "default": 0.25,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Winter min-OA damper"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ6_compute",
+      "datafusion_sql_implementation": "econ6_econ_freezing.sql",
+      "sql_file": "econ6_econ_freezing.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#econ-6",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -3582,7 +10053,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3659,20 +10129,93 @@
     {
       "canonical_id": "ECON-7",
       "pandas_id": "ECON-7",
+      "rule_id": "ECON-7",
+      "title": "Economizer OK but not economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "econ_7",
-      "sql_file": "econ7_ok_not_economizing.sql",
-      "equipment_kinds": null,
-      "required_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+      "equipment_types": [
+        "ahu"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "equipment_kinds": [
+        "ahu"
+      ],
+      "required_roles": [
+        "outside-air-damper"
+      ],
+      "optional_roles": [
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity",
+        "cooling-valve",
+        "compressor-status",
+        "dx-cool-cmd"
+      ],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "econ7_db_min": {
+          "default": 35.0,
+          "unit": "\u00b0F",
+          "min": 20.0,
+          "max": 50.0,
+          "step": 1.0,
+          "label": "Econ-OK dry-bulb floor (freeze guard)"
+        },
+        "econ7_db_max": {
+          "default": 72.0,
+          "unit": "\u00b0F",
+          "min": 65.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Econ-OK dry-bulb max"
+        },
+        "econ7_dp_max": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 68.0,
+          "step": 1.0,
+          "label": "Econ-OK dew point max"
+        },
+        "econ7_damper_min": {
+          "default": 0.5,
+          "unit": "frac",
+          "min": 0.2,
+          "max": 0.9,
+          "step": 0.02,
+          "label": "Economizing damper threshold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "econ7_compute",
+      "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
+      "sql_file": "econ7_ok_not_economizing.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#econ-7",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -3731,7 +10274,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3808,18 +10350,66 @@
     {
       "canonical_id": "MECH-OAT-1",
       "pandas_id": "MECH-OAT-1",
+      "rule_id": "MECH-OAT-1",
+      "title": "Mechanical cooling below 60\u00b0F web OAT",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "mech_oat_1",
-      "sql_file": "mech_oat_1.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
       "required_roles": [
         "web_oa_t",
         "clg_valve_pct"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "optional_roles": [
+        "web-outside-air-temp",
+        "compressor-status",
+        "chiller-status",
+        "chw-pump-status",
+        "dx-cool-cmd"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "mech_oat_max_f": {
+          "default": 60.0,
+          "unit": "\u00b0F",
+          "min": 45.0,
+          "max": 65.0,
+          "step": 1.0,
+          "label": "Mech-cool OAT ceiling"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "mech_oat1_compute",
+      "datafusion_sql_implementation": "mech_oat_1.sql",
+      "sql_file": "mech_oat_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#mech-oat-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -3848,7 +10438,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -3925,19 +10514,79 @@
     {
       "canonical_id": "CHW-NOLOAD-1",
       "pandas_id": "CHW-NOLOAD-1",
+      "rule_id": "CHW-NOLOAD-1",
+      "title": "Chiller running with no building load",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "chw_noload_1",
-      "sql_file": "chw_noload_1.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
         "chw_supply_t",
         "chw_supply_sp",
         "chw_pump_cmd"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "optional_roles": [
+        "chiller-status",
+        "chw-pump-status",
+        "compressor-status",
+        "building-zone-load-satisfied",
+        "building-ahu-load-satisfied"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
+        },
+        "sat_band_f": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "AHU SAT\u2248SP band"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw_noload1_compute",
+      "datafusion_sql_implementation": "chw_noload_1.sql",
+      "sql_file": "chw_noload_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#chw-noload-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -3966,7 +10615,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4043,17 +10691,65 @@
     {
       "canonical_id": "VAV-1",
       "pandas_id": "VAV-1",
+      "rule_id": "VAV-1",
+      "title": "Zone comfort band",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vav1",
-      "sql_file": "vav1_comfort_fault.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav",
+        "zone"
+      ],
+      "equipment_kinds": [
+        "vav",
+        "zone"
+      ],
       "required_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_lo": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 55.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone low"
+        },
+        "zone_hi": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone high"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav1",
+      "datafusion_sql_implementation": "vav1_comfort_fault.sql",
+      "sql_file": "vav1_comfort_fault.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 900,
       "parameters": {
         "zone_t_lo": {
@@ -4093,7 +10789,6 @@
         "fault_hours",
         "fault_pct"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4170,19 +10865,79 @@
     {
       "canonical_id": "VAV-3",
       "pandas_id": "VAV-3",
+      "rule_id": "VAV-3",
+      "title": "Excessive reheat during warm weather",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vav_3",
-      "sql_file": "vav3_excessive_reheat.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "oa_t",
-        "reheat_valve_pct",
-        "zone_flow"
+        "outside-air-temp",
+        "reheat-valve"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "reheat_oat": {
+          "default": 78.0,
+          "unit": "\u00b0F",
+          "min": 65.0,
+          "max": 90.0,
+          "step": 1.0,
+          "label": "Warm OAT"
+        },
+        "reheat_pct": {
+          "default": 0.52,
+          "unit": "frac",
+          "min": 0.1,
+          "max": 1.0,
+          "step": 0.02,
+          "label": "Reheat frac"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav3",
+      "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
+      "sql_file": "vav3_excessive_reheat.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -4231,7 +10986,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4308,18 +11062,79 @@
     {
       "canonical_id": "VAV-4",
       "pandas_id": "VAV-4",
+      "rule_id": "VAV-4",
+      "title": "Damper stuck at full open",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vav_4",
-      "sql_file": "vav4_damper_full_open.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "damper_pct",
-        "zone_flow"
+        "damper"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
+      "default_thresholds": {
+        "full_open_pct": {
+          "default": 0.975,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.005,
+          "label": "Full open frac"
+        },
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav4",
+      "datafusion_sql_implementation": "vav4_damper_full_open.sql",
+      "sql_file": "vav4_damper_full_open.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -4358,7 +11173,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4435,18 +11249,55 @@
     {
       "canonical_id": "VAV-5",
       "pandas_id": "VAV-5",
+      "rule_id": "VAV-5",
+      "title": "Airflow sensor bias",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vav_5",
-      "sql_file": "vav5_airflow_bias.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "damper_pct"
+        "zone-airflow",
+        "damper"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav5",
+      "datafusion_sql_implementation": "vav5_airflow_bias.sql",
+      "sql_file": "vav5_airflow_bias.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-5",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -4465,7 +11316,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4542,20 +11392,80 @@
     {
       "canonical_id": "VAV-REHEAT",
       "pandas_id": "VAV-REHEAT",
+      "rule_id": "VAV-REHEAT",
+      "title": "Reheat valve stuck / no temp rise",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vav_reheat",
-      "sql_file": "vav_reheat.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "reheat_valve_pct",
-        "vav_discharge_t",
-        "vav_inlet_t",
-        "zone_flow"
+        "reheat-valve",
+        "vav-discharge-air-temp",
+        "vav-inlet-air-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "reheat_cmd": {
+          "default": 0.3,
+          "unit": "frac",
+          "min": 0.1,
+          "max": 1.0,
+          "step": 0.05,
+          "label": "Reheat open frac"
+        },
+        "min_rise": {
+          "default": 3.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Min temp rise"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav_reheat_stuck",
+      "datafusion_sql_implementation": "vav_reheat.sql",
+      "sql_file": "vav_reheat.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-reheat",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -4604,7 +11514,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4681,19 +11590,71 @@
     {
       "canonical_id": "VAV-AHU-LEAVE",
       "pandas_id": "VAV-AHU-LEAVE",
+      "rule_id": "VAV-AHU-LEAVE",
+      "title": "VAV leave vs parent AHU SAT (fedBy)",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vav_ahu_leave",
-      "sql_file": "vav_ahu_leave.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "vav_discharge_t",
-        "ahu_sat",
-        "zone_flow"
+        "vav-discharge-air-temp",
+        "ahu-discharge-air-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "delta_f": {
+          "default": 8.0,
+          "unit": "\u00b0F",
+          "min": 2.0,
+          "max": 25.0,
+          "step": 0.5,
+          "label": "Leave \u0394 vs AHU SAT"
+        },
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav_vs_ahu_leave",
+      "datafusion_sql_implementation": "vav_ahu_leave.sql",
+      "sql_file": "vav_ahu_leave.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-ahu-leave",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -4732,7 +11693,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4809,18 +11769,86 @@
     {
       "canonical_id": "VAV-7",
       "pandas_id": "VAV-7",
+      "rule_id": "VAV-7",
+      "title": "Min airflow / fixed high flow",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vav_7",
-      "sql_file": "vav7_min_airflow.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "min_flow_sp"
+        "zone-airflow"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "fixed_flow_max_std": {
+          "default": 15.0,
+          "unit": "cfm",
+          "min": 1.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Fixed-flow max std"
+        },
+        "fixed_flow_min_mean": {
+          "default": 200.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "Fixed-flow min mean"
+        },
+        "high_min_flow_sp": {
+          "default": 250.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "High min-flow SP"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vav7",
+      "datafusion_sql_implementation": "vav7_min_airflow.sql",
+      "sql_file": "vav7_min_airflow.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-7",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -4849,7 +11877,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -4926,19 +11953,72 @@
     {
       "canonical_id": "CHW-1",
       "pandas_id": "CHW-1",
+      "rule_id": "CHW-1",
+      "title": "Low chilled-water \u0394T",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "chw_1",
-      "sql_file": "chw1_low_dt.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_return_t",
-        "chw_pump_cmd"
+        "chilled-water-supply-temp",
+        "chilled-water-return-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "min_dt": {
+          "default": 4.0,
+          "unit": "\u00b0F",
+          "min": 1.0,
+          "max": 12.0,
+          "step": 0.5,
+          "label": "Min \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw1",
+      "datafusion_sql_implementation": "chw1_low_dt.sql",
+      "sql_file": "chw1_low_dt.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#chw-1",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "semantic_gap",
+      "known_semantic_differences": "pandas chw1() treats missing chw-pump-cmd as always-on; hydronic gate returns ungated_no_proof_roles (all True) and does not use chiller status/amps/power; SQL chw1_low_dt.sql only inspects chw_pump_cmd and still scores \u0394T when pump is NULL",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 900,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -4967,7 +12047,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5044,19 +12123,79 @@
     {
       "canonical_id": "CHW-2",
       "pandas_id": "CHW-2",
+      "rule_id": "CHW-2",
+      "title": "DP below SP at max pump speed",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "chw_2",
-      "sql_file": "chw2_dp_low.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_dp",
-        "chw_dp_sp",
-        "chw_pump_cmd"
+        "chw-diff-pressure",
+        "chw-diff-pressure-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "dp_margin": {
+          "default": 2.2,
+          "unit": "psi",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.1,
+          "label": "DP margin"
+        },
+        "pump_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw2",
+      "datafusion_sql_implementation": "chw2_dp_low.sql",
+      "sql_file": "chw2_dp_low.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#chw-2",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5095,7 +12234,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5172,19 +12310,71 @@
     {
       "canonical_id": "CHW-3",
       "pandas_id": "CHW-3",
+      "rule_id": "CHW-3",
+      "title": "Plant supply temp outside deadband",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "chw_3",
-      "sql_file": "chw3_supply_band.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_supply_sp",
-        "chw_pump_cmd"
+        "chilled-water-supply-temp",
+        "chilled-water-supply-temp-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "sp_band": {
+          "default": 2.2,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.1,
+          "label": "SP band"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw3",
+      "datafusion_sql_implementation": "chw3_supply_band.sql",
+      "sql_file": "chw3_supply_band.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#chw-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5213,7 +12403,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5290,18 +12479,78 @@
     {
       "canonical_id": "CHW-4",
       "pandas_id": "CHW-4",
+      "rule_id": "CHW-4",
+      "title": "Flow high at max pump",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "chw_4",
-      "sql_file": "chw4_flow_high.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_flow",
-        "chw_pump_cmd"
+        "chw-flow",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "flow_hi": {
+          "default": 1100,
+          "unit": "gpm",
+          "min": 200,
+          "max": 3000,
+          "step": 50,
+          "label": "Flow high"
+        },
+        "pump_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "chw4",
+      "datafusion_sql_implementation": "chw4_flow_high.sql",
+      "sql_file": "chw4_flow_high.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#chw-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5340,7 +12589,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5417,19 +12665,70 @@
     {
       "canonical_id": "HP-1",
       "pandas_id": "HP-1",
+      "rule_id": "HP-1",
+      "title": "Discharge cold when heating",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "hp_1",
-      "sql_file": "hp1_discharge_cold.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "heatpump"
+      ],
       "required_roles": [
-        "sat",
-        "zone_t",
-        "fan_cmd"
+        "discharge-air-temp",
+        "zone-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "compressor-status",
+        "equipment-enable",
+        "fan-status",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "min_sat": {
+          "default": 85.0,
+          "unit": "\u00b0F",
+          "min": 70.0,
+          "max": 110.0,
+          "step": 1.0,
+          "label": "Min heating SAT"
+        },
+        "zone_cold": {
+          "default": 69.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone cold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "hp1",
+      "datafusion_sql_implementation": "hp1_discharge_cold.sql",
+      "sql_file": "hp1_discharge_cold.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#hp-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "compressor",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -5468,7 +12767,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5545,17 +12843,55 @@
     {
       "canonical_id": "WX-1",
       "pandas_id": "WX-1",
+      "rule_id": "WX-1",
+      "title": "OA temperature spike",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "wx_1",
-      "sql_file": "wx1_oa_spike.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "weather"
+      ],
+      "equipment_kinds": [
+        "weather"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "spike_limit": {
+          "default": 16.0,
+          "unit": "\u00b0F",
+          "min": 4.0,
+          "max": 40.0,
+          "step": 1.0,
+          "label": "Spike limit"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "wx1",
+      "datafusion_sql_implementation": "wx1_oa_spike.sql",
+      "sql_file": "wx1_oa_spike.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#wx-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5584,7 +12920,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5661,18 +12996,79 @@
     {
       "canonical_id": "CW-OPT-1",
       "pandas_id": "CW-OPT-1",
+      "rule_id": "CW-OPT-1",
+      "title": "Condenser water not optimized vs wet-bulb",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "cw_opt_1",
-      "sql_file": "cw_opt_1.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "cw_approach": {
+          "default": 7.0,
+          "unit": "\u00b0F",
+          "min": 3.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Design approach"
+        },
+        "cw_slack": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Slack below target"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cw_opt",
+      "datafusion_sql_implementation": "cw_opt_1.sql",
+      "sql_file": "cw_opt_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#cw-opt-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -5711,7 +13107,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5788,19 +13183,84 @@
     {
       "canonical_id": "CW-APR-1",
       "pandas_id": "CW-APR-1",
+      "rule_id": "CW-APR-1",
+      "title": "High CW approach at full tower fan",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "cw_apr_1",
-      "sql_file": "cw_apr_1.sql",
-      "equipment_kinds": null,
-      "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "required_roles": [
+        "condenser-water-supply-temp"
+      ],
+      "optional_roles": [
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
+      ],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "approach_max_f": {
+          "default": 8.0,
+          "unit": "\u00b0F",
+          "min": 5.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Max approach at full fan"
+        },
+        "tower_fan_hi": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cw_apr",
+      "datafusion_sql_implementation": "cw_apr_1.sql",
+      "sql_file": "cw_apr_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#cw-apr-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -5839,7 +13299,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -5916,19 +13375,92 @@
     {
       "canonical_id": "CW-FAN-1",
       "pandas_id": "CW-FAN-1",
+      "rule_id": "CW-FAN-1",
+      "title": "Excess tower fan energy vs wet-bulb limit",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "cw_fan_1",
-      "sql_file": "cw_fan_1.sql",
-      "equipment_kinds": null,
-      "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "required_roles": [
+        "condenser-water-supply-temp"
+      ],
+      "optional_roles": [
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
+      ],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "cw_approach": {
+          "default": 7.0,
+          "unit": "\u00b0F",
+          "min": 3.0,
+          "max": 15.0,
+          "step": 0.5,
+          "label": "Design approach"
+        },
+        "excess_beyond_approach_f": {
+          "default": 5.0,
+          "unit": "\u00b0F",
+          "min": 2.0,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Excess beyond approach"
+        },
+        "tower_fan_hi": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cw_fan_excess",
+      "datafusion_sql_implementation": "cw_fan_1.sql",
+      "sql_file": "cw_fan_1.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#cw-fan-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -5977,7 +13509,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6054,17 +13585,71 @@
     {
       "canonical_id": "TRIM-1",
       "pandas_id": "TRIM-1",
+      "rule_id": "TRIM-1",
+      "title": "Duct static trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "trim_1",
-      "sql_file": "trim1_duct_static.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static_sp"
+        "duct-static-pressure",
+        "vav-pressure-request-sum"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "duct_hi": {
+          "default": 1.35,
+          "unit": "in. w.c.",
+          "min": 0.5,
+          "max": 3.0,
+          "step": 0.05,
+          "label": "Duct static high"
+        },
+        "request_lo": {
+          "default": 1.0,
+          "unit": "count",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "trim1",
+      "datafusion_sql_implementation": "trim1_duct_static.sql",
+      "sql_file": "trim1_duct_static.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#trim-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -6103,7 +13688,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6180,17 +13764,78 @@
     {
       "canonical_id": "TRIM-3",
       "pandas_id": "TRIM-3",
+      "rule_id": "TRIM-3",
+      "title": "HWST trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "trim_3",
-      "sql_file": "trim3_hwst.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "boiler"
+      ],
+      "equipment_kinds": [
+        "boiler"
+      ],
       "required_roles": [
-        "hw_supply_t"
+        "hot-water-supply-temp",
+        "hw-reset-request-sum"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "hwst_hi": {
+          "default": 160.0,
+          "unit": "\u00b0F",
+          "min": 120.0,
+          "max": 200.0,
+          "step": 1.0,
+          "label": "HWST high"
+        },
+        "request_lo": {
+          "default": 1.0,
+          "unit": "count",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "trim3",
+      "datafusion_sql_implementation": "trim3_hwst.sql",
+      "sql_file": "trim3_hwst.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#trim-3",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -6229,7 +13874,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6306,17 +13950,78 @@
     {
       "canonical_id": "TRIM-4",
       "pandas_id": "TRIM-4",
+      "rule_id": "TRIM-4",
+      "title": "CHW plant reset advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "trim_4",
-      "sql_file": "trim4_chw_reset.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t"
+        "chilled-water-supply-temp",
+        "chw-reset-request-sum"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
+      "default_thresholds": {
+        "chw_lo": {
+          "default": 45.0,
+          "unit": "\u00b0F",
+          "min": 35.0,
+          "max": 55.0,
+          "step": 0.5,
+          "label": "CHWS low"
+        },
+        "request_lo": {
+          "default": 1.0,
+          "unit": "count",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.5,
+          "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "trim4",
+      "datafusion_sql_implementation": "trim4_chw_reset.sql",
+      "sql_file": "trim4_chw_reset.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#trim-4",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -6355,7 +14060,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6432,22 +14136,71 @@
     {
       "canonical_id": "SCHED-1",
       "pandas_id": "SCHED-1",
+      "rule_id": "SCHED-1",
+      "title": "Unoccupied runtime",
       "aliases": [
         "excess_runtime"
       ],
       "kind": "diagnostic",
-      "pandas_implementation": "sched1",
-      "sql_file": "sched1_unoccupied_runtime.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "occ_mode",
-        "fan_status"
+        "occupied",
+        "fan-status"
       ],
       "optional_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "sched1",
+      "datafusion_sql_implementation": "sched1_unoccupied_runtime.sql",
+      "sql_file": "sched1_unoccupied_runtime.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sched-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#sched-1",
+      "test_coverage": [
+        "tests/reporting/test_findings_smoke.py",
+        "tests/rules/test_catalog_smoke.py"
+      ],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "alias",
+      "known_semantic_differences": "aliases: excess_runtime (not independent rules)",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -6486,7 +14239,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6563,17 +14315,87 @@
     {
       "canonical_id": "SCHED-247",
       "pandas_id": "SCHED-247",
+      "rule_id": "SCHED-247",
+      "title": "Always-on fan or pump runtime",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "sched_247",
-      "sql_file": "sched247_always_on.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [
         "fan_cmd"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "optional_roles": [
+        "fan-status",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "chiller-status",
+        "compressor-status",
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd",
+        "duct-static-pressure",
+        "chw-diff-pressure"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "always_on_pct": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Always-on fraction"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "eng",
+          "min": 0.05,
+          "max": 2.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "_sched247",
+      "datafusion_sql_implementation": "sched247_always_on.sql",
+      "sql_file": "sched247_always_on.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sched-247",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#sched-247",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "semantic_gap",
+      "known_semantic_differences": "pandas _sched247 ORs fan/pump/chiller status, commands, and duct pressure; SQL sched247_always_on.sql uses fan_cmd only",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -6592,7 +14414,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6669,18 +14490,48 @@
     {
       "canonical_id": "CMD-1",
       "pandas_id": "CMD-1",
+      "rule_id": "CMD-1",
+      "title": "Fan cmd/status mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "cmd_1",
-      "sql_file": "cmd1_fan_mismatch.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "fan_status"
+        "fan-cmd",
+        "fan-status"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "cmd1",
+      "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
+      "sql_file": "cmd1_fan_mismatch.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#cmd-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -6699,7 +14550,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6776,20 +14626,73 @@
     {
       "canonical_id": "OA-1",
       "pandas_id": "OA-1",
+      "rule_id": "OA-1",
+      "title": "Low OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "oa_1",
-      "sql_file": "oa1_low_oa_frac.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-status"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "min_oa_frac": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 0.4,
+          "step": 0.01,
+          "label": "Min OA fraction"
+        },
+        "oat_rat_guard": {
+          "default": 2.2,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.1,
+          "label": "Min |RAT\u2212OAT| guard"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "oa1",
+      "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
+      "sql_file": "oa1_low_oa_frac.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#oa-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -6828,7 +14731,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -6905,19 +14807,57 @@
     {
       "canonical_id": "DMP-1",
       "pandas_id": "DMP-1",
+      "rule_id": "DMP-1",
+      "title": "OA damper leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "dmp_1",
-      "sql_file": "dmp1_oa_damper_leak.sql",
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "oa_t",
-        "mat"
+        "outside-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "leak_delta": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "dmp1",
+      "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
+      "sql_file": "dmp1_oa_damper_leak.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#dmp-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -6946,7 +14886,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -7023,20 +14962,69 @@
     {
       "canonical_id": "VLV-1",
       "pandas_id": "VLV-1",
+      "rule_id": "VLV-1",
+      "title": "Cooling valve leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "pandas_implementation": "vlv_1",
-      "sql_file": "vlv1_clg_valve_leak.sql",
-      "equipment_kinds": null,
-      "required_roles": [
-        "clg_valve_pct",
-        "sat",
-        "sat_sp",
-        "mat"
+      "equipment_types": [
+        "ahu"
       ],
-      "optional_roles": [],
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "equipment_kinds": [
+        "ahu"
+      ],
+      "required_roles": [
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "cooling-valve"
+      ],
+      "optional_roles": [
+        "mixed-air-temp",
+        "fan-status",
+        "fan-cmd"
+      ],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "sat_err": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
+          "label": "SAT vs SP leak \u0394T"
+        },
+        "mat_leak_delta": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 12.0,
+          "step": 0.5,
+          "label": "SAT vs MAT leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
+        }
+      },
+      "pandas_implementation": "vlv1",
+      "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
+      "sql_file": "vlv1_clg_valve_leak.sql",
+      "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vlv-1",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "none",
+      "known_semantic_differences": "",
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -7075,7 +15063,6 @@
         "equipment_id",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": [
         {
           "case": "normal",
@@ -7152,15 +15139,45 @@
     {
       "canonical_id": "AVG-ZONE-TEMP",
       "pandas_id": null,
+      "rule_id": "AVG-ZONE-TEMP",
+      "title": "Average zone temperature per equipment",
       "aliases": [],
       "kind": "sql_analytics",
-      "pandas_implementation": null,
-      "sql_file": "avg_zone_temp.sql",
+      "equipment_types": [],
       "equipment_kinds": null,
       "required_roles": [
         "zone_t"
       ],
       "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_t_lo": {
+          "default": 68.0,
+          "unit": "degF",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone comfort low (reference)"
+        },
+        "zone_t_hi": {
+          "default": 76.0,
+          "unit": "degF",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone comfort high (reference)"
+        }
+      },
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "avg_zone_temp.sql",
+      "sql_file": "avg_zone_temp.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#avg-zone-temp",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#avg-zone-temp",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "intentional_non_applicability",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
       "operational_gate": null,
       "startup_delay_seconds": null,
       "confirm_seconds": 0,
@@ -7193,21 +15210,35 @@
         "min_zone_temp",
         "max_zone_temp"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": []
     },
     {
       "canonical_id": "FAN-RUNTIME-HOURS",
       "pandas_id": null,
+      "rule_id": "FAN-RUNTIME-HOURS",
+      "title": "Fan running hours where fan_cmd > 5% (normalized 0-1)",
       "aliases": [],
       "kind": "sql_analytics",
-      "pandas_implementation": null,
-      "sql_file": "fan_runtime_hours.sql",
+      "equipment_types": [],
       "equipment_kinds": null,
       "required_roles": [
         "fan_cmd"
       ],
       "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {},
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "fan_runtime_hours.sql",
+      "sql_file": "fan_runtime_hours.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fan-runtime-hours",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fan-runtime-hours",
+      "test_coverage": [
+        "tests/rules/test_parity_inventory.py"
+      ],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "intentional_non_applicability",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
       "operational_gate": null,
       "startup_delay_seconds": null,
       "confirm_seconds": 0,
@@ -7218,21 +15249,50 @@
         "fan_runtime_hours",
         "total_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": []
     },
     {
       "canonical_id": "FAULT-ELAPSED-HOURS",
       "pandas_id": null,
+      "rule_id": "FAULT-ELAPSED-HOURS",
+      "title": "Comfort fault sample count \u2192 hours",
       "aliases": [],
       "kind": "sql_analytics",
-      "pandas_implementation": null,
-      "sql_file": "fault_elapsed_hours.sql",
+      "equipment_types": [],
       "equipment_kinds": null,
       "required_roles": [
         "zone_t"
       ],
       "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_t_lo": {
+          "default": 68.0,
+          "unit": "degF",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone comfort low"
+        },
+        "zone_t_hi": {
+          "default": 76.0,
+          "unit": "degF",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone comfort high"
+        }
+      },
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "fault_elapsed_hours.sql",
+      "sql_file": "fault_elapsed_hours.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fault-elapsed-hours",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fault-elapsed-hours",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "intentional_non_applicability",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
       "operational_gate": null,
       "startup_delay_seconds": null,
       "confirm_seconds": 0,
@@ -7264,21 +15324,50 @@
         "fault_samples",
         "fault_hours"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": []
     },
     {
       "canonical_id": "ZONE-COMFORT-PCT",
       "pandas_id": null,
+      "rule_id": "ZONE-COMFORT-PCT",
+      "title": "Percent of samples in comfort band",
       "aliases": [],
       "kind": "sql_analytics",
-      "pandas_implementation": null,
-      "sql_file": "zone_comfort_pct.sql",
+      "equipment_types": [],
       "equipment_kinds": null,
       "required_roles": [
         "zone_t"
       ],
       "optional_roles": [],
+      "operational_proof_roles": [],
+      "default_thresholds": {
+        "zone_t_lo": {
+          "default": 68.0,
+          "unit": "degF",
+          "min": 60.0,
+          "max": 72.0,
+          "step": 0.5,
+          "label": "Zone comfort low"
+        },
+        "zone_t_hi": {
+          "default": 76.0,
+          "unit": "degF",
+          "min": 72.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Zone comfort high"
+        }
+      },
+      "pandas_implementation": null,
+      "datafusion_sql_implementation": "zone_comfort_pct.sql",
+      "sql_file": "zone_comfort_pct.sql",
+      "documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#zone-comfort-pct",
+      "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#zone-comfort-pct",
+      "test_coverage": [],
+      "parity_status": "sql_screening",
+      "parity_level": "sql_screening",
+      "difference_class": "intentional_non_applicability",
+      "known_semantic_differences": "SQL analytics rollup \u2014 not a pandas diagnostic",
       "operational_gate": null,
       "startup_delay_seconds": null,
       "confirm_seconds": 0,
@@ -7309,7 +15398,6 @@
         "equipment_id",
         "comfort_pct"
       ],
-      "parity_level": "sql_screening",
       "proof_fixtures": []
     }
   ]

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -1,10 +1,15 @@
-schema_version: parity-inventory-v1
+schema_version: parity-inventory-v2
 generated_by: scripts/generate_parity_inventory.py
 counts:
   pandas_diagnostics: 59
   sql_analytics: 4
   sql_registry: 63
   concepts: 63
+  aliases: 3
+  building_100_cartesian: 48 equipment × 59 diagnostics = 2832 results
+count_explanation: '59 is the executable pandas cookbook (CookbookRule constructors).
+  63 is the SQL registry: those 59 twins plus 4 SQL-only analytics. Aliases SV-SLEW,
+  FC13, and excess_runtime are not extra rules.'
 parity_levels:
 - concept_only
 - duration_parity
@@ -12,23 +17,3560 @@ parity_levels:
 - predicate_parity
 - site_soak
 - sql_screening
+difference_classes:
+- none
+- alias
+- missing_implementation
+- intentional_non_applicability
+- unsupported_datafusion_expression
+- documentation_error
+- semantic_gap
+difference_class_counts:
+  none: 53
+  alias: 3
+  missing_implementation: 1
+  semantic_gap: 2
+  intentional_non_applicability: 4
 aliases_index:
   FC13: FC13-SAT-HIGH
   SV-SLEW: SV-RATE
   excess_runtime: SCHED-1
+matrix:
+- rule_id: SV-RANGE
+  title: Sensor out of hard range
+  equipment_types: &id001
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
+  required_roles: &id002
+  - oa_t
+  optional_roles: &id003 []
+  operational_proof_roles: &id004
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-current
+  - chw-flow
+  - compressor-status
+  - equipment-enable
+  default_thresholds: &id005
+    range_scale_temperature:
+      default: 1.0
+      unit: x
+      min: 0.5
+      max: 2.0
+      step: 0.1
+      label: Temp range scale
+    range_scale_humidity:
+      default: 1.0
+      unit: x
+      min: 0.5
+      max: 2.0
+      step: 0.1
+      label: Humidity range scale
+    range_scale_pressure:
+      default: 1.0
+      unit: x
+      min: 0.5
+      max: 2.0
+      step: 0.1
+      label: Pressure range scale
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_range
+  datafusion_sql_implementation: sv_range.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
+  test_coverage: &id006 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: SV-FLATLINE
+  title: Sensor flatline (stuck)
+  equipment_types: &id007
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
+  required_roles: &id008
+  - oa_t
+  optional_roles: &id009 []
+  operational_proof_roles: &id010 []
+  default_thresholds: &id011
+    flatline_tol:
+      default: 0.1
+      unit: °F
+      min: 0.02
+      max: 1.0
+      step: 0.02
+      label: Flatline tolerance
+    flatline_hours:
+      default: 1.0
+      unit: h
+      min: 0.5
+      max: 8.0
+      step: 0.5
+      label: Flatline window
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_flatline
+  datafusion_sql_implementation: sv_flatline.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
+  test_coverage: &id012 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: SV-SPIKE
+  title: Sensor rate-of-change spike
+  equipment_types: &id013
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
+  required_roles: &id014
+  - oa_t
+  optional_roles: &id015 []
+  operational_proof_roles: &id016
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-current
+  - chw-flow
+  - compressor-status
+  - equipment-enable
+  default_thresholds: &id017
+    spike_scale:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Spike limit scale (global)
+    spike_scale_temperature:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Temp spike scale
+    spike_scale_humidity:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Humidity spike scale
+    spike_scale_pressure:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Pressure spike scale
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_spike
+  datafusion_sql_implementation: sv_spike.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
+  test_coverage: &id018 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: SV-STALE
+  title: Stale data (no fresh samples)
+  equipment_types: &id019
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
+  required_roles: &id020
+  - fan_cmd
+  optional_roles: &id021 []
+  operational_proof_roles: &id022 []
+  default_thresholds: &id023
+    stale_hours:
+      default: 2.0
+      unit: h
+      min: 0.5
+      max: 12.0
+      step: 0.5
+      label: Stale window
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_stale
+  datafusion_sql_implementation: sv_stale.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
+  test_coverage: &id024 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: SV-RATE
+  title: Context-aware sensor rate of change
+  equipment_types: &id025
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
+  required_roles: &id026
+  - oa_t
+  optional_roles: &id027 []
+  operational_proof_roles: &id028 []
+  default_thresholds: &id029
+    persistence_min:
+      default: 10.0
+      unit: min
+      min: 5.0
+      max: 60.0
+      step: 1.0
+      label: Fault persistence
+    transition_window_min:
+      default: 20.0
+      unit: min
+      min: 5.0
+      max: 60.0
+      step: 5.0
+      label: Transition window
+    max_gap_hours:
+      default: 2.0
+      unit: h
+      min: 0.25
+      max: 6.0
+      step: 0.25
+      label: Max sample gap
+    design_flow:
+      default: 0.0
+      unit: cfm
+      min: 0.0
+      max: 100000.0
+      step: 100.0
+      label: Design flow (flow profiles)
+    sensor_span:
+      default: 0.0
+      unit: eng
+      min: 0.0
+      max: 100000.0
+      step: 10.0
+      label: Sensor span (flow/pressure)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: _sv_rate_compute
+  datafusion_sql_implementation: sv_rate.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
+  test_coverage: &id030
+  - scripts/sql_pandas_oracle_check.py
+  - tests/rules/test_parity_inventory.py
+  parity_status: sql_screening
+  known_semantic_differences: 'aliases: SV-SLEW (not independent rules)'
+  difference_class: alias
+- rule_id: PID-HUNT-1
+  title: Suspected control-output hunting
+  equipment_types: &id031
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - heatpump
+  required_roles: &id032
+  - clg_valve_pct
+  optional_roles: &id033
+  - loop-enabled
+  operational_proof_roles: &id034
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
+  default_thresholds: &id035
+    change_deadband_pct:
+      default: 1.0
+      unit: '% out'
+      min: 0.0
+      max: 10.0
+      step: 0.5
+      label: Ignore changes below
+    minimum_span_pct:
+      default: 20.0
+      unit: '% out'
+      min: 5.0
+      max: 100.0
+      step: 5.0
+      label: Minimum observed span
+    total_variation_fault_pct:
+      default: 500.0
+      unit: '%/h'
+      min: 50.0
+      max: 2000.0
+      step: 50.0
+      label: Total travel threshold
+    minimum_equivalent_cycles:
+      default: 2.5
+      unit: cyc/h
+      min: 0.5
+      max: 20.0
+      step: 0.5
+      label: Min equivalent cycles
+    minimum_reversals:
+      default: 4
+      unit: count
+      min: 1
+      max: 40
+      step: 1
+      label: Min direction reversals
+    minimum_coverage_pct:
+      default: 80.0
+      unit: '%'
+      min: 25.0
+      max: 100.0
+      step: 5.0
+      label: Minimum data coverage
+    confirm_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _pid_hunt_1
+  datafusion_sql_implementation: pid_hunt_1.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
+  test_coverage: &id036 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC1
+  title: Duct static below SP at full fan (GL36 A)
+  equipment_types: &id037
+  - ahu
+  required_roles: &id038
+  - duct-static-pressure
+  - duct-static-pressure-sp
+  - fan-cmd
+  optional_roles: &id039 []
+  operational_proof_roles: &id040
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id041
+    eps_dsp:
+      default: 0.12
+      unit: in. w.c.
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Duct-static error εDSP (GL36 default 0.1 in.w.c.)
+    eps_vfd_spd:
+      default: 0.13
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: VFD speed error εVFDSPD (GL36 default 5%)
+    duct_static_err:
+      default: 0.12
+      unit: in. w.c.
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Legacy duct-static error (sets εDSP)
+    fan_hi:
+      default: 0.87
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Legacy fan-high threshold (sets εVFDSPD)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: fc1
+  datafusion_sql_implementation: fc1_duct_static_low.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc1
+  test_coverage: &id042 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC2
+  title: MAT below OAT/RAT envelope (GL36 B)
+  equipment_types: &id043
+  - ahu
+  required_roles: &id044
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - fan-cmd
+  optional_roles: &id045 []
+  operational_proof_roles: &id046
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id047
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_rat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: RAT sensor error εRAT (GL36 default 2°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc2
+  datafusion_sql_implementation: fc2_mat_low.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc2
+  test_coverage: &id048 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC3
+  title: MAT above OAT/RAT envelope (GL36 C)
+  equipment_types: &id049
+  - ahu
+  required_roles: &id050
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - fan-cmd
+  optional_roles: &id051 []
+  operational_proof_roles: &id052
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id053
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_rat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: RAT sensor error εRAT (GL36 default 2°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc3
+  datafusion_sql_implementation: fc3_mat_high.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc3
+  test_coverage: &id054 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC4
+  title: PID hunting (operating-state oscillation)
+  equipment_types: &id055
+  - ahu
+  required_roles: &id056
+  - outside-air-damper
+  - cooling-valve
+  - fan-cmd
+  optional_roles: &id057 []
+  operational_proof_roles: &id058
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
+  default_thresholds: &id059
+    delta_os_max:
+      default: 5
+      unit: count
+      min: 1
+      max: 30
+      step: 1
+      label: Max mode changes/hr ΔOSmax (GL36 default 7)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 60.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 3600.0
+      unit: sec
+  pandas_implementation: fc4
+  datafusion_sql_implementation: fc4_os_hunting.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc4
+  test_coverage: &id060 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC5
+  title: SAT cold when heating commanded (GL36 D)
+  equipment_types: &id061
+  - ahu
+  required_roles: &id062
+  - discharge-air-temp
+  - mixed-air-temp
+  - fan-cmd
+  - heating-valve
+  optional_roles: &id063 []
+  operational_proof_roles: &id064
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id065
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    htg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Heating-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc5
+  datafusion_sql_implementation: fc5_sat_cold_heating.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc5
+  test_coverage: &id066 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC6
+  title: Estimated OA fraction mismatch
+  equipment_types: &id067
+  - ahu
+  required_roles: &id068
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - vav-total-airflow
+  optional_roles: &id069 []
+  operational_proof_roles: &id070
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id071
+    eps_airflow:
+      default: 0.15
+      unit: frac
+      min: 0.05
+      max: 1.0
+      step: 0.01
+      label: Airflow error εF (GL36 default 30%)
+    delta_t_min:
+      default: 5.0
+      unit: °F
+      min: 0.0
+      max: 30.0
+      step: 0.5
+      label: Minimum |OAT−RAT| ΔTmin (GL36 default 10°F)
+    airflow_err:
+      default: 0.15
+      unit: frac
+      min: 0.05
+      max: 1.0
+      step: 0.01
+      label: Legacy OA-fraction error (sets εF)
+    oat_rat_delta_min:
+      default: 5.0
+      unit: °F
+      min: 0.0
+      max: 30.0
+      step: 0.5
+      label: Legacy OAT/RAT guard (sets ΔTmin)
+    min_cfm_design:
+      default: 5000
+      unit: cfm
+      min: 500
+      max: 20000
+      step: 500
+      label: Design min OA CFM
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc6
+  datafusion_sql_implementation: fc6_oa_frac_mismatch.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc6
+  test_coverage: &id072 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC7
+  title: SAT low with full heating (GL36 E)
+  equipment_types: &id073
+  - ahu
+  required_roles: &id074
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - fan-cmd
+  - heating-valve
+  optional_roles: &id075 []
+  operational_proof_roles: &id076
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id077
+    eps_sat:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    sat_err:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT error (sets εSAT)
+    htg_full_min:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Full-heating threshold (GL36 99%)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc7
+  datafusion_sql_implementation: fc7_sat_low_heating.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc7
+  test_coverage: &id078
+  - tests/rules/test_parity_inventory.py
+  parity_status: concept_only
+  known_semantic_differences: concept_only — SQL file is a placeholder; do not claim
+    twin parity
+  difference_class: missing_implementation
+- rule_id: FC8
+  title: SAT/MAT mismatch in economizer (GL36 F)
+  equipment_types: &id079
+  - ahu
+  required_roles: &id080
+  - discharge-air-temp
+  - mixed-air-temp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id081 []
+  operational_proof_roles: &id082
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id083
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    supply_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT tolerance master (sets εSAT)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc8
+  datafusion_sql_implementation: fc8_sat_mat_econ.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc8
+  test_coverage: &id084 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC9
+  title: OAT too warm for free cooling (GL36 G)
+  equipment_types: &id085
+  - ahu
+  required_roles: &id086
+  - outside-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id087 []
+  operational_proof_roles: &id088
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id089
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc9
+  datafusion_sql_implementation: fc9_oa_sat_sp_econ.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc9
+  test_coverage: &id090 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC10
+  title: OAT/MAT mismatch + mech cooling (GL36 H)
+  equipment_types: &id091
+  - ahu
+  required_roles: &id092
+  - mixed-air-temp
+  - outside-air-temp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id093 []
+  operational_proof_roles: &id094
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id095
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc10
+  datafusion_sql_implementation: fc10_mat_oa_clg.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc10
+  test_coverage: &id096 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC11
+  title: OAT/MAT mismatch economizer-only (GL36 I)
+  equipment_types: &id097
+  - ahu
+  required_roles: &id098
+  - outside-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id099 []
+  operational_proof_roles: &id100
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id101
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc11
+  datafusion_sql_implementation: fc11_oa_sat_sp_clg.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc11
+  test_coverage: &id102 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC12
+  title: SAT above blend in cooling (GL36 J)
+  equipment_types: &id103
+  - ahu
+  required_roles: &id104
+  - discharge-air-temp
+  - mixed-air-temp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id105 []
+  operational_proof_roles: &id106
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id107
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    supply_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT tolerance master (sets εSAT)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc12
+  datafusion_sql_implementation: fc12_sat_mat_clg.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc12
+  test_coverage: &id108 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC13
+  title: SAT above SP at full cooling (GL36 K)
+  equipment_types: &id109
+  - ahu
+  required_roles: &id110
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id111 []
+  operational_proof_roles: &id112
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id113
+    eps_sat:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    sat_err:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT error (sets εSAT)
+    clg_full_min:
+      default: 0.01
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Full-cooling threshold (GL36 99%)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc13
+  datafusion_sql_implementation: sat_high_fault.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc13
+  test_coverage: &id114
+  - tests/rules/test_parity_inventory.py
+  parity_status: sql_screening
+  known_semantic_differences: 'aliases: FC13 (not independent rules)'
+  difference_class: alias
+- rule_id: FC14
+  title: CHW coil ΔT when inactive (GL36 L)
+  equipment_types: &id115
+  - ahu
+  required_roles: &id116
+  - cooling-coil-entering-temp
+  - cooling-coil-leaving-temp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id117 []
+  operational_proof_roles: &id118
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id119
+    eps_ccet:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Cooling-coil entering sensor error εCCET
+    eps_cclt:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Cooling-coil leaving sensor error εCCLT
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    htg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Heating-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc14
+  datafusion_sql_implementation: fc14_chw_coil_dt_inactive.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc14
+  test_coverage: &id120 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: FC15
+  title: HW coil ΔT when inactive (GL36 M)
+  equipment_types: &id121
+  - ahu
+  required_roles: &id122
+  - heating-coil-entering-temp
+  - heating-coil-leaving-temp
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id123 []
+  operational_proof_roles: &id124
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id125
+    eps_hcet:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Heating-coil entering sensor error εHCET
+    eps_hclt:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Heating-coil leaving sensor error εHCLT
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: fc15
+  datafusion_sql_implementation: fc15_hw_coil_dt_inactive.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc15
+  test_coverage: &id126 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: AHU-SATDEV
+  title: SAT deviation from setpoint
+  equipment_types: &id127
+  - ahu
+  required_roles: &id128
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  optional_roles: &id129 []
+  operational_proof_roles: &id130
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id131
+    sat_dev_err:
+      default: 5.0
+      unit: °F
+      min: 1.0
+      max: 15.0
+      step: 0.5
+      label: SAT deviation
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: ahu_sat_dev
+  datafusion_sql_implementation: ahu_satdev.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
+  test_coverage: &id132 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: AHU-DUCTHI
+  title: Duct static pressure high
+  equipment_types: &id133
+  - ahu
+  required_roles: &id134
+  - duct-static-pressure
+  - duct-static-pressure-sp
+  optional_roles: &id135 []
+  operational_proof_roles: &id136 []
+  default_thresholds: &id137
+    duct_high_margin:
+      default: 0.25
+      unit: in. w.c.
+      min: 0.05
+      max: 1.0
+      step: 0.05
+      label: High margin
+    pressure_on_min:
+      default: 0.2
+      unit: in. w.c.
+      min: 0.05
+      max: 1.0
+      step: 0.05
+      label: Pressure-on evidence
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: ahu_duct_high
+  datafusion_sql_implementation: ahu_ducthi.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
+  test_coverage: &id138 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: AHU-SIMUL
+  title: Heating and cooling simultaneous
+  equipment_types: &id139
+  - ahu
+  required_roles: &id140
+  - heating-valve
+  - cooling-valve
+  optional_roles: &id141 []
+  operational_proof_roles: &id142
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id143
+    valve_open_pct:
+      default: 0.1
+      unit: frac
+      min: 0.05
+      max: 0.5
+      step: 0.01
+      label: Valve open threshold
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: ahu_simul_heat_cool
+  datafusion_sql_implementation: ahu_simul.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
+  test_coverage: &id144 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: OAT-METEO
+  title: BAS outdoor-air sensor vs Open-Meteo
+  equipment_types: &id145
+  - ahu
+  required_roles: &id146
+  - outside-air-temp
+  - web-outside-air-temp
+  optional_roles: &id147 []
+  operational_proof_roles: &id148 []
+  default_thresholds: &id149
+    oat_err:
+      default: 5.0
+      unit: °F
+      min: 2.0
+      max: 20.0
+      step: 0.5
+      label: Max OAT disagreement
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: oat_vs_meteo
+  datafusion_sql_implementation: oat_meteo_fault.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#oat-meteo
+  test_coverage: &id150 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: ECON-1
+  title: Economizer stuck closed
+  equipment_types: &id151
+  - ahu
+  required_roles: &id152
+  - fan-cmd
+  - outside-air-damper
+  - outside-air-temp
+  optional_roles: &id153 []
+  operational_proof_roles: &id154
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id155
+    econ1_oat_min:
+      default: 55.0
+      unit: °F
+      min: 45.0
+      max: 70.0
+      step: 1.0
+      label: Favorable OAT
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ1
+  datafusion_sql_implementation: econ1_stuck_closed.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-1
+  test_coverage: &id156 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: ECON-2
+  title: Economizing when outdoor unfavorable
+  equipment_types: &id157
+  - ahu
+  required_roles: &id158
+  - outside-air-temp
+  - outside-air-damper
+  optional_roles: &id159 []
+  operational_proof_roles: &id160
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id161
+    econ2_oat_hi:
+      default: 63.0
+      unit: °F
+      min: 55.0
+      max: 80.0
+      step: 1.0
+      label: OAT high cutoff
+    econ2_damper:
+      default: 0.42
+      unit: frac
+      min: 0.2
+      max: 0.9
+      step: 0.02
+      label: Damper open frac
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: econ2
+  datafusion_sql_implementation: economizer_fault.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-2
+  test_coverage: &id162 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: ECON-3
+  title: Mech cooling without integrated economizer
+  equipment_types: &id163
+  - ahu
+  required_roles: &id164
+  - outside-air-damper
+  - cooling-valve
+  optional_roles: &id165
+  - web-outside-air-temp
+  - web-outside-air-dewpoint
+  - web-outside-air-humidity
+  operational_proof_roles: &id166
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id167
+    econ3_db_min:
+      default: 60.0
+      unit: °F
+      min: 50.0
+      max: 68.0
+      step: 1.0
+      label: Free-cool OA dry-bulb min
+    econ3_db_max:
+      default: 72.0
+      unit: °F
+      min: 65.0
+      max: 80.0
+      step: 1.0
+      label: Free-cool OA dry-bulb max
+    econ3_dp_max:
+      default: 60.0
+      unit: °F
+      min: 45.0
+      max: 68.0
+      step: 1.0
+      label: Free-cool OA dew point max
+    econ3_damper_hi:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.02
+      label: Integrated economizer damper
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: econ2
+  datafusion_sql_implementation: econ3_mech_without_econ.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
+  test_coverage: &id168 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: ECON-4
+  title: Low estimated OA fraction
+  equipment_types: &id169
+  - ahu
+  required_roles: &id170
+  - mixed-air-temp
+  - return-air-temp
+  - outside-air-temp
+  - fan-cmd
+  optional_roles: &id171 []
+  operational_proof_roles: &id172
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id173
+    oa_min_pct:
+      default: 21.0
+      unit: '%'
+      min: 5.0
+      max: 40.0
+      step: 1.0
+      label: Min OA fraction
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ4
+  datafusion_sql_implementation: econ4_low_oa_frac.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-4
+  test_coverage: &id174 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: ECON-5
+  title: Preheat over-conditioning
+  equipment_types: &id175
+  - ahu
+  required_roles: &id176
+  - preheat-leaving-temp
+  - discharge-air-temp-sp
+  - outside-air-temp
+  - heating-valve
+  optional_roles: &id177 []
+  operational_proof_roles: &id178
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id179
+    preheat_over_f:
+      default: 2.2
+      unit: °F
+      min: 0.5
+      max: 8.0
+      step: 0.1
+      label: Preheat over ΔT
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ5
+  datafusion_sql_implementation: econ5_preheat_over.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
+  test_coverage: &id180 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: ECON-6
+  title: Economizing in freezing weather
+  equipment_types: &id181
+  - ahu
+  required_roles: &id182
+  - outside-air-damper
+  optional_roles: &id183
+  - web-outside-air-temp
+  operational_proof_roles: &id184
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id185
+    econ6_oat_max_f:
+      default: 25.0
+      unit: °F
+      min: 15.0
+      max: 40.0
+      step: 1.0
+      label: Winter OAT ceiling
+    econ6_damper_max:
+      default: 0.25
+      unit: frac
+      min: 0.05
+      max: 0.5
+      step: 0.01
+      label: Winter min-OA damper
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ6_compute
+  datafusion_sql_implementation: econ6_econ_freezing.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
+  test_coverage: &id186 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: ECON-7
+  title: Economizer OK but not economizing
+  equipment_types: &id187
+  - ahu
+  required_roles: &id188
+  - outside-air-damper
+  optional_roles: &id189
+  - web-outside-air-temp
+  - web-outside-air-dewpoint
+  - web-outside-air-humidity
+  - cooling-valve
+  - compressor-status
+  - dx-cool-cmd
+  operational_proof_roles: &id190
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id191
+    econ7_db_min:
+      default: 35.0
+      unit: °F
+      min: 20.0
+      max: 50.0
+      step: 1.0
+      label: Econ-OK dry-bulb floor (freeze guard)
+    econ7_db_max:
+      default: 72.0
+      unit: °F
+      min: 65.0
+      max: 80.0
+      step: 1.0
+      label: Econ-OK dry-bulb max
+    econ7_dp_max:
+      default: 60.0
+      unit: °F
+      min: 45.0
+      max: 68.0
+      step: 1.0
+      label: Econ-OK dew point max
+    econ7_damper_min:
+      default: 0.5
+      unit: frac
+      min: 0.2
+      max: 0.9
+      step: 0.02
+      label: Economizing damper threshold
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ7_compute
+  datafusion_sql_implementation: econ7_ok_not_economizing.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
+  test_coverage: &id192 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: MECH-OAT-1
+  title: Mechanical cooling below 60°F web OAT
+  equipment_types: &id193
+  - ahu
+  - chiller
+  - heatpump
+  required_roles: &id194
+  - web_oa_t
+  - clg_valve_pct
+  optional_roles: &id195
+  - web-outside-air-temp
+  - compressor-status
+  - chiller-status
+  - chw-pump-status
+  - dx-cool-cmd
+  operational_proof_roles: &id196 []
+  default_thresholds: &id197
+    mech_oat_max_f:
+      default: 60.0
+      unit: °F
+      min: 45.0
+      max: 65.0
+      step: 1.0
+      label: Mech-cool OAT ceiling
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: mech_oat1_compute
+  datafusion_sql_implementation: mech_oat_1.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
+  test_coverage: &id198 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: CHW-NOLOAD-1
+  title: Chiller running with no building load
+  equipment_types: &id199
+  - chiller
+  required_roles: &id200
+  - chw_supply_t
+  - chw_supply_sp
+  - chw_pump_cmd
+  optional_roles: &id201
+  - chiller-status
+  - chw-pump-status
+  - compressor-status
+  - building-zone-load-satisfied
+  - building-ahu-load-satisfied
+  operational_proof_roles: &id202 []
+  default_thresholds: &id203
+    comfort_low_f:
+      default: 70.0
+      unit: °F
+      min: 60.0
+      max: 78.0
+      step: 0.5
+      label: Comfort low
+    comfort_high_f:
+      default: 75.0
+      unit: °F
+      min: 68.0
+      max: 85.0
+      step: 0.5
+      label: Comfort high
+    sat_band_f:
+      default: 2.0
+      unit: °F
+      min: 0.5
+      max: 6.0
+      step: 0.5
+      label: AHU SAT≈SP band
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: chw_noload1_compute
+  datafusion_sql_implementation: chw_noload_1.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
+  test_coverage: &id204 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VAV-1
+  title: Zone comfort band
+  equipment_types: &id205
+  - vav
+  - zone
+  required_roles: &id206
+  - zone-air-temp
+  optional_roles: &id207 []
+  operational_proof_roles: &id208 []
+  default_thresholds: &id209
+    zone_lo:
+      default: 70.0
+      unit: °F
+      min: 55.0
+      max: 72.0
+      step: 0.5
+      label: Zone low
+    zone_hi:
+      default: 75.0
+      unit: °F
+      min: 72.0
+      max: 85.0
+      step: 0.5
+      label: Zone high
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav1
+  datafusion_sql_implementation: vav1_comfort_fault.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-1
+  test_coverage: &id210 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VAV-3
+  title: Excessive reheat during warm weather
+  equipment_types: &id211
+  - vav
+  required_roles: &id212
+  - outside-air-temp
+  - reheat-valve
+  optional_roles: &id213 []
+  operational_proof_roles: &id214
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id215
+    reheat_oat:
+      default: 78.0
+      unit: °F
+      min: 65.0
+      max: 90.0
+      step: 1.0
+      label: Warm OAT
+    reheat_pct:
+      default: 0.52
+      unit: frac
+      min: 0.1
+      max: 1.0
+      step: 0.02
+      label: Reheat frac
+    flow_on_min:
+      default: 25.0
+      unit: cfm
+      min: 0.0
+      max: 200.0
+      step: 5.0
+      label: Airflow-on min
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: vav3
+  datafusion_sql_implementation: vav3_excessive_reheat.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
+  test_coverage: &id216 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VAV-4
+  title: Damper stuck at full open
+  equipment_types: &id217
+  - vav
+  required_roles: &id218
+  - damper
+  optional_roles: &id219 []
+  operational_proof_roles: &id220
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
+  default_thresholds: &id221
+    full_open_pct:
+      default: 0.975
+      unit: frac
+      min: 0.8
+      max: 1.0
+      step: 0.005
+      label: Full open frac
+    sustain_hours:
+      default: 1.5
+      unit: h
+      min: 0.5
+      max: 6.0
+      step: 0.5
+      label: Sustain window
+    flow_on_min:
+      default: 25.0
+      unit: cfm
+      min: 0.0
+      max: 200.0
+      step: 5.0
+      label: Airflow-on min
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav4
+  datafusion_sql_implementation: vav4_damper_full_open.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
+  test_coverage: &id222 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VAV-5
+  title: Airflow sensor bias
+  equipment_types: &id223
+  - vav
+  required_roles: &id224
+  - zone-airflow
+  - damper
+  optional_roles: &id225 []
+  operational_proof_roles: &id226
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id227
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav5
+  datafusion_sql_implementation: vav5_airflow_bias.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
+  test_coverage: &id228 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VAV-REHEAT
+  title: Reheat valve stuck / no temp rise
+  equipment_types: &id229
+  - vav
+  required_roles: &id230
+  - reheat-valve
+  - vav-discharge-air-temp
+  - vav-inlet-air-temp
+  optional_roles: &id231 []
+  operational_proof_roles: &id232
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id233
+    reheat_cmd:
+      default: 0.3
+      unit: frac
+      min: 0.1
+      max: 1.0
+      step: 0.05
+      label: Reheat open frac
+    min_rise:
+      default: 3.0
+      unit: °F
+      min: 0.5
+      max: 15.0
+      step: 0.5
+      label: Min temp rise
+    flow_on_min:
+      default: 25.0
+      unit: cfm
+      min: 0.0
+      max: 200.0
+      step: 5.0
+      label: Airflow-on min
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav_reheat_stuck
+  datafusion_sql_implementation: vav_reheat.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
+  test_coverage: &id234 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VAV-AHU-LEAVE
+  title: VAV leave vs parent AHU SAT (fedBy)
+  equipment_types: &id235
+  - vav
+  required_roles: &id236
+  - vav-discharge-air-temp
+  - ahu-discharge-air-temp
+  optional_roles: &id237 []
+  operational_proof_roles: &id238
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id239
+    delta_f:
+      default: 8.0
+      unit: °F
+      min: 2.0
+      max: 25.0
+      step: 0.5
+      label: Leave Δ vs AHU SAT
+    flow_on_min:
+      default: 25.0
+      unit: cfm
+      min: 0.0
+      max: 200.0
+      step: 5.0
+      label: Airflow-on min
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav_vs_ahu_leave
+  datafusion_sql_implementation: vav_ahu_leave.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
+  test_coverage: &id240 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VAV-7
+  title: Min airflow / fixed high flow
+  equipment_types: &id241
+  - vav
+  required_roles: &id242
+  - zone-airflow
+  optional_roles: &id243 []
+  operational_proof_roles: &id244
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id245
+    flow_on_min:
+      default: 25.0
+      unit: cfm
+      min: 0.0
+      max: 200.0
+      step: 5.0
+      label: Airflow-on min
+    fixed_flow_max_std:
+      default: 15.0
+      unit: cfm
+      min: 1.0
+      max: 80.0
+      step: 1.0
+      label: Fixed-flow max std
+    fixed_flow_min_mean:
+      default: 200.0
+      unit: cfm
+      min: 50.0
+      max: 2000.0
+      step: 10.0
+      label: Fixed-flow min mean
+    high_min_flow_sp:
+      default: 250.0
+      unit: cfm
+      min: 50.0
+      max: 2000.0
+      step: 10.0
+      label: High min-flow SP
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav7
+  datafusion_sql_implementation: vav7_min_airflow.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
+  test_coverage: &id246 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: CHW-1
+  title: Low chilled-water ΔT
+  equipment_types: &id247
+  - chiller
+  required_roles: &id248
+  - chilled-water-supply-temp
+  - chilled-water-return-temp
+  optional_roles: &id249 []
+  operational_proof_roles: &id250
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id251
+    min_dt:
+      default: 4.0
+      unit: °F
+      min: 1.0
+      max: 12.0
+      step: 0.5
+      label: Min ΔT
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: chw1
+  datafusion_sql_implementation: chw1_low_dt.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-1
+  test_coverage: &id252
+  - tests/rules/test_parity_inventory.py
+  parity_status: sql_screening
+  known_semantic_differences: pandas chw1() treats missing chw-pump-cmd as always-on;
+    hydronic gate returns ungated_no_proof_roles (all True) and does not use chiller
+    status/amps/power; SQL chw1_low_dt.sql only inspects chw_pump_cmd and still scores
+    ΔT when pump is NULL
+  difference_class: semantic_gap
+- rule_id: CHW-2
+  title: DP below SP at max pump speed
+  equipment_types: &id253
+  - chiller
+  required_roles: &id254
+  - chw-diff-pressure
+  - chw-diff-pressure-sp
+  - chw-pump-cmd
+  optional_roles: &id255 []
+  operational_proof_roles: &id256
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id257
+    dp_margin:
+      default: 2.2
+      unit: psi
+      min: 0.5
+      max: 6.0
+      step: 0.1
+      label: DP margin
+    pump_hi:
+      default: 0.87
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Pump high-speed threshold
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw2
+  datafusion_sql_implementation: chw2_dp_low.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
+  test_coverage: &id258 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: CHW-3
+  title: Plant supply temp outside deadband
+  equipment_types: &id259
+  - chiller
+  required_roles: &id260
+  - chilled-water-supply-temp
+  - chilled-water-supply-temp-sp
+  - chw-pump-cmd
+  optional_roles: &id261 []
+  operational_proof_roles: &id262
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id263
+    sp_band:
+      default: 2.2
+      unit: °F
+      min: 0.5
+      max: 6.0
+      step: 0.1
+      label: SP band
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw3
+  datafusion_sql_implementation: chw3_supply_band.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
+  test_coverage: &id264 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: CHW-4
+  title: Flow high at max pump
+  equipment_types: &id265
+  - chiller
+  required_roles: &id266
+  - chw-flow
+  - chw-pump-cmd
+  optional_roles: &id267 []
+  operational_proof_roles: &id268
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id269
+    flow_hi:
+      default: 1100
+      unit: gpm
+      min: 200
+      max: 3000
+      step: 50
+      label: Flow high
+    pump_hi:
+      default: 0.87
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Pump high-speed threshold
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw4
+  datafusion_sql_implementation: chw4_flow_high.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
+  test_coverage: &id270 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: HP-1
+  title: Discharge cold when heating
+  equipment_types: &id271
+  - heatpump
+  required_roles: &id272
+  - discharge-air-temp
+  - zone-air-temp
+  - fan-cmd
+  optional_roles: &id273 []
+  operational_proof_roles: &id274
+  - compressor-status
+  - equipment-enable
+  - fan-status
+  - fan-cmd
+  default_thresholds: &id275
+    min_sat:
+      default: 85.0
+      unit: °F
+      min: 70.0
+      max: 110.0
+      step: 1.0
+      label: Min heating SAT
+    zone_cold:
+      default: 69.0
+      unit: °F
+      min: 60.0
+      max: 72.0
+      step: 0.5
+      label: Zone cold
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: hp1
+  datafusion_sql_implementation: hp1_discharge_cold.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
+  test_coverage: &id276 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: WX-1
+  title: OA temperature spike
+  equipment_types: &id277
+  - weather
+  required_roles: &id278
+  - outside-air-temp
+  optional_roles: &id279 []
+  operational_proof_roles: &id280 []
+  default_thresholds: &id281
+    spike_limit:
+      default: 16.0
+      unit: °F
+      min: 4.0
+      max: 40.0
+      step: 1.0
+      label: Spike limit
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: wx1
+  datafusion_sql_implementation: wx1_oa_spike.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
+  test_coverage: &id282 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: CW-OPT-1
+  title: Condenser water not optimized vs wet-bulb
+  equipment_types: &id283
+  - chiller
+  - cooling_tower
+  required_roles: &id284
+  - condenser-water-supply-temp
+  optional_roles: &id285 []
+  operational_proof_roles: &id286
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id287
+    cw_approach:
+      default: 7.0
+      unit: °F
+      min: 3.0
+      max: 15.0
+      step: 0.5
+      label: Design approach
+    cw_slack:
+      default: 2.0
+      unit: °F
+      min: 0.5
+      max: 6.0
+      step: 0.5
+      label: Slack below target
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_opt
+  datafusion_sql_implementation: cw_opt_1.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
+  test_coverage: &id288 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: CW-APR-1
+  title: High CW approach at full tower fan
+  equipment_types: &id289
+  - chiller
+  - cooling_tower
+  required_roles: &id290
+  - condenser-water-supply-temp
+  optional_roles: &id291
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - web-outside-air-wetbulb
+  operational_proof_roles: &id292
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id293
+    approach_max_f:
+      default: 8.0
+      unit: °F
+      min: 5.0
+      max: 15.0
+      step: 0.5
+      label: Max approach at full fan
+    tower_fan_hi:
+      default: 0.95
+      unit: frac
+      min: 0.8
+      max: 1.0
+      step: 0.01
+      label: Tower fan full-speed threshold
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_apr
+  datafusion_sql_implementation: cw_apr_1.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
+  test_coverage: &id294 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: CW-FAN-1
+  title: Excess tower fan energy vs wet-bulb limit
+  equipment_types: &id295
+  - chiller
+  - cooling_tower
+  required_roles: &id296
+  - condenser-water-supply-temp
+  optional_roles: &id297
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - web-outside-air-wetbulb
+  operational_proof_roles: &id298
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id299
+    cw_approach:
+      default: 7.0
+      unit: °F
+      min: 3.0
+      max: 15.0
+      step: 0.5
+      label: Design approach
+    excess_beyond_approach_f:
+      default: 5.0
+      unit: °F
+      min: 2.0
+      max: 20.0
+      step: 0.5
+      label: Excess beyond approach
+    tower_fan_hi:
+      default: 0.95
+      unit: frac
+      min: 0.8
+      max: 1.0
+      step: 0.01
+      label: Tower fan full-speed threshold
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_fan_excess
+  datafusion_sql_implementation: cw_fan_1.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
+  test_coverage: &id300 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: TRIM-1
+  title: Duct static trim advisory
+  equipment_types: &id301
+  - ahu
+  required_roles: &id302
+  - duct-static-pressure
+  - vav-pressure-request-sum
+  optional_roles: &id303 []
+  operational_proof_roles: &id304
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id305
+    duct_hi:
+      default: 1.35
+      unit: in. w.c.
+      min: 0.5
+      max: 3.0
+      step: 0.05
+      label: Duct static high
+    request_lo:
+      default: 1.0
+      unit: count
+      min: 0.0
+      max: 10.0
+      step: 0.5
+      label: Request sum low
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim1
+  datafusion_sql_implementation: trim1_duct_static.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
+  test_coverage: &id306 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: TRIM-3
+  title: HWST trim advisory
+  equipment_types: &id307
+  - boiler
+  required_roles: &id308
+  - hot-water-supply-temp
+  - hw-reset-request-sum
+  optional_roles: &id309 []
+  operational_proof_roles: &id310
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id311
+    hwst_hi:
+      default: 160.0
+      unit: °F
+      min: 120.0
+      max: 200.0
+      step: 1.0
+      label: HWST high
+    request_lo:
+      default: 1.0
+      unit: count
+      min: 0.0
+      max: 10.0
+      step: 0.5
+      label: Request sum low
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim3
+  datafusion_sql_implementation: trim3_hwst.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
+  test_coverage: &id312 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: TRIM-4
+  title: CHW plant reset advisory
+  equipment_types: &id313
+  - chiller
+  required_roles: &id314
+  - chilled-water-supply-temp
+  - chw-reset-request-sum
+  optional_roles: &id315 []
+  operational_proof_roles: &id316
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  default_thresholds: &id317
+    chw_lo:
+      default: 45.0
+      unit: °F
+      min: 35.0
+      max: 55.0
+      step: 0.5
+      label: CHWS low
+    request_lo:
+      default: 1.0
+      unit: count
+      min: 0.0
+      max: 10.0
+      step: 0.5
+      label: Request sum low
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim4
+  datafusion_sql_implementation: trim4_chw_reset.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
+  test_coverage: &id318 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: SCHED-1
+  title: Unoccupied runtime
+  equipment_types: &id319
+  - ahu
+  required_roles: &id320
+  - occupied
+  - fan-status
+  optional_roles: &id321
+  - zone-air-temp
+  operational_proof_roles: &id322 []
+  default_thresholds: &id323
+    comfort_low_f:
+      default: 70.0
+      unit: °F
+      min: 60.0
+      max: 78.0
+      step: 0.5
+      label: Comfort low
+    comfort_high_f:
+      default: 75.0
+      unit: °F
+      min: 68.0
+      max: 85.0
+      step: 0.5
+      label: Comfort high
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: sched1
+  datafusion_sql_implementation: sched1_unoccupied_runtime.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-1
+  test_coverage: &id324
+  - tests/reporting/test_findings_smoke.py
+  - tests/rules/test_catalog_smoke.py
+  parity_status: sql_screening
+  known_semantic_differences: 'aliases: excess_runtime (not independent rules)'
+  difference_class: alias
+- rule_id: SCHED-247
+  title: Always-on fan or pump runtime
+  equipment_types: &id325
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - heatpump
+  required_roles: &id326
+  - fan_cmd
+  optional_roles: &id327
+  - fan-status
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - chiller-status
+  - compressor-status
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  - duct-static-pressure
+  - chw-diff-pressure
+  operational_proof_roles: &id328 []
+  default_thresholds: &id329
+    always_on_pct:
+      default: 0.95
+      unit: frac
+      min: 0.8
+      max: 1.0
+      step: 0.01
+      label: Always-on fraction
+    pressure_on_min:
+      default: 0.2
+      unit: eng
+      min: 0.05
+      max: 2.0
+      step: 0.05
+      label: Pressure-on evidence
+    confirm_min:
+      default: 60.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 3600.0
+      unit: sec
+  pandas_implementation: _sched247
+  datafusion_sql_implementation: sched247_always_on.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-247
+  test_coverage: &id330
+  - tests/rules/test_parity_inventory.py
+  parity_status: sql_screening
+  known_semantic_differences: pandas _sched247 ORs fan/pump/chiller status, commands,
+    and duct pressure; SQL sched247_always_on.sql uses fan_cmd only
+  difference_class: semantic_gap
+- rule_id: CMD-1
+  title: Fan cmd/status mismatch
+  equipment_types: &id331
+  - ahu
+  required_roles: &id332
+  - fan-cmd
+  - fan-status
+  optional_roles: &id333 []
+  operational_proof_roles: &id334 []
+  default_thresholds: &id335
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: cmd1
+  datafusion_sql_implementation: cmd1_fan_mismatch.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
+  test_coverage: &id336 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: OA-1
+  title: Low OA fraction
+  equipment_types: &id337
+  - ahu
+  required_roles: &id338
+  - mixed-air-temp
+  - return-air-temp
+  - outside-air-temp
+  - fan-status
+  optional_roles: &id339 []
+  operational_proof_roles: &id340
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id341
+    min_oa_frac:
+      default: 0.15
+      unit: frac
+      min: 0.05
+      max: 0.4
+      step: 0.01
+      label: Min OA fraction
+    oat_rat_guard:
+      default: 2.2
+      unit: °F
+      min: 0.5
+      max: 6.0
+      step: 0.1
+      label: Min |RAT−OAT| guard
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: oa1
+  datafusion_sql_implementation: oa1_low_oa_frac.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
+  test_coverage: &id342 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: DMP-1
+  title: OA damper leakage
+  equipment_types: &id343
+  - ahu
+  required_roles: &id344
+  - outside-air-temp
+  - mixed-air-temp
+  - outside-air-damper
+  optional_roles: &id345 []
+  operational_proof_roles: &id346 []
+  default_thresholds: &id347
+    leak_delta:
+      default: 2.0
+      unit: °F
+      min: 0.5
+      max: 6.0
+      step: 0.5
+      label: Leak ΔT
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: dmp1
+  datafusion_sql_implementation: dmp1_oa_damper_leak.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
+  test_coverage: &id348 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: VLV-1
+  title: Cooling valve leakage
+  equipment_types: &id349
+  - ahu
+  required_roles: &id350
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - cooling-valve
+  optional_roles: &id351
+  - mixed-air-temp
+  - fan-status
+  - fan-cmd
+  operational_proof_roles: &id352 []
+  default_thresholds: &id353
+    sat_err:
+      default: 2.0
+      unit: °F
+      min: 0.5
+      max: 8.0
+      step: 0.5
+      label: SAT vs SP leak ΔT
+    mat_leak_delta:
+      default: 2.0
+      unit: °F
+      min: 0.5
+      max: 12.0
+      step: 0.5
+      label: SAT vs MAT leak ΔT
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vlv1
+  datafusion_sql_implementation: vlv1_clg_valve_leak.sql
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
+  test_coverage: &id354 []
+  parity_status: sql_screening
+  known_semantic_differences: ''
+  difference_class: none
+- rule_id: AVG-ZONE-TEMP
+  title: Average zone temperature per equipment
+  equipment_types: []
+  required_roles: &id355
+  - zone_t
+  optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: &id356
+    zone_t_lo:
+      default: 68.0
+      unit: degF
+      min: 60.0
+      max: 72.0
+      step: 0.5
+      label: Zone comfort low (reference)
+    zone_t_hi:
+      default: 76.0
+      unit: degF
+      min: 72.0
+      max: 85.0
+      step: 0.5
+      label: Zone comfort high (reference)
+  pandas_implementation: null
+  datafusion_sql_implementation: avg_zone_temp.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#avg-zone-temp
+  test_coverage: &id357 []
+  parity_status: sql_screening
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
+  difference_class: intentional_non_applicability
+- rule_id: FAN-RUNTIME-HOURS
+  title: Fan running hours where fan_cmd > 5% (normalized 0-1)
+  equipment_types: []
+  required_roles: &id358
+  - fan_cmd
+  optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: &id359 {}
+  pandas_implementation: null
+  datafusion_sql_implementation: fan_runtime_hours.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fan-runtime-hours
+  test_coverage: &id360
+  - tests/rules/test_parity_inventory.py
+  parity_status: sql_screening
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
+  difference_class: intentional_non_applicability
+- rule_id: FAULT-ELAPSED-HOURS
+  title: Comfort fault sample count → hours
+  equipment_types: []
+  required_roles: &id361
+  - zone_t
+  optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: &id362
+    zone_t_lo:
+      default: 68.0
+      unit: degF
+      min: 60.0
+      max: 72.0
+      step: 0.5
+      label: Zone comfort low
+    zone_t_hi:
+      default: 76.0
+      unit: degF
+      min: 72.0
+      max: 85.0
+      step: 0.5
+      label: Zone comfort high
+  pandas_implementation: null
+  datafusion_sql_implementation: fault_elapsed_hours.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fault-elapsed-hours
+  test_coverage: &id363 []
+  parity_status: sql_screening
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
+  difference_class: intentional_non_applicability
+- rule_id: ZONE-COMFORT-PCT
+  title: Percent of samples in comfort band
+  equipment_types: []
+  required_roles: &id364
+  - zone_t
+  optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: &id365
+    zone_t_lo:
+      default: 68.0
+      unit: degF
+      min: 60.0
+      max: 72.0
+      step: 0.5
+      label: Zone comfort low
+    zone_t_hi:
+      default: 76.0
+      unit: degF
+      min: 72.0
+      max: 85.0
+      step: 0.5
+      label: Zone comfort high
+  pandas_implementation: null
+  datafusion_sql_implementation: zone_comfort_pct.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#zone-comfort-pct
+  test_coverage: &id366 []
+  parity_status: sql_screening
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
+  difference_class: intentional_non_applicability
 concepts:
 - canonical_id: SV-RANGE
   pandas_id: SV-RANGE
+  rule_id: SV-RANGE
+  title: Sensor out of hard range
   aliases: []
   kind: diagnostic
-  pandas_implementation: sv_range
+  equipment_types: *id001
+  equipment_kinds: *id001
+  required_roles: *id002
+  optional_roles: *id003
+  operational_proof_roles: *id004
+  default_thresholds: *id005
+  pandas_implementation: _sweep_range
+  datafusion_sql_implementation: sv_range.sql
   sql_file: sv_range.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#sv-range
+  test_coverage: *id006
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: equipment_energized
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -53,7 +3595,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/SV-RANGE/normal
@@ -107,16 +3648,28 @@ concepts:
     oracle_seed: false
 - canonical_id: SV-FLATLINE
   pandas_id: SV-FLATLINE
+  rule_id: SV-FLATLINE
+  title: Sensor flatline (stuck)
   aliases: []
   kind: diagnostic
-  pandas_implementation: sv_flatline
+  equipment_types: *id007
+  equipment_kinds: *id007
+  required_roles: *id008
+  optional_roles: *id009
+  operational_proof_roles: *id010
+  default_thresholds: *id011
+  pandas_implementation: _sweep_flatline
+  datafusion_sql_implementation: sv_flatline.sql
   sql_file: sv_flatline.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#sv-flatline
+  test_coverage: *id012
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: conditional
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -141,7 +3694,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/SV-FLATLINE/normal
@@ -195,16 +3747,28 @@ concepts:
     oracle_seed: false
 - canonical_id: SV-SPIKE
   pandas_id: SV-SPIKE
+  rule_id: SV-SPIKE
+  title: Sensor rate-of-change spike
   aliases: []
   kind: diagnostic
-  pandas_implementation: sv_spike
+  equipment_types: *id013
+  equipment_kinds: *id013
+  required_roles: *id014
+  optional_roles: *id015
+  operational_proof_roles: *id016
+  default_thresholds: *id017
+  pandas_implementation: _sweep_spike
+  datafusion_sql_implementation: sv_spike.sql
   sql_file: sv_spike.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#sv-spike
+  test_coverage: *id018
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: equipment_energized
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -229,7 +3793,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/SV-SPIKE/normal
@@ -283,16 +3846,28 @@ concepts:
     oracle_seed: false
 - canonical_id: SV-STALE
   pandas_id: SV-STALE
+  rule_id: SV-STALE
+  title: Stale data (no fresh samples)
   aliases: []
   kind: diagnostic
-  pandas_implementation: sv_stale
+  equipment_types: *id019
+  equipment_kinds: *id019
+  required_roles: *id020
+  optional_roles: *id021
+  operational_proof_roles: *id022
+  default_thresholds: *id023
+  pandas_implementation: _sweep_stale
+  datafusion_sql_implementation: sv_stale.sql
   sql_file: sv_stale.sql
-  equipment_kinds: null
-  required_roles:
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#sv-stale
+  test_coverage: *id024
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -317,7 +3892,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/SV-STALE/normal
@@ -371,17 +3945,29 @@ concepts:
     oracle_seed: false
 - canonical_id: SV-RATE
   pandas_id: SV-RATE
+  rule_id: SV-RATE
+  title: Context-aware sensor rate of change
   aliases:
   - SV-SLEW
   kind: diagnostic
-  pandas_implementation: sv_rate
+  equipment_types: *id025
+  equipment_kinds: *id025
+  required_roles: *id026
+  optional_roles: *id027
+  operational_proof_roles: *id028
+  default_thresholds: *id029
+  pandas_implementation: _sv_rate_compute
+  datafusion_sql_implementation: sv_rate.sql
   sql_file: sv_rate.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#sv-rate
+  test_coverage: *id030
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: alias
+  known_semantic_differences: 'aliases: SV-SLEW (not independent rules)'
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -406,7 +3992,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/SV-RATE/normal
@@ -460,16 +4045,28 @@ concepts:
     oracle_seed: false
 - canonical_id: PID-HUNT-1
   pandas_id: PID-HUNT-1
+  rule_id: PID-HUNT-1
+  title: Suspected control-output hunting
   aliases: []
   kind: diagnostic
-  pandas_implementation: pid_hunt_1
+  equipment_types: *id031
+  equipment_kinds: *id031
+  required_roles: *id032
+  optional_roles: *id033
+  operational_proof_roles: *id034
+  default_thresholds: *id035
+  pandas_implementation: _pid_hunt_1
+  datafusion_sql_implementation: pid_hunt_1.sql
   sql_file: pid_hunt_1.sql
-  equipment_kinds: null
-  required_roles:
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#pid-hunt-1
+  test_coverage: *id036
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 0
   parameters:
     confirm_seconds:
@@ -503,7 +4100,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/PID-HUNT-1/normal
@@ -557,18 +4153,28 @@ concepts:
     oracle_seed: false
 - canonical_id: FC1
   pandas_id: FC1
+  rule_id: FC1
+  title: Duct static below SP at full fan (GL36 A)
   aliases: []
   kind: diagnostic
+  equipment_types: *id037
+  equipment_kinds: *id037
+  required_roles: *id038
+  optional_roles: *id039
+  operational_proof_roles: *id040
+  default_thresholds: *id041
   pandas_implementation: fc1
+  datafusion_sql_implementation: fc1_duct_static_low.sql
   sql_file: fc1_duct_static_low.sql
-  equipment_kinds: null
-  required_roles:
-  - duct_static
-  - duct_static_sp
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc1
+  test_coverage: *id042
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     eps_dsp:
@@ -602,7 +4208,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC1/normal
@@ -656,26 +4261,34 @@ concepts:
     oracle_seed: false
 - canonical_id: FC2
   pandas_id: FC2
+  rule_id: FC2
+  title: MAT below OAT/RAT envelope (GL36 B)
   aliases: []
   kind: diagnostic
+  equipment_types: *id043
+  equipment_kinds: *id043
+  required_roles: *id044
+  optional_roles: *id045
+  operational_proof_roles: *id046
+  default_thresholds: *id047
   pandas_implementation: fc2
+  datafusion_sql_implementation: fc2_mat_low.sql
   sql_file: fc2_mat_low.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - oa_t
-  - rat
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc2
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc2
+  test_coverage: *id048
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC2/normal
@@ -729,26 +4342,34 @@ concepts:
     oracle_seed: false
 - canonical_id: FC3
   pandas_id: FC3
+  rule_id: FC3
+  title: MAT above OAT/RAT envelope (GL36 C)
   aliases: []
   kind: diagnostic
+  equipment_types: *id049
+  equipment_kinds: *id049
+  required_roles: *id050
+  optional_roles: *id051
+  operational_proof_roles: *id052
+  default_thresholds: *id053
   pandas_implementation: fc3
+  datafusion_sql_implementation: fc3_mat_high.sql
   sql_file: fc3_mat_high.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - oa_t
-  - rat
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc3
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc3
+  test_coverage: *id054
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC3/normal
@@ -802,18 +4423,28 @@ concepts:
     oracle_seed: false
 - canonical_id: FC4
   pandas_id: FC4
+  rule_id: FC4
+  title: PID hunting (operating-state oscillation)
   aliases: []
   kind: diagnostic
+  equipment_types: *id055
+  equipment_kinds: *id055
+  required_roles: *id056
+  optional_roles: *id057
+  operational_proof_roles: *id058
+  default_thresholds: *id059
   pandas_implementation: fc4
+  datafusion_sql_implementation: fc4_os_hunting.sql
   sql_file: fc4_os_hunting.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_damper_pct
-  - clg_valve_pct
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc4
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc4
+  test_coverage: *id060
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -829,7 +4460,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC4/normal
@@ -883,19 +4513,28 @@ concepts:
     oracle_seed: false
 - canonical_id: FC5
   pandas_id: FC5
+  rule_id: FC5
+  title: SAT cold when heating commanded (GL36 D)
   aliases: []
   kind: diagnostic
+  equipment_types: *id061
+  equipment_kinds: *id061
+  required_roles: *id062
+  optional_roles: *id063
+  operational_proof_roles: *id064
+  default_thresholds: *id065
   pandas_implementation: fc5
+  datafusion_sql_implementation: fc5_sat_cold_heating.sql
   sql_file: fc5_sat_cold_heating.sql
-  equipment_kinds: null
-  required_roles:
-  - sat
-  - mat
-  - htg_valve_pct
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc5
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc5
+  test_coverage: *id066
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -929,7 +4568,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC5/normal
@@ -983,19 +4621,28 @@ concepts:
     oracle_seed: false
 - canonical_id: FC6
   pandas_id: FC6
+  rule_id: FC6
+  title: Estimated OA fraction mismatch
   aliases: []
   kind: diagnostic
+  equipment_types: *id067
+  equipment_kinds: *id067
+  required_roles: *id068
+  optional_roles: *id069
+  operational_proof_roles: *id070
+  default_thresholds: *id071
   pandas_implementation: fc6
+  datafusion_sql_implementation: fc6_oa_frac_mismatch.sql
   sql_file: fc6_oa_frac_mismatch.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc6
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc6
+  test_coverage: *id072
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -1029,7 +4676,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC6/normal
@@ -1083,19 +4729,29 @@ concepts:
     oracle_seed: false
 - canonical_id: FC7
   pandas_id: FC7
+  rule_id: FC7
+  title: SAT low with full heating (GL36 E)
   aliases: []
   kind: diagnostic
+  equipment_types: *id073
+  equipment_kinds: *id073
+  required_roles: *id074
+  optional_roles: *id075
+  operational_proof_roles: *id076
+  default_thresholds: *id077
   pandas_implementation: fc7
+  datafusion_sql_implementation: fc7_sat_low_heating.sql
   sql_file: fc7_sat_low_heating.sql
-  equipment_kinds: null
-  required_roles:
-  - sat
-  - sat_sp
-  - htg_valve_pct
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc7
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc7
+  test_coverage: *id078
+  parity_status: concept_only
+  parity_level: concept_only
+  difference_class: missing_implementation
+  known_semantic_differences: concept_only — SQL file is a placeholder; do not claim
+    twin parity
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -1129,7 +4785,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: concept_only
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC7/normal
@@ -1183,26 +4838,34 @@ concepts:
     oracle_seed: false
 - canonical_id: FC8
   pandas_id: FC8
+  rule_id: FC8
+  title: SAT/MAT mismatch in economizer (GL36 F)
   aliases: []
   kind: diagnostic
+  equipment_types: *id079
+  equipment_kinds: *id079
+  required_roles: *id080
+  optional_roles: *id081
+  operational_proof_roles: *id082
+  default_thresholds: *id083
   pandas_implementation: fc8
+  datafusion_sql_implementation: fc8_sat_mat_econ.sql
   sql_file: fc8_sat_mat_econ.sql
-  equipment_kinds: null
-  required_roles:
-  - sat
-  - mat
-  - oa_damper_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc8
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc8
+  test_coverage: *id084
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC8/normal
@@ -1256,26 +4919,34 @@ concepts:
     oracle_seed: false
 - canonical_id: FC9
   pandas_id: FC9
+  rule_id: FC9
+  title: OAT too warm for free cooling (GL36 G)
   aliases: []
   kind: diagnostic
+  equipment_types: *id085
+  equipment_kinds: *id085
+  required_roles: *id086
+  optional_roles: *id087
+  operational_proof_roles: *id088
+  default_thresholds: *id089
   pandas_implementation: fc9
+  datafusion_sql_implementation: fc9_oa_sat_sp_econ.sql
   sql_file: fc9_oa_sat_sp_econ.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  - sat_sp
-  - oa_damper_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc9
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc9
+  test_coverage: *id090
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC9/normal
@@ -1329,26 +5000,34 @@ concepts:
     oracle_seed: false
 - canonical_id: FC10
   pandas_id: FC10
+  rule_id: FC10
+  title: OAT/MAT mismatch + mech cooling (GL36 H)
   aliases: []
   kind: diagnostic
+  equipment_types: *id091
+  equipment_kinds: *id091
+  required_roles: *id092
+  optional_roles: *id093
+  operational_proof_roles: *id094
+  default_thresholds: *id095
   pandas_implementation: fc10
+  datafusion_sql_implementation: fc10_mat_oa_clg.sql
   sql_file: fc10_mat_oa_clg.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - oa_t
-  - oa_damper_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc10
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc10
+  test_coverage: *id096
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC10/normal
@@ -1402,26 +5081,34 @@ concepts:
     oracle_seed: false
 - canonical_id: FC11
   pandas_id: FC11
+  rule_id: FC11
+  title: OAT/MAT mismatch economizer-only (GL36 I)
   aliases: []
   kind: diagnostic
+  equipment_types: *id097
+  equipment_kinds: *id097
+  required_roles: *id098
+  optional_roles: *id099
+  operational_proof_roles: *id100
+  default_thresholds: *id101
   pandas_implementation: fc11
+  datafusion_sql_implementation: fc11_oa_sat_sp_clg.sql
   sql_file: fc11_oa_sat_sp_clg.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  - sat_sp
-  - oa_damper_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc11
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc11
+  test_coverage: *id102
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC11/normal
@@ -1475,26 +5162,34 @@ concepts:
     oracle_seed: false
 - canonical_id: FC12
   pandas_id: FC12
+  rule_id: FC12
+  title: SAT above blend in cooling (GL36 J)
   aliases: []
   kind: diagnostic
+  equipment_types: *id103
+  equipment_kinds: *id103
+  required_roles: *id104
+  optional_roles: *id105
+  operational_proof_roles: *id106
+  default_thresholds: *id107
   pandas_implementation: fc12
+  datafusion_sql_implementation: fc12_sat_mat_clg.sql
   sql_file: fc12_sat_mat_clg.sql
-  equipment_kinds: null
-  required_roles:
-  - sat
-  - mat
-  - oa_damper_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc12
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc12
+  test_coverage: *id108
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC12/normal
@@ -1548,20 +5243,29 @@ concepts:
     oracle_seed: false
 - canonical_id: FC13-SAT-HIGH
   pandas_id: FC13
+  rule_id: FC13
+  title: SAT above SP at full cooling (GL36 K)
   aliases:
   - FC13
   kind: diagnostic
+  equipment_types: *id109
+  equipment_kinds: *id109
+  required_roles: *id110
+  optional_roles: *id111
+  operational_proof_roles: *id112
+  default_thresholds: *id113
   pandas_implementation: fc13
+  datafusion_sql_implementation: sat_high_fault.sql
   sql_file: sat_high_fault.sql
-  equipment_kinds: null
-  required_roles:
-  - sat
-  - sat_sp
-  - clg_valve_pct
-  - oa_damper_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc13
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc13-sat-high
+  test_coverage: *id114
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: alias
+  known_semantic_differences: 'aliases: FC13 (not independent rules)'
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -1613,7 +5317,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC13-SAT-HIGH/normal
@@ -1667,20 +5370,28 @@ concepts:
     oracle_seed: false
 - canonical_id: FC14
   pandas_id: FC14
+  rule_id: FC14
+  title: CHW coil ΔT when inactive (GL36 L)
   aliases: []
   kind: diagnostic
+  equipment_types: *id115
+  equipment_kinds: *id115
+  required_roles: *id116
+  optional_roles: *id117
+  operational_proof_roles: *id118
+  default_thresholds: *id119
   pandas_implementation: fc14
+  datafusion_sql_implementation: fc14_chw_coil_dt_inactive.sql
   sql_file: fc14_chw_coil_dt_inactive.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - sat
-  - clg_valve_pct
-  - oa_damper_pct
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc14
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc14
+  test_coverage: *id120
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -1705,7 +5416,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC14/normal
@@ -1759,19 +5469,28 @@ concepts:
     oracle_seed: false
 - canonical_id: FC15
   pandas_id: FC15
+  rule_id: FC15
+  title: HW coil ΔT when inactive (GL36 M)
   aliases: []
   kind: diagnostic
+  equipment_types: *id121
+  equipment_kinds: *id121
+  required_roles: *id122
+  optional_roles: *id123
+  operational_proof_roles: *id124
+  default_thresholds: *id125
   pandas_implementation: fc15
+  datafusion_sql_implementation: fc15_hw_coil_dt_inactive.sql
   sql_file: fc15_hw_coil_dt_inactive.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - sat
-  - htg_valve_pct
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc15
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fc15
+  test_coverage: *id126
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -1796,7 +5515,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/FC15/normal
@@ -1850,17 +5568,28 @@ concepts:
     oracle_seed: false
 - canonical_id: AHU-SATDEV
   pandas_id: AHU-SATDEV
+  rule_id: AHU-SATDEV
+  title: SAT deviation from setpoint
   aliases: []
   kind: diagnostic
-  pandas_implementation: ahu_satdev
+  equipment_types: *id127
+  equipment_kinds: *id127
+  required_roles: *id128
+  optional_roles: *id129
+  operational_proof_roles: *id130
+  default_thresholds: *id131
+  pandas_implementation: ahu_sat_dev
+  datafusion_sql_implementation: ahu_satdev.sql
   sql_file: ahu_satdev.sql
-  equipment_kinds: null
-  required_roles:
-  - sat
-  - sat_sp
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#ahu-satdev
+  test_coverage: *id132
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -1885,7 +5614,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/AHU-SATDEV/normal
@@ -1939,18 +5667,28 @@ concepts:
     oracle_seed: false
 - canonical_id: AHU-DUCTHI
   pandas_id: AHU-DUCTHI
+  rule_id: AHU-DUCTHI
+  title: Duct static pressure high
   aliases: []
   kind: diagnostic
-  pandas_implementation: ahu_ducthi
+  equipment_types: *id133
+  equipment_kinds: *id133
+  required_roles: *id134
+  optional_roles: *id135
+  operational_proof_roles: *id136
+  default_thresholds: *id137
+  pandas_implementation: ahu_duct_high
+  datafusion_sql_implementation: ahu_ducthi.sql
   sql_file: ahu_ducthi.sql
-  equipment_kinds: null
-  required_roles:
-  - duct_static
-  - duct_static_sp
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#ahu-ducthi
+  test_coverage: *id138
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: conditional
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -1984,7 +5722,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/AHU-DUCTHI/normal
@@ -2038,17 +5775,28 @@ concepts:
     oracle_seed: false
 - canonical_id: AHU-SIMUL
   pandas_id: AHU-SIMUL
+  rule_id: AHU-SIMUL
+  title: Heating and cooling simultaneous
   aliases: []
   kind: diagnostic
-  pandas_implementation: ahu_simul
+  equipment_types: *id139
+  equipment_kinds: *id139
+  required_roles: *id140
+  optional_roles: *id141
+  operational_proof_roles: *id142
+  default_thresholds: *id143
+  pandas_implementation: ahu_simul_heat_cool
+  datafusion_sql_implementation: ahu_simul.sql
   sql_file: ahu_simul.sql
-  equipment_kinds: null
-  required_roles:
-  - htg_valve_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#ahu-simul
+  test_coverage: *id144
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2073,7 +5821,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/AHU-SIMUL/normal
@@ -2127,16 +5874,28 @@ concepts:
     oracle_seed: false
 - canonical_id: OAT-METEO
   pandas_id: OAT-METEO
+  rule_id: OAT-METEO
+  title: BAS outdoor-air sensor vs Open-Meteo
   aliases: []
   kind: diagnostic
+  equipment_types: *id145
+  equipment_kinds: *id145
+  required_roles: *id146
+  optional_roles: *id147
+  operational_proof_roles: *id148
+  default_thresholds: *id149
   pandas_implementation: oat_vs_meteo
+  datafusion_sql_implementation: oat_meteo_fault.sql
   sql_file: oat_meteo_fault.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#oat-meteo
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#oat-meteo
+  test_coverage: *id150
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 900
   parameters:
     oat_err:
@@ -2162,7 +5921,6 @@ concepts:
   - equipment_id
   - fault_hours
   - fault_pct
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/OAT-METEO/normal
@@ -2216,18 +5974,28 @@ concepts:
     oracle_seed: false
 - canonical_id: ECON-1
   pandas_id: ECON-1
+  rule_id: ECON-1
+  title: Economizer stuck closed
   aliases: []
   kind: diagnostic
+  equipment_types: *id151
+  equipment_kinds: *id151
+  required_roles: *id152
+  optional_roles: *id153
+  operational_proof_roles: *id154
+  default_thresholds: *id155
   pandas_implementation: econ1
+  datafusion_sql_implementation: econ1_stuck_closed.sql
   sql_file: econ1_stuck_closed.sql
-  equipment_kinds: null
-  required_roles:
-  - fan_cmd
-  - oa_damper_pct
-  - oa_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#econ-1
+  test_coverage: *id156
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     econ1_oat_min:
@@ -2243,7 +6011,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/ECON-1/normal
@@ -2297,17 +6064,28 @@ concepts:
     oracle_seed: false
 - canonical_id: ECON-2
   pandas_id: ECON-2
+  rule_id: ECON-2
+  title: Economizing when outdoor unfavorable
   aliases: []
   kind: diagnostic
+  equipment_types: *id157
+  equipment_kinds: *id157
+  required_roles: *id158
+  optional_roles: *id159
+  operational_proof_roles: *id160
+  default_thresholds: *id161
   pandas_implementation: econ2
+  datafusion_sql_implementation: economizer_fault.sql
   sql_file: economizer_fault.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  - oa_damper_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-2
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#econ-2
+  test_coverage: *id162
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     econ2_oat_hi:
@@ -2341,7 +6119,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/ECON-2/normal
@@ -2395,19 +6172,28 @@ concepts:
     oracle_seed: false
 - canonical_id: ECON-3
   pandas_id: ECON-3
+  rule_id: ECON-3
+  title: Mech cooling without integrated economizer
   aliases: []
   kind: diagnostic
-  pandas_implementation: econ_3
+  equipment_types: *id163
+  equipment_kinds: *id163
+  required_roles: *id164
+  optional_roles: *id165
+  operational_proof_roles: *id166
+  default_thresholds: *id167
+  pandas_implementation: econ2
+  datafusion_sql_implementation: econ3_mech_without_econ.sql
   sql_file: econ3_mech_without_econ.sql
-  equipment_kinds: null
-  required_roles:
-  - web_oa_t
-  - web_oa_dp
-  - oa_damper_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#econ-3
+  test_coverage: *id168
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2459,7 +6245,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/ECON-3/normal
@@ -2513,19 +6298,28 @@ concepts:
     oracle_seed: false
 - canonical_id: ECON-4
   pandas_id: ECON-4
+  rule_id: ECON-4
+  title: Low estimated OA fraction
   aliases: []
   kind: diagnostic
+  equipment_types: *id169
+  equipment_kinds: *id169
+  required_roles: *id170
+  optional_roles: *id171
+  operational_proof_roles: *id172
+  default_thresholds: *id173
   pandas_implementation: econ4
+  datafusion_sql_implementation: econ4_low_oa_frac.sql
   sql_file: econ4_low_oa_frac.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-4
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#econ-4
+  test_coverage: *id174
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     oa_min_pct:
@@ -2550,7 +6344,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/ECON-4/normal
@@ -2604,19 +6397,28 @@ concepts:
     oracle_seed: false
 - canonical_id: ECON-5
   pandas_id: ECON-5
+  rule_id: ECON-5
+  title: Preheat over-conditioning
   aliases: []
   kind: diagnostic
-  pandas_implementation: econ_5
+  equipment_types: *id175
+  equipment_kinds: *id175
+  required_roles: *id176
+  optional_roles: *id177
+  operational_proof_roles: *id178
+  default_thresholds: *id179
+  pandas_implementation: econ5
+  datafusion_sql_implementation: econ5_preheat_over.sql
   sql_file: econ5_preheat_over.sql
-  equipment_kinds: null
-  required_roles:
-  - preheat_leave_t
-  - sat_sp
-  - oa_t
-  - htg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#econ-5
+  test_coverage: *id180
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -2641,7 +6443,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/ECON-5/normal
@@ -2695,17 +6496,28 @@ concepts:
     oracle_seed: false
 - canonical_id: ECON-6
   pandas_id: ECON-6
+  rule_id: ECON-6
+  title: Economizing in freezing weather
   aliases: []
   kind: diagnostic
-  pandas_implementation: econ_6
+  equipment_types: *id181
+  equipment_kinds: *id181
+  required_roles: *id182
+  optional_roles: *id183
+  operational_proof_roles: *id184
+  default_thresholds: *id185
+  pandas_implementation: econ6_compute
+  datafusion_sql_implementation: econ6_econ_freezing.sql
   sql_file: econ6_econ_freezing.sql
-  equipment_kinds: null
-  required_roles:
-  - web_oa_t
-  - oa_damper_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#econ-6
+  test_coverage: *id186
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -2739,7 +6551,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/ECON-6/normal
@@ -2793,19 +6604,28 @@ concepts:
     oracle_seed: false
 - canonical_id: ECON-7
   pandas_id: ECON-7
+  rule_id: ECON-7
+  title: Economizer OK but not economizing
   aliases: []
   kind: diagnostic
-  pandas_implementation: econ_7
+  equipment_types: *id187
+  equipment_kinds: *id187
+  required_roles: *id188
+  optional_roles: *id189
+  operational_proof_roles: *id190
+  default_thresholds: *id191
+  pandas_implementation: econ7_compute
+  datafusion_sql_implementation: econ7_ok_not_economizing.sql
   sql_file: econ7_ok_not_economizing.sql
-  equipment_kinds: null
-  required_roles:
-  - web_oa_t
-  - web_oa_dp
-  - oa_damper_pct
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#econ-7
+  test_coverage: *id192
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -2857,7 +6677,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/ECON-7/normal
@@ -2911,17 +6730,28 @@ concepts:
     oracle_seed: false
 - canonical_id: MECH-OAT-1
   pandas_id: MECH-OAT-1
+  rule_id: MECH-OAT-1
+  title: Mechanical cooling below 60°F web OAT
   aliases: []
   kind: diagnostic
-  pandas_implementation: mech_oat_1
+  equipment_types: *id193
+  equipment_kinds: *id193
+  required_roles: *id194
+  optional_roles: *id195
+  operational_proof_roles: *id196
+  default_thresholds: *id197
+  pandas_implementation: mech_oat1_compute
+  datafusion_sql_implementation: mech_oat_1.sql
   sql_file: mech_oat_1.sql
-  equipment_kinds: null
-  required_roles:
-  - web_oa_t
-  - clg_valve_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#mech-oat-1
+  test_coverage: *id198
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -2946,7 +6776,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/MECH-OAT-1/normal
@@ -3000,18 +6829,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CHW-NOLOAD-1
   pandas_id: CHW-NOLOAD-1
+  rule_id: CHW-NOLOAD-1
+  title: Chiller running with no building load
   aliases: []
   kind: diagnostic
-  pandas_implementation: chw_noload_1
+  equipment_types: *id199
+  equipment_kinds: *id199
+  required_roles: *id200
+  optional_roles: *id201
+  operational_proof_roles: *id202
+  default_thresholds: *id203
+  pandas_implementation: chw_noload1_compute
+  datafusion_sql_implementation: chw_noload_1.sql
   sql_file: chw_noload_1.sql
-  equipment_kinds: null
-  required_roles:
-  - chw_supply_t
-  - chw_supply_sp
-  - chw_pump_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#chw-noload-1
+  test_coverage: *id204
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -3036,7 +6875,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CHW-NOLOAD-1/normal
@@ -3090,16 +6928,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VAV-1
   pandas_id: VAV-1
+  rule_id: VAV-1
+  title: Zone comfort band
   aliases: []
   kind: diagnostic
+  equipment_types: *id205
+  equipment_kinds: *id205
+  required_roles: *id206
+  optional_roles: *id207
+  operational_proof_roles: *id208
+  default_thresholds: *id209
   pandas_implementation: vav1
+  datafusion_sql_implementation: vav1_comfort_fault.sql
   sql_file: vav1_comfort_fault.sql
-  equipment_kinds: null
-  required_roles:
-  - zone_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vav-1
+  test_coverage: *id210
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: conditional
+  startup_delay_seconds: 0.0
   confirm_seconds: 900
   parameters:
     zone_t_lo:
@@ -3134,7 +6984,6 @@ concepts:
   - equipment_id
   - fault_hours
   - fault_pct
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VAV-1/normal
@@ -3188,18 +7037,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VAV-3
   pandas_id: VAV-3
+  rule_id: VAV-3
+  title: Excessive reheat during warm weather
   aliases: []
   kind: diagnostic
-  pandas_implementation: vav_3
+  equipment_types: *id211
+  equipment_kinds: *id211
+  required_roles: *id212
+  optional_roles: *id213
+  operational_proof_roles: *id214
+  default_thresholds: *id215
+  pandas_implementation: vav3
+  datafusion_sql_implementation: vav3_excessive_reheat.sql
   sql_file: vav3_excessive_reheat.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  - reheat_valve_pct
-  - zone_flow
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vav-3
+  test_coverage: *id216
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -3242,7 +7101,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VAV-3/normal
@@ -3296,17 +7154,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VAV-4
   pandas_id: VAV-4
+  rule_id: VAV-4
+  title: Damper stuck at full open
   aliases: []
   kind: diagnostic
-  pandas_implementation: vav_4
+  equipment_types: *id217
+  equipment_kinds: *id217
+  required_roles: *id218
+  optional_roles: *id219
+  operational_proof_roles: *id220
+  default_thresholds: *id221
+  pandas_implementation: vav4
+  datafusion_sql_implementation: vav4_damper_full_open.sql
   sql_file: vav4_damper_full_open.sql
-  equipment_kinds: null
-  required_roles:
-  - damper_pct
-  - zone_flow
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vav-4
+  test_coverage: *id222
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -3340,7 +7209,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VAV-4/normal
@@ -3394,17 +7262,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VAV-5
   pandas_id: VAV-5
+  rule_id: VAV-5
+  title: Airflow sensor bias
   aliases: []
   kind: diagnostic
-  pandas_implementation: vav_5
+  equipment_types: *id223
+  equipment_kinds: *id223
+  required_roles: *id224
+  optional_roles: *id225
+  operational_proof_roles: *id226
+  default_thresholds: *id227
+  pandas_implementation: vav5
+  datafusion_sql_implementation: vav5_airflow_bias.sql
   sql_file: vav5_airflow_bias.sql
-  equipment_kinds: null
-  required_roles:
-  - zone_flow
-  - damper_pct
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vav-5
+  test_coverage: *id228
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -3420,7 +7299,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VAV-5/normal
@@ -3474,19 +7352,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VAV-REHEAT
   pandas_id: VAV-REHEAT
+  rule_id: VAV-REHEAT
+  title: Reheat valve stuck / no temp rise
   aliases: []
   kind: diagnostic
-  pandas_implementation: vav_reheat
+  equipment_types: *id229
+  equipment_kinds: *id229
+  required_roles: *id230
+  optional_roles: *id231
+  operational_proof_roles: *id232
+  default_thresholds: *id233
+  pandas_implementation: vav_reheat_stuck
+  datafusion_sql_implementation: vav_reheat.sql
   sql_file: vav_reheat.sql
-  equipment_kinds: null
-  required_roles:
-  - reheat_valve_pct
-  - vav_discharge_t
-  - vav_inlet_t
-  - zone_flow
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vav-reheat
+  test_coverage: *id234
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -3529,7 +7416,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VAV-REHEAT/normal
@@ -3583,18 +7469,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VAV-AHU-LEAVE
   pandas_id: VAV-AHU-LEAVE
+  rule_id: VAV-AHU-LEAVE
+  title: VAV leave vs parent AHU SAT (fedBy)
   aliases: []
   kind: diagnostic
-  pandas_implementation: vav_ahu_leave
+  equipment_types: *id235
+  equipment_kinds: *id235
+  required_roles: *id236
+  optional_roles: *id237
+  operational_proof_roles: *id238
+  default_thresholds: *id239
+  pandas_implementation: vav_vs_ahu_leave
+  datafusion_sql_implementation: vav_ahu_leave.sql
   sql_file: vav_ahu_leave.sql
-  equipment_kinds: null
-  required_roles:
-  - vav_discharge_t
-  - ahu_sat
-  - zone_flow
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vav-ahu-leave
+  test_coverage: *id240
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -3628,7 +7524,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VAV-AHU-LEAVE/normal
@@ -3682,17 +7577,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VAV-7
   pandas_id: VAV-7
+  rule_id: VAV-7
+  title: Min airflow / fixed high flow
   aliases: []
   kind: diagnostic
-  pandas_implementation: vav_7
+  equipment_types: *id241
+  equipment_kinds: *id241
+  required_roles: *id242
+  optional_roles: *id243
+  operational_proof_roles: *id244
+  default_thresholds: *id245
+  pandas_implementation: vav7
+  datafusion_sql_implementation: vav7_min_airflow.sql
   sql_file: vav7_min_airflow.sql
-  equipment_kinds: null
-  required_roles:
-  - zone_flow
-  - min_flow_sp
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vav-7
+  test_coverage: *id246
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -3717,7 +7623,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VAV-7/normal
@@ -3771,18 +7676,31 @@ concepts:
     oracle_seed: false
 - canonical_id: CHW-1
   pandas_id: CHW-1
+  rule_id: CHW-1
+  title: Low chilled-water ΔT
   aliases: []
   kind: diagnostic
-  pandas_implementation: chw_1
+  equipment_types: *id247
+  equipment_kinds: *id247
+  required_roles: *id248
+  optional_roles: *id249
+  operational_proof_roles: *id250
+  default_thresholds: *id251
+  pandas_implementation: chw1
+  datafusion_sql_implementation: chw1_low_dt.sql
   sql_file: chw1_low_dt.sql
-  equipment_kinds: null
-  required_roles:
-  - chw_supply_t
-  - chw_return_t
-  - chw_pump_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#chw-1
+  test_coverage: *id252
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: semantic_gap
+  known_semantic_differences: pandas chw1() treats missing chw-pump-cmd as always-on;
+    hydronic gate returns ungated_no_proof_roles (all True) and does not use chiller
+    status/amps/power; SQL chw1_low_dt.sql only inspects chw_pump_cmd and still scores
+    ΔT when pump is NULL
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 900
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -3807,7 +7725,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CHW-1/normal
@@ -3861,18 +7778,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CHW-2
   pandas_id: CHW-2
+  rule_id: CHW-2
+  title: DP below SP at max pump speed
   aliases: []
   kind: diagnostic
-  pandas_implementation: chw_2
+  equipment_types: *id253
+  equipment_kinds: *id253
+  required_roles: *id254
+  optional_roles: *id255
+  operational_proof_roles: *id256
+  default_thresholds: *id257
+  pandas_implementation: chw2
+  datafusion_sql_implementation: chw2_dp_low.sql
   sql_file: chw2_dp_low.sql
-  equipment_kinds: null
-  required_roles:
-  - chw_dp
-  - chw_dp_sp
-  - chw_pump_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#chw-2
+  test_coverage: *id258
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -3906,7 +7833,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CHW-2/normal
@@ -3960,18 +7886,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CHW-3
   pandas_id: CHW-3
+  rule_id: CHW-3
+  title: Plant supply temp outside deadband
   aliases: []
   kind: diagnostic
-  pandas_implementation: chw_3
+  equipment_types: *id259
+  equipment_kinds: *id259
+  required_roles: *id260
+  optional_roles: *id261
+  operational_proof_roles: *id262
+  default_thresholds: *id263
+  pandas_implementation: chw3
+  datafusion_sql_implementation: chw3_supply_band.sql
   sql_file: chw3_supply_band.sql
-  equipment_kinds: null
-  required_roles:
-  - chw_supply_t
-  - chw_supply_sp
-  - chw_pump_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#chw-3
+  test_coverage: *id264
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -3996,7 +7932,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CHW-3/normal
@@ -4050,17 +7985,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CHW-4
   pandas_id: CHW-4
+  rule_id: CHW-4
+  title: Flow high at max pump
   aliases: []
   kind: diagnostic
-  pandas_implementation: chw_4
+  equipment_types: *id265
+  equipment_kinds: *id265
+  required_roles: *id266
+  optional_roles: *id267
+  operational_proof_roles: *id268
+  default_thresholds: *id269
+  pandas_implementation: chw4
+  datafusion_sql_implementation: chw4_flow_high.sql
   sql_file: chw4_flow_high.sql
-  equipment_kinds: null
-  required_roles:
-  - chw_flow
-  - chw_pump_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#chw-4
+  test_coverage: *id270
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4094,7 +8040,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CHW-4/normal
@@ -4148,18 +8093,28 @@ concepts:
     oracle_seed: false
 - canonical_id: HP-1
   pandas_id: HP-1
+  rule_id: HP-1
+  title: Discharge cold when heating
   aliases: []
   kind: diagnostic
-  pandas_implementation: hp_1
+  equipment_types: *id271
+  equipment_kinds: *id271
+  required_roles: *id272
+  optional_roles: *id273
+  operational_proof_roles: *id274
+  default_thresholds: *id275
+  pandas_implementation: hp1
+  datafusion_sql_implementation: hp1_discharge_cold.sql
   sql_file: hp1_discharge_cold.sql
-  equipment_kinds: null
-  required_roles:
-  - sat
-  - zone_t
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#hp-1
+  test_coverage: *id276
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: compressor
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4193,7 +8148,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/HP-1/normal
@@ -4247,16 +8201,28 @@ concepts:
     oracle_seed: false
 - canonical_id: WX-1
   pandas_id: WX-1
+  rule_id: WX-1
+  title: OA temperature spike
   aliases: []
   kind: diagnostic
-  pandas_implementation: wx_1
+  equipment_types: *id277
+  equipment_kinds: *id277
+  required_roles: *id278
+  optional_roles: *id279
+  operational_proof_roles: *id280
+  default_thresholds: *id281
+  pandas_implementation: wx1
+  datafusion_sql_implementation: wx1_oa_spike.sql
   sql_file: wx1_oa_spike.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#wx-1
+  test_coverage: *id282
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4281,7 +8247,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/WX-1/normal
@@ -4335,17 +8300,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CW-OPT-1
   pandas_id: CW-OPT-1
+  rule_id: CW-OPT-1
+  title: Condenser water not optimized vs wet-bulb
   aliases: []
   kind: diagnostic
-  pandas_implementation: cw_opt_1
+  equipment_types: *id283
+  equipment_kinds: *id283
+  required_roles: *id284
+  optional_roles: *id285
+  operational_proof_roles: *id286
+  default_thresholds: *id287
+  pandas_implementation: cw_opt
+  datafusion_sql_implementation: cw_opt_1.sql
   sql_file: cw_opt_1.sql
-  equipment_kinds: null
-  required_roles:
-  - cw_supply_t
-  - web_wb_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#cw-opt-1
+  test_coverage: *id288
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -4379,7 +8355,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CW-OPT-1/normal
@@ -4433,18 +8408,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CW-APR-1
   pandas_id: CW-APR-1
+  rule_id: CW-APR-1
+  title: High CW approach at full tower fan
   aliases: []
   kind: diagnostic
-  pandas_implementation: cw_apr_1
+  equipment_types: *id289
+  equipment_kinds: *id289
+  required_roles: *id290
+  optional_roles: *id291
+  operational_proof_roles: *id292
+  default_thresholds: *id293
+  pandas_implementation: cw_apr
+  datafusion_sql_implementation: cw_apr_1.sql
   sql_file: cw_apr_1.sql
-  equipment_kinds: null
-  required_roles:
-  - cw_supply_t
-  - web_wb_t
-  - tower_fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#cw-apr-1
+  test_coverage: *id294
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -4478,7 +8463,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CW-APR-1/normal
@@ -4532,18 +8516,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CW-FAN-1
   pandas_id: CW-FAN-1
+  rule_id: CW-FAN-1
+  title: Excess tower fan energy vs wet-bulb limit
   aliases: []
   kind: diagnostic
-  pandas_implementation: cw_fan_1
+  equipment_types: *id295
+  equipment_kinds: *id295
+  required_roles: *id296
+  optional_roles: *id297
+  operational_proof_roles: *id298
+  default_thresholds: *id299
+  pandas_implementation: cw_fan_excess
+  datafusion_sql_implementation: cw_fan_1.sql
   sql_file: cw_fan_1.sql
-  equipment_kinds: null
-  required_roles:
-  - cw_supply_t
-  - web_wb_t
-  - tower_fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#cw-fan-1
+  test_coverage: *id300
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -4586,7 +8580,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CW-FAN-1/normal
@@ -4640,16 +8633,28 @@ concepts:
     oracle_seed: false
 - canonical_id: TRIM-1
   pandas_id: TRIM-1
+  rule_id: TRIM-1
+  title: Duct static trim advisory
   aliases: []
   kind: diagnostic
-  pandas_implementation: trim_1
+  equipment_types: *id301
+  equipment_kinds: *id301
+  required_roles: *id302
+  optional_roles: *id303
+  operational_proof_roles: *id304
+  default_thresholds: *id305
+  pandas_implementation: trim1
+  datafusion_sql_implementation: trim1_duct_static.sql
   sql_file: trim1_duct_static.sql
-  equipment_kinds: null
-  required_roles:
-  - duct_static_sp
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#trim-1
+  test_coverage: *id306
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -4683,7 +8688,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/TRIM-1/normal
@@ -4737,16 +8741,28 @@ concepts:
     oracle_seed: false
 - canonical_id: TRIM-3
   pandas_id: TRIM-3
+  rule_id: TRIM-3
+  title: HWST trim advisory
   aliases: []
   kind: diagnostic
-  pandas_implementation: trim_3
+  equipment_types: *id307
+  equipment_kinds: *id307
+  required_roles: *id308
+  optional_roles: *id309
+  operational_proof_roles: *id310
+  default_thresholds: *id311
+  pandas_implementation: trim3
+  datafusion_sql_implementation: trim3_hwst.sql
   sql_file: trim3_hwst.sql
-  equipment_kinds: null
-  required_roles:
-  - hw_supply_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#trim-3
+  test_coverage: *id312
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -4780,7 +8796,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/TRIM-3/normal
@@ -4834,16 +8849,28 @@ concepts:
     oracle_seed: false
 - canonical_id: TRIM-4
   pandas_id: TRIM-4
+  rule_id: TRIM-4
+  title: CHW plant reset advisory
   aliases: []
   kind: diagnostic
-  pandas_implementation: trim_4
+  equipment_types: *id313
+  equipment_kinds: *id313
+  required_roles: *id314
+  optional_roles: *id315
+  operational_proof_roles: *id316
+  default_thresholds: *id317
+  pandas_implementation: trim4
+  datafusion_sql_implementation: trim4_chw_reset.sql
   sql_file: trim4_chw_reset.sql
-  equipment_kinds: null
-  required_roles:
-  - chw_supply_t
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#trim-4
+  test_coverage: *id318
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -4877,7 +8904,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/TRIM-4/normal
@@ -4931,19 +8957,29 @@ concepts:
     oracle_seed: false
 - canonical_id: SCHED-1
   pandas_id: SCHED-1
+  rule_id: SCHED-1
+  title: Unoccupied runtime
   aliases:
   - excess_runtime
   kind: diagnostic
+  equipment_types: *id319
+  equipment_kinds: *id319
+  required_roles: *id320
+  optional_roles: *id321
+  operational_proof_roles: *id322
+  default_thresholds: *id323
   pandas_implementation: sched1
+  datafusion_sql_implementation: sched1_unoccupied_runtime.sql
   sql_file: sched1_unoccupied_runtime.sql
-  equipment_kinds: null
-  required_roles:
-  - occ_mode
-  - fan_status
-  optional_roles:
-  - zone_t
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#sched-1
+  test_coverage: *id324
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: alias
+  known_semantic_differences: 'aliases: excess_runtime (not independent rules)'
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -4977,7 +9013,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/SCHED-1/normal
@@ -5031,16 +9066,29 @@ concepts:
     oracle_seed: false
 - canonical_id: SCHED-247
   pandas_id: SCHED-247
+  rule_id: SCHED-247
+  title: Always-on fan or pump runtime
   aliases: []
   kind: diagnostic
-  pandas_implementation: sched_247
+  equipment_types: *id325
+  equipment_kinds: *id325
+  required_roles: *id326
+  optional_roles: *id327
+  operational_proof_roles: *id328
+  default_thresholds: *id329
+  pandas_implementation: _sched247
+  datafusion_sql_implementation: sched247_always_on.sql
   sql_file: sched247_always_on.sql
-  equipment_kinds: null
-  required_roles:
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-247
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#sched-247
+  test_coverage: *id330
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: semantic_gap
+  known_semantic_differences: pandas _sched247 ORs fan/pump/chiller status, commands,
+    and duct pressure; SQL sched247_always_on.sql uses fan_cmd only
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -5056,7 +9104,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/SCHED-247/normal
@@ -5110,17 +9157,28 @@ concepts:
     oracle_seed: false
 - canonical_id: CMD-1
   pandas_id: CMD-1
+  rule_id: CMD-1
+  title: Fan cmd/status mismatch
   aliases: []
   kind: diagnostic
-  pandas_implementation: cmd_1
+  equipment_types: *id331
+  equipment_kinds: *id331
+  required_roles: *id332
+  optional_roles: *id333
+  operational_proof_roles: *id334
+  default_thresholds: *id335
+  pandas_implementation: cmd1
+  datafusion_sql_implementation: cmd1_fan_mismatch.sql
   sql_file: cmd1_fan_mismatch.sql
-  equipment_kinds: null
-  required_roles:
-  - fan_cmd
-  - fan_status
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#cmd-1
+  test_coverage: *id336
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5136,7 +9194,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/CMD-1/normal
@@ -5190,19 +9247,28 @@ concepts:
     oracle_seed: false
 - canonical_id: OA-1
   pandas_id: OA-1
+  rule_id: OA-1
+  title: Low OA fraction
   aliases: []
   kind: diagnostic
-  pandas_implementation: oa_1
+  equipment_types: *id337
+  equipment_kinds: *id337
+  required_roles: *id338
+  optional_roles: *id339
+  operational_proof_roles: *id340
+  default_thresholds: *id341
+  pandas_implementation: oa1
+  datafusion_sql_implementation: oa1_low_oa_frac.sql
   sql_file: oa1_low_oa_frac.sql
-  equipment_kinds: null
-  required_roles:
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#oa-1
+  test_coverage: *id342
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -5236,7 +9302,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/OA-1/normal
@@ -5290,18 +9355,28 @@ concepts:
     oracle_seed: false
 - canonical_id: DMP-1
   pandas_id: DMP-1
+  rule_id: DMP-1
+  title: OA damper leakage
   aliases: []
   kind: diagnostic
-  pandas_implementation: dmp_1
+  equipment_types: *id343
+  equipment_kinds: *id343
+  required_roles: *id344
+  optional_roles: *id345
+  operational_proof_roles: *id346
+  default_thresholds: *id347
+  pandas_implementation: dmp1
+  datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   sql_file: dmp1_oa_damper_leak.sql
-  equipment_kinds: null
-  required_roles:
-  - oa_damper_pct
-  - oa_t
-  - mat
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#dmp-1
+  test_coverage: *id348
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: conditional
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -5326,7 +9401,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/DMP-1/normal
@@ -5380,19 +9454,28 @@ concepts:
     oracle_seed: false
 - canonical_id: VLV-1
   pandas_id: VLV-1
+  rule_id: VLV-1
+  title: Cooling valve leakage
   aliases: []
   kind: diagnostic
-  pandas_implementation: vlv_1
+  equipment_types: *id349
+  equipment_kinds: *id349
+  required_roles: *id350
+  optional_roles: *id351
+  operational_proof_roles: *id352
+  default_thresholds: *id353
+  pandas_implementation: vlv1
+  datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   sql_file: vlv1_clg_valve_leak.sql
-  equipment_kinds: null
-  required_roles:
-  - clg_valve_pct
-  - sat
-  - sat_sp
-  - mat
-  optional_roles: []
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#vlv-1
+  test_coverage: *id354
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: none
+  known_semantic_differences: ''
+  operational_gate: conditional
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -5426,7 +9509,6 @@ concepts:
   output_schema:
   - equipment_id
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures:
   - case: normal
     path: crates/fdd_rules/fixtures/oracle/VLV-1/normal
@@ -5480,14 +9562,26 @@ concepts:
     oracle_seed: false
 - canonical_id: AVG-ZONE-TEMP
   pandas_id: null
+  rule_id: AVG-ZONE-TEMP
+  title: Average zone temperature per equipment
   aliases: []
   kind: sql_analytics
-  pandas_implementation: null
-  sql_file: avg_zone_temp.sql
+  equipment_types: []
   equipment_kinds: null
-  required_roles:
-  - zone_t
+  required_roles: *id355
   optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: *id356
+  pandas_implementation: null
+  datafusion_sql_implementation: avg_zone_temp.sql
+  sql_file: avg_zone_temp.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#avg-zone-temp
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#avg-zone-temp
+  test_coverage: *id357
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: intentional_non_applicability
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
   operational_gate: null
   startup_delay_seconds: null
   confirm_seconds: 0
@@ -5516,18 +9610,29 @@ concepts:
   - avg_zone_temp
   - min_zone_temp
   - max_zone_temp
-  parity_level: sql_screening
   proof_fixtures: []
 - canonical_id: FAN-RUNTIME-HOURS
   pandas_id: null
+  rule_id: FAN-RUNTIME-HOURS
+  title: Fan running hours where fan_cmd > 5% (normalized 0-1)
   aliases: []
   kind: sql_analytics
-  pandas_implementation: null
-  sql_file: fan_runtime_hours.sql
+  equipment_types: []
   equipment_kinds: null
-  required_roles:
-  - fan_cmd
+  required_roles: *id358
   optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: *id359
+  pandas_implementation: null
+  datafusion_sql_implementation: fan_runtime_hours.sql
+  sql_file: fan_runtime_hours.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fan-runtime-hours
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fan-runtime-hours
+  test_coverage: *id360
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: intentional_non_applicability
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
   operational_gate: null
   startup_delay_seconds: null
   confirm_seconds: 0
@@ -5537,18 +9642,29 @@ concepts:
   - equipment_id
   - fan_runtime_hours
   - total_hours
-  parity_level: sql_screening
   proof_fixtures: []
 - canonical_id: FAULT-ELAPSED-HOURS
   pandas_id: null
+  rule_id: FAULT-ELAPSED-HOURS
+  title: Comfort fault sample count → hours
   aliases: []
   kind: sql_analytics
-  pandas_implementation: null
-  sql_file: fault_elapsed_hours.sql
+  equipment_types: []
   equipment_kinds: null
-  required_roles:
-  - zone_t
+  required_roles: *id361
   optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: *id362
+  pandas_implementation: null
+  datafusion_sql_implementation: fault_elapsed_hours.sql
+  sql_file: fault_elapsed_hours.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fault-elapsed-hours
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#fault-elapsed-hours
+  test_coverage: *id363
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: intentional_non_applicability
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
   operational_gate: null
   startup_delay_seconds: null
   confirm_seconds: 0
@@ -5576,18 +9692,29 @@ concepts:
   - equipment_id
   - fault_samples
   - fault_hours
-  parity_level: sql_screening
   proof_fixtures: []
 - canonical_id: ZONE-COMFORT-PCT
   pandas_id: null
+  rule_id: ZONE-COMFORT-PCT
+  title: Percent of samples in comfort band
   aliases: []
   kind: sql_analytics
-  pandas_implementation: null
-  sql_file: zone_comfort_pct.sql
+  equipment_types: []
   equipment_kinds: null
-  required_roles:
-  - zone_t
+  required_roles: *id364
   optional_roles: []
+  operational_proof_roles: []
+  default_thresholds: *id365
+  pandas_implementation: null
+  datafusion_sql_implementation: zone_comfort_pct.sql
+  sql_file: zone_comfort_pct.sql
+  documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#zone-comfort-pct
+  sql_documentation_link: docs/rules/cookbook/datafusion-sql-cookbook.md#zone-comfort-pct
+  test_coverage: *id366
+  parity_status: sql_screening
+  parity_level: sql_screening
+  difference_class: intentional_non_applicability
+  known_semantic_differences: SQL analytics rollup — not a pandas diagnostic
   operational_gate: null
   startup_delay_seconds: null
   confirm_seconds: 0
@@ -5614,5 +9741,4 @@ concepts:
   output_schema:
   - equipment_id
   - comfort_pct
-  parity_level: sql_screening
   proof_fixtures: []

--- a/tests/rules/test_parity_inventory.py
+++ b/tests/rules/test_parity_inventory.py
@@ -1,0 +1,72 @@
+"""Parity inventory contract: 59 diagnostics, 4 SQL analytics, no alias padding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+INV_YAML = ROOT / "sql_rules" / "generated" / "parity_inventory.yaml"
+INV_JSON = ROOT / "sql_rules" / "generated" / "parity_inventory.json"
+
+REQUIRED = {
+    "rule_id",
+    "title",
+    "equipment_types",
+    "required_roles",
+    "optional_roles",
+    "operational_proof_roles",
+    "default_thresholds",
+    "pandas_implementation",
+    "datafusion_sql_implementation",
+    "documentation_link",
+    "test_coverage",
+    "parity_status",
+    "known_semantic_differences",
+    "difference_class",
+}
+
+
+def test_inventory_files_exist_and_agree():
+    assert INV_YAML.is_file()
+    assert INV_JSON.is_file()
+    y = yaml.safe_load(INV_YAML.read_text(encoding="utf-8"))
+    j = json.loads(INV_JSON.read_text(encoding="utf-8"))
+    assert y["schema_version"] == "parity-inventory-v2"
+    assert y["counts"] == j["counts"]
+    assert y["counts"]["pandas_diagnostics"] == 59
+    assert y["counts"]["sql_analytics"] == 59 - 55  # 4
+    assert y["counts"]["sql_analytics"] == 4
+    assert y["counts"]["sql_registry"] == 63
+    assert "59" in y["count_explanation"] and "63" in y["count_explanation"]
+
+
+def test_matrix_has_required_columns_and_true_counts():
+    inv = yaml.safe_load(INV_YAML.read_text(encoding="utf-8"))
+    matrix = inv["matrix"]
+    assert len(matrix) == 63
+    diagnostics = [r for r in matrix if r["pandas_implementation"]]
+    analytics = [r for r in matrix if r["pandas_implementation"] is None]
+    assert len(diagnostics) == 59
+    assert len(analytics) == 4
+    for row in matrix:
+        assert REQUIRED <= set(row)
+    aliases = set(inv["aliases_index"])
+    assert "SV-SLEW" in aliases
+    assert "FC13" in aliases
+    assert "excess_runtime" in aliases
+    # Aliases are not extra executable rules
+    ids = [r["rule_id"] for r in diagnostics]
+    assert "SV-SLEW" not in ids
+    assert "excess_runtime" not in ids
+
+
+def test_known_gaps_classified():
+    inv = yaml.safe_load(INV_YAML.read_text(encoding="utf-8"))
+    by = {r["rule_id"]: r for r in inv["matrix"]}
+    assert by["CHW-1"]["difference_class"] == "semantic_gap"
+    assert by["SCHED-247"]["difference_class"] == "semantic_gap"
+    assert by["FC7"]["difference_class"] == "missing_implementation"
+    assert by["FAN-RUNTIME-HOURS"]["difference_class"] == "intentional_non_applicability"


### PR DESCRIPTION
## Purpose
Machine-readable rule parity matrix with true executable counts. No behavior change.

## Architecture impact
None. Generated inventory + check scripts only.

## Changes
- `parity-inventory-v2` flat `matrix[]` with title, roles, proof roles, thresholds, pandas/SQL impl, docs, tests, difference class
- Classifies CHW-1 / SCHED-247 as `semantic_gap`, FC7 as `missing_implementation`, 4 SQL analytics as `intentional_non_applicability`
- Documents 59 pandas diagnostics vs 63 SQL registry (aliases are not extra rules)

## Tests
- Baseline: 23 passed (`tests/ecm|rules|analytics|reporting`)
- After: 26 passed (+3 inventory schema tests)
- `generate_parity_inventory.py --check` and `parity_inventory_check.py`

## Cookbook impact
`docs/rules/cookbook/parity-matrix.md` explains 59 vs 63.

## Packaging impact
None.

## Container impact
None.

## Compatibility and migration
None.

## Known non-goals
CHW-1 / SCHED-247 semantic fixes (later PRs). Golden fixtures (later PR).

## Acceptance checklist
- [x] Targeted tests pass
- [x] Broader affected suite pass
- [x] Docs match code
- [x] No duplicate canonical modules left active (or exception documented)
- [ ] CodeRabbit actionable threads resolved

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the parity matrix with generated inventory details, regeneration instructions, audit entries, rule-count explanations, and documented product boundaries.
* **Chores**
  * Expanded parity inventory generation with coverage, metadata, diagnostics, analytics, aliases, and difference classifications.
  * Added validation for the versioned 63-entry inventory contract and required semantic-gap classifications.
* **Tests**
  * Added contract checks for inventory files, schema version, row counts, required fields, aliases, and known parity gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->