### PR TITLE
B100 soak notes for sha-8ab0b5e and vibe19 Prompt 2

### DIFF
--- a/docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md
+++ b/docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md
@@ -1,31 +1,75 @@
-# Vibe19 Prompt 2 — pin PyPI analytics + export `vav_health_matrix.csv`
+# Prompt 2 — vibe_code_apps_19 (Windows Cursor)
 
-Run on the **vibe19 / playground machine only**. bensbench pulls `ghcr.io/bbartling/vibe19`; it does not rebuild this image.
+Copy this whole file into the **Windows Cursor** session that owns
+`py-bacnet-stacks-playground` / `vibe_code_apps_19`. Do **not** run this on
+bensbench. bensbench only `docker pull ghcr.io/bbartling/vibe19`.
+
+## Goal
+
+Pin the OpenFDD **PyPI** analytics oracle and **export** the same CSVs the
+OpenFDD dump-vs-dump scripts already compare. Do **not** reimplement VAV health,
+mech OAT bins, or motor hours in Streamlit.
+
+PyPI is live: `open-fdd==4.4.1` (GHA Trusted Publishing, tag `open-fdd-v4.4.1`).
 
 ## Pin
+
+In `vibe_code_apps_19` requirements / Docker image:
 
 ```text
 open-fdd[reporting]==4.4.1
 ```
 
-(Use **4.4.1** once tagged on PyPI; 4.4.0 already has `vav_health_matrix_v1`.)
-
-## Shim (do not reimplement)
+Smoke after install:
 
 ```python
-from open_fdd.analytics import dump_tables, vav_health_matrix
-
-# Diagnostic WattLab dump MUST write:
-#   vav_health_matrix.csv
-#   mech_cooling_oat_bins.csv
-#   motor_hours.csv
-#   motor_weekly.csv
-# Prefer dump_tables(out_dir, frames=..., role_map=..., rule_results=...)
-# Overview matrix is presentation only.
+import open_fdd
+from open_fdd.analytics import dump_tables, vav_health_matrix, mech_cooling_oat_bins
+assert open_fdd.__version__ == "4.4.1"
+assert callable(dump_tables) and callable(vav_health_matrix)
 ```
 
-Rebuild `ghcr.io/bbartling/vibe19` there; on bensbench:
+## Diagnostic WattLab dump (required files)
+
+The 4.4.0 image imported `vav_health_matrix_v1` but the **diagnostic dump did
+not write** `vav_health_matrix.csv`. Fix export only.
+
+Call pandas (do not fork):
+
+```python
+from open_fdd.analytics import dump_tables
+
+dump_tables(
+    out_dir,  # same folder as MANIFEST / fdd_findings.csv
+    frames=frames,
+    role_map=role_map,
+    rule_results=findings_df,  # so broken_box is not always ?/3
+    weather=weather,
+    building_id=building_id,
+)
+```
+
+Must appear in the diagnostic Engineering Bundle + `MANIFEST.json`:
+
+- `vav_health_matrix.csv`
+- `mech_cooling_oat_bins.csv`
+- `motor_hours.csv`
+- `motor_weekly.csv`
+
+Overview matrix is presentation. Do not skip the CSV because the UI already shows a table.
+
+## Rebuild and publish
+
+Rebuild `ghcr.io/bbartling/vibe19` on Windows (or that CI). Tag `:latest` / `:develop` as you already do.
+
+bensbench will then:
 
 ```bash
 docker pull ghcr.io/bbartling/vibe19:latest
 ```
+
+## Out of scope
+
+- Do not reimplement FDD rules (call `open_fdd.rules`).
+- Do not port Rust-only sensor-stats/diurnal into pandas.
+- Do not edit `bbartling/open-fdd` from the playground machine for this prompt.

--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -1,34 +1,42 @@
-# WattLab-to-WattLab dump parity (Building 100) — 4.4.0 cycle
+# WattLab-to-WattLab dump parity (Building 100) — 4.4.1 / `sha-8ab0b5e`
 
-Oracle: vibe19 Engineering Bundle (`ghcr.io/bbartling/vibe19:latest`, wheel **4.4.0**).  
-OpenFDD: DataFusion assembler [`scripts/wattlab_parity_ofdd_rust_bundle.py`](../../scripts/wattlab_parity_ofdd_rust_bundle.py) on `sha-9e280ae`.
+Oracle: vibe19 Engineering Bundle (`ghcr.io/bbartling/vibe19:latest`, wheel **4.4.0** until Prompt 2 pins **4.4.1**).  
+OpenFDD: DataFusion assembler on **`sha-8ab0b5e`** (PR #725), health `3.3.0+8ab0b5e347d8`.
 
 ## Cycle header
 
 | Metric | Value |
 | --- | --- |
 | Date | 2026-08-15 |
-| OpenFDD pin | `sha-9e280ae` health `3.3.0+9e280ae294b0` |
-| Vibe19 | `:latest` == `:develop` digest `sha256:6a4297b9…e6f54d` rev `8ca6a3b` |
-| `diff_matrix.csv` / summary rows | 4233 |
-| **blockers** | **2596** |
-| accepted | 63 |
+| OpenFDD pin | `sha-8ab0b5e` health `3.3.0+8ab0b5e347d8` |
+| PyPI | **open-fdd 4.4.1** (tag `open-fdd-v4.4.1`, Trusted Publishing) |
+| Vibe19 | `:latest` digest `sha256:6a4297b9…e6f54d` (still 4.4.0 wheel; Prompt 2 on Windows) |
+| **blockers** | **405** (was 2596 on the 4.4.0 / `sha-9e280ae` cycle) |
+| accepted | 2690 |
+| rows | 3260 |
 | stop_rule_met | **false** |
 
-Stop rule remains `blocker_count == 0`. FAULT∩FAULT hour gaps are blockers.
+Classifier (A2): blockers are FAULT vs PASS and FAULT∩FAULT hours. N/A-omit and one-sided sensor columns are accepted. FDD blockers 217; remaining sensor_diurnal/stats ~187 are two-sided numeric gaps, not one-sided `mean`.
 
-Program A (this cycle) patches SQL for AHU-DUCTHI / ECON-1 / ECON-2 / CHW-NOLOAD-1 and treats N/A-omit plus one-sided sensor columns as **accepted**. Re-count blockers after `sha-<7>` retarget. Stop rule remains `blocker_count == 0`.
+## Four B100 examples after SQL patch
 
-Largest FDD class previously: vibe19 `NOT_APPLICABLE_EQUIPMENT_TYPE` rows omitted by Rust (750) plus skip-vs-PASS. Those are no longer dump blockers. Remaining blockers should be FAULT vs PASS and FAULT∩FAULT hour gaps.
+| ID | vibe19 pandas | OpenFDD SQL `sha-8ab0b5e` | Notes |
+| --- | ---: | ---: | --- |
+| `AHU-DUCTHI` AHU_2 | FAULT **0.5 h** | FAULT **1.83 h** | Overnight 7" fan-off **cleared** (was 1341 h). Residual ~1.3 h FAULT∩FAULT still a blocker. |
+| `ECON-2` AHU_1 | PASS **0 h** | FAULT **952.5 h** | Still the unnormalized-damper class on this historian; not cleared. |
+| `ECON-1` AHU_1 | FAULT **326 h** | PASS **0 h** | Still a FAULT/PASS blocker (fan-cmd 0–100 vs status). |
+| `CHW-NOLOAD-1` CHILLER_2 | FAULT **524.5 h** | **SKIPPED_MISSING_ROLES** | No false PASS. Skip until load-satisfaction enrichment is mapped. Accepted vs FAULT. |
 
-Vibe19 diagnostic dump did **not** emit `vav_health_matrix.csv`; OpenFDD did. That is export lag on vibe19 (Prompt 2), not a 4.3.0 pin — the image already imports 4.4.0 / `vav_health_matrix_v1`.
+Do not greenwash: A1 fixed DUCTHI physics and CHW skip; ECON-1/2 remain open on B100.
 
 ## Commands
 
 ```bash
-python3 scripts/wattlab_parity_oracle_dump.py
-OPENFDD_ADMIN_PASSWORD=… python3 scripts/wattlab_parity_ofdd_rust_bundle.py
+export OPENFDD_IMAGE_TAG=sha-8ab0b5e
+docker pull ghcr.io/bbartling/openfdd-central:sha-8ab0b5e  # + web/fieldbus/mqtt
+./scripts/openfdd_stack_up.sh react-ot --no-pull
+python3 scripts/wattlab_parity_ofdd_rust_bundle.py
 python3 scripts/wattlab_parity_diff.py
 ```
 
-No local `docker build`. Pin `OPENFDD_IMAGE_TAG=sha-9e280ae`.
+No local `docker build`. Vibe19 Prompt 2: [`docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md`](../agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md).

--- a/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
@@ -1,6 +1,6 @@
-# WattLab / Vibe19 parity — Building 100 (OpenFDD 4.4.0)
+# WattLab / Vibe19 parity — Building 100 (OpenFDD 4.4.1 / `sha-8ab0b5e`)
 
-New dump-vs-dump cycle 2026-08-15. Oracle is GHCR vibe19 `docker exec scripts/agent_afdd.py` (not `tools/wattlab_export`). OpenFDD is DataFusion JWT APIs (`wattlab_parity_ofdd_rust_bundle.py`).
+Dump-vs-dump after Program A SQL patches (PR **#725**). Oracle remains GHCR vibe19 until Windows Prompt 2 pins PyPI **4.4.1**. OpenFDD is DataFusion JWT APIs.
 
 Working copy: `reports/wattlab-parity/` (gitignored artifacts).
 
@@ -9,68 +9,50 @@ Working copy: `reports/wattlab-parity/` (gitignored artifacts).
 | Side | Value |
 | --- | --- |
 | Date | 2026-08-15 |
-| OpenFDD git | `9e280ae` |
-| OpenFDD image | `ghcr.io/bbartling/openfdd-*:sha-9e280ae` |
-| Central health | `3.3.0+9e280ae294b0` |
+| OpenFDD git | `8ab0b5e` (#725) |
+| OpenFDD image | `ghcr.io/bbartling/openfdd-*:sha-8ab0b5e` |
+| Central health | `3.3.0+8ab0b5e347d8` |
 | `/api/fdd/rules` | **66** (62 pandas + 4 SQL analytics) |
-| PyPI / vibe19 wheel | **4.4.0** catalog hash `2e684dbb8f3188f06942c3cb0155aef4149713e7244b9f7733262f182465cba9` |
-| Vibe19 image | `:latest` == `:develop` digest `sha256:6a4297b9d461befdba19891a087e6a4ef26af345aff0e5b1274756f528e6f54d` rev `8ca6a3b` |
-| Package | `/home/ben/raw_BUILDING_100_openfdd.zip` sha256 `5a8d9ff2…` |
-| Gate 0 | PUT kept `occupancy_schedule` (no disk restore) |
-| Mech cooling | `web_oa_t` peak **70–75 / 204.58 h**, total **1156.5** |
-| VAV Health (OpenFDD after FDD) | `1/3`: 22, `2/3`: 19, `?/3`: 2 (not all unknown) |
-| `diff_summary.json` | **2596 blockers**, 63 accepted, 4233 rows, `stop_rule_met=false` |
+| PyPI (vibe19 should pin) | **4.4.1** (`open-fdd-v4.4.1`) |
+| Vibe19 image wheel today | still **4.4.0** until Prompt 2 |
+| Vibe19 image | `:latest` digest `sha256:6a4297b9…e6f54d` |
+| Gate 0 | PUT kept `occupancy_schedule` |
+| Mech cooling | `web_oa_t` peak **70–75 / 204.58 h**, total **1156.5** (unchanged this pin) |
+| `diff_summary.json` | **405 blockers**, 2690 accepted, 3260 rows, `stop_rule_met=false` |
 
-VAV Health is an analytic, not a 63rd diagnostic.
+Prior cycle (`sha-9e280ae`): **2596** blockers. Drop is mostly A2 classifier (N/A-omit + one-sided columns), plus DUCTHI/CHW SQL.
 
-## Measured blockers (honest)
+## Four-rule soak (`sha-8ab0b5e`)
 
-Primary families from `diff_matrix.csv` (`severity=blocker`):
+| ID | pandas | SQL | Outcome |
+| --- | ---: | ---: | --- |
+| AHU-DUCTHI AHU_2 | 0.5 h FAULT | 1.83 h FAULT | Fan-off 7" static gone (was 1341 h) |
+| ECON-2 AHU_1 | 0 h PASS | 952.5 h FAULT | Still open |
+| ECON-1 AHU_1 | 326 h FAULT | 0 h PASS | Still open |
+| CHW-NOLOAD-1 CHILLER_2 | 524.5 h FAULT | SKIPPED_MISSING_ROLES | No false PASS |
 
-| Artifact | Blockers | Notes |
-| --- | --- | --- |
-| `fdd_findings` | 1429 | See pairs below |
-| sensor_* tables | ~1037 | hour/row schema seams vs pandas dump |
-| `motor_weekly` / `motor_hours` | 83 | |
-| RCx / schedule inference | 47 | |
+## Measured blockers
 
-FDD status pairs (oracle → OpenFDD):
+| Artifact | Blockers |
+| --- | ---: |
+| `fdd_findings` | 217 |
+| `sensor_diurnal_24h.csv` | 89 |
+| `sensor_stats_fan_off.csv` | 74 |
+| `sensor_stats_all.csv` | 21 |
+| other | 4 |
 
-| vibe19 | ofdd | n |
-| --- | --- | --- |
-| `NOT_APPLICABLE_EQUIPMENT_TYPE` | *(row omitted)* | 750 |
-| `SKIPPED_EQUIPMENT_OFF` | `PASS` | 174 |
-| `SKIPPED_MISSING_ROLES` | `PASS` | 118 |
-| `SKIPPED_MISSING_ROLES` | omitted | 112 |
-| `FAULT` ∩ `FAULT` hour gap | | 97 |
-| `FAULT` vs `PASS` | | 66 |
-| `PASS` vs `FAULT` | | 51 |
-| skip vs `FAULT` | | 56 |
+Stop rule remains `blocker_count == 0`. Remaining FDD blockers are real FAULT/PASS and FAULT∩FAULT hours.
 
-SQL omitted N/A rows (863) is the largest FDD class: vibe19 emits N/A per equipment; Rust omits the row. Product follow-on: emit `NOT_APPLICABLE_EQUIPMENT_TYPE` for every (rule, equipment) in the vibe19 universe **or** drop N/A from the oracle dump before compare.
+## Program B handoff
 
-FAULT∩FAULT hour deltas remain **blockers** (not accepted). Highest-count rules in the FDD blocker set include AHU-SIMUL, CHW-2/3/4, CW-*, ECON-3/5/7, FC5/6/7, OAT-METEO, SV-RATE (48 equipment each — mostly N/A omit).
+- PyPI **4.4.1** is on pypi.org (`dump_tables`, metric bins, vav_health).
+- Windows Cursor: [`docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md`](../agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md) for `vibe_code_apps_19`. bensbench does not edit playground; `docker pull ghcr.io/bbartling/vibe19:latest` only.
 
-## Accepted / consumer lag
-
-- `vav_health_matrix.csv` missing from vibe19 **diagnostic** dump even though the image wheel is **4.4.0** and `open_fdd.analytics.vav_health` imports. OpenFDD bundle wrote the matrix. Prompt 2 (Streamlit/WattLab export) still needed on the vibe19 repo — not an OpenFDD SQL bug.
-- Rust extra `weather`/`unknown` equipment vs pandas 48-equip universe.
-- Bundle `topology.csv` empty (`missing_table:topology.csv`) — assembler gap, filed as missing_apis on capture.
-- Oracle quality flags / setpoints calendar medians without a matching Rust route (pre-existing product gaps).
-
-## Not done this cycle
-
-- No greenwash of `expected_faults.csv`.
-- No FC7 parity promotion (needs executable fixtures, not this B100 matrix).
-- No Windows Prompt 2 edits.
-
-## Commands used
+## Commands
 
 ```bash
-docker pull ghcr.io/bbartling/openfdd-central:sha-9e280ae  # + web/mqtt/fieldbus
-docker pull ghcr.io/bbartling/vibe19:latest
+export OPENFDD_IMAGE_TAG=sha-8ab0b5e
 ./scripts/openfdd_stack_up.sh react-ot --no-pull
-python3 scripts/wattlab_parity_oracle_dump.py
 OPENFDD_ADMIN_PASSWORD=… python3 scripts/wattlab_parity_ofdd_rust_bundle.py
 python3 scripts/wattlab_parity_diff.py
 ```


### PR DESCRIPTION
## Summary
- Bugreports for the `sha-8ab0b5e` dump-vs-dump soak (405 blockers; four-rule table).
- Windows Cursor prompt to pin `open-fdd==4.4.1` and export `vav_health_matrix.csv`.

## Test plan
- [x] Stack already on `sha-8ab0b5e` health `3.3.0+8ab0b5e347d8`
- [ ] Docs-only review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows setup guidance to use OpenFDD 4.4.1 and export four analytics CSVs in the Engineering Bundle.
  * Refreshed Wattlab parity reports with the latest 4.4.1 revision, health metrics, comparison results, and blocker summaries.
  * Added updated rebuild, publishing, diagnostic, and handoff instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->