### PR TITLE
Inline ECON damper CASE; vibe19 4.4.1 soak notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:808
 - **Overview plots:** plot Expanders default **open** so charts are not hidden behind carets (`OverviewPopulated`).
 - **Lab → FDD Plots:** `session_config` `confirm_min` (and rule params) apply to the series overlay (`sql_detail_session`). After **Update this rule**, Reports/FDD Plots must refetch on `RULES_UPDATED`.
 - **SCHED-1 occupancy:** treat numeric `0` / `0.0` / `false` **and** string `unoccupied` (and related tokens) as unoccupied — SQL + pandas cookbook stay aligned.
-- **Synthetic-59:** soak via `scripts/synthetic_59_*.py` under `reports/wattlab-parity/fixtures/synthetic_59/`. Do not greenwash `expected_faults.csv`. B100 dump-parity remains **paused**.
+- **Synthetic-59:** soak via `scripts/synthetic_59_*.py` under `reports/wattlab-parity/fixtures/synthetic_59/`. Do not greenwash `expected_faults.csv`. B100 dump-parity is **active** (`wattlab_parity_*.py` vs vibe19 `:latest` 4.4.1).
 - **Units:** FDD SQL is °F canonical. Metric CSVs convert at query (`unit_system=metric|si`). Lab sliders show °C when metric is selected; Run all rules after switching.
 - **Hourly append:** seed with `POST /api/csv/import/package`, then `POST /api/csv/import/package/append` (JWT, `confirm:true`). Custom appenders stay outside the repo.
 - **Overview layout:** full width beside sidebar (Streamlit-like); named Plotly PNG stems via `downloadFilename`; Lab rule menu A–Z; FDD series = required∪optional roles.

--- a/docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md
+++ b/docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md
@@ -1,75 +1,24 @@
-# Prompt 2 — vibe_code_apps_19 (Windows Cursor)
+# Prompt 2 — CLOSED (playground PR #92)
 
-Copy this whole file into the **Windows Cursor** session that owns
-`py-bacnet-stacks-playground` / `vibe_code_apps_19`. Do **not** run this on
-bensbench. bensbench only `docker pull ghcr.io/bbartling/vibe19`.
+Do **not** run further Windows work for VAV health CSV export. bensbench only `docker pull ghcr.io/bbartling/vibe19:latest`.
 
-## Goal
+## Closeout (Windows Cursor reported)
 
-Pin the OpenFDD **PyPI** analytics oracle and **export** the same CSVs the
-OpenFDD dump-vs-dump scripts already compare. Do **not** reimplement VAV health,
-mech OAT bins, or motor hours in Streamlit.
+| Item | Value |
+| --- | --- |
+| Merge | `4b71061666d1c34c9c93b3c66fa08e043ae856ae` |
+| PR | [#92](https://github.com/bbartling/py-bacnet-stacks-playground/pull/92) into `develop` |
+| Pin | `open-fdd[reporting]==4.4.1` |
+| Catalog hash | `2e684dbb8f3188f06942c3cb0155aef4149713e7244b9f7733262f182465cba9` |
+| GHCR | `:latest` / `:develop` rebuilt green |
 
-PyPI is live: `open-fdd==4.4.1` (GHA Trusted Publishing, tag `open-fdd-v4.4.1`).
+Diagnostic and forensic dumps call `open_fdd.analytics.dump_tables`. Engineering Bundle + `MANIFEST.json` include `vav_health_matrix.csv`, `mech_cooling_oat_bins.csv`, `motor_hours.csv`, `motor_weekly.csv`.
 
-## Pin
+## bensbench verification 2026-08-15
 
-In `vibe_code_apps_19` requirements / Docker image:
+- Image digest `sha256:101126abbe4d0affe4ffac6a8cf03bd5a1f31fe8e7161e6eb354910f32760f07`
+- `docker exec vibe19` → `open_fdd.__version__ == 4.4.1`, `dump_tables` importable
+- Oracle dump wrote all four analytics CSVs
+- Synthetic-59 target pairs **59/59** on vibe19
 
-```text
-open-fdd[reporting]==4.4.1
-```
-
-Smoke after install:
-
-```python
-import open_fdd
-from open_fdd.analytics import dump_tables, vav_health_matrix, mech_cooling_oat_bins
-assert open_fdd.__version__ == "4.4.1"
-assert callable(dump_tables) and callable(vav_health_matrix)
-```
-
-## Diagnostic WattLab dump (required files)
-
-The 4.4.0 image imported `vav_health_matrix_v1` but the **diagnostic dump did
-not write** `vav_health_matrix.csv`. Fix export only.
-
-Call pandas (do not fork):
-
-```python
-from open_fdd.analytics import dump_tables
-
-dump_tables(
-    out_dir,  # same folder as MANIFEST / fdd_findings.csv
-    frames=frames,
-    role_map=role_map,
-    rule_results=findings_df,  # so broken_box is not always ?/3
-    weather=weather,
-    building_id=building_id,
-)
-```
-
-Must appear in the diagnostic Engineering Bundle + `MANIFEST.json`:
-
-- `vav_health_matrix.csv`
-- `mech_cooling_oat_bins.csv`
-- `motor_hours.csv`
-- `motor_weekly.csv`
-
-Overview matrix is presentation. Do not skip the CSV because the UI already shows a table.
-
-## Rebuild and publish
-
-Rebuild `ghcr.io/bbartling/vibe19` on Windows (or that CI). Tag `:latest` / `:develop` as you already do.
-
-bensbench will then:
-
-```bash
-docker pull ghcr.io/bbartling/vibe19:latest
-```
-
-## Out of scope
-
-- Do not reimplement FDD rules (call `open_fdd.rules`).
-- Do not port Rust-only sensor-stats/diurnal into pandas.
-- Do not edit `bbartling/open-fdd` from the playground machine for this prompt.
+No new Windows prompt unless a later dump is missing those files again.

--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -1,7 +1,8 @@
-# WattLab-to-WattLab dump parity (Building 100) — 4.4.1 / `sha-2c12c8e`
+# WattLab-to-WattLab dump parity (Building 100) — vibe19 4.4.1 / `sha-2c12c8e`
 
-Oracle: vibe19 Engineering Bundle (`ghcr.io/bbartling/vibe19:latest`, wheel **4.4.0** until Prompt 2 pins **4.4.1**).  
-OpenFDD: DataFusion assembler on **`sha-2c12c8e`** (PR #727), health `3.3.0+2c12c8e814a8`. `:nightly` digest matches `sha-2c12c8e` (`sha256:54e6fbf5…123d82`).
+Oracle: vibe19 Engineering Bundle `ghcr.io/bbartling/vibe19:latest` digest `sha256:101126ab…32760f07`, wheel **4.4.1**, catalog `2e684dbb…cba9` (playground PR **#92** `4b71061`). Diagnostic dump includes `vav_health_matrix.csv`, `mech_cooling_oat_bins.csv`, `motor_hours.csv`, `motor_weekly.csv`.
+
+OpenFDD: DataFusion on **`sha-2c12c8e`** (PR #727 SQL), health `3.3.0+2c12c8e814a8`. `:nightly` digest matched this pin at soak (`sha256:54e6fbf5…123d82`). Stack: `OPENFDD_IMAGE_TAG=sha-2c12c8e` `react-ot --no-pull`. No local docker/cargo build.
 
 ## Cycle header
 
@@ -9,34 +10,43 @@ OpenFDD: DataFusion assembler on **`sha-2c12c8e`** (PR #727), health `3.3.0+2c12
 | --- | --- |
 | Date | 2026-08-15 |
 | OpenFDD pin | `sha-2c12c8e` health `3.3.0+2c12c8e814a8` |
-| PyPI | **open-fdd 4.4.1** (tag `open-fdd-v4.4.1`, Trusted Publishing) |
-| Vibe19 | `:latest` digest `sha256:6a4297b9…e6f54d` (still 4.4.0 wheel; Prompt 2 on Windows) |
-| **blockers** | **405** (unchanged vs `sha-8ab0b5e`) |
-| accepted | 2690 |
-| rows | 3260 |
+| PyPI / vibe19 wheel | **open-fdd 4.4.1** |
+| Vibe19 | `:latest` = `:develop` `sha256:101126ab…32760f07` |
+| **blockers** | **449** (was 405 before vav_health row compare) |
+| accepted | 2689 |
+| rows | 3303 |
 | stop_rule_met | **false** |
 
-Classifier (A2): blockers are FAULT vs PASS and FAULT∩FAULT hours. N/A-omit and one-sided sensor columns are accepted. FDD blockers 217; remaining sensor_diurnal/stats ~187 are two-sided numeric gaps, not one-sided `mean`.
+`vav_health_matrix.csv` is present on both sides. Missing-oracle is a **blocker** again (Prompt 2 closed). 44 of 449 blockers are per-equipment `vav_health` score/label gaps, not a missing file.
 
-## Four B100 examples after ECON SQL follow-on (#727)
+## Synthetic-59 ground truth (expected_faults.csv, ~1 h planted)
 
-| ID | vibe19 pandas | OpenFDD SQL `sha-2c12c8e` | Notes |
+| Side | Target match |
+| --- | --- |
+| vibe19 pandas | **59/59** |
+| OpenFDD SQL | **59/59** |
+| Overview analytics soak | **PASS** (runtime + mech OAT bins) |
+
+Eyeball: ECON-1/2 synth damper is **0–1** (fault hour damper 0.0 / 1.0). That is why SQL `damper_frac` CTE matches goldens here and still fails B100 **0–100**.
+
+## Four B100 FDD examples (`sha-2c12c8e`)
+
+| ID | vibe19 pandas | OpenFDD SQL | Notes |
 | --- | ---: | ---: | --- |
-| `AHU-DUCTHI` AHU_2 | FAULT **0.5 h** | FAULT **1.83 h** | Unchanged vs #725. Residual ~1.3 h FAULT∩FAULT still a blocker. |
-| `ECON-2` AHU_1 | PASS **0 h** | FAULT **1422.92 h** | Still open. Hours **rose** vs 952.5 h after dropping the extra fan AND; 0–100 damper 20 still behaves like raw `20 > 0.42`. `damper_frac` CTE did not fix DataFusion on this historian. |
-| `ECON-1` AHU_1 | FAULT **326 h** | PASS **0 h** | Still a FAULT/PASS blocker. Raw damper 20 is not `< 0.05`; cmd-first fan did not produce the pandas 326 h. |
-| `CHW-NOLOAD-1` CHILLER_2 | FAULT **524.5 h** | **SKIPPED_MISSING_ROLES** | No false PASS. Skip until load-satisfaction enrichment is mapped. Accepted vs FAULT. |
+| `AHU-DUCTHI` AHU_2 | FAULT **0.5 h** | FAULT **1.83 h** | Residual ~1.3 h FAULT∩FAULT |
+| `ECON-2` AHU_1 | PASS **0 h** | FAULT **1422.92 h** | Raw 0–100 damper vs 0.42 |
+| `ECON-1` AHU_1 | FAULT **326.08 h** | PASS **0 h** | Same damper scale |
+| `CHW-NOLOAD-1` CHILLER_2 | FAULT **524.5 h** | **SKIPPED_MISSING_ROLES** | No false PASS; accepted |
 
-Do not greenwash: #727 shipped `damper_frac` + pandas fan/equation; B100 ECON-1/2 are still open. Next SQL attempt should inline the percent CASE in the same SELECT as `FROM history` (no later-CTE column), matching the historian `damper_fb_pct` pattern.
+Follow-on SQL: inline percent `CASE` in the same `SELECT` as `FROM history` (not a later CTE column).
 
 ## Commands
 
 ```bash
 export OPENFDD_IMAGE_TAG=sha-2c12c8e
-docker pull ghcr.io/bbartling/openfdd-central:sha-2c12c8e  # + web/fieldbus/mqtt
 ./scripts/openfdd_stack_up.sh react-ot --no-pull
+python3 scripts/wattlab_parity_oracle_dump.py
 python3 scripts/wattlab_parity_ofdd_rust_bundle.py
 python3 scripts/wattlab_parity_diff.py
+python3 scripts/synthetic_59_target_pair_soak.py --side both
 ```
-
-No local `docker build`. Vibe19 Prompt 2: [`docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md`](../agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md).

--- a/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
@@ -1,34 +1,34 @@
-# WattLab / Vibe19 parity — Building 100 (OpenFDD 4.4.1 / `sha-2c12c8e`)
+# WattLab / Vibe19 parity — Building 100 + Synthetic-59 (4.4.1 / `sha-2c12c8e`)
 
-Dump-vs-dump after ECON-1/2 SQL follow-on (PR **#727**). Oracle remains GHCR vibe19 until Windows Prompt 2 pins PyPI **4.4.1**. OpenFDD is DataFusion JWT APIs. GHCR `:nightly` digest matches `sha-2c12c8e`.
+Dump-vs-dump after playground **PR #92** (wheel 4.4.1, `dump_tables` in diagnostic/forensic bundles). OpenFDD is DataFusion JWT APIs on **`sha-2c12c8e`**. bensbench: pull only, `--no-pull` stack-up, no local docker/cargo release.
 
-Working copy: `reports/wattlab-parity/` (gitignored artifacts).
+Working copy: `reports/wattlab-parity/` (gitignored).
 
 ## Cycle header
 
 | Side | Value |
 | --- | --- |
 | Date | 2026-08-15 |
-| OpenFDD git | `2c12c8e` (#727) |
-| OpenFDD image | `ghcr.io/bbartling/openfdd-*:sha-2c12c8e` |
+| OpenFDD git/image | `2c12c8e` / `ghcr.io/bbartling/openfdd-*:sha-2c12c8e` |
 | Central health | `3.3.0+2c12c8e814a8` |
-| `/api/fdd/rules` | **66** (62 pandas + 4 SQL analytics) |
-| PyPI (vibe19 should pin) | **4.4.1** (`open-fdd-v4.4.1`) |
-| Vibe19 image wheel today | still **4.4.0** until Prompt 2 |
-| Vibe19 image | `:latest` digest `sha256:6a4297b9…e6f54d` |
+| Vibe19 | `:latest` digest `sha256:101126ab…32760f07` |
+| `open_fdd.__version__` | **4.4.1** catalog `2e684dbb…cba9` |
+| Playground merge | PR **#92** `4b71061666d1c34c9c93b3c66fa08e043ae856ae` |
 | Gate 0 | PUT kept `occupancy_schedule` |
-| `diff_summary.json` | **405 blockers**, 2690 accepted, 3260 rows, `stop_rule_met=false` |
+| `diff_summary.json` | **449 blockers**, 2689 accepted, 3303 rows, `stop_rule_met=false` |
 
-Prior cycle (`sha-8ab0b5e`): also **405** blockers. ECON SQL follow-on did not reduce the dump-vs-dump count.
+## Synthetic-59
 
-## Four-rule soak (`sha-2c12c8e`)
+vibe19 **59/59**, OpenFDD SQL **59/59**, analytics soak PASS. Planted faults are 1.0 h. Synth ECON damper is 0–1, not B100 0–100.
+
+## Four-rule B100 soak
 
 | ID | pandas | SQL | Outcome |
 | --- | ---: | ---: | --- |
-| AHU-DUCTHI AHU_2 | 0.5 h FAULT | 1.83 h FAULT | Unchanged residual |
-| ECON-2 AHU_1 | 0 h PASS | 1422.92 h FAULT | Still open (was 952.5 h; fan AND removed, damper still raw-class) |
-| ECON-1 AHU_1 | 326 h FAULT | 0 h PASS | Still open |
-| CHW-NOLOAD-1 CHILLER_2 | 524.5 h FAULT | SKIPPED_MISSING_ROLES | No false PASS |
+| AHU-DUCTHI AHU_2 | 0.5 h FAULT | 1.83 h FAULT | residual |
+| ECON-2 AHU_1 | 0 h PASS | 1422.92 h FAULT | still open |
+| ECON-1 AHU_1 | 326.08 h FAULT | 0 h PASS | still open |
+| CHW-NOLOAD-1 CHILLER_2 | 524.5 h FAULT | SKIPPED_MISSING_ROLES | no false PASS |
 
 ## Measured blockers
 
@@ -37,21 +37,10 @@ Prior cycle (`sha-8ab0b5e`): also **405** blockers. ECON SQL follow-on did not r
 | `fdd_findings` | 217 |
 | `sensor_diurnal_24h.csv` | 89 |
 | `sensor_stats_fan_off.csv` | 74 |
+| `vav_health_matrix.csv` | 44 |
 | `sensor_stats_all.csv` | 21 |
 | other | 4 |
 
-Stop rule remains `blocker_count == 0`. Remaining FDD blockers are real FAULT/PASS and FAULT∩FAULT hours.
+Oracle dump now writes vav/mech/motor CSVs. Per-row vav_health score gaps are real blockers, not a missing-file skip.
 
-## Program B handoff
-
-- PyPI **4.4.1** is on pypi.org (`dump_tables`, metric bins, vav_health).
-- Windows Cursor: [`docs/agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md`](../agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md) for `vibe_code_apps_19`. bensbench does not edit playground; `docker pull ghcr.io/bbartling/vibe19:latest` only.
-
-## Commands
-
-```bash
-export OPENFDD_IMAGE_TAG=sha-2c12c8e
-./scripts/openfdd_stack_up.sh react-ot --no-pull
-OPENFDD_ADMIN_PASSWORD=… python3 scripts/wattlab_parity_ofdd_rust_bundle.py
-python3 scripts/wattlab_parity_diff.py
-```
+Prompt 2 is **closed** — see [`VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md`](../agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md).

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -69,7 +69,7 @@ retest. Do not confuse those with this engineering OS.
 26. **Overview plot Expanders** default **open** — do not hide motor / mech / econ / BAS plot sections behind carets (`Expander` unmounts children when closed).
 27. **FDD Plots series overlay** honors Lab/`session_config` `confirm_min` (and typed rule params); source may be `sql_detail_session`. After Update-this-rule, listen for `RULES_UPDATED` and refetch results + series.
 28. **SCHED-1 portable occupancy:** numeric/boolean falsey (`0`, `0.0`, `false`) **and** string `unoccupied` (plus related tokens) — keep SQL (`sched1_unoccupied_runtime.sql`) and pandas `sched1` aligned.
-29. **Low-RAM / bensbench:** never local stack `docker build`; prune old images before pull; wait for GHCR publish then pull `sha-*` / `nightly`. Synthetic-59 soaks use `scripts/synthetic_59_*.py`; B100 dump-parity stays paused; never edit goldens to hide misses.
+29. **Low-RAM / bensbench:** never local stack `docker build`; prune old images before pull; wait for GHCR publish then pull `sha-*` / `nightly`. Synthetic-59 soaks use `scripts/synthetic_59_*.py`; B100 dump-parity is active (`wattlab_parity_*.py`); never edit goldens to hide misses.
 30. **Plot PNG downloads:** `PlotlyHost` must pass `toImageButtonOptions.filename` (Overview/Reports). Default Plotly `newplot.png` is a regression.
 31. **Full-width UI:** `.app-content` / `.overview-populated` stretch (`max-width: none`) like Streamlit — do not reintroduce a rem content cap on Overview plots.
 32. **Rule Lab menu:** `RuleTuningPanel` sorts visible rules A–Z by `rule_id` (registry YAML order is engine priority only).

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,12 @@
 # Session log
 
+## 2026-08-15 — vibe19 4.4.1 + Synthetic-59 59/59 + B100 dump
+
+- Playground PR #92: `open-fdd[reporting]==4.4.1`; diagnostic dump writes vav/mech/motor CSVs. bensbench pulled `ghcr.io/bbartling/vibe19:latest` (`sha256:101126ab…`).
+- Synthetic-59: vibe19 and OpenFDD SQL **59/59**; analytics soak PASS. Synth ECON damper is 0–1.
+- B100 dump-vs-dump on `sha-2c12c8e`: 449 blockers (vav_health rows now compared). ECON-1/2 still open on 0–100 damper; inline percent CASE in same SELECT as `FROM history`.
+- Low-RAM: GHA/GHCR only; pin `sha-*` `--no-pull`. B100 dump-parity unpaused in AGENTS.md.
+
 ## 2026-08-14 — Metric boundary, slice CI, plot contracts, hourly append
 
 - FDD SQL stays °F; `unit_system=metric` converts temperature roles at query; Lab sliders show °C.

--- a/scripts/wattlab_parity_diff.py
+++ b/scripts/wattlab_parity_diff.py
@@ -738,11 +738,7 @@ def compare_vav_health(oracle_dir: Path, ofdd_dir: Path) -> list[dict]:
                 "vibe19": False,
                 "ofdd": r_ok,
                 "delta": "oracle dump missing vav_health_matrix.csv",
-                "severity": "accepted",
-                "rationale": (
-                    "OpenFDD 4.4.0 ships vav_health; vibe19 diagnostic export "
-                    "did not write the CSV even when the wheel is 4.4.0 (Prompt 2)."
-                ),
+                "severity": "blocker",
             }
         )
         return rows

--- a/sql_rules/econ1_stuck_closed.sql
+++ b/sql_rules/econ1_stuck_closed.sql
@@ -1,37 +1,24 @@
 -- econ1_stuck_closed.sql — ECON-1 economizer stuck closed
--- Damper is damper_frac (never aliased back to oa_damper_pct).
--- Pandas _fan is fan-cmd first (percent-normalized), then fan-status.
--- Ranked confirm matches other economizer rules (CONFIRM_ROWS from 600 s).
-WITH h AS (
-  SELECT
-    equipment_id,
-    timestamp_utc,
-    oa_t,
-    CASE
-      WHEN oa_damper_pct IS NULL THEN NULL
-      WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0
-      ELSE oa_damper_pct
-    END AS damper_frac,
-    CASE
-      WHEN fan_cmd IS NOT NULL THEN CASE
-        WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1
-        ELSE 0
-      END
-      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.5 THEN 1 ELSE 0 END
-      ELSE 0
-    END AS fan_on
-  FROM history
-),
-base AS (
+-- Inline damper percent CASE in the same SELECT as FROM history.
+-- Pandas _fan is fan-cmd first (percent-normalized), then fan-status (> 0.5).
+WITH base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
-      WHEN fan_on = 0 THEN 0
-      WHEN damper_frac IS NOT NULL AND oa_t IS NOT NULL
-       AND damper_frac < {{ECON1_DAMPER_MAX}} AND oa_t > {{ECON1_OAT_MIN}}
+      WHEN CASE
+        WHEN fan_cmd IS NOT NULL THEN CASE
+          WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1
+          ELSE 0
+        END
+        WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.5 THEN 1 ELSE 0 END
+        ELSE 0
+      END = 0 THEN 0
+      WHEN oa_damper_pct IS NOT NULL AND oa_t IS NOT NULL
+       AND (CASE WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END) < {{ECON1_DAMPER_MAX}}
+       AND oa_t > {{ECON1_OAT_MIN}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
-  FROM h
+  FROM history
 ),
 lagged AS (
   SELECT

--- a/sql_rules/economizer_fault.sql
+++ b/sql_rules/economizer_fault.sql
@@ -1,28 +1,17 @@
 -- economizer_fault.sql — ECON-2 economizing when outdoor unfavorable + confirm
--- Damper is damper_frac (never aliased back to oa_damper_pct — DataFusion can
--- keep the raw same-name column in later CTEs, so 20 > 0.42 would still fire).
--- Pandas econ2 has no fan gate: OAT > ECON2_OAT_HI AND damper_frac > ECON2_DAMPER.
-WITH h AS (
-  SELECT
-    equipment_id,
-    timestamp_utc,
-    oa_t,
-    CASE
-      WHEN oa_damper_pct IS NULL THEN NULL
-      WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0
-      ELSE oa_damper_pct
-    END AS damper_frac
-  FROM history
-),
-base AS (
+-- Inline percent CASE in the same SELECT as FROM history (do not rely on a later
+-- CTE column). DataFusion can still see raw oa_damper_pct (0–100) after a
+-- damper_frac alias, so 20 > 0.42 would fire. Pandas econ2 has no fan gate.
+WITH base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
-      WHEN oa_t IS NOT NULL AND damper_frac IS NOT NULL
-       AND oa_t > {{ECON2_OAT_HI}} AND damper_frac > {{ECON2_DAMPER}}
+      WHEN oa_t IS NOT NULL AND oa_damper_pct IS NOT NULL
+       AND oa_t > {{ECON2_OAT_HI}}
+       AND (CASE WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END) > {{ECON2_DAMPER}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
-  FROM h
+  FROM history
 ),
 lagged AS (
   SELECT


### PR DESCRIPTION
## Summary
- ECON-1/2 SQL: percent-normalize damper in the same SELECT as FROM history (no later CTE column).
- vibe19 4.4.1 dump has vav/mech/motor CSVs; missing oracle vav_health is a blocker again.
- Bugreports + Prompt 2 closeout; unpause B100 dump-parity in AGENTS.md. Synthetic-59 59/59 on sha-2c12c8e.

## Test plan
- [ ] Cookbook parity / fixtures / fdd-engine GHA
- [ ] After merge: wait GHCR sha, pin --no-pull, re-check ECON-1/2 AHU_1 hours vs pandas


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated migration and parity reports with refreshed 4.4.1, Synthetic-59, B100, and VAV health results.
  - Recorded completion details for the Windows Cursor work, including verification outcomes and reopening criteria.
  - Updated operational guidance and session logs to reflect resumed dump-parity validation.

- **Bug Fixes**
  - Missing VAV health comparison data is now clearly reported as a blocking issue.
  - Improved economizer and damper fault evaluation for more accurate parity results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->