### PR TITLE
Overview expanders, session confirm overlay, SCHED-1 occupancy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,19 @@ Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:808
 4. Read-first; writes need `OPENFDD_MCP_ALLOW_WRITES=1` and `confirm:true`.
 5. Never print secrets. BACnet writes need explicit human approval.
 
+## Product UI / FDD agent notes
+
+- **Overview plots:** plot Expanders default **open** so charts are not hidden behind carets (`OverviewPopulated`).
+- **Lab → FDD Plots:** `session_config` `confirm_min` (and rule params) apply to the series overlay (`sql_detail_session`). After **Update this rule**, Reports/FDD Plots must refetch on `RULES_UPDATED`.
+- **SCHED-1 occupancy:** treat numeric `0` / `0.0` / `false` **and** string `unoccupied` (and related tokens) as unoccupied — SQL + pandas cookbook stay aligned.
+- **Synthetic-59:** soak via `scripts/synthetic_59_*.py` under `reports/wattlab-parity/fixtures/synthetic_59/`. Do not greenwash `expected_faults.csv`. B100 dump-parity remains **paused**.
+
+## Low-RAM hosts (bensbench)
+
+- **Never** local `docker build` / heavy Rust compile for stack images. Ship via PR → GH Actions → GHCR `nightly` / `sha-*`.
+- Before pulling new images: prune unused/old digests first, then `./scripts/openfdd_stack_pull.sh …` and `./scripts/openfdd_stack_up.sh … --no-pull`.
+- Details: [`openfdd_agent_spec/CONTAINER_AGENT.md`](openfdd_agent_spec/CONTAINER_AGENT.md).
+
 ## Never
 
 - delete `workspace/`
@@ -69,6 +82,7 @@ Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:808
 - write BACnet without explicit human approval
 - embed vendor chat relays or model API keys in the stack
 - add Python to the product central/web request path
+- local stack image builds on low-RAM hosts (use GHCR)
 
 See [docs/agent/index.md](docs/agent/index.md) for external-agent architecture.
 

--- a/edge/src/fdd/registry_api.rs
+++ b/edge/src/fdd/registry_api.rs
@@ -40,6 +40,74 @@ fn alias_ui_param_key<'a>(rule_id: &str, key: &'a str) -> &'a str {
     }
 }
 
+/// Persisted Lab / package params bag for one rule (aliases included).
+fn session_rule_param_bag(rule: &RuleSpec) -> Option<serde_json::Map<String, Value>> {
+    let wrap = crate::fdd::session_config::get_session_config();
+    let params = wrap.get("config")?.get("params")?.as_object()?;
+    let bag = params
+        .get(&rule.rule_id)
+        .or_else(|| rule.aliases.iter().find_map(|a| params.get(a)))?
+        .as_object()?;
+    Some(bag.clone())
+}
+
+/// Effective confirm_seconds after session_config confirm_min / confirm_seconds.
+fn confirm_seconds_from_session_bag(rule: &RuleSpec, bag: &serde_json::Map<String, Value>) -> u32 {
+    let mut confirm = rule.confirm_seconds;
+    if let Some(cm) = bag.get("confirm_min").and_then(|v| v.as_f64()) {
+        confirm = (cm * 60.0).round() as u32;
+    }
+    if let Some(cs) = bag.get("confirm_seconds").and_then(|v| v.as_f64()) {
+        confirm = cs.round() as u32;
+    }
+    confirm
+}
+
+/// True when session bag carries confirm or other numeric overrides for this rule.
+fn session_bag_has_overrides(bag: &serde_json::Map<String, Value>) -> bool {
+    bag.iter().any(|(k, v)| {
+        if k == "_ui" {
+            return false;
+        }
+        v.as_f64().is_some()
+    })
+}
+
+/// Fold session bag numbers into SQL placeholder map (same mapping as /api/fdd/run).
+fn apply_session_bag_to_sql_params(
+    rule: &RuleSpec,
+    bag: &serde_json::Map<String, Value>,
+    params: &mut HashMap<String, String>,
+) {
+    for (key, value) in bag {
+        if key == "confirm_min" || key == "_ui" {
+            continue;
+        }
+        let Some(mut number) = value.as_f64() else {
+            continue;
+        };
+        let mut mapped = alias_ui_param_key(&rule.rule_id, key).to_string();
+        if rule.rule_id == "FC1" && key == "fan_hi" {
+            if bag.get("eps_vfd_spd").and_then(|v| v.as_f64()).is_some() {
+                continue;
+            }
+            mapped = "eps_vfd_spd".into();
+            number = (1.0 - number).clamp(0.0, 1.0);
+        }
+        if let Some(def) = rule.parameters.get(&mapped) {
+            params.insert(def.sql_placeholder.clone(), number.to_string());
+        } else if let Some(def) = rule.parameters.get(key) {
+            params.insert(def.sql_placeholder.clone(), number.to_string());
+        } else if let Some((_, def)) = rule
+            .parameters
+            .iter()
+            .find(|(_, def)| def.sql_placeholder == *key || def.sql_placeholder == mapped)
+        {
+            params.insert(def.sql_placeholder.clone(), number.to_string());
+        }
+    }
+}
+
 fn parquet_root() -> PathBuf {
     if let Ok(p) = std::env::var("OPENFDD_PARQUET_ROOT") {
         return PathBuf::from(p);
@@ -490,8 +558,18 @@ pub fn series_response(equipment_id: &str, rule_id: &str, building_id: Option<&s
                 // Registry JSON is equipment-level fault_hours only — when that
                 // index is empty, re-run the rule SQL rewritten to a per-timestamp
                 // confirmed series and join onto history rows.
-                let mut fault_by_ts =
-                    load_confirmed_fault_index(equipment_id, &rule.rule_id, building_id);
+                // When Lab session_config has overrides (e.g. confirm_min), always
+                // recompute sql_detail with those params so Plots match Update rule.
+                let session_bag = session_rule_param_bag(rule);
+                let prefer_session_detail = session_bag
+                    .as_ref()
+                    .map(session_bag_has_overrides)
+                    .unwrap_or(false);
+                let mut fault_by_ts = if prefer_session_detail {
+                    HashMap::new()
+                } else {
+                    load_confirmed_fault_index(equipment_id, &rule.rule_id, building_id)
+                };
                 let mut overlay_source = if fault_by_ts.is_empty() {
                     "none"
                 } else {
@@ -505,12 +583,17 @@ pub fn series_response(equipment_id: &str, rule_id: &str, building_id: Option<&s
                         equipment_id,
                         &root,
                         &history_columns,
+                        session_bag.as_ref(),
                     )
                     .await
                     {
                         fault_by_ts = detail;
                         if !fault_by_ts.is_empty() {
-                            overlay_source = "sql_detail";
+                            overlay_source = if prefer_session_detail {
+                                "sql_detail_session"
+                            } else {
+                                "sql_detail"
+                            };
                         }
                     }
                 }
@@ -731,12 +814,16 @@ async fn compute_confirmed_fault_series(
     equipment_id: &str,
     parquet_root: &Path,
     history_columns: &std::collections::HashSet<String>,
+    session_bag: Option<&serde_json::Map<String, Value>>,
 ) -> Option<HashMap<String, bool>> {
     let sql_path = Path::new(&reg.rules_dir).join(&rule.sql_file);
     let raw_sql = std::fs::read_to_string(&sql_path).ok()?;
     let detail = rewrite_rule_sql_to_fault_series(&raw_sql, equipment_id)?;
     let poll = read_poll_from_cache(parquet_root).unwrap_or(300.0);
-    let mut params = rule_params(poll, rule.confirm_seconds);
+    let confirm = session_bag
+        .map(|bag| confirm_seconds_from_session_bag(rule, bag))
+        .unwrap_or(rule.confirm_seconds);
+    let mut params = rule_params(poll, confirm);
     if let Ok(tuning) = load_tuning_profiles(Path::new(&reg.rules_dir)) {
         if let Ok(tuned) = effective_param_strings(rule, &tuning, None, None, None) {
             for (k, v) in tuned {
@@ -747,9 +834,18 @@ async fn compute_confirmed_fault_series(
             }
         }
     }
-    let confirm_params = rule_params(poll, rule.confirm_seconds);
+    // Catalog confirm defaults must not wipe session confirm_min.
+    let confirm_params = rule_params(poll, confirm);
     for (k, v) in confirm_params {
         params.insert(k, v);
+    }
+    if let Some(bag) = session_bag {
+        apply_session_bag_to_sql_params(rule, bag, &mut params);
+        // Re-assert confirm after bag fold (confirm_seconds key may also be present).
+        let confirm_params = rule_params(poll, confirm);
+        for (k, v) in confirm_params {
+            params.insert(k, v);
+        }
     }
     let mut sql = substitute_sql(&detail, &params);
     sql = sql_with_optional_null_roles_series(&sql, &rule.optional_roles, history_columns);

--- a/frontend/web/src/components/OverviewPopulated.test.tsx
+++ b/frontend/web/src/components/OverviewPopulated.test.tsx
@@ -237,9 +237,12 @@ describe("OverviewPopulated metric isolation", () => {
     await waitFor(() => {
       expect(screen.getByTestId("overview-charts-ready")).toBeTruthy();
     });
-    fireEvent.click(
-      screen.getByTestId("overview-econ-overlay-exp").querySelector("button")!,
-    );
+    // Plot expanders default open; only toggle if still collapsed.
+    const overlayExp = screen.getByTestId("overview-econ-overlay-exp");
+    const trigger = overlayExp.querySelector("button");
+    if (trigger?.getAttribute("aria-expanded") !== "true") {
+      fireEvent.click(trigger!);
+    }
     const overlay = screen
       .getByTestId("overview-econ-overlay-eq")
       .querySelector("select");

--- a/frontend/web/src/components/OverviewPopulated.tsx
+++ b/frontend/web/src/components/OverviewPopulated.tsx
@@ -162,13 +162,14 @@ export function OverviewPopulated({
   const [week, setWeek] = useState(() => loadStoredSchedule().week);
   const [tz, setTz] = useState(() => loadStoredSchedule().tz);
   const [schedOpen, setSchedOpen] = useState(true);
-  const [motorTableOpen, setMotorTableOpen] = useState(false);
-  const [mechBinsOpen, setMechBinsOpen] = useState(false);
-  const [mechCoverageOpen, setMechCoverageOpen] = useState(false);
-  const [econMetricsOpen, setEconMetricsOpen] = useState(false);
-  const [basHistOpen, setBasHistOpen] = useState(false);
-  const [econOverlayOpen, setEconOverlayOpen] = useState(false);
-  const [econSkippedOpen, setEconSkippedOpen] = useState(false);
+  // Plot sections default open so Overview does not hide charts behind carets.
+  const [motorTableOpen, setMotorTableOpen] = useState(true);
+  const [mechBinsOpen, setMechBinsOpen] = useState(true);
+  const [mechCoverageOpen, setMechCoverageOpen] = useState(true);
+  const [econMetricsOpen, setEconMetricsOpen] = useState(true);
+  const [basHistOpen, setBasHistOpen] = useState(true);
+  const [econOverlayOpen, setEconOverlayOpen] = useState(true);
+  const [econSkippedOpen, setEconSkippedOpen] = useState(true);
   const [econOverlayEq, setEconOverlayEq] = useState("");
   const [scheduleBusy, setScheduleBusy] = useState(false);
   const [scheduleNote, setScheduleNote] = useState<string | null>(null);

--- a/frontend/web/src/pages/ReportsPage.tsx
+++ b/frontend/web/src/pages/ReportsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AppShell } from "../components/AppShell";
 import { LockedSiteCaption } from "../components/LockedSiteCaption";
+import { RULES_UPDATED_EVENT } from "../components/RuleTuningPanel";
 import {
   Button,
   DataTable,
@@ -306,6 +307,21 @@ export function ReportsPage() {
   useEffect(() => {
     if (!buildingId || !equipmentId || !ruleId) return;
     void loadSeries();
+  }, [buildingId, equipmentId, ruleId, loadSeries]);
+
+  // After Lab "Update this rule" / Overview run-all, refresh results + fault overlay.
+  useEffect(() => {
+    const onRules = () => {
+      if (!buildingId) return;
+      void getFddResults(buildingId)
+        .then((rows) => setResults(rows))
+        .catch(() => undefined);
+      if (equipmentId && ruleId) {
+        void loadSeries();
+      }
+    };
+    window.addEventListener(RULES_UPDATED_EVENT, onRules);
+    return () => window.removeEventListener(RULES_UPDATED_EVENT, onRules);
   }, [buildingId, equipmentId, ruleId, loadSeries]);
 
   const loadSensorHealth = useCallback(async () => {

--- a/open_fdd/rules/cookbook_catalog.py
+++ b/open_fdd/rules/cookbook_catalog.py
@@ -1213,10 +1213,23 @@ def trim4(d, p, poll):
 
 
 def sched1(d, p, poll):
-    """Unoccupied fan runtime; optional zone comfort band when zone_t is mapped."""
+    """Unoccupied fan runtime; optional zone comfort band when zone_t is mapped.
+
+    Portable occupancy: literal ``unoccupied`` (case-insensitive) **or** numeric /
+    boolean falsey values (``0``, ``0.0``, ``False``). String ``"1"`` / occupied
+    labels are treated as occupied.
+    """
     if "occupied" not in d or "fan-status" not in d:
         return _false(d.index)
-    base = (d["occupied"].astype(str).str.lower() == "unoccupied") & as_bool(d["fan-status"])
+    occ_raw = d["occupied"]
+    occ_str = occ_raw.astype(str).str.strip().str.lower()
+    label_unocc = occ_str.isin(
+        {"unoccupied", "unocc", "off", "false", "night", "standby", "setback", "no"}
+    )
+    occ_num = pd.to_numeric(occ_raw, errors="coerce")
+    numeric_unocc = occ_num.notna() & (occ_num <= 0.05)
+    unoccupied = label_unocc | numeric_unocc
+    base = unoccupied & as_bool(d["fan-status"])
     if "zone-air-temp" not in d.columns or d["zone-air-temp"].notna().sum() == 0:
         return base
     lo = _f(p, "comfort_low_f", 70.0)

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -66,6 +66,10 @@ retest. Do not confuse those with this engineering OS.
 23. **RCx catalog freeze:** every `REQUIRED_RCX_PRESET_IDS` id must stay listed. Family picker order is `RCX_FAMILY_ORDER` (Zones first) plus empty Heat pump / Weather placeholders. Auto-run the selected preset when site+preset are set.
 24. **Actions housekeeping:** default `GET /api/actions?limit=10`; `DELETE /api/actions/:id` and `DELETE /api/actions`; JSONL prune cap 50.
 25. **Section radios:** left, horizontal, **after** hero + Equipment on Overview (never inside `.oracle-hero`, never centered in the logo column). Other pages: same left radio row at the top of the page body.
+26. **Overview plot Expanders** default **open** — do not hide motor / mech / econ / BAS plot sections behind carets (`Expander` unmounts children when closed).
+27. **FDD Plots series overlay** honors Lab/`session_config` `confirm_min` (and typed rule params); source may be `sql_detail_session`. After Update-this-rule, listen for `RULES_UPDATED` and refetch results + series.
+28. **SCHED-1 portable occupancy:** numeric/boolean falsey (`0`, `0.0`, `false`) **and** string `unoccupied` (plus related tokens) — keep SQL (`sched1_unoccupied_runtime.sql`) and pandas `sched1` aligned.
+29. **Low-RAM / bensbench:** never local stack `docker build`; prune old images before pull; wait for GHCR publish then pull `sha-*` / `nightly`. Synthetic-59 soaks use `scripts/synthetic_59_*.py`; B100 dump-parity stays paused; never edit goldens to hide misses.
 
 ---
 

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -69,6 +69,26 @@ curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
 Day-to-day convenience may set `OPENFDD_IMAGE_TAG=nightly`, but qualification
 and post-merge verification must use `sha-*`.
 
+### Low-RAM hosts (bensbench)
+
+Do **not** `docker build` stack images or run full local Rust compiles for
+central/web — OOM risk. Ship code via PR → GH Actions →
+`Publish Open-FDD stack to GHCR`, then refresh the host:
+
+```bash
+# 1) free disk / drop unused digests before pull
+docker image prune -f
+docker images 'ghcr.io/bbartling/openfdd-*' --format '{{.Repository}}:{{.Tag}} {{.ID}}' | head
+
+# 2) pull + up (no rebuild)
+./scripts/openfdd_stack_pull.sh react   # or react-ot
+./scripts/openfdd_stack_up.sh react --no-pull
+curl -fsS http://127.0.0.1:8080/api/health
+```
+
+Confirm `/api/health` (or UI generation) reflects the new `+sha`, and that Lab
+params such as FC1 `confirm_min` match the merged tip.
+
 ### Offline WattLab export (not product)
 
 `tools/wattlab_export` is optional PyPI/offline tooling. Product central does

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,12 @@
 # Session log
 
+## 2026-08-12 — Overview expanders, session confirm overlay, SCHED-1 occupancy
+
+- Overview plot Expanders default open (`OverviewPopulated`) so charts are not caret-hidden.
+- FDD series overlay applies `session_config` `confirm_min`/params (`sql_detail_session`); Reports listens for `RULES_UPDATED`.
+- SCHED-1 SQL + pandas `sched1`: portable occupancy (numeric 0/false + unoccupied tokens).
+- Agent docs: root `AGENTS.md`, `CONTAINER_AGENT.md`, react/sql/ghcr skills — low-RAM GHCR-only refresh; synthetic-59 soak scripts; dump-parity paused.
+
 ## 2026-08-11 — open-fdd 4.3.0 library program
 
 - Independent version API (`open_fdd.version.manifest`), effective catalog hashes, capability extras (`oracle` / `analytics` / `reporting`). `vibe19` extra deprecated until 5.0.

--- a/openfdd_agent_spec/skills/openfdd-react-spa/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-react-spa/SKILL.md
@@ -23,6 +23,10 @@ description: >-
 4. No bench secrets, credential paths, or privileged username prefill on login.
 5. Prefer Vitest unit tests next to changed modules; Playwright for smoke when needed.
 6. Do not add Python to the product SPA or depend on `open_fdd` at runtime.
+7. Overview plot Expanders default **open** — `Expander` unmounts when closed;
+   do not ship plot sections collapsed behind a caret.
+8. After Lab **Update this rule** (`RULES_UPDATED`), FDD Plots / Reports must
+   refetch results + series so `confirm_min` session overlays show up.
 
 ## Key files
 

--- a/openfdd_agent_spec/skills/openfdd-sql-fdd/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-sql-fdd/SKILL.md
@@ -19,3 +19,9 @@ description: >-
 2. New production rules need SQL file + registry + cookbook + parity row.
 3. Pandas oracle may differ — document in parity/gap matrices; do not paper over.
 4. UI production path calls central REST — not local pandas runner for “real” FDD.
+5. Series overlay (`/api/fdd/.../series`) must honor Lab/`session_config`
+   `confirm_min` and typed params the same way `/api/fdd/run` does (prefer
+   session-tuned detail over a stale empty results index when overrides exist).
+6. **SCHED-1:** portable occupancy — numeric/`false` unoccupied **and** string
+   `unoccupied` tokens; keep `sql_rules/sched1_unoccupied_runtime.sql` aligned
+   with pandas `sched1` in `open_fdd/rules/cookbook_catalog.py`.

--- a/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
@@ -23,5 +23,9 @@ Never paste a Caddy login until `./scripts/openfdd_demo_gate.sh` exits 0.
 
 Product central image is Rust/debian only (no Python).
 
+**Low-RAM hosts:** never local `docker build` for stack images. Prune unused
+images before pull; wait for GH Actions publish; then pull +
+`openfdd_stack_up.sh … --no-pull`. See [`CONTAINER_AGENT.md`](../../CONTAINER_AGENT.md).
+
 Workflow: `ghcr-openfdd-stack.yml` (retargets nightly on master).
 MCP: separate `rust-ghcr-mcp.yml`.

--- a/scripts/cookbook_parity_check.py
+++ b/scripts/cookbook_parity_check.py
@@ -63,6 +63,8 @@ def rule_reset1(df):
 
 
 def rule_sched1(df):
+    import pandas as pd
+
     occ = df["occ_mode"]
     occ_str = occ.astype(str).str.strip().str.lower()
     label = occ_str.isin(

--- a/scripts/cookbook_parity_check.py
+++ b/scripts/cookbook_parity_check.py
@@ -63,7 +63,14 @@ def rule_reset1(df):
 
 
 def rule_sched1(df):
-    return df["occ_mode"].eq("unoccupied") & df["fan_status"].astype(bool)
+    occ = df["occ_mode"]
+    occ_str = occ.astype(str).str.strip().str.lower()
+    label = occ_str.isin(
+        {"unoccupied", "unocc", "off", "false", "night", "standby", "setback", "no"}
+    )
+    num = pd.to_numeric(occ, errors="coerce")
+    numeric = num.notna() & (num <= 0.05)
+    return (label | numeric) & df["fan_status"].astype(bool)
 
 
 def rule_fc1(df):

--- a/sql_rules/sched1_unoccupied_runtime.sql
+++ b/sql_rules/sched1_unoccupied_runtime.sql
@@ -3,13 +3,22 @@
 -- (zone already satisfied → optimal-start / bad schedule signal).
 -- When zone_t is absent from history, the runner injects NULL zone_t (optional role)
 -- so behavior matches pandas “no zone → base only”.
+-- Portable occupancy: literal 'unoccupied' OR numeric/boolean falsey (0 / 0.0 / false).
 WITH base AS (
   SELECT
     equipment_id,
     timestamp_utc,
         CAST(CASE
           WHEN occ_mode IS NULL OR fan_status IS NULL THEN 0
-          WHEN LOWER(occ_mode) = 'unoccupied' AND fan_status > 0.5
+          WHEN fan_status > 0.5
+            AND (
+              LOWER(trim(CAST(occ_mode AS VARCHAR))) IN
+                ('unoccupied','unocc','off','false','night','standby','setback','no')
+              OR (
+                try_cast(trim(CAST(occ_mode AS VARCHAR)) AS DOUBLE) IS NOT NULL
+                AND try_cast(trim(CAST(occ_mode AS VARCHAR)) AS DOUBLE) <= 0.05
+              )
+            )
             AND (
               zone_t IS NULL
               OR (zone_t >= {{ZONE_T_LO}} AND zone_t <= {{ZONE_T_HI}})


### PR DESCRIPTION
## Summary
- Overview plot Expanders default **open** so charts are not caret-hidden.
- FDD Plots series overlay honors Lab/`session_config` `confirm_min` (and rule params); Reports refetches on `RULES_UPDATED`.
- SCHED-1 SQL + pandas: portable occupancy (numeric `0`/`false` + `unoccupied` tokens).
- Agent docs (`AGENTS.md`, `CONTAINER_AGENT`, react/sql/ghcr skills) updated for the above and low-RAM GHCR-only refresh.

## Test plan
- [ ] Overview: motor / mech / econ plot sections visible without expanding carets
- [ ] FC1: set `confirm_min` to 60 → Update this rule → FDD Plots fault lane shrinks vs confirm_min 0
- [ ] CI green (web vitest + rustfmt); no local docker build
- [ ] After merge + GHCR publish: prune old images, pull nightly/`sha-*`, stack up `--no-pull`
- [ ] Re-soak synthetic-59; SCHED-1 expected to improve on OpenFDD SQL


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - FDD reports and plots now reflect session-specific rule settings, including confirmation delays and parameter overrides.
  - Reports automatically refresh when rule settings change.
  - Overview plot sections open by default for easier access.

- **Bug Fixes**
  - Improved SCHED-1 detection for unoccupied states, including common text labels, numeric values, and falsey values.
  - Preserved fan-runtime, comfort-band, and confirmation behavior across supported rule evaluation paths.

- **Documentation**
  - Added guidance for low-memory environments, image refresh workflows, agent behavior, and validation procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->