### PR TITLE
docs(oracle): 4.3.0 cookbooks, migration, and Vibe19 handoff

### DIFF
--- a/.github/workflows/cookbook-parity.yml
+++ b/.github/workflows/cookbook-parity.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/cookbook_parity_check.py"
       - "scripts/rule_parity_mutation_check.py"
       - "scripts/generate_parity_inventory.py"
+      - "scripts/generate_cookbook_report.py"
       - "scripts/parity_inventory_check.py"
       - "scripts/sql_pandas_oracle_check.py"
       - "scripts/golden_dual_compare.py"
@@ -39,6 +40,7 @@ on:
       - "scripts/cookbook_parity_check.py"
       - "scripts/rule_parity_mutation_check.py"
       - "scripts/generate_parity_inventory.py"
+      - "scripts/generate_cookbook_report.py"
       - "scripts/parity_inventory_check.py"
       - "scripts/sql_pandas_oracle_check.py"
       - "scripts/golden_dual_compare.py"
@@ -82,6 +84,7 @@ jobs:
         run: |
           python3 scripts/generate_parity_inventory.py --check
           python3 scripts/parity_inventory_check.py
+          python3 scripts/generate_cookbook_report.py --check
 
       - name: Wave 0 pandas oracle seeds (real open_fdd.rules)
         run: python3 scripts/sql_pandas_oracle_check.py

--- a/docs/migration/VIBE19_OPENFDD_4.3_HANDOFF.md
+++ b/docs/migration/VIBE19_OPENFDD_4.3_HANDOFF.md
@@ -1,0 +1,48 @@
+# Vibe19 integration handoff (open-fdd 4.3.0)
+
+Vibe19 application code is **not** in this repository. Consume the PyPI package.
+
+## Constraint
+
+```
+open-fdd>=4.3.0,<5
+```
+
+## Extras
+
+```
+pip install "open-fdd[reporting]"
+# or: pip install "open-fdd[oracle]" / "open-fdd[analytics]"
+# not: open-fdd[vibe19]  (deprecated alias through 4.3; gone in 5.0)
+```
+
+## APIs
+
+| Need | Import |
+| --- | --- |
+| Version / hashes | `open_fdd.manifest()` / `open_fdd.version.manifest()` |
+| Effective catalog | `open_fdd.catalog.effective_catalog`, `rule_catalog_hash`, `effective_config_hash` |
+| Run rules | `open_fdd.rules.run_rule`, `run_all` |
+| Quality | `open_fdd.quality.assess_frame`, `normalize_role_series` |
+| Evidence | `RuleResult.to_dict()` → JSON-safe metrics + `evidence` |
+| Occupancy | `open_fdd.analytics.OccupancySchedule`, `occupied_mask` |
+| Metering | `open_fdd.analytics.build_meter_monthly_table` |
+| RCx ranking | `open_fdd.analytics.zone_comfort_fail_ranking` |
+
+## Schemas
+
+- Catalog JSON: `schema_version` = `open-fdd-catalog-v1`
+- Inventory: `sql_rules/generated/parity_inventory.yaml` `parity-inventory-v2`
+- Result statuses: `PASS`, `FAULT`, `SKIPPED_MISSING_ROLES`, `SKIPPED_EQUIPMENT_OFF`, `NOT_APPLICABLE_EQUIPMENT_TYPE`, `ERROR`
+
+## Semantic notes for existing dashboards
+
+- CHW-1 idle plants will **skip** instead of showing huge fault hours.
+- SCHED-247 pressure-only sites will **PASS** this ID; use `inferred_runtime_hours` in metrics.
+- Persist `rule_catalog_hash` + `effective_config_hash` next to findings.
+
+## Tests consumers should run
+
+```
+python -c "from open_fdd import manifest; assert manifest()['open_fdd_python_version'] >= '4.3.0'"
+```

--- a/docs/migration/open-fdd-4.3.0.md
+++ b/docs/migration/open-fdd-4.3.0.md
@@ -1,0 +1,42 @@
+# open-fdd 4.3.0 — consumer migration
+
+Pin **`open-fdd>=4.3.0,<5`**. Product FDD remains DataFusion on GHCR; this wheel is the pandas oracle.
+
+## Extras
+
+| Install | Use |
+| --- | --- |
+| `open-fdd[oracle]` | pandas rules |
+| `open-fdd[analytics]` | occupancy, metering, RCx, schedule helpers |
+| `open-fdd[reporting]` | Engineering Findings |
+
+`open-fdd[vibe19]` still resolves to `reporting` for this minor series and emits `DeprecationWarning` if you `import open_fdd.vibe19`. **Removed in 5.0.**
+
+## Version API
+
+```python
+from open_fdd import manifest
+doc = manifest()
+# open_fdd_python_version, git_revision, rust_engine_version,
+# rule_catalog_hash, effective_config_hash, catalog_schema_version
+```
+
+CLI: `open-fdd-version --pretty`
+
+Effective catalog (defaults + overrides): `open_fdd.catalog.effective_catalog(overrides_by_rule=...)`.
+
+## Behavior changes
+
+- **CHW-1 / hydronic rules:** missing pump/chiller proof → `SKIPPED_MISSING_ROLES`. Status/amps/power all zero → `SKIPPED_EQUIPMENT_OFF` (no thousands of ΔT hours).
+- **SCHED-247:** status/current outrank command. Duct pressure is inferred runtime only and no longer ORs into this rule ID.
+- **Quality:** sentinels `999`/`888`/`-999` are invalid; zeros remain valid for status/command.
+- **Evidence JSON:** `RuleResult.to_dict()` is compact structured data — never a pandas `...` repr.
+
+## True counts
+
+59 pandas diagnostics. 63 SQL registry entries (those 59 + 4 analytics). Aliases are not extra rules.
+
+## Do not
+
+- Import Streamlit or application UI into Open-FDD.
+- Treat matching rule counts as semantic parity. Use golden fixtures + `rule_catalog_hash`.

--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -6,11 +6,11 @@ nav_order: 1
 
 # DataFusion SQL FDD Cookbook
 
-Open-FDD executes production fault detection as **DataFusion SQL** against Apache Arrow / parquet historian tables via the canonical registry [`sql_rules/registry.yaml`](https://github.com/bbartling/open-fdd/blob/master/sql_rules/registry.yaml) (**63** rules). Operator path: Streamlit **Run Rules** → `POST /api/fdd/run` (`mode=registry`). Integrators may also exercise rules through the registry APIs — raw arbitrary SQL is rejected.
+Open-FDD executes production fault detection as **DataFusion SQL** against Apache Arrow / parquet historian tables via the canonical registry [`sql_rules/registry.yaml`](https://github.com/bbartling/open-fdd/blob/master/sql_rules/registry.yaml) (**63** entries = 59 diagnostic twins + 4 SQL analytics). Operator path: React **Run Rules** → `POST /api/fdd/run` (`mode=registry`). Integrators may also exercise rules through the registry APIs — raw arbitrary SQL is rejected.
 
-**Pandas mirror:** the [Pandas cookbook](pandas-cookbook.html) documents the **59**-rule vibe19 oracle catalog (kept in-tree under `services/ui/app/rules/` and tested in the vibe19 playground). Do **not** treat “59” as the production registry size. See [parity matrix](parity-matrix.html).
+**Pandas mirror:** the [Pandas cookbook](pandas-cookbook.html) documents the **59**-rule PyPI oracle (`open_fdd.rules`). Do **not** treat “59” as the production registry size. See [parity matrix](parity-matrix.html) and the [generated parity report](generated-parity-report.html).
 
-**Updated:** 2026-07-25 · tip `sha-8850b0b`
+**Updated:** 2026-08-11 · PyPI `open-fdd` 4.3.0
 
 ---
 

--- a/docs/rules/cookbook/generated-parity-report.md
+++ b/docs/rules/cookbook/generated-parity-report.md
@@ -1,0 +1,94 @@
+---
+title: Generated parity report
+parent: Rule Cookbook
+nav_order: 7
+---
+
+# Generated parity report
+
+Auto-generated from `sql_rules/generated/parity_inventory.yaml`.
+Do not edit by hand. Run `python3 scripts/generate_cookbook_report.py`.
+
+59 is the executable pandas cookbook (CookbookRule constructors). 63 is the SQL registry: those 59 twins plus 4 SQL-only analytics. Aliases SV-SLEW, FC13, and excess_runtime are not extra rules.
+
+- Pandas diagnostics: **59**
+- SQL analytics: **4**
+- SQL registry: **63**
+- Building 100 cartesian: 48 equipment × 59 diagnostics = 2832 results
+
+## Difference classes
+
+| Class | Count |
+| --- | ---: |
+| `alias` | 3 |
+| `intentional_non_applicability` | 4 |
+| `missing_implementation` | 1 |
+| `none` | 55 |
+
+## Matrix
+
+| rule_id | title | pandas | SQL | parity | class |
+| --- | --- | --- | --- | --- | --- |
+| `SV-RANGE` | Sensor out of hard range | `_sweep_range` | `sv_range.sql` | `sql_screening` | `none` |
+| `SV-FLATLINE` | Sensor flatline (stuck) | `_sweep_flatline` | `sv_flatline.sql` | `sql_screening` | `none` |
+| `SV-SPIKE` | Sensor rate-of-change spike | `_sweep_spike` | `sv_spike.sql` | `sql_screening` | `none` |
+| `SV-STALE` | Stale data (no fresh samples) | `_sweep_stale` | `sv_stale.sql` | `sql_screening` | `none` |
+| `SV-RATE` | Context-aware sensor rate of change | `_sv_rate_compute` | `sv_rate.sql` | `sql_screening` | `alias` |
+| `PID-HUNT-1` | Suspected control-output hunting | `_pid_hunt_1` | `pid_hunt_1.sql` | `sql_screening` | `none` |
+| `FC1` | Duct static below SP at full fan (GL36 A) | `fc1` | `fc1_duct_static_low.sql` | `sql_screening` | `none` |
+| `FC2` | MAT below OAT/RAT envelope (GL36 B) | `fc2` | `fc2_mat_low.sql` | `sql_screening` | `none` |
+| `FC3` | MAT above OAT/RAT envelope (GL36 C) | `fc3` | `fc3_mat_high.sql` | `sql_screening` | `none` |
+| `FC4` | PID hunting (operating-state oscillation) | `fc4` | `fc4_os_hunting.sql` | `sql_screening` | `none` |
+| `FC5` | SAT cold when heating commanded (GL36 D) | `fc5` | `fc5_sat_cold_heating.sql` | `sql_screening` | `none` |
+| `FC6` | Estimated OA fraction mismatch | `fc6` | `fc6_oa_frac_mismatch.sql` | `sql_screening` | `none` |
+| `FC7` | SAT low with full heating (GL36 E) | `fc7` | `fc7_sat_low_heating.sql` | `concept_only` | `missing_implementation` |
+| `FC8` | SAT/MAT mismatch in economizer (GL36 F) | `fc8` | `fc8_sat_mat_econ.sql` | `sql_screening` | `none` |
+| `FC9` | OAT too warm for free cooling (GL36 G) | `fc9` | `fc9_oa_sat_sp_econ.sql` | `sql_screening` | `none` |
+| `FC10` | OAT/MAT mismatch + mech cooling (GL36 H) | `fc10` | `fc10_mat_oa_clg.sql` | `sql_screening` | `none` |
+| `FC11` | OAT/MAT mismatch economizer-only (GL36 I) | `fc11` | `fc11_oa_sat_sp_clg.sql` | `sql_screening` | `none` |
+| `FC12` | SAT above blend in cooling (GL36 J) | `fc12` | `fc12_sat_mat_clg.sql` | `sql_screening` | `none` |
+| `FC13` | SAT above SP at full cooling (GL36 K) | `fc13` | `sat_high_fault.sql` | `sql_screening` | `alias` |
+| `FC14` | CHW coil ΔT when inactive (GL36 L) | `fc14` | `fc14_chw_coil_dt_inactive.sql` | `sql_screening` | `none` |
+| `FC15` | HW coil ΔT when inactive (GL36 M) | `fc15` | `fc15_hw_coil_dt_inactive.sql` | `sql_screening` | `none` |
+| `AHU-SATDEV` | SAT deviation from setpoint | `ahu_sat_dev` | `ahu_satdev.sql` | `sql_screening` | `none` |
+| `AHU-DUCTHI` | Duct static pressure high | `ahu_duct_high` | `ahu_ducthi.sql` | `sql_screening` | `none` |
+| `AHU-SIMUL` | Heating and cooling simultaneous | `ahu_simul_heat_cool` | `ahu_simul.sql` | `sql_screening` | `none` |
+| `OAT-METEO` | BAS outdoor-air sensor vs Open-Meteo | `oat_vs_meteo` | `oat_meteo_fault.sql` | `sql_screening` | `none` |
+| `ECON-1` | Economizer stuck closed | `econ1` | `econ1_stuck_closed.sql` | `sql_screening` | `none` |
+| `ECON-2` | Economizing when outdoor unfavorable | `econ2` | `economizer_fault.sql` | `sql_screening` | `none` |
+| `ECON-3` | Mech cooling without integrated economizer | `econ2` | `econ3_mech_without_econ.sql` | `sql_screening` | `none` |
+| `ECON-4` | Low estimated OA fraction | `econ4` | `econ4_low_oa_frac.sql` | `sql_screening` | `none` |
+| `ECON-5` | Preheat over-conditioning | `econ5` | `econ5_preheat_over.sql` | `sql_screening` | `none` |
+| `ECON-6` | Economizing in freezing weather | `econ6_compute` | `econ6_econ_freezing.sql` | `sql_screening` | `none` |
+| `ECON-7` | Economizer OK but not economizing | `econ7_compute` | `econ7_ok_not_economizing.sql` | `sql_screening` | `none` |
+| `MECH-OAT-1` | Mechanical cooling below 60°F web OAT | `mech_oat1_compute` | `mech_oat_1.sql` | `sql_screening` | `none` |
+| `CHW-NOLOAD-1` | Chiller running with no building load | `chw_noload1_compute` | `chw_noload_1.sql` | `sql_screening` | `none` |
+| `VAV-1` | Zone comfort band | `vav1` | `vav1_comfort_fault.sql` | `sql_screening` | `none` |
+| `VAV-3` | Excessive reheat during warm weather | `vav3` | `vav3_excessive_reheat.sql` | `sql_screening` | `none` |
+| `VAV-4` | Damper stuck at full open | `vav4` | `vav4_damper_full_open.sql` | `sql_screening` | `none` |
+| `VAV-5` | Airflow sensor bias | `vav5` | `vav5_airflow_bias.sql` | `sql_screening` | `none` |
+| `VAV-REHEAT` | Reheat valve stuck / no temp rise | `vav_reheat_stuck` | `vav_reheat.sql` | `sql_screening` | `none` |
+| `VAV-AHU-LEAVE` | VAV leave vs parent AHU SAT (fedBy) | `vav_vs_ahu_leave` | `vav_ahu_leave.sql` | `sql_screening` | `none` |
+| `VAV-7` | Min airflow / fixed high flow | `vav7` | `vav7_min_airflow.sql` | `sql_screening` | `none` |
+| `CHW-1` | Low chilled-water ΔT | `chw1` | `chw1_low_dt.sql` | `sql_screening` | `none` |
+| `CHW-2` | DP below SP at max pump speed | `chw2` | `chw2_dp_low.sql` | `sql_screening` | `none` |
+| `CHW-3` | Plant supply temp outside deadband | `chw3` | `chw3_supply_band.sql` | `sql_screening` | `none` |
+| `CHW-4` | Flow high at max pump | `chw4` | `chw4_flow_high.sql` | `sql_screening` | `none` |
+| `HP-1` | Discharge cold when heating | `hp1` | `hp1_discharge_cold.sql` | `sql_screening` | `none` |
+| `WX-1` | OA temperature spike | `wx1` | `wx1_oa_spike.sql` | `sql_screening` | `none` |
+| `CW-OPT-1` | Condenser water not optimized vs wet-bulb | `cw_opt` | `cw_opt_1.sql` | `sql_screening` | `none` |
+| `CW-APR-1` | High CW approach at full tower fan | `cw_apr` | `cw_apr_1.sql` | `sql_screening` | `none` |
+| `CW-FAN-1` | Excess tower fan energy vs wet-bulb limit | `cw_fan_excess` | `cw_fan_1.sql` | `sql_screening` | `none` |
+| `TRIM-1` | Duct static trim advisory | `trim1` | `trim1_duct_static.sql` | `sql_screening` | `none` |
+| `TRIM-3` | HWST trim advisory | `trim3` | `trim3_hwst.sql` | `sql_screening` | `none` |
+| `TRIM-4` | CHW plant reset advisory | `trim4` | `trim4_chw_reset.sql` | `sql_screening` | `none` |
+| `SCHED-1` | Unoccupied runtime | `sched1` | `sched1_unoccupied_runtime.sql` | `sql_screening` | `alias` |
+| `SCHED-247` | Always-on fan or pump runtime | `_sched247` | `sched247_always_on.sql` | `sql_screening` | `none` |
+| `CMD-1` | Fan cmd/status mismatch | `cmd1` | `cmd1_fan_mismatch.sql` | `sql_screening` | `none` |
+| `OA-1` | Low OA fraction | `oa1` | `oa1_low_oa_frac.sql` | `sql_screening` | `none` |
+| `DMP-1` | OA damper leakage | `dmp1` | `dmp1_oa_damper_leak.sql` | `sql_screening` | `none` |
+| `VLV-1` | Cooling valve leakage | `vlv1` | `vlv1_clg_valve_leak.sql` | `sql_screening` | `none` |
+| `AVG-ZONE-TEMP` | Average zone temperature per equipment | `—` | `avg_zone_temp.sql` | `sql_screening` | `intentional_non_applicability` |
+| `FAN-RUNTIME-HOURS` | Fan running hours where fan_cmd > 5% (normalized 0-1) | `—` | `fan_runtime_hours.sql` | `sql_screening` | `intentional_non_applicability` |
+| `FAULT-ELAPSED-HOURS` | Comfort fault sample count → hours | `—` | `fault_elapsed_hours.sql` | `sql_screening` | `intentional_non_applicability` |
+| `ZONE-COMFORT-PCT` | Percent of samples in comfort band | `—` | `zone_comfort_pct.sql` | `sql_screening` | `intentional_non_applicability` |

--- a/docs/rules/cookbook/index.md
+++ b/docs/rules/cookbook/index.md
@@ -17,7 +17,7 @@ Open-source, **standards-first** fault detection for commercial HVAC. Rules use 
 | **DataFusion SQL** — [`sql_rules/registry.yaml`](https://github.com/bbartling/open-fdd/blob/master/sql_rules/registry.yaml) | **63** | **Production** FDD in Open-FDD Rust / central (`POST /api/fdd/run`) |
 | **Pandas** — `open_fdd.rules` (`pip install "open-fdd[oracle]"`) | **59** | **Oracle / docs / notebooks** — packaged on PyPI; consumers pin the wheel |
 
-Parity honesty ([parity matrix](parity-matrix.html)): see live `sql_rules/registry.yaml` counts. SQL presence ≠ oracle-proven. Do not claim “54 full parity.”
+Parity honesty ([parity matrix](parity-matrix.html), [generated report](generated-parity-report.html)): see live `sql_rules/registry.yaml` counts. SQL presence ≠ oracle-proven. Do not claim “54 full parity.”
 
 ## Two cookbooks — complementary, not identical
 

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -6,13 +6,13 @@ nav_order: 2
 
 # Pandas FDD Cookbook
 
-**Oracle / documentation catalog:** packaged as `open_fdd.rules` on PyPI (`pip install "open-fdd[oracle]"`) — the Streamlit-tested vibe19 catalog — **59 rules**. Source of truth: [`open_fdd/rules/cookbook_catalog.py`](https://github.com/bbartling/open-fdd/blob/master/open_fdd/rules/cookbook_catalog.py). The vibe19 playground and Open-FDD UI consume this package rather than maintaining a second copy.
+**Oracle / documentation catalog:** packaged as `open_fdd.rules` on PyPI (`pip install "open-fdd[oracle]"`) — **59** executable diagnostics. Source of truth: [`open_fdd/rules/cookbook_catalog.py`](https://github.com/bbartling/open-fdd/blob/master/open_fdd/rules/cookbook_catalog.py). Consumers pin the wheel rather than maintaining a second copy.
 
-This cookbook is **intentionally maintained**. It is **not** vibe-coded away. Production Open-FDD FDD math runs **Rust + Apache Arrow + DataFusion SQL** (`sql_rules/registry.yaml`, **63** rules). Use this pandas catalog for notebooks, CSV exports, RCx studies, and SQL↔pandas parity testing. In the Open-FDD UI, pandas FDD runs only with explicit `OPENFDD_ALLOW_PANDAS_FDD=1` (emergency / oracle) — never as a silent fallback.
+This cookbook is **intentionally maintained**. Production Open-FDD FDD math runs **Rust + Apache Arrow + DataFusion SQL** (`sql_rules/registry.yaml`, **63** entries = 59 twins + 4 SQL analytics). Use this pandas catalog for notebooks, CSV exports, RCx studies, and SQL↔pandas parity testing.
 
-See also the [DataFusion SQL cookbook](datafusion-sql-cookbook.html), [parity matrix](parity-matrix.html), and [P0 rule catalog](p0-rule-catalog.html).
+See also the [DataFusion SQL cookbook](datafusion-sql-cookbook.html), [parity matrix](parity-matrix.html), [generated parity report](generated-parity-report.html), and [P0 rule catalog](p0-rule-catalog.html).
 
-**Updated:** 2026-07-27 · PyPI `open-fdd` 4.1.0 (`open_fdd.rules`)
+**Updated:** 2026-08-11 · PyPI `open-fdd` 4.3.0 (`open_fdd.rules`)
 
 
 ---

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,7 +9,7 @@ Production FDD runs as DataFusion SQL in the GHCR container stack.
 from open_fdd.ecm_engineering import ECMJob
 from open_fdd.compat import maybe_warn_vibe19_from_env
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"
 
 maybe_warn_vibe19_from_env()
 

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,13 @@
 # Session log
 
+## 2026-08-11 — open-fdd 4.3.0 library program
+
+- Independent version API (`open_fdd.version.manifest`), effective catalog hashes, capability extras (`oracle` / `analytics` / `reporting`). `vibe19` extra deprecated until 5.0.
+- Role-aware quality API; CHW-1 hydronic proof skip/off; SCHED-247 ranked proof (pressure inferred only).
+- Structured evidence JSON; analytics package exports; wattlab_export copies shimmed.
+- Parity inventory v2 (59/63) + golden fixtures for CHW-1 / SCHED-247. FC7 remains `concept_only`.
+- Handoff: `docs/migration/open-fdd-4.3.0.md`, `docs/migration/VIBE19_OPENFDD_4.3_HANDOFF.md`.
+
 ## 2026-08-11 — Site lock, FDD/RCx vibe19 plots, Actions housekeeping
 
 - SectionTabs + sidebar App pages keep `?site=` / `eq` (`hrefWithSession`). Overview + sidebar Active site are the only site editors; FDD / RCx / Results / WattLab show locked `zip:` caption (no Building select).

--- a/openfdd_agent_spec/docs/VERSIONING.md
+++ b/openfdd_agent_spec/docs/VERSIONING.md
@@ -5,7 +5,7 @@ Distinguish these axes — do not collapse them into one “Open-FDD version” 
 | Axis | Where it lives today | Notes |
 | --- | --- | --- |
 | Platform / Rust workspace | Root `Cargo.toml` `version` | Stack image semver tags |
-| Python package | `open_fdd/__init__.py` / `pyproject.toml` | PyPI `open-fdd` (e.g. 4.2.0) — see `open_fdd.version.manifest()` |
+| Python package | `open_fdd/__init__.py` / `pyproject.toml` | PyPI `open-fdd` **4.3.0** — `open_fdd.version.manifest()` |
 | SQL rule registry | `sql_rules/registry.yaml` (+ file tree) | Prefer content hash in future manifest |
 | Pandas cookbook / oracle | Docs + `open_fdd.rules` | Tied to package version when shipped |
 | WattLab dump schema | vibe19 package / export code | v2/v3 compatibility matrix |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "4.2.0"
+version = "4.3.0"
 description = "Open-FDD libraries: ECM engineering workbooks plus pandas oracle rules, analytics, and Engineering Findings reporting. Production FDD remains the DataFusion/GHCR stack."
 readme = "docs/ecm/README.md"
 license = { text = "MIT" }

--- a/scripts/generate_cookbook_report.py
+++ b/scripts/generate_cookbook_report.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Generate docs/rules/cookbook/generated-parity-report.md from the inventory."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+INV = ROOT / "sql_rules" / "generated" / "parity_inventory.yaml"
+OUT = ROOT / "docs" / "rules" / "cookbook" / "generated-parity-report.md"
+
+
+def render(inv: dict) -> str:
+    counts = inv["counts"]
+    lines = [
+        "---",
+        "title: Generated parity report",
+        "parent: Rule Cookbook",
+        "nav_order: 7",
+        "---",
+        "",
+        "# Generated parity report",
+        "",
+        "Auto-generated from `sql_rules/generated/parity_inventory.yaml`.",
+        "Do not edit by hand. Run `python3 scripts/generate_cookbook_report.py`.",
+        "",
+        inv["count_explanation"],
+        "",
+        f"- Pandas diagnostics: **{counts['pandas_diagnostics']}**",
+        f"- SQL analytics: **{counts['sql_analytics']}**",
+        f"- SQL registry: **{counts['sql_registry']}**",
+        f"- Building 100 cartesian: {counts['building_100_cartesian']}",
+        "",
+        "## Difference classes",
+        "",
+        "| Class | Count |",
+        "| --- | ---: |",
+    ]
+    for k, v in sorted((inv.get("difference_class_counts") or {}).items()):
+        lines.append(f"| `{k}` | {v} |")
+    lines += [
+        "",
+        "## Matrix",
+        "",
+        "| rule_id | title | pandas | SQL | parity | class |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in inv.get("matrix") or []:
+        lines.append(
+            "| `{id}` | {title} | `{pd}` | `{sql}` | `{par}` | `{cls}` |".format(
+                id=row["rule_id"],
+                title=(row.get("title") or "").replace("|", "/"),
+                pd=row.get("pandas_implementation") or "—",
+                sql=row.get("datafusion_sql_implementation") or "—",
+                par=row.get("parity_status"),
+                cls=row.get("difference_class"),
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+    inv = yaml.safe_load(INV.read_text(encoding="utf-8"))
+    text = render(inv)
+    if args.check:
+        if not OUT.is_file() or OUT.read_text(encoding="utf-8") != text:
+            print("FAIL: generated-parity-report.md is stale", flush=True)
+            return 1
+        print("OK: generated-parity-report.md")
+        return 0
+    OUT.write_text(text, encoding="utf-8")
+    print(f"Wrote {OUT.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose
Bump PyPI `open-fdd` to **4.3.0**, regenerate cookbook intros + parity report, and publish Vibe19 consumer migration/handoff.

## Architecture impact
Version bump only on the Python package. Rust/Cargo stays 3.3.x. Tag will be `open-fdd-v4.3.0` (not `v4.3.0`) so GHCR stack `v*` triggers do not fire.

## Changes
- `__version__` / `pyproject.toml` → 4.3.0
- Generated `docs/rules/cookbook/generated-parity-report.md` (59 vs 63)
- Cookbook intros: React operator path, no vibe19 extra in current install wording
- `docs/migration/open-fdd-4.3.0.md` and `docs/migration/VIBE19_OPENFDD_4.3_HANDOFF.md`
- Cookbook-parity CI checks the generated report
- VERSIONING.md extras/version table

## Tests
- `check_version.py` → 4.3.0
- Full package suite (53 tests at program end)
- `generate_cookbook_report.py --check`

## Cookbook impact
Yes — intros + generated report (`[docs-guard-bypass]`).

## Packaging impact
PyPI 4.3.0 after `open-fdd-v4.3.0` tag.

## Container impact
None from this PR alone.

## Compatibility and migration
Pin `open-fdd>=4.3.0,<5` and extra `reporting` (not `vibe19`). CHW-1 skip/off and SCHED-247 ranked proof are the semantic changes.

## Known non-goals
Vibe19 application repo edits. Claiming 59/59 golden metric parity.

## Acceptance checklist
- [x] Targeted tests pass
- [x] Broader affected suite pass
- [x] Docs match code
- [x] No duplicate canonical modules left active (or exception documented)
- [ ] CodeRabbit actionable threads resolved

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Released version 4.3.0 with updated package metadata and versioning guidance.
  - Added a generated cookbook parity report covering rule coverage, classifications, and implementation mappings.
  - Added migration documentation describing supported APIs, configuration options, behavior changes, and upgrade considerations.

- **Documentation**
  - Updated cookbook guides, parity notices, and metadata to reflect current rule counts, SQL coverage, and the React **Run Rules** workflow.

- **Chores**
  - Improved automated validation to detect stale parity reports when report-generation logic changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->