### PR TITLE
Prefer mad_c as OA damper over fan-enable aliases

### DIFF
--- a/crates/fdd_core/src/columns.rs
+++ b/crates/fdd_core/src/columns.rs
@@ -334,7 +334,10 @@ fn infer_role_from_column_name(column: &str) -> Option<String> {
     }
     if c.contains("damper") || c.contains("dmpr") {
         // Fan-enable / min-OA setpoints are not the economizer damper command.
-        if c.contains("enable") || c.contains("minimum") || c.contains("min_pos") || c.contains("minpos")
+        if c.contains("enable")
+            || c.contains("minimum")
+            || c.contains("min_pos")
+            || c.contains("minpos")
         {
             return None;
         }

--- a/crates/fdd_core/src/columns.rs
+++ b/crates/fdd_core/src/columns.rs
@@ -312,11 +312,15 @@ fn infer_role_from_column_name(column: &str) -> Option<String> {
     {
         return Some("rat".into());
     }
+    // Mixed-air *damper command* (mad_c) is OA damper, not mixed-air temperature.
+    // Mapping mad_c → mat made ingest drop the explicit oa_damper_pct role or
+    // lose the race to ex_dmpr_pos_fan_enable_pct (B100 ECON hours).
+    if c == "mad_c" || c == "mad-c" || c == "mad_c_pct" || c.contains("mixed_air_damper") {
+        return Some("oa_damper_pct".into());
+    }
     if c.contains("mixed_air")
         || c.contains("ma_t")
         || c.contains("ma-t")
-        || c == "mad_c"
-        || c == "mad-c"
         || c.starts_with("web_ma")
         || c == "web_mat"
     {
@@ -329,6 +333,11 @@ fn infer_role_from_column_name(column: &str) -> Option<String> {
         return Some("htg_valve_pct".into());
     }
     if c.contains("damper") || c.contains("dmpr") {
+        // Fan-enable / min-OA setpoints are not the economizer damper command.
+        if c.contains("enable") || c.contains("minimum") || c.contains("min_pos") || c.contains("minpos")
+        {
+            return None;
+        }
         return Some("oa_damper_pct".into());
     }
     if c.contains("zone_t") || c.contains("spacetemp") {
@@ -501,5 +510,44 @@ mod tests {
         assert_eq!(map.get("vav_7_space_temp_f"), Some(&"zone_t".to_string()));
         assert!(!map.contains_key("space_temp_f_58"));
         assert_eq!(map.get("space_temp_f_77"), Some(&"zone_t".to_string()));
+    }
+
+    #[test]
+    fn b100_mad_c_is_oa_damper_not_mat_or_enable() {
+        assert_eq!(
+            infer_role_from_column_name("mad_c").as_deref(),
+            Some("oa_damper_pct")
+        );
+        assert_eq!(
+            infer_role_from_column_name("mad_c_pct").as_deref(),
+            Some("oa_damper_pct")
+        );
+        assert_eq!(
+            infer_role_from_column_name("mixed_air_temp_f").as_deref(),
+            Some("mat")
+        );
+        assert_eq!(
+            infer_role_from_column_name("ex_dmpr_pos_fan_enable_pct"),
+            None
+        );
+        assert_eq!(infer_role_from_column_name("oa_minimum_position_pct"), None);
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("columns.csv");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            "column,role\n\
+             mad_c,oa_damper_pct\n\
+             mixed_air_temp_f,mat\n\
+             ex_dmpr_pos_fan_enable_pct,\n\
+             oa_minimum_position_pct,"
+        )
+        .unwrap();
+        let map = load_column_role_map(&path).unwrap();
+        assert_eq!(map.get("mad_c"), Some(&"oa_damper_pct".to_string()));
+        assert_eq!(map.get("mixed_air_temp_f"), Some(&"mat".to_string()));
+        assert!(!map.contains_key("ex_dmpr_pos_fan_enable_pct"));
+        assert!(!map.contains_key("oa_minimum_position_pct"));
     }
 }

--- a/crates/fdd_core/src/role_rank.rs
+++ b/crates/fdd_core/src/role_rank.rs
@@ -37,7 +37,10 @@ pub fn score_column_for_role(role: &str, column: &str) -> i32 {
                 || c.contains("minpos")
             {
                 -100
-            } else if c == "mad_c" || c == "mad-c" || c.contains("mad_c") || c.contains("mixed_air_damper")
+            } else if c == "mad_c"
+                || c == "mad-c"
+                || c.contains("mad_c")
+                || c.contains("mixed_air_damper")
             {
                 100
             } else if (c.contains("ex_dmpr") || c.contains("oa_damper")) && !c.contains("enable") {

--- a/crates/fdd_core/src/role_rank.rs
+++ b/crates/fdd_core/src/role_rank.rs
@@ -31,7 +31,16 @@ pub fn score_column_for_role(role: &str, column: &str) -> i32 {
             }
         }
         "oa_damper_pct" => {
-            if c.contains("ex_dmpr") || c.contains("oa_damper") {
+            if c.contains("enable")
+                || c.contains("minimum")
+                || c.contains("min_pos")
+                || c.contains("minpos")
+            {
+                -100
+            } else if c == "mad_c" || c == "mad-c" || c.contains("mad_c") || c.contains("mixed_air_damper")
+            {
+                100
+            } else if (c.contains("ex_dmpr") || c.contains("oa_damper")) && !c.contains("enable") {
                 90
             } else if c.contains("damper") || c.contains("dmpr") {
                 70
@@ -49,10 +58,11 @@ pub fn score_column_for_role(role: &str, column: &str) -> i32 {
             }
         }
         "mat" => {
-            if c.contains("mixed_air") {
+            if c.contains("mixed_air") && !c.contains("damper") {
                 100
-            } else if c == "mad_c" {
-                80
+            } else if c == "mad_c" || c == "mad-c" || c.contains("mad_c") {
+                // mad_c is damper command; never prefer it as mixed-air temp.
+                -100
             } else {
                 0
             }
@@ -115,5 +125,17 @@ mod tests {
     fn alarm_columns_rejected() {
         assert!(is_zone_t_limit_or_alarm_column("space_temp_f_58"));
         assert!(!is_zone_t_limit_or_alarm_column("vav_7_space_temp_f"));
+    }
+
+    #[test]
+    fn oa_damper_prefers_mad_c_over_fan_enable() {
+        let mad = score_column_for_role("oa_damper_pct", "mad_c");
+        let enable = score_column_for_role("oa_damper_pct", "ex_dmpr_pos_fan_enable_pct");
+        let min_oa = score_column_for_role("oa_damper_pct", "oa_minimum_position_pct");
+        assert!(mad > enable, "mad_c={mad} enable={enable}");
+        assert!(mad > min_oa, "mad_c={mad} min_oa={min_oa}");
+        assert!(enable < 0);
+        assert_eq!(score_column_for_role("mat", "mad_c"), -100);
+        assert_eq!(score_column_for_role("mat", "mixed_air_temp_f"), 100);
     }
 }

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1273,11 +1273,7 @@ timestamp_utc,oa_t,oa_damper_pct,fan_cmd,fan_status
         let tmp = tempfile::TempDir::new().unwrap();
         let building = tmp.path().join("BUILDING_ECON2_MAD");
         std::fs::create_dir_all(&building).unwrap();
-        std::fs::write(
-            building.join("manifest.json"),
-            r#"{"grid_minutes":5}"#,
-        )
-        .unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
         let eq = building.join("AHU_1");
         std::fs::create_dir_all(&eq).unwrap();
         std::fs::write(

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1265,4 +1265,43 @@ timestamp_utc,oa_t,oa_damper_pct,fan_cmd,fan_status
             "ECON-1 percent stuck closed should fault, got {got}h"
         );
     }
+
+    #[tokio::test]
+    async fn econ2_b100_competing_enable_column_uses_mad_c() {
+        // B100: mad_c ~20 (min OA) vs blank-role ex_dmpr_pos_fan_enable_pct ~100.
+        // Ingest must keep mad_c so ECON-2 does not fire at OAT 70.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON2_MAD");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(
+            building.join("manifest.json"),
+            r#"{"grid_minutes":5}"#,
+        )
+        .unwrap();
+        let eq = building.join("AHU_1");
+        std::fs::create_dir_all(&eq).unwrap();
+        std::fs::write(
+            eq.join("columns.csv"),
+            "column,role\n\
+             mad_c,oa_damper_pct\n\
+             ex_dmpr_pos_fan_enable_pct,\n\
+             oa_minimum_position_pct,\n\
+             outside_air_temp_f,oa_t\n",
+        )
+        .unwrap();
+        std::fs::write(
+            eq.join("history_wide.csv"),
+            "timestamp_utc,mad_c,ex_dmpr_pos_fan_enable_pct,oa_minimum_position_pct,outside_air_temp_f\n\
+2026-01-01T00:00:00Z,20,100,20,70\n\
+2026-01-01T00:05:00Z,20,100,20,70\n\
+2026-01-01T00:10:00Z,20,100,20,70\n\
+2026-01-01T00:15:00Z,20,100,20,70\n\
+2026-01-01T00:20:00Z,20,100,20,70\n\
+2026-01-01T00:25:00Z,20,100,20,70\n",
+        )
+        .unwrap();
+
+        let got = run_rule_fault_hours(&building, "economizer_fault.sql", 300.0, 0, &[]).await;
+        assert_hours_close(got, 0.0, "ECON-2 mad_c vs fan-enable");
+    }
 }

--- a/crates/fdd_store/src/ingest.rs
+++ b/crates/fdd_store/src/ingest.rs
@@ -522,6 +522,42 @@ mod tests {
     }
 
     #[test]
+    fn ingest_b100_style_picks_mad_c_not_fan_enable() {
+        let tmp = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(tmp.path().join("columns.csv")).unwrap();
+        writeln!(
+            f,
+            "column,role\n\
+             mad_c,oa_damper_pct\n\
+             ex_dmpr_pos_fan_enable_pct,\n\
+             oa_minimum_position_pct,\n\
+             outside_air_temp_f,oa_t"
+        )
+        .unwrap();
+        let mut h = std::fs::File::create(tmp.path().join("history_wide.csv")).unwrap();
+        writeln!(
+            h,
+            "timestamp_utc,mad_c,ex_dmpr_pos_fan_enable_pct,oa_minimum_position_pct,outside_air_temp_f"
+        )
+        .unwrap();
+        writeln!(h, "2026-01-01T00:00:00Z,20,100,20,70").unwrap();
+        let (batch, rows) = read_csv_batch(
+            &tmp.path().join("history_wide.csv"),
+            &tmp.path().join("columns.csv"),
+        )
+        .unwrap();
+        assert_eq!(rows, 1);
+        let idx = batch.schema().index_of("oa_damper_pct").unwrap();
+        let col = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(col.value(0), 20.0);
+        assert!(!col.is_null(0));
+    }
+
+    #[test]
     fn ingest_records_weather_error_when_path_missing() {
         let tmp = TempDir::new().unwrap();
         let data = tmp.path().join("BUILDING_100");

--- a/crates/fdd_store/src/ingest.rs
+++ b/crates/fdd_store/src/ingest.rs
@@ -554,7 +554,6 @@ mod tests {
             .downcast_ref::<Float64Array>()
             .unwrap();
         assert_eq!(col.value(0), 20.0);
-        assert!(!col.is_null(0));
     }
 
     #[test]

--- a/open_fdd/analytics/role_map.py
+++ b/open_fdd/analytics/role_map.py
@@ -161,7 +161,11 @@ def _rank_column(role: str, col: str) -> int:
         return 90
     # Demote setpoints / min-position masquerading as OA damper command
     if role == "outside-air-damper" and (
-        "setpoint" in cl or "minimum" in cl or "min_pos" in cl or "minpos" in cl
+        "setpoint" in cl
+        or "minimum" in cl
+        or "min_pos" in cl
+        or "minpos" in cl
+        or "enable" in cl
     ):
         return 95
     # Zone damper role must not steal AHU OA / MAD columns


### PR DESCRIPTION
## Summary
- B100 ECON-2 SQL (~1423 h) vs pandas (0 h) was not a min-OA vs `mad_c` role swap: vibe19 `data_model.csv` already maps `outside-air-damper` → `mad_c`.
- Blank-role ingest inferred `ex_dmpr_pos_fan_enable_pct` as `oa_damper_pct` (`contains("dmpr")`) and ranked it above explicit `mad_c` (score 90 vs 0). Enable sits at 100 when OAT>63; `mad_c` maxes at 20.
- Stop inferring enable/min-OA as damper; rank `mad_c` highest; GHA fixture: enable=100 vs mad_c=20 → ECON-2 0 h.

## Test plan
- [ ] GHA `oracle_parity_test::econ2_b100_competing_enable_column_uses_mad_c`
- [ ] After GHCR pin `sha-<7>` `--no-pull`: B100 ECON-2 ~0 h, ECON-1 ~326 h; Synthetic-59 59/59

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic identification of mixed-air damper columns as outside-air damper measurements.
  * Prevented fan-enable and minimum-position columns from being misclassified as damper commands or temperature readings.
  * Improved selection of the correct column when multiple candidates are available.
  * Corrected economizer fault evaluation when mixed-air damper data is present.
* **Tests**
  * Added regression coverage for column mapping, data ingestion, and economizer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->