### PR TITLE
fix(engine): SCHED-247 oracle fixture optional status columns

### DIFF
--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -415,22 +415,36 @@ timestamp_utc,web_oat,web_dp,oa_d,clg_col
         std::fs::create_dir_all(&building).unwrap();
 
         let rows = "\
-timestamp_utc,fan_col
-2026-01-01T00:00:00Z,0
-2026-01-01T00:05:00Z,0
-2026-01-01T00:10:00Z,50
-2026-01-01T00:15:00Z,50
-2026-01-01T00:20:00Z,50
-2026-01-01T00:25:00Z,0
+timestamp_utc,fan_col,fan_st,pump_st,ch_st
+2026-01-01T00:00:00Z,0,,,
+2026-01-01T00:05:00Z,0,,,
+2026-01-01T00:10:00Z,50,,,
+2026-01-01T00:15:00Z,50,,,
+2026-01-01T00:20:00Z,50,,,
+2026-01-01T00:25:00Z,0,,,
 ";
         write_equipment_fixture(
             &building,
             "AHU_1",
             5,
-            &[RoleCol {
-                csv_col: "fan_col",
-                role: "fan_cmd",
-            }],
+            &[
+                RoleCol {
+                    csv_col: "fan_col",
+                    role: "fan_cmd",
+                },
+                RoleCol {
+                    csv_col: "fan_st",
+                    role: "fan_status",
+                },
+                RoleCol {
+                    csv_col: "pump_st",
+                    role: "pump_status",
+                },
+                RoleCol {
+                    csv_col: "ch_st",
+                    role: "chiller_status",
+                },
+            ],
             rows,
         );
 


### PR DESCRIPTION
## Purpose
Green FDD engine CI. SCHED-247 ranked-proof SQL references status roles; the cmd-only oracle fixture omitted them and DataFusion raised `No field named fan_status`.

## Architecture impact
Test fixture only. Production runner already injects NULL optional roles.

## Changes
- Oracle screening fixture includes null `fan_status` / `pump_status` / `chiller_status` so SQL falls back to `fan_cmd`

## Tests
- `cargo test -p fdd_rules --lib sched247_fan_cmd_screening_confirm_streak`

## Cookbook impact
None.

## Packaging impact
None (PyPI 4.3.0 already published).

## Container impact
SQL behavior unchanged; next master GHCR picks up the fixture.

## Compatibility and migration
None.

## Known non-goals
Changing ranked-proof SQL.

## Acceptance checklist
- [x] Targeted tests pass
- [x] Broader affected suite pass
- [x] Docs match code
- [x] No duplicate canonical modules left active (or exception documented)
- [ ] CodeRabbit actionable threads resolved

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded equipment test fixtures to include fan, pump, and chiller status data.
  * Added coverage for the corresponding equipment role mappings.
  * Existing fan command and confirmation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->