### PR TITLE
VAV Health FDD join + open-fdd 4.4.0

### DIFF
--- a/.github/workflows/publish-open-fdd.yml
+++ b/.github/workflows/publish-open-fdd.yml
@@ -85,9 +85,13 @@ jobs:
           import open_fdd
           from open_fdd.ecm_engineering import ECMJob
           from open_fdd.rules import CANONICAL_RULE_COUNT, RULES_BY_ID
-          assert open_fdd.__version__ == version("open-fdd") == "4.3.0"
+          assert open_fdd.__version__ == version("open-fdd") == "4.4.0"
           assert CANONICAL_RULE_COUNT == 62
           assert "SCHED-1" in RULES_BY_ID
+          assert "VAV-2" in RULES_BY_ID
+          from open_fdd.analytics.vav_health import vav_health_matrix, SCHEMA_VERSION
+          assert SCHEMA_VERSION == "vav_health_matrix_v1"
+          assert callable(vav_health_matrix)
           out = Path(tempfile.mkdtemp()) / "smoke.xlsx"
           path = (
               ECMJob("CI Smoke", path=out)

--- a/docs/rules/cookbook/datafusion-sql-cookbook.md
+++ b/docs/rules/cookbook/datafusion-sql-cookbook.md
@@ -10,7 +10,7 @@ Open-FDD executes production fault detection as **DataFusion SQL** against Apach
 
 **Pandas mirror:** the [Pandas cookbook](pandas-cookbook.html) documents the **62**-rule PyPI oracle (`open_fdd.rules`). Do **not** treat “62” as the production registry size. See [parity matrix](parity-matrix.html) and the [generated parity report](generated-parity-report.html).
 
-**Updated:** 2026-08-11 · PyPI `open-fdd` 4.3.0
+**Updated:** 2026-08-14 · PyPI `open-fdd` 4.4.0
 
 ---
 

--- a/docs/rules/cookbook/pandas-cookbook.md
+++ b/docs/rules/cookbook/pandas-cookbook.md
@@ -12,7 +12,7 @@ This cookbook is **intentionally maintained**. Production Open-FDD FDD math runs
 
 See also the [DataFusion SQL cookbook](datafusion-sql-cookbook.html), [parity matrix](parity-matrix.html), [generated parity report](generated-parity-report.html), and [P0 rule catalog](p0-rule-catalog.html).
 
-**Updated:** 2026-08-11 · PyPI `open-fdd` 4.3.0 (`open_fdd.rules`)
+**Updated:** 2026-08-14 · PyPI `open-fdd` 4.4.0 (`open_fdd.rules`)
 
 
 ---

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,7 +9,7 @@ Production FDD runs as DataFusion SQL in the GHCR container stack.
 from open_fdd.ecm_engineering import ECMJob
 from open_fdd.compat import maybe_warn_vibe19_from_env
 
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 
 maybe_warn_vibe19_from_env()
 

--- a/openfdd_agent_spec/docs/VERSIONING.md
+++ b/openfdd_agent_spec/docs/VERSIONING.md
@@ -5,7 +5,7 @@ Distinguish these axes — do not collapse them into one “Open-FDD version” 
 | Axis | Where it lives today | Notes |
 | --- | --- | --- |
 | Platform / Rust workspace | Root `Cargo.toml` `version` | Stack image semver tags |
-| Python package | `open_fdd/__init__.py` / `pyproject.toml` | PyPI `open-fdd` **4.3.0** — `open_fdd.version.manifest()` |
+| Python package | `open_fdd/__init__.py` / `pyproject.toml` | PyPI `open-fdd` **4.4.0** — `open_fdd.version.manifest()` |
 | SQL rule registry | `sql_rules/registry.yaml` (+ file tree) | Prefer content hash in future manifest |
 | Pandas cookbook / oracle | Docs + `open_fdd.rules` | Tied to package version when shipped |
 | WattLab dump schema | vibe19 package / export code | v2/v3 compatibility matrix |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "4.3.0"
+version = "4.4.0"
 description = "Open-FDD libraries: ECM engineering workbooks plus pandas oracle rules, analytics, and Engineering Findings reporting. Production FDD remains the DataFusion/GHCR stack."
 readme = "docs/ecm/README.md"
 license = { text = "MIT" }

--- a/services/central/src/analytics/vav_health.rs
+++ b/services/central/src/analytics/vav_health.rs
@@ -1,5 +1,7 @@
 //! Building-scoped VAV health matrix (vav_health_matrix_v1). No Python.
 
+use std::collections::HashMap;
+
 use anyhow::Result;
 use datafusion::prelude::SessionContext;
 use fdd_sql::run_sql;
@@ -36,6 +38,69 @@ pub async fn handle_async(req: &AnalyticsRequest) -> AnalyticsEnvelope {
 
 pub const QV_VAV_HEALTH: &str = "vav-health-v1";
 pub const SCHEMA_VAV_HEALTH: &str = "vav_health_matrix_v1";
+
+/// Same default IDs as `open_fdd.analytics.vav_health.DEFAULT_BROKEN_RULES`.
+const BROKEN_RULE_IDS: &[&str] = &[
+    "VAV-3",
+    "VAV-4",
+    "VAV-5",
+    "VAV-7",
+    "VAV-REHEAT",
+    "VAV-AHU-LEAVE",
+];
+
+/// Per-equipment broken-box from the last registry run. Empty map + `false`
+/// when no result JSON exists (unknown, not PASS).
+fn broken_box_from_fdd(building_id: &str) -> (bool, HashMap<String, (bool, String, f64)>) {
+    let body = open_fdd_edge_prototype::fdd::registry_api::results_response(Some(building_id));
+    let rows = body
+        .get("results")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if rows.is_empty() {
+        return (false, HashMap::new());
+    }
+    let mut map: HashMap<String, (bool, Vec<String>, f64)> = HashMap::new();
+    for row in rows {
+        let rid = row.get("rule_id").and_then(Value::as_str).unwrap_or("");
+        if !BROKEN_RULE_IDS.contains(&rid) {
+            continue;
+        }
+        let st = row.get("status").and_then(Value::as_str).unwrap_or("");
+        if st.eq_ignore_ascii_case("NOT_APPLICABLE_EQUIPMENT_TYPE") {
+            continue;
+        }
+        let eq = row
+            .get("equipment_id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        if eq.is_empty() {
+            continue;
+        }
+        let hours = row
+            .get("fault_hours")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let fault = st.eq_ignore_ascii_case("FAULT") || hours > 0.0;
+        let e = map.entry(eq).or_insert_with(|| (false, Vec::new(), 0.0));
+        e.2 += hours;
+        if fault {
+            e.0 = true;
+            e.1.push(rid.to_string());
+        }
+    }
+    let out = map
+        .into_iter()
+        .map(|(k, (fault, mut ids, hours))| {
+            ids.sort();
+            ids.dedup();
+            (k, (fault, ids.join(";"), hours))
+        })
+        .collect();
+    (true, out)
+}
 
 pub async fn vav_health_from_history(
     building_id: Option<&str>,
@@ -121,6 +186,7 @@ ORDER BY equipment_id
     let mut n1 = 0u32;
     let mut n0 = 0u32;
     let mut nq = 0u32;
+    let (has_fdd, broken_map) = broken_box_from_fdd(bid);
     for row in result.rows {
         let eq = row
             .get("equipment_id")
@@ -147,12 +213,18 @@ ORDER BY equipment_id
         } else {
             json!(span > 0.0 && (100.0 * open_h / span) >= 95.0)
         };
-        let broken = Value::Null;
+        let (broken, broken_ids, broken_h) = if !has_fdd {
+            (Value::Null, String::new(), 0.0)
+        } else if let Some((fault, ids, hours)) = broken_map.get(eq) {
+            (json!(*fault), ids.clone(), *hours)
+        } else {
+            (json!(false), String::new(), 0.0)
+        };
         let evaluable = [&poor, &rogue, &broken]
             .iter()
             .filter(|v| !v.is_null())
             .count();
-        let hit = [&poor, &rogue]
+        let hit = [&poor, &rogue, &broken]
             .iter()
             .filter(|v| v.as_bool() == Some(true))
             .count();
@@ -183,8 +255,8 @@ ORDER BY equipment_id
             "dimensions_hit": hit,
             "dimensions_evaluable": evaluable,
             "score_label": label,
-            "broken_rule_ids": "",
-            "broken_fault_hours": 0.0,
+            "broken_rule_ids": broken_ids,
+            "broken_fault_hours": broken_h,
             "occupied_comfort_fail_pct": if span > 0.0 { json!(100.0 * fail_h / span) } else { Value::Null },
             "occupied_hours": span,
             "damper_full_open_pct": if span > 0.0 { json!(100.0 * open_h / span) } else { Value::Null },
@@ -194,7 +266,11 @@ ORDER BY equipment_id
             "confidence": if evaluable < 3 { "insufficient" } else { "medium" },
             "engine": DF_ENGINE,
             "schema_version": SCHEMA_VAV_HEALTH,
-            "notes": "broken_box unknown until Run all rules joins FDD results",
+            "notes": if has_fdd {
+                "broken_box from VAV-3/4/5/7/REHEAT/AHU-LEAVE FDD results"
+            } else {
+                "broken_box unknown until Run all rules joins FDD results"
+            },
         }));
     }
     env.coverage = Some(json!({
@@ -208,8 +284,10 @@ ORDER BY equipment_id
         env.warnings
             .push("no VAV% equipment_id rows in historian".into());
     }
-    env.warnings
-        .push("Run all rules to populate broken_box from VAV-3/4/5/7/REHEAT/AHU-LEAVE".into());
+    if !has_fdd {
+        env.warnings
+            .push("Run all rules to populate broken_box from VAV-3/4/5/7/REHEAT/AHU-LEAVE".into());
+    }
     Ok(Some(env))
 }
 


### PR DESCRIPTION
## Summary
- Join last registry FDD results into `POST /api/analytics/vav-health` so `broken_box` is FAULT/PASS instead of always unknown (`?/3`).
- Bump PyPI `open-fdd` to **4.4.0** (Wave 1 rules + `vav_health`); Trusted Publishing still via tag `open-fdd-v4.4.0` after merge.

## Test plan
- [ ] All GHA green on this PR (no merge on local cargo)
- [ ] After GHCR `sha-<7>` pin `--no-pull`, B100 `vav-health` groups are not all `?/3`
- [ ] `workflow_dispatch` Publish open-fdd dry_run=true on this SHA
- [ ] Tag `open-fdd-v4.4.0` after merge (not `v*`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - VAV health scoring now incorporates relevant fault-detection results, including affected rules and fault duration.
  - Health evaluations distinguish unavailable diagnostic data from equipment with no detected faults.
  - Added analytics validation for the VAV health matrix, including schema and usability checks.

- **Documentation**
  - Updated cookbook release information and versioning guidance for the 4.4.0 release.

- **Chores**
  - Updated the package version to 4.4.0 across release metadata and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->