### PR TITLE
fix(oracle): WattLab dump-vs-dump matrix and SQL fan/hydronic gates

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# Allowlist false positives. Gitleaks scans the whole PR commit range,
+# so literal `missing_api:<table>.csv` provenance flags in an intermediate
+# commit must be allowed even after they are renamed.
+title = "Open-FDD"
+
+[allowlist]
+description = "Assembler provenance flags, not credentials"
+regexes = [
+  '''missing_api:[A-Za-z0-9_.-]+\.csv''',
+  '''missing_table:[A-Za-z0-9_.-]+\.csv''',
+]
+paths = [
+  '''scripts/wattlab_parity_ofdd_rust_bundle\.py''',
+]

--- a/crates/fdd_rules/src/econ4_confirm_test.rs
+++ b/crates/fdd_rules/src/econ4_confirm_test.rs
@@ -31,7 +31,7 @@ mod tests {
         std::fs::create_dir_all(&ahu).unwrap();
         std::fs::write(
             ahu.join("columns.csv"),
-            "col,point_role\nmat_col,mat\nrat_col,rat\noat_col,oa_t\nfan_col,fan_cmd\n",
+            "col,point_role\nmat_col,mat\nrat_col,rat\noat_col,oa_t\nfan_col,fan_cmd\nfan_st,fan_status\n",
         )
         .unwrap();
 
@@ -44,10 +44,10 @@ mod tests {
         let mats = [50.0, 50.0, 65.0, 65.0, 65.0, 50.0, 65.0, 65.0, 50.0, 65.0];
 
         let mut f = std::fs::File::create(ahu.join("history_wide.csv")).unwrap();
-        writeln!(f, "timestamp_utc,mat_col,rat_col,oat_col,fan_col").unwrap();
+        writeln!(f, "timestamp_utc,mat_col,rat_col,oat_col,fan_col,fan_st").unwrap();
         for (i, mat) in mats.iter().enumerate() {
             let minute = i * 5;
-            writeln!(f, "2026-01-01T00:{minute:02}:00Z,{mat},70.0,30.0,50.0").unwrap();
+            writeln!(f, "2026-01-01T00:{minute:02}:00Z,{mat},70.0,30.0,50.0,1.0").unwrap();
         }
     }
 

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -72,7 +72,9 @@ pub async fn run_rule_fault_hours(
     }
     let sql = substitute_sql(&raw_sql, &params);
     // Match runner: inject NULL optional fan proof columns when fixtures omit them.
-    let sql = inject_optional_fan_cols(&ctx, sql_file, &sql).await.unwrap();
+    let sql = inject_optional_fan_cols(&ctx, sql_file, &sql)
+        .await
+        .unwrap();
     let result = run_sql(&ctx, &sql).await.unwrap();
     if result.row_count == 0 {
         return 0.0;
@@ -125,11 +127,14 @@ async fn inject_optional_fan_cols(
         .iter()
         .map(|f| f.name().to_ascii_lowercase())
         .collect();
-    let needed = ["fan_cmd", "fan_status", "pump_status", "chiller_status", "chw_flow"];
-    let missing: Vec<&str> = needed
-        .into_iter()
-        .filter(|c| !have.contains(*c))
-        .collect();
+    let needed = [
+        "fan_cmd",
+        "fan_status",
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+    ];
+    let missing: Vec<&str> = needed.into_iter().filter(|c| !have.contains(*c)).collect();
     if missing.is_empty() {
         return Ok(sql.to_string());
     }
@@ -138,9 +143,7 @@ async fn inject_optional_fan_cols(
         .map(|c| format!("CAST(NULL AS DOUBLE) AS \"{c}\""))
         .collect::<Vec<_>>()
         .join(", ");
-    let cte = format!(
-        "history_opt AS (SELECT history.*, {nulls} FROM history)"
-    );
+    let cte = format!("history_opt AS (SELECT history.*, {nulls} FROM history)");
     let rewritten = sql
         .replace(" FROM history", " FROM history_opt")
         .replace(" from history", " from history_opt")

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -133,6 +133,11 @@ async fn inject_optional_fan_cols(
         "pump_status",
         "chiller_status",
         "chw_flow",
+        "chw_pump_cmd",
+        "compressor_status",
+        "occ_mode",
+        "hw_reset_request_sum",
+        "chw_reset_request_sum",
     ];
     let missing: Vec<&str> = needed.into_iter().filter(|c| !have.contains(*c)).collect();
     if missing.is_empty() {

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -145,7 +145,10 @@ async fn inject_optional_fan_cols(
     }
     let nulls = missing
         .iter()
-        .map(|c| format!("CAST(NULL AS DOUBLE) AS \"{c}\""))
+        .map(|c| {
+            let ty = if *c == "occ_mode" { "VARCHAR" } else { "DOUBLE" };
+            format!("CAST(NULL AS {ty}) AS \"{c}\"")
+        })
         .collect::<Vec<_>>()
         .join(", ");
     let cte = format!("history_opt AS (SELECT history.*, {nulls} FROM history)");

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -146,7 +146,11 @@ async fn inject_optional_fan_cols(
     let nulls = missing
         .iter()
         .map(|c| {
-            let ty = if *c == "occ_mode" { "VARCHAR" } else { "DOUBLE" };
+            let ty = if *c == "occ_mode" {
+                "VARCHAR"
+            } else {
+                "DOUBLE"
+            };
             format!("CAST(NULL AS {ty}) AS \"{c}\"")
         })
         .collect::<Vec<_>>()

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
+use datafusion::prelude::SessionContext;
 use fdd_sql::{register_parquet_tree, run_sql};
 use fdd_store::ingest_building;
 
@@ -58,7 +60,7 @@ pub async fn run_rule_fault_hours(
         .into_owned();
     ingest_building(data_root, &building_id, &tmp_parquet).unwrap();
 
-    let ctx = datafusion::prelude::SessionContext::new();
+    let ctx = SessionContext::new();
     register_parquet_tree(&ctx, &tmp_parquet).await.unwrap();
 
     let sql_path = repo_sql_rules().join(sql_file);
@@ -69,6 +71,8 @@ pub async fn run_rule_fault_hours(
         params.insert((*k).into(), (*v).into());
     }
     let sql = substitute_sql(&raw_sql, &params);
+    // Match runner: inject NULL optional fan proof columns when fixtures omit them.
+    let sql = inject_optional_fan_cols(&ctx, sql_file, &sql).await.unwrap();
     let result = run_sql(&ctx, &sql).await.unwrap();
     if result.row_count == 0 {
         return 0.0;
@@ -107,6 +111,53 @@ pub fn assert_hours_close(got: f64, expected: f64, label: &str) {
         (got - expected).abs() < 1e-6,
         "{label}: expected {expected}h, got {got}h"
     );
+}
+
+async fn inject_optional_fan_cols(
+    ctx: &SessionContext,
+    _sql_file: &str,
+    sql: &str,
+) -> Result<String> {
+    let df = ctx.table("history").await?;
+    let have: std::collections::HashSet<String> = df
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().to_ascii_lowercase())
+        .collect();
+    let needed = ["fan_cmd", "fan_status", "pump_status", "chiller_status", "chw_flow"];
+    let missing: Vec<&str> = needed
+        .into_iter()
+        .filter(|c| !have.contains(*c))
+        .collect();
+    if missing.is_empty() {
+        return Ok(sql.to_string());
+    }
+    let nulls = missing
+        .iter()
+        .map(|c| format!("CAST(NULL AS DOUBLE) AS \"{c}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let cte = format!(
+        "history_opt AS (SELECT history.*, {nulls} FROM history)"
+    );
+    let rewritten = sql
+        .replace(" FROM history", " FROM history_opt")
+        .replace(" from history", " from history_opt")
+        .replace("\nFROM history", "\nFROM history_opt")
+        .replace("\nfrom history", "\nfrom history_opt");
+    let rewritten = if let Some(idx) = rewritten.find("WITH ") {
+        let (pre, rest) = rewritten.split_at(idx);
+        let rest = rest.trim_start_matches("WITH ");
+        format!("{pre}WITH {cte}, {rest}")
+    } else if let Some(idx) = rewritten.find("with ") {
+        let (pre, rest) = rewritten.split_at(idx);
+        let rest = rest.trim_start_matches("with ");
+        format!("{pre}WITH {cte}, {rest}")
+    } else {
+        format!("WITH {cte} {rewritten}")
+    };
+    Ok(rewritten)
 }
 
 fn repo_sql_rules() -> PathBuf {

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -669,7 +669,11 @@ timestamp_utc,oat_col,fan_col
             &[("STALE_HOURS", "0.1")],
         )
         .await;
-        assert_hours_close(got, 0.25, "SV-STALE fan-off still counts (pandas always gate)");
+        assert_hours_close(
+            got,
+            0.25,
+            "SV-STALE fan-off still counts (pandas always gate)",
+        );
     }
 
     #[tokio::test]

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -629,8 +629,8 @@ timestamp_utc,oat_col,fan_col
     }
 
     #[tokio::test]
-    async fn sv_stale_fan_off_rows_excluded() {
-        // OFDD-065 regression: fan_cmd=0 rows must not accumulate FAULT hours.
+    async fn sv_stale_fan_off_rows_still_count() {
+        // Pandas SV-STALE gate is `always` — fan-off samples still accumulate hours.
         let tmp = tempfile::TempDir::new().unwrap();
         let building = tmp.path().join("BUILDING_SVSTALE_OFF");
         std::fs::create_dir_all(&building).unwrap();
@@ -669,7 +669,7 @@ timestamp_utc,oat_col,fan_col
             &[("STALE_HOURS", "0.1")],
         )
         .await;
-        assert_hours_close(got, 0.0, "SV-STALE fan-off excluded");
+        assert_hours_close(got, 0.25, "SV-STALE fan-off still counts (pandas always gate)");
     }
 
     #[tokio::test]

--- a/crates/fdd_rules/src/registry.rs
+++ b/crates/fdd_rules/src/registry.rs
@@ -38,6 +38,10 @@ pub struct RuleSpec {
     /// (e.g. SCHED-1 zone comfort gate).
     #[serde(default)]
     pub optional_roles: Vec<String>,
+    /// Pandas cookbook equipment_kinds (ahu/vav/chiller/…). Empty = no type filter
+    /// (SQL-only analytics).
+    #[serde(default)]
+    pub equipment_kinds: Vec<String>,
     #[serde(default)]
     pub output_columns: Vec<String>,
     #[serde(default = "default_confirm")]

--- a/crates/fdd_rules/src/runner.rs
+++ b/crates/fdd_rules/src/runner.rs
@@ -64,47 +64,53 @@ fn write_skip_marker(out_path: &Path, missing_roles: &[String], note: &str) -> s
     std::fs::write(out_path, serde_json::to_string_pretty(&body)?)
 }
 
-/// Inject NULL Float64 columns for optional roles missing from history, then
-/// rewrite SQL `FROM history` → `FROM history_opt_<rule>` so AHU-only buildings
-/// still run (pandas sched1: no zone → base mask only).
-async fn sql_with_optional_null_roles(
-    ctx: &SessionContext,
+/// Inject NULL columns for optional roles missing from history via a WITH CTE
+/// (TEMP VIEW is not available in all DataFusion builds used by tests).
+/// String roles such as `occ_mode` use VARCHAR; numeric proof roles use DOUBLE.
+fn sql_with_optional_null_roles(
     rule_id: &str,
     sql: &str,
     optional_roles: &[String],
     history_columns: &std::collections::HashSet<String>,
-) -> Result<String> {
+) -> String {
     let missing: Vec<String> = optional_roles
         .iter()
         .filter(|role| !history_columns.contains(&role.to_ascii_lowercase()))
         .cloned()
         .collect();
     if missing.is_empty() {
-        return Ok(sql.to_string());
+        return sql.to_string();
     }
-    let view_name = format!(
-        "history_opt_{}",
-        rule_id
-            .chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-            .collect::<String>()
-            .to_ascii_lowercase()
-    );
+    let _ = rule_id;
     let null_cols: String = missing
         .iter()
-        .map(|r| format!("CAST(NULL AS DOUBLE) AS \"{r}\""))
+        .map(|r| {
+            let ty = if r.eq_ignore_ascii_case("occ_mode") {
+                "VARCHAR"
+            } else {
+                "DOUBLE"
+            };
+            format!("CAST(NULL AS {ty}) AS \"{r}\"")
+        })
         .collect::<Vec<_>>()
         .join(", ");
-    let create_sql = format!(
-        "CREATE OR REPLACE TEMP VIEW {view_name} AS SELECT history.*, {null_cols} FROM history"
-    );
-    ctx.sql(&create_sql).await?.collect().await?;
+    let cte = format!("history_opt AS (SELECT history.*, {null_cols} FROM history)");
     let rewritten = sql
-        .replace(" FROM history", &format!(" FROM {view_name}"))
-        .replace(" from history", &format!(" from {view_name}"))
-        .replace("\nFROM history", &format!("\nFROM {view_name}"))
-        .replace("\nfrom history", &format!("\nfrom {view_name}"));
-    Ok(rewritten)
+        .replace(" FROM history", " FROM history_opt")
+        .replace(" from history", " from history_opt")
+        .replace("\nFROM history", "\nFROM history_opt")
+        .replace("\nfrom history", "\nfrom history_opt");
+    if let Some(idx) = rewritten.find("WITH ") {
+        let (pre, rest) = rewritten.split_at(idx);
+        let rest = rest.trim_start_matches("WITH ");
+        format!("{pre}WITH {cte}, {rest}")
+    } else if let Some(idx) = rewritten.find("with ") {
+        let (pre, rest) = rewritten.split_at(idx);
+        let rest = rest.trim_start_matches("with ");
+        format!("{pre}WITH {cte}, {rest}")
+    } else {
+        format!("WITH {cte} {rewritten}")
+    }
 }
 
 pub async fn run_all_rules(
@@ -241,28 +247,12 @@ pub async fn run_all_rules_with_overrides(
                 escaped
             );
         }
-        sql = match sql_with_optional_null_roles(
-            &ctx,
+        sql = sql_with_optional_null_roles(
             &rule.rule_id,
             &sql,
             &rule.optional_roles,
             &history_columns,
-        )
-        .await
-        {
-            Ok(s) => s,
-            Err(e) => {
-                timings.push(RuleTiming {
-                    rule_id: rule.rule_id.clone(),
-                    row_count: 0,
-                    elapsed_ms: t0.elapsed().as_millis(),
-                    output_path: out_path.display().to_string(),
-                    error: Some(format!("optional role inject: {e}")),
-                });
-                rules_failed += 1;
-                continue;
-            }
-        };
+        );
         match run_sql(&ctx, &sql).await {
             Ok(result) => {
                 std::fs::write(

--- a/crates/fdd_rules/src/tuning.rs
+++ b/crates/fdd_rules/src/tuning.rs
@@ -161,6 +161,7 @@ mod tests {
             description: "test".into(),
             required_roles: vec![],
             optional_roles: vec![],
+            equipment_kinds: vec!["vav".into()],
             output_columns: vec![],
             confirm_seconds: 900,
             parity_status: String::new(),

--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -26,7 +26,13 @@ Accepted only: CHW-1 skip/off, SCHED-247 pressure-not-fault, FC7 concept_only, r
 - Ranked `fan_status` > `fan_cmd` on AHU/ECON/FC/OA/DMP/VLV/TRIM-1 SQL
 - FC2 mix_tol no longer cancels (`mat+tol < min(rat,oat)-tol`)
 - CHW-2/3/4 hydronic proof CTE
-- SV-STALE no longer filters fan_cmd (pandas `always`)
+- SV-STALE no longer filters fan_cmd (pandas `always`); required_roles empty
+- SV-FLATLINE/RANGE/SPIKE `equipment_energized` (fan → pump → compressor)
+- VAV-1 occupied-only when `occ_mode` present (no fan_cmd required)
+- VAV-3/4/5/7/REHEAT/AHU-LEAVE fan_on + FLOW_ON_MIN
+- CW-OPT/APR/FAN + TRIM-3/4 hydronic proof (missing proof → 0 h)
+- HP-1 compressor/fan ranked proof; FC4/PID fan_status over cmd
+- New APIs: `/api/analytics/setpoints`, `/diurnal`, `/topology`, `/sensor-stats`
 - Vibe19 `topology.csv` now gets `vav_to_ahu` + `parent_ahu`
 
 ## After tip image

--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -1,0 +1,43 @@
+# WattLab-to-WattLab dump parity (Building 100)
+
+Oracle is playground Vibe19 Engineering Bundle (`openfdd_engineering_bundle_v1`).
+OpenFDD side is a **DataFusion assembler** (`scripts/wattlab_parity_ofdd_rust_bundle.py`) — not pandas `tools/wattlab_export`.
+
+## Baseline (pre-image, capture `sha-2ce9c21`)
+
+| Metric | Value |
+| --- | --- |
+| `diff_matrix.csv` rows | 3803 |
+| **blockers** | **3527** |
+| accepted | 153 |
+| stop_rule_met | false |
+
+This is the honest dump-vs-dump stop rule. The prior cycle’s `blocker_count=0` was a sql_screening **rollup**. FAULT∩FAULT hour gaps are blockers again.
+
+Largest FDD families in the matrix: AHU-DUCTHI / AHU-SATDEV / ECON-* / FC* / SV-FLATLINE / SV-STALE (N/A vs PASS on wrong equipment + hour deltas on AHUs).
+
+Accepted only: CHW-1 skip/off, SCHED-247 pressure-not-fault, FC7 concept_only, rust `weather`/`unknown` extra equipment, SQL-only analytics ids vs pandas findings.
+
+## Code landed this wave (needs GHCR `:nightly` to soak)
+
+- Per-row `wattlab_parity_diff.py` + `diff_matrix.csv`
+- Rust bundle assembler (same filenames as Vibe19)
+- `equipment_kinds` on registry + `NOT_APPLICABLE_EQUIPMENT_TYPE` in `/api/fdd/results`
+- Ranked `fan_status` > `fan_cmd` on AHU/ECON/FC/OA/DMP/VLV/TRIM-1 SQL
+- FC2 mix_tol no longer cancels (`mat+tol < min(rat,oat)-tol`)
+- CHW-2/3/4 hydronic proof CTE
+- SV-STALE no longer filters fan_cmd (pandas `always`)
+- Vibe19 `topology.csv` now gets `vav_to_ahu` + `parent_ahu`
+
+## After tip image
+
+Pull `ghcr.io/bbartling/openfdd-central:nightly` (no local docker build). Re-run:
+
+```bash
+python scripts/wattlab_parity_ofdd_rust_bundle.py
+python scripts/wattlab_parity_diff.py
+```
+
+Stop rule: `blocker_count == 0`. Promote `parity_status` to `duration_parity` per rule when FAULT∩FAULT hours match ±0.05 h / 0.1%.
+
+Runtime: `open_fdd.__version__ == 4.3.0` (no PyPI bump; SQL ships in the image).

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -366,13 +366,12 @@ pub fn results_response(building_id: Option<&str>) -> Value {
                 let status = if !applies {
                     "NOT_APPLICABLE_EQUIPMENT_TYPE".to_string()
                 } else {
-                    row
-                    .get("status")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-                    .unwrap_or_else(|| {
-                        if fault_hours > 0.0 { "FAULT" } else { "PASS" }.to_string()
-                    })
+                    row.get("status")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                        .unwrap_or_else(|| {
+                            if fault_hours > 0.0 { "FAULT" } else { "PASS" }.to_string()
+                        })
                 };
                 let fault_hours = if applies { fault_hours } else { 0.0 };
                 let missing_roles = row

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -223,24 +223,42 @@ fn walkdir_count(root: &Path, ext: &str) -> usize {
 }
 
 fn infer_equipment_type(equipment_id: &str) -> &'static str {
-    let id = equipment_id.to_ascii_uppercase();
-    if id.contains("VAV") || id.contains("ZONE") {
-        "VAV"
-    } else if id.contains("AHU") || id.contains("RTU") || id.contains("MAU") {
-        "AHU"
-    } else if id.contains("CHILL")
-        || id.contains("BOILER")
-        || id.contains("PUMP")
-        || id.contains("TOWER")
-    {
-        "PLANT"
-    } else if id.contains("HP") || id.contains("HEAT_PUMP") {
-        "HEAT_PUMP"
-    } else if id.contains("METER") {
-        "METER"
-    } else {
-        "GENERAL"
+    match infer_equipment_kind(equipment_id) {
+        "vav" => "VAV",
+        "ahu" => "AHU",
+        "chiller" | "boiler" | "cooling_tower" => "PLANT",
+        "heatpump" => "HEAT_PUMP",
+        "weather" => "WEATHER",
+        _ => "GENERAL",
     }
+}
+
+fn infer_equipment_kind(equipment_id: &str) -> &'static str {
+    let id = equipment_id.to_ascii_uppercase();
+    if id.contains("WEATHER") {
+        "weather"
+    } else if id.contains("VAV") || id.contains("ZONE") {
+        "vav"
+    } else if id.contains("AHU") || id.contains("RTU") || id.contains("MAU") {
+        "ahu"
+    } else if id.contains("CHILL") {
+        "chiller"
+    } else if id.contains("BOILER") {
+        "boiler"
+    } else if id.contains("TOWER") {
+        "cooling_tower"
+    } else if id.contains("HP") || id.contains("HEAT_PUMP") || id.contains("HEATPUMP") {
+        "heatpump"
+    } else {
+        "unknown"
+    }
+}
+
+fn rule_applies_to_kind(kinds: &[String], kind: &str) -> bool {
+    if kinds.is_empty() || kind == "unknown" {
+        return true;
+    }
+    kinds.iter().any(|k| k.eq_ignore_ascii_case(kind))
 }
 
 /// `GET /api/fdd/equipment` — equipment present in the parquet cache.
@@ -294,9 +312,14 @@ pub fn results_response(building_id: Option<&str>) -> Value {
     let dir = results_dir(building_id);
     let reg = load_reg().ok();
     let mut metadata = HashMap::new();
+    let mut kinds_by_rule: HashMap<String, Vec<String>> = HashMap::new();
     if let Some(reg) = &reg {
         for rule in &reg.rules {
             metadata.insert(rule.rule_id.clone(), rule.description.clone());
+            kinds_by_rule.insert(rule.rule_id.clone(), rule.equipment_kinds.clone());
+            for alias in &rule.aliases {
+                kinds_by_rule.insert(alias.clone(), rule.equipment_kinds.clone());
+            }
         }
     }
     let mut rows = Vec::new();
@@ -335,13 +358,23 @@ pub fn results_response(building_id: Option<&str>) -> Value {
                     .unwrap_or(0.0);
                 // Emit status directly from the row when present (skip markers),
                 // otherwise derive FAULT/PASS from fault_hours (OFDD-066).
-                let status = row
+                let kind = infer_equipment_kind(equipment_id);
+                let applies = kinds_by_rule
+                    .get(rule_id)
+                    .map(|k| rule_applies_to_kind(k, kind))
+                    .unwrap_or(true);
+                let status = if !applies {
+                    "NOT_APPLICABLE_EQUIPMENT_TYPE".to_string()
+                } else {
+                    row
                     .get("status")
                     .and_then(Value::as_str)
                     .map(str::to_string)
                     .unwrap_or_else(|| {
                         if fault_hours > 0.0 { "FAULT" } else { "PASS" }.to_string()
-                    });
+                    })
+                };
+                let fault_hours = if applies { fault_hours } else { 0.0 };
                 let missing_roles = row
                     .get("missing_roles")
                     .cloned()

--- a/edge/tests/fdd_building_scope_integration.rs
+++ b/edge/tests/fdd_building_scope_integration.rs
@@ -47,6 +47,8 @@ fn write_building(parquet_root: &Path, building_id: &str, zone_t: Option<f64>, r
         Some(z) => {
             fields.push(Field::new("zone_t", DataType::Float64, false));
             columns.push(Arc::new(Float64Array::from(vec![z; rows])) as ArrayRef);
+            fields.push(Field::new("occ_mode", DataType::Utf8, true));
+            columns.push(Arc::new(StringArray::from(vec!["occupied"; rows])) as ArrayRef);
         }
         None => {
             // A benign column so the parquet is non-empty but lacks zone_t.

--- a/edge/tests/fdd_building_scope_integration.rs
+++ b/edge/tests/fdd_building_scope_integration.rs
@@ -14,16 +14,17 @@ use arrow::record_batch::RecordBatch;
 use datafusion::parquet::arrow::ArrowWriter;
 use serde_json::{json, Value};
 
-/// Write `building={id}/equipment=AHU_1/part-0.parquet`. When `zone_t` is
+/// Write `building={id}/equipment=VAV_1/part-0.parquet`. When `zone_t` is
 /// `Some`, a constant zone temp makes VAV-1 comfort faults deterministic; when
 /// `None`, the `zone_t` role is absent so VAV-1 must SKIP (not fail).
+/// Equipment id is VAV_1 so `equipment_kinds: [vav, zone]` applies (AHU_1 is N/A).
 fn write_building(parquet_root: &Path, building_id: &str, zone_t: Option<f64>, rows: usize) {
     let dir = parquet_root
         .join(format!("building={building_id}"))
-        .join("equipment=AHU_1");
+        .join("equipment=VAV_1");
     std::fs::create_dir_all(&dir).unwrap();
 
-    let equipment: Vec<&str> = vec!["AHU_1"; rows];
+    let equipment: Vec<&str> = vec!["VAV_1"; rows];
     // Millisecond epoch @ 5-min cadence so window ORDER BY works on a real
     // timestamp column (string columns break DataFusion RANGE frames).
     let ts: Vec<i64> = (0..rows as i64)
@@ -141,7 +142,7 @@ fn building_id_scopes_results_and_faults() {
         .iter()
         .filter_map(|e| e["equipment_id"].as_str().map(str::to_string))
         .collect();
-    assert!(ids.contains(&"AHU_1".to_string()), "equipment: {eq}");
+    assert!(ids.contains(&"VAV_1".to_string()), "equipment: {eq}");
 
     // results_response reads each scoped dir independently.
     let r50 = open_fdd_edge_prototype::fdd::registry_api::results_response(Some("B50"));

--- a/scripts/inject_sql_fan_gate.py
+++ b/scripts/inject_sql_fan_gate.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Inject ranked fan_status > fan_cmd proof into screening SQL files.
+
+Idempotent: skips files that already define fan_on.
+Does not use a DataFusion UDF — copies the CHW-1 / SCHED-247 CTE pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "sql_rules"
+
+FAN_ON = (
+    "    CASE\n"
+    "      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END\n"
+    "      ELSE 1\n"
+    "    END AS fan_on"
+)
+
+TARGETS = [
+    "ahu_satdev.sql",
+    "ahu_simul.sql",
+    "ahu_ducthi.sql",
+    "economizer_fault.sql",
+    "econ1_stuck_closed.sql",
+    "econ3_mech_without_econ.sql",
+    "econ4_low_oa_frac.sql",
+    "econ5_preheat_over.sql",
+    "econ6_econ_freezing.sql",
+    "econ7_ok_not_economizing.sql",
+    "fc1_duct_static_low.sql",
+    "fc2_mat_low.sql",
+    "fc3_mat_high.sql",
+    "fc5_sat_cold_heating.sql",
+    "fc6_oa_frac_mismatch.sql",
+    "fc8_sat_mat_econ.sql",
+    "fc9_oa_sat_sp_econ.sql",
+    "fc10_mat_oa_clg.sql",
+    "fc11_oa_sat_sp_clg.sql",
+    "fc12_sat_mat_clg.sql",
+    "sat_high_fault.sql",
+    "fc14_chw_coil_dt_inactive.sql",
+    "fc15_hw_coil_dt_inactive.sql",
+    "oa1_low_oa_frac.sql",
+    "dmp1_oa_damper_leak.sql",
+    "vlv1_clg_valve_leak.sql",
+    "trim1_duct_static.sql",
+]
+
+
+def inject(text: str) -> str:
+    if "AS fan_on" in text or " as fan_on" in text:
+        return text
+    # Add fan_on into the first SELECT ... FROM history block.
+    marker = "  FROM history"
+    idx = text.find(marker)
+    if idx < 0:
+        marker = "\nFROM history"
+        idx = text.find(marker)
+    if idx < 0:
+        return text
+    select = text[:idx]
+    # Ensure fan_status/fan_cmd are selected if missing
+    head = select
+    if "fan_status" not in head.split("FROM")[0] and "fan_cmd" not in head.split("FROM")[0]:
+        # insert before last comma-less line of the select list
+        insert_at = select.rfind("\n")
+        extra = ""
+        if "fan_cmd" not in select:
+            extra += "    fan_cmd,\n"
+        if "fan_status" not in select:
+            extra += "    fan_status,\n"
+        extra += FAN_ON + "\n"
+        select = select[:insert_at] + ",\n" + extra + select[insert_at:]
+    else:
+        insert_at = select.rfind("\n")
+        select = select[:insert_at] + ",\n" + FAN_ON + "\n" + select[insert_at:]
+    rest = text[idx:]
+    # Gate raw_fault
+    rest2 = rest.replace(
+        "CAST(CASE\n",
+        "CAST(CASE\n      WHEN COALESCE(fan_on, 1) = 0 THEN 0\n",
+        1,
+    )
+    if rest2 == rest:
+        rest2 = rest.replace(
+            "CAST(CASE\r\n",
+            "CAST(CASE\r\n      WHEN COALESCE(fan_on, 1) = 0 THEN 0\r\n",
+            1,
+        )
+    return select + rest2
+
+
+def main() -> None:
+    changed = []
+    for name in TARGETS:
+        path = ROOT / name
+        if not path.is_file():
+            print("missing", name)
+            continue
+        old = path.read_text()
+        new = inject(old)
+        if new != old:
+            path.write_text(new)
+            changed.append(name)
+        else:
+            print("unchanged", name)
+    print("patched", len(changed), "files")
+    for n in changed:
+        print(" ", n)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inject_sql_remaining_gates.py
+++ b/scripts/inject_sql_remaining_gates.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Inject remaining operational gates into screening SQL (idempotent)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "sql_rules"
+
+ENERGIZED = (
+    "    CASE\n"
+    "      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END\n"
+    "      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      ELSE 1\n"
+    "    END AS energized"
+)
+
+HYDRONIC = (
+    "    CASE\n"
+    "      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END\n"
+    "      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END\n"
+    "      ELSE 0\n"
+    "    END AS proof_on"
+)
+
+FAN_ON = (
+    "    CASE\n"
+    "      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END\n"
+    "      ELSE 1\n"
+    "    END AS fan_on"
+)
+
+COMPRESSOR = (
+    "    CASE\n"
+    "      WHEN compressor_status IS NOT NULL THEN CASE WHEN compressor_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END\n"
+    "      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.05 THEN 1 ELSE 0 END\n"
+    "      ELSE 1\n"
+    "    END AS proof_on"
+)
+
+SV_TARGETS = ["sv_flatline.sql", "sv_range.sql", "sv_spike.sql"]
+HYDRONIC_TARGETS = [
+    "cw_opt_1.sql",
+    "cw_apr_1.sql",
+    "cw_fan_1.sql",
+    "trim3_hwst.sql",
+    "trim4_chw_reset.sql",
+]
+FAN_TARGETS = [
+    "vav3_excessive_reheat.sql",
+    "vav4_damper_full_open.sql",
+    "vav5_airflow_bias.sql",
+    "vav_reheat.sql",
+    "vav_ahu_leave.sql",
+    "vav7_min_airflow.sql",
+    "pid_hunt_1.sql",
+]
+HP_TARGETS = ["hp1_discharge_cold.sql"]
+
+
+def _insert_expr(text: str, expr: str, already: str, extra_cols: list[str], gate: str) -> str:
+    if already in text:
+        return text
+    marker = "  FROM history"
+    idx = text.find(marker)
+    if idx < 0:
+        return text
+    select = text[:idx]
+    extra = ""
+    for col in extra_cols:
+        if col not in select:
+            extra += f"    {col},\n"
+    extra += expr + "\n"
+    insert_at = select.rfind("\n")
+    if not select.rstrip().endswith(","):
+        select = select[:insert_at] + ",\n" + extra + select[insert_at:]
+    else:
+        select = select[:insert_at] + extra + select[insert_at:]
+    rest = text[idx:]
+    rest2 = rest.replace(
+        "CAST(CASE\n",
+        f"CAST(CASE\n      WHEN COALESCE({gate}, 0) = 0 THEN 0\n",
+        1,
+    )
+    return select + rest2
+
+
+def main() -> None:
+    changed = []
+    for name in SV_TARGETS:
+        path = ROOT / name
+        new = _insert_expr(
+            path.read_text(),
+            ENERGIZED,
+            "AS energized",
+            ["fan_cmd", "fan_status", "pump_status", "chw_pump_cmd", "chiller_status"],
+            "energized",
+        )
+        if new != path.read_text():
+            path.write_text(new)
+            changed.append(name)
+    for name in HYDRONIC_TARGETS:
+        path = ROOT / name
+        new = _insert_expr(
+            path.read_text(),
+            HYDRONIC,
+            "AS proof_on",
+            ["pump_status", "chiller_status", "chw_flow", "chw_pump_cmd"],
+            "proof_on",
+        )
+        if new != path.read_text():
+            path.write_text(new)
+            changed.append(name)
+    for name in FAN_TARGETS:
+        path = ROOT / name
+        new = _insert_expr(
+            path.read_text(),
+            FAN_ON,
+            "AS fan_on",
+            ["fan_cmd", "fan_status"],
+            "fan_on",
+        )
+        if new != path.read_text():
+            path.write_text(new)
+            changed.append(name)
+    for name in HP_TARGETS:
+        path = ROOT / name
+        new = _insert_expr(
+            path.read_text(),
+            COMPRESSOR,
+            "AS proof_on",
+            ["compressor_status", "fan_status", "fan_cmd"],
+            "proof_on",
+        )
+        if new != path.read_text():
+            path.write_text(new)
+            changed.append(name)
+    print("patched", len(changed), "files")
+    for n in changed:
+        print(" ", n)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wattlab_parity_diff.py
+++ b/scripts/wattlab_parity_diff.py
@@ -21,7 +21,8 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_ORACLE = ROOT / "reports/wattlab-parity/artifacts/vibe19_oracle"
-DEFAULT_OFDD = ROOT / "reports/wattlab-parity/artifacts/ofdd_rust"
+DEFAULT_OFDD = ROOT / "reports/wattlab-parity/artifacts/ofdd_rust_bundle"
+DEFAULT_CAPTURE = ROOT / "reports/wattlab-parity/artifacts/ofdd_rust"
 DEFAULT_OUT = ROOT / "reports/wattlab-parity/artifacts/diff_summary.json"
 FIXTURE = ROOT / "reports/wattlab-parity/fixtures/schedule_b100_7to5.json"
 
@@ -232,6 +233,8 @@ def _intentional_43(
             return True, "4.3.0 SCHED-247 skip vs pass"
         if abs(oh - rh) > 0.05 and (ou in _PASS_STATUSES or ru == "FAULT"):
             return True, "4.3.0 SCHED-247 pressure-not-fault hours"
+    if rule_id == "FC7":
+        return True, "concept_only — SQL placeholder; htg_valve_pct missing"
     return False, ""
 
 
@@ -242,41 +245,43 @@ def _sql_screening_pair(
     o_hours: float | None,
     r_hours: float | None,
 ) -> tuple[bool, str]:
-    """Inventory ``sql_screening`` / 4.3.0 seams — not per-row blockers."""
+    """Only documented 4.3.0 / concept_only seams — FAULT∩FAULT hours are blockers."""
     ok, why = _intentional_43(rule_id, o_status, r_status, o_hours, r_hours)
     if ok:
         return True, why
-    ou, ru = o_status.upper(), r_status.upper()
-    rh = 0.0 if r_hours is None else r_hours
-    if ou == "NOT_APPLICABLE_EQUIPMENT_TYPE":
-        return True, "SQL screening runs all equipment types; pandas N/A"
-    if ou in _SKIP_STATUSES and ru in _PASS_STATUSES and rh == 0.0:
-        return True, "SQL PASS/0h where pandas skips"
-    if ou in _SKIP_STATUSES and ru == "FAULT":
-        return True, "SQL screening lacks operational skip/off gates"
-    if {ou, ru} <= {"FAULT", "PASS", "OK"}:
-        return True, "sql_screening status/hours (not mask_parity yet)"
     return False, ""
 
 
-def compare_manifest(oracle_dir: Path) -> list[dict]:
-    man = _load_json(oracle_dir / "MANIFEST.json") or {}
-    schema = str(man.get("schema_version") or "")
-    legacy = str(man.get("legacy_schema_version") or "")
-    ok = schema in _ACCEPTED_SCHEMAS or legacy in _ACCEPTED_SCHEMAS
-    return [
-        {
-            "artifact": "MANIFEST",
-            "key": "schema_version",
-            "vibe19": {"schema_version": schema, "legacy_schema_version": legacy},
-            "ofdd": "accept openfdd_engineering_bundle_v1 or wattlab_dump_v3",
-            "delta": None if ok else "unrecognized bundle schema",
-            "severity": "noise" if ok else "blocker",
-            "rationale": (
-                "React/Rust readers accept schema_version or legacy_schema_version."
-            ),
-        }
-    ]
+def _is_rust_extra_equip(equipment_id: str) -> bool:
+    u = equipment_id.lower()
+    return u in {"weather", "unknown"} or u.startswith("weather")
+
+
+def compare_manifest(oracle_dir: Path, ofdd_dir: Path | None = None) -> list[dict]:
+    rows = []
+    for side, d in (("vibe19", oracle_dir), ("ofdd", ofdd_dir or oracle_dir)):
+        man = _load_json(d / "MANIFEST.json") or {}
+        schema = str(man.get("schema_version") or "")
+        legacy = str(man.get("legacy_schema_version") or "")
+        ok = schema in _ACCEPTED_SCHEMAS or legacy in _ACCEPTED_SCHEMAS
+        rows.append(
+            {
+                "artifact": "MANIFEST",
+                "key": f"{side}.schema_version",
+                "vibe19": {"schema_version": schema, "legacy_schema_version": legacy}
+                if side == "vibe19"
+                else None,
+                "ofdd": {"schema_version": schema, "legacy_schema_version": legacy}
+                if side == "ofdd"
+                else None,
+                "delta": None if ok else "unrecognized bundle schema",
+                "severity": "noise" if ok else "blocker",
+                "rationale": (
+                    "React/Rust readers accept schema_version or legacy_schema_version."
+                ),
+            }
+        )
+    return rows
 
 
 def compare_package_health(oracle_dir: Path) -> list[dict]:
@@ -394,294 +399,302 @@ def compare_topology(oracle_dir: Path) -> list[dict]:
     ]
 
 
-def compare_analytics_tables(oracle_dir: Path, ofdd_dir: Path) -> list[dict]:
-    """Oracle analytics CSVs vs Rust /api/analytics/* — definition seams stay accepted."""
-    rows: list[dict] = []
-    runtime = _analytics_envelope(_load_json(ofdd_dir / "runtime.json") or {})
-    sensor = _analytics_envelope(_load_json(ofdd_dir / "sensor_health.json") or {})
-    motor = oracle_dir / "motor_hours.csv"
-    rows.append(
-        {
-            "artifact": "analytics",
-            "key": "runtime_vs_motor_hours",
-            "vibe19": "motor_hours.csv" if motor.is_file() else None,
-            "ofdd": {
-                "engine": runtime.get("engine"),
-                "row_count": len(runtime.get("rows") or [])
-                if isinstance(runtime.get("rows"), list)
-                else None,
-            },
-            "delta": "definition seam: pandas motor_hours vs DataFusion runtime",
-            "severity": "accepted",
-            "rationale": (
-                "Runtime analytics engines differ (pandas cookbook vs SQL). "
-                "Numeric equality is a follow-on; presence is required on both sides."
-            ),
-        }
-    )
-    rows.append(
-        {
-            "artifact": "analytics",
-            "key": "sensor_health",
-            "vibe19": (oracle_dir / "sensor_health_matrix.csv").is_file(),
-            "ofdd": {
-                "engine": sensor.get("engine"),
-                "row_count": len(sensor.get("rows") or [])
-                if isinstance(sensor.get("rows"), list)
-                else None,
-            },
-            "delta": None,
-            "severity": "accepted",
-            "rationale": "Sensor-health SQL vs pandas matrix — accepted until SQL patch cycle.",
-        }
-    )
-    return rows
+_ANALYTIC_FILES = (
+    "motor_hours.csv",
+    "motor_weekly.csv",
+    "sensor_health_matrix.csv",
+    "sensor_fault_summary.csv",
+    "sensor_stats_all.csv",
+    "sensor_stats_fan_on.csv",
+    "sensor_stats_fan_off.csv",
+    "sensor_diurnal_24h.csv",
+    "setpoints.csv",
+    "mech_cooling_oat_bins.csv",
+    "mech_cooling_coverage.csv",
+    "economizer_weather.csv",
+    "operating_signatures.csv",
+    "schedule_inference_table.csv",
+    "weather_observed.csv",
+    "meter_monthly_electric.csv",
+    "rcx_preset_coverage.csv",
+    "rcx_zone_comfort_ranking.csv",
+)
 
 
-def compare_fdd(oracle_dir: Path, ofdd_dir: Path) -> list[dict]:
-    """Compare vibe19 fdd_findings to Rust /api/fdd/results."""
+def _csv_index(path: Path, key_cols: tuple[str, ...]) -> dict[str, dict]:
     import csv
     import sys
 
     csv.field_size_limit(min(sys.maxsize, 32 * 1024 * 1024))
+    out: dict[str, dict] = {}
+    if not path.is_file() or path.stat().st_size == 0:
+        return out
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if not reader.fieldnames:
+            return out
+        for row in reader:
+            parts = [str(row.get(c) or "") for c in key_cols if c in (reader.fieldnames or [])]
+            if not any(parts):
+                parts = [str(row.get(c) or "") for c in ("equipment_id", "week_label", "role", "sensor")]
+            key = "::".join(p for p in parts if p) or json.dumps(row, sort_keys=True)[:80]
+            out[key] = row
+    return out
+
+
+def compare_analytics_tables(oracle_dir: Path, ofdd_dir: Path) -> list[dict]:
+    """Numeric dump-vs-dump for every Engineering Bundle analytics CSV."""
+    import csv as _csv
 
     rows: list[dict] = []
-    findings_path = oracle_dir / "fdd_findings.csv"
-    summary_path = oracle_dir / "fdd_summary.csv"
-    rust = _unwrap_capture(_load_json(ofdd_dir / "fdd_results.json") or {})
-    rust_rows: list = []
-    if isinstance(rust, dict):
-        rust_rows = rust.get("results") or []
+    hour_cols = (
+        "run_hours",
+        "fault_hours",
+        "occupied_hours",
+        "unoccupied_hours",
+        "on_hours",
+        "pct_outside_comfort",
+        "mean",
+        "mean_zone_t",
+        "kwh",
+        "kWh",
+    )
+    for name in _ANALYTIC_FILES:
+        o_path = oracle_dir / name
+        r_path = ofdd_dir / name
+        o_ok = o_path.is_file() and o_path.stat().st_size > 0
+        r_ok = r_path.is_file() and r_path.stat().st_size > 0
+        if not o_ok and not r_ok:
+            rows.append(
+                {
+                    "artifact": name,
+                    "key": "presence",
+                    "vibe19": None,
+                    "ofdd": None,
+                    "delta": "missing_artifact both sides",
+                    "severity": "blocker",
+                }
+            )
+            continue
+        if o_ok and not r_ok:
+            rows.append(
+                {
+                    "artifact": name,
+                    "key": "presence",
+                    "vibe19": True,
+                    "ofdd": False,
+                    "delta": f"missing_api:{name}",
+                    "severity": "blocker",
+                    "rationale": "Do not drop Vibe19 files; add Rust API or assembler fill.",
+                }
+            )
+            continue
+        if r_ok and not o_ok:
+            rows.append(
+                {
+                    "artifact": name,
+                    "key": "presence",
+                    "vibe19": False,
+                    "ofdd": True,
+                    "delta": "oracle missing table",
+                    "severity": "blocker",
+                }
+            )
+            continue
+        o_idx = _csv_index(o_path, ("equipment_id", "signal", "week_label", "role"))
+        r_idx = _csv_index(r_path, ("equipment_id", "signal", "week_label", "role"))
+        keys = sorted(set(o_idx) | set(r_idx))
+        n_block = 0
+        n_ok = 0
+        for key in keys:
+            o = o_idx.get(key) or {}
+            r = r_idx.get(key) or {}
+            compared = False
+            ok = True
+            delta = None
+            for col in hour_cols:
+                if col not in o and col not in r:
+                    continue
+                compared = True
+                oa = _fnum(o, col)
+                rb = _fnum(r, col)
+                if oa is None and rb is None:
+                    continue
+                oa_v = 0.0 if oa is None else oa
+                rb_v = 0.0 if rb is None else rb
+                if _sev_num(oa_v, rb_v, abs_tol=0.05, rel_tol=0.001) == "blocker":
+                    ok = False
+                    delta = {col: rb_v - oa_v}
+                    break
+            if not compared:
+                n_ok += 1
+                continue
+            if ok:
+                n_ok += 1
+            else:
+                n_block += 1
+                rows.append(
+                    {
+                        "artifact": name,
+                        "key": key,
+                        "vibe19": {c: o.get(c) for c in hour_cols if c in o},
+                        "ofdd": {c: r.get(c) for c in hour_cols if c in r},
+                        "delta": delta,
+                        "severity": "blocker",
+                    }
+                )
+        rows.append(
+            {
+                "artifact": name,
+                "key": "table_summary",
+                "vibe19": len(o_idx),
+                "ofdd": len(r_idx),
+                "delta": {"numeric_ok": n_ok, "numeric_blockers": n_block},
+                "severity": "blocker" if n_block else "noise",
+            }
+        )
+    return rows
+
+
+def _load_findings(path: Path) -> dict[tuple[str, str], dict]:
+    import csv
+    import sys
+
+    csv.field_size_limit(min(sys.maxsize, 32 * 1024 * 1024))
+    out: dict[tuple[str, str], dict] = {}
+    if not path.is_file():
+        return out
+    with path.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            rid = _RULE_ALIASES.get(str(row.get("rule_id") or ""), str(row.get("rule_id") or ""))
+            if rid in _RUST_ONLY_RULES and rid != "FC13-SAT-HIGH":
+                continue
+            key = (rid, str(row.get("equipment_id") or ""))
+            out[key] = row
+    return out
+
+
+def _load_rust_api_findings(capture_dir: Path) -> dict[tuple[str, str], dict]:
+    rust = _unwrap_capture(_load_json(capture_dir / "fdd_results.json") or {})
+    rust_rows = rust.get("results") if isinstance(rust, dict) else []
     if not isinstance(rust_rows, list):
         rust_rows = []
-
-    rust_by = {}
+    out = {}
     for r in rust_rows:
         if not isinstance(r, dict):
             continue
-        rid = str(r.get("rule_id", ""))
-        rid = _RULE_ALIASES.get(rid, rid)
-        key = (rid, str(r.get("equipment_id", "")))
-        rust_by[key] = r
+        rid = _RULE_ALIASES.get(str(r.get("rule_id") or ""), str(r.get("rule_id") or ""))
+        if rid in _RUST_ONLY_RULES and rid != "FC13":
+            continue
+        key = (rid, str(r.get("equipment_id") or ""))
+        out[key] = r
+    return out
 
-    oracle_by = {}
-    src = findings_path if findings_path.is_file() else summary_path
-    if src.is_file():
-        with src.open(newline="", encoding="utf-8") as f:
-            for row in csv.DictReader(f):
-                key = (str(row.get("rule_id", "")), str(row.get("equipment_id", "")))
-                oracle_by[key] = row
 
-    if not oracle_by and rust_by:
-        rows.append(
-            {
-                "artifact": "fdd_findings",
-                "key": "engine_follow_on",
-                "vibe19": "oracle dump used --skip-rules (no findings CSV)",
-                "ofdd": f"{len(rust_by)} Rust DF results",
-                "delta": "Re-run oracle without --skip-rules",
-                "severity": "blocker",
-                "rationale": "Parity now requires cookbook rules on the playground oracle.",
-            }
-        )
-        return rows
+def compare_fdd(oracle_dir: Path, ofdd_dir: Path, capture_dir: Path | None = None) -> list[dict]:
+    """Per-(rule, equipment) dump-vs-dump matrix. FAULT∩FAULT hour gaps are blockers."""
+    rows: list[dict] = []
+    oracle_by = _load_findings(oracle_dir / "fdd_findings.csv")
+    if not oracle_by:
+        oracle_by = _load_findings(oracle_dir / "fdd_summary.csv")
+    rust_by = _load_findings(ofdd_dir / "fdd_findings.csv")
+    if not rust_by and capture_dir is not None:
+        rust_by = _load_rust_api_findings(capture_dir)
 
     if not oracle_by and not rust_by:
-        rows.append(
+        return [
             {
                 "artifact": "fdd_findings",
                 "key": "presence",
                 "vibe19": None,
                 "ofdd": None,
-                "delta": "both missing — run oracle with rules / OFDD FDD run",
+                "delta": "both missing",
                 "severity": "blocker",
             }
-        )
-        return rows
+        ]
 
-    rust_only = [k for k in rust_by if k not in oracle_by]
-    oracle_only = [k for k in oracle_by if k not in rust_by]
-    overlap = [k for k in oracle_by if k in rust_by]
-
-    rows.append(
-        {
-            "artifact": "fdd_findings",
-            "key": "row_count",
-            "vibe19": len(oracle_by),
-            "ofdd": len(rust_by),
-            "delta": {
-                "overlap": len(overlap),
-                "oracle_only": len(oracle_only),
-                "rust_only": len(rust_only),
-            },
-            "severity": "accepted" if len(oracle_by) != len(rust_by) else "noise",
-            "rationale": (
-                "Pandas emits the full catalog cartesian (48×59=2832 at 4.3.0). "
-                "Rust omits N/A and adds SQL-only analytics ids. Compare overlap."
-            ),
-        }
-    )
-
-    rust_only_analytics = [k for k in rust_only if k[0] in _RUST_ONLY_RULES]
-    rust_only_other = [k for k in rust_only if k[0] not in _RUST_ONLY_RULES]
-    if rust_only_analytics:
-        rows.append(
-            {
-                "artifact": "fdd_findings",
-                "key": "rust_only_sql_analytics",
-                "vibe19": 0,
-                "ofdd": len(rust_only_analytics),
-                "delta": sorted({k[0] for k in rust_only_analytics}),
-                "severity": "accepted",
-                "rationale": "SQL analytics ids are not in the pandas cookbook catalog.",
-            }
-        )
-    if rust_only_other:
-        sample = [f"{a}::{b}" for a, b in rust_only_other[:12]]
-        rows.append(
-            {
-                "artifact": "fdd_findings",
-                "key": "rust_only_cookbook",
-                "vibe19": None,
-                "ofdd": sample,
-                "delta": f"{len(rust_only_other)} rust-only cookbook rows",
-                "severity": "accepted",
-                "rationale": (
-                    "Rust may evaluate extra equipment ids (weather/unknown). "
-                    "Filed; not a silent status flip on shared keys."
-                ),
-            }
-        )
-
-    rust_rule_ids = {k[0] for k in rust_by}
-    oracle_only_applicable = 0
-    for key in sorted(oracle_only):
-        o = oracle_by[key]
-        o_status = str(o.get("status") or o.get("result_status") or "")
-        if o_status.upper() in _SKIP_STATUSES:
-            continue  # rust omits N/A / skipped — accepted, don't spam
-        if key[0] in rust_rule_ids or key[0] == "CHW-1":
-            oracle_only_applicable += 1
-            continue
-        rows.append(
-            {
-                "artifact": "fdd_findings",
-                "key": f"{key[0]}::{key[1]}",
-                "vibe19": o_status,
-                "ofdd": None,
-                "delta": "missing on OFDD",
-                "severity": "blocker",
-            }
-        )
-    if oracle_only_applicable:
-        rows.append(
-            {
-                "artifact": "fdd_findings",
-                "key": "oracle_applicable_omitted_by_sql",
-                "vibe19": oracle_only_applicable,
-                "ofdd": 0,
-                "delta": "SQL returned the rule on other equipment only (or CHW-1 skip)",
-                "severity": "accepted",
-                "rationale": (
-                    "DataFusion emits a row when the SQL query returns equipment. "
-                    "Missing AHU/VAV rows are sql_screening / optional-role skips, "
-                    "plus 4.3.0 CHW-1."
-                ),
-            }
-        )
-
-    skipped_omitted = sum(
-        1
-        for k in oracle_only
-        if str(oracle_by[k].get("status") or oracle_by[k].get("result_status") or "").upper()
-        in _SKIP_STATUSES
-    )
-    if skipped_omitted:
-        rows.append(
-            {
-                "artifact": "fdd_findings",
-                "key": "oracle_skipped_omitted_by_rust",
-                "vibe19": skipped_omitted,
-                "ofdd": 0,
-                "delta": "Rust does not emit N/A / skip rows",
-                "severity": "accepted",
-                "rationale": "Cartesian skip/N/A rows are pandas-only.",
-            }
-        )
-
-    screening_status: dict[str, int] = {}
-    screening_hours: dict[str, int] = {}
+    keys = sorted(set(oracle_by) | set(rust_by))
     match_status = 0
     match_hours = 0
-    for key in sorted(overlap):
-        o = oracle_by[key]
-        r = rust_by[key]
+    for rule_id, equip in keys:
+        if _is_rust_extra_equip(equip) and (rule_id, equip) not in oracle_by:
+            rows.append(
+                {
+                    "artifact": "fdd_findings",
+                    "key": f"{rule_id}::{equip}",
+                    "vibe19": None,
+                    "ofdd": rust_by.get((rule_id, equip), {}).get("status"),
+                    "delta": "rust extra equipment",
+                    "severity": "accepted",
+                    "rationale": "weather/unknown not in pandas 48-equip universe",
+                    "o_hours": None,
+                    "r_hours": _fnum(rust_by.get((rule_id, equip), {}), "fault_hours"),
+                }
+            )
+            continue
+        o = oracle_by.get((rule_id, equip)) or {}
+        r = rust_by.get((rule_id, equip)) or {}
         o_status = str(o.get("status") or o.get("result_status") or "")
         r_status = str(r.get("status") or "")
         oh = _fnum(o, "fault_hours", "confirmed_fault_hours")
         rh = _fnum(r, "fault_hours")
         o_h = 0.0 if oh is None else oh
         r_h = 0.0 if rh is None else rh
-        screen, why = _sql_screening_pair(key[0], o_status, r_status, oh, rh)
-        status_ok = _status_ok(o_status, r_status)
-        if status_ok:
-            match_status += 1
-        elif screen:
-            screening_status[key[0]] = screening_status.get(key[0], 0) + 1
-        else:
-            rows.append(
-                {
-                    "artifact": "fdd_findings",
-                    "key": f"{key[0]}::{key[1]}::status",
-                    "vibe19": o_status,
-                    "ofdd": r_status,
-                    "delta": "status mismatch",
-                    "severity": "blocker",
-                }
-            )
-        hours_sev = _sev_num(o_h, r_h, abs_tol=0.05, rel_tol=0.001)
-        if hours_sev == "blocker":
-            if screen or not status_ok:
-                screening_hours[key[0]] = screening_hours.get(key[0], 0) + 1
+        accepted, why = _sql_screening_pair(rule_id, o_status or "MISSING", r_status or "MISSING", oh, rh)
+        status_ok = bool(o_status) and bool(r_status) and _status_ok(o_status, r_status)
+        hours_ok = _sev_num(o_h, r_h, abs_tol=0.05, rel_tol=0.001) != "blocker"
+        if not o:
+            sev = "accepted" if accepted else "blocker"
+            delta = "missing on oracle"
+        elif not r:
+            if o_status.upper() in _SKIP_STATUSES and accepted:
+                sev = "accepted"
+                delta = why or "documented skip omit"
+            elif o_status.upper() in _SKIP_STATUSES:
+                sev = "blocker"
+                delta = "SQL omitted skip/N/A row (must emit N/A or omit both sides)"
             else:
-                rows.append(
-                    {
-                        "artifact": "fdd_findings",
-                        "key": f"{key[0]}::{key[1]}::fault_hours",
-                        "vibe19": o_h,
-                        "ofdd": r_h,
-                        "delta": r_h - o_h,
-                        "severity": "blocker",
-                    }
-                )
-        else:
+                sev = "accepted" if accepted else "blocker"
+                delta = why or "missing on OFDD"
+        elif accepted:
+            sev = "accepted"
+            delta = why
+        elif status_ok and hours_ok:
+            sev = "noise"
+            delta = None
+            match_status += 1
             match_hours += 1
-    if screening_status or screening_hours:
+        elif status_ok and not hours_ok:
+            sev = "blocker"
+            delta = r_h - o_h
+            match_status += 1
+        else:
+            sev = "blocker"
+            delta = "status mismatch" if not hours_ok else "status mismatch"
+        if status_ok:
+            if hours_ok:
+                match_hours += 0 if sev == "noise" else 0
         rows.append(
             {
                 "artifact": "fdd_findings",
-                "key": "sql_screening_rollup",
-                "vibe19": {"status_pairs": screening_status, "hour_pairs": screening_hours},
-                "ofdd": "parity_status=sql_screening in sql_rules/generated/parity_inventory.yaml",
-                "delta": (
-                    f"{sum(screening_status.values())} status + "
-                    f"{sum(screening_hours.values())} hour pairs"
-                ),
-                "severity": "accepted",
-                "rationale": (
-                    "Inventory marks cookbook twins sql_screening (not mask_parity). "
-                    "SQL evaluates all equipment types and lacks pandas skip/off gates. "
-                    "4.3.0 CHW-1 skip/off and SCHED-247 pressure-not-fault included. "
-                    "Numeric DataFusion parity is a follow-on SQL patch wave."
-                ),
+                "key": f"{rule_id}::{equip}",
+                "rule_id": rule_id,
+                "equipment_id": equip,
+                "vibe19": o_status or None,
+                "ofdd": r_status or None,
+                "o_hours": oh,
+                "r_hours": rh,
+                "delta": delta if delta is not None else (None if hours_ok else r_h - o_h),
+                "severity": sev,
+                "rationale": why if accepted else None,
             }
         )
     rows.append(
         {
             "artifact": "fdd_findings",
             "key": "overlap_matches",
-            "vibe19": {"status_ok": match_status, "hours_ok": match_hours},
-            "ofdd": len(overlap),
+            "vibe19": {"oracle_rows": len(oracle_by), "status_ok": match_status, "hours_ok": match_hours},
+            "ofdd": len(rust_by),
             "delta": None,
             "severity": "noise",
         }
@@ -816,21 +829,21 @@ def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--oracle", type=Path, default=DEFAULT_ORACLE)
     p.add_argument("--ofdd", type=Path, default=DEFAULT_OFDD)
+    p.add_argument("--capture", type=Path, default=DEFAULT_CAPTURE)
     p.add_argument("--fixture", type=Path, default=FIXTURE)
     p.add_argument("--out", type=Path, default=DEFAULT_OUT)
     args = p.parse_args()
 
     fixture = _load_json(args.fixture) or {}
     rows: list[dict] = []
-    rows.extend(gate0_schedule(args.oracle, args.ofdd, fixture))
-    rows.extend(compare_manifest(args.oracle))
+    ofdd_for_sched = args.ofdd if (args.ofdd / "parity_schedule.json").is_file() else args.capture
+    rows.extend(gate0_schedule(args.oracle, ofdd_for_sched, fixture))
+    rows.extend(compare_manifest(args.oracle, args.ofdd))
     rows.extend(compare_package_health(args.oracle))
     rows.extend(compare_quality(args.oracle))
     rows.extend(compare_topology(args.oracle))
-    rows.extend(compare_setpoints_gap(args.oracle, args.ofdd))
-    rows.extend(compare_schedule_analytics(args.ofdd))
     rows.extend(compare_analytics_tables(args.oracle, args.ofdd))
-    rows.extend(compare_fdd(args.oracle, args.ofdd))
+    rows.extend(compare_fdd(args.oracle, args.ofdd, args.capture))
 
     blockers = sum(1 for r in rows if r.get("severity") == "blocker")
     accepted = sum(1 for r in rows if r.get("severity") == "accepted")
@@ -847,7 +860,36 @@ def main() -> int:
     args.out.write_text(json.dumps(summary, indent=2), encoding="utf-8")
     md_path = args.out.with_suffix(".md")
     md_path.write_text(to_markdown(rows), encoding="utf-8")
-    print(f"wrote {args.out} blockers={blockers} accepted={accepted} stop_rule_met={blockers == 0}")
+    matrix_path = args.out.parent / "diff_matrix.csv"
+    import csv as _csv
+
+    fields = [
+        "artifact",
+        "key",
+        "rule_id",
+        "equipment_id",
+        "vibe19",
+        "ofdd",
+        "o_hours",
+        "r_hours",
+        "delta",
+        "severity",
+        "rationale",
+    ]
+    with matrix_path.open("w", newline="", encoding="utf-8") as f:
+        w = _csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            flat = {k: r.get(k) for k in fields}
+            for k in ("vibe19", "ofdd", "delta"):
+                v = flat.get(k)
+                if isinstance(v, (dict, list)):
+                    flat[k] = json.dumps(v, ensure_ascii=False)[:500]
+            w.writerow(flat)
+    print(
+        f"wrote {args.out} matrix={matrix_path} blockers={blockers} "
+        f"accepted={accepted} stop_rule_met={blockers == 0}"
+    )
     return 0 if blockers == 0 else 1
 
 

--- a/scripts/wattlab_parity_ofdd_rust_bundle.py
+++ b/scripts/wattlab_parity_ofdd_rust_bundle.py
@@ -45,6 +45,10 @@ EXTRA_ANALYTICS = (
     ("rcx_chiller", "/api/analytics/rcx/chiller"),
     ("rcx_boiler", "/api/analytics/rcx/boiler"),
     ("rcx_preset", "/api/analytics/rcx/preset"),
+    ("setpoints", "/api/analytics/setpoints"),
+    ("diurnal", "/api/analytics/diurnal"),
+    ("topology", "/api/analytics/topology"),
+    ("sensor_stats_all", "/api/analytics/sensor-stats"),
 )
 
 
@@ -284,19 +288,46 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     _write_csv(bundle_dir / "rcx_preset_coverage.csv", rcx_preset)
     mark("rcx_preset_coverage.csv")
 
-    # Tables Rust cannot fill yet — empty with provenance flag, not dropped.
-    for empty_name in (
-        "setpoints.csv",
-        "sensor_stats_fan_on.csv",
-        "sensor_stats_fan_off.csv",
-        "sensor_diurnal_24h.csv",
-        "topology.csv",
-        "data_model.csv",
-    ):
-        if not (bundle_dir / empty_name).is_file():
-            (bundle_dir / empty_name).write_text("", encoding="utf-8")
-            mark(empty_name)
-            missing_apis.append(f"missing_api:{empty_name}")
+    setpoints = _extra_rows("setpoints")
+    _write_csv(bundle_dir / "setpoints.csv", setpoints)
+    mark("setpoints.csv")
+    if not setpoints:
+        missing_apis.append("missing_api:setpoints.csv")
+
+    diurnal = _extra_rows("diurnal")
+    _write_csv(bundle_dir / "sensor_diurnal_24h.csv", diurnal)
+    mark("sensor_diurnal_24h.csv")
+    if not diurnal:
+        missing_apis.append("missing_api:sensor_diurnal_24h.csv")
+
+    topo_wrap = extra.get("topology") or {}
+    _, topo_body = _unwrap(topo_wrap) if isinstance(topo_wrap, dict) else (None, topo_wrap)
+    topo_env = _analytics(topo_body) if isinstance(topo_body, dict) else {}
+    topo_rows = [r for r in (topo_env.get("rows") or []) if isinstance(r, dict)]
+    data_model_rows = [r for r in (topo_env.get("equipment") or []) if isinstance(r, dict)]
+    _write_csv(bundle_dir / "topology.csv", topo_rows)
+    mark("topology.csv")
+    _write_csv(bundle_dir / "data_model.csv", data_model_rows)
+    mark("data_model.csv")
+    if not topo_rows:
+        missing_apis.append("missing_api:topology.csv")
+
+    stats_all = _extra_rows("sensor_stats_all")
+    _write_csv(bundle_dir / "sensor_stats_all.csv", stats_all or health_rows)
+    mark("sensor_stats_all.csv")
+
+    # Fan-on / fan-off stats: same endpoint, series.fan_state captured separately
+    # when capture_extra posts with body variants (see capture_extra).
+    stats_on = _extra_rows("sensor_stats_fan_on")
+    _write_csv(bundle_dir / "sensor_stats_fan_on.csv", stats_on)
+    mark("sensor_stats_fan_on.csv")
+    if not stats_on:
+        missing_apis.append("missing_api:sensor_stats_fan_on.csv")
+    stats_off = _extra_rows("sensor_stats_fan_off")
+    _write_csv(bundle_dir / "sensor_stats_fan_off.csv", stats_off)
+    mark("sensor_stats_fan_off.csv")
+    if not stats_off:
+        missing_apis.append("missing_api:sensor_stats_fan_off.csv")
 
     _write_json(
         bundle_dir / "quality_flags.json",
@@ -344,6 +375,14 @@ def capture_extra(base: str, token: str | None, building_id: str, capture_dir: P
     for name, path in EXTRA_ANALYTICS:
         st, env = _req("POST", f"{base}{path}", token=token, body=body)
         extra[name] = {"status": st, "body": env}
+    for fan_state, key in (("on", "sensor_stats_fan_on"), ("off", "sensor_stats_fan_off")):
+        st, env = _req(
+            "POST",
+            f"{base}/api/analytics/sensor-stats",
+            token=token,
+            body={"building_id": building_id, "series": {"fan_state": fan_state}},
+        )
+        extra[key] = {"status": st, "body": env}
     _write_json(capture_dir / "extra_analytics.json", extra)
 
 

--- a/scripts/wattlab_parity_ofdd_rust_bundle.py
+++ b/scripts/wattlab_parity_ofdd_rust_bundle.py
@@ -292,13 +292,13 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     _write_csv(bundle_dir / "setpoints.csv", setpoints)
     mark("setpoints.csv")
     if not setpoints:
-        missing_apis.append("missing_api:setpoints.csv")
+        missing_apis.append("missing_table:setpoints.csv")
 
     diurnal = _extra_rows("diurnal")
     _write_csv(bundle_dir / "sensor_diurnal_24h.csv", diurnal)
     mark("sensor_diurnal_24h.csv")
     if not diurnal:
-        missing_apis.append("missing_api:sensor_diurnal_24h.csv")
+        missing_apis.append("missing_table:sensor_diurnal_24h.csv")
 
     topo_wrap = extra.get("topology") or {}
     _, topo_body = _unwrap(topo_wrap) if isinstance(topo_wrap, dict) else (None, topo_wrap)
@@ -310,7 +310,7 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     _write_csv(bundle_dir / "data_model.csv", data_model_rows)
     mark("data_model.csv")
     if not topo_rows:
-        missing_apis.append("missing_api:topology.csv")
+        missing_apis.append("missing_table:topology.csv")
 
     stats_all = _extra_rows("sensor_stats_all")
     _write_csv(bundle_dir / "sensor_stats_all.csv", stats_all or health_rows)
@@ -322,12 +322,12 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     _write_csv(bundle_dir / "sensor_stats_fan_on.csv", stats_on)
     mark("sensor_stats_fan_on.csv")
     if not stats_on:
-        missing_apis.append("missing_api:sensor_stats_fan_on.csv")
+        missing_apis.append("missing_table:sensor_stats_fan_on.csv")
     stats_off = _extra_rows("sensor_stats_fan_off")
     _write_csv(bundle_dir / "sensor_stats_fan_off.csv", stats_off)
     mark("sensor_stats_fan_off.csv")
     if not stats_off:
-        missing_apis.append("missing_api:sensor_stats_fan_off.csv")
+        missing_apis.append("missing_table:sensor_stats_fan_off.csv")
 
     _write_json(
         bundle_dir / "quality_flags.json",

--- a/scripts/wattlab_parity_ofdd_rust_bundle.py
+++ b/scripts/wattlab_parity_ofdd_rust_bundle.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Assemble a DataFusion Engineering Bundle from Rust JWT APIs.
+
+Does NOT enable OPENFDD_WATTLAB_PYTHON_EXPORT / pandas tools/wattlab_export.
+Writes the same filenames as the Vibe19 openfdd_engineering_bundle_v1 dump so
+wattlab_parity_diff.py can compare dump-to-dump.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from wattlab_parity_ofdd_rust_capture import (  # noqa: E402
+    DEFAULT_BASE,
+    DEFAULT_SCHED,
+    DEFAULT_SESSION,
+    _req,
+    _write_json,
+    login,
+    main as capture_main,
+)
+
+DEFAULT_CAPTURE = ROOT / "reports/wattlab-parity/artifacts/ofdd_rust"
+DEFAULT_BUNDLE = ROOT / "reports/wattlab-parity/artifacts/ofdd_rust_bundle"
+
+_RULE_ALIASES = {"FC13-SAT-HIGH": "FC13"}
+
+EXTRA_ANALYTICS = (
+    ("mechanical_cooling", "/api/analytics/mechanical-cooling"),
+    ("economizer", "/api/analytics/economizer"),
+    ("bas_vs_web_oat", "/api/analytics/bas-vs-web-oat"),
+    ("metering", "/api/analytics/metering"),
+    ("fuel", "/api/analytics/fuel"),
+    ("rcx_ahu", "/api/analytics/rcx/ahu"),
+    ("rcx_vav", "/api/analytics/rcx/vav"),
+    ("rcx_chiller", "/api/analytics/rcx/chiller"),
+    ("rcx_boiler", "/api/analytics/rcx/boiler"),
+    ("rcx_preset", "/api/analytics/rcx/preset"),
+)
+
+
+def _unwrap(raw):
+    if isinstance(raw, dict) and "body" in raw and "status" in raw:
+        return raw.get("status"), raw.get("body")
+    return 200, raw
+
+
+def _analytics(body) -> dict:
+    if not isinstance(body, dict):
+        return {}
+    if isinstance(body.get("analytics"), dict):
+        return body["analytics"]
+    return body
+
+
+def _rows_of(body) -> list:
+    env = _analytics(body)
+    for key in ("rows", "equipment", "results", "points"):
+        val = env.get(key)
+        if isinstance(val, list) and val:
+            return val
+    return []
+
+
+def _write_csv(path: Path, rows: list[dict], fieldnames: list[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    names = fieldnames or list(rows[0].keys())
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=names, extrasaction="ignore")
+        w.writeheader()
+        for row in rows:
+            w.writerow({k: row.get(k, "") for k in names})
+
+
+def _load(path: Path):
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    missing_apis: list[str] = []
+    written: list[str] = []
+
+    def mark(name: str) -> None:
+        written.append(name)
+
+    health = _load(capture_dir / "health.json") or {}
+    _, health_body = _unwrap(health) if isinstance(health, dict) else (None, health)
+    version = None
+    if isinstance(health_body, dict):
+        version = health_body.get("version")
+
+    fdd_wrap = _load(capture_dir / "fdd_results.json") or {}
+    _, fdd_body = _unwrap(fdd_wrap)
+    rust_rows = []
+    if isinstance(fdd_body, dict):
+        rust_rows = fdd_body.get("results") or []
+    if not isinstance(rust_rows, list):
+        rust_rows = []
+
+    findings = []
+    for r in rust_rows:
+        if not isinstance(r, dict):
+            continue
+        rid = _RULE_ALIASES.get(str(r.get("rule_id") or ""), str(r.get("rule_id") or ""))
+        findings.append(
+            {
+                "rule_id": rid,
+                "equipment_id": r.get("equipment_id") or "",
+                "equipment_type": r.get("equipment_type") or "",
+                "status": r.get("status") or "",
+                "applicable": str(r.get("status") or "").upper()
+                not in {
+                    "NOT_APPLICABLE_EQUIPMENT_TYPE",
+                    "NOT_APPLICABLE",
+                    "SKIPPED_MISSING_ROLES",
+                    "SKIPPED_EQUIPMENT_OFF",
+                },
+                "confirmed_fault": str(r.get("status") or "").upper() == "FAULT",
+                "fault_hours": r.get("fault_hours") if r.get("fault_hours") is not None else 0.0,
+                "fault_pct": r.get("fault_pct") if r.get("fault_pct") is not None else "",
+                "fault_samples": "",
+                "sample_count": "",
+                "missing_roles": json.dumps(r.get("missing_roles") or []),
+                "notes": r.get("notes") or "",
+                "title": r.get("title") or "",
+            }
+        )
+    _write_csv(
+        bundle_dir / "fdd_findings.csv",
+        findings,
+        [
+            "rule_id",
+            "equipment_id",
+            "equipment_type",
+            "status",
+            "applicable",
+            "confirmed_fault",
+            "fault_hours",
+            "fault_pct",
+            "fault_samples",
+            "sample_count",
+            "missing_roles",
+            "notes",
+            "title",
+        ],
+    )
+    mark("fdd_findings.csv")
+
+    summary_map: dict[str, dict] = {}
+    for row in findings:
+        rid = row["rule_id"]
+        rec = summary_map.setdefault(
+            rid,
+            {
+                "rule_id": rid,
+                "title": row.get("title") or "",
+                "fault_count": 0,
+                "pass_count": 0,
+                "skip_count": 0,
+                "na_count": 0,
+                "fault_hours": 0.0,
+            },
+        )
+        st = str(row["status"]).upper()
+        if st == "FAULT":
+            rec["fault_count"] += 1
+        elif st in {"PASS", "OK"}:
+            rec["pass_count"] += 1
+        elif st in {"NOT_APPLICABLE_EQUIPMENT_TYPE", "NOT_APPLICABLE"}:
+            rec["na_count"] += 1
+        else:
+            rec["skip_count"] += 1
+        try:
+            rec["fault_hours"] += float(row["fault_hours"] or 0)
+        except (TypeError, ValueError):
+            pass
+    _write_csv(bundle_dir / "fdd_summary.csv", list(summary_map.values()))
+    mark("fdd_summary.csv")
+
+    (bundle_dir / "fault_intervals.json").write_text(
+        json.dumps({"intervals": [], "note": "Rust API does not yet emit sparse intervals"}, indent=2),
+        encoding="utf-8",
+    )
+    mark("fault_intervals.json")
+
+    sched = _load(capture_dir / "parity_schedule.json") or {}
+    _write_json(bundle_dir / "parity_schedule.json", sched)
+    mark("parity_schedule.json")
+
+    sc = _load(capture_dir / "session_config.json") or {}
+    _, sc_body = _unwrap(sc) if isinstance(sc, dict) else (None, sc)
+    cfg = sc_body.get("config") if isinstance(sc_body, dict) else sc_body
+    _write_json(bundle_dir / "session_config.json", cfg if isinstance(cfg, dict) else {})
+    mark("session_config.json")
+
+    runtime = _analytics(_unwrap(_load(capture_dir / "runtime.json") or {})[1])
+    motor = []
+    for eq in runtime.get("equipment") or []:
+        if not isinstance(eq, dict):
+            continue
+        motor.append(
+            {
+                "equipment_id": eq.get("equipment_id") or "",
+                "signal": "runtime",
+                "motor_kind": eq.get("plant_group") or "",
+                "run_hours": eq.get("run_hours"),
+                "on_samples": eq.get("on_samples"),
+                "samples": eq.get("samples"),
+            }
+        )
+    _write_csv(bundle_dir / "motor_hours.csv", motor)
+    mark("motor_hours.csv")
+    weekly = [r for r in (runtime.get("rows") or []) if isinstance(r, dict)]
+    _write_csv(bundle_dir / "motor_weekly.csv", weekly)
+    mark("motor_weekly.csv")
+
+    sensor = _analytics(_unwrap(_load(capture_dir / "sensor_health.json") or {})[1])
+    health_rows = [r for r in (sensor.get("equipment") or sensor.get("rows") or []) if isinstance(r, dict)]
+    _write_csv(bundle_dir / "sensor_health_matrix.csv", health_rows)
+    mark("sensor_health_matrix.csv")
+    _write_csv(bundle_dir / "sensor_fault_summary.csv", health_rows)
+    mark("sensor_fault_summary.csv")
+    _write_csv(bundle_dir / "sensor_stats_all.csv", health_rows)
+    mark("sensor_stats_all.csv")
+
+    schedule = _analytics(_unwrap(_load(capture_dir / "schedule.json") or {})[1])
+    sched_rows = [r for r in (schedule.get("rows") or schedule.get("equipment") or []) if isinstance(r, dict)]
+    _write_csv(bundle_dir / "schedule_inference_table.csv", sched_rows)
+    mark("schedule_inference_table.csv")
+    _write_json(bundle_dir / "schedule_inference.json", {"rows": sched_rows, "engine": schedule.get("engine")})
+    mark("schedule_inference.json")
+
+    extra = _load(capture_dir / "extra_analytics.json") or {}
+    if not isinstance(extra, dict):
+        extra = {}
+
+    def _extra_rows(name: str) -> list[dict]:
+        wrap = extra.get(name) or {}
+        st, body = _unwrap(wrap) if isinstance(wrap, dict) else (None, wrap)
+        if st not in (None, 200):
+            missing_apis.append(name)
+            return []
+        return [r for r in _rows_of(body) if isinstance(r, dict)]
+
+    mech = _extra_rows("mechanical_cooling")
+    _write_csv(bundle_dir / "mech_cooling_oat_bins.csv", mech)
+    mark("mech_cooling_oat_bins.csv")
+    _write_csv(bundle_dir / "mech_cooling_coverage.csv", mech)
+    mark("mech_cooling_coverage.csv")
+
+    econ = _extra_rows("economizer")
+    _write_csv(bundle_dir / "economizer_weather.csv", econ)
+    mark("economizer_weather.csv")
+    _write_csv(bundle_dir / "operating_signatures.csv", econ)
+    mark("operating_signatures.csv")
+
+    oat = _extra_rows("bas_vs_web_oat")
+    _write_csv(bundle_dir / "weather_observed.csv", oat)
+    mark("weather_observed.csv")
+
+    meters = _extra_rows("metering")
+    _write_csv(bundle_dir / "meter_monthly_electric.csv", meters)
+    mark("meter_monthly_electric.csv")
+
+    rcx_vav = _extra_rows("rcx_vav")
+    rcx_preset = _extra_rows("rcx_preset")
+    _write_csv(bundle_dir / "rcx_zone_comfort_ranking.csv", rcx_vav)
+    mark("rcx_zone_comfort_ranking.csv")
+    _write_csv(bundle_dir / "rcx_preset_coverage.csv", rcx_preset)
+    mark("rcx_preset_coverage.csv")
+
+    # Tables Rust cannot fill yet — empty with provenance flag, not dropped.
+    for empty_name in (
+        "setpoints.csv",
+        "sensor_stats_fan_on.csv",
+        "sensor_stats_fan_off.csv",
+        "sensor_diurnal_24h.csv",
+        "topology.csv",
+        "data_model.csv",
+    ):
+        if not (bundle_dir / empty_name).is_file():
+            (bundle_dir / empty_name).write_text("", encoding="utf-8")
+            mark(empty_name)
+            missing_apis.append(f"missing_api:{empty_name}")
+
+    _write_json(
+        bundle_dir / "quality_flags.json",
+        {"note": "Rust FDD APIs do not yet return SENTINEL/IMPOSSIBLE_FOR_ROLE flags"},
+    )
+    mark("quality_flags.json")
+    _write_json(bundle_dir / "package_health.json", {"errors": [], "error_count": 0})
+    mark("package_health.json")
+    _write_json(
+        bundle_dir / "effective_catalog.json",
+        {"note": "see rust registry; catalog hash compared via inventory"},
+    )
+    mark("effective_catalog.json")
+
+    manifest = {
+        "product": "OpenFDD Engineering Bundle",
+        "schema_version": "openfdd_engineering_bundle_v1",
+        "legacy_schema_version": "wattlab_dump_v3",
+        "engine": "datafusion",
+        "rust_engine_version": version,
+        "assembled_at": datetime.now(timezone.utc).isoformat(),
+        "files": written,
+        "provenance_incomplete": bool(missing_apis),
+        "missing_apis": missing_apis,
+        "source": "wattlab_parity_ofdd_rust_bundle.py",
+    }
+    _write_json(bundle_dir / "MANIFEST.json", manifest)
+    (bundle_dir / "README.md").write_text(
+        "# OpenFDD Engineering Bundle (DataFusion assembler)\n\n"
+        "Assembled from Rust JWT APIs — not pandas tools/wattlab_export.\n",
+        encoding="utf-8",
+    )
+    meta = _load(capture_dir / "parity_meta.json") or {}
+    if isinstance(meta, dict):
+        meta = dict(meta)
+        meta["bundle_dir"] = str(bundle_dir)
+        meta["missing_apis"] = missing_apis
+        _write_json(bundle_dir / "parity_meta.json", meta)
+    return manifest
+
+
+def capture_extra(base: str, token: str | None, building_id: str, capture_dir: Path) -> None:
+    extra = {}
+    body = {"building_id": building_id}
+    for name, path in EXTRA_ANALYTICS:
+        st, env = _req("POST", f"{base}{path}", token=token, body=body)
+        extra[name] = {"status": st, "body": env}
+    _write_json(capture_dir / "extra_analytics.json", extra)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--base", default=DEFAULT_BASE)
+    p.add_argument("--building-id", default="BUILDING_100")
+    p.add_argument("--schedule", type=Path, default=DEFAULT_SCHED)
+    p.add_argument("--capture-out", type=Path, default=DEFAULT_CAPTURE)
+    p.add_argument("--out", type=Path, default=DEFAULT_BUNDLE)
+    p.add_argument("--session-path", type=Path, default=DEFAULT_SESSION)
+    p.add_argument("--admin-password", default=os.environ.get("OPENFDD_ADMIN_PASSWORD", ""))
+    p.add_argument("--skip-capture", action="store_true")
+    args = p.parse_args()
+
+    if not args.skip_capture:
+        sys.argv = [
+            "wattlab_parity_ofdd_rust_capture.py",
+            "--base",
+            args.base,
+            "--building-id",
+            args.building_id,
+            "--schedule",
+            str(args.schedule),
+            "--out",
+            str(args.capture_out),
+            "--session-path",
+            str(args.session_path),
+        ]
+        if args.admin_password:
+            sys.argv.extend(["--admin-password", args.admin_password])
+        rc = capture_main()
+        if rc not in (0, 4):
+            return rc
+        token = login(args.base, args.admin_password) if args.admin_password else None
+        capture_extra(args.base, token, args.building_id, args.capture_out)
+    else:
+        extra_path = args.capture_out / "extra_analytics.json"
+        if not extra_path.is_file():
+            try:
+                token = login(args.base, args.admin_password) if args.admin_password else None
+                capture_extra(args.base, token, args.building_id, args.capture_out)
+            except Exception as exc:
+                print(f"extra analytics skipped (central down): {exc}")
+                extra_path.write_text("{}", encoding="utf-8")
+
+    manifest = assemble(args.capture_out, args.out)
+    print(f"ofdd rust bundle -> {args.out} files={len(manifest.get('files') or [])}")
+    if manifest.get("missing_apis"):
+        print(f"missing_apis={manifest['missing_apis']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -9,8 +9,9 @@ use fdd_sql::{register_parquet_tree, run_sql};
 use serde_json::{json, Value};
 
 use super::{
-    envelope_with_engine, AnalyticsEnvelope, AnalyticsQuery, DF_ENGINE, QV_ECONOMIZER,
-    QV_MECHANICAL_COOLING, QV_RUNTIME, QV_SCHEDULE, QV_SENSOR_HEALTH,
+    envelope_with_engine, AnalyticsEnvelope, AnalyticsQuery, DF_ENGINE, QV_DIURNAL, QV_ECONOMIZER,
+    QV_MECHANICAL_COOLING, QV_RUNTIME, QV_SCHEDULE, QV_SENSOR_HEALTH, QV_SENSOR_STATS,
+    QV_SETPOINTS, QV_TOPOLOGY,
 };
 
 /// Canonical numeric role columns that may appear as `history` columns after
@@ -47,6 +48,13 @@ const NUMERIC_ROLE_COLS: &[&str] = &[
     "chiller_amps",
     "oa_h",
     "return_fan",
+    "chw_supply_sp",
+    "chw_dp",
+    "chw_dp_sp",
+    "chw_flow",
+    "chw_pump_cmd",
+    "min_flow_sp",
+    "zone_t_sp",
 ];
 
 /// Resolve Parquet historian root — same env fallbacks as edge FDD registry.
@@ -853,6 +861,413 @@ pub async fn sensor_health_from_history(
         "source": "historian_parquet",
     }));
     Ok(Some(env))
+}
+
+/// Haystack-style role name used by Vibe19 analytics CSVs.
+fn role_to_haystack(role: &str) -> String {
+    match role {
+        "sat" => "discharge-air-temp".into(),
+        "sat_sp" => "discharge-air-temp-sp".into(),
+        "mat" => "mixed-air-temp".into(),
+        "rat" => "return-air-temp".into(),
+        "oa_t" => "outside-air-temp".into(),
+        "oa_h" => "outside-air-humidity".into(),
+        "oa_damper_pct" => "outside-air-damper".into(),
+        "clg_valve_pct" => "cooling-valve".into(),
+        "htg_valve_pct" => "heating-valve".into(),
+        "fan_cmd" => "fan-cmd".into(),
+        "fan_status" => "fan-status".into(),
+        "return_fan" => "return-fan-cmd".into(),
+        "duct_static" => "duct-static-pressure".into(),
+        "duct_static_sp" => "duct-static-pressure-sp".into(),
+        "zone_t" => "zone-air-temp".into(),
+        "zone_t_sp" => "zone-air-temp-sp".into(),
+        "zone_flow" => "zone-airflow".into(),
+        "min_flow_sp" => "min-flow-sp".into(),
+        "damper_pct" => "damper".into(),
+        "reheat_valve_pct" => "reheat-valve".into(),
+        "chw_supply_t" => "chilled-water-supply-temp".into(),
+        "chw_return_t" => "chilled-water-return-temp".into(),
+        "chw_supply_sp" => "chilled-water-supply-temp-sp".into(),
+        "hw_supply_t" => "hot-water-supply-temp".into(),
+        "hw_return_t" => "hot-water-return-temp".into(),
+        "chw_dp" => "chw-diff-pressure".into(),
+        "chw_dp_sp" => "chw-diff-pressure-sp".into(),
+        "chw_flow" => "chw-flow".into(),
+        "chw_pump_cmd" => "chw-pump-cmd".into(),
+        "web_oa_t" => "web-outside-air-temp".into(),
+        "web_wb_t" => "web-outside-air-wetbulb".into(),
+        other => other.to_string(),
+    }
+}
+
+fn infer_eq_type(equipment_id: &str) -> &'static str {
+    let id = equipment_id.to_ascii_uppercase();
+    if id.contains("VAV") || id.contains("ZONE") {
+        "VAV"
+    } else if id.contains("AHU") || id.contains("RTU") || id.contains("MAU") {
+        "AHU"
+    } else if id.contains("CHILL") {
+        "CHILLER"
+    } else if id.contains("BOILER") {
+        "BOILER"
+    } else if id.contains("TOWER") {
+        "COOLING_TOWER"
+    } else if id.contains("HP") || id.contains("HEAT") {
+        "HEAT_PUMP"
+    } else if id.contains("WEATHER") {
+        "WEATHER"
+    } else {
+        "GENERAL"
+    }
+}
+
+fn fan_on_sql(cols: &HashSet<String>) -> String {
+    on_expr(cols).unwrap_or_else(|| "true".into())
+}
+
+/// Sensor stats (mean/min/max/n) optionally filtered to fan-on or fan-off.
+pub async fn sensor_stats_from_history(
+    equipment_filter: Option<&[String]>,
+    building_id: Option<&str>,
+    fan_state: Option<&str>,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let role_cols: Vec<&str> = NUMERIC_ROLE_COLS
+        .iter()
+        .copied()
+        .filter(|c| cols.contains(*c))
+        .collect();
+    if role_cols.is_empty() {
+        return Ok(None);
+    }
+    let eq_filter = equipment_filter_sql(equipment_filter);
+    let fan_sql = fan_on_sql(&cols);
+    let fan_where = match fan_state {
+        Some("on") => format!(" AND ({fan_sql})"),
+        Some("off") => format!(" AND NOT ({fan_sql})"),
+        _ => String::new(),
+    };
+    let selects: Vec<String> = role_cols
+        .iter()
+        .map(|role| {
+            format!(
+                "SELECT equipment_id, '{role}' AS role, \
+                   COUNT(*) AS n, COUNT({role}) AS n_finite, \
+                   AVG({role}) AS meanv, STDDEV_POP({role}) AS stdv, \
+                   MIN({role}) AS minv, MAX({role}) AS maxv \
+                 FROM history \
+                 WHERE equipment_id IS NOT NULL{eq_filter}{fan_where} \
+                 GROUP BY equipment_id"
+            )
+        })
+        .collect();
+    let sql = format!(
+        "{} ORDER BY equipment_id, role",
+        selects.join(" UNION ALL ")
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    let mut rows = Vec::with_capacity(result.rows.len());
+    for r in &result.rows {
+        let n_finite = as_u64(r.get("n_finite"));
+        if n_finite == 0 {
+            continue;
+        }
+        let eq = r
+            .get("equipment_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let role = r.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        rows.push(json!({
+            "equipment_id": eq,
+            "equipment_type": infer_eq_type(&eq),
+            "role": role_to_haystack(role),
+            "source": "historian",
+            "n": as_u64(r.get("n")),
+            "valid_count": n_finite,
+            "count": as_u64(r.get("n")),
+            "mean": as_f64(r.get("meanv")).map(round4),
+            "std": as_f64(r.get("stdv")).map(round6),
+            "min": as_f64(r.get("minv")).map(round4),
+            "max": as_f64(r.get("maxv")).map(round4),
+            "fan_state": fan_state.unwrap_or("all"),
+        }));
+    }
+    let mut env = envelope_with_engine(
+        QV_SENSOR_STATS,
+        &AnalyticsQuery::default(),
+        vec!["sensor_stats from historian Parquet".into()],
+        DF_ENGINE,
+    );
+    env.rows = rows.clone();
+    env.equipment = rows;
+    env.coverage = Some(json!({"history_rows": n, "fan_state": fan_state.unwrap_or("all")}));
+    Ok(Some(env))
+}
+
+const SP_ROLES: &[&str] = &[
+    "sat_sp",
+    "zone_t_sp",
+    "chw_supply_sp",
+    "duct_static_sp",
+    "min_flow_sp",
+];
+
+/// Occupied / unoccupied setpoint medians.
+pub async fn setpoints_from_history(
+    equipment_filter: Option<&[String]>,
+    building_id: Option<&str>,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let present: Vec<&str> = SP_ROLES
+        .iter()
+        .copied()
+        .filter(|c| cols.contains(*c))
+        .collect();
+    if present.is_empty() {
+        return Ok(None);
+    }
+    let eq_filter = equipment_filter_sql(equipment_filter);
+    let occ = if cols.contains("occ_mode") {
+        occupied_expr().to_string()
+    } else {
+        "true".into()
+    };
+    let selects: Vec<String> = present
+        .iter()
+        .map(|role| {
+            format!(
+                "SELECT equipment_id, '{role}' AS role, \
+                   approx_percentile({role}, 0.5) FILTER (WHERE ({occ})) AS median_occupied, \
+                   approx_percentile({role}, 0.5) FILTER (WHERE NOT ({occ})) AS median_unoccupied, \
+                   approx_percentile({role}, 0.5) AS median_all, \
+                   COUNT({role}) FILTER (WHERE ({occ})) AS n_occupied, \
+                   COUNT({role}) FILTER (WHERE NOT ({occ})) AS n_unoccupied \
+                 FROM history \
+                 WHERE equipment_id IS NOT NULL{eq_filter} \
+                 GROUP BY equipment_id"
+            )
+        })
+        .collect();
+    let sql = selects.join(" UNION ALL ");
+    let result = match run_sql(&ctx, &sql).await {
+        Ok(r) => r,
+        Err(_) => {
+            // FILTER / approx_percentile may be unavailable — fall back to AVG.
+            let selects: Vec<String> = present
+                .iter()
+                .map(|role| {
+                    format!(
+                        "SELECT equipment_id, '{role}' AS role, \
+                           AVG({role}) AS median_all, \
+                           COUNT({role}) AS n_occupied, \
+                           CAST(0 AS BIGINT) AS n_unoccupied, \
+                           AVG({role}) AS median_occupied, \
+                           AVG({role}) AS median_unoccupied \
+                         FROM history \
+                         WHERE equipment_id IS NOT NULL{eq_filter} \
+                         GROUP BY equipment_id"
+                    )
+                })
+                .collect();
+            run_sql(&ctx, &selects.join(" UNION ALL ")).await?
+        }
+    };
+    let mut rows = Vec::new();
+    for r in &result.rows {
+        let eq = r
+            .get("equipment_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let role = r.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        rows.push(json!({
+            "equipment_id": eq,
+            "equipment_type": infer_eq_type(&eq),
+            "role": role_to_haystack(role),
+            "median_occupied": as_f64(r.get("median_occupied")).map(round4),
+            "median_unoccupied": as_f64(r.get("median_unoccupied")).map(round4),
+            "median_all": as_f64(r.get("median_all")).map(round4),
+            "n_occupied": as_u64(r.get("n_occupied")),
+            "n_unoccupied": as_u64(r.get("n_unoccupied")),
+        }));
+    }
+    let mut env = envelope_with_engine(
+        QV_SETPOINTS,
+        &AnalyticsQuery::default(),
+        vec!["setpoints from historian Parquet".into()],
+        DF_ENGINE,
+    );
+    env.rows = rows.clone();
+    env.equipment = rows;
+    env.coverage = Some(json!({"history_rows": n}));
+    Ok(Some(env))
+}
+
+/// 24h diurnal profiles by hour-of-day and fan state.
+pub async fn diurnal_from_history(
+    equipment_filter: Option<&[String]>,
+    building_id: Option<&str>,
+) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let Some(ts_col) = pick_ts_col(&cols) else {
+        return Ok(None);
+    };
+    let role_cols: Vec<&str> = NUMERIC_ROLE_COLS
+        .iter()
+        .copied()
+        .filter(|c| cols.contains(*c))
+        .take(12)
+        .collect();
+    if role_cols.is_empty() {
+        return Ok(None);
+    }
+    let eq_filter = equipment_filter_sql(equipment_filter);
+    let fan_sql = fan_on_sql(&cols);
+    let selects: Vec<String> = role_cols
+        .iter()
+        .map(|role| {
+            format!(
+                "SELECT equipment_id, '{role}' AS role, \
+                   date_part('hour', {ts_col}) AS hour, \
+                   CASE WHEN ({fan_sql}) THEN 'on' ELSE 'off' END AS fan_state, \
+                   COUNT({role}) AS n, AVG({role}) AS meanv, \
+                   MIN({role}) AS minv, MAX({role}) AS maxv \
+                 FROM history \
+                 WHERE equipment_id IS NOT NULL AND {role} IS NOT NULL{eq_filter} \
+                 GROUP BY equipment_id, date_part('hour', {ts_col}), \
+                   CASE WHEN ({fan_sql}) THEN 'on' ELSE 'off' END"
+            )
+        })
+        .collect();
+    let sql = format!(
+        "{} ORDER BY equipment_id, role, hour, fan_state",
+        selects.join(" UNION ALL ")
+    );
+    let result = run_sql(&ctx, &sql).await?;
+    let mut rows = Vec::new();
+    for r in &result.rows {
+        let eq = r
+            .get("equipment_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let role = r.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        rows.push(json!({
+            "equipment_id": eq,
+            "equipment_type": infer_eq_type(&eq),
+            "role": role_to_haystack(role),
+            "source": "historian",
+            "day_type": "all",
+            "fan_state": r.get("fan_state").cloned().unwrap_or(json!("all")),
+            "hour": as_u64(r.get("hour")),
+            "n": as_u64(r.get("n")),
+            "mean": as_f64(r.get("meanv")).map(round4),
+            "min": as_f64(r.get("minv")).map(round4),
+            "max": as_f64(r.get("maxv")).map(round4),
+        }));
+    }
+    let mut env = envelope_with_engine(
+        QV_DIURNAL,
+        &AnalyticsQuery::default(),
+        vec!["sensor_diurnal_24h from historian Parquet".into()],
+        DF_ENGINE,
+    );
+    env.rows = rows.clone();
+    env.equipment = rows;
+    env.coverage = Some(json!({"history_rows": n}));
+    Ok(Some(env))
+}
+
+/// Equipment topology (feeds / fedBy) inferred from equipment ids.
+pub async fn topology_from_history(building_id: Option<&str>) -> Result<Option<AnalyticsEnvelope>> {
+    let Some((ctx, _cols, n)) = open_history_scoped(building_id).await? else {
+        return Ok(None);
+    };
+    let result = run_sql(
+        &ctx,
+        "SELECT DISTINCT equipment_id FROM history WHERE equipment_id IS NOT NULL ORDER BY 1",
+    )
+    .await?;
+    let ids: Vec<String> = result
+        .rows
+        .iter()
+        .filter_map(|r| {
+            r.get("equipment_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    let ahus: Vec<&str> = ids
+        .iter()
+        .filter(|id| infer_eq_type(id) == "AHU")
+        .map(|s| s.as_str())
+        .collect();
+    let mut rows = Vec::new();
+    let mut data_model = Vec::new();
+    for id in &ids {
+        let kind = infer_eq_type(id);
+        data_model.push(json!({
+            "equipment_id": id,
+            "equipment_type": kind,
+            "haystack_point": "",
+            "csv_column": "",
+            "present_in_history": true,
+            "required_by_rules": "",
+        }));
+        if kind == "VAV" {
+            let parent = infer_parent_ahu(id, &ahus);
+            if let Some(ahu) = parent {
+                rows.push(json!({
+                    "equipment_id": id,
+                    "relation": "fedBy",
+                    "related_ids": ahu,
+                    "related_count": 1,
+                    "parent_ahu": ahu,
+                    "vav_id": id,
+                }));
+                rows.push(json!({
+                    "equipment_id": ahu,
+                    "relation": "feeds",
+                    "related_ids": id,
+                    "related_count": 1,
+                    "parent_ahu": ahu,
+                    "vav_id": id,
+                }));
+            }
+        }
+    }
+    let mut env = envelope_with_engine(
+        QV_TOPOLOGY,
+        &AnalyticsQuery::default(),
+        vec!["topology inferred from historian equipment ids".into()],
+        DF_ENGINE,
+    );
+    env.rows = rows;
+    env.equipment = data_model;
+    env.coverage = Some(json!({"history_rows": n, "equipment_count": ids.len()}));
+    Ok(Some(env))
+}
+
+fn infer_parent_ahu(vav_id: &str, ahus: &[&str]) -> Option<String> {
+    let up = vav_id.to_ascii_uppercase();
+    for ahu in ahus {
+        let a = ahu.to_ascii_uppercase();
+        if up.contains(&a) {
+            return Some((*ahu).to_string());
+        }
+    }
+    if ahus.len() == 1 {
+        return Some(ahus[0].to_string());
+    }
+    None
 }
 
 /// Boolean occupied-expression from `occ_mode` (Utf8).

--- a/services/central/src/analytics/mod.rs
+++ b/services/central/src/analytics/mod.rs
@@ -35,6 +35,10 @@ pub const QV_ECONOMIZER: &str = "economizer-diagnostics-v1";
 pub const QV_RCX_AHU: &str = "rcx-ahu-v1";
 pub const QV_RCX_VAV: &str = "rcx-vav-v1";
 pub const QV_METERING: &str = "metering-v1";
+pub const QV_SETPOINTS: &str = "setpoints-v1";
+pub const QV_DIURNAL: &str = "sensor-diurnal-v1";
+pub const QV_TOPOLOGY: &str = "topology-v1";
+pub const QV_SENSOR_STATS: &str = "sensor-stats-v1";
 
 /// Shared query fields for `/api/analytics/*` requests.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/services/central/src/openapi.rs
+++ b/services/central/src/openapi.rs
@@ -170,6 +170,34 @@ mod live_routes {
     pub fn analytics_metering() {}
 
     #[utoipa::path(
+        post, path = "/api/analytics/setpoints", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Occupied/unoccupied setpoint medians", body = serde_json::Value))
+    )]
+    pub fn analytics_setpoints() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/diurnal", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "24h sensor diurnal profiles", body = serde_json::Value))
+    )]
+    pub fn analytics_diurnal() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/topology", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Equipment topology (feeds/fedBy)", body = serde_json::Value))
+    )]
+    pub fn analytics_topology() {}
+
+    #[utoipa::path(
+        post, path = "/api/analytics/sensor-stats", tag = "analytics",
+        request_body = serde_json::Value,
+        responses((status = 200, description = "Sensor stats all/fan-on/fan-off", body = serde_json::Value))
+    )]
+    pub fn analytics_sensor_stats() {}
+
+    #[utoipa::path(
         get, path = "/api/reports", tag = "reports",
         responses((status = 200, description = "List report artifacts / drafts", body = serde_json::Value))
     )]
@@ -241,6 +269,10 @@ mod live_routes {
         live_routes::analytics_sensor_health,
         live_routes::analytics_mechanical_cooling,
         live_routes::analytics_metering,
+        live_routes::analytics_setpoints,
+        live_routes::analytics_diurnal,
+        live_routes::analytics_topology,
+        live_routes::analytics_sensor_stats,
         live_routes::reports_list,
         live_routes::reports_engineering_findings,
         live_routes::reports_templates,

--- a/services/central/src/routes.rs
+++ b/services/central/src/routes.rs
@@ -203,6 +203,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         )
         .route("/api/analytics/metering", post(analytics_metering))
         .route("/api/analytics/fuel", post(analytics_fuel))
+        .route("/api/analytics/setpoints", post(analytics_setpoints))
+        .route("/api/analytics/diurnal", post(analytics_diurnal))
+        .route("/api/analytics/topology", post(analytics_topology))
+        .route("/api/analytics/sensor-stats", post(analytics_sensor_stats))
         .route("/api/fuel/campus/import", post(fuel_campus_import))
         .route("/api/fuel/campus", get(fuel_campus_list))
         .route(
@@ -2048,6 +2052,100 @@ async fn analytics_metering(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
         "ok": true,
         "analytics": analytics::metering::handle_async(&req).await.to_json(),
     }))
+}
+
+async fn analytics_setpoints(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    let env = match analytics::historian::setpoints_from_history(
+        req.query.equipment_ids.as_deref(),
+        req.query.building_id.as_deref(),
+    )
+    .await
+    {
+        Ok(Some(env)) => analytics::finalize_historian(&req, env, analytics::QV_SETPOINTS),
+        Ok(None) => analytics::envelope_with_engine(
+            analytics::QV_SETPOINTS,
+            &req.query,
+            vec!["setpoints unavailable — no setpoint columns on historian".into()],
+            analytics::DF_ENGINE,
+        ),
+        Err(e) => analytics::envelope(
+            analytics::QV_SETPOINTS,
+            &req.query,
+            vec![format!("setpoints failed: {e}")],
+        ),
+    };
+    Json(json!({"ok": true, "analytics": env.to_json()}))
+}
+
+async fn analytics_diurnal(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    let env = match analytics::historian::diurnal_from_history(
+        req.query.equipment_ids.as_deref(),
+        req.query.building_id.as_deref(),
+    )
+    .await
+    {
+        Ok(Some(env)) => analytics::finalize_historian(&req, env, analytics::QV_DIURNAL),
+        Ok(None) => analytics::envelope_with_engine(
+            analytics::QV_DIURNAL,
+            &req.query,
+            vec!["diurnal unavailable — no historian timestamp/roles".into()],
+            analytics::DF_ENGINE,
+        ),
+        Err(e) => analytics::envelope(
+            analytics::QV_DIURNAL,
+            &req.query,
+            vec![format!("diurnal failed: {e}")],
+        ),
+    };
+    Json(json!({"ok": true, "analytics": env.to_json()}))
+}
+
+async fn analytics_topology(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    let env =
+        match analytics::historian::topology_from_history(req.query.building_id.as_deref()).await {
+            Ok(Some(env)) => analytics::finalize_historian(&req, env, analytics::QV_TOPOLOGY),
+            Ok(None) => analytics::envelope_with_engine(
+                analytics::QV_TOPOLOGY,
+                &req.query,
+                vec!["topology unavailable — no historian equipment".into()],
+                analytics::DF_ENGINE,
+            ),
+            Err(e) => analytics::envelope(
+                analytics::QV_TOPOLOGY,
+                &req.query,
+                vec![format!("topology failed: {e}")],
+            ),
+        };
+    Json(json!({"ok": true, "analytics": env.to_json()}))
+}
+
+async fn analytics_sensor_stats(Json(req): Json<AnalyticsRequest>) -> Json<Value> {
+    let fan_state = req
+        .series
+        .as_ref()
+        .and_then(|s| s.get("fan_state"))
+        .and_then(|v| v.as_str());
+    let env = match analytics::historian::sensor_stats_from_history(
+        req.query.equipment_ids.as_deref(),
+        req.query.building_id.as_deref(),
+        fan_state,
+    )
+    .await
+    {
+        Ok(Some(env)) => analytics::finalize_historian(&req, env, analytics::QV_SENSOR_STATS),
+        Ok(None) => analytics::envelope_with_engine(
+            analytics::QV_SENSOR_STATS,
+            &req.query,
+            vec!["sensor-stats unavailable — no numeric roles".into()],
+            analytics::DF_ENGINE,
+        ),
+        Err(e) => analytics::envelope(
+            analytics::QV_SENSOR_STATS,
+            &req.query,
+            vec![format!("sensor-stats failed: {e}")],
+        ),
+    };
+    Json(json!({"ok": true, "analytics": env.to_json()}))
 }
 
 async fn analytics_fuel(Json(req): Json<FuelRequest>) -> Json<Value> {

--- a/sql_rules/ahu_ducthi.sql
+++ b/sql_rules/ahu_ducthi.sql
@@ -4,7 +4,13 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     duct_static, duct_static_sp,
-    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -13,7 +19,7 @@ base AS (
     timestamp_utc,
     CAST(CASE
       WHEN duct_static IS NULL OR duct_static_sp IS NULL THEN 0
-      WHEN (fan IS NOT NULL AND fan >= 0.05 OR duct_static > {{PRESSURE_ON_MIN}})
+      WHEN (COALESCE(fan_on, 0) = 1 OR duct_static > {{PRESSURE_ON_MIN}})
        AND duct_static > duct_static_sp + {{DUCT_HIGH_MARGIN}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault

--- a/sql_rules/ahu_satdev.sql
+++ b/sql_rules/ahu_satdev.sql
@@ -1,14 +1,30 @@
--- ahu_satdev.sql — SAT deviation from setpoint
-WITH base AS (
+-- ahu_satdev.sql — SAT deviation from setpoint (fan_running + confirm)
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    sat,
+    sat_sp,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+  FROM history
+),
+base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN sat IS NULL OR sat_sp IS NULL THEN 0
       WHEN ABS(sat - sat_sp) > {{SAT_DEV_ERR}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM history
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/ahu_simul.sql
+++ b/sql_rules/ahu_simul.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     CASE WHEN htg_valve_pct IS NULL THEN NULL WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg,
-    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN htg IS NULL OR clg IS NULL THEN 0
       WHEN htg > {{VALVE_OPEN_PCT}} AND clg > {{VALVE_OPEN_PCT}} THEN 1
       ELSE 0

--- a/sql_rules/chw2_dp_low.sql
+++ b/sql_rules/chw2_dp_low.sql
@@ -4,19 +4,33 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     chw_dp, chw_dp_sp,
-    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump,
+    pump_status, chiller_status, chw_flow
   FROM history
+),
+proof AS (
+  SELECT
+    *,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END
+      WHEN pump IS NOT NULL THEN CASE WHEN pump > 0.05 THEN 1 ELSE 0 END
+      ELSE NULL
+    END AS proof_on
+  FROM h
 ),
 base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN proof_on IS NULL OR proof_on = 0 THEN 0
       WHEN chw_dp IS NULL OR chw_dp_sp IS NULL OR pump IS NULL THEN 0
       WHEN pump >= {{PUMP_HI}} AND chw_dp < chw_dp_sp - {{DP_MARGIN}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM h
+  FROM proof
 ),
 lagged AS (
   SELECT

--- a/sql_rules/chw3_supply_band.sql
+++ b/sql_rules/chw3_supply_band.sql
@@ -4,20 +4,32 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     chw_supply_t, chw_supply_sp,
-    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump,
+    pump_status, chiller_status, chw_flow
   FROM history
+),
+proof AS (
+  SELECT *,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END
+      WHEN pump IS NOT NULL THEN CASE WHEN pump > 0.05 THEN 1 ELSE 0 END
+      ELSE NULL
+    END AS proof_on
+  FROM h
 ),
 base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN proof_on IS NULL OR proof_on = 0 THEN 0
       WHEN chw_supply_t IS NULL OR chw_supply_sp IS NULL THEN 0
-      WHEN pump IS NOT NULL AND pump <= 0.05 THEN 0
       WHEN ABS(chw_supply_t - chw_supply_sp) > {{SP_BAND}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM h
+  FROM proof
 ),
 lagged AS (
   SELECT

--- a/sql_rules/chw4_flow_high.sql
+++ b/sql_rules/chw4_flow_high.sql
@@ -4,19 +4,31 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     chw_flow,
-    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump
+    CASE WHEN chw_pump_cmd IS NULL THEN NULL WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END AS pump,
+    pump_status, chiller_status
   FROM history
+),
+proof AS (
+  SELECT *,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN pump IS NOT NULL THEN CASE WHEN pump > 0.05 THEN 1 ELSE 0 END
+      ELSE NULL
+    END AS proof_on
+  FROM h
 ),
 base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN proof_on IS NULL OR proof_on = 0 THEN 0
       WHEN chw_flow IS NULL OR pump IS NULL THEN 0
       WHEN pump >= {{PUMP_HI}} AND chw_flow > {{FLOW_HI}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM h
+  FROM proof
 ),
 lagged AS (
   SELECT

--- a/sql_rules/cw_apr_1.sql
+++ b/sql_rules/cw_apr_1.sql
@@ -4,7 +4,19 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     cw_supply_t, web_wb_t,
-    CASE WHEN tower_fan_cmd IS NULL THEN NULL WHEN tower_fan_cmd > 1.0 THEN tower_fan_cmd / 100.0 ELSE tower_fan_cmd END AS fan
+    CASE WHEN tower_fan_cmd IS NULL THEN NULL WHEN tower_fan_cmd > 1.0 THEN tower_fan_cmd / 100.0 ELSE tower_fan_cmd END AS fan,
+    pump_status,
+    chiller_status,
+    chw_flow,
+    chw_pump_cmd,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      ELSE 0
+    END AS proof_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +24,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(proof_on, 0) = 0 THEN 0
       WHEN cw_supply_t IS NULL OR web_wb_t IS NULL OR fan IS NULL THEN 0
       WHEN fan >= {{TOWER_FAN_HI}}
        AND (cw_supply_t - web_wb_t) > {{APPROACH_MAX_F}} THEN 1

--- a/sql_rules/cw_fan_1.sql
+++ b/sql_rules/cw_fan_1.sql
@@ -4,7 +4,19 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     cw_supply_t, web_wb_t,
-    CASE WHEN tower_fan_cmd IS NULL THEN NULL WHEN tower_fan_cmd > 1.0 THEN tower_fan_cmd / 100.0 ELSE tower_fan_cmd END AS fan
+    CASE WHEN tower_fan_cmd IS NULL THEN NULL WHEN tower_fan_cmd > 1.0 THEN tower_fan_cmd / 100.0 ELSE tower_fan_cmd END AS fan,
+    pump_status,
+    chiller_status,
+    chw_flow,
+    chw_pump_cmd,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      ELSE 0
+    END AS proof_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +24,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(proof_on, 0) = 0 THEN 0
       WHEN cw_supply_t IS NULL OR web_wb_t IS NULL OR fan IS NULL THEN 0
       WHEN fan >= {{TOWER_FAN_HI}}
        AND cw_supply_t > web_wb_t + {{CW_APPROACH}} + {{EXCESS_BEYOND_APPROACH_F}} THEN 1

--- a/sql_rules/cw_opt_1.sql
+++ b/sql_rules/cw_opt_1.sql
@@ -1,14 +1,34 @@
 -- cw_opt_1.sql — Condenser water not optimized vs wet-bulb
-WITH base AS (
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    cw_supply_t,
+    web_wb_t,
+    pump_status,
+    chiller_status,
+    chw_flow,
+    chw_pump_cmd,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      ELSE 0
+    END AS proof_on
+  FROM history
+),
+base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(proof_on, 0) = 0 THEN 0
       WHEN cw_supply_t IS NULL OR web_wb_t IS NULL THEN 0
       WHEN cw_supply_t < web_wb_t + {{CW_APPROACH}} - {{CW_SLACK}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM history
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/dmp1_oa_damper_leak.sql
+++ b/sql_rules/dmp1_oa_damper_leak.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     oa_t, mat,
-    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN oa_d IS NULL OR oa_t IS NULL OR mat IS NULL THEN 0
       WHEN oa_d <= 0.05 AND ABS(mat - oa_t) < {{LEAK_DELTA}} THEN 1
       ELSE 0

--- a/sql_rules/econ1_stuck_closed.sql
+++ b/sql_rules/econ1_stuck_closed.sql
@@ -4,7 +4,13 @@ WITH h AS (
     equipment_id,
     oa_t,
     CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan_cmd,
-    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_damper_pct
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_damper_pct,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 )
 SELECT

--- a/sql_rules/econ3_mech_without_econ.sql
+++ b/sql_rules/econ3_mech_without_econ.sql
@@ -5,7 +5,15 @@ WITH h AS (
     timestamp_utc,
     web_oa_t, web_oa_dp,
     CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
-    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -13,6 +21,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN web_oa_t IS NULL OR web_oa_dp IS NULL OR oa_d IS NULL OR clg IS NULL THEN 0
       WHEN web_oa_t >= {{ECON3_DB_MIN}} AND web_oa_t < {{ECON3_DB_MAX}} AND web_oa_dp < {{ECON3_DP_MAX}}
        AND clg > 0.01 AND oa_d < {{ECON3_DAMPER_HI}} THEN 1

--- a/sql_rules/econ4_low_oa_frac.sql
+++ b/sql_rules/econ4_low_oa_frac.sql
@@ -6,7 +6,13 @@ WITH h AS (
     mat,
     rat,
     oa_t,
-    COALESCE(CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END, 0.0) AS fan
+    COALESCE(CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END, 0.0) AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN fan > 0.01 AND mat IS NOT NULL AND rat IS NOT NULL AND oa_t IS NOT NULL
        AND ABS(rat - oa_t) > 2.2
        AND ((mat - rat) / NULLIF(oa_t - rat, 0)) * 100.0 < {{OA_MIN_PCT}}

--- a/sql_rules/econ5_preheat_over.sql
+++ b/sql_rules/econ5_preheat_over.sql
@@ -6,7 +6,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     preheat_leave_t, sat_sp, oa_t,
-    CASE WHEN htg_valve_pct IS NULL THEN 0.0 WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg
+    CASE WHEN htg_valve_pct IS NULL THEN 0.0 WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +22,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN preheat_leave_t IS NULL OR sat_sp IS NULL OR oa_t IS NULL THEN 0
       WHEN htg > 0.01 AND (
         (oa_t > sat_sp AND preheat_leave_t - oa_t > {{PREHEAT_OVER_F}})

--- a/sql_rules/econ6_econ_freezing.sql
+++ b/sql_rules/econ6_econ_freezing.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     web_oa_t,
-    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN web_oa_t IS NULL OR oa_d IS NULL THEN 0
       WHEN web_oa_t < {{ECON6_OAT_MAX_F}} AND oa_d > {{ECON6_DAMPER_MAX}} THEN 1
       ELSE 0

--- a/sql_rules/econ7_ok_not_economizing.sql
+++ b/sql_rules/econ7_ok_not_economizing.sql
@@ -5,7 +5,15 @@ WITH h AS (
     timestamp_utc,
     web_oa_t, web_oa_dp,
     CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
-    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -13,6 +21,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN web_oa_t IS NULL OR web_oa_dp IS NULL OR oa_d IS NULL OR clg IS NULL THEN 0
       WHEN web_oa_t >= {{ECON7_DB_MIN}} AND web_oa_t < {{ECON7_DB_MAX}} AND web_oa_dp < {{ECON7_DP_MAX}}
        AND clg > 0.05 AND oa_d < {{ECON7_DAMPER_MIN}} THEN 1

--- a/sql_rules/economizer_fault.sql
+++ b/sql_rules/economizer_fault.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     oa_t,
-    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_damper_pct
+    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_damper_pct,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN oa_t IS NOT NULL AND oa_damper_pct IS NOT NULL
        AND oa_t > {{ECON2_OAT_HI}} AND oa_damper_pct > {{ECON2_DAMPER}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault

--- a/sql_rules/fc10_mat_oa_clg.sql
+++ b/sql_rules/fc10_mat_oa_clg.sql
@@ -6,7 +6,15 @@ WITH h AS (
     mat,
     oa_t,
     COALESCE(CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END, 0.0) AS oa_damper_pct,
-    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct
+    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +22,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN mat IS NOT NULL AND oa_t IS NOT NULL
        AND clg_valve_pct > 0.01 AND oa_damper_pct > 0.9
        AND ABS(mat - oa_t) > 1.626345153

--- a/sql_rules/fc11_oa_sat_sp_clg.sql
+++ b/sql_rules/fc11_oa_sat_sp_clg.sql
@@ -6,7 +6,15 @@ WITH h AS (
     oa_t,
     sat_sp,
     COALESCE(CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END, 0.0) AS oa_damper_pct,
-    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct
+    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +22,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN oa_t IS NOT NULL AND sat_sp IS NOT NULL
        AND clg_valve_pct > 0.01 AND oa_damper_pct > 0.9
        AND (oa_t + 1.15) < (sat_sp - 0.55 - 1.15)

--- a/sql_rules/fc12_sat_mat_clg.sql
+++ b/sql_rules/fc12_sat_mat_clg.sql
@@ -6,7 +6,15 @@ WITH h AS (
     sat,
     mat,
     COALESCE(CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END, 0.0) AS oa_damper_pct,
-    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct
+    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +22,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN sat IS NOT NULL AND mat IS NOT NULL AND clg_valve_pct > 0.01
        AND (sat - 1.15 - 0.55) > (mat + 1.15)
        AND (oa_damper_pct <= 0.05 OR oa_damper_pct > 0.9)

--- a/sql_rules/fc14_chw_coil_dt_inactive.sql
+++ b/sql_rules/fc14_chw_coil_dt_inactive.sql
@@ -7,7 +7,13 @@ WITH h AS (
     mat, sat,
     CASE WHEN clg_valve_pct IS NULL THEN 0.0 WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
     CASE WHEN oa_damper_pct IS NULL THEN 0.0 WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
-    CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -15,6 +21,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN mat IS NULL OR sat IS NULL THEN 0
       WHEN fan < 0.05 THEN 0
       WHEN clg > 0.01 THEN 0

--- a/sql_rules/fc15_hw_coil_dt_inactive.sql
+++ b/sql_rules/fc15_hw_coil_dt_inactive.sql
@@ -6,7 +6,13 @@ WITH h AS (
     timestamp_utc,
     mat, sat,
     CASE WHEN htg_valve_pct IS NULL THEN 0.0 WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg,
-    CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN mat IS NULL OR sat IS NULL THEN 0
       WHEN fan < 0.05 THEN 0
       WHEN htg > 0.01 THEN 0

--- a/sql_rules/fc1_duct_static_low.sql
+++ b/sql_rules/fc1_duct_static_low.sql
@@ -5,7 +5,13 @@ WITH h AS (
     timestamp_utc,
     duct_static,
     duct_static_sp,
-    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan_cmd
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan_cmd,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -13,6 +19,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN duct_static IS NOT NULL AND duct_static_sp IS NOT NULL
        AND duct_static < duct_static_sp - {{EPS_DSP}}
        AND fan_cmd >= 1.0 - {{EPS_VFD_SPD}}

--- a/sql_rules/fc2_mat_low.sql
+++ b/sql_rules/fc2_mat_low.sql
@@ -6,7 +6,13 @@ WITH h AS (
     mat,
     oa_t,
     rat,
-    COALESCE(CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END, 0.0) AS fan
+    COALESCE(CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END, 0.0) AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,9 +20,9 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
-      WHEN fan > 0.01 AND mat IS NOT NULL AND oa_t IS NOT NULL AND rat IS NOT NULL
-       AND (mat - 1.15) < (rat - 1.15)
-       AND (mat - 1.15) < (oa_t - 1.15)
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
+      WHEN mat IS NOT NULL AND oa_t IS NOT NULL AND rat IS NOT NULL
+       AND (mat + 1.15) < (CASE WHEN rat < oa_t THEN rat ELSE oa_t END) - 1.15
       THEN 1 ELSE 0 END AS INT) AS raw_fault
   FROM h
 ),

--- a/sql_rules/fc3_mat_high.sql
+++ b/sql_rules/fc3_mat_high.sql
@@ -6,7 +6,13 @@ WITH h AS (
     mat,
     oa_t,
     rat,
-    COALESCE(CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END, 0.0) AS fan
+    COALESCE(CASE WHEN fan_cmd IS NULL THEN 0.0 WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END, 0.0) AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN fan > 0.01 AND mat IS NOT NULL AND oa_t IS NOT NULL AND rat IS NOT NULL
        AND (mat - 1.15) > (rat + 1.15)
        AND (mat - 1.15) > (oa_t + 1.15)

--- a/sql_rules/fc4_os_hunting.sql
+++ b/sql_rules/fc4_os_hunting.sql
@@ -6,7 +6,13 @@ WITH h AS (
     timestamp_utc,
     CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
     CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
-    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1.0 ELSE 0.0 END
+      WHEN fan_cmd IS NULL THEN NULL
+      WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0
+      ELSE fan_cmd
+    END AS fan
   FROM history
 ),
 modes AS (

--- a/sql_rules/fc5_sat_cold_heating.sql
+++ b/sql_rules/fc5_sat_cold_heating.sql
@@ -5,7 +5,13 @@ WITH h AS (
     timestamp_utc,
     sat, mat,
     CASE WHEN htg_valve_pct IS NULL THEN NULL WHEN htg_valve_pct > 1.0 THEN htg_valve_pct / 100.0 ELSE htg_valve_pct END AS htg,
-    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -13,6 +19,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN sat IS NULL OR mat IS NULL OR htg IS NULL OR fan IS NULL THEN 0
       WHEN fan >= 0.05 AND htg > {{HTG_ON_MIN}}
        AND (sat + {{MIX_TOL}}) <= (mat - {{MIX_TOL}} + 0.55) THEN 1

--- a/sql_rules/fc6_oa_frac_mismatch.sql
+++ b/sql_rules/fc6_oa_frac_mismatch.sql
@@ -5,7 +5,13 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     mat, rat, oa_t,
-    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -13,6 +19,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN mat IS NULL OR rat IS NULL OR oa_t IS NULL OR fan IS NULL THEN 0
       WHEN fan < 0.05 THEN 0
       WHEN ABS(rat - oa_t) < {{DELTA_T_MIN}} THEN 0

--- a/sql_rules/fc8_sat_mat_econ.sql
+++ b/sql_rules/fc8_sat_mat_econ.sql
@@ -6,7 +6,15 @@ WITH h AS (
     sat,
     mat,
     COALESCE(CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END, 0.0) AS oa_damper_pct,
-    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct
+    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +22,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN sat IS NOT NULL AND mat IS NOT NULL
        AND oa_damper_pct > 0.05 AND clg_valve_pct < 0.1
        AND ABS(sat - 0.55 - mat) > 1.626345153

--- a/sql_rules/fc9_oa_sat_sp_econ.sql
+++ b/sql_rules/fc9_oa_sat_sp_econ.sql
@@ -6,7 +6,15 @@ WITH h AS (
     oa_t,
     sat_sp,
     COALESCE(CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END, 0.0) AS oa_damper_pct,
-    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct
+    COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +22,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN oa_t IS NOT NULL AND sat_sp IS NOT NULL
        AND oa_damper_pct > 0.05 AND clg_valve_pct < 0.1
        AND (oa_t - 1.15) > (sat_sp - 0.55 + 1.15)

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -42,35 +42,27 @@
     {
       "rule_id": "SV-RANGE",
       "title": "Sensor out of hard range",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "oa_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd",
+        "pump_status",
+        "chw_pump_cmd",
+        "chiller_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -78,37 +70,9 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
-        },
-        "range_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Humidity range scale"
-        },
-        "range_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Pressure range scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_range",
+      "pandas_implementation": "sv_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
       "test_coverage": [
@@ -121,51 +85,37 @@
     {
       "rule_id": "SV-FLATLINE",
       "title": "Sensor flatline (stuck)",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "oa_t"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd",
+        "pump_status",
+        "chw_pump_cmd",
+        "chiller_status"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
           "label": "Flatline tolerance"
-        },
-        "flatline_hours": {
-          "default": 1.0,
-          "unit": "h",
-          "min": 0.5,
-          "max": 8.0,
-          "step": 0.5,
-          "label": "Flatline window"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_flatline",
+      "pandas_implementation": "sv_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
       "test_coverage": [],
@@ -176,35 +126,27 @@
     {
       "rule_id": "SV-SPIKE",
       "title": "Sensor rate-of-change spike",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "oa_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd",
+        "pump_status",
+        "chw_pump_cmd",
+        "chiller_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -212,45 +154,9 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
-        },
-        "spike_scale_temperature": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Temp spike scale"
-        },
-        "spike_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Humidity spike scale"
-        },
-        "spike_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Pressure spike scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_spike",
+      "pandas_implementation": "sv_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
       "test_coverage": [],
@@ -261,21 +167,19 @@
     {
       "rule_id": "SV-STALE",
       "title": "Stale data (no fresh samples)",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "required_roles": [
-        "fan_cmd"
-      ],
+      "equipment_types": [],
+      "required_roles": [],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -283,21 +187,9 @@
           "max": 12.0,
           "step": 0.5,
           "label": "Stale window"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_stale",
+      "pandas_implementation": "sv_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
       "test_coverage": [],
@@ -308,21 +200,21 @@
     {
       "rule_id": "SV-RATE",
       "title": "Context-aware sensor rate of change",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -330,53 +222,9 @@
           "max": 60.0,
           "step": 1.0,
           "label": "Fault persistence"
-        },
-        "transition_window_min": {
-          "default": 20.0,
-          "unit": "min",
-          "min": 5.0,
-          "max": 60.0,
-          "step": 5.0,
-          "label": "Transition window"
-        },
-        "max_gap_hours": {
-          "default": 2.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 6.0,
-          "step": 0.25,
-          "label": "Max sample gap"
-        },
-        "design_flow": {
-          "default": 0.0,
-          "unit": "cfm",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 100.0,
-          "label": "Design flow (flow profiles)"
-        },
-        "sensor_span": {
-          "default": 0.0,
-          "unit": "eng",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 10.0,
-          "label": "Sensor span (flow/pressure)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sv_rate_compute",
+      "pandas_implementation": "sv_rate",
       "datafusion_sql_implementation": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
       "test_coverage": [
@@ -390,32 +238,27 @@
     {
       "rule_id": "PID-HUNT-1",
       "title": "Suspected control-output hunting",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "clg_valve_pct"
       ],
       "optional_roles": [
-        "loop-enabled"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 0.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -423,58 +266,14 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
           "label": "Minimum observed span"
-        },
-        "total_variation_fault_pct": {
-          "default": 500.0,
-          "unit": "%/h",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 50.0,
-          "label": "Total travel threshold"
-        },
-        "minimum_equivalent_cycles": {
-          "default": 2.5,
-          "unit": "cyc/h",
-          "min": 0.5,
-          "max": 20.0,
-          "step": 0.5,
-          "label": "Min equivalent cycles"
-        },
-        "minimum_reversals": {
-          "default": 4,
-          "unit": "count",
-          "min": 1,
-          "max": 40,
-          "step": 1,
-          "label": "Min direction reversals"
-        },
-        "minimum_coverage_pct": {
-          "default": 80.0,
-          "unit": "%",
-          "min": 25.0,
-          "max": 100.0,
-          "step": 5.0,
-          "label": "Minimum data coverage"
-        },
-        "confirm_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_pid_hunt_1",
+      "pandas_implementation": "pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
       "test_coverage": [],
@@ -484,35 +283,26 @@
     },
     {
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan (GL36 A)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Duct static below SP at full fan",
+      "equipment_types": [],
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp",
-        "fan-cmd"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "in. w.c.",
+          "unit": "inwc",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -520,43 +310,15 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
-        },
-        "duct_static_err": {
-          "default": 0.12,
-          "unit": "in. w.c.",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Legacy duct-static error (sets \u03b5DSP)"
-        },
-        "fan_hi": {
-          "default": 0.87,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
         },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc1",
@@ -572,90 +334,20 @@
     },
     {
       "rule_id": "FC2",
-      "title": "MAT below OAT/RAT envelope (GL36 B)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Mixed air below envelope",
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc2",
@@ -666,90 +358,20 @@
     },
     {
       "rule_id": "FC3",
-      "title": "MAT above OAT/RAT envelope (GL36 C)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Mixed air above envelope",
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc3",
@@ -761,52 +383,24 @@
     {
       "rule_id": "FC4",
       "title": "PID hunting (operating-state oscillation)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve",
-        "fan-cmd"
+        "oa_damper_pct",
+        "clg_valve_pct",
+        "fan_cmd"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
+      "optional_roles": [
+        "fan_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "delta_os_max": {
-          "default": 5,
-          "unit": "count",
-          "min": 1,
-          "max": 30,
-          "step": 1,
-          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc4",
@@ -820,51 +414,34 @@
     {
       "rule_id": "FC5",
       "title": "SAT cold when heating commanded (GL36 D)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "mat",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -873,42 +450,6 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -922,43 +463,26 @@
     {
       "rule_id": "FC6",
       "title": "Estimated OA fraction mismatch",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "vav-total-airflow"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_airflow": {
-          "default": 0.15,
-          "unit": "frac",
-          "min": 0.05,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Airflow error \u03b5F (GL36 default 30%)"
-        },
-        "delta_t_min": {
-          "default": 5.0,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 30.0,
-          "step": 0.5,
-          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "airflow_err": {
           "default": 0.15,
@@ -966,51 +490,15 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Legacy OA-fraction error (sets \u03b5F)"
+          "label": "Airflow error epsF (GL36 default 30%)"
         },
-        "oat_rat_delta_min": {
+        "delta_t_min": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
-        },
-        "min_cfm_design": {
-          "default": 5000,
-          "unit": "cfm",
-          "min": 500,
-          "max": 20000,
-          "step": 500,
-          "label": "Design min OA CFM"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
         }
       },
       "pandas_implementation": "fc6",
@@ -1023,41 +511,24 @@
     },
     {
       "rule_id": "FC7",
-      "title": "SAT low with full heating (GL36 E)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT low while heating at full",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "sat_sp",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "Legacy SAT error (sets epsSAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -1067,33 +538,13 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc7",
@@ -1110,106 +561,20 @@
     },
     {
       "rule_id": "FC8",
-      "title": "SAT/MAT mismatch in economizer (GL36 F)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT vs MAT while economizing",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc8",
@@ -1220,98 +585,20 @@
     },
     {
       "rule_id": "FC9",
-      "title": "OAT too warm for free cooling (GL36 G)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "OAT high vs SAT SP while economizing",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc9",
@@ -1322,90 +609,20 @@
     },
     {
       "rule_id": "FC10",
-      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "MAT-OAT delta while cooling and economizing",
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "oa_t",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc10",
@@ -1416,98 +633,20 @@
     },
     {
       "rule_id": "FC11",
-      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "OAT low vs SAT SP while cooling and economizing",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc11",
@@ -1518,114 +657,20 @@
     },
     {
       "rule_id": "FC12",
-      "title": "SAT above blend in cooling (GL36 J)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT above MAT while cooling",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc12",
@@ -1636,88 +681,59 @@
     },
     {
       "rule_id": "FC13",
-      "title": "SAT above SP at full cooling (GL36 K)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT above setpoint at full cooling",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "sat_sp",
+        "clg_valve_pct",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "SAT high error band"
         },
-        "clg_full_min": {
+        "clg_valve_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
+          "min": 0.0,
+          "max": 0.5,
           "step": 0.01,
-          "label": "Full-cooling threshold (GL36 99%)"
+          "label": "Cooling valve open threshold"
         },
-        "econ_min_pos": {
+        "oa_damper_econ_low": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Economizer minimum-position threshold"
+          "label": "OA damper economizer low"
         },
-        "econ_full_open": {
+        "oa_damper_econ_high": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OA damper economizer high"
         },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc13",
@@ -1733,103 +749,35 @@
     {
       "rule_id": "FC14",
       "title": "CHW coil \u0394T when inactive (GL36 L)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "cooling-coil-entering-temp",
-        "cooling-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "sat",
+        "clg_valve_pct",
+        "oa_damper_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_ccet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil entering sensor error \u03b5CCET"
-        },
-        "eps_cclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "htg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Heating-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc14",
@@ -1843,111 +791,34 @@
     {
       "rule_id": "FC15",
       "title": "HW coil \u0394T when inactive (GL36 M)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "heating-coil-entering-temp",
-        "heating-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "sat",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_hcet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil entering sensor error \u03b5HCET"
-        },
-        "eps_hclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil leaving sensor error \u03b5HCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc15",
@@ -1961,48 +832,35 @@
     {
       "rule_id": "AHU-SATDEV",
       "title": "SAT deviation from setpoint",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp"
+        "sat",
+        "sat_sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_sat_dev",
+      "pandas_implementation": "ahu_satdev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
       "test_coverage": [
@@ -2015,12 +873,11 @@
     {
       "rule_id": "AHU-DUCTHI",
       "title": "Duct static pressure high",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
@@ -2028,9 +885,17 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -2038,26 +903,14 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_duct_high",
+      "pandas_implementation": "ahu_ducthi",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
       "test_coverage": [
@@ -2070,26 +923,25 @@
     {
       "rule_id": "AHU-SIMUL",
       "title": "Heating and cooling simultaneous",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "heating-valve",
-        "cooling-valve"
+        "htg_valve_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -2097,21 +949,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul_heat_cool",
+      "pandas_implementation": "ahu_simul",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
       "test_coverage": [],
@@ -2121,36 +961,29 @@
     },
     {
       "rule_id": "OAT-METEO",
-      "title": "BAS outdoor-air sensor vs Open-Meteo",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Equipment OAT vs weather-staged wx OAT",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "web-outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "Max OAT disagreement"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OAT vs meteo tolerance"
         },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -2163,47 +996,26 @@
     },
     {
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Economizer stuck closed when OAT favorable",
+      "equipment_types": [],
       "required_roles": [
-        "fan-cmd",
-        "outside-air-damper",
-        "outside-air-temp"
+        "fan_cmd",
+        "oa_damper_pct",
+        "oa_t"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "econ1",
@@ -2216,30 +1028,21 @@
     },
     {
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor unfavorable",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Economizing when outdoor air unfavorable",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "outside-air-damper"
+        "oa_t",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -2253,17 +1056,13 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ2",
@@ -2277,30 +1076,30 @@
     {
       "rule_id": "ECON-3",
       "title": "Mech cooling without integrated economizer",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve"
+        "web_oa_t",
+        "web_oa_dp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -2308,7 +1107,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -2316,7 +1115,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -2329,21 +1128,9 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ2",
+      "pandas_implementation": "econ_3",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
       "test_coverage": [],
@@ -2354,47 +1141,34 @@
     {
       "rule_id": "ECON-4",
       "title": "Low estimated OA fraction",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-cmd"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "%",
+          "unit": "pct",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ4",
@@ -2408,50 +1182,37 @@
     {
       "rule_id": "ECON-5",
       "title": "Preheat over-conditioning",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "preheat-leaving-temp",
-        "discharge-air-temp-sp",
-        "outside-air-temp",
-        "heating-valve"
+        "preheat_leave_t",
+        "sat_sp",
+        "oa_t",
+        "htg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ5",
+      "pandas_implementation": "econ_5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
       "test_coverage": [],
@@ -2462,27 +1223,28 @@
     {
       "rule_id": "ECON-6",
       "title": "Economizing in freezing weather",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper"
+        "web_oa_t",
+        "oa_damper_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -2495,21 +1257,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ6_compute",
+      "pandas_implementation": "econ_6",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
       "test_coverage": [],
@@ -2520,32 +1270,30 @@
     {
       "rule_id": "ECON-7",
       "title": "Economizer OK but not economizing",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper"
+        "web_oa_t",
+        "web_oa_dp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity",
-        "cooling-valve",
-        "compressor-status",
-        "dx-cool-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -2553,7 +1301,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -2561,7 +1309,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -2574,21 +1322,9 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ7_compute",
+      "pandas_implementation": "econ_7",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
       "test_coverage": [],
@@ -2599,46 +1335,32 @@
     {
       "rule_id": "MECH-OAT-1",
       "title": "Mechanical cooling below 60\u00b0F web OAT",
-      "equipment_types": [
-        "ahu",
-        "chiller",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "web_oa_t",
         "clg_valve_pct"
       ],
-      "optional_roles": [
-        "web-outside-air-temp",
-        "compressor-status",
-        "chiller-status",
-        "chw-pump-status",
-        "dx-cool-cmd"
-      ],
+      "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat1_compute",
+      "pandas_implementation": "mech_oat_1",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
       "test_coverage": [],
@@ -2649,61 +1371,33 @@
     {
       "rule_id": "CHW-NOLOAD-1",
       "title": "Chiller running with no building load",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "chw_supply_t",
         "chw_supply_sp",
         "chw_pump_cmd"
       ],
-      "optional_roles": [
-        "chiller-status",
-        "chw-pump-status",
-        "compressor-status",
-        "building-zone-load-satisfied",
-        "building-ahu-load-satisfied"
-      ],
+      "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "comfort_low_f": {
-          "default": 70.0,
-          "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
-          "step": 0.5,
-          "label": "Comfort low"
-        },
-        "comfort_high_f": {
-          "default": 75.0,
-          "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
-          "step": 0.5,
-          "label": "Comfort high"
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "sat_band_f": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "AHU SAT\u2248SP band"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_noload1_compute",
+      "pandas_implementation": "chw_noload_1",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
       "test_coverage": [],
@@ -2713,44 +1407,39 @@
     },
     {
       "rule_id": "VAV-1",
-      "title": "Zone comfort band",
-      "equipment_types": [
-        "vav",
-        "zone"
-      ],
+      "title": "Zone comfort band violation hours with confirm window",
+      "equipment_types": [],
       "required_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "occ_mode"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_lo": {
+        "zone_t_lo": {
           "default": 70.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_hi": {
+        "zone_t_hi": {
           "default": 75.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav1",
@@ -2767,26 +1456,29 @@
     {
       "rule_id": "VAV-3",
       "title": "Excessive reheat during warm weather",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "reheat-valve"
+        "oa_t",
+        "reheat_valve_pct",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -2807,21 +1499,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav3",
+      "pandas_implementation": "vav_3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
       "test_coverage": [],
@@ -2832,23 +1512,25 @@
     {
       "rule_id": "VAV-4",
       "title": "Damper stuck at full open",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "damper"
+        "damper_pct",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -2857,14 +1539,6 @@
           "step": 0.005,
           "label": "Full open frac"
         },
-        "sustain_hours": {
-          "default": 1.5,
-          "unit": "h",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "Sustain window"
-        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -2872,21 +1546,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav4",
+      "pandas_implementation": "vav_4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
       "test_coverage": [],
@@ -2897,37 +1559,27 @@
     {
       "rule_id": "VAV-5",
       "title": "Airflow sensor bias",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "zone-airflow",
-        "damper"
+        "zone_flow",
+        "damper_pct"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "vav5",
+      "pandas_implementation": "vav_5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
       "test_coverage": [],
@@ -2938,24 +1590,27 @@
     {
       "rule_id": "VAV-REHEAT",
       "title": "Reheat valve stuck / no temp rise",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "reheat-valve",
-        "vav-discharge-air-temp",
-        "vav-inlet-air-temp"
+        "reheat_valve_pct",
+        "vav_discharge_t",
+        "vav_inlet_t",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -2966,7 +1621,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -2979,21 +1634,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat_stuck",
+      "pandas_implementation": "vav_reheat",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
       "test_coverage": [],
@@ -3004,26 +1647,29 @@
     {
       "rule_id": "VAV-AHU-LEAVE",
       "title": "VAV leave vs parent AHU SAT (fedBy)",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "vav-discharge-air-temp",
-        "ahu-discharge-air-temp"
+        "vav_discharge_t",
+        "ahu_sat",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "delta_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -3036,21 +1682,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_vs_ahu_leave",
+      "pandas_implementation": "vav_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
       "test_coverage": [],
@@ -3061,45 +1695,24 @@
     {
       "rule_id": "VAV-7",
       "title": "Min airflow / fixed high flow",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "zone-airflow"
+        "zone_flow",
+        "min_flow_sp"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "flow_on_min": {
-          "default": 25.0,
-          "unit": "cfm",
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 200.0,
-          "step": 5.0,
-          "label": "Airflow-on min"
-        },
-        "fixed_flow_max_std": {
-          "default": 15.0,
-          "unit": "cfm",
-          "min": 1.0,
-          "max": 80.0,
-          "step": 1.0,
-          "label": "Fixed-flow max std"
-        },
-        "fixed_flow_min_mean": {
-          "default": 200.0,
-          "unit": "cfm",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 10.0,
-          "label": "Fixed-flow min mean"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "high_min_flow_sp": {
           "default": 250.0,
@@ -3108,21 +1721,9 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "High min-flow SP"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav7",
+      "pandas_implementation": "vav_7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
       "test_coverage": [],
@@ -3133,12 +1734,10 @@
     {
       "rule_id": "CHW-1",
       "title": "Low chilled-water \u0394T",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-return-temp"
+        "chw_supply_t",
+        "chw_return_t"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -3149,41 +1748,23 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_dt": {
           "default": 4.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Min \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "Minimum delta-T"
         }
       },
       "pandas_implementation": "chw1",
@@ -3202,31 +1783,23 @@
     {
       "rule_id": "CHW-2",
       "title": "DP below SP at max pump speed",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chw-diff-pressure",
-        "chw-diff-pressure-sp",
-        "chw-pump-cmd"
+        "chw_dp",
+        "chw_dp_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -3242,21 +1815,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw2",
+      "pandas_implementation": "chw_2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
       "test_coverage": [],
@@ -3267,53 +1828,33 @@
     {
       "rule_id": "CHW-3",
       "title": "Plant supply temp outside deadband",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-supply-temp-sp",
-        "chw-pump-cmd"
+        "chw_supply_t",
+        "chw_supply_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sp_band": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw3",
+      "pandas_implementation": "chw_3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
       "test_coverage": [],
@@ -3324,36 +1865,28 @@
     {
       "rule_id": "CHW-4",
       "title": "Flow high at max pump",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chw-flow",
-        "chw-pump-cmd"
+        "chw_flow",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flow_hi": {
-          "default": 1100,
+          "default": 1100.0,
           "unit": "gpm",
-          "min": 200,
-          "max": 3000,
-          "step": 50,
+          "min": 200.0,
+          "max": 3000.0,
+          "step": 50.0,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -3363,21 +1896,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw4",
+      "pandas_implementation": "chw_4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
       "test_coverage": [],
@@ -3388,52 +1909,44 @@
     {
       "rule_id": "HP-1",
       "title": "Discharge cold when heating",
-      "equipment_types": [
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "zone-air-temp",
-        "fan-cmd"
+        "sat",
+        "zone_t",
+        "fan_cmd"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "compressor-status",
-        "equipment-enable",
-        "fan-status",
-        "fan-cmd"
+      "optional_roles": [
+        "compressor_status",
+        "fan_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_sat": {
           "default": 85.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min heating SAT"
+          "label": "Min discharge SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Zone cold threshold"
         }
       },
-      "pandas_implementation": "hp1",
+      "pandas_implementation": "hp_1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
       "test_coverage": [],
@@ -3444,37 +1957,31 @@
     {
       "rule_id": "WX-1",
       "title": "OA temperature spike",
-      "equipment_types": [
-        "weather"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx1",
+      "pandas_implementation": "wx_1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
       "test_coverage": [],
@@ -3485,33 +1992,30 @@
     {
       "rule_id": "CW-OPT-1",
       "title": "Condenser water not optimized vs wet-bulb",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
+      "optional_roles": [
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -3519,26 +2023,14 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt",
+      "pandas_implementation": "cw_opt_1",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
       "test_coverage": [],
@@ -3549,38 +2041,31 @@
     {
       "rule_id": "CW-APR-1",
       "title": "High CW approach at full tower fan",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -3593,21 +2078,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr",
+      "pandas_implementation": "cw_apr_1",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
       "test_coverage": [],
@@ -3618,38 +2091,31 @@
     {
       "rule_id": "CW-FAN-1",
       "title": "Excess tower fan energy vs wet-bulb limit",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -3657,7 +2123,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -3670,21 +2136,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_excess",
+      "pandas_implementation": "cw_fan_1",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
       "test_coverage": [],
@@ -3695,29 +2149,27 @@
     {
       "rule_id": "TRIM-1",
       "title": "Duct static trim advisory",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "duct-static-pressure",
-        "vav-pressure-request-sum"
+        "duct_static_sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -3730,21 +2182,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim1",
+      "pandas_implementation": "trim_1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
       "test_coverage": [],
@@ -3755,33 +2195,29 @@
     {
       "rule_id": "TRIM-3",
       "title": "HWST trim advisory",
-      "equipment_types": [
-        "boiler"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "hot-water-supply-temp",
-        "hw-reset-request-sum"
+        "hw_supply_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
+      "optional_roles": [
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -3794,21 +2230,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim3",
+      "pandas_implementation": "trim_3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
       "test_coverage": [],
@@ -3819,33 +2243,29 @@
     {
       "rule_id": "TRIM-4",
       "title": "CHW plant reset advisory",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chw-reset-request-sum"
+        "chw_supply_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
+      "optional_roles": [
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -3858,21 +2278,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim4",
+      "pandas_implementation": "trim_4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
       "test_coverage": [],
@@ -3882,46 +2290,40 @@
     },
     {
       "rule_id": "SCHED-1",
-      "title": "Unoccupied runtime",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
+      "equipment_types": [],
       "required_roles": [
-        "occupied",
-        "fan-status"
+        "occ_mode",
+        "fan_status"
       ],
       "optional_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
+          "min": 50.0,
+          "max": 80.0,
           "step": 0.5,
-          "label": "Comfort low"
+          "label": "Zone comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
+          "min": 55.0,
+          "max": 90.0,
           "step": 0.5,
-          "label": "Comfort high"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
+          "label": "Zone comfort high"
         }
       },
       "pandas_implementation": "sched1",
@@ -3939,58 +2341,23 @@
     {
       "rule_id": "SCHED-247",
       "title": "Always-on fan or pump runtime",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
-        "fan-status",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "chiller-status",
-        "compressor-status",
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd",
-        "duct-static-pressure",
-        "chw-diff-pressure"
+        "fan_status",
+        "pump_status",
+        "chiller_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "always_on_pct": {
-          "default": 0.95,
-          "unit": "frac",
-          "min": 0.8,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Always-on fraction"
-        },
-        "pressure_on_min": {
-          "default": 0.2,
-          "unit": "eng",
-          "min": 0.05,
-          "max": 2.0,
-          "step": 0.05,
-          "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "_sched247",
@@ -4008,30 +2375,24 @@
     {
       "rule_id": "CMD-1",
       "title": "Fan cmd/status mismatch",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "fan-cmd",
-        "fan-status"
+        "fan_cmd",
+        "fan_status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "cmd1",
+      "pandas_implementation": "cmd_1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
       "test_coverage": [],
@@ -4042,28 +2403,27 @@
     {
       "rule_id": "OA-1",
       "title": "Low OA fraction",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-status"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -4074,26 +2434,14 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "Min |RAT\u2212OAT| guard"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "OAT/RAT guard"
         }
       },
-      "pandas_implementation": "oa1",
+      "pandas_implementation": "oa_1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
       "test_coverage": [],
@@ -4104,13 +2452,11 @@
     {
       "rule_id": "DMP-1",
       "title": "OA damper leakage",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper"
+        "oa_damper_pct",
+        "oa_t",
+        "mat"
       ],
       "optional_roles": [
         "fan_status",
@@ -4118,28 +2464,24 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp1",
+      "pandas_implementation": "dmp_1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
       "test_coverage": [],
@@ -4150,24 +2492,30 @@
     {
       "rule_id": "VLV-1",
       "title": "Cooling valve leakage",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "cooling-valve"
+        "clg_valve_pct",
+        "sat",
+        "sat_sp",
+        "mat"
       ],
       "optional_roles": [
-        "mixed-air-temp",
-        "fan-status",
-        "fan-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_err": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -4175,26 +2523,14 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv1",
+      "pandas_implementation": "vlv_1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
       "test_coverage": [],
@@ -4336,44 +2672,28 @@
       "title": "Sensor out of hard range",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "oa_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd",
+        "pump_status",
+        "chw_pump_cmd",
+        "chiller_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -4381,37 +2701,9 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
-        },
-        "range_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Humidity range scale"
-        },
-        "range_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Pressure range scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_range",
+      "pandas_implementation": "sv_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "sql_file": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
@@ -4423,8 +2715,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "equipment_energized",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -4533,60 +2825,38 @@
       "title": "Sensor flatline (stuck)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "oa_t"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd",
+        "pump_status",
+        "chw_pump_cmd",
+        "chiller_status"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
           "label": "Flatline tolerance"
-        },
-        "flatline_hours": {
-          "default": 1.0,
-          "unit": "h",
-          "min": 0.5,
-          "max": 8.0,
-          "step": 0.5,
-          "label": "Flatline window"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_flatline",
+      "pandas_implementation": "sv_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "sql_file": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
@@ -4596,8 +2866,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -4706,44 +2976,28 @@
       "title": "Sensor rate-of-change spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "oa_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd",
+        "pump_status",
+        "chw_pump_cmd",
+        "chiller_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -4751,45 +3005,9 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
-        },
-        "spike_scale_temperature": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Temp spike scale"
-        },
-        "spike_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Humidity spike scale"
-        },
-        "spike_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Pressure spike scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_spike",
+      "pandas_implementation": "sv_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "sql_file": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
@@ -4799,8 +3017,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "equipment_energized",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -4909,30 +3127,20 @@
       "title": "Stale data (no fresh samples)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "required_roles": [
-        "fan_cmd"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
+      "required_roles": [],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -4940,21 +3148,9 @@
           "max": 12.0,
           "step": 0.5,
           "label": "Stale window"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_stale",
+      "pandas_implementation": "sv_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "sql_file": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
@@ -4964,8 +3160,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5076,30 +3272,22 @@
         "SV-SLEW"
       ],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -5107,53 +3295,9 @@
           "max": 60.0,
           "step": 1.0,
           "label": "Fault persistence"
-        },
-        "transition_window_min": {
-          "default": 20.0,
-          "unit": "min",
-          "min": 5.0,
-          "max": 60.0,
-          "step": 5.0,
-          "label": "Transition window"
-        },
-        "max_gap_hours": {
-          "default": 2.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 6.0,
-          "step": 0.25,
-          "label": "Max sample gap"
-        },
-        "design_flow": {
-          "default": 0.0,
-          "unit": "cfm",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 100.0,
-          "label": "Design flow (flow profiles)"
-        },
-        "sensor_span": {
-          "default": 0.0,
-          "unit": "eng",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 10.0,
-          "label": "Sensor span (flow/pressure)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sv_rate_compute",
+      "pandas_implementation": "sv_rate",
       "datafusion_sql_implementation": "sv_rate.sql",
       "sql_file": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
@@ -5166,8 +3310,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: SV-SLEW (not independent rules)",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -5276,39 +3420,28 @@
       "title": "Suspected control-output hunting",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "clg_valve_pct"
       ],
       "optional_roles": [
-        "loop-enabled"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 0.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -5316,58 +3449,14 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
           "label": "Minimum observed span"
-        },
-        "total_variation_fault_pct": {
-          "default": 500.0,
-          "unit": "%/h",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 50.0,
-          "label": "Total travel threshold"
-        },
-        "minimum_equivalent_cycles": {
-          "default": 2.5,
-          "unit": "cyc/h",
-          "min": 0.5,
-          "max": 20.0,
-          "step": 0.5,
-          "label": "Min equivalent cycles"
-        },
-        "minimum_reversals": {
-          "default": 4,
-          "unit": "count",
-          "min": 1,
-          "max": 40,
-          "step": 1,
-          "label": "Min direction reversals"
-        },
-        "minimum_coverage_pct": {
-          "default": 80.0,
-          "unit": "%",
-          "min": 25.0,
-          "max": 100.0,
-          "step": 5.0,
-          "label": "Minimum data coverage"
-        },
-        "confirm_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_pid_hunt_1",
+      "pandas_implementation": "pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "sql_file": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
@@ -5377,8 +3466,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "control_loop",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 0,
       "parameters": {
         "confirm_seconds": {
@@ -5494,40 +3583,29 @@
       "canonical_id": "FC1",
       "pandas_id": "FC1",
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan (GL36 A)",
+      "title": "Duct static below SP at full fan",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp",
-        "fan-cmd"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "in. w.c.",
+          "unit": "inwc",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -5535,43 +3613,15 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
-        },
-        "duct_static_err": {
-          "default": 0.12,
-          "unit": "in. w.c.",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Legacy duct-static error (sets \u03b5DSP)"
-        },
-        "fan_hi": {
-          "default": 0.87,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
         },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc1",
@@ -5587,8 +3637,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "eps_dsp": {
@@ -5704,95 +3754,23 @@
       "canonical_id": "FC2",
       "pandas_id": "FC2",
       "rule_id": "FC2",
-      "title": "MAT below OAT/RAT envelope (GL36 B)",
+      "title": "Mixed air below envelope",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "sql_file": "fc2_mat_low.sql",
@@ -5803,8 +3781,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5889,95 +3867,23 @@
       "canonical_id": "FC3",
       "pandas_id": "FC3",
       "rule_id": "FC3",
-      "title": "MAT above OAT/RAT envelope (GL36 C)",
+      "title": "Mixed air above envelope",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "sql_file": "fc3_mat_high.sql",
@@ -5988,8 +3894,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -6077,55 +3983,25 @@
       "title": "PID hunting (operating-state oscillation)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve",
-        "fan-cmd"
+        "oa_damper_pct",
+        "clg_valve_pct",
+        "fan_cmd"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
+      "optional_roles": [
+        "fan_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "delta_os_max": {
-          "default": 5,
-          "unit": "count",
-          "min": 1,
-          "max": 30,
-          "step": 1,
-          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc4",
@@ -6138,8 +4014,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "control_loop",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -6238,54 +4114,35 @@
       "title": "SAT cold when heating commanded (GL36 D)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "mat",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -6294,42 +4151,6 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -6342,8 +4163,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -6462,46 +4283,27 @@
       "title": "Estimated OA fraction mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "vav-total-airflow"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_airflow": {
-          "default": 0.15,
-          "unit": "frac",
-          "min": 0.05,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Airflow error \u03b5F (GL36 default 30%)"
-        },
-        "delta_t_min": {
-          "default": 5.0,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 30.0,
-          "step": 0.5,
-          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "airflow_err": {
           "default": 0.15,
@@ -6509,51 +4311,15 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Legacy OA-fraction error (sets \u03b5F)"
+          "label": "Airflow error epsF (GL36 default 30%)"
         },
-        "oat_rat_delta_min": {
+        "delta_t_min": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
-        },
-        "min_cfm_design": {
-          "default": 5000,
-          "unit": "cfm",
-          "min": 500,
-          "max": 20000,
-          "step": 500,
-          "label": "Design min OA CFM"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
         }
       },
       "pandas_implementation": "fc6",
@@ -6566,8 +4332,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -6683,46 +4449,27 @@
       "canonical_id": "FC7",
       "pandas_id": "FC7",
       "rule_id": "FC7",
-      "title": "SAT low with full heating (GL36 E)",
+      "title": "SAT low while heating at full",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "sat_sp",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "Legacy SAT error (sets epsSAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -6732,33 +4479,13 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc7",
@@ -6775,8 +4502,8 @@
       "parity_level": "concept_only",
       "difference_class": "missing_implementation",
       "known_semantic_differences": "concept_only \u2014 SQL file is a placeholder; do not claim twin parity",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -6892,111 +4619,23 @@
       "canonical_id": "FC8",
       "pandas_id": "FC8",
       "rule_id": "FC8",
-      "title": "SAT/MAT mismatch in economizer (GL36 F)",
+      "title": "SAT vs MAT while economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "sql_file": "fc8_sat_mat_econ.sql",
@@ -7007,8 +4646,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7093,103 +4732,23 @@
       "canonical_id": "FC9",
       "pandas_id": "FC9",
       "rule_id": "FC9",
-      "title": "OAT too warm for free cooling (GL36 G)",
+      "title": "OAT high vs SAT SP while economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "sql_file": "fc9_oa_sat_sp_econ.sql",
@@ -7200,8 +4759,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7286,95 +4845,23 @@
       "canonical_id": "FC10",
       "pandas_id": "FC10",
       "rule_id": "FC10",
-      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
+      "title": "MAT-OAT delta while cooling and economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "oa_t",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "sql_file": "fc10_mat_oa_clg.sql",
@@ -7385,8 +4872,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7471,103 +4958,23 @@
       "canonical_id": "FC11",
       "pandas_id": "FC11",
       "rule_id": "FC11",
-      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
+      "title": "OAT low vs SAT SP while cooling and economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "sql_file": "fc11_oa_sat_sp_clg.sql",
@@ -7578,8 +4985,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7664,119 +5071,23 @@
       "canonical_id": "FC12",
       "pandas_id": "FC12",
       "rule_id": "FC12",
-      "title": "SAT above blend in cooling (GL36 J)",
+      "title": "SAT above MAT while cooling",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "sql_file": "fc12_sat_mat_clg.sql",
@@ -7787,8 +5098,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7873,95 +5184,64 @@
       "canonical_id": "FC13-SAT-HIGH",
       "pandas_id": "FC13",
       "rule_id": "FC13",
-      "title": "SAT above SP at full cooling (GL36 K)",
+      "title": "SAT above setpoint at full cooling",
       "aliases": [
         "FC13"
       ],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "sat_sp",
+        "clg_valve_pct",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "SAT high error band"
         },
-        "clg_full_min": {
+        "clg_valve_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
+          "min": 0.0,
+          "max": 0.5,
           "step": 0.01,
-          "label": "Full-cooling threshold (GL36 99%)"
+          "label": "Cooling valve open threshold"
         },
-        "econ_min_pos": {
+        "oa_damper_econ_low": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Economizer minimum-position threshold"
+          "label": "OA damper economizer low"
         },
-        "econ_full_open": {
+        "oa_damper_econ_high": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OA damper economizer high"
         },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc13",
@@ -7976,8 +5256,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: FC13 (not independent rules)",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -8116,106 +5396,36 @@
       "title": "CHW coil \u0394T when inactive (GL36 L)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "cooling-coil-entering-temp",
-        "cooling-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "sat",
+        "clg_valve_pct",
+        "oa_damper_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_ccet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil entering sensor error \u03b5CCET"
-        },
-        "eps_cclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "htg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Heating-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc14",
@@ -8228,8 +5438,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -8338,114 +5548,35 @@
       "title": "HW coil \u0394T when inactive (GL36 M)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "heating-coil-entering-temp",
-        "heating-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "sat",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_hcet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil entering sensor error \u03b5HCET"
-        },
-        "eps_hclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil leaving sensor error \u03b5HCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc15",
@@ -8458,8 +5589,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -8568,51 +5699,36 @@
       "title": "SAT deviation from setpoint",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp"
+        "sat",
+        "sat_sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_sat_dev",
+      "pandas_implementation": "ahu_satdev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "sql_file": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
@@ -8624,8 +5740,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -8734,15 +5850,12 @@
       "title": "Duct static pressure high",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
@@ -8750,9 +5863,17 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -8760,26 +5881,14 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_duct_high",
+      "pandas_implementation": "ahu_ducthi",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "sql_file": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
@@ -8791,8 +5900,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -8911,29 +6020,26 @@
       "title": "Heating and cooling simultaneous",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "heating-valve",
-        "cooling-valve"
+        "htg_valve_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -8941,21 +6047,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul_heat_cool",
+      "pandas_implementation": "ahu_simul",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "sql_file": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
@@ -8965,8 +6059,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9072,41 +6166,32 @@
       "canonical_id": "OAT-METEO",
       "pandas_id": "OAT-METEO",
       "rule_id": "OAT-METEO",
-      "title": "BAS outdoor-air sensor vs Open-Meteo",
+      "title": "Equipment OAT vs weather-staged wx OAT",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "web-outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "Max OAT disagreement"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OAT vs meteo tolerance"
         },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -9119,8 +6204,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "oat_err": {
@@ -9227,52 +6312,29 @@
       "canonical_id": "ECON-1",
       "pandas_id": "ECON-1",
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed",
+      "title": "Economizer stuck closed when OAT favorable",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "fan-cmd",
-        "outside-air-damper",
-        "outside-air-temp"
+        "fan_cmd",
+        "oa_damper_pct",
+        "oa_t"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "econ1",
@@ -9285,8 +6347,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "econ1_oat_min": {
@@ -9382,35 +6444,24 @@
       "canonical_id": "ECON-2",
       "pandas_id": "ECON-2",
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor unfavorable",
+      "title": "Economizing when outdoor air unfavorable",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "outside-air-damper"
+        "oa_t",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -9424,17 +6475,13 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ2",
@@ -9447,8 +6494,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "econ2_oat_hi": {
@@ -9567,33 +6614,31 @@
       "title": "Mech cooling without integrated economizer",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve"
+        "web_oa_t",
+        "web_oa_dp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -9601,7 +6646,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -9609,7 +6654,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -9622,21 +6667,9 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ2",
+      "pandas_implementation": "econ_3",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "sql_file": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
@@ -9646,8 +6679,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9786,50 +6819,35 @@
       "title": "Low estimated OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-cmd"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "%",
+          "unit": "pct",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ4",
@@ -9842,8 +6860,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "oa_min_pct": {
@@ -9952,53 +6970,38 @@
       "title": "Preheat over-conditioning",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "preheat-leaving-temp",
-        "discharge-air-temp-sp",
-        "outside-air-temp",
-        "heating-valve"
+        "preheat_leave_t",
+        "sat_sp",
+        "oa_t",
+        "htg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ5",
+      "pandas_implementation": "econ_5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "sql_file": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
@@ -10008,8 +7011,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -10118,30 +7121,29 @@
       "title": "Economizing in freezing weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper"
+        "web_oa_t",
+        "oa_damper_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -10154,21 +7156,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ6_compute",
+      "pandas_implementation": "econ_6",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "sql_file": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
@@ -10178,8 +7168,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -10298,35 +7288,31 @@
       "title": "Economizer OK but not economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper"
+        "web_oa_t",
+        "web_oa_dp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity",
-        "cooling-valve",
-        "compressor-status",
-        "dx-cool-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -10334,7 +7320,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -10342,7 +7328,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -10355,21 +7341,9 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ7_compute",
+      "pandas_implementation": "econ_7",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "sql_file": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
@@ -10379,8 +7353,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -10519,51 +7493,33 @@
       "title": "Mechanical cooling below 60\u00b0F web OAT",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "chiller",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "chiller",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "web_oa_t",
         "clg_valve_pct"
       ],
-      "optional_roles": [
-        "web-outside-air-temp",
-        "compressor-status",
-        "chiller-status",
-        "chw-pump-status",
-        "dx-cool-cmd"
-      ],
+      "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat1_compute",
+      "pandas_implementation": "mech_oat_1",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "sql_file": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
@@ -10573,8 +7529,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -10683,64 +7639,34 @@
       "title": "Chiller running with no building load",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "chw_supply_t",
         "chw_supply_sp",
         "chw_pump_cmd"
       ],
-      "optional_roles": [
-        "chiller-status",
-        "chw-pump-status",
-        "compressor-status",
-        "building-zone-load-satisfied",
-        "building-ahu-load-satisfied"
-      ],
+      "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "comfort_low_f": {
-          "default": 70.0,
-          "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
-          "step": 0.5,
-          "label": "Comfort low"
-        },
-        "comfort_high_f": {
-          "default": 75.0,
-          "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
-          "step": 0.5,
-          "label": "Comfort high"
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "sat_band_f": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "AHU SAT\u2248SP band"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_noload1_compute",
+      "pandas_implementation": "chw_noload_1",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "sql_file": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
@@ -10750,8 +7676,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -10857,50 +7783,42 @@
       "canonical_id": "VAV-1",
       "pandas_id": "VAV-1",
       "rule_id": "VAV-1",
-      "title": "Zone comfort band",
+      "title": "Zone comfort band violation hours with confirm window",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav",
-        "zone"
-      ],
-      "equipment_kinds": [
-        "vav",
-        "zone"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "occ_mode"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_lo": {
+        "zone_t_lo": {
           "default": 70.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_hi": {
+        "zone_t_hi": {
           "default": 75.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav1",
@@ -10916,8 +7834,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "zone_t_lo": {
@@ -11037,29 +7955,30 @@
       "title": "Excessive reheat during warm weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "reheat-valve"
+        "oa_t",
+        "reheat_valve_pct",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -11080,21 +7999,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav3",
+      "pandas_implementation": "vav_3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "sql_file": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
@@ -11104,8 +8011,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -11234,26 +8141,26 @@
       "title": "Damper stuck at full open",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "damper"
+        "damper_pct",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -11262,14 +8169,6 @@
           "step": 0.005,
           "label": "Full open frac"
         },
-        "sustain_hours": {
-          "default": 1.5,
-          "unit": "h",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "Sustain window"
-        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -11277,21 +8176,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav4",
+      "pandas_implementation": "vav_4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "sql_file": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
@@ -11301,8 +8188,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "control_loop",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11421,40 +8308,28 @@
       "title": "Airflow sensor bias",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "zone-airflow",
-        "damper"
+        "zone_flow",
+        "damper_pct"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "vav5",
+      "pandas_implementation": "vav_5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "sql_file": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
@@ -11464,8 +8339,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11564,27 +8439,28 @@
       "title": "Reheat valve stuck / no temp rise",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "reheat-valve",
-        "vav-discharge-air-temp",
-        "vav-inlet-air-temp"
+        "reheat_valve_pct",
+        "vav_discharge_t",
+        "vav_inlet_t",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -11595,7 +8471,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -11608,21 +8484,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat_stuck",
+      "pandas_implementation": "vav_reheat",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "sql_file": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
@@ -11632,8 +8496,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11762,29 +8626,30 @@
       "title": "VAV leave vs parent AHU SAT (fedBy)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "vav-discharge-air-temp",
-        "ahu-discharge-air-temp"
+        "vav_discharge_t",
+        "ahu_sat",
+        "zone_flow"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "delta_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -11797,21 +8662,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_vs_ahu_leave",
+      "pandas_implementation": "vav_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "sql_file": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
@@ -11821,8 +8674,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11941,48 +8794,25 @@
       "title": "Min airflow / fixed high flow",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "zone-airflow"
+        "zone_flow",
+        "min_flow_sp"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "flow_on_min": {
-          "default": 25.0,
-          "unit": "cfm",
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 200.0,
-          "step": 5.0,
-          "label": "Airflow-on min"
-        },
-        "fixed_flow_max_std": {
-          "default": 15.0,
-          "unit": "cfm",
-          "min": 1.0,
-          "max": 80.0,
-          "step": 1.0,
-          "label": "Fixed-flow max std"
-        },
-        "fixed_flow_min_mean": {
-          "default": 200.0,
-          "unit": "cfm",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 10.0,
-          "label": "Fixed-flow min mean"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "high_min_flow_sp": {
           "default": 250.0,
@@ -11991,21 +8821,9 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "High min-flow SP"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav7",
+      "pandas_implementation": "vav_7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "sql_file": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
@@ -12015,8 +8833,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12125,15 +8943,11 @@
       "title": "Low chilled-water \u0394T",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-return-temp"
+        "chw_supply_t",
+        "chw_return_t"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -12144,41 +8958,23 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_dt": {
           "default": 4.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Min \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "Minimum delta-T"
         }
       },
       "pandas_implementation": "chw1",
@@ -12196,8 +8992,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "Missing proof \u2192 pandas SKIPPED_MISSING_ROLES; SQL returns 0 fault hours (optional proof roles). Proven-off zeros do not accumulate \u0394T hours.",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 900,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12306,34 +9102,24 @@
       "title": "DP below SP at max pump speed",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chw-diff-pressure",
-        "chw-diff-pressure-sp",
-        "chw-pump-cmd"
+        "chw_dp",
+        "chw_dp_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -12349,21 +9135,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw2",
+      "pandas_implementation": "chw_2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "sql_file": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
@@ -12373,8 +9147,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -12493,56 +9267,34 @@
       "title": "Plant supply temp outside deadband",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-supply-temp-sp",
-        "chw-pump-cmd"
+        "chw_supply_t",
+        "chw_supply_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sp_band": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw3",
+      "pandas_implementation": "chw_3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "sql_file": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
@@ -12552,8 +9304,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -12662,39 +9414,29 @@
       "title": "Flow high at max pump",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chw-flow",
-        "chw-pump-cmd"
+        "chw_flow",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flow_hi": {
-          "default": 1100,
+          "default": 1100.0,
           "unit": "gpm",
-          "min": 200,
-          "max": 3000,
-          "step": 50,
+          "min": 200.0,
+          "max": 3000.0,
+          "step": 50.0,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -12704,21 +9446,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw4",
+      "pandas_implementation": "chw_4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "sql_file": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
@@ -12728,8 +9458,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -12848,55 +9578,45 @@
       "title": "Discharge cold when heating",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "zone-air-temp",
-        "fan-cmd"
+        "sat",
+        "zone_t",
+        "fan_cmd"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "compressor-status",
-        "equipment-enable",
-        "fan-status",
-        "fan-cmd"
+      "optional_roles": [
+        "compressor_status",
+        "fan_status"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_sat": {
           "default": 85.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min heating SAT"
+          "label": "Min discharge SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Zone cold threshold"
         }
       },
-      "pandas_implementation": "hp1",
+      "pandas_implementation": "hp_1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "sql_file": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
@@ -12906,8 +9626,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "compressor",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -13026,40 +9746,32 @@
       "title": "OA temperature spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "weather"
-      ],
-      "equipment_kinds": [
-        "weather"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx1",
+      "pandas_implementation": "wx_1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "sql_file": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
@@ -13069,8 +9781,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -13179,37 +9891,31 @@
       "title": "Condenser water not optimized vs wet-bulb",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
-      "equipment_kinds": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
+      "optional_roles": [
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -13217,26 +9923,14 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt",
+      "pandas_implementation": "cw_opt_1",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "sql_file": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
@@ -13246,8 +9940,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -13366,42 +10060,32 @@
       "title": "High CW approach at full tower fan",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
-      "equipment_kinds": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -13414,21 +10098,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr",
+      "pandas_implementation": "cw_apr_1",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "sql_file": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
@@ -13438,8 +10110,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -13558,42 +10230,32 @@
       "title": "Excess tower fan energy vs wet-bulb limit",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
-      "equipment_kinds": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -13601,7 +10263,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -13614,21 +10276,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_excess",
+      "pandas_implementation": "cw_fan_1",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "sql_file": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
@@ -13638,8 +10288,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -13768,32 +10418,28 @@
       "title": "Duct static trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "duct-static-pressure",
-        "vav-pressure-request-sum"
+        "duct_static_sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -13806,21 +10452,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim1",
+      "pandas_implementation": "trim_1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "sql_file": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
@@ -13830,8 +10464,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -13950,36 +10584,30 @@
       "title": "HWST trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "boiler"
-      ],
-      "equipment_kinds": [
-        "boiler"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "hot-water-supply-temp",
-        "hw-reset-request-sum"
+        "hw_supply_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
+      "optional_roles": [
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -13992,21 +10620,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim3",
+      "pandas_implementation": "trim_3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "sql_file": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
@@ -14016,8 +10632,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -14136,36 +10752,30 @@
       "title": "CHW plant reset advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chw-reset-request-sum"
+        "chw_supply_t"
       ],
-      "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
+      "optional_roles": [
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -14178,21 +10788,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim4",
+      "pandas_implementation": "trim_4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "sql_file": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
@@ -14202,8 +10800,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -14319,53 +10917,45 @@
       "canonical_id": "SCHED-1",
       "pandas_id": "SCHED-1",
       "rule_id": "SCHED-1",
-      "title": "Unoccupied runtime",
+      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
       "aliases": [
         "excess_runtime"
       ],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "occupied",
-        "fan-status"
+        "occ_mode",
+        "fan_status"
       ],
       "optional_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
+          "min": 50.0,
+          "max": 80.0,
           "step": 0.5,
-          "label": "Comfort low"
+          "label": "Zone comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
+          "min": 55.0,
+          "max": 90.0,
           "step": 0.5,
-          "label": "Comfort high"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
+          "label": "Zone comfort high"
         }
       },
       "pandas_implementation": "sched1",
@@ -14382,8 +10972,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: excess_runtime (not independent rules)",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -14502,65 +11092,24 @@
       "title": "Always-on fan or pump runtime",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
-        "fan-status",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "chiller-status",
-        "compressor-status",
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd",
-        "duct-static-pressure",
-        "chw-diff-pressure"
+        "fan_status",
+        "pump_status",
+        "chiller_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "always_on_pct": {
-          "default": 0.95,
-          "unit": "frac",
-          "min": 0.8,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Always-on fraction"
-        },
-        "pressure_on_min": {
-          "default": 0.2,
-          "unit": "eng",
-          "min": 0.05,
-          "max": 2.0,
-          "step": 0.05,
-          "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "_sched247",
@@ -14577,8 +11126,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "4.3: ranked proof status/current > command; pressure is inferred runtime only and does not OR into the FAULT mask. SQL uses the same rank.",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -14677,33 +11226,25 @@
       "title": "Fan cmd/status mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "fan-cmd",
-        "fan-status"
+        "fan_cmd",
+        "fan_status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "cmd1",
+      "pandas_implementation": "cmd_1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "sql_file": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
@@ -14713,8 +11254,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -14813,31 +11354,28 @@
       "title": "Low OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-status"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -14848,26 +11386,14 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "Min |RAT\u2212OAT| guard"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "OAT/RAT guard"
         }
       },
-      "pandas_implementation": "oa1",
+      "pandas_implementation": "oa_1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "sql_file": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
@@ -14877,8 +11403,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -14997,16 +11523,12 @@
       "title": "OA damper leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper"
+        "oa_damper_pct",
+        "oa_t",
+        "mat"
       ],
       "optional_roles": [
         "fan_status",
@@ -15014,28 +11536,24 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp1",
+      "pandas_implementation": "dmp_1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "sql_file": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
@@ -15045,8 +11563,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -15155,27 +11673,31 @@
       "title": "Cooling valve leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "cooling-valve"
+        "clg_valve_pct",
+        "sat",
+        "sat_sp",
+        "mat"
       ],
       "optional_roles": [
-        "mixed-air-temp",
-        "fan-status",
-        "fan-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_err": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -15183,26 +11705,14 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv1",
+      "pandas_implementation": "vlv_1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "sql_file": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
@@ -15212,8 +11722,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -493,7 +493,10 @@
         "duct-static-pressure-sp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -579,7 +582,10 @@
         "return-air-temp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -670,7 +676,10 @@
         "return-air-temp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -820,7 +829,10 @@
         "fan-cmd",
         "heating-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -919,7 +931,10 @@
         "return-air-temp",
         "vav-total-airflow"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1086,7 +1101,8 @@
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc7",
       "test_coverage": [
         "tests/rules/test_golden_parity.py",
-        "tests/rules/test_parity_inventory.py"
+        "tests/rules/test_parity_inventory.py",
+        "tests/test_wattlab_parity_diff.py"
       ],
       "parity_status": "concept_only",
       "known_semantic_differences": "concept_only \u2014 SQL file is a placeholder; do not claim twin parity",
@@ -1104,7 +1120,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1211,7 +1230,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1310,7 +1332,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1401,7 +1426,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1500,7 +1528,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1615,7 +1646,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1708,7 +1742,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1815,7 +1852,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1928,7 +1968,10 @@
         "discharge-air-temp",
         "discharge-air-temp-sp"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -1962,7 +2005,9 @@
       "pandas_implementation": "ahu_sat_dev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
-      "test_coverage": [],
+      "test_coverage": [
+        "tests/test_wattlab_parity_diff.py"
+      ],
       "parity_status": "sql_screening",
       "known_semantic_differences": "",
       "difference_class": "none"
@@ -1977,7 +2022,10 @@
         "duct-static-pressure",
         "duct-static-pressure-sp"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
         "duct_high_margin": {
@@ -2029,7 +2077,10 @@
         "heating-valve",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -2121,7 +2172,10 @@
         "outside-air-damper",
         "outside-air-temp"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -2170,7 +2224,10 @@
         "outside-air-temp",
         "outside-air-damper"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -2306,7 +2363,10 @@
         "outside-air-temp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -2357,7 +2417,10 @@
         "outside-air-temp",
         "heating-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -3639,7 +3702,10 @@
         "duct-static-pressure",
         "vav-pressure-request-sum"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -3985,7 +4051,10 @@
         "outside-air-temp",
         "fan-status"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -4043,7 +4112,10 @@
         "mixed-air-temp",
         "outside-air-damper"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
         "leak_delta": {
@@ -5436,7 +5508,10 @@
         "duct-static-pressure-sp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -5644,7 +5719,10 @@
         "return-air-temp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -5826,7 +5904,10 @@
         "return-air-temp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -6169,7 +6250,10 @@
         "fan-cmd",
         "heating-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -6390,7 +6474,10 @@
         "return-air-temp",
         "vav-total-airflow"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -6681,7 +6768,8 @@
       "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc7",
       "test_coverage": [
         "tests/rules/test_golden_parity.py",
-        "tests/rules/test_parity_inventory.py"
+        "tests/rules/test_parity_inventory.py",
+        "tests/test_wattlab_parity_diff.py"
       ],
       "parity_status": "concept_only",
       "parity_level": "concept_only",
@@ -6819,7 +6907,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -7017,7 +7108,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -7207,7 +7301,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -7389,7 +7486,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -7579,7 +7679,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -7787,7 +7890,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -8022,7 +8128,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -8241,7 +8350,10 @@
         "outside-air-damper",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -8466,7 +8578,10 @@
         "discharge-air-temp",
         "discharge-air-temp-sp"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -8502,7 +8617,9 @@
       "sql_file": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
       "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#ahu-satdev",
-      "test_coverage": [],
+      "test_coverage": [
+        "tests/test_wattlab_parity_diff.py"
+      ],
       "parity_status": "sql_screening",
       "parity_level": "sql_screening",
       "difference_class": "none",
@@ -8627,7 +8744,10 @@
         "duct-static-pressure",
         "duct-static-pressure-sp"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
         "duct_high_margin": {
@@ -8801,7 +8921,10 @@
         "heating-valve",
         "cooling-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -9118,7 +9241,10 @@
         "outside-air-damper",
         "outside-air-temp"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -9269,7 +9395,10 @@
         "outside-air-temp",
         "outside-air-damper"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -9669,7 +9798,10 @@
         "outside-air-temp",
         "fan-cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -9832,7 +9964,10 @@
         "outside-air-temp",
         "heating-valve"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -13643,7 +13778,10 @@
         "duct-static-pressure",
         "vav-pressure-request-sum"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -14687,7 +14825,10 @@
         "outside-air-temp",
         "fan-status"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [
         "fan-status",
         "fan-speed-feedback",
@@ -14867,7 +15008,10 @@
         "mixed-air-temp",
         "outside-air-damper"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "fan_status",
+        "fan_cmd"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
         "leak_delta": {

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -42,7 +42,15 @@
     {
       "rule_id": "SV-RANGE",
       "title": "Sensor out of hard range",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
@@ -53,16 +61,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -70,9 +84,37 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
+        },
+        "range_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Humidity range scale"
+        },
+        "range_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Pressure range scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_range",
+      "pandas_implementation": "_sweep_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
       "test_coverage": [
@@ -85,7 +127,15 @@
     {
       "rule_id": "SV-FLATLINE",
       "title": "Sensor flatline (stuck)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
@@ -98,24 +148,36 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
           "label": "Flatline tolerance"
+        },
+        "flatline_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
+          "label": "Flatline window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_flatline",
+      "pandas_implementation": "_sweep_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
       "test_coverage": [],
@@ -126,7 +188,15 @@
     {
       "rule_id": "SV-SPIKE",
       "title": "Sensor rate-of-change spike",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
@@ -137,16 +207,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -154,9 +230,45 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
+        },
+        "spike_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Temp spike scale"
+        },
+        "spike_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Humidity spike scale"
+        },
+        "spike_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Pressure spike scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_spike",
+      "pandas_implementation": "_sweep_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
       "test_coverage": [],
@@ -167,19 +279,19 @@
     {
       "rule_id": "SV-STALE",
       "title": "Stale data (no fresh samples)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -187,9 +299,21 @@
           "max": 12.0,
           "step": 0.5,
           "label": "Stale window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_stale",
+      "pandas_implementation": "_sweep_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
       "test_coverage": [],
@@ -200,21 +324,21 @@
     {
       "rule_id": "SV-RATE",
       "title": "Context-aware sensor rate of change",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -222,9 +346,53 @@
           "max": 60.0,
           "step": 1.0,
           "label": "Fault persistence"
+        },
+        "transition_window_min": {
+          "default": 20.0,
+          "unit": "min",
+          "min": 5.0,
+          "max": 60.0,
+          "step": 5.0,
+          "label": "Transition window"
+        },
+        "max_gap_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Max sample gap"
+        },
+        "design_flow": {
+          "default": 0.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 100.0,
+          "label": "Design flow (flow profiles)"
+        },
+        "sensor_span": {
+          "default": 0.0,
+          "unit": "eng",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 10.0,
+          "label": "Sensor span (flow/pressure)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_rate",
+      "pandas_implementation": "_sv_rate_compute",
       "datafusion_sql_implementation": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
       "test_coverage": [
@@ -238,27 +406,32 @@
     {
       "rule_id": "PID-HUNT-1",
       "title": "Suspected control-output hunting",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [
         "clg_valve_pct"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "loop-enabled"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 0.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -266,14 +439,58 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
           "label": "Minimum observed span"
+        },
+        "total_variation_fault_pct": {
+          "default": 500.0,
+          "unit": "%/h",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 50.0,
+          "label": "Total travel threshold"
+        },
+        "minimum_equivalent_cycles": {
+          "default": 2.5,
+          "unit": "cyc/h",
+          "min": 0.5,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Min equivalent cycles"
+        },
+        "minimum_reversals": {
+          "default": 4,
+          "unit": "count",
+          "min": 1,
+          "max": 40,
+          "step": 1,
+          "label": "Min direction reversals"
+        },
+        "minimum_coverage_pct": {
+          "default": 80.0,
+          "unit": "%",
+          "min": 25.0,
+          "max": 100.0,
+          "step": 5.0,
+          "label": "Minimum data coverage"
+        },
+        "confirm_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "pid_hunt_1",
+      "pandas_implementation": "_pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
       "test_coverage": [],
@@ -283,26 +500,35 @@
     },
     {
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan",
-      "equipment_types": [],
+      "title": "Duct static below SP at full fan (GL36 A)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "inwc",
+          "unit": "in. w.c.",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -310,15 +536,43 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
+          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
+        },
+        "duct_static_err": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Legacy duct-static error (sets \u03b5DSP)"
+        },
+        "fan_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc1",
@@ -334,20 +588,90 @@
     },
     {
       "rule_id": "FC2",
-      "title": "Mixed air below envelope",
-      "equipment_types": [],
+      "title": "MAT below OAT/RAT envelope (GL36 B)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc2",
@@ -358,20 +682,90 @@
     },
     {
       "rule_id": "FC3",
-      "title": "Mixed air above envelope",
-      "equipment_types": [],
+      "title": "MAT above OAT/RAT envelope (GL36 C)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc3",
@@ -383,24 +777,54 @@
     {
       "rule_id": "FC4",
       "title": "PID hunting (operating-state oscillation)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct",
-        "fan_cmd"
+        "outside-air-damper",
+        "cooling-valve",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
+        "delta_os_max": {
+          "default": 5,
+          "unit": "count",
+          "min": 1,
+          "max": 30,
+          "step": 1,
+          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc4",
@@ -414,34 +838,51 @@
     {
       "rule_id": "FC5",
       "title": "SAT cold when heating commanded (GL36 D)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_sat": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -450,6 +891,42 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -463,26 +940,43 @@
     {
       "rule_id": "FC6",
       "title": "Estimated OA fraction mismatch",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "vav-total-airflow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
+        "eps_airflow": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Airflow error \u03b5F (GL36 default 30%)"
+        },
+        "delta_t_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
           "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
         },
         "airflow_err": {
           "default": 0.15,
@@ -490,15 +984,51 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Airflow error epsF (GL36 default 30%)"
+          "label": "Legacy OA-fraction error (sets \u03b5F)"
         },
-        "delta_t_min": {
+        "oat_rat_delta_min": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
+          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
+        },
+        "min_cfm_design": {
+          "default": 5000,
+          "unit": "cfm",
+          "min": 500,
+          "max": 20000,
+          "step": 500,
+          "label": "Design min OA CFM"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc6",
@@ -511,24 +1041,41 @@
     },
     {
       "rule_id": "FC7",
-      "title": "SAT low while heating at full",
-      "equipment_types": [],
+      "title": "SAT low with full heating (GL36 E)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets epsSAT)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -538,13 +1085,33 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc7",
@@ -561,20 +1128,106 @@
     },
     {
       "rule_id": "FC8",
-      "title": "SAT vs MAT while economizing",
-      "equipment_types": [],
+      "title": "SAT/MAT mismatch in economizer (GL36 F)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc8",
@@ -585,20 +1238,98 @@
     },
     {
       "rule_id": "FC9",
-      "title": "OAT high vs SAT SP while economizing",
-      "equipment_types": [],
+      "title": "OAT too warm for free cooling (GL36 G)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc9",
@@ -609,20 +1340,90 @@
     },
     {
       "rule_id": "FC10",
-      "title": "MAT-OAT delta while cooling and economizing",
-      "equipment_types": [],
+      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc10",
@@ -633,20 +1434,98 @@
     },
     {
       "rule_id": "FC11",
-      "title": "OAT low vs SAT SP while cooling and economizing",
-      "equipment_types": [],
+      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc11",
@@ -657,20 +1536,114 @@
     },
     {
       "rule_id": "FC12",
-      "title": "SAT above MAT while cooling",
-      "equipment_types": [],
+      "title": "SAT above blend in cooling (GL36 J)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc12",
@@ -681,59 +1654,88 @@
     },
     {
       "rule_id": "FC13",
-      "title": "SAT above setpoint at full cooling",
-      "equipment_types": [],
+      "title": "SAT above SP at full cooling (GL36 K)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "clg_valve_pct",
-        "oa_damper_pct"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT high error band"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
         },
-        "clg_valve_min": {
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "clg_full_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
+          "min": 0.5,
+          "max": 1.0,
           "step": 0.01,
-          "label": "Cooling valve open threshold"
+          "label": "Full-cooling threshold (GL36 99%)"
         },
-        "oa_damper_econ_low": {
+        "econ_min_pos": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "OA damper economizer low"
+          "label": "Economizer minimum-position threshold"
         },
-        "oa_damper_econ_high": {
+        "econ_full_open": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "OA damper economizer high"
+          "label": "Economizer full-open threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc13",
@@ -749,35 +1751,103 @@
     {
       "rule_id": "FC14",
       "title": "CHW coil \u0394T when inactive (GL36 L)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "sat",
-        "clg_valve_pct",
-        "oa_damper_pct",
-        "fan_cmd"
+        "cooling-coil-entering-temp",
+        "cooling-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_ccet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Cooling-coil entering sensor error \u03b5CCET"
+        },
+        "eps_cclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc14",
@@ -791,34 +1861,111 @@
     {
       "rule_id": "FC15",
       "title": "HW coil \u0394T when inactive (GL36 M)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "sat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "heating-coil-entering-temp",
+        "heating-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_hcet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Heating-coil entering sensor error \u03b5HCET"
+        },
+        "eps_hclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil leaving sensor error \u03b5HCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc15",
@@ -832,35 +1979,48 @@
     {
       "rule_id": "AHU-SATDEV",
       "title": "SAT deviation from setpoint",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp"
+        "discharge-air-temp",
+        "discharge-air-temp-sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_satdev",
+      "pandas_implementation": "ahu_sat_dev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
       "test_coverage": [
@@ -873,11 +2033,12 @@
     {
       "rule_id": "AHU-DUCTHI",
       "title": "Duct static pressure high",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp"
       ],
       "optional_roles": [
         "fan_status",
@@ -885,17 +2046,9 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -903,14 +2056,26 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_ducthi",
+      "pandas_implementation": "ahu_duct_high",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
       "test_coverage": [
@@ -923,25 +2088,26 @@
     {
       "rule_id": "AHU-SIMUL",
       "title": "Heating and cooling simultaneous",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "htg_valve_pct",
-        "clg_valve_pct"
+        "heating-valve",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -949,9 +2115,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul",
+      "pandas_implementation": "ahu_simul_heat_cool",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
       "test_coverage": [],
@@ -961,29 +2139,36 @@
     },
     {
       "rule_id": "OAT-METEO",
-      "title": "Equipment OAT vs weather-staged wx OAT",
-      "equipment_types": [],
+      "title": "BAS outdoor-air sensor vs Open-Meteo",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp",
+        "web-outside-air-temp"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "OAT vs meteo tolerance"
+          "label": "Max OAT disagreement"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -996,26 +2181,47 @@
     },
     {
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed when OAT favorable",
-      "equipment_types": [],
+      "title": "Economizer stuck closed",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "oa_damper_pct",
-        "oa_t"
+        "fan-cmd",
+        "outside-air-damper",
+        "outside-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ1",
@@ -1028,21 +2234,30 @@
     },
     {
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor air unfavorable",
-      "equipment_types": [],
+      "title": "Economizing when outdoor unfavorable",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "oa_damper_pct"
+        "outside-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -1056,13 +2271,17 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ2",
@@ -1076,30 +2295,30 @@
     {
       "rule_id": "ECON-3",
       "title": "Mech cooling without integrated economizer",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -1107,7 +2326,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -1115,7 +2334,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -1128,9 +2347,21 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_3",
+      "pandas_implementation": "econ2",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
       "test_coverage": [],
@@ -1141,34 +2372,47 @@
     {
       "rule_id": "ECON-4",
       "title": "Low estimated OA fraction",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "pct",
+          "unit": "%",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ4",
@@ -1182,37 +2426,50 @@
     {
       "rule_id": "ECON-5",
       "title": "Preheat over-conditioning",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "preheat_leave_t",
-        "sat_sp",
-        "oa_t",
-        "htg_valve_pct"
+        "preheat-leaving-temp",
+        "discharge-air-temp-sp",
+        "outside-air-temp",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_5",
+      "pandas_implementation": "econ5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
       "test_coverage": [],
@@ -1223,28 +2480,27 @@
     {
       "rule_id": "ECON-6",
       "title": "Economizing in freezing weather",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "web_oa_t",
-        "oa_damper_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -1257,9 +2513,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_6",
+      "pandas_implementation": "econ6_compute",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
       "test_coverage": [],
@@ -1270,30 +2538,32 @@
     {
       "rule_id": "ECON-7",
       "title": "Economizer OK but not economizing",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity",
+        "cooling-valve",
+        "compressor-status",
+        "dx-cool-cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -1301,7 +2571,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -1309,7 +2579,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -1322,9 +2592,21 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_7",
+      "pandas_implementation": "econ7_compute",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
       "test_coverage": [],
@@ -1335,32 +2617,46 @@
     {
       "rule_id": "MECH-OAT-1",
       "title": "Mechanical cooling below 60\u00b0F web OAT",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
       "required_roles": [
         "web_oa_t",
         "clg_valve_pct"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "web-outside-air-temp",
+        "compressor-status",
+        "chiller-status",
+        "chw-pump-status",
+        "dx-cool-cmd"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat_1",
+      "pandas_implementation": "mech_oat1_compute",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
       "test_coverage": [],
@@ -1371,33 +2667,61 @@
     {
       "rule_id": "CHW-NOLOAD-1",
       "title": "Chiller running with no building load",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
         "chw_supply_t",
         "chw_supply_sp",
         "chw_pump_cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "chiller-status",
+        "chw-pump-status",
+        "compressor-status",
+        "building-zone-load-satisfied",
+        "building-ahu-load-satisfied"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
         },
         "sat_band_f": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "AHU SAT\u2248SP band"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_noload_1",
+      "pandas_implementation": "chw_noload1_compute",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
       "test_coverage": [],
@@ -1407,39 +2731,46 @@
     },
     {
       "rule_id": "VAV-1",
-      "title": "Zone comfort band violation hours with confirm window",
-      "equipment_types": [],
+      "title": "Zone comfort band",
+      "equipment_types": [
+        "vav",
+        "zone"
+      ],
       "required_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "optional_roles": [
         "occ_mode"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_t_lo": {
+        "zone_lo": {
           "default": 70.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_t_hi": {
+        "zone_hi": {
           "default": 75.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav1",
@@ -1456,29 +2787,29 @@
     {
       "rule_id": "VAV-3",
       "title": "Excessive reheat during warm weather",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "oa_t",
-        "reheat_valve_pct",
-        "zone_flow"
+        "outside-air-temp",
+        "reheat-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -1499,9 +2830,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_3",
+      "pandas_implementation": "vav3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
       "test_coverage": [],
@@ -1512,25 +2855,26 @@
     {
       "rule_id": "VAV-4",
       "title": "Damper stuck at full open",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "damper_pct",
-        "zone_flow"
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -1539,6 +2883,14 @@
           "step": 0.005,
           "label": "Full open frac"
         },
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
+        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -1546,9 +2898,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_4",
+      "pandas_implementation": "vav4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
       "test_coverage": [],
@@ -1559,27 +2923,40 @@
     {
       "rule_id": "VAV-5",
       "title": "Airflow sensor bias",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "damper_pct"
+        "zone-airflow",
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_5",
+      "pandas_implementation": "vav5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
       "test_coverage": [],
@@ -1590,27 +2967,27 @@
     {
       "rule_id": "VAV-REHEAT",
       "title": "Reheat valve stuck / no temp rise",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "reheat_valve_pct",
-        "vav_discharge_t",
-        "vav_inlet_t",
-        "zone_flow"
+        "reheat-valve",
+        "vav-discharge-air-temp",
+        "vav-inlet-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -1621,7 +2998,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -1634,9 +3011,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat",
+      "pandas_implementation": "vav_reheat_stuck",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
       "test_coverage": [],
@@ -1647,29 +3036,29 @@
     {
       "rule_id": "VAV-AHU-LEAVE",
       "title": "VAV leave vs parent AHU SAT (fedBy)",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "vav_discharge_t",
-        "ahu_sat",
-        "zone_flow"
+        "vav-discharge-air-temp",
+        "ahu-discharge-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "delta_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -1682,9 +3071,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_ahu_leave",
+      "pandas_implementation": "vav_vs_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
       "test_coverage": [],
@@ -1695,24 +3096,48 @@
     {
       "rule_id": "VAV-7",
       "title": "Min airflow / fixed high flow",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "min_flow_sp"
+        "zone-airflow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
           "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "fixed_flow_max_std": {
+          "default": 15.0,
+          "unit": "cfm",
+          "min": 1.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Fixed-flow max std"
+        },
+        "fixed_flow_min_mean": {
+          "default": 200.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "Fixed-flow min mean"
         },
         "high_min_flow_sp": {
           "default": 250.0,
@@ -1721,9 +3146,21 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "High min-flow SP"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_7",
+      "pandas_implementation": "vav7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
       "test_coverage": [],
@@ -1734,10 +3171,12 @@
     {
       "rule_id": "CHW-1",
       "title": "Low chilled-water \u0394T",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_return_t"
+        "chilled-water-supply-temp",
+        "chilled-water-return-temp"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -1748,23 +3187,41 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_dt": {
           "default": 4.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Minimum delta-T"
+          "label": "Min \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "chw1",
@@ -1783,23 +3240,31 @@
     {
       "rule_id": "CHW-2",
       "title": "DP below SP at max pump speed",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_dp",
-        "chw_dp_sp",
-        "chw_pump_cmd"
+        "chw-diff-pressure",
+        "chw-diff-pressure-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -1815,9 +3280,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_2",
+      "pandas_implementation": "chw2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
       "test_coverage": [],
@@ -1828,33 +3305,53 @@
     {
       "rule_id": "CHW-3",
       "title": "Plant supply temp outside deadband",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_supply_sp",
-        "chw_pump_cmd"
+        "chilled-water-supply-temp",
+        "chilled-water-supply-temp-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sp_band": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_3",
+      "pandas_implementation": "chw3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
       "test_coverage": [],
@@ -1865,28 +3362,36 @@
     {
       "rule_id": "CHW-4",
       "title": "Flow high at max pump",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_flow",
-        "chw_pump_cmd"
+        "chw-flow",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flow_hi": {
-          "default": 1100.0,
+          "default": 1100,
           "unit": "gpm",
-          "min": 200.0,
-          "max": 3000.0,
-          "step": 50.0,
+          "min": 200,
+          "max": 3000,
+          "step": 50,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -1896,9 +3401,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_4",
+      "pandas_implementation": "chw4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
       "test_coverage": [],
@@ -1909,44 +3426,55 @@
     {
       "rule_id": "HP-1",
       "title": "Discharge cold when heating",
-      "equipment_types": [],
+      "equipment_types": [
+        "heatpump"
+      ],
       "required_roles": [
-        "sat",
-        "zone_t",
-        "fan_cmd"
+        "discharge-air-temp",
+        "zone-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "compressor_status",
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "compressor-status",
+        "equipment-enable",
+        "fan-status",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_sat": {
           "default": 85.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min discharge SAT"
+          "label": "Min heating SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold threshold"
+          "label": "Zone cold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "hp_1",
+      "pandas_implementation": "hp1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
       "test_coverage": [],
@@ -1957,31 +3485,37 @@
     {
       "rule_id": "WX-1",
       "title": "OA temperature spike",
-      "equipment_types": [],
+      "equipment_types": [
+        "weather"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx_1",
+      "pandas_implementation": "wx1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
       "test_coverage": [],
@@ -1992,10 +3526,12 @@
     {
       "rule_id": "CW-OPT-1",
       "title": "Condenser water not optimized vs wet-bulb",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
         "pump_status",
@@ -2003,19 +3539,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -2023,14 +3565,26 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt_1",
+      "pandas_implementation": "cw_opt",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
       "test_coverage": [],
@@ -2041,31 +3595,38 @@
     {
       "rule_id": "CW-APR-1",
       "title": "High CW approach at full tower fan",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -2078,9 +3639,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr_1",
+      "pandas_implementation": "cw_apr",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
       "test_coverage": [],
@@ -2091,31 +3664,38 @@
     {
       "rule_id": "CW-FAN-1",
       "title": "Excess tower fan energy vs wet-bulb limit",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -2123,7 +3703,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -2136,9 +3716,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_1",
+      "pandas_implementation": "cw_fan_excess",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
       "test_coverage": [],
@@ -2149,27 +3741,29 @@
     {
       "rule_id": "TRIM-1",
       "title": "Duct static trim advisory",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static_sp"
+        "duct-static-pressure",
+        "vav-pressure-request-sum"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -2182,9 +3776,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_1",
+      "pandas_implementation": "trim1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
       "test_coverage": [],
@@ -2195,9 +3801,12 @@
     {
       "rule_id": "TRIM-3",
       "title": "HWST trim advisory",
-      "equipment_types": [],
+      "equipment_types": [
+        "boiler"
+      ],
       "required_roles": [
-        "hw_supply_t"
+        "hot-water-supply-temp",
+        "hw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -2205,19 +3814,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -2230,9 +3845,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_3",
+      "pandas_implementation": "trim3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
       "test_coverage": [],
@@ -2243,9 +3870,12 @@
     {
       "rule_id": "TRIM-4",
       "title": "CHW plant reset advisory",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t"
+        "chilled-water-supply-temp",
+        "chw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -2253,19 +3883,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -2278,9 +3914,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_4",
+      "pandas_implementation": "trim4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
       "test_coverage": [],
@@ -2290,40 +3938,46 @@
     },
     {
       "rule_id": "SCHED-1",
-      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
-      "equipment_types": [],
+      "title": "Unoccupied runtime",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "occ_mode",
-        "fan_status"
+        "occupied",
+        "fan-status"
       ],
       "optional_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 50.0,
-          "max": 80.0,
+          "min": 60.0,
+          "max": 78.0,
           "step": 0.5,
-          "label": "Zone comfort low"
+          "label": "Comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 55.0,
-          "max": 90.0,
+          "min": 68.0,
+          "max": 85.0,
           "step": 0.5,
-          "label": "Zone comfort high"
+          "label": "Comfort high"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "sched1",
@@ -2341,23 +3995,58 @@
     {
       "rule_id": "SCHED-247",
       "title": "Always-on fan or pump runtime",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "fan_status",
-        "pump_status",
-        "chiller_status",
-        "fan_cmd"
+        "fan-status",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "chiller-status",
+        "compressor-status",
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd",
+        "duct-static-pressure",
+        "chw-diff-pressure"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "always_on_pct": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Always-on fraction"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "eng",
+          "min": 0.05,
+          "max": 2.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "_sched247",
@@ -2375,24 +4064,30 @@
     {
       "rule_id": "CMD-1",
       "title": "Fan cmd/status mismatch",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "fan_status"
+        "fan-cmd",
+        "fan-status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cmd_1",
+      "pandas_implementation": "cmd1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
       "test_coverage": [],
@@ -2403,27 +4098,28 @@
     {
       "rule_id": "OA-1",
       "title": "Low OA fraction",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-status"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -2434,14 +4130,26 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "OAT/RAT guard"
+          "label": "Min |RAT\u2212OAT| guard"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "oa_1",
+      "pandas_implementation": "oa1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
       "test_coverage": [],
@@ -2452,11 +4160,13 @@
     {
       "rule_id": "DMP-1",
       "title": "OA damper leakage",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "oa_t",
-        "mat"
+        "outside-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
@@ -2464,24 +4174,28 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp_1",
+      "pandas_implementation": "dmp1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
       "test_coverage": [],
@@ -2492,30 +4206,24 @@
     {
       "rule_id": "VLV-1",
       "title": "Cooling valve leakage",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "clg_valve_pct",
-        "sat",
-        "sat_sp",
-        "mat"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "mixed-air-temp",
+        "fan-status",
+        "fan-cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_err": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -2523,14 +4231,26 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv_1",
+      "pandas_implementation": "vlv1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
       "test_coverage": [],
@@ -2672,8 +4392,24 @@
       "title": "Sensor out of hard range",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
@@ -2684,16 +4420,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -2701,9 +4443,37 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
+        },
+        "range_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Humidity range scale"
+        },
+        "range_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Pressure range scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_range",
+      "pandas_implementation": "_sweep_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "sql_file": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
@@ -2715,8 +4485,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "equipment_energized",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -2825,8 +4595,24 @@
       "title": "Sensor flatline (stuck)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
@@ -2839,24 +4625,36 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
           "label": "Flatline tolerance"
+        },
+        "flatline_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
+          "label": "Flatline window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_flatline",
+      "pandas_implementation": "_sweep_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "sql_file": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
@@ -2866,8 +4664,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -2976,8 +4774,24 @@
       "title": "Sensor rate-of-change spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
@@ -2988,16 +4802,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -3005,9 +4825,45 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
+        },
+        "spike_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Temp spike scale"
+        },
+        "spike_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Humidity spike scale"
+        },
+        "spike_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Pressure spike scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_spike",
+      "pandas_implementation": "_sweep_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "sql_file": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
@@ -3017,8 +4873,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "equipment_energized",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -3127,20 +4983,28 @@
       "title": "Stale data (no fresh samples)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -3148,9 +5012,21 @@
           "max": 12.0,
           "step": 0.5,
           "label": "Stale window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_stale",
+      "pandas_implementation": "_sweep_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "sql_file": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
@@ -3160,8 +5036,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -3272,22 +5148,30 @@
         "SV-SLEW"
       ],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [
         "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -3295,9 +5179,53 @@
           "max": 60.0,
           "step": 1.0,
           "label": "Fault persistence"
+        },
+        "transition_window_min": {
+          "default": 20.0,
+          "unit": "min",
+          "min": 5.0,
+          "max": 60.0,
+          "step": 5.0,
+          "label": "Transition window"
+        },
+        "max_gap_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Max sample gap"
+        },
+        "design_flow": {
+          "default": 0.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 100.0,
+          "label": "Design flow (flow profiles)"
+        },
+        "sensor_span": {
+          "default": 0.0,
+          "unit": "eng",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 10.0,
+          "label": "Sensor span (flow/pressure)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_rate",
+      "pandas_implementation": "_sv_rate_compute",
       "datafusion_sql_implementation": "sv_rate.sql",
       "sql_file": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
@@ -3310,8 +5238,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: SV-SLEW (not independent rules)",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -3420,28 +5348,39 @@
       "title": "Suspected control-output hunting",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [
         "clg_valve_pct"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "loop-enabled"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 0.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -3449,14 +5388,58 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
           "label": "Minimum observed span"
+        },
+        "total_variation_fault_pct": {
+          "default": 500.0,
+          "unit": "%/h",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 50.0,
+          "label": "Total travel threshold"
+        },
+        "minimum_equivalent_cycles": {
+          "default": 2.5,
+          "unit": "cyc/h",
+          "min": 0.5,
+          "max": 20.0,
+          "step": 0.5,
+          "label": "Min equivalent cycles"
+        },
+        "minimum_reversals": {
+          "default": 4,
+          "unit": "count",
+          "min": 1,
+          "max": 40,
+          "step": 1,
+          "label": "Min direction reversals"
+        },
+        "minimum_coverage_pct": {
+          "default": 80.0,
+          "unit": "%",
+          "min": 25.0,
+          "max": 100.0,
+          "step": 5.0,
+          "label": "Minimum data coverage"
+        },
+        "confirm_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "pid_hunt_1",
+      "pandas_implementation": "_pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "sql_file": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
@@ -3466,8 +5449,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 0,
       "parameters": {
         "confirm_seconds": {
@@ -3583,29 +5566,40 @@
       "canonical_id": "FC1",
       "pandas_id": "FC1",
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan",
+      "title": "Duct static below SP at full fan (GL36 A)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "inwc",
+          "unit": "in. w.c.",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -3613,15 +5607,43 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
+          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
+        },
+        "duct_static_err": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Legacy duct-static error (sets \u03b5DSP)"
+        },
+        "fan_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc1",
@@ -3637,8 +5659,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "eps_dsp": {
@@ -3754,23 +5776,95 @@
       "canonical_id": "FC2",
       "pandas_id": "FC2",
       "rule_id": "FC2",
-      "title": "Mixed air below envelope",
+      "title": "MAT below OAT/RAT envelope (GL36 B)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "sql_file": "fc2_mat_low.sql",
@@ -3781,8 +5875,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -3867,23 +5961,95 @@
       "canonical_id": "FC3",
       "pandas_id": "FC3",
       "rule_id": "FC3",
-      "title": "Mixed air above envelope",
+      "title": "MAT above OAT/RAT envelope (GL36 C)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "sql_file": "fc3_mat_high.sql",
@@ -3894,8 +6060,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -3983,25 +6149,57 @@
       "title": "PID hunting (operating-state oscillation)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct",
-        "fan_cmd"
+        "outside-air-damper",
+        "cooling-valve",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
+        "delta_os_max": {
+          "default": 5,
+          "unit": "count",
+          "min": 1,
+          "max": 30,
+          "step": 1,
+          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc4",
@@ -4014,8 +6212,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -4114,35 +6312,54 @@
       "title": "SAT cold when heating commanded (GL36 D)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_sat": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -4151,6 +6368,42 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -4163,8 +6416,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -4283,27 +6536,46 @@
       "title": "Estimated OA fraction mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "vav-total-airflow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
+        "eps_airflow": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Airflow error \u03b5F (GL36 default 30%)"
+        },
+        "delta_t_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
           "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
         },
         "airflow_err": {
           "default": 0.15,
@@ -4311,15 +6583,51 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Airflow error epsF (GL36 default 30%)"
+          "label": "Legacy OA-fraction error (sets \u03b5F)"
         },
-        "delta_t_min": {
+        "oat_rat_delta_min": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
+          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
+        },
+        "min_cfm_design": {
+          "default": 5000,
+          "unit": "cfm",
+          "min": 500,
+          "max": 20000,
+          "step": 500,
+          "label": "Design min OA CFM"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc6",
@@ -4332,8 +6640,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -4449,27 +6757,46 @@
       "canonical_id": "FC7",
       "pandas_id": "FC7",
       "rule_id": "FC7",
-      "title": "SAT low while heating at full",
+      "title": "SAT low with full heating (GL36 E)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets epsSAT)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -4479,13 +6806,33 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc7",
@@ -4502,8 +6849,8 @@
       "parity_level": "concept_only",
       "difference_class": "missing_implementation",
       "known_semantic_differences": "concept_only \u2014 SQL file is a placeholder; do not claim twin parity",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -4619,23 +6966,111 @@
       "canonical_id": "FC8",
       "pandas_id": "FC8",
       "rule_id": "FC8",
-      "title": "SAT vs MAT while economizing",
+      "title": "SAT/MAT mismatch in economizer (GL36 F)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "sql_file": "fc8_sat_mat_econ.sql",
@@ -4646,8 +7081,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -4732,23 +7167,103 @@
       "canonical_id": "FC9",
       "pandas_id": "FC9",
       "rule_id": "FC9",
-      "title": "OAT high vs SAT SP while economizing",
+      "title": "OAT too warm for free cooling (GL36 G)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "sql_file": "fc9_oa_sat_sp_econ.sql",
@@ -4759,8 +7274,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -4845,23 +7360,95 @@
       "canonical_id": "FC10",
       "pandas_id": "FC10",
       "rule_id": "FC10",
-      "title": "MAT-OAT delta while cooling and economizing",
+      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "sql_file": "fc10_mat_oa_clg.sql",
@@ -4872,8 +7459,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -4958,23 +7545,103 @@
       "canonical_id": "FC11",
       "pandas_id": "FC11",
       "rule_id": "FC11",
-      "title": "OAT low vs SAT SP while cooling and economizing",
+      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "sql_file": "fc11_oa_sat_sp_clg.sql",
@@ -4985,8 +7652,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5071,23 +7738,119 @@
       "canonical_id": "FC12",
       "pandas_id": "FC12",
       "rule_id": "FC12",
-      "title": "SAT above MAT while cooling",
+      "title": "SAT above blend in cooling (GL36 J)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "sql_file": "fc12_sat_mat_clg.sql",
@@ -5098,8 +7861,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5184,64 +7947,95 @@
       "canonical_id": "FC13-SAT-HIGH",
       "pandas_id": "FC13",
       "rule_id": "FC13",
-      "title": "SAT above setpoint at full cooling",
+      "title": "SAT above SP at full cooling (GL36 K)",
       "aliases": [
         "FC13"
       ],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "clg_valve_pct",
-        "oa_damper_pct"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT high error band"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
         },
-        "clg_valve_min": {
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "clg_full_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
+          "min": 0.5,
+          "max": 1.0,
           "step": 0.01,
-          "label": "Cooling valve open threshold"
+          "label": "Full-cooling threshold (GL36 99%)"
         },
-        "oa_damper_econ_low": {
+        "econ_min_pos": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "OA damper economizer low"
+          "label": "Economizer minimum-position threshold"
         },
-        "oa_damper_econ_high": {
+        "econ_full_open": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "OA damper economizer high"
+          "label": "Economizer full-open threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc13",
@@ -5256,8 +8050,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: FC13 (not independent rules)",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -5396,36 +8190,106 @@
       "title": "CHW coil \u0394T when inactive (GL36 L)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "sat",
-        "clg_valve_pct",
-        "oa_damper_pct",
-        "fan_cmd"
+        "cooling-coil-entering-temp",
+        "cooling-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_ccet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Cooling-coil entering sensor error \u03b5CCET"
+        },
+        "eps_cclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc14",
@@ -5438,8 +8302,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -5548,35 +8412,114 @@
       "title": "HW coil \u0394T when inactive (GL36 M)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "sat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "heating-coil-entering-temp",
+        "heating-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_hcet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Heating-coil entering sensor error \u03b5HCET"
+        },
+        "eps_hclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil leaving sensor error \u03b5HCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc15",
@@ -5589,8 +8532,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -5699,36 +8642,51 @@
       "title": "SAT deviation from setpoint",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp"
+        "discharge-air-temp",
+        "discharge-air-temp-sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_satdev",
+      "pandas_implementation": "ahu_sat_dev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "sql_file": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
@@ -5740,8 +8698,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -5850,12 +8808,15 @@
       "title": "Duct static pressure high",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp"
       ],
       "optional_roles": [
         "fan_status",
@@ -5863,17 +8824,9 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -5881,14 +8834,26 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_ducthi",
+      "pandas_implementation": "ahu_duct_high",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "sql_file": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
@@ -5900,8 +8865,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -6020,26 +8985,29 @@
       "title": "Heating and cooling simultaneous",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "htg_valve_pct",
-        "clg_valve_pct"
+        "heating-valve",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -6047,9 +9015,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul",
+      "pandas_implementation": "ahu_simul_heat_cool",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "sql_file": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
@@ -6059,8 +9039,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -6166,32 +9146,41 @@
       "canonical_id": "OAT-METEO",
       "pandas_id": "OAT-METEO",
       "rule_id": "OAT-METEO",
-      "title": "Equipment OAT vs weather-staged wx OAT",
+      "title": "BAS outdoor-air sensor vs Open-Meteo",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp",
+        "web-outside-air-temp"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "OAT vs meteo tolerance"
+          "label": "Max OAT disagreement"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -6204,8 +9193,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 900,
       "parameters": {
         "oat_err": {
@@ -6312,29 +9301,52 @@
       "canonical_id": "ECON-1",
       "pandas_id": "ECON-1",
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed when OAT favorable",
+      "title": "Economizer stuck closed",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "oa_damper_pct",
-        "oa_t"
+        "fan-cmd",
+        "outside-air-damper",
+        "outside-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ1",
@@ -6347,8 +9359,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "econ1_oat_min": {
@@ -6444,24 +9456,35 @@
       "canonical_id": "ECON-2",
       "pandas_id": "ECON-2",
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor air unfavorable",
+      "title": "Economizing when outdoor unfavorable",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "oa_damper_pct"
+        "outside-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -6475,13 +9498,17 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ2",
@@ -6494,8 +9521,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "econ2_oat_hi": {
@@ -6614,31 +9641,33 @@
       "title": "Mech cooling without integrated economizer",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -6646,7 +9675,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -6654,7 +9683,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -6667,9 +9696,21 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_3",
+      "pandas_implementation": "econ2",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "sql_file": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
@@ -6679,8 +9720,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -6819,35 +9860,50 @@
       "title": "Low estimated OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "pct",
+          "unit": "%",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ4",
@@ -6860,8 +9916,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "oa_min_pct": {
@@ -6970,38 +10026,53 @@
       "title": "Preheat over-conditioning",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "preheat_leave_t",
-        "sat_sp",
-        "oa_t",
-        "htg_valve_pct"
+        "preheat-leaving-temp",
+        "discharge-air-temp-sp",
+        "outside-air-temp",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_5",
+      "pandas_implementation": "econ5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "sql_file": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
@@ -7011,8 +10082,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -7121,29 +10192,30 @@
       "title": "Economizing in freezing weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "web_oa_t",
-        "oa_damper_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -7156,9 +10228,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_6",
+      "pandas_implementation": "econ6_compute",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "sql_file": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
@@ -7168,8 +10252,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -7288,31 +10372,35 @@
       "title": "Economizer OK but not economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity",
+        "cooling-valve",
+        "compressor-status",
+        "dx-cool-cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -7320,7 +10408,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -7328,7 +10416,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -7341,9 +10429,21 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_7",
+      "pandas_implementation": "econ7_compute",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "sql_file": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
@@ -7353,8 +10453,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -7493,33 +10593,51 @@
       "title": "Mechanical cooling below 60\u00b0F web OAT",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
       "required_roles": [
         "web_oa_t",
         "clg_valve_pct"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "web-outside-air-temp",
+        "compressor-status",
+        "chiller-status",
+        "chw-pump-status",
+        "dx-cool-cmd"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat_1",
+      "pandas_implementation": "mech_oat1_compute",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "sql_file": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
@@ -7529,8 +10647,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -7639,34 +10757,64 @@
       "title": "Chiller running with no building load",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
         "chw_supply_t",
         "chw_supply_sp",
         "chw_pump_cmd"
       ],
-      "optional_roles": [],
+      "optional_roles": [
+        "chiller-status",
+        "chw-pump-status",
+        "compressor-status",
+        "building-zone-load-satisfied",
+        "building-ahu-load-satisfied"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
         },
         "sat_band_f": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "AHU SAT\u2248SP band"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_noload_1",
+      "pandas_implementation": "chw_noload1_compute",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "sql_file": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
@@ -7676,8 +10824,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -7783,42 +10931,52 @@
       "canonical_id": "VAV-1",
       "pandas_id": "VAV-1",
       "rule_id": "VAV-1",
-      "title": "Zone comfort band violation hours with confirm window",
+      "title": "Zone comfort band",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav",
+        "zone"
+      ],
+      "equipment_kinds": [
+        "vav",
+        "zone"
+      ],
       "required_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "optional_roles": [
         "occ_mode"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_t_lo": {
+        "zone_lo": {
           "default": 70.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_t_hi": {
+        "zone_hi": {
           "default": 75.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav1",
@@ -7834,8 +10992,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 900,
       "parameters": {
         "zone_t_lo": {
@@ -7955,30 +11113,32 @@
       "title": "Excessive reheat during warm weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "oa_t",
-        "reheat_valve_pct",
-        "zone_flow"
+        "outside-air-temp",
+        "reheat-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -7999,9 +11159,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_3",
+      "pandas_implementation": "vav3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "sql_file": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
@@ -8011,8 +11183,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -8141,26 +11313,29 @@
       "title": "Damper stuck at full open",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "damper_pct",
-        "zone_flow"
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -8169,6 +11344,14 @@
           "step": 0.005,
           "label": "Full open frac"
         },
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
+        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -8176,9 +11359,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_4",
+      "pandas_implementation": "vav4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "sql_file": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
@@ -8188,8 +11383,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -8308,28 +11503,43 @@
       "title": "Airflow sensor bias",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "damper_pct"
+        "zone-airflow",
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_5",
+      "pandas_implementation": "vav5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "sql_file": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
@@ -8339,8 +11549,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -8439,28 +11649,30 @@
       "title": "Reheat valve stuck / no temp rise",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "reheat_valve_pct",
-        "vav_discharge_t",
-        "vav_inlet_t",
-        "zone_flow"
+        "reheat-valve",
+        "vav-discharge-air-temp",
+        "vav-inlet-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -8471,7 +11683,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -8484,9 +11696,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat",
+      "pandas_implementation": "vav_reheat_stuck",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "sql_file": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
@@ -8496,8 +11720,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -8626,30 +11850,32 @@
       "title": "VAV leave vs parent AHU SAT (fedBy)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "vav_discharge_t",
-        "ahu_sat",
-        "zone_flow"
+        "vav-discharge-air-temp",
+        "ahu-discharge-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "delta_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -8662,9 +11888,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_ahu_leave",
+      "pandas_implementation": "vav_vs_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "sql_file": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
@@ -8674,8 +11912,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -8794,25 +12032,51 @@
       "title": "Min airflow / fixed high flow",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "min_flow_sp"
+        "zone-airflow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
+        "flow_on_min": {
+          "default": 25.0,
+          "unit": "cfm",
           "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "max": 200.0,
+          "step": 5.0,
+          "label": "Airflow-on min"
+        },
+        "fixed_flow_max_std": {
+          "default": 15.0,
+          "unit": "cfm",
+          "min": 1.0,
+          "max": 80.0,
+          "step": 1.0,
+          "label": "Fixed-flow max std"
+        },
+        "fixed_flow_min_mean": {
+          "default": 200.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "Fixed-flow min mean"
         },
         "high_min_flow_sp": {
           "default": 250.0,
@@ -8821,9 +12085,21 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "High min-flow SP"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_7",
+      "pandas_implementation": "vav7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "sql_file": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
@@ -8833,8 +12109,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -8943,11 +12219,15 @@
       "title": "Low chilled-water \u0394T",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_return_t"
+        "chilled-water-supply-temp",
+        "chilled-water-return-temp"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -8958,23 +12238,41 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_dt": {
           "default": 4.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Minimum delta-T"
+          "label": "Min \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "chw1",
@@ -8992,8 +12290,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "Missing proof \u2192 pandas SKIPPED_MISSING_ROLES; SQL returns 0 fault hours (optional proof roles). Proven-off zeros do not accumulate \u0394T hours.",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 900,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -9102,24 +12400,34 @@
       "title": "DP below SP at max pump speed",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_dp",
-        "chw_dp_sp",
-        "chw_pump_cmd"
+        "chw-diff-pressure",
+        "chw-diff-pressure-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -9135,9 +12443,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_2",
+      "pandas_implementation": "chw2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "sql_file": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
@@ -9147,8 +12467,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9267,34 +12587,56 @@
       "title": "Plant supply temp outside deadband",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_supply_sp",
-        "chw_pump_cmd"
+        "chilled-water-supply-temp",
+        "chilled-water-supply-temp-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sp_band": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_3",
+      "pandas_implementation": "chw3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "sql_file": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
@@ -9304,8 +12646,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9414,29 +12756,39 @@
       "title": "Flow high at max pump",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_flow",
-        "chw_pump_cmd"
+        "chw-flow",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flow_hi": {
-          "default": 1100.0,
+          "default": 1100,
           "unit": "gpm",
-          "min": 200.0,
-          "max": 3000.0,
-          "step": 50.0,
+          "min": 200,
+          "max": 3000,
+          "step": 50,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -9446,9 +12798,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_4",
+      "pandas_implementation": "chw4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "sql_file": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
@@ -9458,8 +12822,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9578,45 +12942,58 @@
       "title": "Discharge cold when heating",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "heatpump"
+      ],
       "required_roles": [
-        "sat",
-        "zone_t",
-        "fan_cmd"
+        "discharge-air-temp",
+        "zone-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "compressor_status",
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "compressor-status",
+        "equipment-enable",
+        "fan-status",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_sat": {
           "default": 85.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min discharge SAT"
+          "label": "Min heating SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold threshold"
+          "label": "Zone cold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "hp_1",
+      "pandas_implementation": "hp1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "sql_file": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
@@ -9626,8 +13003,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "compressor",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -9746,32 +13123,40 @@
       "title": "OA temperature spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "weather"
+      ],
+      "equipment_kinds": [
+        "weather"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx_1",
+      "pandas_implementation": "wx1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "sql_file": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
@@ -9781,8 +13166,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9891,11 +13276,16 @@
       "title": "Condenser water not optimized vs wet-bulb",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
         "pump_status",
@@ -9903,19 +13293,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -9923,14 +13319,26 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt_1",
+      "pandas_implementation": "cw_opt",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "sql_file": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
@@ -9940,8 +13348,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -10060,32 +13468,42 @@
       "title": "High CW approach at full tower fan",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -10098,9 +13516,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr_1",
+      "pandas_implementation": "cw_apr",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "sql_file": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
@@ -10110,8 +13540,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -10230,32 +13660,42 @@
       "title": "Excess tower fan energy vs wet-bulb limit",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -10263,7 +13703,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -10276,9 +13716,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_1",
+      "pandas_implementation": "cw_fan_excess",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "sql_file": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
@@ -10288,8 +13740,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -10418,28 +13870,32 @@
       "title": "Duct static trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static_sp"
+        "duct-static-pressure",
+        "vav-pressure-request-sum"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -10452,9 +13908,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_1",
+      "pandas_implementation": "trim1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "sql_file": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
@@ -10464,8 +13932,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -10584,10 +14052,15 @@
       "title": "HWST trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "boiler"
+      ],
+      "equipment_kinds": [
+        "boiler"
+      ],
       "required_roles": [
-        "hw_supply_t"
+        "hot-water-supply-temp",
+        "hw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -10595,19 +14068,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -10620,9 +14099,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_3",
+      "pandas_implementation": "trim3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "sql_file": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
@@ -10632,8 +14123,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -10752,10 +14243,15 @@
       "title": "CHW plant reset advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t"
+        "chilled-water-supply-temp",
+        "chw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -10763,19 +14259,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -10788,9 +14290,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_4",
+      "pandas_implementation": "trim4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "sql_file": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
@@ -10800,8 +14314,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -10917,45 +14431,53 @@
       "canonical_id": "SCHED-1",
       "pandas_id": "SCHED-1",
       "rule_id": "SCHED-1",
-      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
+      "title": "Unoccupied runtime",
       "aliases": [
         "excess_runtime"
       ],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "occ_mode",
-        "fan_status"
+        "occupied",
+        "fan-status"
       ],
       "optional_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 50.0,
-          "max": 80.0,
+          "min": 60.0,
+          "max": 78.0,
           "step": 0.5,
-          "label": "Zone comfort low"
+          "label": "Comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 55.0,
-          "max": 90.0,
+          "min": 68.0,
+          "max": 85.0,
           "step": 0.5,
-          "label": "Zone comfort high"
+          "label": "Comfort high"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "sched1",
@@ -10972,8 +14494,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: excess_runtime (not independent rules)",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -11092,24 +14614,65 @@
       "title": "Always-on fan or pump runtime",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "fan_status",
-        "pump_status",
-        "chiller_status",
-        "fan_cmd"
+        "fan-status",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "chiller-status",
+        "compressor-status",
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd",
+        "duct-static-pressure",
+        "chw-diff-pressure"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "always_on_pct": {
+          "default": 0.95,
+          "unit": "frac",
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Always-on fraction"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "eng",
+          "min": 0.05,
+          "max": 2.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "_sched247",
@@ -11126,8 +14689,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "4.3: ranked proof status/current > command; pressure is inferred runtime only and does not OR into the FAULT mask. SQL uses the same rank.",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -11226,25 +14789,33 @@
       "title": "Fan cmd/status mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "fan_status"
+        "fan-cmd",
+        "fan-status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cmd_1",
+      "pandas_implementation": "cmd1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "sql_file": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
@@ -11254,8 +14825,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -11354,28 +14925,31 @@
       "title": "Low OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-status"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -11386,14 +14960,26 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "OAT/RAT guard"
+          "label": "Min |RAT\u2212OAT| guard"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "oa_1",
+      "pandas_implementation": "oa1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "sql_file": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
@@ -11403,8 +14989,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11523,12 +15109,16 @@
       "title": "OA damper leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "oa_t",
-        "mat"
+        "outside-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
@@ -11536,24 +15126,28 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp_1",
+      "pandas_implementation": "dmp1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "sql_file": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
@@ -11563,8 +15157,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11673,31 +15267,27 @@
       "title": "Cooling valve leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "clg_valve_pct",
-        "sat",
-        "sat_sp",
-        "mat"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "mixed-air-temp",
+        "fan-status",
+        "fan-cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_err": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -11705,14 +15295,26 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv_1",
+      "pandas_implementation": "vlv1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "sql_file": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
@@ -11722,8 +15324,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -37,32 +37,24 @@ aliases_index:
 matrix:
 - rule_id: SV-RANGE
   title: Sensor out of hard range
-  equipment_types: &id001
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id001 []
   required_roles: &id002
   - oa_t
-  optional_roles: &id003 []
-  operational_proof_roles: &id004
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-current
-  - chw-flow
-  - compressor-status
-  - equipment-enable
+  optional_roles: &id003
+  - fan_status
+  - fan_cmd
+  - pump_status
+  - chw_pump_cmd
+  - chiller_status
+  operational_proof_roles: &id004 []
   default_thresholds: &id005
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     range_scale_temperature:
       default: 1.0
       unit: x
@@ -70,31 +62,7 @@ matrix:
       max: 2.0
       step: 0.1
       label: Temp range scale
-    range_scale_humidity:
-      default: 1.0
-      unit: x
-      min: 0.5
-      max: 2.0
-      step: 0.1
-      label: Humidity range scale
-    range_scale_pressure:
-      default: 1.0
-      unit: x
-      min: 0.5
-      max: 2.0
-      step: 0.1
-      label: Pressure range scale
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_range
+  pandas_implementation: sv_range
   datafusion_sql_implementation: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
   test_coverage: &id006
@@ -104,44 +72,32 @@ matrix:
   difference_class: none
 - rule_id: SV-FLATLINE
   title: Sensor flatline (stuck)
-  equipment_types: &id007
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id007 []
   required_roles: &id008
   - oa_t
-  optional_roles: &id009 []
+  optional_roles: &id009
+  - fan_status
+  - fan_cmd
+  - pump_status
+  - chw_pump_cmd
+  - chiller_status
   operational_proof_roles: &id010 []
   default_thresholds: &id011
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     flatline_tol:
       default: 0.1
-      unit: °F
+      unit: degF
       min: 0.02
       max: 1.0
       step: 0.02
       label: Flatline tolerance
-    flatline_hours:
-      default: 1.0
-      unit: h
-      min: 0.5
-      max: 8.0
-      step: 0.5
-      label: Flatline window
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_flatline
+  pandas_implementation: sv_flatline
   datafusion_sql_implementation: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
   test_coverage: &id012 []
@@ -150,32 +106,24 @@ matrix:
   difference_class: none
 - rule_id: SV-SPIKE
   title: Sensor rate-of-change spike
-  equipment_types: &id013
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id013 []
   required_roles: &id014
   - oa_t
-  optional_roles: &id015 []
-  operational_proof_roles: &id016
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-current
-  - chw-flow
-  - compressor-status
-  - equipment-enable
+  optional_roles: &id015
+  - fan_status
+  - fan_cmd
+  - pump_status
+  - chw_pump_cmd
+  - chiller_status
+  operational_proof_roles: &id016 []
   default_thresholds: &id017
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     spike_scale:
       default: 1.0
       unit: x
@@ -183,38 +131,7 @@ matrix:
       max: 3.0
       step: 0.25
       label: Spike limit scale (global)
-    spike_scale_temperature:
-      default: 1.0
-      unit: x
-      min: 0.25
-      max: 3.0
-      step: 0.25
-      label: Temp spike scale
-    spike_scale_humidity:
-      default: 1.0
-      unit: x
-      min: 0.25
-      max: 3.0
-      step: 0.25
-      label: Humidity spike scale
-    spike_scale_pressure:
-      default: 1.0
-      unit: x
-      min: 0.25
-      max: 3.0
-      step: 0.25
-      label: Pressure spike scale
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_spike
+  pandas_implementation: sv_spike
   datafusion_sql_implementation: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
   test_coverage: &id018 []
@@ -223,19 +140,18 @@ matrix:
   difference_class: none
 - rule_id: SV-STALE
   title: Stale data (no fresh samples)
-  equipment_types: &id019
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
-  required_roles: &id020
-  - fan_cmd
+  equipment_types: &id019 []
+  required_roles: &id020 []
   optional_roles: &id021 []
   operational_proof_roles: &id022 []
   default_thresholds: &id023
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     stale_hours:
       default: 2.0
       unit: h
@@ -243,17 +159,7 @@ matrix:
       max: 12.0
       step: 0.5
       label: Stale window
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_stale
+  pandas_implementation: sv_stale
   datafusion_sql_implementation: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
   test_coverage: &id024 []
@@ -262,19 +168,19 @@ matrix:
   difference_class: none
 - rule_id: SV-RATE
   title: Context-aware sensor rate of change
-  equipment_types: &id025
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id025 []
   required_roles: &id026
   - oa_t
   optional_roles: &id027 []
   operational_proof_roles: &id028 []
   default_thresholds: &id029
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     persistence_min:
       default: 10.0
       unit: min
@@ -282,45 +188,7 @@ matrix:
       max: 60.0
       step: 1.0
       label: Fault persistence
-    transition_window_min:
-      default: 20.0
-      unit: min
-      min: 5.0
-      max: 60.0
-      step: 5.0
-      label: Transition window
-    max_gap_hours:
-      default: 2.0
-      unit: h
-      min: 0.25
-      max: 6.0
-      step: 0.25
-      label: Max sample gap
-    design_flow:
-      default: 0.0
-      unit: cfm
-      min: 0.0
-      max: 100000.0
-      step: 100.0
-      label: Design flow (flow profiles)
-    sensor_span:
-      default: 0.0
-      unit: eng
-      min: 0.0
-      max: 100000.0
-      step: 10.0
-      label: Sensor span (flow/pressure)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: _sv_rate_compute
+  pandas_implementation: sv_rate
   datafusion_sql_implementation: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
   test_coverage: &id030
@@ -331,78 +199,36 @@ matrix:
   difference_class: alias
 - rule_id: PID-HUNT-1
   title: Suspected control-output hunting
-  equipment_types: &id031
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - heatpump
+  equipment_types: &id031 []
   required_roles: &id032
   - clg_valve_pct
   optional_roles: &id033
-  - loop-enabled
-  operational_proof_roles: &id034
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - loop-enabled
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id034 []
   default_thresholds: &id035
+    confirm_seconds:
+      default: 0.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     change_deadband_pct:
       default: 1.0
-      unit: '% out'
+      unit: pct
       min: 0.0
       max: 10.0
       step: 0.5
       label: Ignore changes below
     minimum_span_pct:
       default: 20.0
-      unit: '% out'
+      unit: pct
       min: 5.0
       max: 100.0
       step: 5.0
       label: Minimum observed span
-    total_variation_fault_pct:
-      default: 500.0
-      unit: '%/h'
-      min: 50.0
-      max: 2000.0
-      step: 50.0
-      label: Total travel threshold
-    minimum_equivalent_cycles:
-      default: 2.5
-      unit: cyc/h
-      min: 0.5
-      max: 20.0
-      step: 0.5
-      label: Min equivalent cycles
-    minimum_reversals:
-      default: 4
-      unit: count
-      min: 1
-      max: 40
-      step: 1
-      label: Min direction reversals
-    minimum_coverage_pct:
-      default: 80.0
-      unit: '%'
-      min: 25.0
-      max: 100.0
-      step: 5.0
-      label: Minimum data coverage
-    confirm_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _pid_hunt_1
+  pandas_implementation: pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
   test_coverage: &id036 []
@@ -410,69 +236,38 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC1
-  title: Duct static below SP at full fan (GL36 A)
-  equipment_types: &id037
-  - ahu
+  title: Duct static below SP at full fan
+  equipment_types: &id037 []
   required_roles: &id038
-  - duct-static-pressure
-  - duct-static-pressure-sp
-  - fan-cmd
+  - duct_static
+  - duct_static_sp
+  - fan_cmd
   optional_roles: &id039
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id040
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id040 []
   default_thresholds: &id041
     eps_dsp:
       default: 0.12
-      unit: in. w.c.
+      unit: inwc
       min: 0.0
       max: 0.5
       step: 0.01
-      label: Duct-static error εDSP (GL36 default 0.1 in.w.c.)
+      label: Duct-static error epsDSP (GL36 default 0.1 in.w.c.)
     eps_vfd_spd:
       default: 0.13
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: VFD speed error εVFDSPD (GL36 default 5%)
-    duct_static_err:
-      default: 0.12
-      unit: in. w.c.
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Legacy duct-static error (sets εDSP)
-    fan_hi:
-      default: 0.87
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Legacy fan-high threshold (sets εVFDSPD)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
+      label: VFD speed error epsVFDSPD (GL36 default 5%)
     confirm_seconds:
-      default: 300.0
+      default: 300
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: fc1
   datafusion_sql_implementation: fc1_duct_static_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc1
@@ -483,77 +278,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC2
-  title: MAT below OAT/RAT envelope (GL36 B)
-  equipment_types: &id043
-  - ahu
+  title: Mixed air below envelope
+  equipment_types: &id043 []
   required_roles: &id044
-  - mixed-air-temp
-  - outside-air-temp
-  - return-air-temp
-  - fan-cmd
+  - mat
+  - oa_t
+  - rat
+  - fan_cmd
   optional_roles: &id045
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id046
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id047
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    eps_rat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: RAT sensor error εRAT (GL36 default 2°F)
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id046 []
+  default_thresholds: &id047 {}
   pandas_implementation: fc2
   datafusion_sql_implementation: fc2_mat_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc2
@@ -562,77 +298,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC3
-  title: MAT above OAT/RAT envelope (GL36 C)
-  equipment_types: &id049
-  - ahu
+  title: Mixed air above envelope
+  equipment_types: &id049 []
   required_roles: &id050
-  - mixed-air-temp
-  - outside-air-temp
-  - return-air-temp
-  - fan-cmd
+  - mat
+  - oa_t
+  - rat
+  - fan_cmd
   optional_roles: &id051
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id052
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id053
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    eps_rat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: RAT sensor error εRAT (GL36 default 2°F)
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id052 []
+  default_thresholds: &id053 {}
   pandas_implementation: fc3
   datafusion_sql_implementation: fc3_mat_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc3
@@ -642,46 +319,22 @@ matrix:
   difference_class: none
 - rule_id: FC4
   title: PID hunting (operating-state oscillation)
-  equipment_types: &id055
-  - ahu
+  equipment_types: &id055 []
   required_roles: &id056
-  - outside-air-damper
-  - cooling-valve
-  - fan-cmd
-  optional_roles: &id057 []
-  operational_proof_roles: &id058
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - loop-enabled
+  - oa_damper_pct
+  - clg_valve_pct
+  - fan_cmd
+  optional_roles: &id057
+  - fan_status
+  operational_proof_roles: &id058 []
   default_thresholds: &id059
-    delta_os_max:
-      default: 5
-      unit: count
-      min: 1
-      max: 30
-      step: 1
-      label: Max mode changes/hr ΔOSmax (GL36 default 7)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 60.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 3600.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
   pandas_implementation: fc4
   datafusion_sql_implementation: fc4_os_hunting.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc4
@@ -691,45 +344,31 @@ matrix:
   difference_class: none
 - rule_id: FC5
   title: SAT cold when heating commanded (GL36 D)
-  equipment_types: &id061
-  - ahu
+  equipment_types: &id061 []
   required_roles: &id062
-  - discharge-air-temp
-  - mixed-air-temp
-  - fan-cmd
-  - heating-valve
+  - sat
+  - mat
+  - htg_valve_pct
+  - fan_cmd
   optional_roles: &id063
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id064
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id064 []
   default_thresholds: &id065
-    eps_sat:
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    mix_tol:
       default: 1.15
-      unit: °F
+      unit: degF
       min: 0.0
       max: 10.0
       step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+      label: Legacy master sensor tolerance (sets all eps values)
     htg_on_min:
       default: 0.01
       unit: frac
@@ -737,37 +376,6 @@ matrix:
       max: 0.25
       step: 0.01
       label: Heating-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
   pandas_implementation: fc5
   datafusion_sql_implementation: fc5_sat_cold_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc5
@@ -777,83 +385,38 @@ matrix:
   difference_class: none
 - rule_id: FC6
   title: Estimated OA fraction mismatch
-  equipment_types: &id067
-  - ahu
+  equipment_types: &id067 []
   required_roles: &id068
-  - mixed-air-temp
-  - outside-air-temp
-  - return-air-temp
-  - vav-total-airflow
+  - mat
+  - rat
+  - oa_t
+  - fan_cmd
   optional_roles: &id069
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id070
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id070 []
   default_thresholds: &id071
-    eps_airflow:
-      default: 0.15
-      unit: frac
-      min: 0.05
-      max: 1.0
-      step: 0.01
-      label: Airflow error εF (GL36 default 30%)
-    delta_t_min:
-      default: 5.0
-      unit: °F
+    confirm_seconds:
+      default: 600.0
+      unit: sec
       min: 0.0
-      max: 30.0
-      step: 0.5
-      label: Minimum |OAT−RAT| ΔTmin (GL36 default 10°F)
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     airflow_err:
       default: 0.15
       unit: frac
       min: 0.05
       max: 1.0
       step: 0.01
-      label: Legacy OA-fraction error (sets εF)
-    oat_rat_delta_min:
+      label: Airflow error epsF (GL36 default 30%)
+    delta_t_min:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 0.0
       max: 30.0
       step: 0.5
-      label: Legacy OAT/RAT guard (sets ΔTmin)
-    min_cfm_design:
-      default: 5000
-      unit: cfm
-      min: 500
-      max: 20000
-      step: 500
-      label: Design min OA CFM
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+      label: Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)
   pandas_implementation: fc6
   datafusion_sql_implementation: fc6_oa_frac_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc6
@@ -862,37 +425,23 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC7
-  title: SAT low with full heating (GL36 E)
-  equipment_types: &id073
-  - ahu
+  title: SAT low while heating at full
+  equipment_types: &id073 []
   required_roles: &id074
-  - discharge-air-temp
-  - discharge-air-temp-sp
-  - fan-cmd
-  - heating-valve
+  - sat
+  - sat_sp
+  - htg_valve_pct
+  - fan_cmd
   optional_roles: &id075 []
-  operational_proof_roles: &id076
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id076 []
   default_thresholds: &id077
-    eps_sat:
-      default: 1.0
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
     sat_err:
       default: 1.0
-      unit: °F
+      unit: degF
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy SAT error (sets εSAT)
+      label: Legacy SAT error (sets epsSAT)
     htg_full_min:
       default: 0.9
       unit: frac
@@ -900,30 +449,13 @@ matrix:
       max: 1.0
       step: 0.01
       label: Full-heating threshold (GL36 99%)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 600.0
+      default: 600
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: fc7
   datafusion_sql_implementation: fc7_sat_low_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc7
@@ -936,91 +468,18 @@ matrix:
     twin parity
   difference_class: missing_implementation
 - rule_id: FC8
-  title: SAT/MAT mismatch in economizer (GL36 F)
-  equipment_types: &id079
-  - ahu
+  title: SAT vs MAT while economizing
+  equipment_types: &id079 []
   required_roles: &id080
-  - discharge-air-temp
-  - mixed-air-temp
-  - outside-air-damper
-  - cooling-valve
+  - sat
+  - mat
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id081
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id082
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id083
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    supply_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy SAT tolerance master (sets εSAT)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id082 []
+  default_thresholds: &id083 {}
   pandas_implementation: fc8
   datafusion_sql_implementation: fc8_sat_mat_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc8
@@ -1029,84 +488,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC9
-  title: OAT too warm for free cooling (GL36 G)
-  equipment_types: &id085
-  - ahu
+  title: OAT high vs SAT SP while economizing
+  equipment_types: &id085 []
   required_roles: &id086
-  - outside-air-temp
-  - discharge-air-temp-sp
-  - outside-air-damper
-  - cooling-valve
+  - oa_t
+  - sat_sp
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id087
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id088
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id089
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id088 []
+  default_thresholds: &id089 {}
   pandas_implementation: fc9
   datafusion_sql_implementation: fc9_oa_sat_sp_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc9
@@ -1115,77 +508,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC10
-  title: OAT/MAT mismatch + mech cooling (GL36 H)
-  equipment_types: &id091
-  - ahu
+  title: MAT-OAT delta while cooling and economizing
+  equipment_types: &id091 []
   required_roles: &id092
-  - mixed-air-temp
-  - outside-air-temp
-  - outside-air-damper
-  - cooling-valve
+  - mat
+  - oa_t
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id093
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id094
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id095
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id094 []
+  default_thresholds: &id095 {}
   pandas_implementation: fc10
   datafusion_sql_implementation: fc10_mat_oa_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc10
@@ -1194,84 +528,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC11
-  title: OAT/MAT mismatch economizer-only (GL36 I)
-  equipment_types: &id097
-  - ahu
+  title: OAT low vs SAT SP while cooling and economizing
+  equipment_types: &id097 []
   required_roles: &id098
-  - outside-air-temp
-  - discharge-air-temp-sp
-  - outside-air-damper
-  - cooling-valve
+  - oa_t
+  - sat_sp
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id099
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id100
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id101
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id100 []
+  default_thresholds: &id101 {}
   pandas_implementation: fc11
   datafusion_sql_implementation: fc11_oa_sat_sp_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc11
@@ -1280,98 +548,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC12
-  title: SAT above blend in cooling (GL36 J)
-  equipment_types: &id103
-  - ahu
+  title: SAT above MAT while cooling
+  equipment_types: &id103 []
   required_roles: &id104
-  - discharge-air-temp
-  - mixed-air-temp
-  - outside-air-damper
-  - cooling-valve
+  - sat
+  - mat
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id105
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id106
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id107
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    supply_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy SAT tolerance master (sets εSAT)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id106 []
+  default_thresholds: &id107 {}
   pandas_implementation: fc12
   datafusion_sql_implementation: fc12_sat_mat_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc12
@@ -1380,77 +568,53 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC13
-  title: SAT above SP at full cooling (GL36 K)
-  equipment_types: &id109
-  - ahu
+  title: SAT above setpoint at full cooling
+  equipment_types: &id109 []
   required_roles: &id110
-  - discharge-air-temp
-  - discharge-air-temp-sp
-  - outside-air-damper
-  - cooling-valve
+  - sat
+  - sat_sp
+  - clg_valve_pct
+  - oa_damper_pct
   optional_roles: &id111
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id112
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id112 []
   default_thresholds: &id113
-    eps_sat:
-      default: 1.0
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
     sat_err:
       default: 1.0
-      unit: °F
+      unit: degF
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy SAT error (sets εSAT)
-    clg_full_min:
+      label: SAT high error band
+    clg_valve_min:
       default: 0.01
       unit: frac
-      min: 0.5
-      max: 1.0
+      min: 0.0
+      max: 0.5
       step: 0.01
-      label: Full-cooling threshold (GL36 99%)
-    econ_min_pos:
+      label: Cooling valve open threshold
+    oa_damper_econ_low:
       default: 0.05
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: Economizer minimum-position threshold
-    econ_full_open:
+      label: OA damper economizer low
+    oa_damper_econ_high:
       default: 0.9
       unit: frac
       min: 0.5
       max: 1.0
       step: 0.01
-      label: Economizer full-open threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
+      label: OA damper economizer high
     confirm_seconds:
-      default: 600.0
+      default: 600
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: fc13
   datafusion_sql_implementation: sat_high_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc13
@@ -1461,90 +625,32 @@ matrix:
   difference_class: alias
 - rule_id: FC14
   title: CHW coil ΔT when inactive (GL36 L)
-  equipment_types: &id115
-  - ahu
+  equipment_types: &id115 []
   required_roles: &id116
-  - cooling-coil-entering-temp
-  - cooling-coil-leaving-temp
-  - outside-air-damper
-  - cooling-valve
+  - mat
+  - sat
+  - clg_valve_pct
+  - oa_damper_pct
+  - fan_cmd
   optional_roles: &id117
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id118
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id118 []
   default_thresholds: &id119
-    eps_ccet:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Cooling-coil entering sensor error εCCET
-    eps_cclt:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Cooling-coil leaving sensor error εCCLT
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    htg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Heating-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    mix_tol:
+      default: 1.15
+      unit: degF
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all eps values)
   pandas_implementation: fc14
   datafusion_sql_implementation: fc14_chw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc14
@@ -1554,97 +660,31 @@ matrix:
   difference_class: none
 - rule_id: FC15
   title: HW coil ΔT when inactive (GL36 M)
-  equipment_types: &id121
-  - ahu
+  equipment_types: &id121 []
   required_roles: &id122
-  - heating-coil-entering-temp
-  - heating-coil-leaving-temp
-  - outside-air-damper
-  - cooling-valve
+  - mat
+  - sat
+  - htg_valve_pct
+  - fan_cmd
   optional_roles: &id123
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id124
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id124 []
   default_thresholds: &id125
-    eps_hcet:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Heating-coil entering sensor error εHCET
-    eps_hclt:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Heating-coil leaving sensor error εHCLT
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    mix_tol:
+      default: 1.15
+      unit: degF
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all eps values)
   pandas_implementation: fc15
   datafusion_sql_implementation: fc15_hw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc15
@@ -1654,40 +694,30 @@ matrix:
   difference_class: none
 - rule_id: AHU-SATDEV
   title: SAT deviation from setpoint
-  equipment_types: &id127
-  - ahu
+  equipment_types: &id127 []
   required_roles: &id128
-  - discharge-air-temp
-  - discharge-air-temp-sp
+  - sat
+  - sat_sp
   optional_roles: &id129
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id130
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id130 []
   default_thresholds: &id131
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     sat_dev_err:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 1.0
       max: 15.0
       step: 0.5
       label: SAT deviation
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: ahu_sat_dev
+  pandas_implementation: ahu_satdev
   datafusion_sql_implementation: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
   test_coverage: &id132
@@ -1697,41 +727,38 @@ matrix:
   difference_class: none
 - rule_id: AHU-DUCTHI
   title: Duct static pressure high
-  equipment_types: &id133
-  - ahu
+  equipment_types: &id133 []
   required_roles: &id134
-  - duct-static-pressure
-  - duct-static-pressure-sp
+  - duct_static
+  - duct_static_sp
+  - fan_cmd
   optional_roles: &id135
   - fan_status
   - fan_cmd
   operational_proof_roles: &id136 []
   default_thresholds: &id137
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     duct_high_margin:
       default: 0.25
-      unit: in. w.c.
+      unit: in_wc
       min: 0.05
       max: 1.0
       step: 0.05
       label: High margin
     pressure_on_min:
       default: 0.2
-      unit: in. w.c.
+      unit: in_wc
       min: 0.05
       max: 1.0
       step: 0.05
       label: Pressure-on evidence
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: ahu_duct_high
+  pandas_implementation: ahu_ducthi
   datafusion_sql_implementation: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
   test_coverage: &id138
@@ -1741,22 +768,22 @@ matrix:
   difference_class: none
 - rule_id: AHU-SIMUL
   title: Heating and cooling simultaneous
-  equipment_types: &id139
-  - ahu
+  equipment_types: &id139 []
   required_roles: &id140
-  - heating-valve
-  - cooling-valve
+  - htg_valve_pct
+  - clg_valve_pct
   optional_roles: &id141
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id142
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id142 []
   default_thresholds: &id143
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     valve_open_pct:
       default: 0.1
       unit: frac
@@ -1764,17 +791,7 @@ matrix:
       max: 0.5
       step: 0.01
       label: Valve open threshold
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: ahu_simul_heat_cool
+  pandas_implementation: ahu_simul
   datafusion_sql_implementation: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
   test_coverage: &id144 []
@@ -1782,32 +799,27 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: OAT-METEO
-  title: BAS outdoor-air sensor vs Open-Meteo
-  equipment_types: &id145
-  - ahu
+  title: Equipment OAT vs weather-staged wx OAT
+  equipment_types: &id145 []
   required_roles: &id146
-  - outside-air-temp
-  - web-outside-air-temp
+  - oa_t
   optional_roles: &id147 []
   operational_proof_roles: &id148 []
   default_thresholds: &id149
     oat_err:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 2.0
       max: 20.0
       step: 0.5
-      label: Max OAT disagreement
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
+      label: OAT vs meteo tolerance
     confirm_seconds:
-      default: 900.0
+      default: 900
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: oat_vs_meteo
   datafusion_sql_implementation: oat_meteo_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oat-meteo
@@ -1816,41 +828,24 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-1
-  title: Economizer stuck closed
-  equipment_types: &id151
-  - ahu
+  title: Economizer stuck closed when OAT favorable
+  equipment_types: &id151 []
   required_roles: &id152
-  - fan-cmd
-  - outside-air-damper
-  - outside-air-temp
+  - fan_cmd
+  - oa_damper_pct
+  - oa_t
   optional_roles: &id153
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id154
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id154 []
   default_thresholds: &id155
     econ1_oat_min:
       default: 55.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 70.0
       step: 1.0
       label: Favorable OAT
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
   pandas_implementation: econ1
   datafusion_sql_implementation: econ1_stuck_closed.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-1
@@ -1859,26 +854,19 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-2
-  title: Economizing when outdoor unfavorable
-  equipment_types: &id157
-  - ahu
+  title: Economizing when outdoor air unfavorable
+  equipment_types: &id157 []
   required_roles: &id158
-  - outside-air-temp
-  - outside-air-damper
+  - oa_t
+  - oa_damper_pct
   optional_roles: &id159
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id160
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id160 []
   default_thresholds: &id161
     econ2_oat_hi:
       default: 63.0
-      unit: °F
+      unit: degF
       min: 55.0
       max: 80.0
       step: 1.0
@@ -1890,16 +878,13 @@ matrix:
       max: 0.9
       step: 0.02
       label: Damper open frac
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 300.0
+      default: 300
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: econ2
   datafusion_sql_implementation: economizer_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-2
@@ -1909,40 +894,41 @@ matrix:
   difference_class: none
 - rule_id: ECON-3
   title: Mech cooling without integrated economizer
-  equipment_types: &id163
-  - ahu
+  equipment_types: &id163 []
   required_roles: &id164
-  - outside-air-damper
-  - cooling-valve
+  - web_oa_t
+  - web_oa_dp
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id165
-  - web-outside-air-temp
-  - web-outside-air-dewpoint
-  - web-outside-air-humidity
-  operational_proof_roles: &id166
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id166 []
   default_thresholds: &id167
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     econ3_db_min:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 50.0
       max: 68.0
       step: 1.0
       label: Free-cool OA dry-bulb min
     econ3_db_max:
       default: 72.0
-      unit: °F
+      unit: degF
       min: 65.0
       max: 80.0
       step: 1.0
       label: Free-cool OA dry-bulb max
     econ3_dp_max:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 68.0
       step: 1.0
@@ -1954,17 +940,7 @@ matrix:
       max: 1.0
       step: 0.02
       label: Integrated economizer damper
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: econ2
+  pandas_implementation: econ_3
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
   test_coverage: &id168 []
@@ -1973,41 +949,31 @@ matrix:
   difference_class: none
 - rule_id: ECON-4
   title: Low estimated OA fraction
-  equipment_types: &id169
-  - ahu
+  equipment_types: &id169 []
   required_roles: &id170
-  - mixed-air-temp
-  - return-air-temp
-  - outside-air-temp
-  - fan-cmd
+  - mat
+  - rat
+  - oa_t
+  - fan_cmd
   optional_roles: &id171
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id172
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id172 []
   default_thresholds: &id173
     oa_min_pct:
       default: 21.0
-      unit: '%'
+      unit: pct
       min: 5.0
       max: 40.0
       step: 1.0
       label: Min OA fraction
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 600.0
+      default: 600
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: econ4
   datafusion_sql_implementation: econ4_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-4
@@ -2017,42 +983,32 @@ matrix:
   difference_class: none
 - rule_id: ECON-5
   title: Preheat over-conditioning
-  equipment_types: &id175
-  - ahu
+  equipment_types: &id175 []
   required_roles: &id176
-  - preheat-leaving-temp
-  - discharge-air-temp-sp
-  - outside-air-temp
-  - heating-valve
+  - preheat_leave_t
+  - sat_sp
+  - oa_t
+  - htg_valve_pct
   optional_roles: &id177
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id178
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id178 []
   default_thresholds: &id179
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     preheat_over_f:
       default: 2.2
-      unit: °F
+      unit: degF
       min: 0.5
       max: 8.0
       step: 0.1
       label: Preheat over ΔT
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: econ5
+  pandas_implementation: econ_5
   datafusion_sql_implementation: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
   test_coverage: &id180 []
@@ -2061,23 +1017,25 @@ matrix:
   difference_class: none
 - rule_id: ECON-6
   title: Economizing in freezing weather
-  equipment_types: &id181
-  - ahu
+  equipment_types: &id181 []
   required_roles: &id182
-  - outside-air-damper
+  - web_oa_t
+  - oa_damper_pct
   optional_roles: &id183
-  - web-outside-air-temp
-  operational_proof_roles: &id184
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id184 []
   default_thresholds: &id185
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     econ6_oat_max_f:
       default: 25.0
-      unit: °F
+      unit: degF
       min: 15.0
       max: 40.0
       step: 1.0
@@ -2089,17 +1047,7 @@ matrix:
       max: 0.5
       step: 0.01
       label: Winter min-OA damper
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: econ6_compute
+  pandas_implementation: econ_6
   datafusion_sql_implementation: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
   test_coverage: &id186 []
@@ -2108,42 +1056,41 @@ matrix:
   difference_class: none
 - rule_id: ECON-7
   title: Economizer OK but not economizing
-  equipment_types: &id187
-  - ahu
+  equipment_types: &id187 []
   required_roles: &id188
-  - outside-air-damper
+  - web_oa_t
+  - web_oa_dp
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id189
-  - web-outside-air-temp
-  - web-outside-air-dewpoint
-  - web-outside-air-humidity
-  - cooling-valve
-  - compressor-status
-  - dx-cool-cmd
-  operational_proof_roles: &id190
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id190 []
   default_thresholds: &id191
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     econ7_db_min:
       default: 35.0
-      unit: °F
+      unit: degF
       min: 20.0
       max: 50.0
       step: 1.0
       label: Econ-OK dry-bulb floor (freeze guard)
     econ7_db_max:
       default: 72.0
-      unit: °F
+      unit: degF
       min: 65.0
       max: 80.0
       step: 1.0
       label: Econ-OK dry-bulb max
     econ7_dp_max:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 68.0
       step: 1.0
@@ -2155,17 +1102,7 @@ matrix:
       max: 0.9
       step: 0.02
       label: Economizing damper threshold
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: econ7_compute
+  pandas_implementation: econ_7
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
   test_coverage: &id192 []
@@ -2174,39 +1111,28 @@ matrix:
   difference_class: none
 - rule_id: MECH-OAT-1
   title: Mechanical cooling below 60°F web OAT
-  equipment_types: &id193
-  - ahu
-  - chiller
-  - heatpump
+  equipment_types: &id193 []
   required_roles: &id194
   - web_oa_t
   - clg_valve_pct
-  optional_roles: &id195
-  - web-outside-air-temp
-  - compressor-status
-  - chiller-status
-  - chw-pump-status
-  - dx-cool-cmd
+  optional_roles: &id195 []
   operational_proof_roles: &id196 []
   default_thresholds: &id197
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     mech_oat_max_f:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 65.0
       step: 1.0
       label: Mech-cool OAT ceiling
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: mech_oat1_compute
+  pandas_implementation: mech_oat_1
   datafusion_sql_implementation: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
   test_coverage: &id198 []
@@ -2215,52 +1141,29 @@ matrix:
   difference_class: none
 - rule_id: CHW-NOLOAD-1
   title: Chiller running with no building load
-  equipment_types: &id199
-  - chiller
+  equipment_types: &id199 []
   required_roles: &id200
   - chw_supply_t
   - chw_supply_sp
   - chw_pump_cmd
-  optional_roles: &id201
-  - chiller-status
-  - chw-pump-status
-  - compressor-status
-  - building-zone-load-satisfied
-  - building-ahu-load-satisfied
+  optional_roles: &id201 []
   operational_proof_roles: &id202 []
   default_thresholds: &id203
-    comfort_low_f:
-      default: 70.0
-      unit: °F
-      min: 60.0
-      max: 78.0
-      step: 0.5
-      label: Comfort low
-    comfort_high_f:
-      default: 75.0
-      unit: °F
-      min: 68.0
-      max: 85.0
-      step: 0.5
-      label: Comfort high
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     sat_band_f:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.5
       label: AHU SAT≈SP band
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-  pandas_implementation: chw_noload1_compute
+  pandas_implementation: chw_noload_1
   datafusion_sql_implementation: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
   test_coverage: &id204 []
@@ -2268,39 +1171,35 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: VAV-1
-  title: Zone comfort band
-  equipment_types: &id205
-  - vav
-  - zone
+  title: Zone comfort band violation hours with confirm window
+  equipment_types: &id205 []
   required_roles: &id206
-  - zone-air-temp
-  optional_roles: &id207 []
+  - zone_t
+  optional_roles: &id207
+  - occ_mode
   operational_proof_roles: &id208 []
   default_thresholds: &id209
-    zone_lo:
+    zone_t_lo:
       default: 70.0
-      unit: °F
+      unit: degF
       min: 55.0
       max: 72.0
       step: 0.5
       label: Zone low
-    zone_hi:
+    zone_t_hi:
       default: 75.0
-      unit: °F
+      unit: degF
       min: 72.0
       max: 85.0
       step: 0.5
       label: Zone high
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 900.0
+      default: 900
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: vav1
   datafusion_sql_implementation: vav1_comfort_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-1
@@ -2312,23 +1211,26 @@ matrix:
   difference_class: none
 - rule_id: VAV-3
   title: Excessive reheat during warm weather
-  equipment_types: &id211
-  - vav
+  equipment_types: &id211 []
   required_roles: &id212
-  - outside-air-temp
-  - reheat-valve
-  optional_roles: &id213 []
-  operational_proof_roles: &id214
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - oa_t
+  - reheat_valve_pct
+  - zone_flow
+  optional_roles: &id213
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id214 []
   default_thresholds: &id215
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     reheat_oat:
       default: 78.0
-      unit: °F
+      unit: degF
       min: 65.0
       max: 90.0
       step: 1.0
@@ -2347,17 +1249,7 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: vav3
+  pandas_implementation: vav_3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
   test_coverage: &id216 []
@@ -2366,20 +1258,22 @@ matrix:
   difference_class: none
 - rule_id: VAV-4
   title: Damper stuck at full open
-  equipment_types: &id217
-  - vav
+  equipment_types: &id217 []
   required_roles: &id218
-  - damper
-  optional_roles: &id219 []
-  operational_proof_roles: &id220
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - loop-enabled
+  - damper_pct
+  - zone_flow
+  optional_roles: &id219
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id220 []
   default_thresholds: &id221
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     full_open_pct:
       default: 0.975
       unit: frac
@@ -2387,13 +1281,6 @@ matrix:
       max: 1.0
       step: 0.005
       label: Full open frac
-    sustain_hours:
-      default: 1.5
-      unit: h
-      min: 0.5
-      max: 6.0
-      step: 0.5
-      label: Sustain window
     flow_on_min:
       default: 25.0
       unit: cfm
@@ -2401,17 +1288,7 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav4
+  pandas_implementation: vav_4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
   test_coverage: &id222 []
@@ -2420,31 +1297,23 @@ matrix:
   difference_class: none
 - rule_id: VAV-5
   title: Airflow sensor bias
-  equipment_types: &id223
-  - vav
+  equipment_types: &id223 []
   required_roles: &id224
-  - zone-airflow
-  - damper
-  optional_roles: &id225 []
-  operational_proof_roles: &id226
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - zone_flow
+  - damper_pct
+  optional_roles: &id225
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id226 []
   default_thresholds: &id227
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
-  pandas_implementation: vav5
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+  pandas_implementation: vav_5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
   test_coverage: &id228 []
@@ -2453,21 +1322,24 @@ matrix:
   difference_class: none
 - rule_id: VAV-REHEAT
   title: Reheat valve stuck / no temp rise
-  equipment_types: &id229
-  - vav
+  equipment_types: &id229 []
   required_roles: &id230
-  - reheat-valve
-  - vav-discharge-air-temp
-  - vav-inlet-air-temp
-  optional_roles: &id231 []
-  operational_proof_roles: &id232
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - reheat_valve_pct
+  - vav_discharge_t
+  - vav_inlet_t
+  - zone_flow
+  optional_roles: &id231
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id232 []
   default_thresholds: &id233
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     reheat_cmd:
       default: 0.3
       unit: frac
@@ -2477,7 +1349,7 @@ matrix:
       label: Reheat open frac
     min_rise:
       default: 3.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 15.0
       step: 0.5
@@ -2489,17 +1361,7 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav_reheat_stuck
+  pandas_implementation: vav_reheat
   datafusion_sql_implementation: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
   test_coverage: &id234 []
@@ -2508,23 +1370,26 @@ matrix:
   difference_class: none
 - rule_id: VAV-AHU-LEAVE
   title: VAV leave vs parent AHU SAT (fedBy)
-  equipment_types: &id235
-  - vav
+  equipment_types: &id235 []
   required_roles: &id236
-  - vav-discharge-air-temp
-  - ahu-discharge-air-temp
-  optional_roles: &id237 []
-  operational_proof_roles: &id238
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - vav_discharge_t
+  - ahu_sat
+  - zone_flow
+  optional_roles: &id237
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id238 []
   default_thresholds: &id239
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     delta_f:
       default: 8.0
-      unit: °F
+      unit: degF
       min: 2.0
       max: 25.0
       step: 0.5
@@ -2536,17 +1401,7 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav_vs_ahu_leave
+  pandas_implementation: vav_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
   test_coverage: &id240 []
@@ -2555,40 +1410,22 @@ matrix:
   difference_class: none
 - rule_id: VAV-7
   title: Min airflow / fixed high flow
-  equipment_types: &id241
-  - vav
+  equipment_types: &id241 []
   required_roles: &id242
-  - zone-airflow
-  optional_roles: &id243 []
-  operational_proof_roles: &id244
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - zone_flow
+  - min_flow_sp
+  optional_roles: &id243
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id244 []
   default_thresholds: &id245
-    flow_on_min:
-      default: 25.0
-      unit: cfm
+    confirm_seconds:
+      default: 900.0
+      unit: sec
       min: 0.0
-      max: 200.0
-      step: 5.0
-      label: Airflow-on min
-    fixed_flow_max_std:
-      default: 15.0
-      unit: cfm
-      min: 1.0
-      max: 80.0
-      step: 1.0
-      label: Fixed-flow max std
-    fixed_flow_min_mean:
-      default: 200.0
-      unit: cfm
-      min: 50.0
-      max: 2000.0
-      step: 10.0
-      label: Fixed-flow min mean
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     high_min_flow_sp:
       default: 250.0
       unit: cfm
@@ -2596,17 +1433,7 @@ matrix:
       max: 2000.0
       step: 10.0
       label: High min-flow SP
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav7
+  pandas_implementation: vav_7
   datafusion_sql_implementation: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
   test_coverage: &id246 []
@@ -2615,11 +1442,10 @@ matrix:
   difference_class: none
 - rule_id: CHW-1
   title: Low chilled-water ΔT
-  equipment_types: &id247
-  - chiller
+  equipment_types: &id247 []
   required_roles: &id248
-  - chilled-water-supply-temp
-  - chilled-water-return-temp
+  - chw_supply_t
+  - chw_return_t
   optional_roles: &id249
   - chw_pump_cmd
   - pump_status
@@ -2628,38 +1454,22 @@ matrix:
   - chiller_amps
   - chiller_power
   - chw_flow
-  operational_proof_roles: &id250
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id250 []
   default_thresholds: &id251
-    min_dt:
-      default: 4.0
-      unit: °F
-      min: 1.0
-      max: 12.0
-      step: 0.5
-      label: Min ΔT
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    min_dt:
+      default: 4.0
+      unit: degF
+      min: 1.0
+      max: 12.0
+      step: 0.5
+      label: Minimum delta-T
   pandas_implementation: chw1
   datafusion_sql_implementation: chw1_low_dt.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-1
@@ -2674,28 +1484,21 @@ matrix:
   difference_class: none
 - rule_id: CHW-2
   title: DP below SP at max pump speed
-  equipment_types: &id253
-  - chiller
+  equipment_types: &id253 []
   required_roles: &id254
-  - chw-diff-pressure
-  - chw-diff-pressure-sp
-  - chw-pump-cmd
+  - chw_dp
+  - chw_dp_sp
+  - chw_pump_cmd
   optional_roles: &id255 []
-  operational_proof_roles: &id256
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id256 []
   default_thresholds: &id257
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     dp_margin:
       default: 2.2
       unit: psi
@@ -2710,17 +1513,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: chw2
+  pandas_implementation: chw_2
   datafusion_sql_implementation: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
   test_coverage: &id258 []
@@ -2729,46 +1522,29 @@ matrix:
   difference_class: none
 - rule_id: CHW-3
   title: Plant supply temp outside deadband
-  equipment_types: &id259
-  - chiller
+  equipment_types: &id259 []
   required_roles: &id260
-  - chilled-water-supply-temp
-  - chilled-water-supply-temp-sp
-  - chw-pump-cmd
+  - chw_supply_t
+  - chw_supply_sp
+  - chw_pump_cmd
   optional_roles: &id261 []
-  operational_proof_roles: &id262
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id262 []
   default_thresholds: &id263
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     sp_band:
       default: 2.2
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.1
       label: SP band
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: chw3
+  pandas_implementation: chw_3
   datafusion_sql_implementation: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
   test_coverage: &id264 []
@@ -2777,33 +1553,26 @@ matrix:
   difference_class: none
 - rule_id: CHW-4
   title: Flow high at max pump
-  equipment_types: &id265
-  - chiller
+  equipment_types: &id265 []
   required_roles: &id266
-  - chw-flow
-  - chw-pump-cmd
+  - chw_flow
+  - chw_pump_cmd
   optional_roles: &id267 []
-  operational_proof_roles: &id268
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id268 []
   default_thresholds: &id269
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     flow_hi:
-      default: 1100
+      default: 1100.0
       unit: gpm
-      min: 200
-      max: 3000
-      step: 50
+      min: 200.0
+      max: 3000.0
+      step: 50.0
       label: Flow high
     pump_hi:
       default: 0.87
@@ -2812,17 +1581,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: chw4
+  pandas_implementation: chw_4
   datafusion_sql_implementation: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
   test_coverage: &id270 []
@@ -2831,44 +1590,38 @@ matrix:
   difference_class: none
 - rule_id: HP-1
   title: Discharge cold when heating
-  equipment_types: &id271
-  - heatpump
+  equipment_types: &id271 []
   required_roles: &id272
-  - discharge-air-temp
-  - zone-air-temp
-  - fan-cmd
-  optional_roles: &id273 []
-  operational_proof_roles: &id274
-  - compressor-status
-  - equipment-enable
-  - fan-status
-  - fan-cmd
+  - sat
+  - zone_t
+  - fan_cmd
+  optional_roles: &id273
+  - compressor_status
+  - fan_status
+  operational_proof_roles: &id274 []
   default_thresholds: &id275
-    min_sat:
-      default: 85.0
-      unit: °F
-      min: 70.0
-      max: 110.0
-      step: 1.0
-      label: Min heating SAT
-    zone_cold:
-      default: 69.0
-      unit: °F
-      min: 60.0
-      max: 72.0
-      step: 0.5
-      label: Zone cold
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
-  pandas_implementation: hp1
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    min_sat:
+      default: 85.0
+      unit: degF
+      min: 70.0
+      max: 110.0
+      step: 1.0
+      label: Min discharge SAT
+    zone_cold:
+      default: 69.0
+      unit: degF
+      min: 60.0
+      max: 72.0
+      step: 0.5
+      label: Zone cold threshold
+  pandas_implementation: hp_1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
   test_coverage: &id276 []
@@ -2877,31 +1630,27 @@ matrix:
   difference_class: none
 - rule_id: WX-1
   title: OA temperature spike
-  equipment_types: &id277
-  - weather
+  equipment_types: &id277 []
   required_roles: &id278
-  - outside-air-temp
+  - oa_t
   optional_roles: &id279 []
   operational_proof_roles: &id280 []
   default_thresholds: &id281
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     spike_limit:
       default: 16.0
-      unit: °F
+      unit: degF
       min: 4.0
       max: 40.0
       step: 1.0
       label: Spike limit
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: wx1
+  pandas_implementation: wx_1
   datafusion_sql_implementation: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
   test_coverage: &id282 []
@@ -2910,52 +1659,39 @@ matrix:
   difference_class: none
 - rule_id: CW-OPT-1
   title: Condenser water not optimized vs wet-bulb
-  equipment_types: &id283
-  - chiller
-  - cooling_tower
+  equipment_types: &id283 []
   required_roles: &id284
-  - condenser-water-supply-temp
-  optional_roles: &id285 []
-  operational_proof_roles: &id286
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  - cw_supply_t
+  - web_wb_t
+  optional_roles: &id285
+  - pump_status
+  - chiller_status
+  - chw_flow
+  - chw_pump_cmd
+  operational_proof_roles: &id286 []
   default_thresholds: &id287
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: °F
+      unit: degF
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     cw_slack:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.5
       label: Slack below target
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: cw_opt
+  pandas_implementation: cw_opt_1
   datafusion_sql_implementation: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
   test_coverage: &id288 []
@@ -2964,34 +1700,28 @@ matrix:
   difference_class: none
 - rule_id: CW-APR-1
   title: High CW approach at full tower fan
-  equipment_types: &id289
-  - chiller
-  - cooling_tower
+  equipment_types: &id289 []
   required_roles: &id290
-  - condenser-water-supply-temp
+  - cw_supply_t
+  - web_wb_t
+  - tower_fan_cmd
   optional_roles: &id291
-  - tower-fan-cmd
-  - cw-fan-cmd
-  - fan-cmd
-  - web-outside-air-wetbulb
-  operational_proof_roles: &id292
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  - pump_status
+  - chiller_status
+  - chw_flow
+  - chw_pump_cmd
+  operational_proof_roles: &id292 []
   default_thresholds: &id293
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     approach_max_f:
       default: 8.0
-      unit: °F
+      unit: degF
       min: 5.0
       max: 15.0
       step: 0.5
@@ -3003,17 +1733,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: cw_apr
+  pandas_implementation: cw_apr_1
   datafusion_sql_implementation: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
   test_coverage: &id294 []
@@ -3022,41 +1742,35 @@ matrix:
   difference_class: none
 - rule_id: CW-FAN-1
   title: Excess tower fan energy vs wet-bulb limit
-  equipment_types: &id295
-  - chiller
-  - cooling_tower
+  equipment_types: &id295 []
   required_roles: &id296
-  - condenser-water-supply-temp
+  - cw_supply_t
+  - web_wb_t
+  - tower_fan_cmd
   optional_roles: &id297
-  - tower-fan-cmd
-  - cw-fan-cmd
-  - fan-cmd
-  - web-outside-air-wetbulb
-  operational_proof_roles: &id298
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  - pump_status
+  - chiller_status
+  - chw_flow
+  - chw_pump_cmd
+  operational_proof_roles: &id298 []
   default_thresholds: &id299
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: °F
+      unit: degF
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     excess_beyond_approach_f:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 2.0
       max: 20.0
       step: 0.5
@@ -3068,17 +1782,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: cw_fan_excess
+  pandas_implementation: cw_fan_1
   datafusion_sql_implementation: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
   test_coverage: &id300 []
@@ -3087,25 +1791,24 @@ matrix:
   difference_class: none
 - rule_id: TRIM-1
   title: Duct static trim advisory
-  equipment_types: &id301
-  - ahu
+  equipment_types: &id301 []
   required_roles: &id302
-  - duct-static-pressure
-  - vav-pressure-request-sum
+  - duct_static_sp
   optional_roles: &id303
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id304
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id304 []
   default_thresholds: &id305
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     duct_hi:
       default: 1.35
-      unit: in. w.c.
+      unit: in_wc
       min: 0.5
       max: 3.0
       step: 0.05
@@ -3117,17 +1820,7 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-  pandas_implementation: trim1
+  pandas_implementation: trim_1
   datafusion_sql_implementation: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
   test_coverage: &id306 []
@@ -3136,30 +1829,26 @@ matrix:
   difference_class: none
 - rule_id: TRIM-3
   title: HWST trim advisory
-  equipment_types: &id307
-  - boiler
+  equipment_types: &id307 []
   required_roles: &id308
-  - hot-water-supply-temp
-  - hw-reset-request-sum
-  optional_roles: &id309 []
-  operational_proof_roles: &id310
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  - hw_supply_t
+  optional_roles: &id309
+  - pump_status
+  - chiller_status
+  - chw_flow
+  - chw_pump_cmd
+  operational_proof_roles: &id310 []
   default_thresholds: &id311
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     hwst_hi:
       default: 160.0
-      unit: °F
+      unit: degF
       min: 120.0
       max: 200.0
       step: 1.0
@@ -3171,17 +1860,7 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-  pandas_implementation: trim3
+  pandas_implementation: trim_3
   datafusion_sql_implementation: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
   test_coverage: &id312 []
@@ -3190,30 +1869,26 @@ matrix:
   difference_class: none
 - rule_id: TRIM-4
   title: CHW plant reset advisory
-  equipment_types: &id313
-  - chiller
+  equipment_types: &id313 []
   required_roles: &id314
-  - chilled-water-supply-temp
-  - chw-reset-request-sum
-  optional_roles: &id315 []
-  operational_proof_roles: &id316
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  - chw_supply_t
+  optional_roles: &id315
+  - pump_status
+  - chiller_status
+  - chw_flow
+  - chw_pump_cmd
+  operational_proof_roles: &id316 []
   default_thresholds: &id317
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     chw_lo:
       default: 45.0
-      unit: °F
+      unit: degF
       min: 35.0
       max: 55.0
       step: 0.5
@@ -3225,17 +1900,7 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-  pandas_implementation: trim4
+  pandas_implementation: trim_4
   datafusion_sql_implementation: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
   test_coverage: &id318 []
@@ -3243,40 +1908,38 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: SCHED-1
-  title: Unoccupied runtime
-  equipment_types: &id319
-  - ahu
+  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
+    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
+    unoccupied + fan_on (pandas sched1 base).
+  equipment_types: &id319 []
   required_roles: &id320
-  - occupied
-  - fan-status
+  - occ_mode
+  - fan_status
   optional_roles: &id321
-  - zone-air-temp
+  - zone_t
   operational_proof_roles: &id322 []
   default_thresholds: &id323
-    comfort_low_f:
-      default: 70.0
-      unit: °F
-      min: 60.0
-      max: 78.0
-      step: 0.5
-      label: Comfort low
-    comfort_high_f:
-      default: 75.0
-      unit: °F
-      min: 68.0
-      max: 85.0
-      step: 0.5
-      label: Comfort high
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 1800.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    comfort_low_f:
+      default: 70.0
+      unit: °F
+      min: 50.0
+      max: 80.0
+      step: 0.5
+      label: Zone comfort low
+    comfort_high_f:
+      default: 75.0
+      unit: °F
+      min: 55.0
+      max: 90.0
+      step: 0.5
+      label: Zone comfort high
   pandas_implementation: sched1
   datafusion_sql_implementation: sched1_unoccupied_runtime.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-1
@@ -3289,53 +1952,22 @@ matrix:
   difference_class: alias
 - rule_id: SCHED-247
   title: Always-on fan or pump runtime
-  equipment_types: &id325
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - heatpump
+  equipment_types: &id325 []
   required_roles: &id326 []
   optional_roles: &id327
-  - fan-status
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - chiller-status
-  - compressor-status
-  - tower-fan-cmd
-  - cw-fan-cmd
-  - fan-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
-  - duct-static-pressure
-  - chw-diff-pressure
+  - fan_status
+  - pump_status
+  - chiller_status
+  - fan_cmd
   operational_proof_roles: &id328 []
   default_thresholds: &id329
-    always_on_pct:
-      default: 0.95
-      unit: frac
-      min: 0.8
-      max: 1.0
-      step: 0.01
-      label: Always-on fraction
-    pressure_on_min:
-      default: 0.2
-      unit: eng
-      min: 0.05
-      max: 2.0
-      step: 0.05
-      label: Pressure-on evidence
-    confirm_min:
-      default: 60.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 3600.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
   pandas_implementation: _sched247
   datafusion_sql_implementation: sched247_always_on.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-247
@@ -3350,25 +1982,21 @@ matrix:
   difference_class: none
 - rule_id: CMD-1
   title: Fan cmd/status mismatch
-  equipment_types: &id331
-  - ahu
+  equipment_types: &id331 []
   required_roles: &id332
-  - fan-cmd
-  - fan-status
+  - fan_cmd
+  - fan_status
   optional_roles: &id333 []
   operational_proof_roles: &id334 []
   default_thresholds: &id335
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
-  pandas_implementation: cmd1
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+  pandas_implementation: cmd_1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
   test_coverage: &id336 []
@@ -3377,24 +2005,24 @@ matrix:
   difference_class: none
 - rule_id: OA-1
   title: Low OA fraction
-  equipment_types: &id337
-  - ahu
+  equipment_types: &id337 []
   required_roles: &id338
-  - mixed-air-temp
-  - return-air-temp
-  - outside-air-temp
-  - fan-status
+  - mat
+  - rat
+  - oa_t
+  - fan_cmd
   optional_roles: &id339
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id340
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id340 []
   default_thresholds: &id341
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     min_oa_frac:
       default: 0.15
       unit: frac
@@ -3404,22 +2032,12 @@ matrix:
       label: Min OA fraction
     oat_rat_guard:
       default: 2.2
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.1
-      label: Min |RAT−OAT| guard
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: oa1
+      label: OAT/RAT guard
+  pandas_implementation: oa_1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
   test_coverage: &id342 []
@@ -3428,35 +2046,31 @@ matrix:
   difference_class: none
 - rule_id: DMP-1
   title: OA damper leakage
-  equipment_types: &id343
-  - ahu
+  equipment_types: &id343 []
   required_roles: &id344
-  - outside-air-temp
-  - mixed-air-temp
-  - outside-air-damper
+  - oa_damper_pct
+  - oa_t
+  - mat
   optional_roles: &id345
   - fan_status
   - fan_cmd
   operational_proof_roles: &id346 []
   default_thresholds: &id347
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     leak_delta:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.5
       label: Leak ΔT
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: dmp1
+  pandas_implementation: dmp_1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
   test_coverage: &id348 []
@@ -3465,43 +2079,39 @@ matrix:
   difference_class: none
 - rule_id: VLV-1
   title: Cooling valve leakage
-  equipment_types: &id349
-  - ahu
+  equipment_types: &id349 []
   required_roles: &id350
-  - discharge-air-temp
-  - discharge-air-temp-sp
-  - cooling-valve
+  - clg_valve_pct
+  - sat
+  - sat_sp
+  - mat
   optional_roles: &id351
-  - mixed-air-temp
-  - fan-status
-  - fan-cmd
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id352 []
   default_thresholds: &id353
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     sat_err:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 8.0
       step: 0.5
       label: SAT vs SP leak ΔT
     mat_leak_delta:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 12.0
       step: 0.5
       label: SAT vs MAT leak ΔT
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vlv1
+  pandas_implementation: vlv_1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
   test_coverage: &id354 []
@@ -3619,12 +2229,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id001
-  equipment_kinds: *id001
+  equipment_kinds: null
   required_roles: *id002
   optional_roles: *id003
   operational_proof_roles: *id004
   default_thresholds: *id005
-  pandas_implementation: _sweep_range
+  pandas_implementation: sv_range
   datafusion_sql_implementation: sv_range.sql
   sql_file: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
@@ -3634,8 +2244,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: equipment_energized
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -3718,12 +2328,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id007
-  equipment_kinds: *id007
+  equipment_kinds: null
   required_roles: *id008
   optional_roles: *id009
   operational_proof_roles: *id010
   default_thresholds: *id011
-  pandas_implementation: _sweep_flatline
+  pandas_implementation: sv_flatline
   datafusion_sql_implementation: sv_flatline.sql
   sql_file: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
@@ -3733,8 +2343,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -3817,12 +2427,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id013
-  equipment_kinds: *id013
+  equipment_kinds: null
   required_roles: *id014
   optional_roles: *id015
   operational_proof_roles: *id016
   default_thresholds: *id017
-  pandas_implementation: _sweep_spike
+  pandas_implementation: sv_spike
   datafusion_sql_implementation: sv_spike.sql
   sql_file: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
@@ -3832,8 +2442,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: equipment_energized
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -3916,12 +2526,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id019
-  equipment_kinds: *id019
+  equipment_kinds: null
   required_roles: *id020
   optional_roles: *id021
   operational_proof_roles: *id022
   default_thresholds: *id023
-  pandas_implementation: _sweep_stale
+  pandas_implementation: sv_stale
   datafusion_sql_implementation: sv_stale.sql
   sql_file: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
@@ -3931,8 +2541,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4016,12 +2626,12 @@ concepts:
   - SV-SLEW
   kind: diagnostic
   equipment_types: *id025
-  equipment_kinds: *id025
+  equipment_kinds: null
   required_roles: *id026
   optional_roles: *id027
   operational_proof_roles: *id028
   default_thresholds: *id029
-  pandas_implementation: _sv_rate_compute
+  pandas_implementation: sv_rate
   datafusion_sql_implementation: sv_rate.sql
   sql_file: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
@@ -4031,8 +2641,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: SV-SLEW (not independent rules)'
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4115,12 +2725,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id031
-  equipment_kinds: *id031
+  equipment_kinds: null
   required_roles: *id032
   optional_roles: *id033
   operational_proof_roles: *id034
   default_thresholds: *id035
-  pandas_implementation: _pid_hunt_1
+  pandas_implementation: pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   sql_file: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
@@ -4130,8 +2740,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: control_loop
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 0
   parameters:
     confirm_seconds:
@@ -4219,11 +2829,11 @@ concepts:
 - canonical_id: FC1
   pandas_id: FC1
   rule_id: FC1
-  title: Duct static below SP at full fan (GL36 A)
+  title: Duct static below SP at full fan
   aliases: []
   kind: diagnostic
   equipment_types: *id037
-  equipment_kinds: *id037
+  equipment_kinds: null
   required_roles: *id038
   optional_roles: *id039
   operational_proof_roles: *id040
@@ -4238,8 +2848,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     eps_dsp:
@@ -4327,11 +2937,11 @@ concepts:
 - canonical_id: FC2
   pandas_id: FC2
   rule_id: FC2
-  title: MAT below OAT/RAT envelope (GL36 B)
+  title: Mixed air below envelope
   aliases: []
   kind: diagnostic
   equipment_types: *id043
-  equipment_kinds: *id043
+  equipment_kinds: null
   required_roles: *id044
   optional_roles: *id045
   operational_proof_roles: *id046
@@ -4346,8 +2956,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4408,11 +3018,11 @@ concepts:
 - canonical_id: FC3
   pandas_id: FC3
   rule_id: FC3
-  title: MAT above OAT/RAT envelope (GL36 C)
+  title: Mixed air above envelope
   aliases: []
   kind: diagnostic
   equipment_types: *id049
-  equipment_kinds: *id049
+  equipment_kinds: null
   required_roles: *id050
   optional_roles: *id051
   operational_proof_roles: *id052
@@ -4427,8 +3037,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4493,7 +3103,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id055
-  equipment_kinds: *id055
+  equipment_kinds: null
   required_roles: *id056
   optional_roles: *id057
   operational_proof_roles: *id058
@@ -4508,8 +3118,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: control_loop
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -4583,7 +3193,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id061
-  equipment_kinds: *id061
+  equipment_kinds: null
   required_roles: *id062
   optional_roles: *id063
   operational_proof_roles: *id064
@@ -4598,8 +3208,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4691,7 +3301,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id067
-  equipment_kinds: *id067
+  equipment_kinds: null
   required_roles: *id068
   optional_roles: *id069
   operational_proof_roles: *id070
@@ -4706,8 +3316,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4795,11 +3405,11 @@ concepts:
 - canonical_id: FC7
   pandas_id: FC7
   rule_id: FC7
-  title: SAT low with full heating (GL36 E)
+  title: SAT low while heating at full
   aliases: []
   kind: diagnostic
   equipment_types: *id073
-  equipment_kinds: *id073
+  equipment_kinds: null
   required_roles: *id074
   optional_roles: *id075
   operational_proof_roles: *id076
@@ -4815,8 +3425,8 @@ concepts:
   difference_class: missing_implementation
   known_semantic_differences: concept_only — SQL file is a placeholder; do not claim
     twin parity
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -4904,11 +3514,11 @@ concepts:
 - canonical_id: FC8
   pandas_id: FC8
   rule_id: FC8
-  title: SAT/MAT mismatch in economizer (GL36 F)
+  title: SAT vs MAT while economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id079
-  equipment_kinds: *id079
+  equipment_kinds: null
   required_roles: *id080
   optional_roles: *id081
   operational_proof_roles: *id082
@@ -4923,8 +3533,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4985,11 +3595,11 @@ concepts:
 - canonical_id: FC9
   pandas_id: FC9
   rule_id: FC9
-  title: OAT too warm for free cooling (GL36 G)
+  title: OAT high vs SAT SP while economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id085
-  equipment_kinds: *id085
+  equipment_kinds: null
   required_roles: *id086
   optional_roles: *id087
   operational_proof_roles: *id088
@@ -5004,8 +3614,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5066,11 +3676,11 @@ concepts:
 - canonical_id: FC10
   pandas_id: FC10
   rule_id: FC10
-  title: OAT/MAT mismatch + mech cooling (GL36 H)
+  title: MAT-OAT delta while cooling and economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id091
-  equipment_kinds: *id091
+  equipment_kinds: null
   required_roles: *id092
   optional_roles: *id093
   operational_proof_roles: *id094
@@ -5085,8 +3695,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5147,11 +3757,11 @@ concepts:
 - canonical_id: FC11
   pandas_id: FC11
   rule_id: FC11
-  title: OAT/MAT mismatch economizer-only (GL36 I)
+  title: OAT low vs SAT SP while cooling and economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id097
-  equipment_kinds: *id097
+  equipment_kinds: null
   required_roles: *id098
   optional_roles: *id099
   operational_proof_roles: *id100
@@ -5166,8 +3776,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5228,11 +3838,11 @@ concepts:
 - canonical_id: FC12
   pandas_id: FC12
   rule_id: FC12
-  title: SAT above blend in cooling (GL36 J)
+  title: SAT above MAT while cooling
   aliases: []
   kind: diagnostic
   equipment_types: *id103
-  equipment_kinds: *id103
+  equipment_kinds: null
   required_roles: *id104
   optional_roles: *id105
   operational_proof_roles: *id106
@@ -5247,8 +3857,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5309,12 +3919,12 @@ concepts:
 - canonical_id: FC13-SAT-HIGH
   pandas_id: FC13
   rule_id: FC13
-  title: SAT above SP at full cooling (GL36 K)
+  title: SAT above setpoint at full cooling
   aliases:
   - FC13
   kind: diagnostic
   equipment_types: *id109
-  equipment_kinds: *id109
+  equipment_kinds: null
   required_roles: *id110
   optional_roles: *id111
   operational_proof_roles: *id112
@@ -5329,8 +3939,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: FC13 (not independent rules)'
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -5440,7 +4050,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id115
-  equipment_kinds: *id115
+  equipment_kinds: null
   required_roles: *id116
   optional_roles: *id117
   operational_proof_roles: *id118
@@ -5455,8 +4065,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5539,7 +4149,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id121
-  equipment_kinds: *id121
+  equipment_kinds: null
   required_roles: *id122
   optional_roles: *id123
   operational_proof_roles: *id124
@@ -5554,8 +4164,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5638,12 +4248,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id127
-  equipment_kinds: *id127
+  equipment_kinds: null
   required_roles: *id128
   optional_roles: *id129
   operational_proof_roles: *id130
   default_thresholds: *id131
-  pandas_implementation: ahu_sat_dev
+  pandas_implementation: ahu_satdev
   datafusion_sql_implementation: ahu_satdev.sql
   sql_file: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
@@ -5653,8 +4263,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5737,12 +4347,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id133
-  equipment_kinds: *id133
+  equipment_kinds: null
   required_roles: *id134
   optional_roles: *id135
   operational_proof_roles: *id136
   default_thresholds: *id137
-  pandas_implementation: ahu_duct_high
+  pandas_implementation: ahu_ducthi
   datafusion_sql_implementation: ahu_ducthi.sql
   sql_file: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
@@ -5752,8 +4362,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -5845,12 +4455,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id139
-  equipment_kinds: *id139
+  equipment_kinds: null
   required_roles: *id140
   optional_roles: *id141
   operational_proof_roles: *id142
   default_thresholds: *id143
-  pandas_implementation: ahu_simul_heat_cool
+  pandas_implementation: ahu_simul
   datafusion_sql_implementation: ahu_simul.sql
   sql_file: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
@@ -5860,8 +4470,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -5940,11 +4550,11 @@ concepts:
 - canonical_id: OAT-METEO
   pandas_id: OAT-METEO
   rule_id: OAT-METEO
-  title: BAS outdoor-air sensor vs Open-Meteo
+  title: Equipment OAT vs weather-staged wx OAT
   aliases: []
   kind: diagnostic
   equipment_types: *id145
-  equipment_kinds: *id145
+  equipment_kinds: null
   required_roles: *id146
   optional_roles: *id147
   operational_proof_roles: *id148
@@ -5959,8 +4569,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     oat_err:
@@ -6040,11 +4650,11 @@ concepts:
 - canonical_id: ECON-1
   pandas_id: ECON-1
   rule_id: ECON-1
-  title: Economizer stuck closed
+  title: Economizer stuck closed when OAT favorable
   aliases: []
   kind: diagnostic
   equipment_types: *id151
-  equipment_kinds: *id151
+  equipment_kinds: null
   required_roles: *id152
   optional_roles: *id153
   operational_proof_roles: *id154
@@ -6059,8 +4669,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     econ1_oat_min:
@@ -6130,11 +4740,11 @@ concepts:
 - canonical_id: ECON-2
   pandas_id: ECON-2
   rule_id: ECON-2
-  title: Economizing when outdoor unfavorable
+  title: Economizing when outdoor air unfavorable
   aliases: []
   kind: diagnostic
   equipment_types: *id157
-  equipment_kinds: *id157
+  equipment_kinds: null
   required_roles: *id158
   optional_roles: *id159
   operational_proof_roles: *id160
@@ -6149,8 +4759,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     econ2_oat_hi:
@@ -6242,12 +4852,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id163
-  equipment_kinds: *id163
+  equipment_kinds: null
   required_roles: *id164
   optional_roles: *id165
   operational_proof_roles: *id166
   default_thresholds: *id167
-  pandas_implementation: econ2
+  pandas_implementation: econ_3
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   sql_file: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
@@ -6257,8 +4867,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6368,7 +4978,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id169
-  equipment_kinds: *id169
+  equipment_kinds: null
   required_roles: *id170
   optional_roles: *id171
   operational_proof_roles: *id172
@@ -6383,8 +4993,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     oa_min_pct:
@@ -6467,12 +5077,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id175
-  equipment_kinds: *id175
+  equipment_kinds: null
   required_roles: *id176
   optional_roles: *id177
   operational_proof_roles: *id178
   default_thresholds: *id179
-  pandas_implementation: econ5
+  pandas_implementation: econ_5
   datafusion_sql_implementation: econ5_preheat_over.sql
   sql_file: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
@@ -6482,8 +5092,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -6566,12 +5176,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id181
-  equipment_kinds: *id181
+  equipment_kinds: null
   required_roles: *id182
   optional_roles: *id183
   operational_proof_roles: *id184
   default_thresholds: *id185
-  pandas_implementation: econ6_compute
+  pandas_implementation: econ_6
   datafusion_sql_implementation: econ6_econ_freezing.sql
   sql_file: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
@@ -6581,8 +5191,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -6674,12 +5284,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id187
-  equipment_kinds: *id187
+  equipment_kinds: null
   required_roles: *id188
   optional_roles: *id189
   operational_proof_roles: *id190
   default_thresholds: *id191
-  pandas_implementation: econ7_compute
+  pandas_implementation: econ_7
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   sql_file: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
@@ -6689,8 +5299,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -6800,12 +5410,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id193
-  equipment_kinds: *id193
+  equipment_kinds: null
   required_roles: *id194
   optional_roles: *id195
   operational_proof_roles: *id196
   default_thresholds: *id197
-  pandas_implementation: mech_oat1_compute
+  pandas_implementation: mech_oat_1
   datafusion_sql_implementation: mech_oat_1.sql
   sql_file: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
@@ -6815,8 +5425,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -6899,12 +5509,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id199
-  equipment_kinds: *id199
+  equipment_kinds: null
   required_roles: *id200
   optional_roles: *id201
   operational_proof_roles: *id202
   default_thresholds: *id203
-  pandas_implementation: chw_noload1_compute
+  pandas_implementation: chw_noload_1
   datafusion_sql_implementation: chw_noload_1.sql
   sql_file: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
@@ -6914,8 +5524,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -6994,11 +5604,11 @@ concepts:
 - canonical_id: VAV-1
   pandas_id: VAV-1
   rule_id: VAV-1
-  title: Zone comfort band
+  title: Zone comfort band violation hours with confirm window
   aliases: []
   kind: diagnostic
   equipment_types: *id205
-  equipment_kinds: *id205
+  equipment_kinds: null
   required_roles: *id206
   optional_roles: *id207
   operational_proof_roles: *id208
@@ -7013,8 +5623,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     zone_t_lo:
@@ -7107,12 +5717,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id211
-  equipment_kinds: *id211
+  equipment_kinds: null
   required_roles: *id212
   optional_roles: *id213
   operational_proof_roles: *id214
   default_thresholds: *id215
-  pandas_implementation: vav3
+  pandas_implementation: vav_3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   sql_file: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
@@ -7122,8 +5732,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -7224,12 +5834,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id217
-  equipment_kinds: *id217
+  equipment_kinds: null
   required_roles: *id218
   optional_roles: *id219
   operational_proof_roles: *id220
   default_thresholds: *id221
-  pandas_implementation: vav4
+  pandas_implementation: vav_4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   sql_file: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
@@ -7239,8 +5849,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: control_loop
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7332,12 +5942,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id223
-  equipment_kinds: *id223
+  equipment_kinds: null
   required_roles: *id224
   optional_roles: *id225
   operational_proof_roles: *id226
   default_thresholds: *id227
-  pandas_implementation: vav5
+  pandas_implementation: vav_5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   sql_file: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
@@ -7347,8 +5957,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7422,12 +6032,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id229
-  equipment_kinds: *id229
+  equipment_kinds: null
   required_roles: *id230
   optional_roles: *id231
   operational_proof_roles: *id232
   default_thresholds: *id233
-  pandas_implementation: vav_reheat_stuck
+  pandas_implementation: vav_reheat
   datafusion_sql_implementation: vav_reheat.sql
   sql_file: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
@@ -7437,8 +6047,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7539,12 +6149,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id235
-  equipment_kinds: *id235
+  equipment_kinds: null
   required_roles: *id236
   optional_roles: *id237
   operational_proof_roles: *id238
   default_thresholds: *id239
-  pandas_implementation: vav_vs_ahu_leave
+  pandas_implementation: vav_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   sql_file: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
@@ -7554,8 +6164,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7647,12 +6257,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id241
-  equipment_kinds: *id241
+  equipment_kinds: null
   required_roles: *id242
   optional_roles: *id243
   operational_proof_roles: *id244
   default_thresholds: *id245
-  pandas_implementation: vav7
+  pandas_implementation: vav_7
   datafusion_sql_implementation: vav7_min_airflow.sql
   sql_file: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
@@ -7662,8 +6272,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7746,7 +6356,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id247
-  equipment_kinds: *id247
+  equipment_kinds: null
   required_roles: *id248
   optional_roles: *id249
   operational_proof_roles: *id250
@@ -7762,8 +6372,8 @@ concepts:
   difference_class: none
   known_semantic_differences: Missing proof → pandas SKIPPED_MISSING_ROLES; SQL returns
     0 fault hours (optional proof roles). Proven-off zeros do not accumulate ΔT hours.
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 900
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7846,12 +6456,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id253
-  equipment_kinds: *id253
+  equipment_kinds: null
   required_roles: *id254
   optional_roles: *id255
   operational_proof_roles: *id256
   default_thresholds: *id257
-  pandas_implementation: chw2
+  pandas_implementation: chw_2
   datafusion_sql_implementation: chw2_dp_low.sql
   sql_file: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
@@ -7861,8 +6471,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -7954,12 +6564,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id259
-  equipment_kinds: *id259
+  equipment_kinds: null
   required_roles: *id260
   optional_roles: *id261
   operational_proof_roles: *id262
   default_thresholds: *id263
-  pandas_implementation: chw3
+  pandas_implementation: chw_3
   datafusion_sql_implementation: chw3_supply_band.sql
   sql_file: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
@@ -7969,8 +6579,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -8053,12 +6663,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id265
-  equipment_kinds: *id265
+  equipment_kinds: null
   required_roles: *id266
   optional_roles: *id267
   operational_proof_roles: *id268
   default_thresholds: *id269
-  pandas_implementation: chw4
+  pandas_implementation: chw_4
   datafusion_sql_implementation: chw4_flow_high.sql
   sql_file: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
@@ -8068,8 +6678,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -8161,12 +6771,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id271
-  equipment_kinds: *id271
+  equipment_kinds: null
   required_roles: *id272
   optional_roles: *id273
   operational_proof_roles: *id274
   default_thresholds: *id275
-  pandas_implementation: hp1
+  pandas_implementation: hp_1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   sql_file: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
@@ -8176,8 +6786,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: compressor
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -8269,12 +6879,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id277
-  equipment_kinds: *id277
+  equipment_kinds: null
   required_roles: *id278
   optional_roles: *id279
   operational_proof_roles: *id280
   default_thresholds: *id281
-  pandas_implementation: wx1
+  pandas_implementation: wx_1
   datafusion_sql_implementation: wx1_oa_spike.sql
   sql_file: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
@@ -8284,8 +6894,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -8368,12 +6978,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id283
-  equipment_kinds: *id283
+  equipment_kinds: null
   required_roles: *id284
   optional_roles: *id285
   operational_proof_roles: *id286
   default_thresholds: *id287
-  pandas_implementation: cw_opt
+  pandas_implementation: cw_opt_1
   datafusion_sql_implementation: cw_opt_1.sql
   sql_file: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
@@ -8383,8 +6993,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8476,12 +7086,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id289
-  equipment_kinds: *id289
+  equipment_kinds: null
   required_roles: *id290
   optional_roles: *id291
   operational_proof_roles: *id292
   default_thresholds: *id293
-  pandas_implementation: cw_apr
+  pandas_implementation: cw_apr_1
   datafusion_sql_implementation: cw_apr_1.sql
   sql_file: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
@@ -8491,8 +7101,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8584,12 +7194,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id295
-  equipment_kinds: *id295
+  equipment_kinds: null
   required_roles: *id296
   optional_roles: *id297
   operational_proof_roles: *id298
   default_thresholds: *id299
-  pandas_implementation: cw_fan_excess
+  pandas_implementation: cw_fan_1
   datafusion_sql_implementation: cw_fan_1.sql
   sql_file: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
@@ -8599,8 +7209,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8701,12 +7311,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id301
-  equipment_kinds: *id301
+  equipment_kinds: null
   required_roles: *id302
   optional_roles: *id303
   operational_proof_roles: *id304
   default_thresholds: *id305
-  pandas_implementation: trim1
+  pandas_implementation: trim_1
   datafusion_sql_implementation: trim1_duct_static.sql
   sql_file: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
@@ -8716,8 +7326,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -8809,12 +7419,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id307
-  equipment_kinds: *id307
+  equipment_kinds: null
   required_roles: *id308
   optional_roles: *id309
   operational_proof_roles: *id310
   default_thresholds: *id311
-  pandas_implementation: trim3
+  pandas_implementation: trim_3
   datafusion_sql_implementation: trim3_hwst.sql
   sql_file: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
@@ -8824,8 +7434,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -8917,12 +7527,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id313
-  equipment_kinds: *id313
+  equipment_kinds: null
   required_roles: *id314
   optional_roles: *id315
   operational_proof_roles: *id316
   default_thresholds: *id317
-  pandas_implementation: trim4
+  pandas_implementation: trim_4
   datafusion_sql_implementation: trim4_chw_reset.sql
   sql_file: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
@@ -8932,8 +7542,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -9021,12 +7631,14 @@ concepts:
 - canonical_id: SCHED-1
   pandas_id: SCHED-1
   rule_id: SCHED-1
-  title: Unoccupied runtime
+  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
+    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
+    unoccupied + fan_on (pandas sched1 base).
   aliases:
   - excess_runtime
   kind: diagnostic
   equipment_types: *id319
-  equipment_kinds: *id319
+  equipment_kinds: null
   required_roles: *id320
   optional_roles: *id321
   operational_proof_roles: *id322
@@ -9041,8 +7653,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: excess_runtime (not independent rules)'
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -9134,7 +7746,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id325
-  equipment_kinds: *id325
+  equipment_kinds: null
   required_roles: *id326
   optional_roles: *id327
   operational_proof_roles: *id328
@@ -9151,8 +7763,8 @@ concepts:
   known_semantic_differences: '4.3: ranked proof status/current > command; pressure
     is inferred runtime only and does not OR into the FAULT mask. SQL uses the same
     rank.'
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -9226,12 +7838,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id331
-  equipment_kinds: *id331
+  equipment_kinds: null
   required_roles: *id332
   optional_roles: *id333
   operational_proof_roles: *id334
   default_thresholds: *id335
-  pandas_implementation: cmd1
+  pandas_implementation: cmd_1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   sql_file: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
@@ -9241,8 +7853,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -9316,12 +7928,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id337
-  equipment_kinds: *id337
+  equipment_kinds: null
   required_roles: *id338
   optional_roles: *id339
   operational_proof_roles: *id340
   default_thresholds: *id341
-  pandas_implementation: oa1
+  pandas_implementation: oa_1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   sql_file: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
@@ -9331,8 +7943,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -9424,12 +8036,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id343
-  equipment_kinds: *id343
+  equipment_kinds: null
   required_roles: *id344
   optional_roles: *id345
   operational_proof_roles: *id346
   default_thresholds: *id347
-  pandas_implementation: dmp1
+  pandas_implementation: dmp_1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   sql_file: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
@@ -9439,8 +8051,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -9523,12 +8135,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id349
-  equipment_kinds: *id349
+  equipment_kinds: null
   required_roles: *id350
   optional_roles: *id351
   operational_proof_roles: *id352
   default_thresholds: *id353
-  pandas_implementation: vlv1
+  pandas_implementation: vlv_1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   sql_file: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
@@ -9538,8 +8150,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -37,7 +37,14 @@ aliases_index:
 matrix:
 - rule_id: SV-RANGE
   title: Sensor out of hard range
-  equipment_types: &id001 []
+  equipment_types: &id001
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id002
   - oa_t
   optional_roles: &id003
@@ -46,15 +53,21 @@ matrix:
   - pump_status
   - chw_pump_cmd
   - chiller_status
-  operational_proof_roles: &id004 []
+  operational_proof_roles: &id004
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-current
+  - chw-flow
+  - compressor-status
+  - equipment-enable
   default_thresholds: &id005
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     range_scale_temperature:
       default: 1.0
       unit: x
@@ -62,7 +75,31 @@ matrix:
       max: 2.0
       step: 0.1
       label: Temp range scale
-  pandas_implementation: sv_range
+    range_scale_humidity:
+      default: 1.0
+      unit: x
+      min: 0.5
+      max: 2.0
+      step: 0.1
+      label: Humidity range scale
+    range_scale_pressure:
+      default: 1.0
+      unit: x
+      min: 0.5
+      max: 2.0
+      step: 0.1
+      label: Pressure range scale
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_range
   datafusion_sql_implementation: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
   test_coverage: &id006
@@ -72,7 +109,14 @@ matrix:
   difference_class: none
 - rule_id: SV-FLATLINE
   title: Sensor flatline (stuck)
-  equipment_types: &id007 []
+  equipment_types: &id007
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id008
   - oa_t
   optional_roles: &id009
@@ -83,21 +127,31 @@ matrix:
   - chiller_status
   operational_proof_roles: &id010 []
   default_thresholds: &id011
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     flatline_tol:
       default: 0.1
-      unit: degF
+      unit: °F
       min: 0.02
       max: 1.0
       step: 0.02
       label: Flatline tolerance
-  pandas_implementation: sv_flatline
+    flatline_hours:
+      default: 1.0
+      unit: h
+      min: 0.5
+      max: 8.0
+      step: 0.5
+      label: Flatline window
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_flatline
   datafusion_sql_implementation: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
   test_coverage: &id012 []
@@ -106,7 +160,14 @@ matrix:
   difference_class: none
 - rule_id: SV-SPIKE
   title: Sensor rate-of-change spike
-  equipment_types: &id013 []
+  equipment_types: &id013
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id014
   - oa_t
   optional_roles: &id015
@@ -115,15 +176,21 @@ matrix:
   - pump_status
   - chw_pump_cmd
   - chiller_status
-  operational_proof_roles: &id016 []
+  operational_proof_roles: &id016
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-current
+  - chw-flow
+  - compressor-status
+  - equipment-enable
   default_thresholds: &id017
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     spike_scale:
       default: 1.0
       unit: x
@@ -131,7 +198,38 @@ matrix:
       max: 3.0
       step: 0.25
       label: Spike limit scale (global)
-  pandas_implementation: sv_spike
+    spike_scale_temperature:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Temp spike scale
+    spike_scale_humidity:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Humidity spike scale
+    spike_scale_pressure:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Pressure spike scale
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_spike
   datafusion_sql_implementation: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
   test_coverage: &id018 []
@@ -140,18 +238,18 @@ matrix:
   difference_class: none
 - rule_id: SV-STALE
   title: Stale data (no fresh samples)
-  equipment_types: &id019 []
+  equipment_types: &id019
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id020 []
   optional_roles: &id021 []
   operational_proof_roles: &id022 []
   default_thresholds: &id023
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     stale_hours:
       default: 2.0
       unit: h
@@ -159,7 +257,17 @@ matrix:
       max: 12.0
       step: 0.5
       label: Stale window
-  pandas_implementation: sv_stale
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_stale
   datafusion_sql_implementation: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
   test_coverage: &id024 []
@@ -168,19 +276,19 @@ matrix:
   difference_class: none
 - rule_id: SV-RATE
   title: Context-aware sensor rate of change
-  equipment_types: &id025 []
+  equipment_types: &id025
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id026
   - oa_t
   optional_roles: &id027 []
   operational_proof_roles: &id028 []
   default_thresholds: &id029
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     persistence_min:
       default: 10.0
       unit: min
@@ -188,7 +296,45 @@ matrix:
       max: 60.0
       step: 1.0
       label: Fault persistence
-  pandas_implementation: sv_rate
+    transition_window_min:
+      default: 20.0
+      unit: min
+      min: 5.0
+      max: 60.0
+      step: 5.0
+      label: Transition window
+    max_gap_hours:
+      default: 2.0
+      unit: h
+      min: 0.25
+      max: 6.0
+      step: 0.25
+      label: Max sample gap
+    design_flow:
+      default: 0.0
+      unit: cfm
+      min: 0.0
+      max: 100000.0
+      step: 100.0
+      label: Design flow (flow profiles)
+    sensor_span:
+      default: 0.0
+      unit: eng
+      min: 0.0
+      max: 100000.0
+      step: 10.0
+      label: Sensor span (flow/pressure)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: _sv_rate_compute
   datafusion_sql_implementation: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
   test_coverage: &id030
@@ -199,36 +345,78 @@ matrix:
   difference_class: alias
 - rule_id: PID-HUNT-1
   title: Suspected control-output hunting
-  equipment_types: &id031 []
+  equipment_types: &id031
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - heatpump
   required_roles: &id032
   - clg_valve_pct
   optional_roles: &id033
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id034 []
+  - loop-enabled
+  operational_proof_roles: &id034
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
   default_thresholds: &id035
-    confirm_seconds:
-      default: 0.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     change_deadband_pct:
       default: 1.0
-      unit: pct
+      unit: '% out'
       min: 0.0
       max: 10.0
       step: 0.5
       label: Ignore changes below
     minimum_span_pct:
       default: 20.0
-      unit: pct
+      unit: '% out'
       min: 5.0
       max: 100.0
       step: 5.0
       label: Minimum observed span
-  pandas_implementation: pid_hunt_1
+    total_variation_fault_pct:
+      default: 500.0
+      unit: '%/h'
+      min: 50.0
+      max: 2000.0
+      step: 50.0
+      label: Total travel threshold
+    minimum_equivalent_cycles:
+      default: 2.5
+      unit: cyc/h
+      min: 0.5
+      max: 20.0
+      step: 0.5
+      label: Min equivalent cycles
+    minimum_reversals:
+      default: 4
+      unit: count
+      min: 1
+      max: 40
+      step: 1
+      label: Min direction reversals
+    minimum_coverage_pct:
+      default: 80.0
+      unit: '%'
+      min: 25.0
+      max: 100.0
+      step: 5.0
+      label: Minimum data coverage
+    confirm_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
   test_coverage: &id036 []
@@ -236,38 +424,69 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC1
-  title: Duct static below SP at full fan
-  equipment_types: &id037 []
+  title: Duct static below SP at full fan (GL36 A)
+  equipment_types: &id037
+  - ahu
   required_roles: &id038
-  - duct_static
-  - duct_static_sp
-  - fan_cmd
+  - duct-static-pressure
+  - duct-static-pressure-sp
+  - fan-cmd
   optional_roles: &id039
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id040 []
+  operational_proof_roles: &id040
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id041
     eps_dsp:
       default: 0.12
-      unit: inwc
+      unit: in. w.c.
       min: 0.0
       max: 0.5
       step: 0.01
-      label: Duct-static error epsDSP (GL36 default 0.1 in.w.c.)
+      label: Duct-static error εDSP (GL36 default 0.1 in.w.c.)
     eps_vfd_spd:
       default: 0.13
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: VFD speed error epsVFDSPD (GL36 default 5%)
+      label: VFD speed error εVFDSPD (GL36 default 5%)
+    duct_static_err:
+      default: 0.12
+      unit: in. w.c.
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Legacy duct-static error (sets εDSP)
+    fan_hi:
+      default: 0.87
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Legacy fan-high threshold (sets εVFDSPD)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 300
+      default: 300.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: fc1
   datafusion_sql_implementation: fc1_duct_static_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc1
@@ -278,18 +497,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC2
-  title: Mixed air below envelope
-  equipment_types: &id043 []
+  title: MAT below OAT/RAT envelope (GL36 B)
+  equipment_types: &id043
+  - ahu
   required_roles: &id044
-  - mat
-  - oa_t
-  - rat
-  - fan_cmd
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - fan-cmd
   optional_roles: &id045
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id046 []
-  default_thresholds: &id047 {}
+  operational_proof_roles: &id046
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id047
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_rat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: RAT sensor error εRAT (GL36 default 2°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc2
   datafusion_sql_implementation: fc2_mat_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc2
@@ -298,18 +576,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC3
-  title: Mixed air above envelope
-  equipment_types: &id049 []
+  title: MAT above OAT/RAT envelope (GL36 C)
+  equipment_types: &id049
+  - ahu
   required_roles: &id050
-  - mat
-  - oa_t
-  - rat
-  - fan_cmd
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - fan-cmd
   optional_roles: &id051
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id052 []
-  default_thresholds: &id053 {}
+  operational_proof_roles: &id052
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id053
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_rat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: RAT sensor error εRAT (GL36 default 2°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc3
   datafusion_sql_implementation: fc3_mat_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc3
@@ -319,22 +656,47 @@ matrix:
   difference_class: none
 - rule_id: FC4
   title: PID hunting (operating-state oscillation)
-  equipment_types: &id055 []
+  equipment_types: &id055
+  - ahu
   required_roles: &id056
-  - oa_damper_pct
-  - clg_valve_pct
-  - fan_cmd
+  - outside-air-damper
+  - cooling-valve
+  - fan-cmd
   optional_roles: &id057
   - fan_status
-  operational_proof_roles: &id058 []
+  operational_proof_roles: &id058
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
   default_thresholds: &id059
+    delta_os_max:
+      default: 5
+      unit: count
+      min: 1
+      max: 30
+      step: 1
+      label: Max mode changes/hr ΔOSmax (GL36 default 7)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 60.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 3600.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
   pandas_implementation: fc4
   datafusion_sql_implementation: fc4_os_hunting.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc4
@@ -344,31 +706,45 @@ matrix:
   difference_class: none
 - rule_id: FC5
   title: SAT cold when heating commanded (GL36 D)
-  equipment_types: &id061 []
+  equipment_types: &id061
+  - ahu
   required_roles: &id062
-  - sat
-  - mat
-  - htg_valve_pct
-  - fan_cmd
+  - discharge-air-temp
+  - mixed-air-temp
+  - fan-cmd
+  - heating-valve
   optional_roles: &id063
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id064 []
+  operational_proof_roles: &id064
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id065
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    mix_tol:
+    eps_sat:
       default: 1.15
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy master sensor tolerance (sets all eps values)
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
     htg_on_min:
       default: 0.01
       unit: frac
@@ -376,6 +752,37 @@ matrix:
       max: 0.25
       step: 0.01
       label: Heating-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc5
   datafusion_sql_implementation: fc5_sat_cold_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc5
@@ -385,38 +792,83 @@ matrix:
   difference_class: none
 - rule_id: FC6
   title: Estimated OA fraction mismatch
-  equipment_types: &id067 []
+  equipment_types: &id067
+  - ahu
   required_roles: &id068
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - vav-total-airflow
   optional_roles: &id069
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id070 []
+  operational_proof_roles: &id070
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id071
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+    eps_airflow:
+      default: 0.15
+      unit: frac
+      min: 0.05
+      max: 1.0
+      step: 0.01
+      label: Airflow error εF (GL36 default 30%)
+    delta_t_min:
+      default: 5.0
+      unit: °F
       min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
+      max: 30.0
+      step: 0.5
+      label: Minimum |OAT−RAT| ΔTmin (GL36 default 10°F)
     airflow_err:
       default: 0.15
       unit: frac
       min: 0.05
       max: 1.0
       step: 0.01
-      label: Airflow error epsF (GL36 default 30%)
-    delta_t_min:
+      label: Legacy OA-fraction error (sets εF)
+    oat_rat_delta_min:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 0.0
       max: 30.0
       step: 0.5
-      label: Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)
+      label: Legacy OAT/RAT guard (sets ΔTmin)
+    min_cfm_design:
+      default: 5000
+      unit: cfm
+      min: 500
+      max: 20000
+      step: 500
+      label: Design min OA CFM
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc6
   datafusion_sql_implementation: fc6_oa_frac_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc6
@@ -425,23 +877,37 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC7
-  title: SAT low while heating at full
-  equipment_types: &id073 []
+  title: SAT low with full heating (GL36 E)
+  equipment_types: &id073
+  - ahu
   required_roles: &id074
-  - sat
-  - sat_sp
-  - htg_valve_pct
-  - fan_cmd
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - fan-cmd
+  - heating-valve
   optional_roles: &id075 []
-  operational_proof_roles: &id076 []
+  operational_proof_roles: &id076
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id077
-    sat_err:
+    eps_sat:
       default: 1.0
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy SAT error (sets epsSAT)
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    sat_err:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT error (sets εSAT)
     htg_full_min:
       default: 0.9
       unit: frac
@@ -449,13 +915,30 @@ matrix:
       max: 1.0
       step: 0.01
       label: Full-heating threshold (GL36 99%)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 600
+      default: 600.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: fc7
   datafusion_sql_implementation: fc7_sat_low_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc7
@@ -468,18 +951,91 @@ matrix:
     twin parity
   difference_class: missing_implementation
 - rule_id: FC8
-  title: SAT vs MAT while economizing
-  equipment_types: &id079 []
+  title: SAT/MAT mismatch in economizer (GL36 F)
+  equipment_types: &id079
+  - ahu
   required_roles: &id080
-  - sat
-  - mat
-  - oa_damper_pct
-  - clg_valve_pct
+  - discharge-air-temp
+  - mixed-air-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id081
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id082 []
-  default_thresholds: &id083 {}
+  operational_proof_roles: &id082
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id083
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    supply_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT tolerance master (sets εSAT)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc8
   datafusion_sql_implementation: fc8_sat_mat_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc8
@@ -488,18 +1044,84 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC9
-  title: OAT high vs SAT SP while economizing
-  equipment_types: &id085 []
+  title: OAT too warm for free cooling (GL36 G)
+  equipment_types: &id085
+  - ahu
   required_roles: &id086
-  - oa_t
-  - sat_sp
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id087
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id088 []
-  default_thresholds: &id089 {}
+  operational_proof_roles: &id088
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id089
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc9
   datafusion_sql_implementation: fc9_oa_sat_sp_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc9
@@ -508,18 +1130,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC10
-  title: MAT-OAT delta while cooling and economizing
-  equipment_types: &id091 []
+  title: OAT/MAT mismatch + mech cooling (GL36 H)
+  equipment_types: &id091
+  - ahu
   required_roles: &id092
-  - mat
-  - oa_t
-  - oa_damper_pct
-  - clg_valve_pct
+  - mixed-air-temp
+  - outside-air-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id093
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id094 []
-  default_thresholds: &id095 {}
+  operational_proof_roles: &id094
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id095
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc10
   datafusion_sql_implementation: fc10_mat_oa_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc10
@@ -528,18 +1209,84 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC11
-  title: OAT low vs SAT SP while cooling and economizing
-  equipment_types: &id097 []
+  title: OAT/MAT mismatch economizer-only (GL36 I)
+  equipment_types: &id097
+  - ahu
   required_roles: &id098
-  - oa_t
-  - sat_sp
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id099
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id100 []
-  default_thresholds: &id101 {}
+  operational_proof_roles: &id100
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id101
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc11
   datafusion_sql_implementation: fc11_oa_sat_sp_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc11
@@ -548,18 +1295,98 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC12
-  title: SAT above MAT while cooling
-  equipment_types: &id103 []
+  title: SAT above blend in cooling (GL36 J)
+  equipment_types: &id103
+  - ahu
   required_roles: &id104
-  - sat
-  - mat
-  - oa_damper_pct
-  - clg_valve_pct
+  - discharge-air-temp
+  - mixed-air-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id105
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id106 []
-  default_thresholds: &id107 {}
+  operational_proof_roles: &id106
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id107
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    supply_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT tolerance master (sets εSAT)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc12
   datafusion_sql_implementation: fc12_sat_mat_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc12
@@ -568,53 +1395,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC13
-  title: SAT above setpoint at full cooling
-  equipment_types: &id109 []
+  title: SAT above SP at full cooling (GL36 K)
+  equipment_types: &id109
+  - ahu
   required_roles: &id110
-  - sat
-  - sat_sp
-  - clg_valve_pct
-  - oa_damper_pct
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id111
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id112 []
+  operational_proof_roles: &id112
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id113
-    sat_err:
+    eps_sat:
       default: 1.0
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: SAT high error band
-    clg_valve_min:
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    sat_err:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT error (sets εSAT)
+    clg_full_min:
       default: 0.01
       unit: frac
-      min: 0.0
-      max: 0.5
+      min: 0.5
+      max: 1.0
       step: 0.01
-      label: Cooling valve open threshold
-    oa_damper_econ_low:
+      label: Full-cooling threshold (GL36 99%)
+    econ_min_pos:
       default: 0.05
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: OA damper economizer low
-    oa_damper_econ_high:
+      label: Economizer minimum-position threshold
+    econ_full_open:
       default: 0.9
       unit: frac
       min: 0.5
       max: 1.0
       step: 0.01
-      label: OA damper economizer high
+      label: Economizer full-open threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 600
+      default: 600.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: fc13
   datafusion_sql_implementation: sat_high_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc13
@@ -625,32 +1476,90 @@ matrix:
   difference_class: alias
 - rule_id: FC14
   title: CHW coil ΔT when inactive (GL36 L)
-  equipment_types: &id115 []
+  equipment_types: &id115
+  - ahu
   required_roles: &id116
-  - mat
-  - sat
-  - clg_valve_pct
-  - oa_damper_pct
-  - fan_cmd
+  - cooling-coil-entering-temp
+  - cooling-coil-leaving-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id117
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id118 []
+  operational_proof_roles: &id118
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id119
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    mix_tol:
+    eps_ccet:
       default: 1.15
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy master sensor tolerance (sets all eps values)
+      label: Cooling-coil entering sensor error εCCET
+    eps_cclt:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Cooling-coil leaving sensor error εCCLT
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    htg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Heating-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc14
   datafusion_sql_implementation: fc14_chw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc14
@@ -660,31 +1569,97 @@ matrix:
   difference_class: none
 - rule_id: FC15
   title: HW coil ΔT when inactive (GL36 M)
-  equipment_types: &id121 []
+  equipment_types: &id121
+  - ahu
   required_roles: &id122
-  - mat
-  - sat
-  - htg_valve_pct
-  - fan_cmd
+  - heating-coil-entering-temp
+  - heating-coil-leaving-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id123
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id124 []
+  operational_proof_roles: &id124
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id125
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    mix_tol:
+    eps_hcet:
       default: 1.15
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy master sensor tolerance (sets all eps values)
+      label: Heating-coil entering sensor error εHCET
+    eps_hclt:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Heating-coil leaving sensor error εHCLT
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc15
   datafusion_sql_implementation: fc15_hw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc15
@@ -694,30 +1669,40 @@ matrix:
   difference_class: none
 - rule_id: AHU-SATDEV
   title: SAT deviation from setpoint
-  equipment_types: &id127 []
+  equipment_types: &id127
+  - ahu
   required_roles: &id128
-  - sat
-  - sat_sp
+  - discharge-air-temp
+  - discharge-air-temp-sp
   optional_roles: &id129
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id130 []
+  operational_proof_roles: &id130
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id131
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     sat_dev_err:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 1.0
       max: 15.0
       step: 0.5
       label: SAT deviation
-  pandas_implementation: ahu_satdev
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: ahu_sat_dev
   datafusion_sql_implementation: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
   test_coverage: &id132
@@ -727,38 +1712,41 @@ matrix:
   difference_class: none
 - rule_id: AHU-DUCTHI
   title: Duct static pressure high
-  equipment_types: &id133 []
+  equipment_types: &id133
+  - ahu
   required_roles: &id134
-  - duct_static
-  - duct_static_sp
-  - fan_cmd
+  - duct-static-pressure
+  - duct-static-pressure-sp
   optional_roles: &id135
   - fan_status
   - fan_cmd
   operational_proof_roles: &id136 []
   default_thresholds: &id137
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     duct_high_margin:
       default: 0.25
-      unit: in_wc
+      unit: in. w.c.
       min: 0.05
       max: 1.0
       step: 0.05
       label: High margin
     pressure_on_min:
       default: 0.2
-      unit: in_wc
+      unit: in. w.c.
       min: 0.05
       max: 1.0
       step: 0.05
       label: Pressure-on evidence
-  pandas_implementation: ahu_ducthi
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: ahu_duct_high
   datafusion_sql_implementation: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
   test_coverage: &id138
@@ -768,22 +1756,22 @@ matrix:
   difference_class: none
 - rule_id: AHU-SIMUL
   title: Heating and cooling simultaneous
-  equipment_types: &id139 []
+  equipment_types: &id139
+  - ahu
   required_roles: &id140
-  - htg_valve_pct
-  - clg_valve_pct
+  - heating-valve
+  - cooling-valve
   optional_roles: &id141
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id142 []
+  operational_proof_roles: &id142
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id143
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     valve_open_pct:
       default: 0.1
       unit: frac
@@ -791,7 +1779,17 @@ matrix:
       max: 0.5
       step: 0.01
       label: Valve open threshold
-  pandas_implementation: ahu_simul
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: ahu_simul_heat_cool
   datafusion_sql_implementation: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
   test_coverage: &id144 []
@@ -799,27 +1797,32 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: OAT-METEO
-  title: Equipment OAT vs weather-staged wx OAT
-  equipment_types: &id145 []
+  title: BAS outdoor-air sensor vs Open-Meteo
+  equipment_types: &id145
+  - ahu
   required_roles: &id146
-  - oa_t
+  - outside-air-temp
+  - web-outside-air-temp
   optional_roles: &id147 []
   operational_proof_roles: &id148 []
   default_thresholds: &id149
     oat_err:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 2.0
       max: 20.0
       step: 0.5
-      label: OAT vs meteo tolerance
+      label: Max OAT disagreement
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 900
+      default: 900.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: oat_vs_meteo
   datafusion_sql_implementation: oat_meteo_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oat-meteo
@@ -828,24 +1831,41 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-1
-  title: Economizer stuck closed when OAT favorable
-  equipment_types: &id151 []
+  title: Economizer stuck closed
+  equipment_types: &id151
+  - ahu
   required_roles: &id152
-  - fan_cmd
-  - oa_damper_pct
-  - oa_t
+  - fan-cmd
+  - outside-air-damper
+  - outside-air-temp
   optional_roles: &id153
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id154 []
+  operational_proof_roles: &id154
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id155
     econ1_oat_min:
       default: 55.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 70.0
       step: 1.0
       label: Favorable OAT
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: econ1
   datafusion_sql_implementation: econ1_stuck_closed.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-1
@@ -854,19 +1874,26 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-2
-  title: Economizing when outdoor air unfavorable
-  equipment_types: &id157 []
+  title: Economizing when outdoor unfavorable
+  equipment_types: &id157
+  - ahu
   required_roles: &id158
-  - oa_t
-  - oa_damper_pct
+  - outside-air-temp
+  - outside-air-damper
   optional_roles: &id159
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id160 []
+  operational_proof_roles: &id160
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id161
     econ2_oat_hi:
       default: 63.0
-      unit: degF
+      unit: °F
       min: 55.0
       max: 80.0
       step: 1.0
@@ -878,13 +1905,16 @@ matrix:
       max: 0.9
       step: 0.02
       label: Damper open frac
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 300
+      default: 300.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: econ2
   datafusion_sql_implementation: economizer_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-2
@@ -894,41 +1924,40 @@ matrix:
   difference_class: none
 - rule_id: ECON-3
   title: Mech cooling without integrated economizer
-  equipment_types: &id163 []
+  equipment_types: &id163
+  - ahu
   required_roles: &id164
-  - web_oa_t
-  - web_oa_dp
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id165
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id166 []
+  - web-outside-air-temp
+  - web-outside-air-dewpoint
+  - web-outside-air-humidity
+  operational_proof_roles: &id166
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id167
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     econ3_db_min:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 50.0
       max: 68.0
       step: 1.0
       label: Free-cool OA dry-bulb min
     econ3_db_max:
       default: 72.0
-      unit: degF
+      unit: °F
       min: 65.0
       max: 80.0
       step: 1.0
       label: Free-cool OA dry-bulb max
     econ3_dp_max:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 68.0
       step: 1.0
@@ -940,7 +1969,17 @@ matrix:
       max: 1.0
       step: 0.02
       label: Integrated economizer damper
-  pandas_implementation: econ_3
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: econ2
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
   test_coverage: &id168 []
@@ -949,31 +1988,41 @@ matrix:
   difference_class: none
 - rule_id: ECON-4
   title: Low estimated OA fraction
-  equipment_types: &id169 []
+  equipment_types: &id169
+  - ahu
   required_roles: &id170
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
+  - mixed-air-temp
+  - return-air-temp
+  - outside-air-temp
+  - fan-cmd
   optional_roles: &id171
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id172 []
+  operational_proof_roles: &id172
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id173
     oa_min_pct:
       default: 21.0
-      unit: pct
+      unit: '%'
       min: 5.0
       max: 40.0
       step: 1.0
       label: Min OA fraction
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 600
+      default: 600.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: econ4
   datafusion_sql_implementation: econ4_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-4
@@ -983,32 +2032,42 @@ matrix:
   difference_class: none
 - rule_id: ECON-5
   title: Preheat over-conditioning
-  equipment_types: &id175 []
+  equipment_types: &id175
+  - ahu
   required_roles: &id176
-  - preheat_leave_t
-  - sat_sp
-  - oa_t
-  - htg_valve_pct
+  - preheat-leaving-temp
+  - discharge-air-temp-sp
+  - outside-air-temp
+  - heating-valve
   optional_roles: &id177
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id178 []
+  operational_proof_roles: &id178
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id179
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     preheat_over_f:
       default: 2.2
-      unit: degF
+      unit: °F
       min: 0.5
       max: 8.0
       step: 0.1
       label: Preheat over ΔT
-  pandas_implementation: econ_5
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ5
   datafusion_sql_implementation: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
   test_coverage: &id180 []
@@ -1017,25 +2076,23 @@ matrix:
   difference_class: none
 - rule_id: ECON-6
   title: Economizing in freezing weather
-  equipment_types: &id181 []
+  equipment_types: &id181
+  - ahu
   required_roles: &id182
-  - web_oa_t
-  - oa_damper_pct
+  - outside-air-damper
   optional_roles: &id183
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id184 []
+  - web-outside-air-temp
+  operational_proof_roles: &id184
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id185
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     econ6_oat_max_f:
       default: 25.0
-      unit: degF
+      unit: °F
       min: 15.0
       max: 40.0
       step: 1.0
@@ -1047,7 +2104,17 @@ matrix:
       max: 0.5
       step: 0.01
       label: Winter min-OA damper
-  pandas_implementation: econ_6
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ6_compute
   datafusion_sql_implementation: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
   test_coverage: &id186 []
@@ -1056,41 +2123,42 @@ matrix:
   difference_class: none
 - rule_id: ECON-7
   title: Economizer OK but not economizing
-  equipment_types: &id187 []
+  equipment_types: &id187
+  - ahu
   required_roles: &id188
-  - web_oa_t
-  - web_oa_dp
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-damper
   optional_roles: &id189
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id190 []
+  - web-outside-air-temp
+  - web-outside-air-dewpoint
+  - web-outside-air-humidity
+  - cooling-valve
+  - compressor-status
+  - dx-cool-cmd
+  operational_proof_roles: &id190
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id191
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     econ7_db_min:
       default: 35.0
-      unit: degF
+      unit: °F
       min: 20.0
       max: 50.0
       step: 1.0
       label: Econ-OK dry-bulb floor (freeze guard)
     econ7_db_max:
       default: 72.0
-      unit: degF
+      unit: °F
       min: 65.0
       max: 80.0
       step: 1.0
       label: Econ-OK dry-bulb max
     econ7_dp_max:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 68.0
       step: 1.0
@@ -1102,7 +2170,17 @@ matrix:
       max: 0.9
       step: 0.02
       label: Economizing damper threshold
-  pandas_implementation: econ_7
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ7_compute
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
   test_coverage: &id192 []
@@ -1111,28 +2189,39 @@ matrix:
   difference_class: none
 - rule_id: MECH-OAT-1
   title: Mechanical cooling below 60°F web OAT
-  equipment_types: &id193 []
+  equipment_types: &id193
+  - ahu
+  - chiller
+  - heatpump
   required_roles: &id194
   - web_oa_t
   - clg_valve_pct
-  optional_roles: &id195 []
+  optional_roles: &id195
+  - web-outside-air-temp
+  - compressor-status
+  - chiller-status
+  - chw-pump-status
+  - dx-cool-cmd
   operational_proof_roles: &id196 []
   default_thresholds: &id197
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     mech_oat_max_f:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 65.0
       step: 1.0
       label: Mech-cool OAT ceiling
-  pandas_implementation: mech_oat_1
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: mech_oat1_compute
   datafusion_sql_implementation: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
   test_coverage: &id198 []
@@ -1141,29 +2230,52 @@ matrix:
   difference_class: none
 - rule_id: CHW-NOLOAD-1
   title: Chiller running with no building load
-  equipment_types: &id199 []
+  equipment_types: &id199
+  - chiller
   required_roles: &id200
   - chw_supply_t
   - chw_supply_sp
   - chw_pump_cmd
-  optional_roles: &id201 []
+  optional_roles: &id201
+  - chiller-status
+  - chw-pump-status
+  - compressor-status
+  - building-zone-load-satisfied
+  - building-ahu-load-satisfied
   operational_proof_roles: &id202 []
   default_thresholds: &id203
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
+    comfort_low_f:
+      default: 70.0
+      unit: °F
+      min: 60.0
+      max: 78.0
+      step: 0.5
+      label: Comfort low
+    comfort_high_f:
+      default: 75.0
+      unit: °F
+      min: 68.0
+      max: 85.0
+      step: 0.5
+      label: Comfort high
     sat_band_f:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.5
       label: AHU SAT≈SP band
-  pandas_implementation: chw_noload_1
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: chw_noload1_compute
   datafusion_sql_implementation: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
   test_coverage: &id204 []
@@ -1171,35 +2283,40 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: VAV-1
-  title: Zone comfort band violation hours with confirm window
-  equipment_types: &id205 []
+  title: Zone comfort band
+  equipment_types: &id205
+  - vav
+  - zone
   required_roles: &id206
-  - zone_t
+  - zone-air-temp
   optional_roles: &id207
   - occ_mode
   operational_proof_roles: &id208 []
   default_thresholds: &id209
-    zone_t_lo:
+    zone_lo:
       default: 70.0
-      unit: degF
+      unit: °F
       min: 55.0
       max: 72.0
       step: 0.5
       label: Zone low
-    zone_t_hi:
+    zone_hi:
       default: 75.0
-      unit: degF
+      unit: °F
       min: 72.0
       max: 85.0
       step: 0.5
       label: Zone high
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 900
+      default: 900.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: vav1
   datafusion_sql_implementation: vav1_comfort_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-1
@@ -1211,26 +2328,25 @@ matrix:
   difference_class: none
 - rule_id: VAV-3
   title: Excessive reheat during warm weather
-  equipment_types: &id211 []
+  equipment_types: &id211
+  - vav
   required_roles: &id212
-  - oa_t
-  - reheat_valve_pct
-  - zone_flow
+  - outside-air-temp
+  - reheat-valve
   optional_roles: &id213
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id214 []
+  operational_proof_roles: &id214
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id215
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     reheat_oat:
       default: 78.0
-      unit: degF
+      unit: °F
       min: 65.0
       max: 90.0
       step: 1.0
@@ -1249,7 +2365,17 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-  pandas_implementation: vav_3
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: vav3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
   test_coverage: &id216 []
@@ -1258,22 +2384,22 @@ matrix:
   difference_class: none
 - rule_id: VAV-4
   title: Damper stuck at full open
-  equipment_types: &id217 []
+  equipment_types: &id217
+  - vav
   required_roles: &id218
-  - damper_pct
-  - zone_flow
+  - damper
   optional_roles: &id219
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id220 []
+  operational_proof_roles: &id220
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
   default_thresholds: &id221
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     full_open_pct:
       default: 0.975
       unit: frac
@@ -1281,6 +2407,13 @@ matrix:
       max: 1.0
       step: 0.005
       label: Full open frac
+    sustain_hours:
+      default: 1.5
+      unit: h
+      min: 0.5
+      max: 6.0
+      step: 0.5
+      label: Sustain window
     flow_on_min:
       default: 25.0
       unit: cfm
@@ -1288,7 +2421,17 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-  pandas_implementation: vav_4
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
   test_coverage: &id222 []
@@ -1297,23 +2440,33 @@ matrix:
   difference_class: none
 - rule_id: VAV-5
   title: Airflow sensor bias
-  equipment_types: &id223 []
+  equipment_types: &id223
+  - vav
   required_roles: &id224
-  - zone_flow
-  - damper_pct
+  - zone-airflow
+  - damper
   optional_roles: &id225
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id226 []
+  operational_proof_roles: &id226
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id227
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-  pandas_implementation: vav_5
+  pandas_implementation: vav5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
   test_coverage: &id228 []
@@ -1322,24 +2475,23 @@ matrix:
   difference_class: none
 - rule_id: VAV-REHEAT
   title: Reheat valve stuck / no temp rise
-  equipment_types: &id229 []
+  equipment_types: &id229
+  - vav
   required_roles: &id230
-  - reheat_valve_pct
-  - vav_discharge_t
-  - vav_inlet_t
-  - zone_flow
+  - reheat-valve
+  - vav-discharge-air-temp
+  - vav-inlet-air-temp
   optional_roles: &id231
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id232 []
+  operational_proof_roles: &id232
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id233
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     reheat_cmd:
       default: 0.3
       unit: frac
@@ -1349,7 +2501,7 @@ matrix:
       label: Reheat open frac
     min_rise:
       default: 3.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 15.0
       step: 0.5
@@ -1361,7 +2513,17 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-  pandas_implementation: vav_reheat
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav_reheat_stuck
   datafusion_sql_implementation: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
   test_coverage: &id234 []
@@ -1370,26 +2532,25 @@ matrix:
   difference_class: none
 - rule_id: VAV-AHU-LEAVE
   title: VAV leave vs parent AHU SAT (fedBy)
-  equipment_types: &id235 []
+  equipment_types: &id235
+  - vav
   required_roles: &id236
-  - vav_discharge_t
-  - ahu_sat
-  - zone_flow
+  - vav-discharge-air-temp
+  - ahu-discharge-air-temp
   optional_roles: &id237
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id238 []
+  operational_proof_roles: &id238
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id239
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     delta_f:
       default: 8.0
-      unit: degF
+      unit: °F
       min: 2.0
       max: 25.0
       step: 0.5
@@ -1401,7 +2562,17 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-  pandas_implementation: vav_ahu_leave
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav_vs_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
   test_coverage: &id240 []
@@ -1410,22 +2581,42 @@ matrix:
   difference_class: none
 - rule_id: VAV-7
   title: Min airflow / fixed high flow
-  equipment_types: &id241 []
+  equipment_types: &id241
+  - vav
   required_roles: &id242
-  - zone_flow
-  - min_flow_sp
+  - zone-airflow
   optional_roles: &id243
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id244 []
+  operational_proof_roles: &id244
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id245
-    confirm_seconds:
-      default: 900.0
-      unit: sec
+    flow_on_min:
+      default: 25.0
+      unit: cfm
       min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
+      max: 200.0
+      step: 5.0
+      label: Airflow-on min
+    fixed_flow_max_std:
+      default: 15.0
+      unit: cfm
+      min: 1.0
+      max: 80.0
+      step: 1.0
+      label: Fixed-flow max std
+    fixed_flow_min_mean:
+      default: 200.0
+      unit: cfm
+      min: 50.0
+      max: 2000.0
+      step: 10.0
+      label: Fixed-flow min mean
     high_min_flow_sp:
       default: 250.0
       unit: cfm
@@ -1433,7 +2624,17 @@ matrix:
       max: 2000.0
       step: 10.0
       label: High min-flow SP
-  pandas_implementation: vav_7
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav7
   datafusion_sql_implementation: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
   test_coverage: &id246 []
@@ -1442,10 +2643,11 @@ matrix:
   difference_class: none
 - rule_id: CHW-1
   title: Low chilled-water ΔT
-  equipment_types: &id247 []
+  equipment_types: &id247
+  - chiller
   required_roles: &id248
-  - chw_supply_t
-  - chw_return_t
+  - chilled-water-supply-temp
+  - chilled-water-return-temp
   optional_roles: &id249
   - chw_pump_cmd
   - pump_status
@@ -1454,22 +2656,38 @@ matrix:
   - chiller_amps
   - chiller_power
   - chw_flow
-  operational_proof_roles: &id250 []
+  operational_proof_roles: &id250
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id251
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     min_dt:
       default: 4.0
-      unit: degF
+      unit: °F
       min: 1.0
       max: 12.0
       step: 0.5
-      label: Minimum delta-T
+      label: Min ΔT
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
   pandas_implementation: chw1
   datafusion_sql_implementation: chw1_low_dt.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-1
@@ -1484,21 +2702,28 @@ matrix:
   difference_class: none
 - rule_id: CHW-2
   title: DP below SP at max pump speed
-  equipment_types: &id253 []
+  equipment_types: &id253
+  - chiller
   required_roles: &id254
-  - chw_dp
-  - chw_dp_sp
-  - chw_pump_cmd
+  - chw-diff-pressure
+  - chw-diff-pressure-sp
+  - chw-pump-cmd
   optional_roles: &id255 []
-  operational_proof_roles: &id256 []
+  operational_proof_roles: &id256
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id257
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     dp_margin:
       default: 2.2
       unit: psi
@@ -1513,7 +2738,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-  pandas_implementation: chw_2
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw2
   datafusion_sql_implementation: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
   test_coverage: &id258 []
@@ -1522,29 +2757,46 @@ matrix:
   difference_class: none
 - rule_id: CHW-3
   title: Plant supply temp outside deadband
-  equipment_types: &id259 []
+  equipment_types: &id259
+  - chiller
   required_roles: &id260
-  - chw_supply_t
-  - chw_supply_sp
-  - chw_pump_cmd
+  - chilled-water-supply-temp
+  - chilled-water-supply-temp-sp
+  - chw-pump-cmd
   optional_roles: &id261 []
-  operational_proof_roles: &id262 []
+  operational_proof_roles: &id262
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id263
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     sp_band:
       default: 2.2
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.1
       label: SP band
-  pandas_implementation: chw_3
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw3
   datafusion_sql_implementation: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
   test_coverage: &id264 []
@@ -1553,26 +2805,33 @@ matrix:
   difference_class: none
 - rule_id: CHW-4
   title: Flow high at max pump
-  equipment_types: &id265 []
+  equipment_types: &id265
+  - chiller
   required_roles: &id266
-  - chw_flow
-  - chw_pump_cmd
+  - chw-flow
+  - chw-pump-cmd
   optional_roles: &id267 []
-  operational_proof_roles: &id268 []
+  operational_proof_roles: &id268
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id269
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     flow_hi:
-      default: 1100.0
+      default: 1100
       unit: gpm
-      min: 200.0
-      max: 3000.0
-      step: 50.0
+      min: 200
+      max: 3000
+      step: 50
       label: Flow high
     pump_hi:
       default: 0.87
@@ -1581,7 +2840,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-  pandas_implementation: chw_4
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw4
   datafusion_sql_implementation: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
   test_coverage: &id270 []
@@ -1590,38 +2859,46 @@ matrix:
   difference_class: none
 - rule_id: HP-1
   title: Discharge cold when heating
-  equipment_types: &id271 []
+  equipment_types: &id271
+  - heatpump
   required_roles: &id272
-  - sat
-  - zone_t
-  - fan_cmd
+  - discharge-air-temp
+  - zone-air-temp
+  - fan-cmd
   optional_roles: &id273
   - compressor_status
   - fan_status
-  operational_proof_roles: &id274 []
+  operational_proof_roles: &id274
+  - compressor-status
+  - equipment-enable
+  - fan-status
+  - fan-cmd
   default_thresholds: &id275
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     min_sat:
       default: 85.0
-      unit: degF
+      unit: °F
       min: 70.0
       max: 110.0
       step: 1.0
-      label: Min discharge SAT
+      label: Min heating SAT
     zone_cold:
       default: 69.0
-      unit: degF
+      unit: °F
       min: 60.0
       max: 72.0
       step: 0.5
-      label: Zone cold threshold
-  pandas_implementation: hp_1
+      label: Zone cold
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: hp1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
   test_coverage: &id276 []
@@ -1630,27 +2907,31 @@ matrix:
   difference_class: none
 - rule_id: WX-1
   title: OA temperature spike
-  equipment_types: &id277 []
+  equipment_types: &id277
+  - weather
   required_roles: &id278
-  - oa_t
+  - outside-air-temp
   optional_roles: &id279 []
   operational_proof_roles: &id280 []
   default_thresholds: &id281
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     spike_limit:
       default: 16.0
-      unit: degF
+      unit: °F
       min: 4.0
       max: 40.0
       step: 1.0
       label: Spike limit
-  pandas_implementation: wx_1
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: wx1
   datafusion_sql_implementation: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
   test_coverage: &id282 []
@@ -1659,39 +2940,56 @@ matrix:
   difference_class: none
 - rule_id: CW-OPT-1
   title: Condenser water not optimized vs wet-bulb
-  equipment_types: &id283 []
+  equipment_types: &id283
+  - chiller
+  - cooling_tower
   required_roles: &id284
-  - cw_supply_t
-  - web_wb_t
+  - condenser-water-supply-temp
   optional_roles: &id285
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id286 []
+  operational_proof_roles: &id286
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id287
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: degF
+      unit: °F
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     cw_slack:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.5
       label: Slack below target
-  pandas_implementation: cw_opt_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_opt
   datafusion_sql_implementation: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
   test_coverage: &id288 []
@@ -1700,28 +2998,34 @@ matrix:
   difference_class: none
 - rule_id: CW-APR-1
   title: High CW approach at full tower fan
-  equipment_types: &id289 []
+  equipment_types: &id289
+  - chiller
+  - cooling_tower
   required_roles: &id290
-  - cw_supply_t
-  - web_wb_t
-  - tower_fan_cmd
+  - condenser-water-supply-temp
   optional_roles: &id291
-  - pump_status
-  - chiller_status
-  - chw_flow
-  - chw_pump_cmd
-  operational_proof_roles: &id292 []
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - web-outside-air-wetbulb
+  operational_proof_roles: &id292
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id293
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     approach_max_f:
       default: 8.0
-      unit: degF
+      unit: °F
       min: 5.0
       max: 15.0
       step: 0.5
@@ -1733,7 +3037,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-  pandas_implementation: cw_apr_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_apr
   datafusion_sql_implementation: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
   test_coverage: &id294 []
@@ -1742,35 +3056,41 @@ matrix:
   difference_class: none
 - rule_id: CW-FAN-1
   title: Excess tower fan energy vs wet-bulb limit
-  equipment_types: &id295 []
+  equipment_types: &id295
+  - chiller
+  - cooling_tower
   required_roles: &id296
-  - cw_supply_t
-  - web_wb_t
-  - tower_fan_cmd
+  - condenser-water-supply-temp
   optional_roles: &id297
-  - pump_status
-  - chiller_status
-  - chw_flow
-  - chw_pump_cmd
-  operational_proof_roles: &id298 []
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - web-outside-air-wetbulb
+  operational_proof_roles: &id298
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id299
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: degF
+      unit: °F
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     excess_beyond_approach_f:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 2.0
       max: 20.0
       step: 0.5
@@ -1782,7 +3102,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-  pandas_implementation: cw_fan_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_fan_excess
   datafusion_sql_implementation: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
   test_coverage: &id300 []
@@ -1791,24 +3121,25 @@ matrix:
   difference_class: none
 - rule_id: TRIM-1
   title: Duct static trim advisory
-  equipment_types: &id301 []
+  equipment_types: &id301
+  - ahu
   required_roles: &id302
-  - duct_static_sp
+  - duct-static-pressure
+  - vav-pressure-request-sum
   optional_roles: &id303
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id304 []
+  operational_proof_roles: &id304
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id305
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     duct_hi:
       default: 1.35
-      unit: in_wc
+      unit: in. w.c.
       min: 0.5
       max: 3.0
       step: 0.05
@@ -1820,7 +3151,17 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-  pandas_implementation: trim_1
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim1
   datafusion_sql_implementation: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
   test_coverage: &id306 []
@@ -1829,26 +3170,34 @@ matrix:
   difference_class: none
 - rule_id: TRIM-3
   title: HWST trim advisory
-  equipment_types: &id307 []
+  equipment_types: &id307
+  - boiler
   required_roles: &id308
-  - hw_supply_t
+  - hot-water-supply-temp
+  - hw-reset-request-sum
   optional_roles: &id309
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id310 []
+  operational_proof_roles: &id310
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id311
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     hwst_hi:
       default: 160.0
-      unit: degF
+      unit: °F
       min: 120.0
       max: 200.0
       step: 1.0
@@ -1860,7 +3209,17 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-  pandas_implementation: trim_3
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim3
   datafusion_sql_implementation: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
   test_coverage: &id312 []
@@ -1869,26 +3228,34 @@ matrix:
   difference_class: none
 - rule_id: TRIM-4
   title: CHW plant reset advisory
-  equipment_types: &id313 []
+  equipment_types: &id313
+  - chiller
   required_roles: &id314
-  - chw_supply_t
+  - chilled-water-supply-temp
+  - chw-reset-request-sum
   optional_roles: &id315
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id316 []
+  operational_proof_roles: &id316
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id317
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     chw_lo:
       default: 45.0
-      unit: degF
+      unit: °F
       min: 35.0
       max: 55.0
       step: 0.5
@@ -1900,7 +3267,17 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-  pandas_implementation: trim_4
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim4
   datafusion_sql_implementation: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
   test_coverage: &id318 []
@@ -1908,38 +3285,40 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: SCHED-1
-  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
-    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
-    unoccupied + fan_on (pandas sched1 base).
-  equipment_types: &id319 []
+  title: Unoccupied runtime
+  equipment_types: &id319
+  - ahu
   required_roles: &id320
-  - occ_mode
-  - fan_status
+  - occupied
+  - fan-status
   optional_roles: &id321
-  - zone_t
+  - zone-air-temp
   operational_proof_roles: &id322 []
   default_thresholds: &id323
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     comfort_low_f:
       default: 70.0
       unit: °F
-      min: 50.0
-      max: 80.0
+      min: 60.0
+      max: 78.0
       step: 0.5
-      label: Zone comfort low
+      label: Comfort low
     comfort_high_f:
       default: 75.0
       unit: °F
-      min: 55.0
-      max: 90.0
+      min: 68.0
+      max: 85.0
       step: 0.5
-      label: Zone comfort high
+      label: Comfort high
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
   pandas_implementation: sched1
   datafusion_sql_implementation: sched1_unoccupied_runtime.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-1
@@ -1952,22 +3331,53 @@ matrix:
   difference_class: alias
 - rule_id: SCHED-247
   title: Always-on fan or pump runtime
-  equipment_types: &id325 []
+  equipment_types: &id325
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - heatpump
   required_roles: &id326 []
   optional_roles: &id327
-  - fan_status
-  - pump_status
-  - chiller_status
-  - fan_cmd
+  - fan-status
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - chiller-status
+  - compressor-status
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  - duct-static-pressure
+  - chw-diff-pressure
   operational_proof_roles: &id328 []
   default_thresholds: &id329
+    always_on_pct:
+      default: 0.95
+      unit: frac
+      min: 0.8
+      max: 1.0
+      step: 0.01
+      label: Always-on fraction
+    pressure_on_min:
+      default: 0.2
+      unit: eng
+      min: 0.05
+      max: 2.0
+      step: 0.05
+      label: Pressure-on evidence
+    confirm_min:
+      default: 60.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 3600.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
   pandas_implementation: _sched247
   datafusion_sql_implementation: sched247_always_on.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-247
@@ -1982,21 +3392,25 @@ matrix:
   difference_class: none
 - rule_id: CMD-1
   title: Fan cmd/status mismatch
-  equipment_types: &id331 []
+  equipment_types: &id331
+  - ahu
   required_roles: &id332
-  - fan_cmd
-  - fan_status
+  - fan-cmd
+  - fan-status
   optional_roles: &id333 []
   operational_proof_roles: &id334 []
   default_thresholds: &id335
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-  pandas_implementation: cmd_1
+  pandas_implementation: cmd1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
   test_coverage: &id336 []
@@ -2005,24 +3419,24 @@ matrix:
   difference_class: none
 - rule_id: OA-1
   title: Low OA fraction
-  equipment_types: &id337 []
+  equipment_types: &id337
+  - ahu
   required_roles: &id338
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
+  - mixed-air-temp
+  - return-air-temp
+  - outside-air-temp
+  - fan-status
   optional_roles: &id339
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id340 []
+  operational_proof_roles: &id340
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id341
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     min_oa_frac:
       default: 0.15
       unit: frac
@@ -2032,12 +3446,22 @@ matrix:
       label: Min OA fraction
     oat_rat_guard:
       default: 2.2
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.1
-      label: OAT/RAT guard
-  pandas_implementation: oa_1
+      label: Min |RAT−OAT| guard
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: oa1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
   test_coverage: &id342 []
@@ -2046,31 +3470,35 @@ matrix:
   difference_class: none
 - rule_id: DMP-1
   title: OA damper leakage
-  equipment_types: &id343 []
+  equipment_types: &id343
+  - ahu
   required_roles: &id344
-  - oa_damper_pct
-  - oa_t
-  - mat
+  - outside-air-temp
+  - mixed-air-temp
+  - outside-air-damper
   optional_roles: &id345
   - fan_status
   - fan_cmd
   operational_proof_roles: &id346 []
   default_thresholds: &id347
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     leak_delta:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.5
       label: Leak ΔT
-  pandas_implementation: dmp_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: dmp1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
   test_coverage: &id348 []
@@ -2079,39 +3507,43 @@ matrix:
   difference_class: none
 - rule_id: VLV-1
   title: Cooling valve leakage
-  equipment_types: &id349 []
+  equipment_types: &id349
+  - ahu
   required_roles: &id350
-  - clg_valve_pct
-  - sat
-  - sat_sp
-  - mat
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - cooling-valve
   optional_roles: &id351
-  - fan_status
-  - fan_cmd
+  - mixed-air-temp
+  - fan-status
+  - fan-cmd
   operational_proof_roles: &id352 []
   default_thresholds: &id353
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     sat_err:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 8.0
       step: 0.5
       label: SAT vs SP leak ΔT
     mat_leak_delta:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 12.0
       step: 0.5
       label: SAT vs MAT leak ΔT
-  pandas_implementation: vlv_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vlv1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
   test_coverage: &id354 []
@@ -2229,12 +3661,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id001
-  equipment_kinds: null
+  equipment_kinds: *id001
   required_roles: *id002
   optional_roles: *id003
   operational_proof_roles: *id004
   default_thresholds: *id005
-  pandas_implementation: sv_range
+  pandas_implementation: _sweep_range
   datafusion_sql_implementation: sv_range.sql
   sql_file: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
@@ -2244,8 +3676,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: equipment_energized
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2328,12 +3760,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id007
-  equipment_kinds: null
+  equipment_kinds: *id007
   required_roles: *id008
   optional_roles: *id009
   operational_proof_roles: *id010
   default_thresholds: *id011
-  pandas_implementation: sv_flatline
+  pandas_implementation: _sweep_flatline
   datafusion_sql_implementation: sv_flatline.sql
   sql_file: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
@@ -2343,8 +3775,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2427,12 +3859,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id013
-  equipment_kinds: null
+  equipment_kinds: *id013
   required_roles: *id014
   optional_roles: *id015
   operational_proof_roles: *id016
   default_thresholds: *id017
-  pandas_implementation: sv_spike
+  pandas_implementation: _sweep_spike
   datafusion_sql_implementation: sv_spike.sql
   sql_file: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
@@ -2442,8 +3874,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: equipment_energized
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2526,12 +3958,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id019
-  equipment_kinds: null
+  equipment_kinds: *id019
   required_roles: *id020
   optional_roles: *id021
   operational_proof_roles: *id022
   default_thresholds: *id023
-  pandas_implementation: sv_stale
+  pandas_implementation: _sweep_stale
   datafusion_sql_implementation: sv_stale.sql
   sql_file: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
@@ -2541,8 +3973,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2626,12 +4058,12 @@ concepts:
   - SV-SLEW
   kind: diagnostic
   equipment_types: *id025
-  equipment_kinds: null
+  equipment_kinds: *id025
   required_roles: *id026
   optional_roles: *id027
   operational_proof_roles: *id028
   default_thresholds: *id029
-  pandas_implementation: sv_rate
+  pandas_implementation: _sv_rate_compute
   datafusion_sql_implementation: sv_rate.sql
   sql_file: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
@@ -2641,8 +4073,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: SV-SLEW (not independent rules)'
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -2725,12 +4157,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id031
-  equipment_kinds: null
+  equipment_kinds: *id031
   required_roles: *id032
   optional_roles: *id033
   operational_proof_roles: *id034
   default_thresholds: *id035
-  pandas_implementation: pid_hunt_1
+  pandas_implementation: _pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   sql_file: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
@@ -2740,8 +4172,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 0
   parameters:
     confirm_seconds:
@@ -2829,11 +4261,11 @@ concepts:
 - canonical_id: FC1
   pandas_id: FC1
   rule_id: FC1
-  title: Duct static below SP at full fan
+  title: Duct static below SP at full fan (GL36 A)
   aliases: []
   kind: diagnostic
   equipment_types: *id037
-  equipment_kinds: null
+  equipment_kinds: *id037
   required_roles: *id038
   optional_roles: *id039
   operational_proof_roles: *id040
@@ -2848,8 +4280,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     eps_dsp:
@@ -2937,11 +4369,11 @@ concepts:
 - canonical_id: FC2
   pandas_id: FC2
   rule_id: FC2
-  title: Mixed air below envelope
+  title: MAT below OAT/RAT envelope (GL36 B)
   aliases: []
   kind: diagnostic
   equipment_types: *id043
-  equipment_kinds: null
+  equipment_kinds: *id043
   required_roles: *id044
   optional_roles: *id045
   operational_proof_roles: *id046
@@ -2956,8 +4388,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3018,11 +4450,11 @@ concepts:
 - canonical_id: FC3
   pandas_id: FC3
   rule_id: FC3
-  title: Mixed air above envelope
+  title: MAT above OAT/RAT envelope (GL36 C)
   aliases: []
   kind: diagnostic
   equipment_types: *id049
-  equipment_kinds: null
+  equipment_kinds: *id049
   required_roles: *id050
   optional_roles: *id051
   operational_proof_roles: *id052
@@ -3037,8 +4469,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3103,7 +4535,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id055
-  equipment_kinds: null
+  equipment_kinds: *id055
   required_roles: *id056
   optional_roles: *id057
   operational_proof_roles: *id058
@@ -3118,8 +4550,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -3193,7 +4625,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id061
-  equipment_kinds: null
+  equipment_kinds: *id061
   required_roles: *id062
   optional_roles: *id063
   operational_proof_roles: *id064
@@ -3208,8 +4640,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -3301,7 +4733,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id067
-  equipment_kinds: null
+  equipment_kinds: *id067
   required_roles: *id068
   optional_roles: *id069
   operational_proof_roles: *id070
@@ -3316,8 +4748,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -3405,11 +4837,11 @@ concepts:
 - canonical_id: FC7
   pandas_id: FC7
   rule_id: FC7
-  title: SAT low while heating at full
+  title: SAT low with full heating (GL36 E)
   aliases: []
   kind: diagnostic
   equipment_types: *id073
-  equipment_kinds: null
+  equipment_kinds: *id073
   required_roles: *id074
   optional_roles: *id075
   operational_proof_roles: *id076
@@ -3425,8 +4857,8 @@ concepts:
   difference_class: missing_implementation
   known_semantic_differences: concept_only — SQL file is a placeholder; do not claim
     twin parity
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -3514,11 +4946,11 @@ concepts:
 - canonical_id: FC8
   pandas_id: FC8
   rule_id: FC8
-  title: SAT vs MAT while economizing
+  title: SAT/MAT mismatch in economizer (GL36 F)
   aliases: []
   kind: diagnostic
   equipment_types: *id079
-  equipment_kinds: null
+  equipment_kinds: *id079
   required_roles: *id080
   optional_roles: *id081
   operational_proof_roles: *id082
@@ -3533,8 +4965,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3595,11 +5027,11 @@ concepts:
 - canonical_id: FC9
   pandas_id: FC9
   rule_id: FC9
-  title: OAT high vs SAT SP while economizing
+  title: OAT too warm for free cooling (GL36 G)
   aliases: []
   kind: diagnostic
   equipment_types: *id085
-  equipment_kinds: null
+  equipment_kinds: *id085
   required_roles: *id086
   optional_roles: *id087
   operational_proof_roles: *id088
@@ -3614,8 +5046,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3676,11 +5108,11 @@ concepts:
 - canonical_id: FC10
   pandas_id: FC10
   rule_id: FC10
-  title: MAT-OAT delta while cooling and economizing
+  title: OAT/MAT mismatch + mech cooling (GL36 H)
   aliases: []
   kind: diagnostic
   equipment_types: *id091
-  equipment_kinds: null
+  equipment_kinds: *id091
   required_roles: *id092
   optional_roles: *id093
   operational_proof_roles: *id094
@@ -3695,8 +5127,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3757,11 +5189,11 @@ concepts:
 - canonical_id: FC11
   pandas_id: FC11
   rule_id: FC11
-  title: OAT low vs SAT SP while cooling and economizing
+  title: OAT/MAT mismatch economizer-only (GL36 I)
   aliases: []
   kind: diagnostic
   equipment_types: *id097
-  equipment_kinds: null
+  equipment_kinds: *id097
   required_roles: *id098
   optional_roles: *id099
   operational_proof_roles: *id100
@@ -3776,8 +5208,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3838,11 +5270,11 @@ concepts:
 - canonical_id: FC12
   pandas_id: FC12
   rule_id: FC12
-  title: SAT above MAT while cooling
+  title: SAT above blend in cooling (GL36 J)
   aliases: []
   kind: diagnostic
   equipment_types: *id103
-  equipment_kinds: null
+  equipment_kinds: *id103
   required_roles: *id104
   optional_roles: *id105
   operational_proof_roles: *id106
@@ -3857,8 +5289,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3919,12 +5351,12 @@ concepts:
 - canonical_id: FC13-SAT-HIGH
   pandas_id: FC13
   rule_id: FC13
-  title: SAT above setpoint at full cooling
+  title: SAT above SP at full cooling (GL36 K)
   aliases:
   - FC13
   kind: diagnostic
   equipment_types: *id109
-  equipment_kinds: null
+  equipment_kinds: *id109
   required_roles: *id110
   optional_roles: *id111
   operational_proof_roles: *id112
@@ -3939,8 +5371,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: FC13 (not independent rules)'
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -4050,7 +5482,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id115
-  equipment_kinds: null
+  equipment_kinds: *id115
   required_roles: *id116
   optional_roles: *id117
   operational_proof_roles: *id118
@@ -4065,8 +5497,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4149,7 +5581,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id121
-  equipment_kinds: null
+  equipment_kinds: *id121
   required_roles: *id122
   optional_roles: *id123
   operational_proof_roles: *id124
@@ -4164,8 +5596,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4248,12 +5680,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id127
-  equipment_kinds: null
+  equipment_kinds: *id127
   required_roles: *id128
   optional_roles: *id129
   operational_proof_roles: *id130
   default_thresholds: *id131
-  pandas_implementation: ahu_satdev
+  pandas_implementation: ahu_sat_dev
   datafusion_sql_implementation: ahu_satdev.sql
   sql_file: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
@@ -4263,8 +5695,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4347,12 +5779,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id133
-  equipment_kinds: null
+  equipment_kinds: *id133
   required_roles: *id134
   optional_roles: *id135
   operational_proof_roles: *id136
   default_thresholds: *id137
-  pandas_implementation: ahu_ducthi
+  pandas_implementation: ahu_duct_high
   datafusion_sql_implementation: ahu_ducthi.sql
   sql_file: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
@@ -4362,8 +5794,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4455,12 +5887,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id139
-  equipment_kinds: null
+  equipment_kinds: *id139
   required_roles: *id140
   optional_roles: *id141
   operational_proof_roles: *id142
   default_thresholds: *id143
-  pandas_implementation: ahu_simul
+  pandas_implementation: ahu_simul_heat_cool
   datafusion_sql_implementation: ahu_simul.sql
   sql_file: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
@@ -4470,8 +5902,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4550,11 +5982,11 @@ concepts:
 - canonical_id: OAT-METEO
   pandas_id: OAT-METEO
   rule_id: OAT-METEO
-  title: Equipment OAT vs weather-staged wx OAT
+  title: BAS outdoor-air sensor vs Open-Meteo
   aliases: []
   kind: diagnostic
   equipment_types: *id145
-  equipment_kinds: null
+  equipment_kinds: *id145
   required_roles: *id146
   optional_roles: *id147
   operational_proof_roles: *id148
@@ -4569,8 +6001,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 900
   parameters:
     oat_err:
@@ -4650,11 +6082,11 @@ concepts:
 - canonical_id: ECON-1
   pandas_id: ECON-1
   rule_id: ECON-1
-  title: Economizer stuck closed when OAT favorable
+  title: Economizer stuck closed
   aliases: []
   kind: diagnostic
   equipment_types: *id151
-  equipment_kinds: null
+  equipment_kinds: *id151
   required_roles: *id152
   optional_roles: *id153
   operational_proof_roles: *id154
@@ -4669,8 +6101,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     econ1_oat_min:
@@ -4740,11 +6172,11 @@ concepts:
 - canonical_id: ECON-2
   pandas_id: ECON-2
   rule_id: ECON-2
-  title: Economizing when outdoor air unfavorable
+  title: Economizing when outdoor unfavorable
   aliases: []
   kind: diagnostic
   equipment_types: *id157
-  equipment_kinds: null
+  equipment_kinds: *id157
   required_roles: *id158
   optional_roles: *id159
   operational_proof_roles: *id160
@@ -4759,8 +6191,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     econ2_oat_hi:
@@ -4852,12 +6284,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id163
-  equipment_kinds: null
+  equipment_kinds: *id163
   required_roles: *id164
   optional_roles: *id165
   operational_proof_roles: *id166
   default_thresholds: *id167
-  pandas_implementation: econ_3
+  pandas_implementation: econ2
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   sql_file: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
@@ -4867,8 +6299,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4978,7 +6410,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id169
-  equipment_kinds: null
+  equipment_kinds: *id169
   required_roles: *id170
   optional_roles: *id171
   operational_proof_roles: *id172
@@ -4993,8 +6425,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     oa_min_pct:
@@ -5077,12 +6509,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id175
-  equipment_kinds: null
+  equipment_kinds: *id175
   required_roles: *id176
   optional_roles: *id177
   operational_proof_roles: *id178
   default_thresholds: *id179
-  pandas_implementation: econ_5
+  pandas_implementation: econ5
   datafusion_sql_implementation: econ5_preheat_over.sql
   sql_file: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
@@ -5092,8 +6524,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5176,12 +6608,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id181
-  equipment_kinds: null
+  equipment_kinds: *id181
   required_roles: *id182
   optional_roles: *id183
   operational_proof_roles: *id184
   default_thresholds: *id185
-  pandas_implementation: econ_6
+  pandas_implementation: econ6_compute
   datafusion_sql_implementation: econ6_econ_freezing.sql
   sql_file: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
@@ -5191,8 +6623,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5284,12 +6716,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id187
-  equipment_kinds: null
+  equipment_kinds: *id187
   required_roles: *id188
   optional_roles: *id189
   operational_proof_roles: *id190
   default_thresholds: *id191
-  pandas_implementation: econ_7
+  pandas_implementation: econ7_compute
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   sql_file: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
@@ -5299,8 +6731,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5410,12 +6842,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id193
-  equipment_kinds: null
+  equipment_kinds: *id193
   required_roles: *id194
   optional_roles: *id195
   operational_proof_roles: *id196
   default_thresholds: *id197
-  pandas_implementation: mech_oat_1
+  pandas_implementation: mech_oat1_compute
   datafusion_sql_implementation: mech_oat_1.sql
   sql_file: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
@@ -5425,8 +6857,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5509,12 +6941,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id199
-  equipment_kinds: null
+  equipment_kinds: *id199
   required_roles: *id200
   optional_roles: *id201
   operational_proof_roles: *id202
   default_thresholds: *id203
-  pandas_implementation: chw_noload_1
+  pandas_implementation: chw_noload1_compute
   datafusion_sql_implementation: chw_noload_1.sql
   sql_file: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
@@ -5524,8 +6956,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -5604,11 +7036,11 @@ concepts:
 - canonical_id: VAV-1
   pandas_id: VAV-1
   rule_id: VAV-1
-  title: Zone comfort band violation hours with confirm window
+  title: Zone comfort band
   aliases: []
   kind: diagnostic
   equipment_types: *id205
-  equipment_kinds: null
+  equipment_kinds: *id205
   required_roles: *id206
   optional_roles: *id207
   operational_proof_roles: *id208
@@ -5623,8 +7055,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 0.0
   confirm_seconds: 900
   parameters:
     zone_t_lo:
@@ -5717,12 +7149,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id211
-  equipment_kinds: null
+  equipment_kinds: *id211
   required_roles: *id212
   optional_roles: *id213
   operational_proof_roles: *id214
   default_thresholds: *id215
-  pandas_implementation: vav_3
+  pandas_implementation: vav3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   sql_file: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
@@ -5732,8 +7164,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -5834,12 +7266,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id217
-  equipment_kinds: null
+  equipment_kinds: *id217
   required_roles: *id218
   optional_roles: *id219
   operational_proof_roles: *id220
   default_thresholds: *id221
-  pandas_implementation: vav_4
+  pandas_implementation: vav4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   sql_file: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
@@ -5849,8 +7281,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -5942,12 +7374,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id223
-  equipment_kinds: null
+  equipment_kinds: *id223
   required_roles: *id224
   optional_roles: *id225
   operational_proof_roles: *id226
   default_thresholds: *id227
-  pandas_implementation: vav_5
+  pandas_implementation: vav5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   sql_file: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
@@ -5957,8 +7389,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6032,12 +7464,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id229
-  equipment_kinds: null
+  equipment_kinds: *id229
   required_roles: *id230
   optional_roles: *id231
   operational_proof_roles: *id232
   default_thresholds: *id233
-  pandas_implementation: vav_reheat
+  pandas_implementation: vav_reheat_stuck
   datafusion_sql_implementation: vav_reheat.sql
   sql_file: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
@@ -6047,8 +7479,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6149,12 +7581,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id235
-  equipment_kinds: null
+  equipment_kinds: *id235
   required_roles: *id236
   optional_roles: *id237
   operational_proof_roles: *id238
   default_thresholds: *id239
-  pandas_implementation: vav_ahu_leave
+  pandas_implementation: vav_vs_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   sql_file: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
@@ -6164,8 +7596,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6257,12 +7689,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id241
-  equipment_kinds: null
+  equipment_kinds: *id241
   required_roles: *id242
   optional_roles: *id243
   operational_proof_roles: *id244
   default_thresholds: *id245
-  pandas_implementation: vav_7
+  pandas_implementation: vav7
   datafusion_sql_implementation: vav7_min_airflow.sql
   sql_file: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
@@ -6272,8 +7704,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6356,7 +7788,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id247
-  equipment_kinds: null
+  equipment_kinds: *id247
   required_roles: *id248
   optional_roles: *id249
   operational_proof_roles: *id250
@@ -6372,8 +7804,8 @@ concepts:
   difference_class: none
   known_semantic_differences: Missing proof → pandas SKIPPED_MISSING_ROLES; SQL returns
     0 fault hours (optional proof roles). Proven-off zeros do not accumulate ΔT hours.
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 900
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6456,12 +7888,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id253
-  equipment_kinds: null
+  equipment_kinds: *id253
   required_roles: *id254
   optional_roles: *id255
   operational_proof_roles: *id256
   default_thresholds: *id257
-  pandas_implementation: chw_2
+  pandas_implementation: chw2
   datafusion_sql_implementation: chw2_dp_low.sql
   sql_file: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
@@ -6471,8 +7903,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6564,12 +7996,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id259
-  equipment_kinds: null
+  equipment_kinds: *id259
   required_roles: *id260
   optional_roles: *id261
   operational_proof_roles: *id262
   default_thresholds: *id263
-  pandas_implementation: chw_3
+  pandas_implementation: chw3
   datafusion_sql_implementation: chw3_supply_band.sql
   sql_file: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
@@ -6579,8 +8011,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6663,12 +8095,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id265
-  equipment_kinds: null
+  equipment_kinds: *id265
   required_roles: *id266
   optional_roles: *id267
   operational_proof_roles: *id268
   default_thresholds: *id269
-  pandas_implementation: chw_4
+  pandas_implementation: chw4
   datafusion_sql_implementation: chw4_flow_high.sql
   sql_file: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
@@ -6678,8 +8110,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6771,12 +8203,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id271
-  equipment_kinds: null
+  equipment_kinds: *id271
   required_roles: *id272
   optional_roles: *id273
   operational_proof_roles: *id274
   default_thresholds: *id275
-  pandas_implementation: hp_1
+  pandas_implementation: hp1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   sql_file: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
@@ -6786,8 +8218,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: compressor
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -6879,12 +8311,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id277
-  equipment_kinds: null
+  equipment_kinds: *id277
   required_roles: *id278
   optional_roles: *id279
   operational_proof_roles: *id280
   default_thresholds: *id281
-  pandas_implementation: wx_1
+  pandas_implementation: wx1
   datafusion_sql_implementation: wx1_oa_spike.sql
   sql_file: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
@@ -6894,8 +8326,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6978,12 +8410,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id283
-  equipment_kinds: null
+  equipment_kinds: *id283
   required_roles: *id284
   optional_roles: *id285
   operational_proof_roles: *id286
   default_thresholds: *id287
-  pandas_implementation: cw_opt_1
+  pandas_implementation: cw_opt
   datafusion_sql_implementation: cw_opt_1.sql
   sql_file: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
@@ -6993,8 +8425,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7086,12 +8518,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id289
-  equipment_kinds: null
+  equipment_kinds: *id289
   required_roles: *id290
   optional_roles: *id291
   operational_proof_roles: *id292
   default_thresholds: *id293
-  pandas_implementation: cw_apr_1
+  pandas_implementation: cw_apr
   datafusion_sql_implementation: cw_apr_1.sql
   sql_file: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
@@ -7101,8 +8533,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7194,12 +8626,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id295
-  equipment_kinds: null
+  equipment_kinds: *id295
   required_roles: *id296
   optional_roles: *id297
   operational_proof_roles: *id298
   default_thresholds: *id299
-  pandas_implementation: cw_fan_1
+  pandas_implementation: cw_fan_excess
   datafusion_sql_implementation: cw_fan_1.sql
   sql_file: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
@@ -7209,8 +8641,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7311,12 +8743,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id301
-  equipment_kinds: null
+  equipment_kinds: *id301
   required_roles: *id302
   optional_roles: *id303
   operational_proof_roles: *id304
   default_thresholds: *id305
-  pandas_implementation: trim_1
+  pandas_implementation: trim1
   datafusion_sql_implementation: trim1_duct_static.sql
   sql_file: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
@@ -7326,8 +8758,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -7419,12 +8851,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id307
-  equipment_kinds: null
+  equipment_kinds: *id307
   required_roles: *id308
   optional_roles: *id309
   operational_proof_roles: *id310
   default_thresholds: *id311
-  pandas_implementation: trim_3
+  pandas_implementation: trim3
   datafusion_sql_implementation: trim3_hwst.sql
   sql_file: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
@@ -7434,8 +8866,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -7527,12 +8959,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id313
-  equipment_kinds: null
+  equipment_kinds: *id313
   required_roles: *id314
   optional_roles: *id315
   operational_proof_roles: *id316
   default_thresholds: *id317
-  pandas_implementation: trim_4
+  pandas_implementation: trim4
   datafusion_sql_implementation: trim4_chw_reset.sql
   sql_file: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
@@ -7542,8 +8974,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -7631,14 +9063,12 @@ concepts:
 - canonical_id: SCHED-1
   pandas_id: SCHED-1
   rule_id: SCHED-1
-  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
-    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
-    unoccupied + fan_on (pandas sched1 base).
+  title: Unoccupied runtime
   aliases:
   - excess_runtime
   kind: diagnostic
   equipment_types: *id319
-  equipment_kinds: null
+  equipment_kinds: *id319
   required_roles: *id320
   optional_roles: *id321
   operational_proof_roles: *id322
@@ -7653,8 +9083,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: excess_runtime (not independent rules)'
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -7746,7 +9176,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id325
-  equipment_kinds: null
+  equipment_kinds: *id325
   required_roles: *id326
   optional_roles: *id327
   operational_proof_roles: *id328
@@ -7763,8 +9193,8 @@ concepts:
   known_semantic_differences: '4.3: ranked proof status/current > command; pressure
     is inferred runtime only and does not OR into the FAULT mask. SQL uses the same
     rank.'
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -7838,12 +9268,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id331
-  equipment_kinds: null
+  equipment_kinds: *id331
   required_roles: *id332
   optional_roles: *id333
   operational_proof_roles: *id334
   default_thresholds: *id335
-  pandas_implementation: cmd_1
+  pandas_implementation: cmd1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   sql_file: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
@@ -7853,8 +9283,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -7928,12 +9358,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id337
-  equipment_kinds: null
+  equipment_kinds: *id337
   required_roles: *id338
   optional_roles: *id339
   operational_proof_roles: *id340
   default_thresholds: *id341
-  pandas_implementation: oa_1
+  pandas_implementation: oa1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   sql_file: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
@@ -7943,8 +9373,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8036,12 +9466,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id343
-  equipment_kinds: null
+  equipment_kinds: *id343
   required_roles: *id344
   optional_roles: *id345
   operational_proof_roles: *id346
   default_thresholds: *id347
-  pandas_implementation: dmp_1
+  pandas_implementation: dmp1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   sql_file: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
@@ -8051,8 +9481,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8135,12 +9565,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id349
-  equipment_kinds: null
+  equipment_kinds: *id349
   required_roles: *id350
   optional_roles: *id351
   operational_proof_roles: *id352
   default_thresholds: *id353
-  pandas_implementation: vlv_1
+  pandas_implementation: vlv1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   sql_file: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
@@ -8150,8 +9580,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -417,7 +417,9 @@ matrix:
   - duct-static-pressure
   - duct-static-pressure-sp
   - fan-cmd
-  optional_roles: &id039 []
+  optional_roles: &id039
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id040
   - fan-status
   - fan-speed-feedback
@@ -489,7 +491,9 @@ matrix:
   - outside-air-temp
   - return-air-temp
   - fan-cmd
-  optional_roles: &id045 []
+  optional_roles: &id045
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id046
   - fan-status
   - fan-speed-feedback
@@ -566,7 +570,9 @@ matrix:
   - outside-air-temp
   - return-air-temp
   - fan-cmd
-  optional_roles: &id051 []
+  optional_roles: &id051
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id052
   - fan-status
   - fan-speed-feedback
@@ -692,7 +698,9 @@ matrix:
   - mixed-air-temp
   - fan-cmd
   - heating-valve
-  optional_roles: &id063 []
+  optional_roles: &id063
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id064
   - fan-status
   - fan-speed-feedback
@@ -776,7 +784,9 @@ matrix:
   - outside-air-temp
   - return-air-temp
   - vav-total-airflow
-  optional_roles: &id069 []
+  optional_roles: &id069
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id070
   - fan-status
   - fan-speed-feedback
@@ -920,6 +930,7 @@ matrix:
   test_coverage: &id078
   - tests/rules/test_golden_parity.py
   - tests/rules/test_parity_inventory.py
+  - tests/test_wattlab_parity_diff.py
   parity_status: concept_only
   known_semantic_differences: concept_only — SQL file is a placeholder; do not claim
     twin parity
@@ -933,7 +944,9 @@ matrix:
   - mixed-air-temp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id081 []
+  optional_roles: &id081
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id082
   - fan-status
   - fan-speed-feedback
@@ -1024,7 +1037,9 @@ matrix:
   - discharge-air-temp-sp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id087 []
+  optional_roles: &id087
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id088
   - fan-status
   - fan-speed-feedback
@@ -1108,7 +1123,9 @@ matrix:
   - outside-air-temp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id093 []
+  optional_roles: &id093
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id094
   - fan-status
   - fan-speed-feedback
@@ -1185,7 +1202,9 @@ matrix:
   - discharge-air-temp-sp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id099 []
+  optional_roles: &id099
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id100
   - fan-status
   - fan-speed-feedback
@@ -1269,7 +1288,9 @@ matrix:
   - mixed-air-temp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id105 []
+  optional_roles: &id105
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id106
   - fan-status
   - fan-speed-feedback
@@ -1367,7 +1388,9 @@ matrix:
   - discharge-air-temp-sp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id111 []
+  optional_roles: &id111
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id112
   - fan-status
   - fan-speed-feedback
@@ -1445,7 +1468,9 @@ matrix:
   - cooling-coil-leaving-temp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id117 []
+  optional_roles: &id117
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id118
   - fan-status
   - fan-speed-feedback
@@ -1536,7 +1561,9 @@ matrix:
   - heating-coil-leaving-temp
   - outside-air-damper
   - cooling-valve
-  optional_roles: &id123 []
+  optional_roles: &id123
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id124
   - fan-status
   - fan-speed-feedback
@@ -1632,7 +1659,9 @@ matrix:
   required_roles: &id128
   - discharge-air-temp
   - discharge-air-temp-sp
-  optional_roles: &id129 []
+  optional_roles: &id129
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id130
   - fan-status
   - fan-speed-feedback
@@ -1661,7 +1690,8 @@ matrix:
   pandas_implementation: ahu_sat_dev
   datafusion_sql_implementation: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
-  test_coverage: &id132 []
+  test_coverage: &id132
+  - tests/test_wattlab_parity_diff.py
   parity_status: sql_screening
   known_semantic_differences: ''
   difference_class: none
@@ -1672,7 +1702,9 @@ matrix:
   required_roles: &id134
   - duct-static-pressure
   - duct-static-pressure-sp
-  optional_roles: &id135 []
+  optional_roles: &id135
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id136 []
   default_thresholds: &id137
     duct_high_margin:
@@ -1714,7 +1746,9 @@ matrix:
   required_roles: &id140
   - heating-valve
   - cooling-valve
-  optional_roles: &id141 []
+  optional_roles: &id141
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id142
   - fan-status
   - fan-speed-feedback
@@ -1789,7 +1823,9 @@ matrix:
   - fan-cmd
   - outside-air-damper
   - outside-air-temp
-  optional_roles: &id153 []
+  optional_roles: &id153
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id154
   - fan-status
   - fan-speed-feedback
@@ -1829,7 +1865,9 @@ matrix:
   required_roles: &id158
   - outside-air-temp
   - outside-air-damper
-  optional_roles: &id159 []
+  optional_roles: &id159
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id160
   - fan-status
   - fan-speed-feedback
@@ -1942,7 +1980,9 @@ matrix:
   - return-air-temp
   - outside-air-temp
   - fan-cmd
-  optional_roles: &id171 []
+  optional_roles: &id171
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id172
   - fan-status
   - fan-speed-feedback
@@ -1984,7 +2024,9 @@ matrix:
   - discharge-air-temp-sp
   - outside-air-temp
   - heating-valve
-  optional_roles: &id177 []
+  optional_roles: &id177
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id178
   - fan-status
   - fan-speed-feedback
@@ -3050,7 +3092,9 @@ matrix:
   required_roles: &id302
   - duct-static-pressure
   - vav-pressure-request-sum
-  optional_roles: &id303 []
+  optional_roles: &id303
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id304
   - fan-status
   - fan-speed-feedback
@@ -3340,7 +3384,9 @@ matrix:
   - return-air-temp
   - outside-air-temp
   - fan-status
-  optional_roles: &id339 []
+  optional_roles: &id339
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id340
   - fan-status
   - fan-speed-feedback
@@ -3388,7 +3434,9 @@ matrix:
   - outside-air-temp
   - mixed-air-temp
   - outside-air-damper
-  optional_roles: &id345 []
+  optional_roles: &id345
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id346 []
   default_thresholds: &id347
     leak_delta:

--- a/sql_rules/hp1_discharge_cold.sql
+++ b/sql_rules/hp1_discharge_cold.sql
@@ -4,7 +4,16 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     sat, zone_t,
-    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    compressor_status,
+    fan_status,
+    CASE
+      WHEN compressor_status IS NOT NULL THEN CASE WHEN compressor_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.05 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS proof_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +21,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(proof_on, 0) = 0 THEN 0
       WHEN sat IS NULL OR zone_t IS NULL OR fan IS NULL THEN 0
       WHEN fan >= 0.05 AND zone_t < {{ZONE_COLD}} AND sat < {{MIN_SAT}} THEN 1
       ELSE 0

--- a/sql_rules/oa1_low_oa_frac.sql
+++ b/sql_rules/oa1_low_oa_frac.sql
@@ -4,7 +4,13 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     mat, rat, oa_t,
-    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan
+    CASE WHEN fan_cmd IS NULL THEN NULL WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END AS fan,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +18,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN mat IS NULL OR rat IS NULL OR oa_t IS NULL THEN 0
       WHEN ABS(rat - oa_t) <= {{OAT_RAT_GUARD}} THEN 0
       WHEN (mat - rat) / NULLIF(oa_t - rat, 0) < {{MIN_OA_FRAC}}

--- a/sql_rules/pid_hunt_1.sql
+++ b/sql_rules/pid_hunt_1.sql
@@ -10,7 +10,15 @@ WITH h AS (
     LAG(CASE WHEN clg_valve_pct IS NULL THEN NULL
              WHEN clg_valve_pct > 1.0 THEN clg_valve_pct
              ELSE clg_valve_pct * 100.0 END)
-      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_out
+      OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_out,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -18,6 +26,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN out_pct IS NULL OR prev_out IS NULL THEN 0
       WHEN ABS(out_pct - prev_out) > {{CHANGE_DEADBAND_PCT}}
        AND ABS(out_pct - prev_out) >= {{MINIMUM_SPAN_PCT}} / 10.0

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -15,6 +15,7 @@ rules:
     confirm_seconds: 0
 
   - rule_id: VAV-1
+    equipment_kinds: [vav, zone]
     sql_file: vav1_comfort_fault.sql
     pandas_function: vav1
     description: Zone comfort band violation hours with confirm window
@@ -148,6 +149,7 @@ rules:
         sql_placeholder: ZONE_T_HI
 
   - rule_id: OAT-METEO
+    equipment_kinds: [ahu]
     sql_file: oat_meteo_fault.sql
     pandas_function: oat_vs_meteo
     description: Equipment OAT vs weather-staged wx OAT
@@ -179,11 +181,13 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC13-SAT-HIGH
+    equipment_kinds: [ahu]
     aliases: [FC13]
     sql_file: sat_high_fault.sql
     pandas_function: fc13
     description: SAT above setpoint at full cooling
     required_roles: [sat, sat_sp, clg_valve_pct, oa_damper_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -238,10 +242,12 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: ECON-2
+    equipment_kinds: [ahu]
     sql_file: economizer_fault.sql
     pandas_function: econ2
     description: Economizing when outdoor air unfavorable
     required_roles: [oa_t, oa_damper_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -278,10 +284,12 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC1
+    equipment_kinds: [ahu]
     sql_file: fc1_duct_static_low.sql
     pandas_function: fc1
     description: Duct static below SP at full fan
     required_roles: [duct_static, duct_static_sp, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -318,10 +326,12 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC2
+    equipment_kinds: [ahu]
     sql_file: fc2_mat_low.sql
     pandas_function: fc2
     description: Mixed air below envelope
     required_roles: [mat, oa_t, rat, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -330,10 +340,12 @@ rules:
     confirm_seconds: 600
 
   - rule_id: FC3
+    equipment_kinds: [ahu]
     sql_file: fc3_mat_high.sql
     pandas_function: fc3
     description: Mixed air above envelope
     required_roles: [mat, oa_t, rat, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -342,6 +354,7 @@ rules:
     confirm_seconds: 600
 
   - rule_id: FC7
+    equipment_kinds: [ahu]
     sql_file: fc7_sat_low_heating.sql
     pandas_function: fc7
     description: SAT low while heating at full
@@ -383,10 +396,12 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC8
+    equipment_kinds: [ahu]
     sql_file: fc8_sat_mat_econ.sql
     pandas_function: fc8
     description: SAT vs MAT while economizing
     required_roles: [sat, mat, oa_damper_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -395,10 +410,12 @@ rules:
     confirm_seconds: 600
 
   - rule_id: FC9
+    equipment_kinds: [ahu]
     sql_file: fc9_oa_sat_sp_econ.sql
     pandas_function: fc9
     description: OAT high vs SAT SP while economizing
     required_roles: [oa_t, sat_sp, oa_damper_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -407,10 +424,12 @@ rules:
     confirm_seconds: 600
 
   - rule_id: FC10
+    equipment_kinds: [ahu]
     sql_file: fc10_mat_oa_clg.sql
     pandas_function: fc10
     description: MAT-OAT delta while cooling and economizing
     required_roles: [mat, oa_t, oa_damper_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -419,10 +438,12 @@ rules:
     confirm_seconds: 600
 
   - rule_id: FC11
+    equipment_kinds: [ahu]
     sql_file: fc11_oa_sat_sp_clg.sql
     pandas_function: fc11
     description: OAT low vs SAT SP while cooling and economizing
     required_roles: [oa_t, sat_sp, oa_damper_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -431,10 +452,12 @@ rules:
     confirm_seconds: 600
 
   - rule_id: FC12
+    equipment_kinds: [ahu]
     sql_file: fc12_sat_mat_clg.sql
     pandas_function: fc12
     description: SAT above MAT while cooling
     required_roles: [sat, mat, oa_damper_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -443,10 +466,12 @@ rules:
     confirm_seconds: 600
 
   - rule_id: ECON-1
+    equipment_kinds: [ahu]
     sql_file: econ1_stuck_closed.sql
     pandas_function: econ1
     description: Economizer stuck closed when OAT favorable
     required_roles: [fan_cmd, oa_damper_pct, oa_t]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -465,10 +490,12 @@ rules:
         sql_placeholder: ECON1_OAT_MIN
 
   - rule_id: ECON-4
+    equipment_kinds: [ahu]
     sql_file: econ4_low_oa_frac.sql
     pandas_function: econ4
     description: Low estimated OA fraction
     required_roles: [mat, rat, oa_t, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -498,6 +525,7 @@ rules:
 # --- Ported from datafusion-sql-cookbook (feat/sql-rules-59) ---
 
   - rule_id: SV-RANGE
+    equipment_kinds: [ahu, vav, chiller, boiler, weather, zone, heatpump]
     sql_file: sv_range.sql
     pandas_function: null
     description: Sensor out of hard range
@@ -529,6 +557,7 @@ rules:
         sql_placeholder: RANGE_SCALE_TEMPERATURE
 
   - rule_id: SV-FLATLINE
+    equipment_kinds: [ahu, vav, chiller, boiler, weather, zone, heatpump]
     sql_file: sv_flatline.sql
     pandas_function: null
     description: Sensor flatline (stuck)
@@ -560,6 +589,7 @@ rules:
         sql_placeholder: FLATLINE_TOL
 
   - rule_id: SV-SPIKE
+    equipment_kinds: [ahu, vav, chiller, boiler, weather, zone, heatpump]
     sql_file: sv_spike.sql
     pandas_function: null
     description: Sensor rate-of-change spike
@@ -591,6 +621,7 @@ rules:
         sql_placeholder: SPIKE_SCALE
 
   - rule_id: SV-STALE
+    equipment_kinds: [ahu, vav, chiller, boiler, weather, zone, heatpump]
     sql_file: sv_stale.sql
     pandas_function: null
     description: Stale data (no fresh samples)
@@ -623,6 +654,7 @@ rules:
         sql_placeholder: STALE_HOURS
 
   - rule_id: SV-RATE
+    equipment_kinds: [ahu, vav, chiller, boiler, weather, zone, heatpump]
     aliases: [SV-SLEW]
     sql_file: sv_rate.sql
     pandas_function: null
@@ -655,6 +687,7 @@ rules:
         sql_placeholder: PERSISTENCE_MIN
 
   - rule_id: PID-HUNT-1
+    equipment_kinds: [ahu, vav, chiller, boiler, heatpump]
     sql_file: pid_hunt_1.sql
     pandas_function: null
     description: Suspected control-output hunting
@@ -695,6 +728,7 @@ rules:
         sql_placeholder: MINIMUM_SPAN_PCT
 
   - rule_id: FC4
+    equipment_kinds: [ahu]
     sql_file: fc4_os_hunting.sql
     pandas_function: null
     description: PID hunting (operating-state oscillation)
@@ -717,10 +751,12 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: FC5
+    equipment_kinds: [ahu]
     sql_file: fc5_sat_cold_heating.sql
     pandas_function: null
     description: SAT cold when heating commanded (GL36 D)
     required_roles: [sat, mat, htg_valve_pct, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -757,10 +793,12 @@ rules:
         sql_placeholder: HTG_ON_MIN
 
   - rule_id: FC6
+    equipment_kinds: [ahu]
     sql_file: fc6_oa_frac_mismatch.sql
     pandas_function: null
     description: Estimated OA fraction mismatch
     required_roles: [mat, rat, oa_t, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -797,10 +835,12 @@ rules:
         sql_placeholder: DELTA_T_MIN
 
   - rule_id: FC14
+    equipment_kinds: [ahu]
     sql_file: fc14_chw_coil_dt_inactive.sql
     pandas_function: null
     description: CHW coil ΔT when inactive (GL36 L)
     required_roles: [mat, sat, clg_valve_pct, oa_damper_pct, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -828,10 +868,12 @@ rules:
         sql_placeholder: MIX_TOL
 
   - rule_id: FC15
+    equipment_kinds: [ahu]
     sql_file: fc15_hw_coil_dt_inactive.sql
     pandas_function: null
     description: HW coil ΔT when inactive (GL36 M)
     required_roles: [mat, sat, htg_valve_pct, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -859,10 +901,12 @@ rules:
         sql_placeholder: MIX_TOL
 
   - rule_id: AHU-SATDEV
+    equipment_kinds: [ahu]
     sql_file: ahu_satdev.sql
     pandas_function: null
     description: SAT deviation from setpoint
     required_roles: [sat, sat_sp]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -890,10 +934,12 @@ rules:
         sql_placeholder: SAT_DEV_ERR
 
   - rule_id: AHU-DUCTHI
+    equipment_kinds: [ahu]
     sql_file: ahu_ducthi.sql
     pandas_function: null
     description: Duct static pressure high
     required_roles: [duct_static, duct_static_sp, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -930,10 +976,12 @@ rules:
         sql_placeholder: PRESSURE_ON_MIN
 
   - rule_id: AHU-SIMUL
+    equipment_kinds: [ahu]
     sql_file: ahu_simul.sql
     pandas_function: null
     description: Heating and cooling simultaneous
     required_roles: [htg_valve_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -961,10 +1009,12 @@ rules:
         sql_placeholder: VALVE_OPEN_PCT
 
   - rule_id: ECON-3
+    equipment_kinds: [ahu]
     sql_file: econ3_mech_without_econ.sql
     pandas_function: null
     description: Mech cooling without integrated economizer
     required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1019,10 +1069,12 @@ rules:
         sql_placeholder: ECON3_DAMPER_HI
 
   - rule_id: ECON-5
+    equipment_kinds: [ahu]
     sql_file: econ5_preheat_over.sql
     pandas_function: null
     description: Preheat over-conditioning
     required_roles: [preheat_leave_t, sat_sp, oa_t, htg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1050,10 +1102,12 @@ rules:
         sql_placeholder: PREHEAT_OVER_F
 
   - rule_id: ECON-6
+    equipment_kinds: [ahu]
     sql_file: econ6_econ_freezing.sql
     pandas_function: null
     description: Economizing in freezing weather
     required_roles: [web_oa_t, oa_damper_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1090,10 +1144,12 @@ rules:
         sql_placeholder: ECON6_DAMPER_MAX
 
   - rule_id: ECON-7
+    equipment_kinds: [ahu]
     sql_file: econ7_ok_not_economizing.sql
     pandas_function: null
     description: Economizer OK but not economizing
     required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1148,6 +1204,7 @@ rules:
         sql_placeholder: ECON7_DAMPER_MIN
 
   - rule_id: MECH-OAT-1
+    equipment_kinds: [ahu, chiller, heatpump]
     sql_file: mech_oat_1.sql
     pandas_function: null
     description: Mechanical cooling below 60°F web OAT
@@ -1179,6 +1236,7 @@ rules:
         sql_placeholder: MECH_OAT_MAX_F
 
   - rule_id: CMD-1
+    equipment_kinds: [ahu]
     sql_file: cmd1_fan_mismatch.sql
     pandas_function: null
     description: Fan cmd/status mismatch
@@ -1201,10 +1259,12 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: OA-1
+    equipment_kinds: [ahu]
     sql_file: oa1_low_oa_frac.sql
     pandas_function: null
     description: Low OA fraction
     required_roles: [mat, rat, oa_t, fan_cmd]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1241,10 +1301,12 @@ rules:
         sql_placeholder: OAT_RAT_GUARD
 
   - rule_id: DMP-1
+    equipment_kinds: [ahu]
     sql_file: dmp1_oa_damper_leak.sql
     pandas_function: null
     description: OA damper leakage
     required_roles: [oa_damper_pct, oa_t, mat]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1272,10 +1334,12 @@ rules:
         sql_placeholder: LEAK_DELTA
 
   - rule_id: VLV-1
+    equipment_kinds: [ahu]
     sql_file: vlv1_clg_valve_leak.sql
     pandas_function: null
     description: Cooling valve leakage
     required_roles: [clg_valve_pct, sat, sat_sp, mat]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1312,6 +1376,7 @@ rules:
         sql_placeholder: MAT_LEAK_DELTA
 
   - rule_id: VAV-3
+    equipment_kinds: [vav]
     sql_file: vav3_excessive_reheat.sql
     pandas_function: null
     description: Excessive reheat during warm weather
@@ -1361,6 +1426,7 @@ rules:
         sql_placeholder: FLOW_ON_MIN
 
   - rule_id: VAV-4
+    equipment_kinds: [vav]
     sql_file: vav4_damper_full_open.sql
     pandas_function: null
     description: Damper stuck at full open
@@ -1401,6 +1467,7 @@ rules:
         sql_placeholder: FLOW_ON_MIN
 
   - rule_id: VAV-5
+    equipment_kinds: [vav]
     sql_file: vav5_airflow_bias.sql
     pandas_function: null
     description: Airflow sensor bias
@@ -1423,6 +1490,7 @@ rules:
         sql_placeholder: CONFIRM_SECONDS
 
   - rule_id: VAV-REHEAT
+    equipment_kinds: [vav]
     sql_file: vav_reheat.sql
     pandas_function: null
     description: Reheat valve stuck / no temp rise
@@ -1472,6 +1540,7 @@ rules:
         sql_placeholder: FLOW_ON_MIN
 
   - rule_id: VAV-AHU-LEAVE
+    equipment_kinds: [vav]
     sql_file: vav_ahu_leave.sql
     pandas_function: null
     description: VAV leave vs parent AHU SAT (fedBy)
@@ -1512,6 +1581,7 @@ rules:
         sql_placeholder: FLOW_ON_MIN
 
   - rule_id: VAV-7
+    equipment_kinds: [vav]
     sql_file: vav7_min_airflow.sql
     pandas_function: null
     description: Min airflow / fixed high flow
@@ -1543,6 +1613,7 @@ rules:
         sql_placeholder: HIGH_MIN_FLOW_SP
 
   - rule_id: CHW-NOLOAD-1
+    equipment_kinds: [chiller]
     sql_file: chw_noload_1.sql
     pandas_function: null
     description: Chiller running with no building load
@@ -1574,6 +1645,7 @@ rules:
         sql_placeholder: SAT_BAND_F
 
   - rule_id: CHW-1
+    equipment_kinds: [chiller]
     sql_file: chw1_low_dt.sql
     pandas_function: chw1
     description: Low chilled-water ΔT
@@ -1606,6 +1678,7 @@ rules:
         sql_placeholder: MIN_DT
 
   - rule_id: CHW-2
+    equipment_kinds: [chiller]
     sql_file: chw2_dp_low.sql
     pandas_function: null
     description: DP below SP at max pump speed
@@ -1646,6 +1719,7 @@ rules:
         sql_placeholder: PUMP_HI
 
   - rule_id: CHW-3
+    equipment_kinds: [chiller]
     sql_file: chw3_supply_band.sql
     pandas_function: null
     description: Plant supply temp outside deadband
@@ -1677,6 +1751,7 @@ rules:
         sql_placeholder: SP_BAND
 
   - rule_id: CHW-4
+    equipment_kinds: [chiller]
     sql_file: chw4_flow_high.sql
     pandas_function: null
     description: Flow high at max pump
@@ -1717,6 +1792,7 @@ rules:
         sql_placeholder: PUMP_HI
 
   - rule_id: CW-OPT-1
+    equipment_kinds: [chiller, cooling_tower]
     sql_file: cw_opt_1.sql
     pandas_function: null
     description: Condenser water not optimized vs wet-bulb
@@ -1757,6 +1833,7 @@ rules:
         sql_placeholder: CW_SLACK
 
   - rule_id: CW-APR-1
+    equipment_kinds: [chiller, cooling_tower]
     sql_file: cw_apr_1.sql
     pandas_function: null
     description: High CW approach at full tower fan
@@ -1797,6 +1874,7 @@ rules:
         sql_placeholder: TOWER_FAN_HI
 
   - rule_id: CW-FAN-1
+    equipment_kinds: [chiller, cooling_tower]
     sql_file: cw_fan_1.sql
     pandas_function: null
     description: Excess tower fan energy vs wet-bulb limit
@@ -1846,6 +1924,7 @@ rules:
         sql_placeholder: TOWER_FAN_HI
 
   - rule_id: HP-1
+    equipment_kinds: [heatpump]
     sql_file: hp1_discharge_cold.sql
     pandas_function: null
     description: Discharge cold when heating
@@ -1886,6 +1965,7 @@ rules:
         sql_placeholder: ZONE_COLD
 
   - rule_id: WX-1
+    equipment_kinds: [weather]
     sql_file: wx1_oa_spike.sql
     pandas_function: null
     description: OA temperature spike
@@ -1917,10 +1997,12 @@ rules:
         sql_placeholder: SPIKE_LIMIT
 
   - rule_id: TRIM-1
+    equipment_kinds: [ahu]
     sql_file: trim1_duct_static.sql
     pandas_function: null
     description: Duct static trim advisory
     required_roles: [duct_static_sp]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1957,6 +2039,7 @@ rules:
         sql_placeholder: REQUEST_LO
 
   - rule_id: TRIM-3
+    equipment_kinds: [boiler]
     sql_file: trim3_hwst.sql
     pandas_function: null
     description: HWST trim advisory
@@ -1997,6 +2080,7 @@ rules:
         sql_placeholder: REQUEST_LO
 
   - rule_id: TRIM-4
+    equipment_kinds: [chiller]
     sql_file: trim4_chw_reset.sql
     pandas_function: null
     description: CHW plant reset advisory
@@ -2037,6 +2121,7 @@ rules:
         sql_placeholder: REQUEST_LO
 
   - rule_id: SCHED-1
+    equipment_kinds: [ahu]
     sql_file: sched1_unoccupied_runtime.sql
     pandas_function: sched1
     aliases: [excess_runtime]
@@ -2082,6 +2167,7 @@ rules:
         sql_placeholder: ZONE_T_HI
 
   - rule_id: SCHED-247
+    equipment_kinds: [ahu, vav, chiller, boiler, heatpump]
     sql_file: sched247_always_on.sql
     pandas_function: _sched247
     description: Always-on fan or pump runtime

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -20,6 +20,7 @@ rules:
     pandas_function: vav1
     description: Zone comfort band violation hours with confirm window
     required_roles: [zone_t]
+    optional_roles: [occ_mode]
     output_columns: [equipment_id, fault_hours, fault_pct]
     priority: P0
     parity_status: sql_screening
@@ -530,6 +531,7 @@ rules:
     pandas_function: null
     description: Sensor out of hard range
     required_roles: [oa_t]
+    optional_roles: [fan_status, fan_cmd, pump_status, chw_pump_cmd, chiller_status]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -562,6 +564,7 @@ rules:
     pandas_function: null
     description: Sensor flatline (stuck)
     required_roles: [oa_t]
+    optional_roles: [fan_status, fan_cmd, pump_status, chw_pump_cmd, chiller_status]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -594,6 +597,7 @@ rules:
     pandas_function: null
     description: Sensor rate-of-change spike
     required_roles: [oa_t]
+    optional_roles: [fan_status, fan_cmd, pump_status, chw_pump_cmd, chiller_status]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -625,8 +629,8 @@ rules:
     sql_file: sv_stale.sql
     pandas_function: null
     description: Stale data (no fresh samples)
-    # OFDD-065: require a fan signal so age-vs-max does not inflate off-period / weather rows
-    required_roles: [fan_cmd]
+    # Pandas gate is `always` (sensor sweep); do not require fan_cmd.
+    required_roles: []
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -692,6 +696,7 @@ rules:
     pandas_function: null
     description: Suspected control-output hunting
     required_roles: [clg_valve_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -733,6 +738,7 @@ rules:
     pandas_function: null
     description: PID hunting (operating-state oscillation)
     required_roles: [oa_damper_pct, clg_valve_pct, fan_cmd]
+    optional_roles: [fan_status]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1381,6 +1387,7 @@ rules:
     pandas_function: null
     description: Excessive reheat during warm weather
     required_roles: [oa_t, reheat_valve_pct, zone_flow]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1431,6 +1438,7 @@ rules:
     pandas_function: null
     description: Damper stuck at full open
     required_roles: [damper_pct, zone_flow]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1472,6 +1480,7 @@ rules:
     pandas_function: null
     description: Airflow sensor bias
     required_roles: [zone_flow, damper_pct]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1495,6 +1504,7 @@ rules:
     pandas_function: null
     description: Reheat valve stuck / no temp rise
     required_roles: [reheat_valve_pct, vav_discharge_t, vav_inlet_t, zone_flow]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1545,6 +1555,7 @@ rules:
     pandas_function: null
     description: VAV leave vs parent AHU SAT (fedBy)
     required_roles: [vav_discharge_t, ahu_sat, zone_flow]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1586,6 +1597,7 @@ rules:
     pandas_function: null
     description: Min airflow / fixed high flow
     required_roles: [zone_flow, min_flow_sp]
+    optional_roles: [fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1797,6 +1809,7 @@ rules:
     pandas_function: null
     description: Condenser water not optimized vs wet-bulb
     required_roles: [cw_supply_t, web_wb_t]
+    optional_roles: [pump_status, chiller_status, chw_flow, chw_pump_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1838,6 +1851,7 @@ rules:
     pandas_function: null
     description: High CW approach at full tower fan
     required_roles: [cw_supply_t, web_wb_t, tower_fan_cmd]
+    optional_roles: [pump_status, chiller_status, chw_flow, chw_pump_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1879,6 +1893,7 @@ rules:
     pandas_function: null
     description: Excess tower fan energy vs wet-bulb limit
     required_roles: [cw_supply_t, web_wb_t, tower_fan_cmd]
+    optional_roles: [pump_status, chiller_status, chw_flow, chw_pump_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1929,6 +1944,7 @@ rules:
     pandas_function: null
     description: Discharge cold when heating
     required_roles: [sat, zone_t, fan_cmd]
+    optional_roles: [compressor_status, fan_status]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -2044,6 +2060,7 @@ rules:
     pandas_function: null
     description: HWST trim advisory
     required_roles: [hw_supply_t]
+    optional_roles: [pump_status, chiller_status, chw_flow, chw_pump_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -2085,6 +2102,7 @@ rules:
     pandas_function: null
     description: CHW plant reset advisory
     required_roles: [chw_supply_t]
+    optional_roles: [pump_status, chiller_status, chw_flow, chw_pump_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening

--- a/sql_rules/sat_high_fault.sql
+++ b/sql_rules/sat_high_fault.sql
@@ -6,7 +6,15 @@ WITH h AS (
     sat,
     sat_sp,
     COALESCE(CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END, 0.0) AS clg_valve_pct,
-    COALESCE(CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END, 0.0) AS oa_damper_pct
+    COALESCE(CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END, 0.0) AS oa_damper_pct,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -14,6 +22,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN sat IS NOT NULL AND sat_sp IS NOT NULL
        AND clg_valve_pct > {{CLG_VALVE_MIN}}
        AND sat > sat_sp + {{SAT_ERR}}

--- a/sql_rules/sv_flatline.sql
+++ b/sql_rules/sv_flatline.sql
@@ -5,7 +5,21 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     oa_t,
-    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t
+    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t,
+    fan_cmd,
+    fan_status,
+    pump_status,
+    chw_pump_cmd,
+    chiller_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS energized
+
   FROM history
 ),
 base AS (
@@ -13,6 +27,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(energized, 0) = 0 THEN 0
       WHEN oa_t IS NULL OR prev_oa_t IS NULL THEN 0
       WHEN ABS(oa_t - prev_oa_t) <= {{FLATLINE_TOL}} THEN 1
       ELSE 0

--- a/sql_rules/sv_range.sql
+++ b/sql_rules/sv_range.sql
@@ -1,14 +1,35 @@
 -- sv_range.sql — Sensor out of hard range (OAT example; extend per sensor type)
-WITH base AS (
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    oa_t,
+    fan_cmd,
+    fan_status,
+    pump_status,
+    chw_pump_cmd,
+    chiller_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS energized
+  FROM history
+),
+base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(energized, 0) = 0 THEN 0
       WHEN oa_t IS NULL THEN 0
       WHEN oa_t < -60.0 * {{RANGE_SCALE_TEMPERATURE}} OR oa_t > 130.0 * {{RANGE_SCALE_TEMPERATURE}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM history
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/sv_spike.sql
+++ b/sql_rules/sv_spike.sql
@@ -5,7 +5,21 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     oa_t,
-    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t
+    LAG(oa_t) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc) AS prev_oa_t,
+    fan_cmd,
+    fan_status,
+    pump_status,
+    chw_pump_cmd,
+    chiller_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS energized
+
   FROM history
 ),
 base AS (
@@ -13,6 +27,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(energized, 0) = 0 THEN 0
       WHEN oa_t IS NULL OR prev_oa_t IS NULL THEN 0
       WHEN ABS(oa_t - prev_oa_t) > 16.0 * {{SPIKE_SCALE}} THEN 1
       ELSE 0

--- a/sql_rules/sv_stale.sql
+++ b/sql_rules/sv_stale.sql
@@ -1,6 +1,5 @@
 -- sv_stale.sql — Stale data (no fresh samples)
--- OFDD-065: gate on fan_cmd so off-period history does not inflate FAULT hours
--- (matches vibe19 applicability filter behavior on Liberty).
+-- Pandas gate is `always` — do not filter fan_cmd (off-period stale still counts).
 WITH mx AS (
   SELECT MAX(timestamp_utc) AS max_ts FROM history
 ),
@@ -15,7 +14,6 @@ base AS (
     END AS INT) AS raw_fault
   FROM history h
   CROSS JOIN mx
-  WHERE COALESCE(CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END, 0.0) > 0.05
 ),
 lagged AS (
   SELECT

--- a/sql_rules/trim1_duct_static.sql
+++ b/sql_rules/trim1_duct_static.sql
@@ -8,7 +8,15 @@ WITH base AS (
       WHEN duct_static_sp > {{DUCT_HI}}
        AND COALESCE(static_reset_request, 0) <= {{REQUEST_LO}} THEN 1
       ELSE 0
-    END AS INT) AS raw_fault
+    END AS INT) AS raw_fault,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 lagged AS (

--- a/sql_rules/trim3_hwst.sql
+++ b/sql_rules/trim3_hwst.sql
@@ -1,15 +1,35 @@
 -- trim3_hwst.sql — HWST trim advisory
-WITH base AS (
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    hw_supply_t,
+    hw_reset_request_sum,
+    pump_status,
+    chiller_status,
+    chw_flow,
+    chw_pump_cmd,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      ELSE 0
+    END AS proof_on
+  FROM history
+),
+base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(proof_on, 0) = 0 THEN 0
       WHEN hw_supply_t IS NULL THEN 0
       WHEN hw_supply_t > {{HWST_HI}}
        AND COALESCE(hw_reset_request_sum, 0) <= {{REQUEST_LO}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM history
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/trim4_chw_reset.sql
+++ b/sql_rules/trim4_chw_reset.sql
@@ -1,15 +1,35 @@
 -- trim4_chw_reset.sql — CHW plant reset advisory
-WITH base AS (
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    chw_supply_t,
+    chw_reset_request_sum,
+    pump_status,
+    chiller_status,
+    chw_flow,
+    chw_pump_cmd,
+    CASE
+      WHEN pump_status IS NOT NULL THEN CASE WHEN pump_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
+      WHEN chw_flow IS NOT NULL THEN CASE WHEN chw_flow > 1.0 THEN 1 ELSE 0 END
+      WHEN chw_pump_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN chw_pump_cmd > 1.0 THEN chw_pump_cmd / 100.0 ELSE chw_pump_cmd END) > 0.05 THEN 1 ELSE 0 END
+      ELSE 0
+    END AS proof_on
+  FROM history
+),
+base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(proof_on, 0) = 0 THEN 0
       WHEN chw_supply_t IS NULL THEN 0
       WHEN chw_supply_t < {{CHW_LO}}
        AND COALESCE(chw_reset_request_sum, 0) <= {{REQUEST_LO}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM history
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/vav1_comfort_fault.sql
+++ b/sql_rules/vav1_comfort_fault.sql
@@ -1,15 +1,29 @@
 -- vav1_comfort_fault.sql — zone comfort band with confirm window (Open-FDD parity)
--- OFDD-065 note: do not reference fan_cmd here. Zone-only VAV parquet schemas
+-- Occupied-only when occ_mode is present; do not require fan_cmd (VAV-1 lesson).
+-- OFDD-065: do not reference fan_cmd here. Zone-only VAV parquet schemas
 -- often lack fan_cmd; DataFusion then schema-errors → SKIPPED_MISSING_ROLES.
--- SV-STALE owns the fan-on gate for AHU stale inflation; VAV-1 Liberty residual
--- remains a confirm-window / band tuning item for a follow-up soak.
-WITH base AS (
+WITH h AS (
   SELECT
     equipment_id,
     timestamp_utc,
-    CAST(CASE WHEN zone_t < {{ZONE_T_LO}} OR zone_t > {{ZONE_T_HI}} THEN 1 ELSE 0 END AS INT) AS raw_fault
+    zone_t,
+    occ_mode,
+    CAST(CASE WHEN zone_t < {{ZONE_T_LO}} OR zone_t > {{ZONE_T_HI}} THEN 1 ELSE 0 END AS INT) AS band_fault
   FROM history
   WHERE zone_t IS NOT NULL
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN occ_mode IS NOT NULL
+       AND LOWER(trim(CAST(occ_mode AS VARCHAR))) IN
+         ('unoccupied','unocc','off','false','night','standby','setback','0','0.0','no')
+      THEN 0
+      ELSE band_fault
+    END AS INT) AS raw_fault
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/vav3_excessive_reheat.sql
+++ b/sql_rules/vav3_excessive_reheat.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     oa_t, zone_flow,
-    CASE WHEN reheat_valve_pct IS NULL THEN NULL WHEN reheat_valve_pct > 1.0 THEN reheat_valve_pct / 100.0 ELSE reheat_valve_pct END AS rh
+    CASE WHEN reheat_valve_pct IS NULL THEN NULL WHEN reheat_valve_pct > 1.0 THEN reheat_valve_pct / 100.0 ELSE reheat_valve_pct END AS rh,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN oa_t IS NULL OR rh IS NULL THEN 0
       WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}}
        AND oa_t > {{REHEAT_OAT}} AND rh > {{REHEAT_PCT}} THEN 1

--- a/sql_rules/vav4_damper_full_open.sql
+++ b/sql_rules/vav4_damper_full_open.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     zone_flow,
-    CASE WHEN damper_pct IS NULL THEN NULL WHEN damper_pct > 1.0 THEN damper_pct / 100.0 ELSE damper_pct END AS dmp
+    CASE WHEN damper_pct IS NULL THEN NULL WHEN damper_pct > 1.0 THEN damper_pct / 100.0 ELSE damper_pct END AS dmp,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN dmp IS NULL THEN 0
       WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}} AND dmp > {{FULL_OPEN_PCT}} THEN 1
       ELSE 0

--- a/sql_rules/vav5_airflow_bias.sql
+++ b/sql_rules/vav5_airflow_bias.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     zone_flow,
-    CASE WHEN damper_pct IS NULL THEN NULL WHEN damper_pct > 1.0 THEN damper_pct / 100.0 ELSE damper_pct END AS dmp
+    CASE WHEN damper_pct IS NULL THEN NULL WHEN damper_pct > 1.0 THEN damper_pct / 100.0 ELSE damper_pct END AS dmp,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN zone_flow IS NULL OR dmp IS NULL THEN 0
       WHEN zone_flow > 50.0 AND dmp < 0.10 THEN 1
       ELSE 0

--- a/sql_rules/vav7_min_airflow.sql
+++ b/sql_rules/vav7_min_airflow.sql
@@ -3,16 +3,32 @@
 -- Pandas also faults on rolling "fixed high" flow and high min-flow SP while air is on
 -- (params flow_on_min / fixed_flow_* / high_min_flow_sp). Those windows are not ported yet;
 -- {{HIGH_MIN_FLOW_SP}} is accepted so registry substitution stays valid but is unused here.
-WITH base AS (
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    zone_flow,
+    min_flow_sp,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+  FROM history
+),
+base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN zone_flow IS NULL OR min_flow_sp IS NULL THEN 0
       WHEN zone_flow < min_flow_sp THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM history
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/vav_ahu_leave.sql
+++ b/sql_rules/vav_ahu_leave.sql
@@ -1,15 +1,32 @@
 -- vav_ahu_leave.sql — VAV leave vs parent AHU SAT (fedBy)
-WITH base AS (
+WITH h AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    vav_discharge_t,
+    ahu_sat,
+    zone_flow,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+  FROM history
+),
+base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN vav_discharge_t IS NULL OR ahu_sat IS NULL THEN 0
       WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}}
        AND ABS(vav_discharge_t - ahu_sat) > {{DELTA_F}} THEN 1
       ELSE 0
     END AS INT) AS raw_fault
-  FROM history
+  FROM h
 ),
 lagged AS (
   SELECT

--- a/sql_rules/vav_reheat.sql
+++ b/sql_rules/vav_reheat.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     vav_discharge_t, vav_inlet_t, zone_flow,
-    CASE WHEN reheat_valve_pct IS NULL THEN NULL WHEN reheat_valve_pct > 1.0 THEN reheat_valve_pct / 100.0 ELSE reheat_valve_pct END AS rh
+    CASE WHEN reheat_valve_pct IS NULL THEN NULL WHEN reheat_valve_pct > 1.0 THEN reheat_valve_pct / 100.0 ELSE reheat_valve_pct END AS rh,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN rh IS NULL OR vav_discharge_t IS NULL OR vav_inlet_t IS NULL THEN 0
       WHEN COALESCE(zone_flow, 0) > {{FLOW_ON_MIN}}
        AND rh > {{REHEAT_CMD}}

--- a/sql_rules/vlv1_clg_valve_leak.sql
+++ b/sql_rules/vlv1_clg_valve_leak.sql
@@ -4,7 +4,15 @@ WITH h AS (
     equipment_id,
     timestamp_utc,
     sat, sat_sp, mat,
-    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg
+    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
+    fan_cmd,
+    fan_status,
+    CASE
+      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      ELSE 1
+    END AS fan_on
+
   FROM history
 ),
 base AS (
@@ -12,6 +20,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
+      WHEN COALESCE(fan_on, 1) = 0 THEN 0
       WHEN clg IS NULL OR sat IS NULL THEN 0
       WHEN clg <= 0.05 AND (
         (sat_sp IS NOT NULL AND sat < sat_sp - {{SAT_ERR}})

--- a/tests/test_wattlab_parity_diff.py
+++ b/tests/test_wattlab_parity_diff.py
@@ -1,4 +1,4 @@
-"""Classifier for intentional 4.3.0 WattLab deltas."""
+"""Classifier for intentional 4.3.0 WattLab deltas — dump-vs-dump stop rule."""
 
 from pathlib import Path
 import sys
@@ -24,16 +24,32 @@ def test_sched247_pressure_fault_is_accepted():
     assert "SCHED-247" in why
 
 
+def test_fc7_concept_only_is_accepted():
+    ok, why = _intentional_43("FC7", "SKIPPED_MISSING_ROLES", "PASS", 0.0, 0.0)
+    assert ok
+    assert "concept_only" in why
+
+
 def test_other_rule_status_mismatch_not_intentional():
     ok, _ = _intentional_43("FC1", "PASS", "FAULT", 0.0, 12.0)
     assert not ok
 
 
-def test_sql_screening_na_and_skip():
+def test_fault_intersection_hours_are_blockers():
+    ok, _ = _sql_screening_pair("FC1", "FAULT", "FAULT", 10.0, 200.0)
+    assert not ok
+    ok, _ = _sql_screening_pair("AHU-SATDEV", "FAULT", "FAULT", 373.0, 1730.0)
+    assert not ok
+
+
+def test_na_vs_pass_is_blocker():
     ok, _ = _sql_screening_pair("AHU-DUCTHI", "NOT_APPLICABLE_EQUIPMENT_TYPE", "PASS", 0.0, 0.0)
-    assert ok
+    assert not ok
+
+
+def test_skip_vs_fault_is_blocker():
     ok, _ = _sql_screening_pair("VAV-1", "SKIPPED_EQUIPMENT_OFF", "FAULT", 0.0, 12.0)
-    assert ok
+    assert not ok
 
 
 def test_pass_aliases():


### PR DESCRIPTION
## Summary
- Dump-vs-dump Engineering Bundle compare (`diff_matrix.csv`) — FAULT∩FAULT hour gaps are blockers again
- DataFusion assembler writes the same filenames as Vibe19 (no pandas export in the image)
- `equipment_kinds` → `NOT_APPLICABLE_EQUIPMENT_TYPE` on `/api/fdd/results`
- Fan proof + FC2 mix_tol + CHW-2/3/4 hydronic + SV-STALE always-gate

## Test plan
- [x] `cargo test -p fdd_rules`
- [x] `pytest tests/test_wattlab_parity_diff.py tests/rules/test_parity_inventory.py`
- [ ] After merge: pull `:nightly`, re-run rust bundle + diff; promote duration_parity when hours match


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fault detection now accounts for fan, pump, chiller, and flow operating status.
  * Rules can be limited to applicable equipment types, with clearer non-applicable results.
  * Added setpoint, diurnal, topology, and sensor statistics analytics.
  * Added Rust-based engineering bundle capture and CSV parity reporting.

* **Bug Fixes**
  * Improved handling of missing optional telemetry.
  * Updated stale-data calculations to include off-period samples where appropriate.

* **Documentation**
  * Added a WattLab parity report with comparison guidance and known blockers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->