### PR TITLE
WattLab 4.4.0 dump-vs-dump tooling and B100 bugreport reset

### DIFF
--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -1,49 +1,32 @@
-# WattLab-to-WattLab dump parity (Building 100)
+# WattLab-to-WattLab dump parity (Building 100) — 4.4.0 cycle
 
-Oracle is playground Vibe19 Engineering Bundle (`openfdd_engineering_bundle_v1`).
-OpenFDD side is a **DataFusion assembler** (`scripts/wattlab_parity_ofdd_rust_bundle.py`) — not pandas `tools/wattlab_export`.
+Oracle: vibe19 Engineering Bundle (`ghcr.io/bbartling/vibe19:latest`, wheel **4.4.0**).  
+OpenFDD: DataFusion assembler [`scripts/wattlab_parity_ofdd_rust_bundle.py`](../../scripts/wattlab_parity_ofdd_rust_bundle.py) on `sha-9e280ae`.
 
-## Baseline (pre-image, capture `sha-2ce9c21`)
+## Cycle header
 
 | Metric | Value |
 | --- | --- |
-| `diff_matrix.csv` rows | 3803 |
-| **blockers** | **3527** |
-| accepted | 153 |
-| stop_rule_met | false |
+| Date | 2026-08-15 |
+| OpenFDD pin | `sha-9e280ae` health `3.3.0+9e280ae294b0` |
+| Vibe19 | `:latest` == `:develop` digest `sha256:6a4297b9…e6f54d` rev `8ca6a3b` |
+| `diff_matrix.csv` / summary rows | 4233 |
+| **blockers** | **2596** |
+| accepted | 63 |
+| stop_rule_met | **false** |
 
-This is the honest dump-vs-dump stop rule. The prior cycle’s `blocker_count=0` was a sql_screening **rollup**. FAULT∩FAULT hour gaps are blockers again.
+Stop rule remains `blocker_count == 0`. FAULT∩FAULT hour gaps are blockers.
 
-Largest FDD families in the matrix: AHU-DUCTHI / AHU-SATDEV / ECON-* / FC* / SV-FLATLINE / SV-STALE (N/A vs PASS on wrong equipment + hour deltas on AHUs).
+Largest FDD class: vibe19 `NOT_APPLICABLE_EQUIPMENT_TYPE` rows omitted by Rust (750) plus skip-vs-PASS (174+118). Sensor/motor analytic tables add ~1100 numeric blockers (schema/denominator seams, not catalog-count parity).
 
-Accepted only: CHW-1 skip/off, SCHED-247 pressure-not-fault, FC7 concept_only, rust `weather`/`unknown` extra equipment, SQL-only analytics ids vs pandas findings.
+Vibe19 diagnostic dump did **not** emit `vav_health_matrix.csv`; OpenFDD did. That is export lag on vibe19 (Prompt 2), not a 4.3.0 pin — the image already imports 4.4.0 / `vav_health_matrix_v1`.
 
-## Code landed this wave (needs GHCR `:nightly` to soak)
-
-- Per-row `wattlab_parity_diff.py` + `diff_matrix.csv`
-- Rust bundle assembler (same filenames as Vibe19)
-- `equipment_kinds` on registry + `NOT_APPLICABLE_EQUIPMENT_TYPE` in `/api/fdd/results`
-- Ranked `fan_status` > `fan_cmd` on AHU/ECON/FC/OA/DMP/VLV/TRIM-1 SQL
-- FC2 mix_tol no longer cancels (`mat+tol < min(rat,oat)-tol`)
-- CHW-2/3/4 hydronic proof CTE
-- SV-STALE no longer filters fan_cmd (pandas `always`); required_roles empty
-- SV-FLATLINE/RANGE/SPIKE `equipment_energized` (fan → pump → compressor)
-- VAV-1 occupied-only when `occ_mode` present (no fan_cmd required)
-- VAV-3/4/5/7/REHEAT/AHU-LEAVE fan_on + FLOW_ON_MIN
-- CW-OPT/APR/FAN + TRIM-3/4 hydronic proof (missing proof → 0 h)
-- HP-1 compressor/fan ranked proof; FC4/PID fan_status over cmd
-- New APIs: `/api/analytics/setpoints`, `/diurnal`, `/topology`, `/sensor-stats`
-- Vibe19 `topology.csv` now gets `vav_to_ahu` + `parent_ahu`
-
-## After tip image
-
-Pull `ghcr.io/bbartling/openfdd-central:nightly` (no local docker build). Re-run:
+## Commands
 
 ```bash
-python scripts/wattlab_parity_ofdd_rust_bundle.py
-python scripts/wattlab_parity_diff.py
+python3 scripts/wattlab_parity_oracle_dump.py
+OPENFDD_ADMIN_PASSWORD=… python3 scripts/wattlab_parity_ofdd_rust_bundle.py
+python3 scripts/wattlab_parity_diff.py
 ```
 
-Stop rule: `blocker_count == 0`. Promote `parity_status` to `duration_parity` per rule when FAULT∩FAULT hours match ±0.05 h / 0.1%.
-
-Runtime: `open_fdd.__version__ == 4.3.0` (no PyPI bump; SQL ships in the image).
+No local `docker build`. Pin `OPENFDD_IMAGE_TAG=sha-9e280ae`.

--- a/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
@@ -1,88 +1,76 @@
-# WattLab / Vibe19 parity — Building 100 (OpenFDD 4.3.0)
+# WattLab / Vibe19 parity — Building 100 (OpenFDD 4.4.0)
 
-## Current cycle (synthetic 59)
+New dump-vs-dump cycle 2026-08-15. Oracle is GHCR vibe19 `docker exec scripts/agent_afdd.py` (not `tools/wattlab_export`). OpenFDD is DataFusion JWT APIs (`wattlab_parity_ofdd_rust_bundle.py`).
 
-**Live working copy for this cycle:** [`reports/wattlab-parity/BUGREPORT_WATTLAB_VIBE19_PARITY.md`](../../reports/wattlab-parity/BUGREPORT_WATTLAB_VIBE19_PARITY.md) — primary fixture is the **synthetic 59-rule** golden soak (Vibe19 **58/59**, OpenFDD SQL **42/59**, shared `confirm_min=0` tuning). **B100 dump-parity soak remains paused**; see [`BUGREPORT_WATTLAB_DUMP_PARITY.md`](BUGREPORT_WATTLAB_DUMP_PARITY.md) for the historical dump matrix only.
+Working copy: `reports/wattlab-parity/` (gitignored artifacts).
 
-The narrative below is the earlier Building 100 / engineering-bundle context and is retained for reference.
+## Cycle header
 
----
-
-Oracle is **playground Vibe19** (`py-bacnet-stacks-playground/vibe_code_apps_19`) + live `open-fdd` 4.3.x (PR `#707`), **not** `tools/wattlab_export` and **not** `--skip-rules`.
-
-A working copy also lives at `reports/wattlab-parity/BUGREPORT_WATTLAB_VIBE19_PARITY.md` (gitignored `/reports/`).
-
-## Versions
-
-| Side | Version / SHA |
+| Side | Value |
 | --- | --- |
-| OpenFDD Python | **4.3.0** (not 3.0.1 / 4.2.0) |
-| Python git | `0bb85fe` (occupied strings + hydronic ungate + lean `apply_normalized`) |
-| PyPI 4.3.0 wheel catalog hash | `097eeda2282a17e785e70f1e9f941c554a8eeeb294ae581746d4d3c21b2e6072` |
-| Live catalog hash (repo tree, `sql_rules/` visible) | `5acedd0ddc0bd91e0307539c4f029683197c995fdabb111412b760e74568d274` |
-| Vibe19 app | playground PR `#86` |
-| Rust central image | `ghcr.io/bbartling/openfdd-central:sha-2ce9c21` → health `3.3.0+2ce9c212a8b4` |
-| Bundle schema | `openfdd_engineering_bundle_v1` (`legacy_schema_version`: `wattlab_dump_v3`) |
+| Date | 2026-08-15 |
+| OpenFDD git | `9e280ae` |
+| OpenFDD image | `ghcr.io/bbartling/openfdd-*:sha-9e280ae` |
+| Central health | `3.3.0+9e280ae294b0` |
+| `/api/fdd/rules` | **66** (62 pandas + 4 SQL analytics) |
+| PyPI / vibe19 wheel | **4.4.0** catalog hash `2e684dbb8f3188f06942c3cb0155aef4149713e7244b9f7733262f182465cba9` |
+| Vibe19 image | `:latest` == `:develop` digest `sha256:6a4297b9d461befdba19891a087e6a4ef26af345aff0e5b1274756f528e6f54d` rev `8ca6a3b` |
 | Package | `/home/ben/raw_BUILDING_100_openfdd.zip` sha256 `5a8d9ff2…` |
-| Gate 0 schedule | `fixtures/schedule_b100_7to5.json` (America/Chicago, 07:00–17:00 M–F) |
+| Gate 0 | PUT kept `occupancy_schedule` (no disk restore) |
+| Mech cooling | `web_oa_t` peak **70–75 / 204.58 h**, total **1156.5** |
+| VAV Health (OpenFDD after FDD) | `1/3`: 22, `2/3`: 19, `?/3`: 2 (not all unknown) |
+| `diff_summary.json` | **2596 blockers**, 63 accepted, 4233 rows, `stop_rule_met=false` |
 
-Wheel vs repo catalog hashes differ because `effective_catalog()` reads `sql_rules/registry.yaml` next to the repo root; a site-packages install does not ship that file. Both hashes are accepted by the Vibe19 pin.
+VAV Health is an analytic, not a 63rd diagnostic.
 
-## Before / after
+## Measured blockers (honest)
 
-| | Previous oracle | This run |
+Primary families from `diff_matrix.csv` (`severity=blocker`):
+
+| Artifact | Blockers | Notes |
 | --- | --- | --- |
-| Oracle tree | `tools/wattlab_export` | playground `vibe_code_apps_19` |
-| Rules | `--skip-rules` | `--run-all` → **2832** rows (48 × 59) |
-| Schema | `wattlab_dump_v3` | `openfdd_engineering_bundle_v1` + legacy v3 |
-| Zip | (skip-rules dump) | **7.7 MiB** (`vibe19_oracle_summary.zip`) |
-| Timing | n/a (no rules) | rules **104.1 s** / analytics **9.2 s** / serialization **540.3 s** / zip **2.8 s** |
-| Rust | `3.3.0+a2cca15` (1818 cached rows) | pulled `sha-2ce9c21`, `POST /api/fdd/run`, 1817 rows |
-| Diff stop rule | met only because findings were deferred | **`blocker_count=0`** with rules on |
+| `fdd_findings` | 1429 | See pairs below |
+| sensor_* tables | ~1037 | hour/row schema seams vs pandas dump |
+| `motor_weekly` / `motor_hours` | 83 | |
+| RCx / schedule inference | 47 | |
 
-Serialization is still the long pole (shared telemetry + parquet + findings). Quality no longer triples frames; Building 100 fits in ~2.3 GiB RSS on an 8 GiB host (previous apply_normalized insert loop was OOM-killed).
+FDD status pairs (oracle → OpenFDD):
 
-## Status counts (pandas oracle)
+| vibe19 | ofdd | n |
+| --- | --- | --- |
+| `NOT_APPLICABLE_EQUIPMENT_TYPE` | *(row omitted)* | 750 |
+| `SKIPPED_EQUIPMENT_OFF` | `PASS` | 174 |
+| `SKIPPED_MISSING_ROLES` | `PASS` | 118 |
+| `SKIPPED_MISSING_ROLES` | omitted | 112 |
+| `FAULT` ∩ `FAULT` hour gap | | 97 |
+| `FAULT` vs `PASS` | | 66 |
+| `PASS` vs `FAULT` | | 51 |
+| skip vs `FAULT` | | 56 |
 
-| Status | Count |
-| --- | ---: |
-| NOT_APPLICABLE_EQUIPMENT_TYPE | 2108 |
-| SKIPPED_EQUIPMENT_OFF | 210 |
-| FAULT | 191 |
-| SKIPPED_MISSING_ROLES | 180 |
-| PASS | 143 |
-| **Total** | **2832** |
+SQL omitted N/A rows (863) is the largest FDD class: vibe19 emits N/A per equipment; Rust omits the row. Product follow-on: emit `NOT_APPLICABLE_EQUIPMENT_TYPE` for every (rule, equipment) in the vibe19 universe **or** drop N/A from the oracle dump before compare.
 
-Rust DataFusion: 1627 PASS / 168 FAULT / 22 SKIPPED_MISSING_ROLES (no N/A cartesian; extra SQL analytics ids).
+FAULT∩FAULT hour deltas remain **blockers** (not accepted). Highest-count rules in the FDD blocker set include AHU-SIMUL, CHW-2/3/4, CW-*, ECON-3/5/7, FC5/6/7, OAT-METEO, SV-RATE (48 equipment each — mostly N/A omit).
 
-## Intentional calculation changes (accepted, not blockers)
+## Accepted / consumer lag
 
-- **CHW-1**: missing hydronic proof → `SKIPPED_MISSING_ROLES`; zeros → `SKIPPED_EQUIPMENT_OFF`. SQL often omits the row or reports 0 h.
-- **SCHED-247**: pressure is inferred runtime only; pandas PASS vs SQL FAULT on AHU duct static is 4.3.0 pressure-not-fault.
-- **Occupied / unoccupied strings**: quality no longer marks them `NON_NUMERIC` (fixes SCHED-1 skip).
-- **Hydronic missing proof**: `equipment_energized` continues instead of treating `missing_proof` as off (SV-RANGE / RCx on plants).
-- **`parent_ahu`**: parser recognizes the Building 100 header; AHU_* is never mapped to tower `100`. Observed topology rows without a VAV folder are not `stale_map_ids`.
-- **SQL `sql_screening`**: inventory is not at `mask_parity`. SQL runs all equipment types, lacks pandas skip/off gates, and uses `FC13-SAT-HIGH` as the FC13 alias. Rollup in `diff_summary.json` (`sql_screening_rollup`).
+- `vav_health_matrix.csv` missing from vibe19 **diagnostic** dump even though the image wheel is **4.4.0** and `open_fdd.analytics.vav_health` imports. OpenFDD bundle wrote the matrix. Prompt 2 (Streamlit/WattLab export) still needed on the vibe19 repo — not an OpenFDD SQL bug.
+- Rust extra `weather`/`unknown` equipment vs pandas 48-equip universe.
+- Bundle `topology.csv` empty (`missing_table:topology.csv`) — assembler gap, filed as missing_apis on capture.
+- Oracle quality flags / setpoints calendar medians without a matching Rust route (pre-existing product gaps).
 
-## Remaining OpenFDD work (not blockers this wave)
+## Not done this cycle
 
-Numeric DataFusion hours still diverge on applicable FAULT∩FAULT pairs (AHU-DUCTHI, AHU-SATDEV, ECON-*, FC*) — confirm windows / fan gates. Next wave should promote selected rules from `sql_screening` → `mask_parity` in SQL, not by weakening Vibe19.
+- No greenwash of `expected_faults.csv`.
+- No FC7 parity promotion (needs executable fixtures, not this B100 matrix).
+- No Windows Prompt 2 edits.
 
-No PyPI **4.3.1** bump: pandas API is compatible; occupied-string + lean normalize ship in git/`master` after merge. Image SQL-only changes can ship without a wheel.
+## Commands used
 
-## Bundle / React / Rust readers
-
-Accept **either**:
-
-- `schema_version == openfdd_engineering_bundle_v1`, or
-- `legacy_schema_version == wattlab_dump_v3` / `schema_version == wattlab_dump_v3`
-
-New writes use `README.md` (still emit `README_WATTLAB.md` alias). `calibration_readiness.json` labels fuel + local TZ + geometry missing — do not treat `model_seed.json` as a calibrated EnergyPlus model.
-
-## Runtime confirmation
-
+```bash
+docker pull ghcr.io/bbartling/openfdd-central:sha-9e280ae  # + web/mqtt/fieldbus
+docker pull ghcr.io/bbartling/vibe19:latest
+./scripts/openfdd_stack_up.sh react-ot --no-pull
+python3 scripts/wattlab_parity_oracle_dump.py
+OPENFDD_ADMIN_PASSWORD=… python3 scripts/wattlab_parity_ofdd_rust_bundle.py
+python3 scripts/wattlab_parity_diff.py
 ```
-open_fdd.__version__ == 4.3.0
-```
-
-Host 3.0.1 and Vibe19 `.venv` 4.2.0 are refused by `app.openfdd_runtime.require_supported_open_fdd()`.

--- a/scripts/wattlab_parity_diff.py
+++ b/scripts/wattlab_parity_diff.py
@@ -147,11 +147,10 @@ def gate0_schedule(oracle_dir: Path, ofdd_dir: Path, fixture: dict) -> list[dict
                     "BUG-C confirmed on running image; code fix in "
                     "edge/src/fdd/session_config.rs. Accepted until tip publish."
                 ),
-                "severity": "accepted",
+                "severity": "blocker",
                 "rationale": (
-                    "Unit test keeps_occupancy_schedule_calendar proves branch; "
-                    "nightly 83fc4d3 still strips. Disk restore makes compare "
-                    "calendar-equal without claiming PUT is fixed in the image."
+                    "PUT /api/fdd/session-config dropped occupancy_schedule; "
+                    "disk restore is a workaround, not Gate-0 pass."
                 ),
             }
         )
@@ -163,7 +162,7 @@ _RULE_ALIASES = {
     "FC13-SAT-HIGH": "FC13",
 }
 
-# Rust-only SQL analytics / aliases — not in the 4.3.0 pandas cookbook catalog.
+# Rust-only SQL analytics / aliases — not in the pandas cookbook catalog.
 _RUST_ONLY_RULES = frozenset(
     {
         "AVG-ZONE-TEMP",
@@ -173,6 +172,7 @@ _RUST_ONLY_RULES = frozenset(
         "FC13-SAT-HIGH",
     }
 )
+WAVE1_RULES = ("VAV-2", "VAV-6", "RESET-1")
 _SKIP_STATUSES = frozenset(
     {
         "SKIPPED_MISSING_ROLES",
@@ -210,32 +210,18 @@ def _status_ok(o: str, r: str) -> bool:
     return False
 
 
+def _intentional_accepted(
+    rule_id: str, o_status: str, r_status: str, o_hours: float | None, r_hours: float | None
+) -> tuple[bool, str]:
+    """Documented seams for *this* soak only — default empty (do not inherit 4.3.0)."""
+    _ = (rule_id, o_status, r_status, o_hours, r_hours)
+    return False, ""
+
+
 def _intentional_43(
     rule_id: str, o_status: str, r_status: str, o_hours: float | None, r_hours: float | None
 ) -> tuple[bool, str]:
-    """4.3.0 semantic diffs that must not be blockers."""
-    ou, ru = o_status.upper(), r_status.upper()
-    oh = 0.0 if o_hours is None else o_hours
-    rh = 0.0 if r_hours is None else r_hours
-    if rule_id == "CHW-1":
-        if ou in _SKIP_STATUSES and (
-            ru in _SKIP_STATUSES or (ru in _PASS_STATUSES | {"FAULT"} and rh == 0.0)
-        ):
-            return True, "4.3.0 CHW-1 skip/off (missing proof or zeros)"
-        if ru in _SKIP_STATUSES and ou in _SKIP_STATUSES:
-            return True, "4.3.0 CHW-1 skip/off"
-    if rule_id == "SCHED-247":
-        if ou in _PASS_STATUSES and ru == "FAULT":
-            return True, "4.3.0 SCHED-247 pressure-not-fault"
-        if ou in _PASS_STATUSES and ru in _PASS_STATUSES:
-            return True, "4.3.0 SCHED-247 pass"
-        if ou in _SKIP_STATUSES and ru in _SKIP_STATUSES | _PASS_STATUSES:
-            return True, "4.3.0 SCHED-247 skip vs pass"
-        if abs(oh - rh) > 0.05 and (ou in _PASS_STATUSES or ru == "FAULT"):
-            return True, "4.3.0 SCHED-247 pressure-not-fault hours"
-    if rule_id == "FC7":
-        return True, "concept_only — SQL placeholder; htg_valve_pct missing"
-    return False, ""
+    return _intentional_accepted(rule_id, o_status, r_status, o_hours, r_hours)
 
 
 def _sql_screening_pair(
@@ -245,8 +231,8 @@ def _sql_screening_pair(
     o_hours: float | None,
     r_hours: float | None,
 ) -> tuple[bool, str]:
-    """Only documented 4.3.0 / concept_only seams — FAULT∩FAULT hours are blockers."""
-    ok, why = _intentional_43(rule_id, o_status, r_status, o_hours, r_hours)
+    """Empty default — FAULT∩FAULT hours are blockers. Re-admit seams only with soak evidence."""
+    ok, why = _intentional_accepted(rule_id, o_status, r_status, o_hours, r_hours)
     if ok:
         return True, why
     return False, ""
@@ -644,8 +630,14 @@ def compare_fdd(oracle_dir: Path, ofdd_dir: Path, capture_dir: Path | None = Non
         status_ok = bool(o_status) and bool(r_status) and _status_ok(o_status, r_status)
         hours_ok = _sev_num(o_h, r_h, abs_tol=0.05, rel_tol=0.001) != "blocker"
         if not o:
-            sev = "accepted" if accepted else "blocker"
-            delta = "missing on oracle"
+            if rule_id in WAVE1_RULES:
+                accepted = True
+                why = "vibe19 open-fdd wheel does not include VAV-2/VAV-6/RESET-1"
+                sev = "accepted"
+                delta = "catalog_lag Wave 1 missing on oracle"
+            else:
+                sev = "accepted" if accepted else "blocker"
+                delta = "missing on oracle"
         elif not r:
             if o_status.upper() in _SKIP_STATUSES and accepted:
                 sev = "accepted"
@@ -697,6 +689,131 @@ def compare_fdd(oracle_dir: Path, ofdd_dir: Path, capture_dir: Path | None = Non
             "ofdd": len(rust_by),
             "delta": None,
             "severity": "noise",
+        }
+    )
+    return rows
+
+
+def compare_vav_health(oracle_dir: Path, ofdd_dir: Path) -> list[dict]:
+    """vav_health_matrix_v1 dump-vs-dump. Missing oracle file is consumer lag, not PASS."""
+    import csv
+
+    rows: list[dict] = []
+    o_path = oracle_dir / "vav_health_matrix.csv"
+    r_path = ofdd_dir / "vav_health_matrix.csv"
+    o_ok = o_path.is_file() and o_path.stat().st_size > 0
+    r_ok = r_path.is_file() and r_path.stat().st_size > 0
+    if not o_ok and not r_ok:
+        rows.append(
+            {
+                "artifact": "vav_health_matrix.csv",
+                "key": "presence",
+                "vibe19": False,
+                "ofdd": False,
+                "delta": "both missing",
+                "severity": "blocker",
+            }
+        )
+        return rows
+    if not o_ok:
+        rows.append(
+            {
+                "artifact": "vav_health_matrix.csv",
+                "key": "presence",
+                "vibe19": False,
+                "ofdd": r_ok,
+                "delta": "oracle dump missing vav_health_matrix.csv",
+                "severity": "accepted",
+                "rationale": (
+                    "OpenFDD 4.4.0 ships vav_health; vibe19 diagnostic export "
+                    "did not write the CSV even when the wheel is 4.4.0 (Prompt 2)."
+                ),
+            }
+        )
+        return rows
+    if not r_ok:
+        rows.append(
+            {
+                "artifact": "vav_health_matrix.csv",
+                "key": "presence",
+                "vibe19": True,
+                "ofdd": False,
+                "delta": "OpenFDD bundle missing vav_health_matrix.csv",
+                "severity": "blocker",
+            }
+        )
+        return rows
+
+    def _idx(path: Path) -> dict[str, dict]:
+        out = {}
+        with path.open(newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                eq = str(row.get("equipment_id") or "")
+                if eq:
+                    out[eq] = row
+        return out
+
+    o_idx = _idx(o_path)
+    r_idx = _idx(r_path)
+    keys = sorted(set(o_idx) | set(r_idx))
+    n_block = 0
+    for eq in keys:
+        o = o_idx.get(eq) or {}
+        r = r_idx.get(eq) or {}
+        o_lab = str(o.get("score_label") or "")
+        r_lab = str(r.get("score_label") or "")
+        if not o:
+            n_block += 1
+            rows.append(
+                {
+                    "artifact": "vav_health_matrix.csv",
+                    "key": eq,
+                    "vibe19": None,
+                    "ofdd": r_lab or r.get("broken_box"),
+                    "delta": "missing on oracle",
+                    "severity": "blocker",
+                }
+            )
+            continue
+        if not r:
+            n_block += 1
+            rows.append(
+                {
+                    "artifact": "vav_health_matrix.csv",
+                    "key": eq,
+                    "vibe19": o_lab,
+                    "ofdd": None,
+                    "delta": "missing on OFDD",
+                    "severity": "blocker",
+                }
+            )
+            continue
+        mismatch = []
+        for col in ("score_label", "broken_box", "poor_zone_performance", "rogue_damper"):
+            ov = str(o.get(col) or "").lower()
+            rv = str(r.get(col) or "").lower()
+            if ov != rv:
+                mismatch.append(col)
+        if mismatch:
+            n_block += 1
+            rows.append(
+                {
+                    "artifact": "vav_health_matrix.csv",
+                    "key": eq,
+                    "vibe19": {c: o.get(c) for c in mismatch},
+                    "ofdd": {c: r.get(c) for c in mismatch},
+                    "delta": mismatch,
+                    "severity": "blocker",
+                }
+            )
+    rows.append(
+        {
+            "artifact": "vav_health_matrix.csv",
+            "key": "table_summary",
+            "vibe19": len(o_idx),
+            "ofdd": len(r_idx),
+            "delta": {"column_blockers": n_block},
+            "severity": "blocker" if n_block else "noise",
         }
     )
     return rows
@@ -844,6 +961,7 @@ def main() -> int:
     rows.extend(compare_topology(args.oracle))
     rows.extend(compare_analytics_tables(args.oracle, args.ofdd))
     rows.extend(compare_fdd(args.oracle, args.ofdd, args.capture))
+    rows.extend(compare_vav_health(args.oracle, args.ofdd))
 
     blockers = sum(1 for r in rows if r.get("severity") == "blocker")
     accepted = sum(1 for r in rows if r.get("severity") == "accepted")

--- a/scripts/wattlab_parity_ofdd_rust_bundle.py
+++ b/scripts/wattlab_parity_ofdd_rust_bundle.py
@@ -49,6 +49,7 @@ EXTRA_ANALYTICS = (
     ("diurnal", "/api/analytics/diurnal"),
     ("topology", "/api/analytics/topology"),
     ("sensor_stats_all", "/api/analytics/sensor-stats"),
+    ("vav_health", "/api/analytics/vav-health"),
 )
 
 
@@ -252,6 +253,10 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     extra = _load(capture_dir / "extra_analytics.json") or {}
     if not isinstance(extra, dict):
         extra = {}
+    if "vav_health" not in extra:
+        cap_vh = _load(capture_dir / "vav_health.json")
+        if cap_vh is not None:
+            extra["vav_health"] = cap_vh
 
     def _extra_rows(name: str) -> list[dict]:
         wrap = extra.get(name) or {}
@@ -328,6 +333,27 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     mark("sensor_stats_fan_off.csv")
     if not stats_off:
         missing_apis.append("missing_table:sensor_stats_fan_off.csv")
+
+    vh_wrap = extra.get("vav_health") or {}
+    _, vh_body = _unwrap(vh_wrap) if isinstance(vh_wrap, dict) else (None, vh_wrap)
+    vh_env = _analytics(vh_body) if isinstance(vh_body, dict) else {}
+    vh_rows = [r for r in (vh_env.get("rows") or []) if isinstance(r, dict)]
+    _write_csv(bundle_dir / "vav_health_matrix.csv", vh_rows)
+    mark("vav_health_matrix.csv")
+    cov = vh_env.get("coverage") if isinstance(vh_env.get("coverage"), dict) else {}
+    _write_json(
+        bundle_dir / "vav_health_summary.json",
+        {
+            "schema_version": vh_env.get("schema_version") or cov.get("schema_version"),
+            "groups": cov.get("groups"),
+            "row_count": len(vh_rows),
+            "engine": vh_env.get("engine"),
+            "warnings": vh_env.get("warnings") or [],
+        },
+    )
+    mark("vav_health_summary.json")
+    if not vh_rows:
+        missing_apis.append("missing_table:vav_health_matrix.csv")
 
     _write_json(
         bundle_dir / "quality_flags.json",

--- a/scripts/wattlab_parity_ofdd_rust_capture.py
+++ b/scripts/wattlab_parity_ofdd_rust_capture.py
@@ -41,8 +41,9 @@ def _req(
         data = json.dumps(body).encode("utf-8")
         headers["Content-Type"] = "application/json"
     r = urllib.request.Request(url, data=data, headers=headers, method=method)
+    timeout = 900 if "/api/fdd/run" in url else 120
     try:
-        with urllib.request.urlopen(r, timeout=120) as resp:
+        with urllib.request.urlopen(r, timeout=timeout) as resp:
             raw = resp.read().decode("utf-8")
             try:
                 return resp.status, json.loads(raw)
@@ -178,6 +179,11 @@ def main() -> int:
         (
             "sensor_health",
             "/api/analytics/sensor-health",
+            {"building_id": args.building_id},
+        ),
+        (
+            "vav_health",
+            "/api/analytics/vav-health",
             {"building_id": args.building_id},
         ),
     ):

--- a/scripts/wattlab_parity_oracle_dump.py
+++ b/scripts/wattlab_parity_oracle_dump.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Offline playground Vibe19 (pandas) WattLab oracle dump for Building 100 parity.
+"""Vibe19 (pandas) WattLab oracle dump for Building 100 parity.
 
-Oracle is *playground* Vibe19 + OpenFDD >=4.3.0 — not tools/wattlab_export.
-Default runs cookbook rules (no --skip-rules).
+Prefers a running GHCR vibe19 container (`docker exec`). Falls back to a
+local playground checkout. Not tools/wattlab_export. Default runs cookbook
+rules (no --skip-rules).
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ import importlib.util
 import json
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -21,6 +23,7 @@ DEFAULT_VIBE19 = Path("/home/ben/py-bacnet-stacks-playground/vibe_code_apps_19")
 DEFAULT_PKG = Path("/home/ben/raw_BUILDING_100_openfdd.zip")
 DEFAULT_SCHED = ROOT / "reports/wattlab-parity/fixtures/schedule_b100_7to5.json"
 DEFAULT_OUT = ROOT / "reports/wattlab-parity/artifacts/vibe19_oracle"
+DEFAULT_CONTAINER = "vibe19"
 
 
 def _sha256(path: Path) -> str:
@@ -28,7 +31,36 @@ def _sha256(path: Path) -> str:
     with path.open("rb") as f:
         for chunk in iter(lambda: f.read(1 << 20), b""):
             h.update(chunk)
-    return h.hexdigest()
+        return h.hexdigest()
+
+
+def _docker_running(name: str) -> bool:
+    r = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", name],
+        capture_output=True,
+        text=True,
+    )
+    return r.returncode == 0 and r.stdout.strip() == "true"
+
+
+def _docker_inspect(name: str) -> dict:
+    r = subprocess.run(
+        [
+            "docker",
+            "inspect",
+            name,
+            "--format",
+            '{{json .}}',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        return {}
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return {}
 
 
 def _load_afdd(vibe19_root: Path):
@@ -53,66 +85,8 @@ def _maybe_reexec_vibe19_venv(vibe19_root: Path) -> None:
     os.execv(str(venv_py), [str(venv_py), str(Path(__file__).resolve()), *sys.argv[1:]])
 
 
-def main() -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--package", type=Path, default=DEFAULT_PKG)
-    p.add_argument("--schedule", type=Path, default=DEFAULT_SCHED)
-    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
-    p.add_argument(
-        "--vibe19-root",
-        type=Path,
-        default=DEFAULT_VIBE19,
-        help="Playground vibe_code_apps_19 root (oracle consumer)",
-    )
-    p.add_argument(
-        "--profile",
-        choices=("summary", "diagnostic", "forensic"),
-        default="summary",
-    )
-    p.add_argument(
-        "--skip-rules",
-        action="store_true",
-        help="Skip cookbook FDD rules (faster; still writes setpoints/analytics)",
-    )
-    args = p.parse_args()
-
-    vibe19 = args.vibe19_root.resolve()
-    _maybe_reexec_vibe19_venv(vibe19)
-
-    if not args.package.is_file():
-        print(f"package not found: {args.package}", file=sys.stderr)
-        return 2
-    if not args.schedule.is_file():
-        print(f"schedule not found: {args.schedule}", file=sys.stderr)
-        return 2
-
-    afdd_main = _load_afdd(vibe19)
-
-    if args.out.exists():
-        shutil.rmtree(args.out)
-    args.out.mkdir(parents=True, exist_ok=True)
-
-    argv = [
-        "--package",
-        str(args.package),
-        "--out",
-        str(args.out),
-        "--export-profile",
-        args.profile,
-        "--schedule",
-        str(args.schedule),
-        "--no-bootstrap",
-    ]
-    if args.skip_rules:
-        argv += ["--run-analytics", "--run-rcx"]
-    else:
-        argv += ["--run-all"]
-
-    rc = afdd_main(argv)
-
-    of_ver = None
-    of_sha = None
-    cat_hash = None
+def _stamp_open_fdd_host() -> tuple[str | None, str | None, str | None]:
+    of_ver = of_sha = cat_hash = None
     try:
         import open_fdd
 
@@ -126,11 +100,169 @@ def main() -> int:
 
         cat_hash = rule_catalog_hash()
     except Exception as exc:  # pragma: no cover
-        print(f"warning: could not read open_fdd manifest: {exc}", file=sys.stderr)
+        print(f"warning: could not read host open_fdd manifest: {exc}", file=sys.stderr)
+    return of_ver, of_sha, cat_hash
 
+
+def _stamp_open_fdd_docker(container: str) -> tuple[str | None, str | None, str | None]:
+    code = (
+        "import json,open_fdd\n"
+        "man=open_fdd.manifest() if hasattr(open_fdd,'manifest') else {}\n"
+        "h=None\n"
+        "try:\n"
+        " from open_fdd.catalog import rule_catalog_hash as f\n"
+        " h=f()\n"
+        "except Exception:\n"
+        " pass\n"
+        "print(json.dumps({'v': man.get('open_fdd_python_version') or getattr(open_fdd,'__version__',None),'sha': man.get('open_fdd_python_git_sha'),'h': h}))\n"
+    )
+    r = subprocess.run(
+        ["docker", "exec", container, "python", "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        print(f"warning: docker open_fdd stamp failed: {r.stderr}", file=sys.stderr)
+        return None, None, None
+    try:
+        d = json.loads(r.stdout.strip().splitlines()[-1])
+        return d.get("v"), d.get("sha"), d.get("h")
+    except (json.JSONDecodeError, IndexError):
+        return None, None, None
+
+
+def _afdd_argv(package: str, out: str, schedule: str, profile: str, skip_rules: bool) -> list[str]:
+    argv = [
+        "--package",
+        package,
+        "--out",
+        out,
+        "--export-profile",
+        profile,
+        "--schedule",
+        schedule,
+        "--no-bootstrap",
+    ]
+    if skip_rules:
+        argv += ["--run-analytics", "--run-rcx"]
+    else:
+        argv += ["--run-all"]
+    return argv
+
+
+def _run_docker(
+    container: str,
+    package: Path,
+    schedule: Path,
+    out: Path,
+    profile: str,
+    skip_rules: bool,
+) -> int:
+    host_parity = ROOT / "reports/wattlab-parity"
+    host_parity.mkdir(parents=True, exist_ok=True)
+    # Bind is expected at /data/parity on the container (started by the soak).
+    c_pkg = "/data/raw_BUILDING_100_openfdd.zip"
+    c_sched = "/data/parity/fixtures/schedule_b100_7to5.json"
+    c_out = "/data/parity/artifacts/vibe19_oracle"
+    if package.resolve() != DEFAULT_PKG.resolve():
+        print(
+            f"warning: docker dump uses bind {c_pkg}; --package {package} ignored",
+            file=sys.stderr,
+        )
+    argv = _afdd_argv(c_pkg, c_out, c_sched, profile, skip_rules)
+    cmd = ["docker", "exec", container, "python", "scripts/agent_afdd.py", *argv]
+    print("docker:", " ".join(cmd), flush=True)
+    proc = subprocess.run(cmd)
+    # Copy out if agent wrote to c_out which is bind-mounted to host_parity/artifacts
+    bind_out = host_parity / "artifacts" / "vibe19_oracle"
+    if bind_out.resolve() != out.resolve() and bind_out.is_dir():
+        if out.exists():
+            shutil.rmtree(out)
+        shutil.copytree(bind_out, out)
+    return proc.returncode
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--package", type=Path, default=DEFAULT_PKG)
+    p.add_argument("--schedule", type=Path, default=DEFAULT_SCHED)
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument(
+        "--vibe19-root",
+        type=Path,
+        default=DEFAULT_VIBE19,
+        help="Playground vibe_code_apps_19 root (host fallback)",
+    )
+    p.add_argument("--container", default=DEFAULT_CONTAINER)
+    p.add_argument("--no-docker", action="store_true")
+    p.add_argument(
+        "--profile",
+        choices=("summary", "diagnostic", "forensic"),
+        default="diagnostic",
+    )
+    p.add_argument(
+        "--skip-rules",
+        action="store_true",
+        help="Skip cookbook FDD rules (not the default soak path)",
+    )
+    args = p.parse_args()
+
+    if args.skip_rules:
+        print("warning: --skip-rules is not the B100 soak path", file=sys.stderr)
+
+    if not args.package.is_file():
+        print(f"package not found: {args.package}", file=sys.stderr)
+        return 2
+    if not args.schedule.is_file():
+        print(f"schedule not found: {args.schedule}", file=sys.stderr)
+        return 2
+
+    use_docker = (not args.no_docker) and _docker_running(args.container)
+    docker_meta = {}
+    of_ver = of_sha = cat_hash = None
+    rc: int
+
+    if args.out.exists():
+        shutil.rmtree(args.out)
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    if use_docker:
+        insp = _docker_inspect(args.container)
+        labels = (insp.get("Config") or {}).get("Labels") or {}
+        docker_meta = {
+            "container": args.container,
+            "image": (insp.get("Config") or {}).get("Image"),
+            "image_id": insp.get("Image"),
+            "revision": labels.get("org.opencontainers.image.revision"),
+        }
+        rc = _run_docker(
+            args.container,
+            args.package,
+            args.schedule,
+            args.out,
+            args.profile,
+            args.skip_rules,
+        )
+        of_ver, of_sha, cat_hash = _stamp_open_fdd_docker(args.container)
+    else:
+        vibe19 = args.vibe19_root.resolve()
+        _maybe_reexec_vibe19_venv(vibe19)
+        afdd_main = _load_afdd(vibe19)
+        argv = _afdd_argv(
+            str(args.package),
+            str(args.out),
+            str(args.schedule),
+            args.profile,
+            args.skip_rules,
+        )
+        rc = afdd_main(argv)
+        of_ver, of_sha, cat_hash = _stamp_open_fdd_host()
+
+    vh = args.out / "vav_health_matrix.csv"
     meta = {
         "side": "vibe19_oracle",
-        "vibe19_root": str(vibe19),
+        "mode": "docker" if use_docker else "host_playground",
+        "docker": docker_meta,
         "package": str(args.package),
         "package_sha256": _sha256(args.package),
         "schedule": str(args.schedule),
@@ -140,7 +272,9 @@ def main() -> int:
         "open_fdd_python_version": of_ver,
         "open_fdd_python_git_sha": of_sha,
         "rule_catalog_hash": cat_hash,
+        "vav_health_matrix_present": vh.is_file() and vh.stat().st_size > 0,
         "python": sys.executable,
+        "agent_afdd_rc": rc,
     }
     (args.out / "parity_meta.json").write_text(
         json.dumps(meta, indent=2), encoding="utf-8"
@@ -151,7 +285,7 @@ def main() -> int:
     shutil.make_archive(str(zip_path.with_suffix("")), "zip", args.out)
     print(f"oracle dump -> {args.out}")
     print(f"oracle zip  -> {zip_path}")
-    print(f"open_fdd    -> {of_ver} catalog={cat_hash}")
+    print(f"open_fdd    -> {of_ver} catalog={cat_hash} docker={use_docker}")
     return rc
 
 

--- a/scripts/wattlab_parity_watch_ghcr.py
+++ b/scripts/wattlab_parity_watch_ghcr.py
@@ -90,6 +90,7 @@ def newest_central(repo: str = "bbartling/openfdd-central") -> dict:
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo", default="bbartling/openfdd-central")
     p.add_argument(
         "--baseline-created",
         required=True,
@@ -101,17 +102,17 @@ def main() -> int:
 
     baseline = args.baseline_created
     print(
-        f"watching GHCR openfdd-central for created > {baseline} every {args.interval_sec}s",
+        f"watching GHCR {args.repo} for created > {baseline} every {args.interval_sec}s",
         flush=True,
     )
     while True:
         try:
-            info = newest_central()
+            info = newest_central(args.repo)
             args.state.write_text(json.dumps(info, indent=2), encoding="utf-8")
             if info["created"] > baseline:
                 payload = {
                     "prompt": (
-                        "Newest GHCR openfdd-central is newer than baseline. "
+                        f"Newest GHCR {args.repo} is newer than baseline. "
                         f"Pull tag={info['tag']} created={info['created']} "
                         f"digest={info['digest']}, stack up react-ot, re-run "
                         "vibe19 oracle + OFDD Rust capture + wattlab_parity_diff, "

--- a/tests/test_wattlab_parity_diff.py
+++ b/tests/test_wattlab_parity_diff.py
@@ -1,4 +1,4 @@
-"""Classifier for intentional 4.3.0 WattLab deltas — dump-vs-dump stop rule."""
+"""Classifier for WattLab dump-vs-dump — empty accepted list until soak evidence."""
 
 from pathlib import Path
 import sys
@@ -6,32 +6,24 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 from wattlab_parity_diff import (  # noqa: E402
-    _intentional_43,
+    _intentional_accepted,
     _sql_screening_pair,
     _status_ok,
 )
 
 
-def test_chw1_skip_vs_zero_fault_is_accepted():
-    ok, why = _intentional_43("CHW-1", "SKIPPED_EQUIPMENT_OFF", "FAULT", 0.0, 0.0)
-    assert ok
-    assert "CHW-1" in why
-
-
-def test_sched247_pressure_fault_is_accepted():
-    ok, why = _intentional_43("SCHED-247", "PASS", "FAULT", 0.0, 1561.0)
-    assert ok
-    assert "SCHED-247" in why
-
-
-def test_fc7_concept_only_is_accepted():
-    ok, why = _intentional_43("FC7", "SKIPPED_MISSING_ROLES", "PASS", 0.0, 0.0)
-    assert ok
-    assert "concept_only" in why
+def test_empty_accepted_list():
+    ok, why = _intentional_accepted("CHW-1", "SKIPPED_EQUIPMENT_OFF", "FAULT", 0.0, 0.0)
+    assert not ok
+    assert why == ""
+    ok, _ = _intentional_accepted("SCHED-247", "PASS", "FAULT", 0.0, 1561.0)
+    assert not ok
+    ok, _ = _intentional_accepted("FC7", "SKIPPED_MISSING_ROLES", "PASS", 0.0, 0.0)
+    assert not ok
 
 
 def test_other_rule_status_mismatch_not_intentional():
-    ok, _ = _intentional_43("FC1", "PASS", "FAULT", 0.0, 12.0)
+    ok, _ = _intentional_accepted("FC1", "PASS", "FAULT", 0.0, 12.0)
     assert not ok
 
 


### PR DESCRIPTION
## Summary
- Prefer GHCR `vibe19` `docker exec` for the B100 oracle dump; stamp image digest and `open-fdd` 4.4.0.
- Capture/assemble `POST /api/analytics/vav-health`; compare `vav_health_matrix.csv` (missing vibe19 export is accepted Prompt-2 lag).
- Empty inherited 4.3.0 accepted-seam list. FAULT∩FAULT hours stay blockers.
- Reset dump/vibe19 bugreports from the 2026-08-15 soak (`sha-9e280ae`, 2596 blockers, stop rule false).

## Test plan
- [ ] Cookbook/python GHA green
- [ ] Do not treat this PR as dump-vs-dump agreement (stop_rule_met is still false)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VAV health analytics capture, reporting, and parity validation.
  * Added support for running oracle diagnostics in Docker or host environments.
  * Added configurable repository selection for image monitoring workflows.
* **Bug Fixes**
  * Improved request timeouts and handling of missing health data.
  * Updated parity checks to identify confirmed occupancy-schedule failures and health mismatches.
* **Documentation**
  * Refreshed migration and parity reports with current metrics, diagnostics, blockers, image details, and execution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->