### PR TITLE
CAST ECON damper percent (0–100) for DataFusion

### DIFF
--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1260,6 +1260,9 @@ timestamp_utc,oa_t,oa_damper_pct,fan_cmd,fan_status
         );
 
         let got = run_rule_fault_hours(&building, "econ1_stuck_closed.sql", 300.0, 0, &[]).await;
-        assert!(got > 0.0, "ECON-1 percent stuck closed should fault, got {got}h");
+        assert!(
+            got > 0.0,
+            "ECON-1 percent stuck closed should fault, got {got}h"
+        );
     }
 }

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1144,4 +1144,122 @@ timestamp_utc,ch_col,pump_col,load_col
         let got = run_rule_fault_hours(&building, "chw_noload_1.sql", 300.0, 0, &[]).await;
         assert_hours_close(got, 0.0, "CHW-NOLOAD-1 loaded building");
     }
+
+    #[tokio::test]
+    async fn econ2_percent_min_oa_does_not_fault() {
+        // B100-style 0–100 damper at min OA 20 with OAT 70 must not fire ECON-2
+        // (0.20 < 0.42). Utf8/int 20 > 0.42 without CAST/percent gate would.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON2_PCT");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,oa_t,oa_damper_pct
+2026-01-01T00:00:00Z,70,20
+2026-01-01T00:05:00Z,70,20
+2026-01-01T00:10:00Z,70,20
+2026-01-01T00:15:00Z,70,20
+2026-01-01T00:20:00Z,70,20
+2026-01-01T00:25:00Z,70,20
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "oa_t",
+                    role: "outside-air-temp",
+                },
+                RoleCol {
+                    csv_col: "oa_damper_pct",
+                    role: "outside-air-damper",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(&building, "economizer_fault.sql", 300.0, 0, &[]).await;
+        assert_hours_close(got, 0.0, "ECON-2 percent min OA");
+    }
+
+    #[tokio::test]
+    async fn econ2_fraction_damper_still_faults() {
+        // Synthetic-59 style 0–1 damper 0.55 with OAT 70 must still fault.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON2_FRAC");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,oa_t,oa_damper_pct
+2026-01-01T00:00:00Z,70,0.55
+2026-01-01T00:05:00Z,70,0.55
+2026-01-01T00:10:00Z,70,0.55
+2026-01-01T00:15:00Z,70,0.55
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "oa_t",
+                    role: "outside-air-temp",
+                },
+                RoleCol {
+                    csv_col: "oa_damper_pct",
+                    role: "outside-air-damper",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(&building, "economizer_fault.sql", 300.0, 0, &[]).await;
+        assert!(got > 0.0, "ECON-2 fraction damper should fault, got {got}h");
+    }
+
+    #[tokio::test]
+    async fn econ1_percent_stuck_closed_faults() {
+        // Damper 0 (0–100 or fraction), fan-cmd 60 percent, OAT 70 → ECON-1 hours > 0.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON1_PCT");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,oa_t,oa_damper_pct,fan_cmd,fan_status
+2026-01-01T00:00:00Z,70,0,60,1
+2026-01-01T00:05:00Z,70,0,60,1
+2026-01-01T00:10:00Z,70,0,60,1
+2026-01-01T00:15:00Z,70,0,60,1
+2026-01-01T00:20:00Z,70,0,60,1
+2026-01-01T00:25:00Z,70,0,60,1
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "oa_t",
+                    role: "outside-air-temp",
+                },
+                RoleCol {
+                    csv_col: "oa_damper_pct",
+                    role: "outside-air-damper",
+                },
+                RoleCol {
+                    csv_col: "fan_cmd",
+                    role: "fan-cmd",
+                },
+                RoleCol {
+                    csv_col: "fan_status",
+                    role: "fan-status",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(&building, "econ1_stuck_closed.sql", 300.0, 0, &[]).await;
+        assert!(got > 0.0, "ECON-1 percent stuck closed should fault, got {got}h");
+    }
 }

--- a/docs/agent/B100_MECH_OAT_BINS_FIX.md
+++ b/docs/agent/B100_MECH_OAT_BINS_FIX.md
@@ -28,3 +28,5 @@ workspace/data/csv_buildings/BUILDING_100/weather/columns.csv
 Then re-upload/re-ingest Building 100 so historian sees `web_oa_t`. Empty `role` for `dry_bulb_f` leaves only BAS `oa_t` on the stack.
 
 **2026-08-14:** Operator wrote `dry_bulb_f,web_oa_t` via `sudo tee`. Re-ingest BUILDING_100 after the stack is on `OPENFDD_IMAGE_TAG=sha-*` (`openfdd_stack_up.sh … --no-pull`) so parquet/historian pick up `web_oa_t`. Spot-check mech OAT bins vs vibe19 after that ingest.
+
+**Soak (bensbench, `OPENFDD_IMAGE_TAG=sha-a13c8b4`, master `a13c8b4`):** `POST /api/analytics/mechanical-cooling` for `BUILDING_100` reports `oat_column=web_oa_t`, `oat_join=site_broadcast_web_by_ts`. Aggregate peak bin **70–75°F / 204.58 h**, total **1156.5** device-h — matches vibe19 in the table above. `POST /api/analytics/vav-health` returns `vav_health_matrix_v1` (43 terminals; `?/3` until FDD results populate broken-box). Catalog `/api/fdd/rules` count **63**.

--- a/sql_rules/econ1_stuck_closed.sql
+++ b/sql_rules/econ1_stuck_closed.sql
@@ -1,5 +1,5 @@
 -- econ1_stuck_closed.sql — ECON-1 economizer stuck closed
--- Inline damper percent CASE in the same SELECT as FROM history.
+-- CAST DOUBLE + percent gate >= 1.5 on damper and fan_cmd (B100 0–100).
 -- Pandas _fan is fan-cmd first (percent-normalized), then fan-status (> 0.5).
 WITH base AS (
   SELECT
@@ -8,15 +8,27 @@ WITH base AS (
     CAST(CASE
       WHEN CASE
         WHEN fan_cmd IS NOT NULL THEN CASE
-          WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1
+          WHEN (
+            CASE
+              WHEN CAST(fan_cmd AS DOUBLE) >= 1.5
+              THEN CAST(fan_cmd AS DOUBLE) / 100.0
+              ELSE CAST(fan_cmd AS DOUBLE)
+            END
+          ) > 0.01 THEN 1
           ELSE 0
         END
-        WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.5 THEN 1 ELSE 0 END
+        WHEN fan_status IS NOT NULL THEN CASE WHEN CAST(fan_status AS DOUBLE) > 0.5 THEN 1 ELSE 0 END
         ELSE 0
       END = 0 THEN 0
       WHEN oa_damper_pct IS NOT NULL AND oa_t IS NOT NULL
-       AND (CASE WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END) < {{ECON1_DAMPER_MAX}}
-       AND oa_t > {{ECON1_OAT_MIN}}
+       AND (
+         CASE
+           WHEN CAST(oa_damper_pct AS DOUBLE) >= 1.5
+           THEN CAST(oa_damper_pct AS DOUBLE) / 100.0
+           ELSE CAST(oa_damper_pct AS DOUBLE)
+         END
+       ) < {{ECON1_DAMPER_MAX}}
+       AND CAST(oa_t AS DOUBLE) > {{ECON1_OAT_MIN}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
   FROM history
 ),

--- a/sql_rules/economizer_fault.sql
+++ b/sql_rules/economizer_fault.sql
@@ -1,15 +1,21 @@
 -- economizer_fault.sql — ECON-2 economizing when outdoor unfavorable + confirm
--- Inline percent CASE in the same SELECT as FROM history (do not rely on a later
--- CTE column). DataFusion can still see raw oa_damper_pct (0–100) after a
--- damper_frac alias, so 20 > 0.42 would fire. Pandas econ2 has no fan gate.
+-- CAST DOUBLE + percent gate >= 1.5 (not > 1.0) so Utf8/int 0–100 (B100 min OA 20)
+-- becomes 0.20 and does not fire vs ECON2_DAMPER 0.42. Fraction 0–1 stays 0–1.
+-- Pandas econ2 has no fan gate.
 WITH base AS (
   SELECT
     equipment_id,
     timestamp_utc,
     CAST(CASE
       WHEN oa_t IS NOT NULL AND oa_damper_pct IS NOT NULL
-       AND oa_t > {{ECON2_OAT_HI}}
-       AND (CASE WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END) > {{ECON2_DAMPER}}
+       AND CAST(oa_t AS DOUBLE) > {{ECON2_OAT_HI}}
+       AND (
+         CASE
+           WHEN CAST(oa_damper_pct AS DOUBLE) >= 1.5
+           THEN CAST(oa_damper_pct AS DOUBLE) / 100.0
+           ELSE CAST(oa_damper_pct AS DOUBLE)
+         END
+       ) > {{ECON2_DAMPER}}
       THEN 1 ELSE 0 END AS INT) AS raw_fault
   FROM history
 ),


### PR DESCRIPTION
## Summary
- CAST `oa_damper_pct` / `fan_cmd` / `oa_t` to DOUBLE and scale percent when `>= 1.5` so B100 0–100 min OA 20 is 0.20, not a raw `20 > 0.42` ECON-2 fire.
- GHA oracle tests: damper 20 + OAT 70 → ECON-2 0 h; damper 0 + fan-cmd 60 → ECON-1 hours > 0; fraction 0.55 still faults ECON-2.
- Records B100 mech OAT bins soak (already matched vibe19); no historian code.

## Test plan
- [ ] Rust Stack CI `fdd_rules` oracle tests green (no local cargo on bensbench)
- [ ] After merge: GHCR `sha-<7>` equals `:nightly`; pin `--no-pull`; B100 ECON-2 ~0 h, ECON-1 ~326 h; Synthetic-59 still 59/59


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved economizer fault detection for both percentage-based and fractional damper readings.
  * Correctly identifies fully closed dampers while fans are operating.
  * Prevents false ECON-2 alerts from valid minimum outside-air inputs.
  * Improved handling of outdoor-air temperature values and mechanical-cooling results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->