### PR TITLE
Record sha-2c12c8e B100 soak (ECON still open)

### DIFF
--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -1,39 +1,39 @@
-# WattLab-to-WattLab dump parity (Building 100) — 4.4.1 / `sha-8ab0b5e`
+# WattLab-to-WattLab dump parity (Building 100) — 4.4.1 / `sha-2c12c8e`
 
 Oracle: vibe19 Engineering Bundle (`ghcr.io/bbartling/vibe19:latest`, wheel **4.4.0** until Prompt 2 pins **4.4.1**).  
-OpenFDD: DataFusion assembler on **`sha-8ab0b5e`** (PR #725), health `3.3.0+8ab0b5e347d8`.
+OpenFDD: DataFusion assembler on **`sha-2c12c8e`** (PR #727), health `3.3.0+2c12c8e814a8`. `:nightly` digest matches `sha-2c12c8e` (`sha256:54e6fbf5…123d82`).
 
 ## Cycle header
 
 | Metric | Value |
 | --- | --- |
 | Date | 2026-08-15 |
-| OpenFDD pin | `sha-8ab0b5e` health `3.3.0+8ab0b5e347d8` |
+| OpenFDD pin | `sha-2c12c8e` health `3.3.0+2c12c8e814a8` |
 | PyPI | **open-fdd 4.4.1** (tag `open-fdd-v4.4.1`, Trusted Publishing) |
 | Vibe19 | `:latest` digest `sha256:6a4297b9…e6f54d` (still 4.4.0 wheel; Prompt 2 on Windows) |
-| **blockers** | **405** (was 2596 on the 4.4.0 / `sha-9e280ae` cycle) |
+| **blockers** | **405** (unchanged vs `sha-8ab0b5e`) |
 | accepted | 2690 |
 | rows | 3260 |
 | stop_rule_met | **false** |
 
 Classifier (A2): blockers are FAULT vs PASS and FAULT∩FAULT hours. N/A-omit and one-sided sensor columns are accepted. FDD blockers 217; remaining sensor_diurnal/stats ~187 are two-sided numeric gaps, not one-sided `mean`.
 
-## Four B100 examples after SQL patch
+## Four B100 examples after ECON SQL follow-on (#727)
 
-| ID | vibe19 pandas | OpenFDD SQL `sha-8ab0b5e` | Notes |
+| ID | vibe19 pandas | OpenFDD SQL `sha-2c12c8e` | Notes |
 | --- | ---: | ---: | --- |
-| `AHU-DUCTHI` AHU_2 | FAULT **0.5 h** | FAULT **1.83 h** | Overnight 7" fan-off **cleared** (was 1341 h). Residual ~1.3 h FAULT∩FAULT still a blocker. |
-| `ECON-2` AHU_1 | PASS **0 h** | FAULT **952.5 h** | Still the unnormalized-damper class on this historian; not cleared. |
-| `ECON-1` AHU_1 | FAULT **326 h** | PASS **0 h** | Still a FAULT/PASS blocker (fan-cmd 0–100 vs status). |
+| `AHU-DUCTHI` AHU_2 | FAULT **0.5 h** | FAULT **1.83 h** | Unchanged vs #725. Residual ~1.3 h FAULT∩FAULT still a blocker. |
+| `ECON-2` AHU_1 | PASS **0 h** | FAULT **1422.92 h** | Still open. Hours **rose** vs 952.5 h after dropping the extra fan AND; 0–100 damper 20 still behaves like raw `20 > 0.42`. `damper_frac` CTE did not fix DataFusion on this historian. |
+| `ECON-1` AHU_1 | FAULT **326 h** | PASS **0 h** | Still a FAULT/PASS blocker. Raw damper 20 is not `< 0.05`; cmd-first fan did not produce the pandas 326 h. |
 | `CHW-NOLOAD-1` CHILLER_2 | FAULT **524.5 h** | **SKIPPED_MISSING_ROLES** | No false PASS. Skip until load-satisfaction enrichment is mapped. Accepted vs FAULT. |
 
-Do not greenwash: A1 fixed DUCTHI physics and CHW skip; ECON-1/2 remain open on B100.
+Do not greenwash: #727 shipped `damper_frac` + pandas fan/equation; B100 ECON-1/2 are still open. Next SQL attempt should inline the percent CASE in the same SELECT as `FROM history` (no later-CTE column), matching the historian `damper_fb_pct` pattern.
 
 ## Commands
 
 ```bash
-export OPENFDD_IMAGE_TAG=sha-8ab0b5e
-docker pull ghcr.io/bbartling/openfdd-central:sha-8ab0b5e  # + web/fieldbus/mqtt
+export OPENFDD_IMAGE_TAG=sha-2c12c8e
+docker pull ghcr.io/bbartling/openfdd-central:sha-2c12c8e  # + web/fieldbus/mqtt
 ./scripts/openfdd_stack_up.sh react-ot --no-pull
 python3 scripts/wattlab_parity_ofdd_rust_bundle.py
 python3 scripts/wattlab_parity_diff.py

--- a/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
@@ -1,6 +1,6 @@
-# WattLab / Vibe19 parity — Building 100 (OpenFDD 4.4.1 / `sha-8ab0b5e`)
+# WattLab / Vibe19 parity — Building 100 (OpenFDD 4.4.1 / `sha-2c12c8e`)
 
-Dump-vs-dump after Program A SQL patches (PR **#725**). Oracle remains GHCR vibe19 until Windows Prompt 2 pins PyPI **4.4.1**. OpenFDD is DataFusion JWT APIs.
+Dump-vs-dump after ECON-1/2 SQL follow-on (PR **#727**). Oracle remains GHCR vibe19 until Windows Prompt 2 pins PyPI **4.4.1**. OpenFDD is DataFusion JWT APIs. GHCR `:nightly` digest matches `sha-2c12c8e`.
 
 Working copy: `reports/wattlab-parity/` (gitignored artifacts).
 
@@ -9,25 +9,24 @@ Working copy: `reports/wattlab-parity/` (gitignored artifacts).
 | Side | Value |
 | --- | --- |
 | Date | 2026-08-15 |
-| OpenFDD git | `8ab0b5e` (#725) |
-| OpenFDD image | `ghcr.io/bbartling/openfdd-*:sha-8ab0b5e` |
-| Central health | `3.3.0+8ab0b5e347d8` |
+| OpenFDD git | `2c12c8e` (#727) |
+| OpenFDD image | `ghcr.io/bbartling/openfdd-*:sha-2c12c8e` |
+| Central health | `3.3.0+2c12c8e814a8` |
 | `/api/fdd/rules` | **66** (62 pandas + 4 SQL analytics) |
 | PyPI (vibe19 should pin) | **4.4.1** (`open-fdd-v4.4.1`) |
 | Vibe19 image wheel today | still **4.4.0** until Prompt 2 |
 | Vibe19 image | `:latest` digest `sha256:6a4297b9…e6f54d` |
 | Gate 0 | PUT kept `occupancy_schedule` |
-| Mech cooling | `web_oa_t` peak **70–75 / 204.58 h**, total **1156.5** (unchanged this pin) |
 | `diff_summary.json` | **405 blockers**, 2690 accepted, 3260 rows, `stop_rule_met=false` |
 
-Prior cycle (`sha-9e280ae`): **2596** blockers. Drop is mostly A2 classifier (N/A-omit + one-sided columns), plus DUCTHI/CHW SQL.
+Prior cycle (`sha-8ab0b5e`): also **405** blockers. ECON SQL follow-on did not reduce the dump-vs-dump count.
 
-## Four-rule soak (`sha-8ab0b5e`)
+## Four-rule soak (`sha-2c12c8e`)
 
 | ID | pandas | SQL | Outcome |
 | --- | ---: | ---: | --- |
-| AHU-DUCTHI AHU_2 | 0.5 h FAULT | 1.83 h FAULT | Fan-off 7" static gone (was 1341 h) |
-| ECON-2 AHU_1 | 0 h PASS | 952.5 h FAULT | Still open |
+| AHU-DUCTHI AHU_2 | 0.5 h FAULT | 1.83 h FAULT | Unchanged residual |
+| ECON-2 AHU_1 | 0 h PASS | 1422.92 h FAULT | Still open (was 952.5 h; fan AND removed, damper still raw-class) |
 | ECON-1 AHU_1 | 326 h FAULT | 0 h PASS | Still open |
 | CHW-NOLOAD-1 CHILLER_2 | 524.5 h FAULT | SKIPPED_MISSING_ROLES | No false PASS |
 
@@ -51,7 +50,7 @@ Stop rule remains `blocker_count == 0`. Remaining FDD blockers are real FAULT/PA
 ## Commands
 
 ```bash
-export OPENFDD_IMAGE_TAG=sha-8ab0b5e
+export OPENFDD_IMAGE_TAG=sha-2c12c8e
 ./scripts/openfdd_stack_up.sh react-ot --no-pull
 OPENFDD_ADMIN_PASSWORD=… python3 scripts/wattlab_parity_ofdd_rust_bundle.py
 python3 scripts/wattlab_parity_diff.py


### PR DESCRIPTION
## Summary
- Pin soak to `sha-2c12c8e` / health `3.3.0+2c12c8e814a8`; nightly digest matches.
- Four-rule table: DUCTHI 1.83 h and CHW skip unchanged; ECON-2 1422.92 h FAULT; ECON-1 0 h PASS. Blockers still 405.

## Test plan
- [ ] docs-guard green
- [ ] No claim that ECON-1/2 passed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WattLab parity and migration reports with the latest validation results.
  * Refreshed health checks, cycle metadata, blocker details, and ECON follow-up findings.
  * Added new rule-soak examples and updated command references for the current release image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->