### PR TITLE
feat(oracle): role-aware quality normalization

### DIFF
--- a/open_fdd/quality.py
+++ b/open_fdd/quality.py
@@ -54,6 +54,8 @@ ROLE_BOUNDS: dict[str, tuple[float | None, float | None]] = {
     "fan-current": (0.0, 500.0),
     "chiller-current": (0.0, 2000.0),
     "pump-current": (0.0, 500.0),
+    "fan-speed-feedback": (0.0, 100.0),
+    "pump-speed-feedback": (0.0, 100.0),
 }
 
 STATUS_ROLES = {
@@ -186,7 +188,8 @@ def normalize_role_series(
         # Status/command: 0/1 (and 0–100 cmd) are legitimate. Only sentinels/nulls fail.
         num = pd.to_numeric(raw, errors="coerce")
         non_num = (~nulls) & num.isna() & ~raw.map(lambda x: isinstance(x, (bool, np.bool_)))
-        # string occ-mode etc. stay valid if not null
+        reason = reason.mask(non_num, REASON_NON_NUMERIC)
+        valid = valid & ~non_num
         if family in COMMAND_ROLES or str(role).endswith("-cmd"):
             sent = _is_sentinel(num, sentinels)
             reason = reason.mask(sent, REASON_SENTINEL)
@@ -288,6 +291,7 @@ def assess_frame(
     sentinels: Iterable[float] = DEFAULT_SENTINELS,
 ) -> FrameQuality:
     cols = list(roles) if roles is not None else [c for c in df.columns if c != "timestamp_utc"]
+    sentinels = tuple(sentinels)
     fq = FrameQuality()
     any_valid = pd.Series(False, index=df.index)
     totals = {"valid": 0, "invalid": 0}

--- a/open_fdd/quality.py
+++ b/open_fdd/quality.py
@@ -1,0 +1,330 @@
+"""Role-aware input quality normalization.
+
+Preserves raw values. Returns normalized series plus structured flags.
+Zeros and ones are valid for status/command; they are not global sentinels.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+import numpy as np
+import pandas as pd
+
+DEFAULT_SENTINELS = (999.0, 888.0, -999.0, 9999.0, -9999.0)
+
+REASON_SENTINEL = "SENTINEL"
+REASON_NULL = "NULL"
+REASON_NON_NUMERIC = "NON_NUMERIC"
+REASON_OUT_OF_RANGE = "OUT_OF_RANGE"
+REASON_IMPOSSIBLE = "IMPOSSIBLE_FOR_ROLE"
+
+# Role family → (lo, hi) in native units after 0–1 vs 0–100 scaling for positions.
+# None bound means “do not apply that side”.
+ROLE_BOUNDS: dict[str, tuple[float | None, float | None]] = {
+    "zone-air-temp": (40.0, 100.0),
+    "zone-temp": (40.0, 100.0),
+    "discharge-air-temp": (35.0, 140.0),
+    "supply-air-temp": (35.0, 140.0),
+    "mixed-air-temp": (20.0, 130.0),
+    "return-air-temp": (40.0, 110.0),
+    "outside-air-temp": (-40.0, 130.0),
+    "chilled-water-supply-temp": (32.0, 80.0),
+    "chilled-water-return-temp": (32.0, 90.0),
+    "hot-water-supply-temp": (60.0, 220.0),
+    "hot-water-return-temp": (50.0, 210.0),
+    "zone-airflow": (0.0, 20000.0),
+    "supply-airflow": (0.0, 100000.0),
+    "airflow": (0.0, 100000.0),
+    "duct-static-pressure": (-2.0, 6.0),
+    "chw-diff-pressure": (0.0, 50.0),
+    "chw-flow": (0.0, 20000.0),
+    "water-flow": (0.0, 20000.0),
+    "cooling-valve": (0.0, 100.0),
+    "heating-valve": (0.0, 100.0),
+    "economizer-damper": (0.0, 100.0),
+    "oa-damper": (0.0, 100.0),
+    "damper": (0.0, 100.0),
+    "valve": (0.0, 100.0),
+    "fan-power": (0.0, 500.0),
+    "chiller-power": (0.0, 5000.0),
+    "pump-power": (0.0, 500.0),
+    "elec-power": (0.0, 50000.0),
+    "fan-current": (0.0, 500.0),
+    "chiller-current": (0.0, 2000.0),
+    "pump-current": (0.0, 500.0),
+}
+
+STATUS_ROLES = {
+    "fan-status",
+    "pump-status",
+    "chw-pump-status",
+    "hw-pump-status",
+    "chiller-status",
+    "compressor-status",
+    "occupied",
+    "occ-mode",
+    "equipment-enable",
+    "loop-enabled",
+}
+COMMAND_ROLES = {
+    "fan-cmd",
+    "pump-cmd",
+    "chw-pump-cmd",
+    "hw-pump-cmd",
+    "tower-fan-cmd",
+    "cw-fan-cmd",
+}
+POSITION_ROLES = {
+    "cooling-valve",
+    "heating-valve",
+    "economizer-damper",
+    "oa-damper",
+    "damper",
+    "valve",
+    "fan-speed-feedback",
+    "pump-speed-feedback",
+}
+
+
+def _role_family(role: str) -> str:
+    r = role.replace("_", "-").lower()
+    if r in ROLE_BOUNDS:
+        return r
+    for key in ROLE_BOUNDS:
+        if key in r:
+            return key
+    if r.endswith("-status") or r in STATUS_ROLES:
+        return "status"
+    if r.endswith("-cmd") or r in COMMAND_ROLES:
+        return "command"
+    return r
+
+
+@dataclass
+class RoleQuality:
+    role: str
+    raw: pd.Series
+    normalized: pd.Series
+    valid: pd.Series
+    reason_codes: pd.Series
+    valid_sample_count: int
+    invalid_sample_count: int
+    valid_coverage: float
+    reason_counts: dict[str, int]
+    first_valid_timestamp: str | None
+    last_valid_timestamp: str | None
+    quality_confidence: float
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "valid_sample_count": self.valid_sample_count,
+            "invalid_sample_count": self.invalid_sample_count,
+            "valid_coverage": self.valid_coverage,
+            "reason_counts": dict(self.reason_counts),
+            "first_valid_timestamp": self.first_valid_timestamp,
+            "last_valid_timestamp": self.last_valid_timestamp,
+            "quality_confidence": self.quality_confidence,
+        }
+
+
+@dataclass
+class FrameQuality:
+    roles: dict[str, RoleQuality] = field(default_factory=dict)
+    valid_sample_count: int = 0
+    invalid_sample_count: int = 0
+    valid_coverage: float = 1.0
+    reason_counts: dict[str, int] = field(default_factory=dict)
+    first_valid_timestamp: str | None = None
+    last_valid_timestamp: str | None = None
+    quality_confidence: float = 1.0
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "valid_sample_count": self.valid_sample_count,
+            "invalid_sample_count": self.invalid_sample_count,
+            "valid_coverage": self.valid_coverage,
+            "reason_counts": dict(self.reason_counts),
+            "first_valid_timestamp": self.first_valid_timestamp,
+            "last_valid_timestamp": self.last_valid_timestamp,
+            "quality_confidence": self.quality_confidence,
+            "roles": {k: v.summary() for k, v in self.roles.items()},
+        }
+
+
+def _is_sentinel(num: pd.Series, sentinels: Iterable[float]) -> pd.Series:
+    out = pd.Series(False, index=num.index)
+    for s in sentinels:
+        out = out | np.isclose(num, s, atol=0.0, rtol=0.0) | (num == s)
+    return out.fillna(False)
+
+
+def _scale_position(num: pd.Series) -> pd.Series:
+    """Leave 0–1 fractions; map 0–100 percentages to 0–100 for bounds checks."""
+    return num
+
+
+def normalize_role_series(
+    series: pd.Series,
+    role: str,
+    *,
+    sentinels: Iterable[float] = DEFAULT_SENTINELS,
+    bounds: tuple[float | None, float | None] | None = None,
+) -> RoleQuality:
+    raw = series.copy()
+    family = _role_family(role)
+    reason = pd.Series("", index=raw.index, dtype=object)
+    valid = pd.Series(True, index=raw.index)
+
+    nulls = raw.isna()
+    reason = reason.mask(nulls, REASON_NULL)
+    valid = valid & ~nulls
+
+    if family in {"status", "command"} or family in STATUS_ROLES or family in COMMAND_ROLES:
+        # Status/command: 0/1 (and 0–100 cmd) are legitimate. Only sentinels/nulls fail.
+        num = pd.to_numeric(raw, errors="coerce")
+        non_num = (~nulls) & num.isna() & ~raw.map(lambda x: isinstance(x, (bool, np.bool_)))
+        # string occ-mode etc. stay valid if not null
+        if family in COMMAND_ROLES or str(role).endswith("-cmd"):
+            sent = _is_sentinel(num, sentinels)
+            reason = reason.mask(sent, REASON_SENTINEL)
+            valid = valid & ~sent
+            if bounds is None:
+                bounds = (0.0, 100.0)
+            lo, hi = bounds
+            out_of = pd.Series(False, index=raw.index)
+            if lo is not None:
+                out_of = out_of | (num < lo)
+            if hi is not None:
+                out_of = out_of | (num > hi)
+            # 0–1 fraction commands are in range
+            frac = num.between(0.0, 1.0)
+            out_of = out_of & ~frac
+            reason = reason.mask(out_of & valid, REASON_OUT_OF_RANGE)
+            valid = valid & ~out_of
+            normalized = num.where(valid, np.nan)
+        else:
+            sent = _is_sentinel(num, sentinels)
+            reason = reason.mask(sent, REASON_SENTINEL)
+            valid = valid & ~sent
+            normalized = raw.where(valid)
+        return _finish(role, raw, normalized, valid, reason)
+
+    num = pd.to_numeric(raw, errors="coerce")
+    non_num = (~nulls) & num.isna()
+    reason = reason.mask(non_num, REASON_NON_NUMERIC)
+    valid = valid & ~non_num
+
+    sent = _is_sentinel(num, sentinels)
+    reason = reason.mask(sent, REASON_SENTINEL)
+    valid = valid & ~sent
+
+    lo_hi = bounds if bounds is not None else ROLE_BOUNDS.get(family)
+    if lo_hi is not None:
+        lo, hi = lo_hi
+        scaled = _scale_position(num)
+        if family in POSITION_ROLES or any(k in family for k in ("valve", "damper", "speed")):
+            # Accept 0–1 or 0–100
+            in_frac = scaled.between(0.0, 1.0)
+            in_pct = scaled.between(0.0, 100.0)
+            bad = valid & ~(in_frac | in_pct)
+            reason = reason.mask(bad, REASON_OUT_OF_RANGE)
+            valid = valid & ~bad
+        else:
+            out_of = pd.Series(False, index=raw.index)
+            if lo is not None:
+                out_of = out_of | (scaled < lo)
+            if hi is not None:
+                out_of = out_of | (scaled > hi)
+            # Negative flow/power/current is impossible
+            if family.endswith("flow") or family.endswith("power") or family.endswith("current"):
+                neg = scaled < 0
+                reason = reason.mask(neg & valid, REASON_IMPOSSIBLE)
+                valid = valid & ~neg
+            reason = reason.mask(out_of & valid, REASON_OUT_OF_RANGE)
+            valid = valid & ~out_of
+
+    normalized = num.where(valid, np.nan)
+    return _finish(role, raw, normalized, valid, reason)
+
+
+def _finish(role: str, raw: pd.Series, normalized: pd.Series, valid: pd.Series, reason: pd.Series) -> RoleQuality:
+    valid = valid.fillna(False).astype(bool)
+    n_valid = int(valid.sum())
+    n_invalid = int((~valid).sum())
+    cov = n_valid / max(len(valid), 1)
+    counts: dict[str, int] = {}
+    for code in reason[reason != ""]:
+        counts[str(code)] = counts.get(str(code), 0) + 1
+    first = last = None
+    if n_valid and isinstance(valid.index, pd.DatetimeIndex):
+        idx = valid.index[valid]
+        first, last = str(idx[0]), str(idx[-1])
+    # Confidence: coverage damped by sentinel share
+    sent_share = counts.get(REASON_SENTINEL, 0) / max(len(valid), 1)
+    confidence = max(0.0, min(1.0, cov * (1.0 - 0.5 * sent_share)))
+    return RoleQuality(
+        role=role,
+        raw=raw,
+        normalized=normalized,
+        valid=valid,
+        reason_codes=reason,
+        valid_sample_count=n_valid,
+        invalid_sample_count=n_invalid,
+        valid_coverage=round(float(cov), 4),
+        reason_counts=counts,
+        first_valid_timestamp=first,
+        last_valid_timestamp=last,
+        quality_confidence=round(float(confidence), 4),
+    )
+
+
+def assess_frame(
+    df: pd.DataFrame,
+    roles: Iterable[str] | None = None,
+    *,
+    sentinels: Iterable[float] = DEFAULT_SENTINELS,
+) -> FrameQuality:
+    cols = list(roles) if roles is not None else [c for c in df.columns if c != "timestamp_utc"]
+    fq = FrameQuality()
+    any_valid = pd.Series(False, index=df.index)
+    totals = {"valid": 0, "invalid": 0}
+    merged_reasons: dict[str, int] = {}
+    for role in cols:
+        if role not in df.columns:
+            continue
+        rq = normalize_role_series(df[role], role, sentinels=sentinels)
+        fq.roles[role] = rq
+        any_valid = any_valid | rq.valid
+        totals["valid"] += rq.valid_sample_count
+        totals["invalid"] += rq.invalid_sample_count
+        for k, v in rq.reason_counts.items():
+            merged_reasons[k] = merged_reasons.get(k, 0) + v
+    n = max(sum(totals.values()), 1)
+    fq.valid_sample_count = totals["valid"]
+    fq.invalid_sample_count = totals["invalid"]
+    fq.valid_coverage = round(totals["valid"] / n, 4)
+    fq.reason_counts = merged_reasons
+    if any_valid.any() and isinstance(df.index, pd.DatetimeIndex):
+        idx = df.index[any_valid]
+        fq.first_valid_timestamp = str(idx[0])
+        fq.last_valid_timestamp = str(idx[-1])
+    if fq.roles:
+        fq.quality_confidence = round(
+            float(min(r.quality_confidence for r in fq.roles.values())), 4
+        )
+    return fq
+
+
+def apply_normalized(df: pd.DataFrame, quality: FrameQuality) -> pd.DataFrame:
+    """Replace analog columns with normalized values; keep raw in ``raw:<role>``."""
+    out = df.copy()
+    for role, rq in quality.roles.items():
+        raw_col = f"raw:{role}"
+        if raw_col not in out.columns:
+            out[raw_col] = rq.raw
+        out[role] = rq.normalized
+        out[f"quality:{role}"] = rq.valid.astype(int)
+    return out

--- a/open_fdd/rules/runner.py
+++ b/open_fdd/rules/runner.py
@@ -442,6 +442,30 @@ def run_cookbook_rule(
     wx_ok = weather_available(d)
     spec = RULE_GATES.get(rule.id)
 
+    from open_fdd.quality import assess_frame, apply_normalized
+
+    q_roles = list(dict.fromkeys(list(rule.required_roles) + list(rule.optional_roles)))
+    quality = assess_frame(d, [r for r in q_roles if r in d.columns])
+    min_cov = float(params.get("min_valid_coverage", 0.5))
+    req_cov = [
+        quality.roles[r].valid_coverage
+        for r in rule.required_roles
+        if r in quality.roles
+    ]
+    worst_req = min(req_cov) if req_cov else 1.0
+    if req_cov and worst_req <= 0.0:
+        return skipped(
+            rule.id,
+            equipment_id,
+            [r for r in rule.required_roles if r in quality.roles and quality.roles[r].valid_coverage <= 0],
+            notes="SKIPPED — no valid samples after quality normalization",
+            site_id=sid,
+            building_id=bid,
+            equipment_type=eq_type,
+            params_fingerprint=fp,
+        )
+    d = apply_normalized(d, quality)
+
     try:
         active, gate_meta = resolve_operational_mask(
             d,
@@ -477,6 +501,11 @@ def run_cookbook_rule(
             raw = rule.compute(d, params, poll_seconds)
         raw = raw.reindex(d.index).fillna(False).astype(bool)
         metrics: dict[str, Any] = {**dict(gate_meta), **weather_source_metrics(d)}
+        metrics["quality"] = quality.summary()
+        metrics["quality_confidence"] = quality.quality_confidence
+        if worst_req < min_cov:
+            metrics["quality_below_minimum"] = True
+            metrics["quality_confidence"] = min(quality.quality_confidence, worst_req)
         use_active = bool(gate_meta.get("gate_applied"))
         if rule.id == "ECON-3":
             metrics["weather_gate"] = d.attrs.get("econ3_weather_source", "")

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -2686,7 +2686,9 @@
       "pandas_implementation": "vav1",
       "datafusion_sql_implementation": "vav1_comfort_fault.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-1",
-      "test_coverage": [],
+      "test_coverage": [
+        "tests/rules/test_quality.py"
+      ],
       "parity_status": "sql_screening",
       "known_semantic_differences": "",
       "difference_class": "none"
@@ -3109,6 +3111,7 @@
       "datafusion_sql_implementation": "chw1_low_dt.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-1",
       "test_coverage": [
+        "tests/rules/test_effective_catalog.py",
         "tests/rules/test_parity_inventory.py"
       ],
       "parity_status": "sql_screening",
@@ -10743,7 +10746,9 @@
       "sql_file": "vav1_comfort_fault.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-1",
       "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-1",
-      "test_coverage": [],
+      "test_coverage": [
+        "tests/rules/test_quality.py"
+      ],
       "parity_status": "sql_screening",
       "parity_level": "sql_screening",
       "difference_class": "none",
@@ -12011,6 +12016,7 @@
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-1",
       "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#chw-1",
       "test_coverage": [
+        "tests/rules/test_effective_catalog.py",
         "tests/rules/test_parity_inventory.py"
       ],
       "parity_status": "sql_screening",

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -2258,7 +2258,8 @@ matrix:
   pandas_implementation: vav1
   datafusion_sql_implementation: vav1_comfort_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-1
-  test_coverage: &id210 []
+  test_coverage: &id210
+  - tests/rules/test_quality.py
   parity_status: sql_screening
   known_semantic_differences: ''
   difference_class: none
@@ -2609,6 +2610,7 @@ matrix:
   datafusion_sql_implementation: chw1_low_dt.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-1
   test_coverage: &id252
+  - tests/rules/test_effective_catalog.py
   - tests/rules/test_parity_inventory.py
   parity_status: sql_screening
   known_semantic_differences: pandas chw1() treats missing chw-pump-cmd as always-on;

--- a/tests/rules/test_quality.py
+++ b/tests/rules/test_quality.py
@@ -1,0 +1,63 @@
+"""Role-aware quality normalization."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from open_fdd.quality import (
+    REASON_SENTINEL,
+    assess_frame,
+    normalize_role_series,
+)
+from open_fdd.rules import run_rule
+
+
+def _idx(n=6):
+    return pd.date_range("2026-01-01", periods=n, freq="5min", tz="UTC")
+
+
+def test_sentinels_invalid_but_zero_status_is_valid():
+    idx = _idx()
+    zone = pd.Series([72.0, 999.0, 888.0, -999.0, 71.0, 70.0], index=idx)
+    qz = normalize_role_series(zone, "zone-air-temp")
+    assert qz.valid_sample_count == 3
+    assert qz.reason_counts[REASON_SENTINEL] == 3
+    assert qz.normalized.isna().sum() == 3
+
+    status = pd.Series([0, 1, 0, 1, 0, 0], index=idx)
+    qs = normalize_role_series(status, "fan-status")
+    assert qs.valid_sample_count == 6
+    assert qs.invalid_sample_count == 0
+
+
+def test_command_zero_and_one_are_valid():
+    idx = _idx()
+    cmd = pd.Series([0.0, 1.0, 0.5, 100.0, 0.0, 25.0], index=idx)
+    q = normalize_role_series(cmd, "fan-cmd")
+    assert q.valid_sample_count == 6
+
+
+def test_negative_flow_impossible():
+    idx = _idx()
+    flow = pd.Series([200.0, -5.0, 180.0, 0.0, 190.0, 210.0], index=idx)
+    q = normalize_role_series(flow, "zone-airflow")
+    assert q.invalid_sample_count == 1
+    assert "IMPOSSIBLE_FOR_ROLE" in q.reason_counts
+
+
+def test_frame_summary_and_rule_skips_all_sentinel_required():
+    idx = _idx()
+    df = pd.DataFrame(
+        {
+            "zone-air-temp": [999.0] * 6,
+            "fan-status": [1, 1, 1, 1, 1, 1],
+        },
+        index=idx,
+    )
+    df.attrs["equipment_id"] = "VAV_1"
+    df.attrs["equipment_type"] = "VAV"
+    fq = assess_frame(df, ["zone-air-temp", "fan-status"])
+    assert fq.roles["zone-air-temp"].valid_coverage == 0
+    assert fq.roles["fan-status"].valid_coverage == 1
+    result = run_rule("VAV-1", df, poll_seconds=300.0, require_operational_gates=False)
+    assert result.status == "SKIPPED_MISSING_ROLES"

--- a/tests/rules/test_quality.py
+++ b/tests/rules/test_quality.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pandas as pd
 
 from open_fdd.quality import (
+    REASON_NON_NUMERIC,
+    REASON_OUT_OF_RANGE,
     REASON_SENTINEL,
     assess_frame,
     normalize_role_series,
@@ -35,6 +37,22 @@ def test_command_zero_and_one_are_valid():
     cmd = pd.Series([0.0, 1.0, 0.5, 100.0, 0.0, 25.0], index=idx)
     q = normalize_role_series(cmd, "fan-cmd")
     assert q.valid_sample_count == 6
+
+
+def test_non_numeric_command_is_invalid():
+    idx = _idx()
+    cmd = pd.Series([0.0, "invalid", 1.0, 0.0, 1.0, 0.0], index=idx)
+    q = normalize_role_series(cmd, "fan-cmd")
+    assert q.reason_counts[REASON_NON_NUMERIC] == 1
+    assert q.valid_sample_count == 5
+
+
+def test_speed_feedback_out_of_range():
+    idx = _idx()
+    spd = pd.Series([0.0, 50.0, -5.0, 101.0, 1.0, 80.0], index=idx)
+    q = normalize_role_series(spd, "fan-speed-feedback")
+    assert q.reason_counts[REASON_OUT_OF_RANGE] == 2
+    assert q.valid_sample_count == 4
 
 
 def test_negative_flow_impossible():


### PR DESCRIPTION
## Purpose
Role-aware data quality API and runner coverage gating. Preserve raw values; return normalized series plus structured flags.

## Architecture impact
New `open_fdd.quality` (separate from `reporting/quality_gate.py` report-priority gate). No request-path Python.

## Changes
- Configurable sentinels `999` / `888` / `-999` and role-specific impossibles
- Do not treat every 0/1 as invalid
- Role plausibility: zone/discharge temp, airflow, pressure, valve/damper, power, current, status, command
- Outputs: valid/invalid counts, coverage, reason codes, first/last valid ts, `quality_confidence`
- Runner skips or lowers confidence when coverage is below the rule minimum

## Tests
- `tests/rules/test_quality.py`

## Cookbook impact
None.

## Packaging impact
None.

## Container impact
None.

## Compatibility and migration
Quality is additive. Existing callers that ignore the new module are unchanged.

## Known non-goals
CHW-1 hydronic proof fix (next PR).

## Acceptance checklist
- [x] Targeted tests pass
- [x] Broader affected suite pass
- [x] Docs match code
- [x] No duplicate canonical modules left active (or exception documented)
- [ ] CodeRabbit actionable threads resolved

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-aware data quality normalization for sensor and operational values.
  * Identifies null, non-numeric, sentinel, out-of-range, and impossible values.
  * Reports quality coverage, confidence, timestamps, and reason summaries.
  * Preserves raw data while adding normalized values and quality indicators.

* **Bug Fixes**
  * Rules now skip safely when required inputs contain no valid samples.
  * Status and command values of zero and one are handled correctly.
  * Rule results include quality confidence and coverage indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->