### PR TITLE
Dump-parity grain keys, RCx coverage, VAV health accept

### DIFF
--- a/scripts/wattlab_parity_diff.py
+++ b/scripts/wattlab_parity_diff.py
@@ -347,20 +347,25 @@ def compare_quality(oracle_dir: Path) -> list[dict]:
     return rows
 
 
-def compare_topology(oracle_dir: Path) -> list[dict]:
+def compare_topology(oracle_dir: Path, ofdd_dir: Path | None = None) -> list[dict]:
     import csv
 
     topo = oracle_dir / "topology.csv"
+    ofdd_topo = (ofdd_dir / "topology.csv") if ofdd_dir else None
     if not topo.is_file():
+        ofdd_ok = bool(ofdd_topo and ofdd_topo.is_file() and ofdd_topo.stat().st_size > 0)
         return [
             {
                 "artifact": "topology",
                 "key": "presence",
                 "vibe19": None,
-                "ofdd": "n/a",
+                "ofdd": "present" if ofdd_ok else "n/a",
                 "delta": "oracle topology.csv missing",
                 "severity": "accepted",
-                "rationale": "Topology is an Engineering Bundle table; Rust capture is API-only.",
+                "rationale": (
+                    "vibe19 dump has no topology.csv; OpenFDD POST /api/analytics/topology "
+                    "is historian-inferred feeds/fedBy, not a pandas table to match."
+                ),
             }
         ]
     bad = []
@@ -406,6 +411,18 @@ _ANALYTIC_FILES = (
     "rcx_zone_comfort_ranking.csv",
 )
 
+# Last-write-wins on equipment_id+role collapsed diurnal hour/fan_state rows into
+# false mean blockers. Index the same grain vibe19 dumps use.
+_ANALYTIC_KEY_COLS: dict[str, tuple[str, ...]] = {
+    "sensor_diurnal_24h.csv": ("equipment_id", "role", "day_type", "fan_state", "hour"),
+    "sensor_stats_all.csv": ("equipment_id", "role", "fan_state"),
+    "sensor_stats_fan_on.csv": ("equipment_id", "role", "fan_state"),
+    "sensor_stats_fan_off.csv": ("equipment_id", "role", "fan_state"),
+    "rcx_preset_coverage.csv": ("preset_id",),
+    "motor_weekly.csv": ("equipment_id", "week_label", "signal"),
+    "motor_hours.csv": ("equipment_id", "signal"),
+}
+
 
 def _csv_index(path: Path, key_cols: tuple[str, ...]) -> dict[str, dict]:
     import csv
@@ -420,7 +437,10 @@ def _csv_index(path: Path, key_cols: tuple[str, ...]) -> dict[str, dict]:
         if not reader.fieldnames:
             return out
         for row in reader:
-            parts = [str(row.get(c) or "") for c in key_cols if c in (reader.fieldnames or [])]
+            row = dict(row)
+            if "fan_state" in key_cols and not str(row.get("fan_state") or "").strip():
+                row["fan_state"] = "all"
+            parts = [str(row.get(c) or "") for c in key_cols if c in (reader.fieldnames or []) or c == "fan_state"]
             if not any(parts):
                 parts = [str(row.get(c) or "") for c in ("equipment_id", "week_label", "role", "sensor")]
             key = "::".join(p for p in parts if p) or json.dumps(row, sort_keys=True)[:80]
@@ -487,8 +507,11 @@ def compare_analytics_tables(oracle_dir: Path, ofdd_dir: Path) -> list[dict]:
                 }
             )
             continue
-        o_idx = _csv_index(o_path, ("equipment_id", "signal", "week_label", "role"))
-        r_idx = _csv_index(r_path, ("equipment_id", "signal", "week_label", "role"))
+        key_cols = _ANALYTIC_KEY_COLS.get(
+            name, ("equipment_id", "signal", "week_label", "role")
+        )
+        o_idx = _csv_index(o_path, key_cols)
+        r_idx = _csv_index(r_path, key_cols)
         keys = sorted(set(o_idx) | set(r_idx))
         n_block = 0
         n_ok = 0
@@ -806,6 +829,27 @@ def compare_vav_health(oracle_dir: Path, ofdd_dir: Path) -> list[dict]:
             if ov != rv:
                 mismatch.append(col)
         if mismatch:
+            o_notes = str(o.get("notes") or "")
+            r_eng = str(r.get("engine") or "")
+            pandas_missing = "missing_damper" in o_notes or str(
+                o.get("score_label") or ""
+            ).startswith("?")
+            if pandas_missing and r_eng == "datafusion":
+                rows.append(
+                    {
+                        "artifact": "vav_health_matrix.csv",
+                        "key": eq,
+                        "vibe19": {c: o.get(c) for c in mismatch},
+                        "ofdd": {c: r.get(c) for c in mismatch},
+                        "delta": mismatch,
+                        "severity": "accepted",
+                        "rationale": (
+                            "Pandas vav_health_matrix_v1 scores ?/3 when damper role is missing; "
+                            "DataFusion scores n/3 from FDD broken-box + comfort + rogue."
+                        ),
+                    }
+                )
+                continue
             n_block += 1
             rows.append(
                 {
@@ -969,7 +1013,7 @@ def main() -> int:
     rows.extend(compare_manifest(args.oracle, args.ofdd))
     rows.extend(compare_package_health(args.oracle))
     rows.extend(compare_quality(args.oracle))
-    rows.extend(compare_topology(args.oracle))
+    rows.extend(compare_topology(args.oracle, args.ofdd))
     rows.extend(compare_analytics_tables(args.oracle, args.ofdd))
     rows.extend(compare_fdd(args.oracle, args.ofdd, args.capture))
     rows.extend(compare_vav_health(args.oracle, args.ofdd))

--- a/scripts/wattlab_parity_ofdd_rust_bundle.py
+++ b/scripts/wattlab_parity_ofdd_rust_bundle.py
@@ -44,7 +44,7 @@ EXTRA_ANALYTICS = (
     ("rcx_vav", "/api/analytics/rcx/vav"),
     ("rcx_chiller", "/api/analytics/rcx/chiller"),
     ("rcx_boiler", "/api/analytics/rcx/boiler"),
-    ("rcx_preset", "/api/analytics/rcx/preset"),
+    ("rcx_preset", "/api/analytics/rcx/presets"),
     ("setpoints", "/api/analytics/setpoints"),
     ("diurnal", "/api/analytics/diurnal"),
     ("topology", "/api/analytics/topology"),
@@ -74,6 +74,56 @@ def _rows_of(body) -> list:
         if isinstance(val, list) and val:
             return val
     return []
+
+
+DIURNAL_FIELDS = [
+    "equipment_id",
+    "equipment_type",
+    "role",
+    "source",
+    "day_type",
+    "fan_state",
+    "hour",
+    "n",
+    "mean",
+    "std",
+    "min",
+    "p50",
+    "max",
+]
+
+STATS_FIELDS = [
+    "equipment_id",
+    "equipment_type",
+    "role",
+    "source",
+    "source_column",
+    "fan_state",
+    "count",
+    "valid_count",
+    "n",
+    "mean",
+    "std",
+    "min",
+    "p50",
+    "max",
+]
+
+
+def _normalize_analytics_row(row: dict, *, source: str = "role_map") -> dict:
+    out = dict(row)
+    if "p50" not in out or out.get("p50") in (None, ""):
+        for alt in ("median", "p50_approx"):
+            if out.get(alt) not in (None, ""):
+                if alt != "mean":
+                    out["p50"] = out[alt]
+                break
+    if "std" not in out and out.get("stddev") not in (None, ""):
+        out["std"] = out.get("stddev")
+    out["source"] = out.get("source") or source
+    if not out.get("day_type"):
+        out["day_type"] = "all"
+    return out
 
 
 def _write_csv(path: Path, rows: list[dict], fieldnames: list[str] | None = None) -> None:
@@ -240,8 +290,6 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     mark("sensor_health_matrix.csv")
     _write_csv(bundle_dir / "sensor_fault_summary.csv", health_rows)
     mark("sensor_fault_summary.csv")
-    _write_csv(bundle_dir / "sensor_stats_all.csv", health_rows)
-    mark("sensor_stats_all.csv")
 
     schedule = _analytics(_unwrap(_load(capture_dir / "schedule.json") or {})[1])
     sched_rows = [r for r in (schedule.get("rows") or schedule.get("equipment") or []) if isinstance(r, dict)]
@@ -287,10 +335,47 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     mark("meter_monthly_electric.csv")
 
     rcx_vav = _extra_rows("rcx_vav")
-    rcx_preset = _extra_rows("rcx_preset")
+    rcx_preset_wrap = extra.get("rcx_preset") or {}
+    _, rcx_preset_body = (
+        _unwrap(rcx_preset_wrap) if isinstance(rcx_preset_wrap, dict) else (None, rcx_preset_wrap)
+    )
+    rcx_preset_rows: list[dict] = []
+    if isinstance(rcx_preset_body, dict):
+        presets = rcx_preset_body.get("presets")
+        if isinstance(presets, list):
+            for p in presets:
+                if not isinstance(p, dict):
+                    continue
+                rcx_preset_rows.append(
+                    {
+                        "preset_id": p.get("id") or p.get("preset_id") or "",
+                        "title": p.get("title") or "",
+                        "chart_type": p.get("chart") or p.get("chart_type") or "",
+                        "role": p.get("role_col") or p.get("role") or "",
+                        "series_count": p.get("series_count") or "",
+                        "row_count": p.get("row_count") or "",
+                        "outlier_count": p.get("outlier_count") or "",
+                        "empty_reason": p.get("empty_reason") or "",
+                    }
+                )
+        if not rcx_preset_rows:
+            rcx_preset_rows = [r for r in _rows_of(rcx_preset_body) if isinstance(r, dict)]
     _write_csv(bundle_dir / "rcx_zone_comfort_ranking.csv", rcx_vav)
     mark("rcx_zone_comfort_ranking.csv")
-    _write_csv(bundle_dir / "rcx_preset_coverage.csv", rcx_preset)
+    _write_csv(
+        bundle_dir / "rcx_preset_coverage.csv",
+        rcx_preset_rows,
+        [
+            "preset_id",
+            "title",
+            "chart_type",
+            "role",
+            "series_count",
+            "row_count",
+            "outlier_count",
+            "empty_reason",
+        ],
+    )
     mark("rcx_preset_coverage.csv")
 
     setpoints = _extra_rows("setpoints")
@@ -299,8 +384,8 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     if not setpoints:
         missing_apis.append("missing_table:setpoints.csv")
 
-    diurnal = _extra_rows("diurnal")
-    _write_csv(bundle_dir / "sensor_diurnal_24h.csv", diurnal)
+    diurnal = [_normalize_analytics_row(r) for r in _extra_rows("diurnal")]
+    _write_csv(bundle_dir / "sensor_diurnal_24h.csv", diurnal, DIURNAL_FIELDS)
     mark("sensor_diurnal_24h.csv")
     if not diurnal:
         missing_apis.append("missing_table:sensor_diurnal_24h.csv")
@@ -317,19 +402,19 @@ def assemble(capture_dir: Path, bundle_dir: Path) -> dict:
     if not topo_rows:
         missing_apis.append("missing_table:topology.csv")
 
-    stats_all = _extra_rows("sensor_stats_all")
-    _write_csv(bundle_dir / "sensor_stats_all.csv", stats_all or health_rows)
+    stats_all = [_normalize_analytics_row(r) for r in (_extra_rows("sensor_stats_all") or health_rows)]
+    _write_csv(bundle_dir / "sensor_stats_all.csv", stats_all, STATS_FIELDS)
     mark("sensor_stats_all.csv")
 
     # Fan-on / fan-off stats: same endpoint, series.fan_state captured separately
     # when capture_extra posts with body variants (see capture_extra).
-    stats_on = _extra_rows("sensor_stats_fan_on")
-    _write_csv(bundle_dir / "sensor_stats_fan_on.csv", stats_on)
+    stats_on = [_normalize_analytics_row(r) for r in _extra_rows("sensor_stats_fan_on")]
+    _write_csv(bundle_dir / "sensor_stats_fan_on.csv", stats_on, STATS_FIELDS)
     mark("sensor_stats_fan_on.csv")
     if not stats_on:
         missing_apis.append("missing_table:sensor_stats_fan_on.csv")
-    stats_off = _extra_rows("sensor_stats_fan_off")
-    _write_csv(bundle_dir / "sensor_stats_fan_off.csv", stats_off)
+    stats_off = [_normalize_analytics_row(r) for r in _extra_rows("sensor_stats_fan_off")]
+    _write_csv(bundle_dir / "sensor_stats_fan_off.csv", stats_off, STATS_FIELDS)
     mark("sensor_stats_fan_off.csv")
     if not stats_off:
         missing_apis.append("missing_table:sensor_stats_fan_off.csv")


### PR DESCRIPTION
## Summary
- Index diurnal/stats at vibe19 grain (hour/day_type/fan_state) so last-write-wins means are not false blockers.
- Assemble `rcx_preset_coverage.csv` from `/api/analytics/rcx/presets`.
- Accept pandas `?/3` VAV health vs DataFusion `n/3` when damper role is missing; accept missing vibe19 `topology.csv`.

## Test plan
- [ ] After #734 GHCR soak: re-run `wattlab_parity_diff.py` — expect dump blockers down without widening 0.05 h FDD tolerance
- [ ] Synthetic-59 still 59/59

Made with [Cursor](https://cursor.com)