### PR TITLE
Add sequenced leftover FDD dump-blocker cycle specs

### DIFF
--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -15,5 +15,6 @@ Paste prompts and dev-agent charters for Cursor/Codex on bench and WSL. **Not pu
 | `linux-edge-tester-stack-recipes-prompt.md` | Living daily bench prompt (overwrite in place, never date) |
 | `openfdd-agent-architecture.md` | Architecture reference (repo-only) |
 | `index.md` | Folder index (repo-only) |
+| `fdd_parity_cycles/` | Sequenced leftover dump-blocker cycles (docs-only specs; GHA product PRs later) |
 
 Raw links: `https://github.com/bbartling/open-fdd/blob/master/docs/agent/<file>.md`

--- a/docs/agent/fdd_parity_cycles/00_INDEX.md
+++ b/docs/agent/fdd_parity_cycles/00_INDEX.md
@@ -1,0 +1,54 @@
+# FDD leftover dump blockers — cycle index
+
+Building 100 dump-vs-dump after `#734`/`#735`/`#736` (`sha-69494c2`): **212 blockers**, all `fdd_findings`. Schema buckets (diurnal/stats/vav_health/rcx) are cleared. These cycles close **pandas vs SQL FDD hours/status**, not dump CSV grain.
+
+Do **not** run this as one mega-PR. Do **not** wait for GHCR / `:nightly` unless a later soak is explicitly requested. Do **not** promise `stop_rule_met=true` or 212→0.
+
+```mermaid
+flowchart LR
+  idx[00_index]
+  c1[01_ducthi_satdev_econ2]
+  c2[02_vav_ingest]
+  c3[03_chw1_econ347]
+  c4[04_sv_sensors]
+  c5[05_sched247]
+  idx --> c1 --> c2 --> c3 --> c4 --> c5
+```
+
+| Order | File | Family | Later PR may change |
+| ---: | --- | --- | --- |
+| 0 | this file | contract | — |
+| 1 | [01_ducthi_satdev_econ2.md](01_ducthi_satdev_econ2.md) | DUCTHI, SATDEV fan-gate, ECON-2 AHU_2 0.25 h | one SQL fan-gate + tiny GHA |
+| 2 | [02_vav_ingest.md](02_vav_ingest.md) | VAV-4/6 pandas FAULT / SQL PASS 0 | ingest rank like mad_c |
+| 3 | [03_chw1_econ347.md](03_chw1_econ347.md) | CHW-1 hours; ECON-3/4/6/7 | proof pack then one mapping/SQL |
+| 4 | [04_sv_sensors.md](04_sv_sensors.md) | SV-* 122 rows | per-sensor vs 5-role SQL |
+| 5 | [05_sched247.md](05_sched247.md) | SCHED-247 0 vs ~1500 h | window `%` vs streak, or semantic_gap |
+
+Baseline soak (do not greenwash away): [BUGREPORT_WATTLAB_DUMP_PARITY.md](../../migration/BUGREPORT_WATTLAB_DUMP_PARITY.md).
+
+## Shared test contract (every cycle)
+
+**Synthetic, short, few fault hours** — not Building 100 thousands of hours.
+
+1. Frozen golden: [`scripts/synthetic_59_target_pair_soak.py`](../../../scripts/synthetic_59_target_pair_soak.py) and [`reports/wattlab-parity/fixtures/synthetic_59/openfdd_synthetic_59_rule_fixture_v1/expected_faults.csv`](../../../reports/wattlab-parity/fixtures/synthetic_59/openfdd_synthetic_59_rule_fixture_v1/expected_faults.csv). Package `confirm_min=0`. Target **59/59**. Do **not** edit pandas thresholds so B100 “matches.”
+2. GHA: add fixtures in [`crates/fdd_rules/src/oracle_parity_test.rs`](../../../crates/fdd_rules/src/oracle_parity_test.rs) via `write_equipment_fixture`. Pattern: 6 samples × 5 min, `confirm_rows=2`, hours from `pandas_confirm_fault_hours` (see `sched247_fan_cmd_screening_confirm_streak` and ECON competing-column).
+3. Classifier: [`tests/test_wattlab_parity_diff.py`](../../../tests/test_wattlab_parity_diff.py). Do not auto-accept FAULT∩FAULT without a one-line rationale in [`scripts/wattlab_parity_diff.py`](../../../scripts/wattlab_parity_diff.py).
+
+**Bensbench low RAM:** no local `docker build`, `openfdd_stack_up.sh --build`, or `cargo test --all`. GHA still runs cargo. **Do not** wait for **Publish Open-FDD stack to GHCR**. Pin `sha-<7>` only on an explicit later soak.
+
+**Do not** mass-edit `ELSE 1` — [FAN_ON_ELSE_1_FOLLOWON.md](../FAN_ON_ELSE_1_FOLLOWON.md). One rule’s fan-gate per cycle.
+
+**Do not** mix [WINDOWS_PLAYGROUND_CLOSEOUT_PROMPT.md](../WINDOWS_PLAYGROUND_CLOSEOUT_PROMPT.md) into these PRs.
+
+## How to execute a cycle
+
+1. Open that cycle `.md` as the spec.
+2. Branch from `origin/master`. Implement the smallest SQL/mapping slice + GHA fixture.
+3. Wait **Rust CI** (and pytest if Python). Squash-merge.
+4. Stop. No GHCR watch, no B100 re-diff unless the user asks for a soak.
+
+## Stop rules
+
+- Blockers drop only when vibe19 and OpenFDD match **or** a row is `accepted` with a written rationale.
+- Synthetic-59 must stay 59/59 after every cycle that touches ingest or SQL.
+- Catalog `sql_screening` stays until the equation matches pandas on fixtures — do not flip `proven` from B100 hours alone.

--- a/docs/agent/fdd_parity_cycles/01_ducthi_satdev_econ2.md
+++ b/docs/agent/fdd_parity_cycles/01_ducthi_satdev_econ2.md
@@ -1,0 +1,48 @@
+# Cycle 1 — DUCTHI residual, SATDEV fan-gate, ECON-2 AHU_2 0.25 h
+
+Execute after [00_INDEX.md](00_INDEX.md). One GHA-only product PR. Do **not** wait for GHCR / `:nightly`.
+
+## Hypothesis
+
+Dump leftover (post `#736`, `sha-69494c2`):
+
+| Pair | Pandas | SQL | Notes |
+| --- | ---: | ---: | --- |
+| AHU-DUCTHI / AHU_2 | 0.5 h FAULT | 1.83 h FAULT | Fan gate already honest in SQL; residual is confirm/window, not `ELSE 1` |
+| AHU-SATDEV / (2 AHUs) | ~76 h FAULT | ~76 h FAULT | Both FAULT; hours close enough that the dump still flags if \|Δ\| > 0.05 h **or** SATDEV still invents on-hours when fan cols missing |
+| ECON-2 / AHU_2 | 140.58 h | 140.83 h | 0.25 h over the 0.05 h gate. **Not** the mad_c bug (`#734` cleared ECON-2 AHU_1 to 0 h PASS) |
+
+**SATDEV:** [`sql_rules/ahu_satdev.sql`](../../../sql_rules/ahu_satdev.sql) lines 10–13 still `ELSE 1` when fan columns are missing. Pandas treats missing fan as not-on. A GHA fixture with SAT off-setpoint and **no fan cols** must not invent on-hours.
+
+**DUCTHI:** [`sql_rules/ahu_ducthi.sql`](../../../sql_rules/ahu_ducthi.sql) already avoids fan `ELSE 1`. Prove the 0.5 vs 1.83 h residual on a **short** fixture (tiny exact hours), not by soaking B100.
+
+**ECON-2 AHU_2:** fixture-only if you can isolate 0.25 h; otherwise leave until cycle 3 (econ proof pack). Do **not** accept FAULT∩FAULT without a written rationale.
+
+## Files a later agent may change
+
+- [`sql_rules/ahu_satdev.sql`](../../../sql_rules/ahu_satdev.sql) — this cycle’s **one** fan-gate (`ELSE 1` → missing-fan = off). See [FAN_ON_ELSE_1_FOLLOWON.md](../FAN_ON_ELSE_1_FOLLOWON.md). Do **not** mass-edit other rules.
+- [`sql_rules/ahu_ducthi.sql`](../../../sql_rules/ahu_ducthi.sql) — only if the short fixture proves a real confirm/window bug.
+- [`crates/fdd_rules/src/oracle_parity_test.rs`](../../../crates/fdd_rules/src/oracle_parity_test.rs) — GHA fixtures.
+- Optional: one-line accept in [`scripts/wattlab_parity_diff.py`](../../../scripts/wattlab_parity_diff.py) **only** for ECON-2 AHU_2 0.25 h with rationale (rounding / last-interval), not a blanket hour gate.
+
+Do **not** edit pandas thresholds. Do **not** edit [`expected_faults.csv`](../../../reports/wattlab-parity/fixtures/synthetic_59/openfdd_synthetic_59_rule_fixture_v1/expected_faults.csv).
+
+## Tests (synthetic + GHA)
+
+Follow the [shared contract](00_INDEX.md#shared-test-contract-every-cycle).
+
+1. **GHA SATDEV missing-fan:** `write_equipment_fixture` with SAT off-setpoint, **no** `fan_status` / `sfn_c` columns. Expect SQL fault hours **0** (not invented on-hours). 6 samples × 5 min, `confirm_rows=2`.
+2. **GHA DUCTHI residual:** short fixture that encodes the 0.5 vs 1.83 pattern at tiny scale (e.g. one extra confirm row vs pandas). Hours must be **tiny and exact** (`pandas_confirm_fault_hours`), not B100 1.83 h.
+3. **GHA ECON-2 0.25 h (optional this cycle):** skip unless isolated in ≤6 samples. Else defer to cycle 3.
+4. Synthetic-59 soak must stay **59/59**. Do not run `cargo test --all` on Bensbench.
+
+## Do not GHCR
+
+Merge = squash after **Rust CI** (and pytest if Python classifier touched). No `OPENFDD_IMAGE_TAG=nightly`. No pin `sha-<7>`. Soak optional **later** if the user asks.
+
+## Out of scope
+
+- VAV ingest, CHW-1, SV sensor sweep, SCHED-247 (cycles 2–5)
+- Mass `ELSE 1` edits
+- Windows playground closeout
+- Promising dump 212→0

--- a/docs/agent/fdd_parity_cycles/02_vav_ingest.md
+++ b/docs/agent/fdd_parity_cycles/02_vav_ingest.md
@@ -1,0 +1,46 @@
+# Cycle 2 — VAV damper/flow ingest vs VAV-4/6 PASS 0
+
+Execute after [01_ducthi_satdev_econ2.md](01_ducthi_satdev_econ2.md). One GHA-only product PR. Do **not** wait for GHCR / `:nightly`.
+
+## Hypothesis
+
+Dump leftover: **~55 VAV** rows. Several **VAV-4 / VAV-6** pairs are pandas **FAULT** (~1300–1600 h) vs SQL **PASS 0**. Same shape as the ECON mad_c miss: SQL never sees the analog the pandas rule uses.
+
+[`sql_rules/vav4_damper_full_open.sql`](../../../sql_rules/vav4_damper_full_open.sql) needs `damper_pct`. If ingest in [`crates/fdd_core/src/columns.rs`](../../../crates/fdd_core/src/columns.rs) / [`crates/fdd_core/src/role_rank.rs`](../../../crates/fdd_core/src/role_rank.rs) ranks a competing column (or a blank-role `contains("dmpr")`) above the mapped damper, SQL evaluates empty and reports PASS 0.
+
+VAV-6 airflow analog is the same class of bug (flow role vs competing column).
+
+Synthetic VAV cases already exist in the 59 zip — **keep 59/59**. Do not invent new synthetic expected hours by editing pandas.
+
+**VAV-4 still has fan `ELSE 1`.** This cycle’s product change is **ingest rank**, not the fan-gate. Fan-gate for VAV-4 is a later one-rule follow-on (see [FAN_ON_ELSE_1_FOLLOWON.md](../FAN_ON_ELSE_1_FOLLOWON.md)) — do not mix it in unless the short fixture proves missing-fan is the PASS-0 cause.
+
+## Files a later agent may change
+
+- [`crates/fdd_core/src/columns.rs`](../../../crates/fdd_core/src/columns.rs)
+- [`crates/fdd_core/src/role_rank.rs`](../../../crates/fdd_core/src/role_rank.rs) (or equivalent rank table)
+- [`sql_rules/vav4_damper_full_open.sql`](../../../sql_rules/vav4_damper_full_open.sql) — only if the mapped column name in SQL does not match ingest
+- Sibling VAV-6 flow SQL under `sql_rules/`
+- [`crates/fdd_rules/src/oracle_parity_test.rs`](../../../crates/fdd_rules/src/oracle_parity_test.rs) — competing-column fixtures (same style as ECON mad_c vs `ex_dmpr_pos_fan_enable_pct`)
+
+Do **not** edit pandas. Do **not** auto-accept VAV FAULT∩PASS.
+
+## Tests (synthetic + GHA)
+
+Follow the [shared contract](00_INDEX.md#shared-test-contract-every-cycle).
+
+1. **GHA VAV-4 competing damper:** fixture with mapped `damper_pct` (or vibe19 damper column) **and** a higher-ranked junk `*dmpr*` analog that is not the damper. Pandas FAULT on the real damper; SQL must FAULT the same tiny hours — not PASS 0.
+2. **GHA VAV-6 competing flow:** same pattern for airflow.
+3. Hours: 6 samples × 5 min, `confirm_rows=2`, `pandas_confirm_fault_hours` exact. Not B100 1300 h.
+4. Synthetic-59 **59/59**.
+
+## Do not GHCR
+
+Merge = squash after **Rust CI**. No nightly pin. B100 re-diff only on an explicit later soak.
+
+## Out of scope
+
+- CHW-1 / remaining econ (cycle 3)
+- SV all-sensor sweep (cycle 4)
+- SCHED-247 definition (cycle 5)
+- Mass `ELSE 1` / CAST edits
+- Promising 212→0

--- a/docs/agent/fdd_parity_cycles/03_chw1_econ347.md
+++ b/docs/agent/fdd_parity_cycles/03_chw1_econ347.md
@@ -1,0 +1,58 @@
+# Cycle 3 — CHW-1 hours + remaining econ (3/4/6/7) proof-first
+
+Execute after [02_vav_ingest.md](02_vav_ingest.md). One GHA-only product PR **after** a written proof pack. Do **not** wait for GHCR / `:nightly`.
+
+## Hypothesis
+
+Dump leftover:
+
+| Family | n | Shape |
+| --- | ---: | --- |
+| CHW-1 | 1 | Both FAULT; **217 vs 767 h** — not a status flip |
+| ECON-3/4/6/7 | ~8 | Mix of hours and status after `#734` mad_c fix |
+| ECON-2 AHU_2 | 1 | 140.58 vs 140.83 (0.25 h) if cycle 1 deferred it |
+
+CHW-1 SQL: [`sql_rules/chw1_low_dt.sql`](../../../sql_rules/chw1_low_dt.sql). Hours diverge by hundreds — likely confirm window, ΔT column choice, or fan/pump gate — **not** a CAST/`ELSE 1` mass-edit.
+
+ECON-3/4/6/7: roles may still bind the wrong analog (mixed-air, OA fraction, cooling-enable) even though OA damper is `mad_c`. **Proof pack first** (column names on AHU_1/AHU_2 vs SQL `AS` roles), then one mapping or SQL PR. Do not guess from B100 hour tables.
+
+CAST / `>= 1.5` is already in economizer SQL — keep it. Do not mass-edit `ELSE 1`.
+
+## Proof pack (required before code)
+
+For each leftover pair, write (in the PR description or a short note under this folder, not a new soak report):
+
+1. Pandas inputs: which vibe19 `data_model.csv` points feed the rule.
+2. SQL roles: which `columns.rs` / rank winner lands in the SQL `AS` name.
+3. One sentence: missing column vs competing column vs confirm/streak vs true semantic gap.
+
+If the pack says **semantic gap**, stop and leave a `semantic_gap` rationale — do not streak-tune hours to fake a match.
+
+## Files a later agent may change
+
+- [`sql_rules/chw1_low_dt.sql`](../../../sql_rules/chw1_low_dt.sql)
+- Remaining `sql_rules/econ*.sql` for ECON-3/4/6/7 (one gate or one role per rule, not a sweep)
+- Ingest rank only if the proof pack shows a mad_c-class miss
+- [`crates/fdd_rules/src/oracle_parity_test.rs`](../../../crates/fdd_rules/src/oracle_parity_test.rs)
+- Optional one-line accept for ECON-2 AHU_2 0.25 h with rationale
+
+Do **not** edit pandas thresholds. Do **not** rewrite B100 bugreports in this PR.
+
+## Tests (synthetic + GHA)
+
+Follow the [shared contract](00_INDEX.md#shared-test-contract-every-cycle).
+
+1. **GHA CHW-1:** short fixture with the proven ΔT/gate mismatch at tiny hours (`pandas_confirm_fault_hours`). Not 217 vs 767.
+2. **GHA ECON-3/4/6/7:** one competing-column or missing-role fixture per rule that the proof pack names. Skip rules the pack marks `semantic_gap`.
+3. Synthetic-59 **59/59**.
+
+## Do not GHCR
+
+Merge = squash after **Rust CI**. No nightly. Soak later only if requested.
+
+## Out of scope
+
+- SV all-sensor port (cycle 4)
+- SCHED-247 window vs streak (cycle 5)
+- Mass CAST / `ELSE 1`
+- `stop_rule_met=true`

--- a/docs/agent/fdd_parity_cycles/04_sv_sensors.md
+++ b/docs/agent/fdd_parity_cycles/04_sv_sensors.md
@@ -1,0 +1,42 @@
+# Cycle 4 — SV sensors: 5-role SQL vs pandas all-sensor sweep
+
+Execute after [03_chw1_econ347.md](03_chw1_econ347.md). Hard DataFusion port — expect a large PR or a deliberate `sql_screening` keep. Do **not** wait for GHCR / `:nightly`.
+
+## Hypothesis
+
+Dump leftover: **~122 SV-RATE / STALE / FLATLINE / RANGE / SPIKE** rows — the bulk of the 212.
+
+Pandas sweeps **all mapped sensors** on the equipment. SQL [`sql_rules/sv_stale.sql`](../../../sql_rules/sv_stale.sql) (and siblings) window only **five** analog roles: `oa_t`, `mat`, `zone_t`, `rat`, `sat`. Extra points (DP, CO2, humidity, extra zone sensors, …) fault in pandas and stay silent in SQL → pandas FAULT / SQL PASS, or hours that only count the five roles.
+
+Liberty OFDD-065 is still **WIDE** on the catalog; do not flip `proven` from B100 hours.
+
+This is a **definition + port** problem, not an `ELSE 1` fan-gate.
+
+## Files a later agent may change
+
+- [`sql_rules/sv_stale.sql`](../../../sql_rules/sv_stale.sql) and sibling `sv_*.sql`
+- Ingest only if extra analogs never get roles (then SQL cannot see them even after a sweep)
+- [`crates/fdd_rules/src/oracle_parity_test.rs`](../../../crates/fdd_rules/src/oracle_parity_test.rs)
+- Catalog: keep `sql_screening` until fixtures prove the equation. Do **not** mark `proven` because dump hours moved.
+
+If a full per-sensor SQL sweep is not feasible in DataFusion this cycle: document `semantic_gap` (pandas all-sensor vs SQL five-role) and **leave screening**. That is an allowed stop — do not fake 0 vs thousands of hours.
+
+## Tests (synthetic + GHA)
+
+Follow the [shared contract](00_INDEX.md#shared-test-contract-every-cycle).
+
+1. **GHA two-column fixture:** one live analog **outside** the five roles (e.g. extra humidity) that is stale/flat in pandas; the five roles are healthy. Today SQL must **not** report stale on that extra point. After a real port, SQL must match pandas **tiny** hours on that point. If you keep screening, the test documents the gap (pandas FAULT / SQL PASS) and must **not** be auto-accepted in [`tests/test_wattlab_parity_diff.py`](../../../tests/test_wattlab_parity_diff.py).
+2. **GHA five-role healthy:** all five roles changing → SQL no stale. Guards a false-positive sweep.
+3. 6 samples × 5 min, `confirm_rows=2`. Not B100 thousands of hours.
+4. Synthetic-59 **59/59**.
+
+## Do not GHCR
+
+Merge = squash after **Rust CI**. No nightly pin. A later soak is the only way to see dump 122 → N.
+
+## Out of scope
+
+- SCHED-247 (cycle 5)
+- Editing vibe19 pandas so B100 matches
+- Mass `ELSE 1`
+- Promising 212→0

--- a/docs/agent/fdd_parity_cycles/05_sched247.md
+++ b/docs/agent/fdd_parity_cycles/05_sched247.md
@@ -1,0 +1,52 @@
+# Cycle 5 — SCHED-247: window `always_on_pct` vs confirm streak
+
+Execute after [04_sv_sensors.md](04_sv_sensors.md). This is a **definition gap**, not a mapping miss. Do **not** wait for GHCR / `:nightly`.
+
+## Hypothesis
+
+Dump leftover: **4 SCHED-247** rows, typically pandas **FAULT ~1500 h** vs SQL **PASS 0** (or the reverse after screening).
+
+Pandas [`_sched247`](../../../open_fdd/rules/cookbook_catalog.py) is `mean(on) ≥ always_on_pct` over the **whole analysis window**.
+
+SQL [`sql_rules/sched247_always_on.sql`](../../../sql_rules/sched247_always_on.sql) is confirm **streaks** (consecutive on-rows ≥ `confirm_rows`).
+
+Existing GHA `sched247_fan_cmd_screening_confirm_streak` in [`crates/fdd_rules/src/oracle_parity_test.rs`](../../../crates/fdd_rules/src/oracle_parity_test.rs) already documents **screening ≠ vibe19**. Classifier tests assert PASS vs FAULT is **not** auto-accepted.
+
+Do **not** streak-tune (`confirm_rows`, duration) to fake 0 vs 1500 h. That would make SQL look like pandas on B100 while remaining a different equation.
+
+## Decision (later agent picks one)
+
+| Option | When | Product change |
+| --- | --- | --- |
+| **A — port window fraction** | Product wants vibe19 SCHED-247 | Rewrite SQL (and catalog notes) to `mean(on)` over the window; GHA: high duty cycle with **no** long streak → both FAULT at tiny hours |
+| **B — `semantic_gap`** | Product keeps streak “always-on” | Leave SQL; add a written accept/rationale in the classifier **only** if product explicitly wants dump to ignore SCHED-247; keep `sql_screening`; do not auto-accept in tests |
+
+Default if unspecified: **A** only with a window-fraction fixture; otherwise **B** without pretending hours match.
+
+## Files a later agent may change
+
+- [`sql_rules/sched247_always_on.sql`](../../../sql_rules/sched247_always_on.sql) — option A only
+- Catalog / cookbook notes for SCHED-247
+- [`crates/fdd_rules/src/oracle_parity_test.rs`](../../../crates/fdd_rules/src/oracle_parity_test.rs) — extend the existing screening test; do not delete it
+- [`scripts/wattlab_parity_diff.py`](../../../scripts/wattlab_parity_diff.py) / [`tests/test_wattlab_parity_diff.py`](../../../tests/test_wattlab_parity_diff.py) — option B rationale only
+
+Do **not** edit pandas `_sched247` so B100 matches SQL streaks.
+
+## Tests (synthetic + GHA)
+
+Follow the [shared contract](00_INDEX.md#shared-test-contract-every-cycle).
+
+1. Keep `sched247_fan_cmd_screening_confirm_streak` (6 samples × 5 min, `confirm_rows=2`).
+2. **Option A extra fixture:** on-fraction ≥ `always_on_pct` across the window but longest streak `< confirm_rows` → pandas FAULT; SQL after the rewrite must FAULT the same **tiny** `pandas_confirm_fault_hours`.
+3. Synthetic-59 **59/59**.
+
+## Do not GHCR
+
+Merge = squash after **Rust CI**. No nightly. A soak is optional later and will not go to 0 remaining if option B is chosen.
+
+## Out of scope
+
+- Re-opening cycles 1–4
+- Mass `ELSE 1`
+- Windows playground
+- `stop_rule_met=true` / 212→0


### PR DESCRIPTION
## Summary
- Adds `docs/agent/fdd_parity_cycles/` (index + five cycle specs) so leftover dump blockers are executed later as separate GHA-only PRs, not one mega-diff.
- Shared contract: frozen synthetic-59 golden, tiny `write_equipment_fixture` hours, no pandas threshold edits, no mass `ELSE 1`, no GHCR/`:nightly` wait.
- Docs only — no SQL/ingest. Windows playground closeout is out of scope.

## Test plan
- [ ] Skim `00_INDEX.md` order and stop rules
- [ ] Confirm each cycle names hypothesis, files, GHA fixtures, and “do not GHCR”
- [ ] Rust CI is a no-op for this docs-only change (no `cargo` / stack-up)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an index and five execution guides for FDD parity cleanup cycles.
  * Documented validation plans for duct heating, VAV ingest, chilled water, sensor, and scheduling scenarios.
  * Defined testing requirements, workflow constraints, merge guidance, and out-of-scope work for each cycle.
  * Documented preservation of the Synthetic-59 59/59 test contract and low-resource CI requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->