### PR TITLE
Record sha-5aebdfc B100 soak (ECON CAST did not change hours)

### DIFF
--- a/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_DUMP_PARITY.md
@@ -1,52 +1,53 @@
-# WattLab-to-WattLab dump parity (Building 100) — vibe19 4.4.1 / `sha-8525cfc`
+# WattLab-to-WattLab dump parity (Building 100) — vibe19 4.4.1 / `sha-5aebdfc`
 
 Oracle: vibe19 Engineering Bundle `ghcr.io/bbartling/vibe19:latest` digest `sha256:101126ab…32760f07`, wheel **4.4.1**, catalog `2e684dbb…cba9` (playground PR **#92** `4b71061`). Diagnostic dump includes `vav_health_matrix.csv`, `mech_cooling_oat_bins.csv`, `motor_hours.csv`, `motor_weekly.csv`.
 
-OpenFDD: DataFusion on **`sha-8525cfc`** (PR #729 inline damper CASE), health `3.3.0+8525cfca140f`. `:nightly` digest matches (`sha256:1b2a9128…be1d8c`). Stack: `OPENFDD_IMAGE_TAG=sha-8525cfc` `react-ot --no-pull`. No local docker/cargo build.
+OpenFDD: DataFusion on **`sha-5aebdfc`** (PR **#731** CAST DOUBLE + `>= 1.5` percent gate). Health `3.3.0+5aebdfc54434`. `:nightly` digest matches central `sha256:a56846e2…4006351a`. Stack: `OPENFDD_IMAGE_TAG=sha-5aebdfc` `react-ot --no-pull`. No local docker/cargo build. Image SQL contains the CAST gate (docker exec confirmed).
 
 ## Cycle header
 
 | Metric | Value |
 | --- | --- |
-| Date | 2026-08-15 |
-| OpenFDD pin | `sha-8525cfc` health `3.3.0+8525cfca140f` |
+| Date | 2026-08-16 |
+| OpenFDD pin | `sha-5aebdfc` health `3.3.0+5aebdfc54434` |
 | PyPI / vibe19 wheel | **open-fdd 4.4.1** |
 | Vibe19 | `:latest` = `:develop` `sha256:101126ab…32760f07` |
-| **blockers** | **449** (was 405 before vav_health row compare) |
+| **blockers** | **449** |
 | accepted | 2689 |
 | rows | 3303 |
 | stop_rule_met | **false** |
 
-`vav_health_matrix.csv` is present on both sides. Missing-oracle is a **blocker** again (Prompt 2 closed). 44 of 449 blockers are per-equipment `vav_health` score/label gaps, not a missing file.
+`vav_health_matrix.csv` is present on both sides. 44 of 449 blockers are per-equipment `vav_health` score/label gaps, not a missing file.
 
 ## Synthetic-59 ground truth (expected_faults.csv, ~1 h planted)
 
 | Side | Target match |
 | --- | --- |
-| vibe19 pandas | **59/59** |
-| OpenFDD SQL | **59/59** |
-| Overview analytics soak | **PASS** (runtime + mech OAT bins) |
+| vibe19 pandas | **59/59** (prior cycle; damper 0–1) |
+| OpenFDD SQL | **59/59** on `sha-5aebdfc` |
+| Overview analytics soak | **PASS** (prior cycle) |
 
-Eyeball: ECON-1/2 synth damper is **0–1** (fault hour damper 0.0 / 1.0). That is why SQL `damper_frac` CTE matches goldens here and still fails B100 **0–100**.
+GHA oracle tests on #731: damper **20** + OAT 70 → ECON-2 **0 h**; damper **0** + fan-cmd **60** → ECON-1 hours **> 0**; fraction **0.55** still faults ECON-2.
 
-## Four B100 FDD examples (`sha-8525cfc` after inline CASE)
+## Four B100 FDD examples (`sha-5aebdfc` after CAST / `>= 1.5`)
+
+AHU_1 parquet `oa_damper_pct` is **Float64**, min 0 max 100 (not Utf8). When `oa_t > 63`, damper median/p90 is **100**, so fraction 1.0 **does** exceed 0.42. SQL **1422.92 h** matches `frac(damper)>0.42` **and** raw `damper>0.42` on this historian (17075 samples). The “min OA 20 compared as 20 > 0.42” story does **not** hold for current parquet.
 
 | ID | vibe19 pandas | OpenFDD SQL | Notes |
 | --- | ---: | ---: | --- |
 | `AHU-DUCTHI` AHU_2 | FAULT **0.5 h** | FAULT **1.83 h** | Residual ~1.3 h FAULT∩FAULT |
-| `ECON-2` AHU_1 | PASS **0 h** | FAULT **1422.92 h** | Unchanged vs CTE alias. Image SQL has inline `> 1.0` `/100`; hours still match raw `20 > 0.42`. |
-| `ECON-1` AHU_1 | FAULT **326.08 h** | PASS **0 h** | Unchanged |
+| `ECON-2` AHU_1 | PASS **0 h** | FAULT **1422.92 h** | Unchanged hours. CAST is live; historian damper is ~100% in high OAT, not stuck at min OA 20. Pandas still 0 h → **series/equation mismatch**, not DF types. |
+| `ECON-1` AHU_1 | FAULT **326.08 h** | PASS **0 h** | Unchanged. SQL sees damper open (not stuck closed). |
 | `CHW-NOLOAD-1` CHILLER_2 | FAULT **524.5 h** | **SKIPPED_MISSING_ROLES** | No false PASS; accepted |
 
-Do not claim the inline CASE cleared B100. Next: prove DataFusion comparison types on `oa_damper_pct` (CAST DOUBLE / `>= 1.5`) in GHA fixtures with **0–100** damper, not only 0–1 Synthetic-59.
+Do not claim #731 cleared B100 ECON vs pandas. Next: which AHU_1 point pandas uses for econ damper vs historian `oa_damper_pct` (and OAT), not another CAST.
 
 ## Commands
 
 ```bash
-export OPENFDD_IMAGE_TAG=sha-8525cfc
+export OPENFDD_IMAGE_TAG=sha-5aebdfc
 ./scripts/openfdd_stack_up.sh react-ot --no-pull
-python3 scripts/wattlab_parity_oracle_dump.py
 python3 scripts/wattlab_parity_ofdd_rust_bundle.py
 python3 scripts/wattlab_parity_diff.py
-python3 scripts/synthetic_59_target_pair_soak.py --side both
+python3 scripts/synthetic_59_target_pair_soak.py --side ofdd
 ```

--- a/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
+++ b/docs/migration/BUGREPORT_WATTLAB_VIBE19_PARITY.md
@@ -1,6 +1,6 @@
-# WattLab / Vibe19 parity — Building 100 + Synthetic-59 (4.4.1 / `sha-8525cfc`)
+# WattLab / Vibe19 parity — Building 100 + Synthetic-59 (4.4.1 / `sha-5aebdfc`)
 
-Dump-vs-dump after playground **PR #92** (wheel 4.4.1, `dump_tables` in diagnostic/forensic bundles). OpenFDD is DataFusion JWT APIs on **`sha-8525cfc`** (PR **#729**). bensbench: pull only, `--no-pull` stack-up, no local docker/cargo release.
+Dump-vs-dump after playground **PR #92** (wheel 4.4.1, `dump_tables` in diagnostic/forensic bundles). OpenFDD is DataFusion JWT APIs on **`sha-5aebdfc`** (PR **#731** CAST / `>= 1.5`). bensbench: pull only, `--no-pull` stack-up, no local docker/cargo release.
 
 Working copy: `reports/wattlab-parity/` (gitignored).
 
@@ -8,9 +8,9 @@ Working copy: `reports/wattlab-parity/` (gitignored).
 
 | Side | Value |
 | --- | --- |
-| Date | 2026-08-15 |
-| OpenFDD git/image | `8525cfc` / `ghcr.io/bbartling/openfdd-*:sha-8525cfc` |
-| Central health | `3.3.0+8525cfca140f` |
+| Date | 2026-08-16 |
+| OpenFDD git/image | `5aebdfc` / `ghcr.io/bbartling/openfdd-*:sha-5aebdfc` |
+| Central health | `3.3.0+5aebdfc54434` |
 | Vibe19 | `:latest` digest `sha256:101126ab…32760f07` |
 | `open_fdd.__version__` | **4.4.1** catalog `2e684dbb…cba9` |
 | Playground merge | PR **#92** `4b71061666d1c34c9c93b3c66fa08e043ae856ae` |
@@ -19,15 +19,15 @@ Working copy: `reports/wattlab-parity/` (gitignored).
 
 ## Synthetic-59
 
-vibe19 **59/59**, OpenFDD SQL **59/59**, analytics soak PASS. Planted faults are 1.0 h. Synth ECON damper is 0–1, not B100 0–100.
+OpenFDD SQL **59/59** on `sha-5aebdfc`. Planted faults are 1.0 h. Synth ECON damper is 0–1. GHA percent fixtures (damper 20) pass; they are not B100 historian (damper ~100 when OAT > 63 °F).
 
 ## Four-rule B100 soak
 
 | ID | pandas | SQL | Outcome |
 | --- | ---: | ---: | --- |
 | AHU-DUCTHI AHU_2 | 0.5 h FAULT | 1.83 h FAULT | residual |
-| ECON-2 AHU_1 | 0 h PASS | 1422.92 h FAULT | still open after inline CASE |
-| ECON-1 AHU_1 | 326.08 h FAULT | 0 h PASS | still open |
+| ECON-2 AHU_1 | 0 h PASS | 1422.92 h FAULT | CAST live; parquet Float64 0–100, high-OAT median 100. Not a type bug. |
+| ECON-1 AHU_1 | 326.08 h FAULT | 0 h PASS | SQL damper not stuck closed |
 | CHW-NOLOAD-1 CHILLER_2 | 524.5 h FAULT | SKIPPED_MISSING_ROLES | no false PASS |
 
 ## Measured blockers
@@ -40,7 +40,5 @@ vibe19 **59/59**, OpenFDD SQL **59/59**, analytics soak PASS. Planted faults are
 | `vav_health_matrix.csv` | 44 |
 | `sensor_stats_all.csv` | 21 |
 | other | 4 |
-
-Oracle dump now writes vav/mech/motor CSVs. Per-row vav_health score gaps are real blockers, not a missing-file skip.
 
 Prompt 2 is **closed** — see [`VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md`](../agent/VIBE19_PROMPT2_VAV_HEALTH_EXPORT.md).

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,12 @@
 # Session log
 
+## 2026-08-16 — ECON CAST/`>= 1.5` (#731) soak `sha-5aebdfc`
+
+- SQL: CAST damper/fan/OAT DOUBLE; percent if `>= 1.5`. GHA: damper 20 → ECON-2 0 h; fan-cmd 60 + damper 0 → ECON-1 > 0; fraction 0.55 still faults.
+- GHCR `:nightly` = `sha-5aebdfc` digest `sha256:a56846e2…4006351a`. Pin `--no-pull`. Health `3.3.0+5aebdfc54434`.
+- Synthetic-59 SQL **59/59**. B100 ECON hours **unchanged** (1422.92 / 0). AHU_1 parquet damper is Float64 0–100; when OAT>63 median is **100**, so 1422.92 h is frac-correct on this historian. Pandas 0 h / 326 h is a **point mapping** gap, not Utf8 CAST.
+- Dump parity still **449** blockers. Mech OAT bins soak note committed with #731.
+
 ## 2026-08-15 — vibe19 4.4.1 + Synthetic-59 59/59 + B100 dump
 
 - Playground PR #92: `open-fdd[reporting]==4.4.1`; diagnostic dump writes vav/mech/motor CSVs. bensbench pulled `ghcr.io/bbartling/vibe19:latest` (`sha256:101126ab…`).


### PR DESCRIPTION
## Summary
- Soak pin `sha-5aebdfc` / health `3.3.0+5aebdfc54434`; nightly digest matches.
- Synthetic-59 SQL 59/59. B100 ECON-1/2 hours unchanged; parquet damper ~100% when OAT>63 (not Utf8 min-OA 20).
- Do not claim #731 cleared pandas vs SQL ECON on Building 100.

## Test plan
- [x] Docs only; no SQL change


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration parity reports with the latest health version, validation date, digest, and CAST/`>= 1.5` gate results.
  * Documented current SQL parity, Synthetic-59 validation, and B100 economizer findings.
  * Clarified AHU damper data handling and ongoing ECON-1/ECON-2 data mismatches.
  * Updated remaining blocker counts, next steps, and removed outdated Oracle dump guidance.
  * Added a session-log entry covering soak results, image details, parity checks, and remaining blockers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->