### PR TITLE
feat(oracle): synthetic-59 soak + Vibe19 confirm_min tuning parity

### DIFF
--- a/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
@@ -1,5 +1,13 @@
 # WattLab / Vibe19 parity — Building 100 (OpenFDD 4.3.0)
 
+## Current cycle (synthetic 59)
+
+**Live working copy for this cycle:** [`reports/wattlab-parity/BUGREPORT_WATTLAB_VIBE19_PARITY.md`](../../reports/wattlab-parity/BUGREPORT_WATTLAB_VIBE19_PARITY.md) — primary fixture is the **synthetic 59-rule** golden soak (Vibe19 **58/59**, OpenFDD SQL **42/59**, shared `confirm_min=0` tuning). **B100 dump-parity soak remains paused**; see [`BUGREPORT_WATTLAB_DUMP_PARITY.md`](BUGREPORT_WATTLAB_DUMP_PARITY.md) for the historical dump matrix only.
+
+The narrative below is the earlier Building 100 / engineering-bundle context and is retained for reference.
+
+---
+
 Oracle is **playground Vibe19** (`py-bacnet-stacks-playground/vibe_code_apps_19`) + live `open-fdd` 4.3.x (PR `#707`), **not** `tools/wattlab_export` and **not** `--skip-rules`.
 
 A working copy also lives at `reports/wattlab-parity/BUGREPORT_WATTLAB_VIBE19_PARITY.md` (gitignored `/reports/`).

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use fdd_rules::{
-    effective_param_strings, load_registry, load_tuning_profiles, read_poll_from_cache, rule_params,
-    run_all_rules_with_overrides, substitute_sql, RuleRegistry, RuleSpec,
+    effective_param_strings, load_registry, load_tuning_profiles, read_poll_from_cache,
+    rule_params, run_all_rules_with_overrides, substitute_sql, RuleRegistry, RuleSpec,
 };
 use fdd_sql::{register_parquet_tree, register_weather_if_present, run_sql};
 use serde_json::{json, Value};
@@ -1217,14 +1217,19 @@ mod tests {
         let lower = out.to_ascii_lowercase();
         assert!(lower.contains("confirmed as confirmed_fault"), "{out}");
         assert!(lower.contains("timestamp_utc"), "{out}");
-        assert!(lower.contains("where equipment_id = 'ahu_1'") || lower.contains("where equipment_id = 'AHU_1'"), "{out}");
+        assert!(
+            lower.contains("where equipment_id = 'ahu_1'")
+                || lower.contains("where equipment_id = 'AHU_1'"),
+            "{out}"
+        );
         assert!(!lower.contains("fault_hours"), "{out}");
         assert!(lower.contains("from final"), "{out}");
     }
 
     #[test]
     fn rewrite_skips_analytics_rollups() {
-        let raw = "SELECT equipment_id, AVG(zone_t) AS avg_zone_temp FROM history GROUP BY equipment_id";
+        let raw =
+            "SELECT equipment_id, AVG(zone_t) AS avg_zone_temp FROM history GROUP BY equipment_id";
         assert!(rewrite_rule_sql_to_fault_series(raw, "VAV_1").is_none());
     }
 

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -4,10 +4,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use fdd_rules::{
-    effective_param_strings, load_registry, load_tuning_profiles, rule_params,
+    effective_param_strings, load_registry, load_tuning_profiles, read_poll_from_cache, rule_params,
     run_all_rules_with_overrides, substitute_sql, RuleRegistry, RuleSpec,
 };
-use fdd_sql::{register_parquet_tree, run_sql};
+use fdd_sql::{register_parquet_tree, register_weather_if_present, run_sql};
 use serde_json::{json, Value};
 
 fn sql_rules_dir() -> PathBuf {
@@ -100,6 +100,11 @@ pub fn load_registry_rules_map() -> HashMap<String, RuleSpec> {
 fn param_to_json(rule: &RuleSpec) -> Value {
     let mut params = serde_json::Map::new();
     for (key, def) in &rule.parameters {
+        // confirm_seconds is exposed only as confirm_min (minutes) below so Lab /
+        // Overview sliders match Vibe19 session_config + fault_settings units.
+        if key == "confirm_seconds" {
+            continue;
+        }
         params.insert(
             key.clone(),
             json!({
@@ -116,16 +121,26 @@ fn param_to_json(rule: &RuleSpec) -> Value {
         );
     }
     // Always expose confirm as confirm_min (minutes) for vibe19 UI parity.
-    if !params.contains_key("confirm_min") && !params.contains_key("confirm_seconds") {
+    if !params.contains_key("confirm_min") {
+        let default_min = rule
+            .parameters
+            .get("confirm_seconds")
+            .map(|def| def.default / 60.0)
+            .unwrap_or((rule.confirm_seconds as f64) / 60.0);
+        let (min_m, max_m, step_m) = rule
+            .parameters
+            .get("confirm_seconds")
+            .map(|def| (def.min / 60.0, def.max / 60.0, (def.step / 60.0).max(0.05)))
+            .unwrap_or((0.0, 120.0, 1.0));
         params.insert(
             "confirm_min".into(),
             json!({
                 "key": "confirm_min",
                 "label": "Fault confirm delay",
-                "default": (rule.confirm_seconds as f64) / 60.0,
-                "min": 0.0,
-                "max": 120.0,
-                "step": 1.0,
+                "default": default_min,
+                "min": min_m,
+                "max": max_m,
+                "step": step_m,
                 "unit": "min",
                 "control": "slider",
                 "sql_placeholder": "CONFIRM_SECONDS",
@@ -437,6 +452,7 @@ pub fn series_response(equipment_id: &str, rule_id: &str, building_id: Option<&s
         if let Err(e) = register_parquet_tree(&ctx, &root).await {
             return json!({"ok": false, "error": e.to_string()});
         }
+        let _ = register_weather_if_present(&ctx, &root).await;
         // Preflight required roles against history schema (no SchemaError banners).
         let history_columns: std::collections::HashSet<String> = match ctx.table("history").await {
             Ok(df) => df
@@ -470,10 +486,35 @@ pub fn series_response(equipment_id: &str, rule_id: &str, building_id: Option<&s
         }
         match run_sql(&ctx, &sql).await {
             Ok(mut result) => {
-                // Overlay confirmed_fault from last registry run when present so
-                // FDD Plots can draw the bottom fault swim lane (vibe19 parity).
-                let fault_by_ts =
+                // Overlay confirmed_fault for the FDD Plots swim lane (vibe19).
+                // Registry JSON is equipment-level fault_hours only — when that
+                // index is empty, re-run the rule SQL rewritten to a per-timestamp
+                // confirmed series and join onto history rows.
+                let mut fault_by_ts =
                     load_confirmed_fault_index(equipment_id, &rule.rule_id, building_id);
+                let mut overlay_source = if fault_by_ts.is_empty() {
+                    "none"
+                } else {
+                    "results"
+                };
+                if fault_by_ts.is_empty() {
+                    if let Some(detail) = compute_confirmed_fault_series(
+                        &ctx,
+                        &reg,
+                        rule,
+                        equipment_id,
+                        &root,
+                        &history_columns,
+                    )
+                    .await
+                    {
+                        fault_by_ts = detail;
+                        if !fault_by_ts.is_empty() {
+                            overlay_source = "sql_detail";
+                        }
+                    }
+                }
+                let mut overlay_hits = 0usize;
                 if !fault_by_ts.is_empty() {
                     for row in &mut result.rows {
                         if let Some(obj) = row.as_object_mut() {
@@ -484,6 +525,7 @@ pub fn series_response(equipment_id: &str, rule_id: &str, building_id: Option<&s
                                 .unwrap_or("");
                             if let Some(flag) = lookup_fault_flag(&fault_by_ts, ts) {
                                 obj.insert("confirmed_fault".into(), json!(flag));
+                                overlay_hits += 1;
                             }
                         }
                     }
@@ -497,7 +539,9 @@ pub fn series_response(equipment_id: &str, rule_id: &str, building_id: Option<&s
                     "rows": result.rows,
                     "downsampled": result.row_count >= 5000,
                     "max_points": 5000,
-                    "has_confirmed_fault": !fault_by_ts.is_empty(),
+                    "has_confirmed_fault": overlay_hits > 0,
+                    "fault_overlay_source": overlay_source,
+                    "fault_overlay_hits": overlay_hits,
                     "building_id": building_id,
                 })
             }
@@ -522,7 +566,8 @@ pub fn series_response(equipment_id: &str, rule_id: &str, building_id: Option<&s
 }
 
 /// Normalize timestamp keys so series rows join fault overlays across slight
-/// format drift (trim; `timestamp` vs `timestamp_utc`; fractional seconds).
+/// format drift (trim; `timestamp` vs `timestamp_utc`; fractional seconds;
+/// `Z` vs `+00:00`).
 fn normalize_ts_keys(raw: &str) -> Vec<String> {
     let s = raw.trim().to_string();
     if s.is_empty() {
@@ -544,12 +589,20 @@ fn normalize_ts_keys(raw: &str) -> Vec<String> {
             push_unique(&mut keys, format!("{}T{}", &s[..10], &s[11..]));
         }
     }
-    // Optional trailing Z.
+    // Optional trailing Z / +00:00 / -00:00.
     let snapshot = keys.clone();
     for k in snapshot {
         if k.ends_with('Z') {
             push_unique(&mut keys, k[..k.len() - 1].to_string());
+            push_unique(&mut keys, format!("{}+00:00", &k[..k.len() - 1]));
+        } else if let Some(stripped) = k
+            .strip_suffix("+00:00")
+            .or_else(|| k.strip_suffix("-00:00"))
+        {
+            push_unique(&mut keys, stripped.to_string());
+            push_unique(&mut keys, format!("{stripped}Z"));
         } else if k.len() >= 19 && !k.contains('Z') && !k.contains('+') {
+            // No zone suffix — add Z (date dashes are fine; `+` marks offsets).
             push_unique(&mut keys, format!("{k}Z"));
         }
     }
@@ -566,6 +619,175 @@ fn normalize_ts_keys(raw: &str) -> Vec<String> {
         }
     }
     keys
+}
+
+/// Rewrite aggregated cookbook SQL (`final` ← `ranked` → `fault_hours`) into a
+/// per-timestamp `confirmed_fault` series for one equipment (FDD Plots overlay).
+///
+/// Registry runs persist equipment-level `fault_hours` only; Plots need the
+/// swim-lane bool joined onto history timestamps. Returns `None` for analytics
+/// rollups / non-confirm SQL shapes.
+fn rewrite_rule_sql_to_fault_series(sql: &str, equipment_id: &str) -> Option<String> {
+    let sql = sql.trim().trim_end_matches(';');
+    let lower = sql.to_ascii_lowercase();
+    if !lower.contains("final as") || !lower.contains("from ranked") {
+        return None;
+    }
+    if !lower.contains("fault_hours") {
+        return None;
+    }
+    let final_at = lower.find("final as (")?;
+    let select_at = lower.rfind("select")?;
+    if select_at <= final_at {
+        return None;
+    }
+    // Outer aggregate SELECT must be the trailing one after `final`.
+    if !lower[select_at..].contains("fault_hours") {
+        return None;
+    }
+
+    let mut head = sql[..select_at].to_string();
+    // Inject timestamp_utc into the `final` CTE select list when missing.
+    let head_lower = head.to_ascii_lowercase();
+    if let Some(rel_final) = head_lower[final_at..].find("final as (") {
+        let body_start = final_at + rel_final + "final as (".len();
+        let body_slice = &head_lower[body_start..];
+        // Only the final CTE body (until FROM ranked).
+        let from_ranked = body_slice.find("from ranked")?;
+        let final_body = &head_lower[body_start..body_start + from_ranked];
+        if !final_body.contains("timestamp_utc") {
+            // Insert after first `equipment_id,` inside final.
+            if let Some(eq_rel) = final_body.find("equipment_id") {
+                let abs = body_start + eq_rel;
+                // Find comma after equipment_id (allow whitespace/newlines).
+                let after = &head[abs..];
+                if let Some(comma_rel) = after.find(',') {
+                    let insert_at = abs + comma_rel + 1;
+                    head.insert_str(insert_at, "\n    timestamp_utc,");
+                }
+            }
+        }
+    }
+
+    let escaped = equipment_id.replace('\'', "''");
+    Some(format!(
+        "{head}SELECT equipment_id, timestamp_utc, confirmed AS confirmed_fault\n\
+         FROM final\n\
+         WHERE equipment_id = '{escaped}'\n\
+         ORDER BY timestamp_utc"
+    ))
+}
+
+/// Inject NULL columns for optional roles missing from history (CTE form).
+fn sql_with_optional_null_roles_series(
+    sql: &str,
+    optional_roles: &[String],
+    history_columns: &std::collections::HashSet<String>,
+) -> String {
+    let missing: Vec<String> = optional_roles
+        .iter()
+        .filter(|role| !history_columns.contains(&role.to_ascii_lowercase()))
+        .cloned()
+        .collect();
+    if missing.is_empty() {
+        return sql.to_string();
+    }
+    let null_cols: String = missing
+        .iter()
+        .map(|r| {
+            let ty = if r.eq_ignore_ascii_case("occ_mode") {
+                "VARCHAR"
+            } else {
+                "DOUBLE"
+            };
+            format!("CAST(NULL AS {ty}) AS \"{r}\"")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let cte = format!("history_opt AS (SELECT history.*, {null_cols} FROM history)");
+    let rewritten = sql
+        .replace(" FROM history", " FROM history_opt")
+        .replace(" from history", " from history_opt")
+        .replace("\nFROM history", "\nFROM history_opt")
+        .replace("\nfrom history", "\nfrom history_opt");
+    if let Some(idx) = rewritten.find("WITH ") {
+        let (pre, rest) = rewritten.split_at(idx);
+        let rest = rest.trim_start_matches("WITH ");
+        format!("{pre}WITH {cte}, {rest}")
+    } else if let Some(idx) = rewritten.find("with ") {
+        let (pre, rest) = rewritten.split_at(idx);
+        let rest = rest.trim_start_matches("with ");
+        format!("{pre}WITH {cte}, {rest}")
+    } else {
+        format!("WITH {cte} {rewritten}")
+    }
+}
+
+/// Compute per-timestamp confirmed_fault by rewriting + running cookbook SQL.
+async fn compute_confirmed_fault_series(
+    ctx: &datafusion::prelude::SessionContext,
+    reg: &RuleRegistry,
+    rule: &RuleSpec,
+    equipment_id: &str,
+    parquet_root: &Path,
+    history_columns: &std::collections::HashSet<String>,
+) -> Option<HashMap<String, bool>> {
+    let sql_path = Path::new(&reg.rules_dir).join(&rule.sql_file);
+    let raw_sql = std::fs::read_to_string(&sql_path).ok()?;
+    let detail = rewrite_rule_sql_to_fault_series(&raw_sql, equipment_id)?;
+    let poll = read_poll_from_cache(parquet_root).unwrap_or(300.0);
+    let mut params = rule_params(poll, rule.confirm_seconds);
+    if let Ok(tuning) = load_tuning_profiles(Path::new(&reg.rules_dir)) {
+        if let Ok(tuned) = effective_param_strings(rule, &tuning, None, None, None) {
+            for (k, v) in tuned {
+                if k == "CONFIRM_SECONDS" || k == "CONFIRM_ROWS" {
+                    continue;
+                }
+                params.insert(k, v);
+            }
+        }
+    }
+    let confirm_params = rule_params(poll, rule.confirm_seconds);
+    for (k, v) in confirm_params {
+        params.insert(k, v);
+    }
+    let mut sql = substitute_sql(&detail, &params);
+    sql = sql_with_optional_null_roles_series(&sql, &rule.optional_roles, history_columns);
+    let result = run_sql(ctx, &sql).await.ok()?;
+    let mut out = HashMap::new();
+    for row in result.rows {
+        let ts = row
+            .get("timestamp_utc")
+            .or_else(|| row.get("timestamp"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if ts.is_empty() {
+            continue;
+        }
+        let flag = row
+            .get("confirmed_fault")
+            .and_then(|v| v.as_bool())
+            .or_else(|| {
+                row.get("confirmed_fault")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n != 0)
+            })
+            .or_else(|| {
+                row.get("confirmed")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n != 0)
+            });
+        if let Some(f) = flag {
+            for key in normalize_ts_keys(ts) {
+                out.insert(key, f);
+            }
+        }
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
 }
 
 fn lookup_fault_flag(map: &HashMap<String, bool>, ts: &str) -> Option<bool> {
@@ -980,11 +1202,30 @@ mod tests {
             None => std::env::remove_var("OPENFDD_RULE_RESULTS_DIR"),
         }
         let _ = std::fs::remove_dir_all(&tmp);
-        assert_eq!(
-            lookup_fault_flag(&idx, "2024-01-01T00:00:00Z"),
-            Some(true),
-            "expected join after trim + fractional-second normalize: {idx:?}"
+        assert!(
+            idx.values().any(|v| *v),
+            "expected confirmed_fault true in index, got {idx:?}"
         );
+    }
+
+    #[test]
+    fn rewrite_fc1_sql_emits_confirmed_fault_series() {
+        let raw = std::fs::read_to_string("sql_rules/fc1_duct_static_low.sql")
+            .or_else(|_| std::fs::read_to_string("../sql_rules/fc1_duct_static_low.sql"))
+            .expect("fc1 sql");
+        let out = rewrite_rule_sql_to_fault_series(&raw, "AHU_1").expect("rewrite");
+        let lower = out.to_ascii_lowercase();
+        assert!(lower.contains("confirmed as confirmed_fault"), "{out}");
+        assert!(lower.contains("timestamp_utc"), "{out}");
+        assert!(lower.contains("where equipment_id = 'ahu_1'") || lower.contains("where equipment_id = 'AHU_1'"), "{out}");
+        assert!(!lower.contains("fault_hours"), "{out}");
+        assert!(lower.contains("from final"), "{out}");
+    }
+
+    #[test]
+    fn rewrite_skips_analytics_rollups() {
+        let raw = "SELECT equipment_id, AVG(zone_t) AS avg_zone_temp FROM history GROUP BY equipment_id";
+        assert!(rewrite_rule_sql_to_fault_series(raw, "VAV_1").is_none());
     }
 
     #[test]
@@ -1009,6 +1250,22 @@ mod tests {
             lookup_fault_flag(&idx, "2024-01-01 00:00:00"),
             Some(true),
             "T vs space + fractional seconds must join"
+        );
+    }
+
+    #[test]
+    fn normalize_ts_keys_joins_plus_zero_offset() {
+        let idx = {
+            let mut m = HashMap::new();
+            for k in normalize_ts_keys("2024-01-01T00:00:00+00:00") {
+                m.insert(k, true);
+            }
+            m
+        };
+        assert_eq!(
+            lookup_fault_flag(&idx, "2024-01-01T00:00:00Z"),
+            Some(true),
+            "+00:00 must join to Z"
         );
     }
 }

--- a/frontend/web/src/components/AppShell.test.tsx
+++ b/frontend/web/src/components/AppShell.test.tsx
@@ -6,6 +6,11 @@ import { MAIN_SECTIONS } from "../nav/sections";
 
 vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => []),
+  getSessionConfig: vi.fn(async () => ({
+    ok: true,
+    config: { schema_version: "openfdd_session_v1", params: {} },
+  })),
+  putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../api/uploadApi", () => ({

--- a/frontend/web/src/components/OverviewPopulated.test.tsx
+++ b/frontend/web/src/components/OverviewPopulated.test.tsx
@@ -165,8 +165,21 @@ describe("OverviewPopulated metric isolation", () => {
     vi.mocked(postInspect).mockClear();
   });
 
-  it("auto-runs analytics and keeps mapping rows/span after inspect", async () => {
+  it("does not auto-run analytics; Update analytics loads charts and keeps mapping rows/span", async () => {
     renderOverview();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("overview-idle-hint")).toBeTruthy();
+    });
+    expect(fetchCentralOverview).not.toHaveBeenCalled();
+    expect(screen.getByTestId("overview-rule-count").textContent).toContain("59");
+    expect(screen.getByTestId("overview-rule-caption").textContent).toMatch(
+      /\+4 SQL rollups/,
+    );
+
+    fireEvent.click(
+      screen.getByTestId("overview-refresh").querySelector("button")!,
+    );
 
     await waitFor(() => {
       expect(fetchCentralOverview).toHaveBeenCalled();
@@ -174,10 +187,6 @@ describe("OverviewPopulated metric isolation", () => {
         "35536",
       );
     });
-    expect(screen.getByTestId("overview-rule-count").textContent).toContain("59");
-    expect(screen.getByTestId("overview-rule-caption").textContent).toMatch(
-      /\+4 SQL rollups/,
-    );
     expect(screen.getByTestId("overview-kind").textContent).toMatch(/ahu/i);
     expect(screen.getByTestId("overview-kind").textContent).not.toMatch(/AHU/);
     expect(screen.getByTestId("overview-start").textContent).toContain(
@@ -187,21 +196,13 @@ describe("OverviewPopulated metric isolation", () => {
       "2026-07-17 10:00",
     );
     expect(screen.getByTestId("overview-span").textContent).toContain("2961.3");
-
-    await waitFor(() => {
-      expect(postInspect).toHaveBeenCalled();
-    });
-    expect(screen.getByTestId("overview-row-count").textContent).toContain(
-      "35536",
-    );
-    expect(screen.getByTestId("overview-end").textContent).toContain(
-      "2026-07-17 10:00",
-    );
-    expect(screen.getByTestId("overview-span").textContent).toContain("2961.3");
   });
 
   it("does not offer a column toggle and plots inspect without clearing overview", async () => {
     renderOverview();
+    fireEvent.click(
+      screen.getByTestId("overview-refresh").querySelector("button")!,
+    );
     await waitFor(() => {
       expect(screen.getByTestId("overview-charts-ready")).toBeTruthy();
     });
@@ -230,6 +231,9 @@ describe("OverviewPopulated metric isolation", () => {
 
   it("overlay select does not null building overview", async () => {
     renderOverview();
+    fireEvent.click(
+      screen.getByTestId("overview-refresh").querySelector("button")!,
+    );
     await waitFor(() => {
       expect(screen.getByTestId("overview-charts-ready")).toBeTruthy();
     });
@@ -249,19 +253,11 @@ describe("OverviewPopulated metric isolation", () => {
     expect(screen.getByTestId("overview-econ-mat-resid-plot")).toBeTruthy();
   });
 
-  it("equipment select has no empty option", async () => {
+  it("does not render an Overview equipment picker", async () => {
     renderOverview();
     await waitFor(() => {
-      expect(screen.getByTestId("overview-equipment-select")).toBeTruthy();
+      expect(screen.getByTestId("overview-idle-hint")).toBeTruthy();
     });
-    const opts = [
-      ...screen
-        .getByTestId("overview-equipment-select")
-        .querySelectorAll("option"),
-    ];
-    expect(opts.map((o) => (o as HTMLOptionElement).value)).toEqual([
-      "AHU_1",
-      "BOILER_1",
-    ]);
+    expect(screen.queryByTestId("overview-equipment-select")).toBeNull();
   });
 });

--- a/frontend/web/src/components/OverviewPopulated.tsx
+++ b/frontend/web/src/components/OverviewPopulated.tsx
@@ -39,6 +39,11 @@ import {
   isWeatherEquipmentId,
   spanHoursBetween,
 } from "../lib/overviewMetrics";
+import {
+  effectiveRunParams,
+  loadLocalRuleParams,
+  SESSION_SCHEMA,
+} from "../lib/ruleParams";
 
 const DAYS = [
   "Monday",
@@ -62,20 +67,8 @@ const DEFAULT_WEEK: Record<(typeof DAYS)[number], DaySched> = {
   Sunday: { occupied: false, start: "07:00", end: "17:00" },
 };
 
-const PARAMS_KEY = "openfdd.ui.rule_params";
 /** v2 defaults: M–F 07:00–17:00 occupied; weekends unoccupied. */
 const SCHEDULE_KEY = "openfdd.ui.occupancy_schedule.v2";
-
-function loadStoredParams(): Record<string, Record<string, number>> {
-  try {
-    const raw = localStorage.getItem(PARAMS_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as Record<string, Record<string, number>>;
-    return parsed && typeof parsed === "object" ? parsed : {};
-  } catch {
-    return {};
-  }
-}
 
 function loadStoredSchedule(): {
   week: Record<(typeof DAYS)[number], DaySched>;
@@ -153,7 +146,7 @@ export function OverviewPopulated({
   buildingId,
   equipment,
   equipmentId,
-  onEquipmentChange,
+  onEquipmentChange: _onEquipmentChange,
   unitSystem,
 }: OverviewPopulatedProps) {
   const [ruleCount, setRuleCount] = useState(0);
@@ -417,10 +410,8 @@ export function OverviewPopulated({
 
   useEffect(() => {
     if (!buildingId) return;
-    void refreshOverview();
-    const pick = inspectPick || equipmentId;
-    if (pick) void refreshInspect({ pick });
-    // Auto-run Update analytics once per building (button remains a refresh).
+    // Meta only — do not auto-run Update analytics / Run all rules.
+    void refreshMeta();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [buildingId]);
 
@@ -430,10 +421,10 @@ export function OverviewPopulated({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [econOverlayEq]);
 
+  // Seed inspect picker from session equipment once; do not auto-plot on change.
   useEffect(() => {
     if (!equipmentId) return;
-    setInspectPick(equipmentId);
-    void refreshInspect({ pick: equipmentId });
+    setInspectPick((prev) => prev || equipmentId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [equipmentId]);
 
@@ -533,11 +524,16 @@ export function OverviewPopulated({
     setRulesErr(null);
     setRulesNote("Running all rules with tuned params…");
     try {
-      const params = loadStoredParams();
+      // Same tuning source as Vibe19: package session_config.params (confirm_min=0
+      // etc.), then Lab localStorage overrides.
       const prev = await getSessionConfig().catch(() => null);
+      const params = effectiveRunParams(
+        prev?.config?.params as Record<string, unknown> | undefined,
+        loadLocalRuleParams(),
+      );
       await putSessionConfig({
         ...(prev?.config ?? {}),
-        schema_version: prev?.config?.schema_version ?? "openfdd.session.v1",
+        schema_version: prev?.config?.schema_version ?? SESSION_SCHEMA,
         params: { ...(prev?.config?.params ?? {}), ...params },
       });
       const result = await runFdd({
@@ -677,8 +673,7 @@ export function OverviewPopulated({
             testId="overview-refresh"
           />
           <p className="oracle-sidebar__caption">
-            Auto-runs once when the site is set; click to refresh building
-            charts
+            Manual — builds building charts when you click
           </p>
         </div>
         <div className="overview-toolbar__action">
@@ -690,7 +685,7 @@ export function OverviewPopulated({
             testId="overview-update-all-rules"
           />
           <p className="oracle-sidebar__caption">
-            DataFusion FDD registry → Results / FDD Plots
+            Manual — DataFusion FDD registry → Results / FDD Plots
           </p>
         </div>
         {overview ? (
@@ -700,7 +695,7 @@ export function OverviewPopulated({
           </span>
         ) : (
           <span className="oracle-sidebar__caption" data-testid="overview-idle-hint">
-            Loading building analytics…
+            Click <strong>Update analytics</strong> to load building charts
           </span>
         )}
       </div>
@@ -713,25 +708,11 @@ export function OverviewPopulated({
       ) : null}
 
       <p className="oracle-sidebar__caption" data-testid="overview-dual-catalog">
-        Two actions, one engine family: <strong>Update analytics</strong>{" "}
-        builds Overview charts (auto once per site, then refresh);{" "}
-        <strong>Run all rules</strong> runs the FDD SQL registry. Sidebar{" "}
-        <strong>Update this rule</strong> re-runs one rule.
+        Two manual actions: <strong>Update analytics</strong> builds Overview
+        charts; <strong>Run all rules</strong> runs the FDD SQL registry.
+        Sidebar <strong>Update this rule</strong> re-runs one rule. Equipment
+        for Data inspection / FDD Plots is chosen in those sections — not here.
       </p>
-
-      <div className="form-row">
-        <Select
-          id="overview-equipment-select"
-          label="Equipment"
-          value={equipmentId || String(selected?.equipment_id ?? "")}
-          options={sortedEquipment.map((e) => ({
-            value: String(e.equipment_id),
-            label: String(e.equipment_id),
-          }))}
-          onChange={onEquipmentChange}
-          testId="overview-equipment-select"
-        />
-      </div>
 
       <SectionTabs activeSectionId="overview" embedded />
 

--- a/frontend/web/src/components/RuleTuningPanel.tsx
+++ b/frontend/web/src/components/RuleTuningPanel.tsx
@@ -7,29 +7,16 @@ import {
   type FddRuleSummary,
 } from "../api/fddApi";
 import { getSessionConfig, putSessionConfig } from "../api/mappingApi";
+import {
+  effectiveRunParams,
+  loadLocalRuleParams,
+  saveLocalRuleParams,
+  SESSION_SCHEMA,
+  type RuleParamMap,
+} from "../lib/ruleParams";
 import { useSessionQuery } from "../session";
 
-const PARAMS_KEY = "openfdd.ui.rule_params";
 export const RULES_UPDATED_EVENT = "openfdd:rules-updated";
-
-function loadStoredParams(): Record<string, Record<string, number>> {
-  try {
-    const raw = localStorage.getItem(PARAMS_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as Record<string, Record<string, number>>;
-    return parsed && typeof parsed === "object" ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
-function saveStoredParams(map: Record<string, Record<string, number>>): void {
-  try {
-    localStorage.setItem(PARAMS_KEY, JSON.stringify(map));
-  } catch {
-    /* ignore */
-  }
-}
 
 function familyOf(ruleId: string): string {
   const i = ruleId.indexOf("-");
@@ -165,7 +152,7 @@ export function RuleTuningPanel() {
   const [rules, setRules] = useState<FddRuleSummary[]>([]);
   const [family, setFamily] = useState<string>("(all)");
   const [opsGate, setOpsGate] = useState(true);
-  const [params, setParams] = useState(loadStoredParams);
+  const [params, setParams] = useState<RuleParamMap>(loadLocalRuleParams);
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [runMsg, setRunMsg] = useState<string | null>(null);
   const [runErr, setRunErr] = useState<string | null>(null);
@@ -185,6 +172,20 @@ export function RuleTuningPanel() {
           setLoadErr(e instanceof Error ? e.message : String(e));
         }
       });
+    // Seed Lab sliders from persisted session_config (package / Vibe19 parity),
+    // then apply any local browser overrides on top.
+    void getSessionConfig()
+      .then((body) => {
+        if (cancelled) return;
+        const merged = effectiveRunParams(
+          body.config?.params as Record<string, unknown>,
+        );
+        setParams(merged);
+        saveLocalRuleParams(merged);
+      })
+      .catch(() => {
+        /* keep localStorage seed */
+      });
     return () => {
       cancelled = true;
       if (persistTimer.current) clearTimeout(persistTimer.current);
@@ -202,18 +203,17 @@ export function RuleTuningPanel() {
   }, [rules, family]);
 
   const persistSession = useCallback(
-    async (nextParams: Record<string, Record<string, number>>) => {
+    async (nextParams: RuleParamMap) => {
       const gen = ++persistGen.current;
       try {
         const prev = await getSessionConfig();
         if (gen !== persistGen.current) return;
         await putSessionConfig({
           ...(prev.config ?? {}),
-          schema_version: prev.config?.schema_version ?? "openfdd.session.v1",
+          schema_version: prev.config?.schema_version ?? SESSION_SCHEMA,
           params: {
             ...nextParams,
             _ui: {
-              ...(nextParams._ui ?? {}),
               require_operational_proof: opsGate ? 1 : 0,
             },
           },
@@ -248,7 +248,7 @@ export function RuleTuningPanel() {
           ...prev,
           [ruleId]: { ...(prev[ruleId] ?? {}), [key]: value },
         };
-        saveStoredParams(next);
+        saveLocalRuleParams(next);
         schedulePersist(next);
         return next;
       });
@@ -303,7 +303,7 @@ export function RuleTuningPanel() {
 
   const reset = () => {
     setParams({});
-    saveStoredParams({});
+    saveLocalRuleParams({});
     if (persistTimer.current) clearTimeout(persistTimer.current);
     void persistSession({});
   };

--- a/frontend/web/src/lib/ruleParams.ts
+++ b/frontend/web/src/lib/ruleParams.ts
@@ -1,0 +1,81 @@
+/** Shared rule-tuning params (Vibe19 session_config ↔ OpenFDD Lab/Overview). */
+
+export const RULE_PARAMS_STORAGE_KEY = "openfdd.ui.rule_params";
+export const SESSION_SCHEMA = "openfdd_session_v1";
+
+export type RuleParamMap = Record<string, Record<string, number>>;
+
+export function loadLocalRuleParams(): RuleParamMap {
+  try {
+    const raw = localStorage.getItem(RULE_PARAMS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as RuleParamMap;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveLocalRuleParams(map: RuleParamMap): void {
+  try {
+    localStorage.setItem(RULE_PARAMS_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Drop UI-only keys and coerce numeric param bags from session_config.params. */
+export function numericParamsFromSession(
+  params: Record<string, unknown> | null | undefined,
+): RuleParamMap {
+  if (!params || typeof params !== "object") return {};
+  const out: RuleParamMap = {};
+  for (const [ruleId, raw] of Object.entries(params)) {
+    if (ruleId === "_ui" || !raw || typeof raw !== "object" || Array.isArray(raw)) {
+      continue;
+    }
+    const bag: Record<string, number> = {};
+    for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof val === "number" && Number.isFinite(val)) {
+        bag[key] = val;
+      } else if (typeof val === "string" && val.trim() !== "" && Number.isFinite(Number(val))) {
+        bag[key] = Number(val);
+      }
+    }
+    // Vibe19 / package session uses confirm_min; keep that unit for Lab + /api/fdd/run.
+    if (
+      bag.confirm_min == null &&
+      typeof bag.confirm_seconds === "number" &&
+      Number.isFinite(bag.confirm_seconds)
+    ) {
+      bag.confirm_min = bag.confirm_seconds / 60;
+      delete bag.confirm_seconds;
+    }
+    if (Object.keys(bag).length) out[ruleId] = bag;
+  }
+  return out;
+}
+
+/** Deep-merge per-rule bags; overlay wins on shared keys. */
+export function mergeRuleParams(base: RuleParamMap, overlay: RuleParamMap): RuleParamMap {
+  const out: RuleParamMap = { ...base };
+  for (const [ruleId, bag] of Object.entries(overlay)) {
+    if (ruleId === "_ui") continue;
+    out[ruleId] = { ...(out[ruleId] ?? {}), ...bag };
+  }
+  return out;
+}
+
+/**
+ * Effective tuning for FDD runs: package/session_config first (Vibe19 parity),
+ * then browser local overrides from Lab sliders.
+ */
+export function effectiveRunParams(
+  sessionParams: Record<string, unknown> | null | undefined,
+  localOverrides?: RuleParamMap,
+): RuleParamMap {
+  return mergeRuleParams(
+    numericParamsFromSession(sessionParams),
+    localOverrides ?? loadLocalRuleParams(),
+  );
+}

--- a/frontend/web/src/pages/ActionsPage.test.tsx
+++ b/frontend/web/src/pages/ActionsPage.test.tsx
@@ -28,6 +28,11 @@ vi.mock("../api/actionsApi", async () => {
 
 vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => []),
+  getSessionConfig: vi.fn(async () => ({
+    ok: true,
+    config: { schema_version: "openfdd_session_v1", params: {} },
+  })),
+  putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../api/uploadApi", () => ({ uploadPackage: vi.fn() }));

--- a/frontend/web/src/pages/FindingsPage.test.tsx
+++ b/frontend/web/src/pages/FindingsPage.test.tsx
@@ -22,6 +22,11 @@ vi.mock("../api/jobsApi", () => ({
 
 vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => ["BUILDING_100"]),
+  getSessionConfig: vi.fn(async () => ({
+    ok: true,
+    config: { schema_version: "openfdd_session_v1", params: {} },
+  })),
+  putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../api/fddApi", () => ({

--- a/frontend/web/src/pages/HomePage.test.tsx
+++ b/frontend/web/src/pages/HomePage.test.tsx
@@ -185,11 +185,9 @@ describe("HomePage overview", () => {
     expect(listFddEquipment).toHaveBeenCalled();
     const hero = screen.getByTestId("oracle-hero");
     expect(hero.querySelector('[data-testid="section-tabs"]')).toBeNull();
-    const eq = screen.getByTestId("overview-equipment-select");
-    const tabs = screen.getByTestId("section-tabs");
-    expect(
-      !!(eq.compareDocumentPosition(tabs) & Node.DOCUMENT_POSITION_FOLLOWING),
-    ).toBe(true);
+    expect(screen.queryByTestId("overview-equipment-select")).toBeNull();
+    expect(screen.getByTestId("section-tabs")).toBeTruthy();
+    expect(screen.getByTestId("overview-idle-hint")).toBeTruthy();
   });
 
   it("loads site inventory without a browser token (open mode)", async () => {

--- a/frontend/web/src/pages/RcxPage.test.tsx
+++ b/frontend/web/src/pages/RcxPage.test.tsx
@@ -34,6 +34,11 @@ vi.mock("../api/mappingApi", () => ({
     ok: true,
     equipment: [],
   })),
+  getSessionConfig: vi.fn(async () => ({
+    ok: true,
+    config: { schema_version: "openfdd_session_v1", params: {} },
+  })),
+  putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../api/analyticsApi", () => ({

--- a/frontend/web/src/pages/SitesPage.test.tsx
+++ b/frontend/web/src/pages/SitesPage.test.tsx
@@ -5,6 +5,11 @@ import { SitesPage } from "./SitesPage";
 
 vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => ["ZIP_BUILDING_1", "BUILDING_50"]),
+  getSessionConfig: vi.fn(async () => ({
+    ok: true,
+    config: { schema_version: "openfdd_session_v1", params: {} },
+  })),
+  putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../api/datasetsApi", () => ({

--- a/frontend/web/src/pages/UploadPage.test.tsx
+++ b/frontend/web/src/pages/UploadPage.test.tsx
@@ -14,6 +14,11 @@ vi.mock("../api/uploadApi", () => ({
 
 vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => []),
+  getSessionConfig: vi.fn(async () => ({
+    ok: true,
+    config: { schema_version: "openfdd_session_v1", params: {} },
+  })),
+  putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../api/fddApi", () => ({

--- a/frontend/web/src/pages/WattLabPage.test.tsx
+++ b/frontend/web/src/pages/WattLabPage.test.tsx
@@ -24,6 +24,11 @@ vi.mock("../api/jobsApi", () => ({
 
 vi.mock("../api/mappingApi", () => ({
   listPackageBuildings: vi.fn(async () => ["BUILDING_100"]),
+  getSessionConfig: vi.fn(async () => ({
+    ok: true,
+    config: { schema_version: "openfdd_session_v1", params: {} },
+  })),
+  putSessionConfig: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../api/reportsApi", () => ({

--- a/scripts/synthetic_59_stage.py
+++ b/scripts/synthetic_59_stage.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Stage + lightly enhance the OpenFDD synthetic 59-rule golden fixture.
+
+Source handoff ZIP → reports/wattlab-parity/fixtures/synthetic_59/
+Enhancements (do not rewrite expected_faults.csv goldens):
+  - copy default_confirmation_expectations.csv to outer root
+  - add AHU_CASE_SCHED_1_STRING companion + expected_faults_extra.csv
+  - emit test_contract/role_map_normalized.json (kebab→snake)
+  - re-zip package; refresh checksums.csv / validation_report.json
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SRC = Path.home() / "OPENFDD_SYNTHETIC_59_RULE_HANDOFF_V1_20260812_085050.zip"
+DEFAULT_OUT = ROOT / "reports/wattlab-parity/fixtures/synthetic_59"
+
+# Mirrors edge/src/csv_ingest/package.rs haystack_point_to_role (explicit arms).
+HAYSTACK_TO_SNAKE: dict[str, str] = {
+    "discharge-air-temp": "sat",
+    "discharge-air-temp-sp": "sat_sp",
+    "mixed-air-temp": "mat",
+    "return-air-temp": "rat",
+    "outside-air-temp": "oa_t",
+    "bas-outside-air-temp": "oa_t",
+    "outside-air-humidity": "oa_h",
+    "outside-air-damper": "oa_damper_pct",
+    "cooling-valve": "clg_valve_pct",
+    "heating-valve": "htg_valve_pct",
+    "fan-cmd": "fan_cmd",
+    "return-fan-cmd": "return_fan",
+    "fan-status": "fan_status",
+    "duct-static-pressure": "duct_static",
+    "duct-static-pressure-sp": "duct_static_sp",
+    "zone-air-temp": "zone_t",
+    "zone-airflow": "zone_flow",
+    "min-flow-sp": "min_flow_sp",
+    "damper": "damper_pct",
+    "reheat-valve": "reheat_valve_pct",
+    "vav-discharge-air-temp": "vav_discharge_t",
+    "vav-inlet-air-temp": "vav_inlet_t",
+    "ahu-discharge-air-temp": "ahu_sat",
+    "chilled-water-supply-temp": "chw_supply_t",
+    "chilled-water-return-temp": "chw_return_t",
+    "chilled-water-supply-temp-sp": "chw_supply_sp",
+    "hot-water-supply-temp": "hw_supply_t",
+    "hot-water-return-temp": "hw_return_t",
+    "occupied": "occ_mode",
+    "chw-diff-pressure": "chw_dp",
+    "chw-diff-pressure-sp": "chw_dp_sp",
+    "chw-flow": "chw_flow",
+    "chw-pump-cmd": "chw_pump_cmd",
+    "cw-pump-cmd": "cw_pump_cmd",
+    "tower-fan-cmd": "tower_fan_cmd",
+    "cw-fan-cmd": "tower_fan_cmd",
+    "condenser-water-supply-temp": "cw_supply_t",
+    "condenser-water-return-temp": "cw_return_t",
+    "preheat-leaving-temp": "preheat_leave_t",
+    "web-outside-air-temp": "web_oa_t",
+    "web-outside-air-dewpoint": "web_oa_dp",
+    "web-outside-air-wetbulb": "web_wb_t",
+    "web-outside-air-humidity": "web_oa_h",
+}
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def haystack_point_to_role(point: str) -> str:
+    slug = point.strip().lower().replace(" ", "-").replace("_", "-")
+    if slug in HAYSTACK_TO_SNAKE:
+        return HAYSTACK_TO_SNAKE[slug]
+    return slug.replace("-", "_")
+
+
+def unzip_handoff(src: Path, dest: Path) -> Path:
+    """Extract handoff ZIP, rewriting Windows backslash entry names into dirs."""
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+    with zipfile.ZipFile(src) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            # ZIP from Windows may use literal backslashes in the entry name.
+            rel = info.filename.replace("\\", "/")
+            if rel.endswith("/"):
+                continue
+            out = dest / rel
+            out.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src_f, out.open("wb") as dst_f:
+                shutil.copyfileobj(src_f, dst_f)
+    nested = dest / "openfdd_synthetic_59_rule_fixture_v1"
+    if nested.is_dir() and (nested / "expected_faults.csv").is_file():
+        return nested
+    kids = [p for p in dest.iterdir() if p.is_dir()]
+    if len(kids) == 1 and (kids[0] / "expected_faults.csv").is_file():
+        return kids[0]
+    for p in dest.rglob("expected_faults.csv"):
+        return p.parent
+    raise SystemExit(f"could not find fixture root under {dest}")
+
+
+def unpack_package(fixture_root: Path) -> Path:
+    pkg_zip = fixture_root / "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1.zip"
+    pkg_dir = fixture_root / "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1"
+    if pkg_dir.exists():
+        shutil.rmtree(pkg_dir)
+    with zipfile.ZipFile(pkg_zip) as zf:
+        zf.extractall(fixture_root)
+    if not pkg_dir.is_dir():
+        raise SystemExit(f"package dir missing after unzip: {pkg_dir}")
+    return pkg_dir
+
+
+def copy_confirmation_csv(pkg_dir: Path, fixture_root: Path) -> Path:
+    src = pkg_dir / "test_contract" / "default_confirmation_expectations.csv"
+    if not src.is_file():
+        raise SystemExit(f"missing {src}")
+    dst = fixture_root / "default_confirmation_expectations.csv"
+    shutil.copy2(src, dst)
+    # keep test_contract copy in sync
+    return dst
+
+
+def build_role_map_normalized(pkg_dir: Path) -> Path:
+    roles: dict[str, str] = {}
+    for cm in pkg_dir.rglob("column_map.json"):
+        if "test_contract" in cm.parts:
+            continue
+        data = json.loads(cm.read_text())
+        col_roles = data.get("column_roles") or data.get("points") or {}
+        for raw in col_roles.values():
+            if not isinstance(raw, str):
+                continue
+            roles[raw] = haystack_point_to_role(raw)
+        for raw in col_roles.keys():
+            if isinstance(raw, str) and "-" in raw:
+                roles.setdefault(raw, haystack_point_to_role(raw))
+    out = {
+        "schema": "openfdd_synthetic_role_map_normalized_v1",
+        "source": "haystack_point_to_role (package.rs mirror)",
+        "mapping": dict(sorted(roles.items())),
+        "count": len(roles),
+    }
+    dest = pkg_dir / "test_contract" / "role_map_normalized.json"
+    dest.write_text(json.dumps(out, indent=2) + "\n")
+    # also outer copy for handoff consumers
+    (pkg_dir.parent / "role_map_normalized.json").write_text(
+        json.dumps(out, indent=2) + "\n"
+    )
+    return dest
+
+
+def add_sched1_string_companion(pkg_dir: Path, fixture_root: Path) -> None:
+    src_eq = pkg_dir / "AHU_CASE_SCHED_1"
+    dst_eq = pkg_dir / "AHU_CASE_SCHED_1_STRING"
+    if not src_eq.is_dir():
+        raise SystemExit(f"missing {src_eq}")
+    if dst_eq.exists():
+        shutil.rmtree(dst_eq)
+    shutil.copytree(src_eq, dst_eq)
+
+    # Rewrite history: map occupied 1→occupied, 0→unoccupied
+    hist = dst_eq / "history_wide.csv"
+    rows = list(csv.DictReader(hist.open()))
+    if not rows or "occupied" not in rows[0]:
+        raise SystemExit("SCHED-1 history missing occupied column")
+    fieldnames = list(rows[0].keys())
+    for r in rows:
+        v = str(r["occupied"]).strip()
+        if v in ("1", "1.0", "true", "True"):
+            r["occupied"] = "occupied"
+        elif v in ("0", "0.0", "false", "False"):
+            r["occupied"] = "unoccupied"
+    with hist.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+    # column_map / columns equipment id
+    cm_path = dst_eq / "column_map.json"
+    cm = json.loads(cm_path.read_text())
+    cm["device"] = "AHU_CASE_SCHED_1_STRING"
+    cm["test_target_rule_id"] = "SCHED-1"
+    cm["notes"] = (
+        "Companion to AHU_CASE_SCHED_1: literal occupied/unoccupied strings "
+        "for the same Wed 11:00-12:00 UTC window. Additive probe — does not "
+        "replace the numeric 0/1 golden in expected_faults.csv."
+    )
+    cm_path.write_text(json.dumps(cm, indent=2) + "\n")
+
+    cols_path = dst_eq / "columns.csv"
+    col_rows = list(csv.DictReader(cols_path.open()))
+    if col_rows:
+        fn = list(col_rows[0].keys())
+        for r in col_rows:
+            if "equipment_id" in r:
+                r["equipment_id"] = "AHU_CASE_SCHED_1_STRING"
+        with cols_path.open("w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=fn)
+            w.writeheader()
+            w.writerows(col_rows)
+
+    # expected_faults_extra.csv (outer + test_contract)
+    primary = list(csv.DictReader((fixture_root / "expected_faults.csv").open()))
+    sched = next(r for r in primary if r["rule_id"] == "SCHED-1")
+    extra = dict(sched)
+    extra["ordinal"] = "59b"
+    extra["equipment_id"] = "AHU_CASE_SCHED_1_STRING"
+    extra["injection_note"] = (
+        (extra.get("injection_note") or "")
+        + " | STRING occupancy companion (occupied/unoccupied literals)"
+    ).strip(" |")
+    extra_path = fixture_root / "expected_faults_extra.csv"
+    with extra_path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(extra.keys()))
+        w.writeheader()
+        w.writerow(extra)
+    shutil.copy2(extra_path, pkg_dir / "test_contract" / "expected_faults_extra.csv")
+
+
+def rezip_package(pkg_dir: Path, fixture_root: Path) -> Path:
+    out_zip = fixture_root / "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1.zip"
+    if out_zip.exists():
+        out_zip.unlink()
+    with zipfile.ZipFile(out_zip, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(pkg_dir.rglob("*")):
+            if path.is_file():
+                arc = path.relative_to(fixture_root).as_posix()
+                zf.write(path, arcname=arc)
+    return out_zip
+
+
+def refresh_checksums(fixture_root: Path) -> None:
+    # Track key handoff files (existing + new)
+    names = [
+        "CURSOR_AGENT_PROMPT.md",
+        "README.md",
+        "checksums.csv",
+        "default_confirmation_expectations.csv",
+        "equation_review.csv",
+        "equipment_legend.csv",
+        "expected_faults.csv",
+        "expected_faults_extra.csv",
+        "OpenFDD_Synthetic_59_Rule_Legend.xlsx",
+        "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1.zip",
+        "point_legend.csv",
+        "role_map_normalized.json",
+        "rule_catalog.csv",
+        "runtime_legend.csv",
+        "validation_report.json",
+        "verification_observed.csv",
+        "verification_summary.json",
+        "vibe19_integration_observed.csv",
+        "vibe19_integration_summary.json",
+    ]
+    rows = []
+    for name in names:
+        p = fixture_root / name
+        if not p.is_file():
+            continue
+        rows.append(
+            {
+                "file": name,
+                "sha256": sha256_file(p),
+                "bytes": str(p.stat().st_size),
+            }
+        )
+    # write checksums without hashing itself first — then rewrite with self hash omitted
+    ck = fixture_root / "checksums.csv"
+    with ck.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["file", "sha256", "bytes"])
+        w.writeheader()
+        w.writerows([r for r in rows if r["file"] != "checksums.csv"])
+    # include checksums.csv entry with hash of content without self — skip self
+    # (common pattern: list peers only)
+
+
+def refresh_validation_report(fixture_root: Path, pkg_zip: Path) -> None:
+    path = fixture_root / "validation_report.json"
+    prev = {}
+    if path.is_file():
+        prev = json.loads(path.read_text())
+    assertions = dict(prev.get("assertions") or {})
+    assertions["outer_has_default_confirmation"] = (
+        fixture_root / "default_confirmation_expectations.csv"
+    ).is_file()
+    assertions["has_sched1_string_companion"] = (
+        fixture_root / "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1" / "AHU_CASE_SCHED_1_STRING"
+    ).is_dir()
+    assertions["has_role_map_normalized"] = (
+        fixture_root / "role_map_normalized.json"
+    ).is_file()
+    assertions["has_expected_faults_extra"] = (
+        fixture_root / "expected_faults_extra.csv"
+    ).is_file()
+    report = {
+        "status": prev.get("status", "PASS"),
+        "fixture_note": (
+            "Staged + enhanced for OpenFDD/Vibe19 target-pair soak. "
+            "Primary goldens unchanged (58/59; SCHED-1 numeric occupancy defect). "
+            "AHU_CASE_SCHED_1_STRING is additive (expected_faults_extra.csv)."
+        ),
+        "staged_at_utc": datetime.now(timezone.utc).isoformat(),
+        "zip_bytes": pkg_zip.stat().st_size,
+        "zip_sha256": sha256_file(pkg_zip),
+        "assertions": assertions,
+        "failures": prev.get("failures") or [],
+    }
+    path.write_text(json.dumps(report, indent=2) + "\n")
+
+
+def write_stage_readme(fixture_root: Path) -> None:
+    text = """# Synthetic 59 fixture (staged)
+
+Canonical equation-isolation golden for Vibe19 + OpenFDD SQL target-pair soaks.
+
+- Package: `OPENFDD_SYNTHETIC_59_RULE_WEEK_V1.zip` (also unpacked beside it)
+- Primary goldens: `expected_faults.csv` (do not rewrite to match bugs)
+- Additive string occupancy probe: `expected_faults_extra.csv` + `AHU_CASE_SCHED_1_STRING`
+- Confirmation defaults: `default_confirmation_expectations.csv`
+- Role map smoke: `role_map_normalized.json` (kebab→snake, mirrors central ingest)
+
+See `CURSOR_AGENT_PROMPT.md` and repo script `scripts/synthetic_59_target_pair_soak.py`.
+"""
+    (fixture_root / "STAGED.md").write_text(text)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--src", type=Path, default=DEFAULT_SRC)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = ap.parse_args()
+    if not args.src.is_file():
+        raise SystemExit(f"handoff zip not found: {args.src}")
+
+    fixture_root = unzip_handoff(args.src, args.out)
+    print(f"fixture_root={fixture_root}")
+    pkg_dir = unpack_package(fixture_root)
+    print(f"package_dir={pkg_dir}")
+
+    conf = copy_confirmation_csv(pkg_dir, fixture_root)
+    print(f"copied {conf.name}")
+    rm = build_role_map_normalized(pkg_dir)
+    print(f"role_map {rm} mappings={json.loads(rm.read_text())['count']}")
+    add_sched1_string_companion(pkg_dir, fixture_root)
+    print("added AHU_CASE_SCHED_1_STRING + expected_faults_extra.csv")
+
+    pkg_zip = rezip_package(pkg_dir, fixture_root)
+    print(f"rezipped {pkg_zip} ({pkg_zip.stat().st_size} bytes)")
+    refresh_validation_report(fixture_root, pkg_zip)
+    refresh_checksums(fixture_root)
+    write_stage_readme(fixture_root)
+    print("OK stage complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/synthetic_59_target_pair_soak.py
+++ b/scripts/synthetic_59_target_pair_soak.py
@@ -1,0 +1,656 @@
+#!/usr/bin/env python3
+"""Target-pair soak for the synthetic 59-rule golden fixture.
+
+Compares expected_faults.csv pairs only (ignore correlated detections).
+
+  --side vibe19   Run agent_afdd inside vibe19 container (or host) against package ZIP
+  --side ofdd     Upload package to OpenFDD central, run registry, compare results
+  --side both     Default
+
+Writes reports/wattlab-parity/artifacts/synthetic_59/*.csv + *.json
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = (
+    ROOT
+    / "reports/wattlab-parity/fixtures/synthetic_59/openfdd_synthetic_59_rule_fixture_v1"
+)
+ARTIFACTS = ROOT / "reports/wattlab-parity/artifacts/synthetic_59"
+PKG_ZIP = FIXTURE / "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1.zip"
+EXPECTED = FIXTURE / "expected_faults.csv"
+BUILDING_ID = "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1"
+
+HOURS_TOL = 0.05
+
+# SQL registry primary ids that differ from pandas rule_id (aliases).
+SQL_RULE_ALIASES: dict[str, list[str]] = {
+    "FC13": ["FC13-SAT-HIGH", "FC13"],
+}
+
+
+def load_shared_fault_params() -> dict:
+    """Same rule tuning blob for Vibe19 --params and OpenFDD session + /api/fdd/run.
+
+    Source of truth: package session_config.json (confirm_min=0 equation-isolation).
+    Also mirrors params onto SQL primary ids (e.g. FC13 → FC13-SAT-HIGH).
+    """
+    sess = FIXTURE / "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1" / "session_config.json"
+    params: dict = {}
+    if sess.is_file():
+        params = dict((json.loads(sess.read_text()).get("params")) or {})
+    # Mirror alias keys so SQL registry primary ids get the same confirm_min.
+    for pandas_id, aliases in SQL_RULE_ALIASES.items():
+        if pandas_id not in params:
+            continue
+        for alias in aliases:
+            params.setdefault(alias, dict(params[pandas_id]))
+    return params
+
+
+def load_expected(path: Path) -> list[dict]:
+    return list(csv.DictReader(path.open()))
+
+
+def lookup_result(
+    by_key: dict[tuple[str, str], dict], rule_id: str, equipment_id: str
+) -> dict | None:
+    for rid in SQL_RULE_ALIASES.get(rule_id, [rule_id]):
+        hit = by_key.get((rid, equipment_id))
+        if hit:
+            return hit
+    return by_key.get((rule_id, equipment_id))
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def write_csv(path: Path, rows: list[dict], fieldnames: list[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("")
+        return
+    fn = fieldnames or list(rows[0].keys())
+    with path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fn, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(rows)
+
+
+def http_json(
+    method: str,
+    url: str,
+    token: str | None = None,
+    body: bytes | None = None,
+    content_type: str | None = None,
+    timeout: float = 600.0,
+) -> dict:
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if content_type:
+        headers["Content-Type"] = content_type
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        try:
+            return json.loads(detail)
+        except json.JSONDecodeError:
+            return {"ok": False, "error": f"HTTP {e.code}: {detail[:500]}"}
+
+
+def login(base: str, user: str, password: str) -> str:
+    out = http_json(
+        "POST",
+        f"{base}/api/auth/login",
+        body=json.dumps({"username": user, "password": password}).encode(),
+        content_type="application/json",
+        timeout=30,
+    )
+    tok = out.get("access_token") or out.get("token")
+    if not tok:
+        raise SystemExit(f"login failed: {out}")
+    return str(tok)
+
+
+def hours_match(observed: float | None, expected: float) -> bool:
+    if observed is None:
+        return False
+    return abs(float(observed) - float(expected)) <= HOURS_TOL
+
+
+def compare_pair(exp: dict, status: str, fault_hours: float | None) -> dict:
+    want_status = exp["expected_status"]
+    want_h = float(exp["expected_fault_hours"])
+    status_ok = status == want_status
+    # PASS with 0h when expecting FAULT is a clear miss
+    hours_ok = hours_match(fault_hours, want_h) if status_ok else False
+    # Allow FAULT with matching hours even if samples unavailable
+    contract = status_ok and hours_ok
+    return {
+        "rule_id": exp["rule_id"],
+        "equipment_id": exp["equipment_id"],
+        "expected_status": want_status,
+        "observed_status": status,
+        "expected_fault_hours": want_h,
+        "observed_fault_hours": fault_hours if fault_hours is not None else "",
+        "status_match": status_ok,
+        "hours_match": hours_ok,
+        "contract_match": contract,
+        "expected_fault_start_utc": exp.get("expected_fault_start_utc", ""),
+        "expected_fault_end_exclusive_utc": exp.get(
+            "expected_fault_end_exclusive_utc", ""
+        ),
+        "expected_fault_samples": exp.get("expected_fault_samples", ""),
+    }
+
+
+# ---- Vibe19 -----------------------------------------------------------------
+
+
+def run_vibe19(
+    package_zip: Path,
+    expected: list[dict],
+    host_workspace: Path,
+) -> dict:
+    """Copy package into vibe19 /data bind and run agent_afdd --run-rules."""
+    host_workspace.mkdir(parents=True, exist_ok=True)
+    dest_zip = host_workspace / package_zip.name
+    shutil.copy2(package_zip, dest_zip)
+    out_host = host_workspace / "synthetic_59_agent_out"
+    summary_csv = out_host / "fdd_summary.csv"
+    force = os.environ.get("SYNTH59_FORCE_VIBE19") == "1"
+    reuse = (
+        not force
+        and summary_csv.is_file()
+        and summary_csv.stat().st_size > 1000
+    )
+    if force and out_host.exists():
+        shutil.rmtree(out_host)
+    out_host.mkdir(parents=True, exist_ok=True)
+
+    # Shared fault tuning (identical blob for Vibe19 --params).
+    params_path = host_workspace / "synthetic_59_params.json"
+    params_obj = load_shared_fault_params()
+    params_path.write_text(json.dumps(params_obj, indent=2))
+
+    container_pkg = f"/data/{package_zip.name}"
+    container_out = "/data/synthetic_59_agent_out"
+    container_params = "/data/synthetic_59_params.json"
+
+    cmd = [
+        "docker",
+        "exec",
+        "vibe19",
+        "python",
+        "scripts/agent_afdd.py",
+        "--package",
+        container_pkg,
+        "--out",
+        container_out,
+        "--params",
+        container_params,
+        "--run-rules",
+        "--no-bootstrap",
+        "--export-profile",
+        "summary",
+    ]
+    proc = None
+    t0 = time.time()
+    if reuse:
+        print(f">> reusing existing {summary_csv} (set SYNTH59_FORCE_VIBE19=1 to rerun)")
+        elapsed = 0.0
+    else:
+        print(">>", " ".join(cmd))
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        elapsed = time.time() - t0
+        print(proc.stdout[-2000:] if proc.stdout else "")
+        if proc.returncode != 0:
+            print(proc.stderr[-2000:] if proc.stderr else "")
+            # Export may crash after fdd_summary.csv is written (pandas quantile on bool).
+            if not summary_csv.is_file():
+                raise SystemExit(f"vibe19 agent_afdd failed rc={proc.returncode}")
+            print(
+                f"WARN: agent_afdd rc={proc.returncode} but {summary_csv.name} present; "
+                "continuing with target-pair compare"
+            )
+
+    # Find results summary table
+    summary_candidates = list(out_host.rglob("*summary*.csv")) + list(
+        out_host.rglob("fdd_findings*.csv")
+    )
+    results_by_key: dict[tuple[str, str], dict] = {}
+    # Also try JSON results
+    for jf in out_host.rglob("*.json"):
+        if jf.name in ("streamlit_bootstrap.json", "session_config.json"):
+            continue
+        try:
+            data = json.loads(jf.read_text())
+        except Exception:
+            continue
+        rows = data if isinstance(data, list) else data.get("results") or data.get("rows")
+        if not isinstance(rows, list):
+            continue
+        for r in rows:
+            if not isinstance(r, dict):
+                continue
+            rid = str(r.get("rule_id") or "")
+            eid = str(r.get("equipment_id") or "")
+            if rid and eid:
+                results_by_key[(rid, eid)] = r
+
+    for csv_path in summary_candidates:
+        try:
+            for r in csv.DictReader(csv_path.open()):
+                rid = str(r.get("rule_id") or "")
+                eid = str(r.get("equipment_id") or "")
+                if rid and eid:
+                    results_by_key[(rid, eid)] = r
+        except Exception:
+            continue
+
+    # Fallback: parse run_report / agent meta
+    for p in out_host.rglob("run_report.json"):
+        data = json.loads(p.read_text())
+        for r in data.get("results") or []:
+            rid = str(r.get("rule_id") or "")
+            eid = str(r.get("equipment_id") or "")
+            if rid and eid:
+                results_by_key[(rid, eid)] = r
+
+    pairs = []
+    for exp in expected:
+        key = (exp["rule_id"], exp["equipment_id"])
+        obs = results_by_key.get(key)
+        if not obs:
+            pairs.append(
+                {
+                    **compare_pair(exp, "MISSING", None),
+                    "notes": "no result row for target pair",
+                }
+            )
+            continue
+        status = str(obs.get("status") or "")
+        fh = obs.get("fault_hours")
+        if fh in ("", None):
+            fh = obs.get("confirmed_fault_hours")
+        try:
+            fh_f = float(fh) if fh is not None and fh != "" else None
+        except (TypeError, ValueError):
+            fh_f = None
+        row = compare_pair(exp, status, fh_f)
+        row["notes"] = obs.get("notes") or ""
+        pairs.append(row)
+
+    matched = sum(1 for p in pairs if p["contract_match"])
+    summary = {
+        "side": "vibe19",
+        "building_id": BUILDING_ID,
+        "elapsed_s": round(elapsed, 1),
+        "target_total": len(expected),
+        "target_match": matched,
+        "target_mismatch": len(expected) - matched,
+        "mismatches": [
+            {
+                "rule_id": p["rule_id"],
+                "equipment_id": p["equipment_id"],
+                "observed_status": p["observed_status"],
+                "observed_fault_hours": p["observed_fault_hours"],
+            }
+            for p in pairs
+            if not p["contract_match"]
+        ],
+        "agent_stdout_tail": ((proc.stdout if proc else "") or "")[-500:],
+        "agent_rc": None if proc is None else proc.returncode,
+        "reused_existing_summary": reuse and proc is None,
+        "result_keys_found": len(results_by_key),
+        "generated_at": utc_now(),
+    }
+    write_csv(ARTIFACTS / "vibe19_target_pairs.csv", pairs)
+    (ARTIFACTS / "vibe19_target_pairs_summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n"
+    )
+    return summary
+
+
+# ---- OpenFDD ----------------------------------------------------------------
+
+
+def run_ofdd(
+    package_zip: Path,
+    expected: list[dict],
+    base: str,
+    user: str,
+    password: str,
+) -> dict:
+    token = login(base, user, password)
+    print(f"logged in → upload {package_zip.name}")
+    zip_bytes = package_zip.read_bytes()
+    t0 = time.time()
+    # Raw zip body (central accepts multipart, JSON base64, or raw zip)
+    imp = http_json(
+        "POST",
+        f"{base}/api/csv/import/package",
+        token=token,
+        body=zip_bytes,
+        content_type="application/zip",
+        timeout=900.0,
+    )
+    if not imp.get("ok"):
+        # try multipart via curl for robustness
+        print("raw zip import failed, trying curl multipart…", imp.get("error"))
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".json") as tf:
+            cmd = [
+                "curl",
+                "-sf",
+                "-X",
+                "POST",
+                f"{base}/api/csv/import/package",
+                "-H",
+                f"Authorization: Bearer {token}",
+                "-F",
+                f"file=@{package_zip}",
+                "-o",
+                tf.name,
+            ]
+            subprocess.run(cmd, check=False)
+            imp = json.loads(Path(tf.name).read_text() or "{}")
+    if not imp.get("ok"):
+        raise SystemExit(f"package import failed: {imp}")
+    building = imp.get("building_id") or BUILDING_ID
+    print(
+        f"imported building={building} equipment={imp.get('equipment_written')} "
+        f"rows={imp.get('total_rows')} ms={imp.get('total_ms')}"
+    )
+
+    # Same fault tuning as Vibe19: PUT session-config then pass identical params to run.
+    sess_path = FIXTURE / "OPENFDD_SYNTHETIC_59_RULE_WEEK_V1" / "session_config.json"
+    sess_cfg = json.loads(sess_path.read_text()) if sess_path.is_file() else {}
+    params = load_shared_fault_params()
+    put_body = {
+        **sess_cfg,
+        "schema_version": sess_cfg.get("schema_version") or "openfdd_session_v1",
+        "params": params,
+    }
+    put = http_json(
+        "PUT",
+        f"{base}/api/fdd/session-config",
+        token=token,
+        body=json.dumps(put_body).encode(),
+        content_type="application/json",
+        timeout=60.0,
+    )
+    if not put.get("ok"):
+        print("WARN: session-config PUT failed:", put.get("error") or put)
+
+    run_body = {
+        "mode": "registry",
+        "building_id": building,
+        "params": params,
+    }
+    print(
+        f">> POST /api/fdd/run (registry, shared confirm_min params "
+        f"n_rules={len(params)})"
+    )
+    run = http_json(
+        "POST",
+        f"{base}/api/fdd/run",
+        token=token,
+        body=json.dumps(run_body).encode(),
+        content_type="application/json",
+        timeout=1200.0,
+    )
+    elapsed = time.time() - t0
+    if not run.get("ok"):
+        raise SystemExit(f"fdd run failed: {run}")
+    print(
+        f"run ok rules_succeeded={run.get('rules_succeeded')} "
+        f"failed={run.get('rules_failed')} skipped={run.get('rules_skipped')} "
+        f"total_ms={run.get('total_ms')}"
+    )
+
+    results = run.get("results") or []
+    if not results:
+        # fetch separately
+        res = http_json(
+            "GET",
+            f"{base}/api/fdd/results?building_id={building}",
+            token=token,
+            timeout=60,
+        )
+        results = res.get("results") or res.get("rows") or []
+
+    by_key: dict[tuple[str, str], dict] = {}
+    for r in results:
+        rid = str(r.get("rule_id") or "")
+        eid = str(r.get("equipment_id") or "")
+        if rid and eid:
+            by_key[(rid, eid)] = r
+
+    pairs = []
+    for exp in expected:
+        obs = lookup_result(by_key, exp["rule_id"], exp["equipment_id"])
+        if not obs:
+            pairs.append(
+                {
+                    **compare_pair(exp, "MISSING", None),
+                    "notes": "no OFDD result for target pair",
+                    "missing_roles": "",
+                    "sql_rule_id": "",
+                }
+            )
+            continue
+        status = str(obs.get("status") or "")
+        fh = obs.get("fault_hours")
+        try:
+            fh_f = float(fh) if fh is not None else None
+        except (TypeError, ValueError):
+            fh_f = None
+        row = compare_pair(exp, status, fh_f)
+        mr = obs.get("missing_roles")
+        row["missing_roles"] = (
+            ",".join(mr) if isinstance(mr, list) else (str(mr) if mr else "")
+        )
+        row["notes"] = str(obs.get("notes") or "")
+        row["sql_rule_id"] = str(obs.get("rule_id") or "")
+        pairs.append(row)
+
+    # Series overlay spot-checks
+    spot = []
+    for rule_id, equipment_id in (
+        ("FC1", "AHU_CASE_FC1"),
+        ("VAV-1", "VAV_CASE_VAV_1"),
+        ("SCHED-1", "AHU_CASE_SCHED_1"),
+    ):
+        series = http_json(
+            "GET",
+            f"{base}/api/fdd/series?equipment_id={equipment_id}"
+            f"&rule_id={rule_id}&building_id={building}",
+            token=token,
+            timeout=120,
+        )
+        rows = series.get("rows") or []
+        cf = [
+            r.get("confirmed_fault")
+            for r in rows
+            if isinstance(r, dict) and r.get("confirmed_fault") is not None
+        ]
+        spot.append(
+            {
+                "rule_id": rule_id,
+                "equipment_id": equipment_id,
+                "ok": series.get("ok"),
+                "has_confirmed_fault": series.get("has_confirmed_fault"),
+                "fault_overlay_source": series.get("fault_overlay_source"),
+                "fault_overlay_hits": series.get("fault_overlay_hits"),
+                "row_count": len(rows),
+                "confirmed_fault_nonnull": len(cf),
+                "error": series.get("error"),
+            }
+        )
+
+    matched = sum(1 for p in pairs if p["contract_match"])
+    summary = {
+        "side": "ofdd_sql",
+        "building_id": building,
+        "elapsed_s": round(elapsed, 1),
+        "import": {
+            "equipment_written": imp.get("equipment_written"),
+            "total_rows": imp.get("total_rows"),
+            "warnings": imp.get("warnings") or [],
+        },
+        "run": {
+            "rules_run": run.get("rules_run"),
+            "rules_succeeded": run.get("rules_succeeded"),
+            "rules_failed": run.get("rules_failed"),
+            "rules_skipped": run.get("rules_skipped"),
+            "total_ms": run.get("total_ms"),
+            "result_count": len(results),
+        },
+        "target_total": len(expected),
+        "target_match": matched,
+        "target_mismatch": len(expected) - matched,
+        "mismatches": [
+            {
+                "rule_id": p["rule_id"],
+                "equipment_id": p["equipment_id"],
+                "observed_status": p["observed_status"],
+                "observed_fault_hours": p["observed_fault_hours"],
+                "missing_roles": p.get("missing_roles"),
+            }
+            for p in pairs
+            if not p["contract_match"]
+        ],
+        "series_spot_checks": spot,
+        "generated_at": utc_now(),
+        "central_health": http_json("GET", f"{base}/api/health", timeout=10),
+    }
+    write_csv(ARTIFACTS / "ofdd_sql_target_pairs.csv", pairs)
+    (ARTIFACTS / "ofdd_sql_target_pairs_summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n"
+    )
+    (ARTIFACTS / "ofdd_series_spot_checks.json").write_text(
+        json.dumps(spot, indent=2) + "\n"
+    )
+    return summary
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--side", choices=("vibe19", "ofdd", "both"), default="both")
+    ap.add_argument("--package", type=Path, default=PKG_ZIP)
+    ap.add_argument("--expected", type=Path, default=EXPECTED)
+    ap.add_argument("--api-base", default=os.environ.get("OPENFDD_API_BASE", "http://127.0.0.1:8080"))
+    ap.add_argument("--user", default=os.environ.get("OPENFDD_USER", "admin"))
+    ap.add_argument(
+        "--password",
+        default=os.environ.get("OPENFDD_ADMIN_PASSWORD", "bensbench-local-admin"),
+    )
+    ap.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.home() / "wattlab_workspace",
+        help="Host path bind-mounted to vibe19 /data",
+    )
+    ap.add_argument(
+        "--skip-vibe19-rerun",
+        action="store_true",
+        help="Reuse handoff vibe19_integration_observed.csv instead of re-running agent",
+    )
+    args = ap.parse_args()
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    if not args.package.is_file():
+        raise SystemExit(f"package zip missing: {args.package} (run synthetic_59_stage.py)")
+    expected = load_expected(args.expected)
+    print(f"expected target pairs: {len(expected)}")
+
+    summaries = {}
+    if args.side in ("vibe19", "both"):
+        if args.skip_vibe19_rerun:
+            obs_path = FIXTURE / "vibe19_integration_observed.csv"
+            rows = list(csv.DictReader(obs_path.open()))
+            pairs = []
+            for exp in expected:
+                o = next(
+                    (
+                        r
+                        for r in rows
+                        if r["rule_id"] == exp["rule_id"]
+                        and r["equipment_id"] == exp["equipment_id"]
+                    ),
+                    None,
+                )
+                if not o:
+                    pairs.append(compare_pair(exp, "MISSING", None))
+                    continue
+                fh = o.get("observed_fault_hours")
+                try:
+                    fh_f = float(fh) if fh not in (None, "") else None
+                except ValueError:
+                    fh_f = None
+                row = compare_pair(exp, o.get("observed_status") or "", fh_f)
+                row["contract_match"] = str(o.get("contract_match")).lower() in (
+                    "true",
+                    "1",
+                )
+                pairs.append(row)
+            matched = sum(1 for p in pairs if p["contract_match"])
+            summaries["vibe19"] = {
+                "side": "vibe19",
+                "source": "handoff vibe19_integration_observed.csv",
+                "target_total": len(expected),
+                "target_match": matched,
+                "target_mismatch": len(expected) - matched,
+                "mismatches": [
+                    p for p in pairs if not p["contract_match"]
+                ],
+                "generated_at": utc_now(),
+            }
+            write_csv(ARTIFACTS / "vibe19_target_pairs.csv", pairs)
+            (ARTIFACTS / "vibe19_target_pairs_summary.json").write_text(
+                json.dumps(summaries["vibe19"], indent=2) + "\n"
+            )
+        else:
+            summaries["vibe19"] = run_vibe19(args.package, expected, args.workspace)
+        print(
+            f"Vibe19 target match {summaries['vibe19']['target_match']}/"
+            f"{summaries['vibe19']['target_total']}"
+        )
+
+    if args.side in ("ofdd", "both"):
+        summaries["ofdd"] = run_ofdd(
+            args.package, expected, args.api_base.rstrip("/"), args.user, args.password
+        )
+        print(
+            f"OpenFDD SQL target match {summaries['ofdd']['target_match']}/"
+            f"{summaries['ofdd']['target_total']}"
+        )
+
+    (ARTIFACTS / "soak_summary.json").write_text(
+        json.dumps({"generated_at": utc_now(), "sides": summaries}, indent=2) + "\n"
+    )
+    print(f"artifacts → {ARTIFACTS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Shared rule tuning: Lab/Overview seed from `session_config` and expose **`confirm_min` (minutes)** like Vibe19 (not empty localStorage / confirm_seconds-only sliders).
- FDD Plots: rewrite aggregated SQL into per-timestamp `confirmed_fault` overlay (`sql_detail`) when result JSON lacks a fault lane.
- Add `scripts/synthetic_59_stage.py` + `synthetic_59_target_pair_soak.py` for the equation-isolation golden (target pairs only).
- Docs: Current cycle pointer for synthetic 59; B100 dump-parity remains paused. Full evidence stays under gitignored `reports/wattlab-parity/`.

## Test plan
- [ ] CI `Publish Open-FDD stack to GHCR` test job (fmt/clippy/crate tests + web image build)
- [ ] After merge, pull new `nightly` / `sha-*` on bensbench; confirm `GET /api/fdd/rules/SV-RANGE/params` has `confirm_min` and not `confirm_seconds`
- [ ] Re-run `python3 scripts/synthetic_59_target_pair_soak.py --side both` against updated images (expect Vibe19 58/59; OFDD SQL still ~42/59 until equation gaps close)
- [ ] Overview “Run all rules” uses session `confirm_min=0` after package load


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added series-query support for confirmed-fault overlays, with clearer result details and improved timestamp handling.
  - Added persistent rule-tuning preferences that combine session settings with local adjustments.

- **Improvements**
  - Overview analytics and inspections now run when manually refreshed instead of automatically after selections change.
  - Removed the Overview equipment selector.
  - Updated labels and guidance to distinguish analytics from fault-detection workflows.

- **Documentation**
  - Added current-cycle status and validation context for the synthetic rule fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->