### PR TITLE
feat(oracle): independent version API and capability extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,10 @@ The [PyPI package](https://pypi.org/project/open-fdd/) is a **library** surface 
 |---------|----------------|
 | `pip install open-fdd` | ECM engineering helpers / workbook builders |
 | `pip install "open-fdd[oracle]"` | Optional pandas oracle for rule screening |
+| `pip install "open-fdd[analytics]"` | Analytics helpers (same deps as `oracle`) |
 | `pip install "open-fdd[reporting]"` | Engineering findings / report writers |
-| `pip install "open-fdd[vibe19]"` | vibe19-aligned pandas rule helpers |
+
+The extra `vibe19` remains a deprecated alias of `reporting` through the 4.3 series and is removed in 5.0.
 
 **FDD (DataFusion SQL)** — historian, registry, React SPA, BACnet/Modbus — ships in the **GHCR container stack** (`openfdd-central` / `openfdd-web` / …), not as the default PyPI runtime. Use `./scripts/openfdd_stack_up.sh react` (above) for that path.
 

--- a/docs/ecm/README.md
+++ b/docs/ecm/README.md
@@ -3,7 +3,7 @@
 `open-fdd` (PyPI **4.1+**) ships:
 
 1. **ECM engineering** (`open_fdd.ecm_engineering`) — agent-drivable HVAC spreadsheet workbooks + Python benchmarks.
-2. **Pandas oracle** (`open_fdd.rules`, `open_fdd.analytics`, `open_fdd.reporting`) — vibe19 catalog, analytics helpers, Engineering Findings.
+2. **Pandas oracle** (`open_fdd.rules`, `open_fdd.analytics`, `open_fdd.reporting`) — cookbook catalog, analytics helpers, Engineering Findings.
 
 The ECM API fills the same workbook input cells a human engineer would fill.
 It does not replace the visible spreadsheet calculations.
@@ -17,10 +17,10 @@ It does not replace the visible spreadsheet calculations.
 ## Install
 
 ```bash
-pip install open-fdd                 # ECM only (stdlib)
-pip install "open-fdd[oracle]"       # + pandas rules / analytics
+pip install open-fdd                 # ECM only (openpyxl)
+pip install "open-fdd[oracle]"       # + pandas rules
+pip install "open-fdd[analytics]"    # + analytics helpers (same as oracle)
 pip install "open-fdd[reporting]"    # + Engineering Findings extras
-pip install "open-fdd[vibe19]"       # playground meta-extra
 ```
 
 For the FastAPI ECM example:

--- a/docs/rules/cookbook/index.md
+++ b/docs/rules/cookbook/index.md
@@ -15,7 +15,7 @@ Open-source, **standards-first** fault detection for commercial HVAC. Rules use 
 | Catalog | Count | Role |
 |---------|------:|------|
 | **DataFusion SQL** — [`sql_rules/registry.yaml`](https://github.com/bbartling/open-fdd/blob/master/sql_rules/registry.yaml) | **63** | **Production** FDD in Open-FDD Rust / central (`POST /api/fdd/run`) |
-| **Pandas** — `open_fdd.rules` (`pip install "open-fdd[oracle]"`) | **59** | **Oracle / docs / notebooks** — packaged on PyPI; vibe19 playground + Open-FDD UI consume the package |
+| **Pandas** — `open_fdd.rules` (`pip install "open-fdd[oracle]"`) | **59** | **Oracle / docs / notebooks** — packaged on PyPI; consumers pin the wheel |
 
 Parity honesty ([parity matrix](parity-matrix.html)): see live `sql_rules/registry.yaml` counts. SQL presence ≠ oracle-proven. Do not claim “54 full parity.”
 
@@ -24,11 +24,11 @@ Parity honesty ([parity matrix](parity-matrix.html)): see live `sql_rules/regist
 | Cookbook | Runtime | Use when |
 |----------|---------|----------|
 | [**DataFusion SQL**](datafusion-sql-cookbook.html) | **Open-FDD central / edge** | Live historian, registry SQL FDD, confirmation engine |
-| [**Pandas**](pandas-cookbook.html) | **Docs + vibe19 playground (+ emergency `OPENFDD_ALLOW_PANDAS_FDD=1`)** | CSV exports, notebooks, RCx studies, parity oracles |
+| [**Pandas**](pandas-cookbook.html) | **Docs + PyPI oracle** | CSV exports, notebooks, RCx studies, parity oracles |
 
 SQL adds rollups (`FAN-RUNTIME-HOURS`, `AVG-ZONE-TEMP`, `ZONE-COMFORT-PCT`, `FAULT-ELAPSED-HOURS`) and aliases `FC13` → `FC13-SAT-HIGH`. Rolling / multi-sensor screens (e.g. `SV-RATE`, `PID-HUNT-1`) may ship a **simplified SQL** variant with an explicit caveat — full logic stays Pandas-validated until proven.
 
-Open-FDD ships **one Streamlit app** (`services/ui`) for vibe19 engineering + vibe20 WattLab **export** — not two Streamlit apps.
+Product UI is the React SPA. Pandas stays on PyPI for third-party tooling.
 
 ## Framework
 

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -7,7 +7,16 @@ Production FDD runs as DataFusion SQL in the GHCR container stack.
 """
 
 from open_fdd.ecm_engineering import ECMJob
+from open_fdd.compat import maybe_warn_vibe19_from_env
 
 __version__ = "4.2.0"
 
-__all__ = ["ECMJob", "__version__"]
+maybe_warn_vibe19_from_env()
+
+__all__ = ["ECMJob", "__version__", "manifest"]
+
+
+def manifest(**kwargs):
+    from open_fdd.version import manifest as _manifest
+
+    return _manifest(**kwargs)

--- a/open_fdd/analytics/__init__.py
+++ b/open_fdd/analytics/__init__.py
@@ -1,4 +1,4 @@
-"""Open-FDD analytics helpers (oracle / vibe19 library surface)."""
+"""Open-FDD analytics helpers (oracle library surface)."""
 
 from open_fdd.analytics.poll import infer_poll_seconds
 from open_fdd.analytics.runtime_intervals import (

--- a/open_fdd/analytics/open_meteo.py
+++ b/open_fdd/analytics/open_meteo.py
@@ -1,6 +1,5 @@
-"""Open-Meteo historical weather fetch for vibe19 model-seed / FDD.
+"""Open-Meteo historical weather fetch for model-seed / FDD.
 
-Ports the TADCO sidecar historical-forecast fetch into a Streamlit-safe module.
 Network calls are optional — callers should catch exceptions; tests mock HTTP.
 """
 

--- a/open_fdd/analytics/rcx_plots.py
+++ b/open_fdd/analytics/rcx_plots.py
@@ -241,7 +241,7 @@ PRESETS: list[RcxPreset] = [
 
 
 # Full existing RCx catalog freeze — agents must not delete any of these without an
-# explicit product decision + vibe19_agent_spec/docs/DASHBOARD_CONTRACT.md update.
+# explicit product decision.
 # New presets may be added to PRESETS; promote them into this set when they become
 # part of the supported dashboard.
 REQUIRED_RCX_PRESET_IDS: frozenset[str] = frozenset(

--- a/open_fdd/compat.py
+++ b/open_fdd/compat.py
@@ -1,0 +1,25 @@
+"""Compatibility shims. The ``vibe19`` extra is deprecated for the 4.3 series."""
+
+from __future__ import annotations
+
+import warnings
+
+_VIBE19_EXTRA_REMOVED_IN = "5.0"
+
+_VIBE19_MSG = (
+    "The pip extra 'open-fdd[vibe19]' is deprecated and will be removed in "
+    f"open-fdd {_VIBE19_EXTRA_REMOVED_IN}. Install 'open-fdd[reporting]' "
+    "(findings/docs) or 'open-fdd[analytics]' / 'open-fdd[oracle]' instead."
+)
+
+
+def warn_deprecated_vibe19_extra() -> None:
+    warnings.warn(_VIBE19_MSG, DeprecationWarning, stacklevel=3)
+
+
+def maybe_warn_vibe19_from_env() -> None:
+    import os
+
+    extra = (os.environ.get("OPEN_FDD_REQUESTED_EXTRA") or "").strip().lower()
+    if extra == "vibe19":
+        warn_deprecated_vibe19_extra()

--- a/open_fdd/reporting/cli.py
+++ b/open_fdd/reporting/cli.py
@@ -60,7 +60,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     p.add_argument("--checklist-json", type=Path, help="controls_service_checklist JSON")
-    p.add_argument("--dump", type=Path, help="WattLab dump / vibe19 package zip or folder")
+    p.add_argument("--dump", type=Path, help="WattLab dump / site package zip or folder")
     p.add_argument("--package", type=Path, help="Alias for --dump (agent-friendly)")
     p.add_argument("--building", default="", help="Override building name")
     p.add_argument("--out-dir", type=Path, help="Output directory")
@@ -168,7 +168,7 @@ def main(argv: list[str] | None = None) -> int:
             from open_fdd.analytics.agent_bridge import load_package_path, run_rules
         except ImportError as exc:  # pragma: no cover - host app provides bridge
             raise SystemExit(
-                "Dump/run-rules requires a host bridge (vibe19 agent_api). "
+                "Dump/run-rules requires a host bridge (open_fdd.analytics.agent_bridge). "
                 f"Import failed: {exc}"
             ) from exc
 

--- a/open_fdd/reporting/docx.py
+++ b/open_fdd/reporting/docx.py
@@ -16,7 +16,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
     except ImportError as exc:
         raise RuntimeError(
             "python-docx is required for Engineering Findings DOCX. "
-            "Install: pip install 'vibe19-fdd-demo[engineering-report]' or python-docx"
+            "Install: pip install 'open-fdd[reporting]' or python-docx"
         ) from exc
 
     path = Path(path)

--- a/open_fdd/rules/custom_boilerplate.py
+++ b/open_fdd/rules/custom_boilerplate.py
@@ -7,8 +7,7 @@ Location (copy / extend from here)
 | ``app/rules/custom_boilerplate.py`` | **This file** — templates, helpers, worked examples |
 | ``app/rules/custom_rules.py`` | **Agent workspace** — put finished ``CookbookRule`` objects in ``CUSTOM_RULES`` |
 | ``app/rules/custom_registry.py`` | Merges custom rules into the active catalog |
-| ``vibe19_agent_spec/docs/CUSTOM_RULES.md`` | Spec for agents |
-| ``vibe19_agent_spec/skills/vibe19-pandas-fdd-rules/SKILL.md`` | Pipeline reminder |
+| ``docs/rules/cookbook/`` | Dual expression cookbooks |
 
 Hard rules
 ----------

--- a/open_fdd/rules/runner.py
+++ b/open_fdd/rules/runner.py
@@ -637,7 +637,7 @@ def run_batch(
                 stamp_feed_attrs,
             )
         except ImportError:
-            # Host apps (vibe19 / services/ui) may still keep a local module.
+            # Host apps may still keep a local topology_enrich module.
             try:
                 from app.topology_enrich import (  # type: ignore
                     enrich_frames_with_ahu_feeds,

--- a/open_fdd/version.py
+++ b/open_fdd/version.py
@@ -1,0 +1,113 @@
+"""Independent version axes for the Open-FDD Python package.
+
+These are intentionally not collapsed into one “Open-FDD version” string.
+``rule_catalog_hash`` / ``effective_config_hash`` are filled by
+``open_fdd.catalog`` when that module is available; otherwise they are null.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+CATALOG_SCHEMA_VERSION = "open-fdd-catalog-v1"
+RULE_CATALOG_VERSION = "59-diagnostics+4-sql-analytics"
+
+_CARGO_VERSION_RE = re.compile(
+    r"^\[workspace\.package\][^\[]*?^version\s*=\s*\"([^\"]+)\"",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _repo_root() -> Path | None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "Cargo.toml").is_file() and (parent / "open_fdd").is_dir():
+            return parent
+    return None
+
+
+def git_revision() -> str | None:
+    env = os.environ.get("OPENFDD_GIT_REVISION") or os.environ.get("GITHUB_SHA")
+    if env:
+        return env.strip()
+    root = _repo_root()
+    if root is None:
+        return None
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=3,
+        )
+        return out.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def rust_engine_version() -> str | None:
+    env = os.environ.get("OPENFDD_RUST_ENGINE_VERSION")
+    if env:
+        return env.strip()
+    root = _repo_root()
+    if root is None:
+        return None
+    text = (root / "Cargo.toml").read_text(encoding="utf-8")
+    m = _CARGO_VERSION_RE.search(text)
+    return m.group(1) if m else None
+
+
+def _catalog_hashes() -> tuple[str | None, str | None]:
+    try:
+        from open_fdd.catalog import effective_config_hash, rule_catalog_hash
+    except ImportError:
+        return None, None
+    try:
+        return rule_catalog_hash(), effective_config_hash()
+    except Exception:
+        return None, None
+
+
+def python_version() -> str:
+    from open_fdd import __version__
+
+    return __version__
+
+
+def manifest(*, overrides: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return the version/identity document consumers should persist."""
+    cat_hash, cfg_hash = _catalog_hashes()
+    doc = {
+        "open_fdd_python_version": python_version(),
+        "git_revision": git_revision(),
+        "rust_engine_version": rust_engine_version(),
+        "rule_catalog_version": RULE_CATALOG_VERSION,
+        "catalog_schema_version": CATALOG_SCHEMA_VERSION,
+        "rule_catalog_hash": cat_hash,
+        "effective_config_hash": cfg_hash,
+    }
+    if overrides:
+        doc.update(overrides)
+    return doc
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Print Open-FDD version axes as JSON.")
+    p.add_argument("--pretty", action="store_true")
+    args = p.parse_args(argv)
+    payload = manifest()
+    if args.pretty:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/open_fdd/vibe19.py
+++ b/open_fdd/vibe19.py
@@ -1,0 +1,12 @@
+"""Deprecated import path for the retired product-generation extra name.
+
+Importing this module emits ``DeprecationWarning``. Prefer
+``open_fdd.rules`` / ``open_fdd.analytics`` / ``open_fdd.reporting``.
+Removed in open-fdd 5.0.
+"""
+
+from __future__ import annotations
+
+from open_fdd.compat import warn_deprecated_vibe19_extra
+
+warn_deprecated_vibe19_extra()

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -33,7 +33,7 @@ retest. Do not confuse those with this engineering OS.
 | Concept | Module / extra |
 | --- | --- |
 | Pandas oracle (PyPI) | `open_fdd.rules` (+ `open_fdd.analytics`) |
-| Pip extras | `oracle`, `reporting`, `vibe19` |
+| Pip extras | `oracle`, `analytics`, `reporting` (`vibe19` deprecated alias through 4.3) |
 | ECM math | `open_fdd.ecm_engineering` |
 | Shared contracts | `open_fdd.contracts` — Phase 2 target (not shipped) |
 

--- a/openfdd_agent_spec/docs/VERSIONING.md
+++ b/openfdd_agent_spec/docs/VERSIONING.md
@@ -5,7 +5,7 @@ Distinguish these axes — do not collapse them into one “Open-FDD version” 
 | Axis | Where it lives today | Notes |
 | --- | --- | --- |
 | Platform / Rust workspace | Root `Cargo.toml` `version` | Stack image semver tags |
-| Python package | `open_fdd/__init__.py` / `pyproject.toml` | PyPI `open-fdd` (e.g. 4.1.1) |
+| Python package | `open_fdd/__init__.py` / `pyproject.toml` | PyPI `open-fdd` (e.g. 4.2.0) — see `open_fdd.version.manifest()` |
 | SQL rule registry | `sql_rules/registry.yaml` (+ file tree) | Prefer content hash in future manifest |
 | Pandas cookbook / oracle | Docs + `open_fdd.rules` | Tied to package version when shipped |
 | WattLab dump schema | vibe19 package / export code | v2/v3 compatibility matrix |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Repository = "https://github.com/bbartling/open-fdd"
 [project.scripts]
 open-fdd-ecm = "open_fdd.ecm_engineering.cli:main"
 open-fdd-report = "open_fdd.reporting.cli:main"
+open-fdd-version = "open_fdd.version:main"
 
 [project.optional-dependencies]
 ecm-web = [
@@ -66,6 +67,10 @@ reporting = [
     "plotly>=5.22.0",
     "kaleido>=0.2.1",
 ]
+analytics = [
+    "open-fdd[oracle]",
+]
+# Deprecated alias of reporting; removed in open-fdd 5.0. Prefer reporting/analytics/oracle.
 vibe19 = [
     "open-fdd[reporting]",
 ]

--- a/tests/rules/test_version_manifest.py
+++ b/tests/rules/test_version_manifest.py
@@ -1,0 +1,47 @@
+"""Independent version axes and deprecated extra alias."""
+
+from __future__ import annotations
+
+import json
+import warnings
+
+from open_fdd import __version__, manifest
+from open_fdd.version import python_version, rust_engine_version
+
+
+def test_manifest_has_independent_axes():
+    doc = manifest()
+    assert doc["open_fdd_python_version"] == __version__ == python_version()
+    assert set(doc) >= {
+        "open_fdd_python_version",
+        "git_revision",
+        "rust_engine_version",
+        "rule_catalog_version",
+        "catalog_schema_version",
+        "rule_catalog_hash",
+        "effective_config_hash",
+    }
+    rust = rust_engine_version()
+    if rust is not None:
+        assert rust == doc["rust_engine_version"]
+        assert rust.startswith("3.")
+
+
+def test_manifest_json_roundtrip():
+    blob = json.dumps(manifest(), sort_keys=True)
+    assert "open_fdd_python_version" in blob
+    assert "..." not in blob
+
+
+def test_vibe19_import_warns():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        import importlib
+
+        import open_fdd.vibe19 as mod
+
+        importlib.reload(mod)
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations
+    assert "reporting" in str(deprecations[-1].message)
+    assert "5.0" in str(deprecations[-1].message)


### PR DESCRIPTION
## Purpose
Independent version axes (`open_fdd.version.manifest`) and capability extras. Deprecate the `vibe19` extra until 5.0.

## Architecture impact
Python package surface only. Rust/Cargo stays 3.3.x. No request-path Python.

## Changes
- `open_fdd.version.manifest()` + `open-fdd-version` CLI
- Extras: keep `oracle` / `reporting`; add `analytics` (alias of oracle deps); `vibe19` is a deprecated alias of `reporting`
- `open_fdd.vibe19` / `compat` emit `DeprecationWarning`
- Strip vibe19/vibe20 from current README, CLI help, and cookbook install wording

## Tests
- `tests/rules/test_version_manifest.py`
- Full `tests/ecm tests/rules tests/analytics tests/reporting`

## Cookbook impact
Install extra wording on the cookbook index (`[docs-guard-bypass]`).

## Packaging impact
New extras and `open-fdd-version` script. Version remains 4.2.0 until the docs/handoff PR.

## Container impact
None.

## Compatibility and migration
`open-fdd[vibe19]` still installs reporting this minor series. Prefer `reporting` / `oracle` / `analytics`.

## Known non-goals
Catalog hashes (next PR). Version bump to 4.3.0 (final docs PR).

## Acceptance checklist
- [x] Targeted tests pass
- [x] Broader affected suite pass
- [x] Docs match code
- [x] No duplicate canonical modules left active (or exception documented)
- [ ] CodeRabbit actionable threads resolved

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version manifest support covering package, engine, catalog, configuration, and source revision details.
  - Added the `open-fdd-version` command with compact and readable JSON output.
  - Added an `analytics` installation option for analytics tools.

- **Deprecations**
  - Retained `vibe19` compatibility through version 4.3 with warnings; removal is planned for version 5.0.

- **Documentation**
  - Updated installation guidance, catalog descriptions, versioning information, and CLI error messages to reflect current terminology and supported options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->