### PR TITLE
Record sha-8525cfc B100 soak (ECON still open)

### DIFF
--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -1,15 +1,15 @@
-# WattLab-to-WattLab dump parity (Building 100) — vibe19 4.4.1 / `sha-2c12c8e`
+# WattLab-to-WattLab dump parity (Building 100) — vibe19 4.4.1 / `sha-8525cfc`
 
 Oracle: vibe19 Engineering Bundle `ghcr.io/bbartling/vibe19:latest` digest `sha256:101126ab…32760f07`, wheel **4.4.1**, catalog `2e684dbb…cba9` (playground PR **#92** `4b71061`). Diagnostic dump includes `vav_health_matrix.csv`, `mech_cooling_oat_bins.csv`, `motor_hours.csv`, `motor_weekly.csv`.
 
-OpenFDD: DataFusion on **`sha-2c12c8e`** (PR #727 SQL), health `3.3.0+2c12c8e814a8`. `:nightly` digest matched this pin at soak (`sha256:54e6fbf5…123d82`). Stack: `OPENFDD_IMAGE_TAG=sha-2c12c8e` `react-ot --no-pull`. No local docker/cargo build.
+OpenFDD: DataFusion on **`sha-8525cfc`** (PR #729 inline damper CASE), health `3.3.0+8525cfca140f`. `:nightly` digest matches (`sha256:1b2a9128…be1d8c`). Stack: `OPENFDD_IMAGE_TAG=sha-8525cfc` `react-ot --no-pull`. No local docker/cargo build.
 
 ## Cycle header
 
 | Metric | Value |
 | --- | --- |
 | Date | 2026-08-15 |
-| OpenFDD pin | `sha-2c12c8e` health `3.3.0+2c12c8e814a8` |
+| OpenFDD pin | `sha-8525cfc` health `3.3.0+8525cfca140f` |
 | PyPI / vibe19 wheel | **open-fdd 4.4.1** |
 | Vibe19 | `:latest` = `:develop` `sha256:101126ab…32760f07` |
 | **blockers** | **449** (was 405 before vav_health row compare) |
@@ -29,21 +29,21 @@ OpenFDD: DataFusion on **`sha-2c12c8e`** (PR #727 SQL), health `3.3.0+2c12c8e814
 
 Eyeball: ECON-1/2 synth damper is **0–1** (fault hour damper 0.0 / 1.0). That is why SQL `damper_frac` CTE matches goldens here and still fails B100 **0–100**.
 
-## Four B100 FDD examples (`sha-2c12c8e`)
+## Four B100 FDD examples (`sha-8525cfc` after inline CASE)
 
 | ID | vibe19 pandas | OpenFDD SQL | Notes |
 | --- | ---: | ---: | --- |
 | `AHU-DUCTHI` AHU_2 | FAULT **0.5 h** | FAULT **1.83 h** | Residual ~1.3 h FAULT∩FAULT |
-| `ECON-2` AHU_1 | PASS **0 h** | FAULT **1422.92 h** | Raw 0–100 damper vs 0.42 |
-| `ECON-1` AHU_1 | FAULT **326.08 h** | PASS **0 h** | Same damper scale |
+| `ECON-2` AHU_1 | PASS **0 h** | FAULT **1422.92 h** | Unchanged vs CTE alias. Image SQL has inline `> 1.0` `/100`; hours still match raw `20 > 0.42`. |
+| `ECON-1` AHU_1 | FAULT **326.08 h** | PASS **0 h** | Unchanged |
 | `CHW-NOLOAD-1` CHILLER_2 | FAULT **524.5 h** | **SKIPPED_MISSING_ROLES** | No false PASS; accepted |
 
-Follow-on SQL: inline percent `CASE` in the same `SELECT` as `FROM history` (not a later CTE column).
+Do not claim the inline CASE cleared B100. Next: prove DataFusion comparison types on `oa_damper_pct` (CAST DOUBLE / `>= 1.5`) in GHA fixtures with **0–100** damper, not only 0–1 Synthetic-59.
 
 ## Commands
 
 ```bash
-export OPENFDD_IMAGE_TAG=sha-2c12c8e
+export OPENFDD_IMAGE_TAG=sha-8525cfc
 ./scripts/openfdd_stack_up.sh react-ot --no-pull
 python3 scripts/wattlab_parity_oracle_dump.py
 python3 scripts/wattlab_parity_ofdd_rust_bundle.py

--- a/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
@@ -1,6 +1,6 @@
-# WattLab / Vibe19 parity — Building 100 + Synthetic-59 (4.4.1 / `sha-2c12c8e`)
+# WattLab / Vibe19 parity — Building 100 + Synthetic-59 (4.4.1 / `sha-8525cfc`)
 
-Dump-vs-dump after playground **PR #92** (wheel 4.4.1, `dump_tables` in diagnostic/forensic bundles). OpenFDD is DataFusion JWT APIs on **`sha-2c12c8e`**. bensbench: pull only, `--no-pull` stack-up, no local docker/cargo release.
+Dump-vs-dump after playground **PR #92** (wheel 4.4.1, `dump_tables` in diagnostic/forensic bundles). OpenFDD is DataFusion JWT APIs on **`sha-8525cfc`** (PR **#729**). bensbench: pull only, `--no-pull` stack-up, no local docker/cargo release.
 
 Working copy: `reports/wattlab-parity/` (gitignored).
 
@@ -9,8 +9,8 @@ Working copy: `reports/wattlab-parity/` (gitignored).
 | Side | Value |
 | --- | --- |
 | Date | 2026-08-15 |
-| OpenFDD git/image | `2c12c8e` / `ghcr.io/bbartling/openfdd-*:sha-2c12c8e` |
-| Central health | `3.3.0+2c12c8e814a8` |
+| OpenFDD git/image | `8525cfc` / `ghcr.io/bbartling/openfdd-*:sha-8525cfc` |
+| Central health | `3.3.0+8525cfca140f` |
 | Vibe19 | `:latest` digest `sha256:101126ab…32760f07` |
 | `open_fdd.__version__` | **4.4.1** catalog `2e684dbb…cba9` |
 | Playground merge | PR **#92** `4b71061666d1c34c9c93b3c66fa08e043ae856ae` |
@@ -26,7 +26,7 @@ vibe19 **59/59**, OpenFDD SQL **59/59**, analytics soak PASS. Planted faults are
 | ID | pandas | SQL | Outcome |
 | --- | ---: | ---: | --- |
 | AHU-DUCTHI AHU_2 | 0.5 h FAULT | 1.83 h FAULT | residual |
-| ECON-2 AHU_1 | 0 h PASS | 1422.92 h FAULT | still open |
+| ECON-2 AHU_1 | 0 h PASS | 1422.92 h FAULT | still open after inline CASE |
 | ECON-1 AHU_1 | 326.08 h FAULT | 0 h PASS | still open |
 | CHW-NOLOAD-1 CHILLER_2 | 524.5 h FAULT | SKIPPED_MISSING_ROLES | no false PASS |
 


### PR DESCRIPTION
## Summary
- Pin soak to sha-8525cfc / 3.3.0+8525cfca140f; nightly digest matches.
- Inline damper CASE is in the image; B100 ECON-1/2 hours unchanged. Synthetic-59 still 59/59.

## Test plan
- [ ] docs-guard green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated WattLab and Vibe19 migration reports with the latest OpenFDD revision, container image references, and health version.
  - Added refreshed diagnostic context, including updated blocker counts and per-equipment score and label findings.
  - Documented revised B100 results, ECON-2 observations, and follow-up validation for damper percentage values.
  - Updated command examples to use the latest image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->