### PR TITLE
Fix GHCR compose config: optional admin password env

### DIFF
--- a/docker/compose.react.yml
+++ b/docker/compose.react.yml
@@ -38,7 +38,7 @@ services:
       # Product recipe: require a deployment-unique secret (no public default).
       # Compose config fails loudly if unset — set in host .env / CI.
       OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:?Set a unique OPENFDD_JWT_SECRET}
-      OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:?Set OPENFDD_ADMIN_PASSWORD}
+      OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-}
       OPENFDD_REACT_UI: "1"
       # P2-M4: React is the production default UI generation.
       OPENFDD_UI_GENERATION_DEFAULT: react


### PR DESCRIPTION
## Summary
- Restore optional `OPENFDD_ADMIN_PASSWORD` interpolation in `compose.react.yml` so GHCR publish compose-config matches JWT-only CI env.
- Runtime fail-closed policy in central is unchanged.

## Test plan
- [ ] GHCR stack publish compose-config job green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker Compose configurations now work when the admin password is not provided, using an empty default value instead of failing during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->