### PR TITLE
Treat missing fan as off in AHU-SATDEV SQL

### DIFF
--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1300,4 +1300,226 @@ timestamp_utc,oa_t,oa_damper_pct,fan_cmd,fan_status
         let got = run_rule_fault_hours(&building, "economizer_fault.sql", 300.0, 0, &[]).await;
         assert_hours_close(got, 0.0, "ECON-2 mad_c vs fan-enable");
     }
+
+    #[tokio::test]
+    async fn satdev_missing_fan_does_not_invent_on_hours() {
+        // SAT off-setpoint, no fan_status / fan_cmd. ELSE 1 used to invent on-hours.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SATDEV_NOFAN");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,sat,sat_sp
+2026-01-01T00:00:00Z,65,55
+2026-01-01T00:05:00Z,65,55
+2026-01-01T00:10:00Z,65,55
+2026-01-01T00:15:00Z,65,55
+2026-01-01T00:20:00Z,65,55
+2026-01-01T00:25:00Z,65,55
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "sat",
+                    role: "sat",
+                },
+                RoleCol {
+                    csv_col: "sat_sp",
+                    role: "sat_sp",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "ahu_satdev.sql",
+            300.0,
+            600,
+            &[("SAT_DEV_ERR", "5")],
+        )
+        .await;
+        assert_hours_close(got, 0.0, "AHU-SATDEV missing fan");
+    }
+
+    #[tokio::test]
+    async fn satdev_fan_on_off_setpoint_matches_pandas_confirm() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SATDEV_FAN");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,sat,sat_sp,fan_status
+2026-01-01T00:00:00Z,65,55,1
+2026-01-01T00:05:00Z,65,55,1
+2026-01-01T00:10:00Z,65,55,1
+2026-01-01T00:15:00Z,65,55,1
+2026-01-01T00:20:00Z,65,55,1
+2026-01-01T00:25:00Z,65,55,1
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "sat",
+                    role: "sat",
+                },
+                RoleCol {
+                    csv_col: "sat_sp",
+                    role: "sat_sp",
+                },
+                RoleCol {
+                    csv_col: "fan_status",
+                    role: "fan_status",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "ahu_satdev.sql",
+            300.0,
+            600,
+            &[("SAT_DEV_ERR", "5")],
+        )
+        .await;
+
+        let raw = [true, true, true, true, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.4166666666666667, "pandas reference");
+        assert_hours_close(got, expected, "AHU-SATDEV fan-on SQL");
+    }
+
+    #[tokio::test]
+    async fn ducthi_fan_on_high_static_matches_pandas_confirm() {
+        // B100 AHU_2 0.5 vs 1.83 h is not isolable as extra confirm rows in 6 samples.
+        // Fan-on + high static must match pandas_confirm_fault_hours — do not patch SQL.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_DUCTHI_ON");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,duct_static,duct_static_sp,fan_status
+2026-01-01T00:00:00Z,2.0,1.0,1
+2026-01-01T00:05:00Z,2.0,1.0,1
+2026-01-01T00:10:00Z,2.0,1.0,1
+2026-01-01T00:15:00Z,2.0,1.0,1
+2026-01-01T00:20:00Z,2.0,1.0,1
+2026-01-01T00:25:00Z,2.0,1.0,1
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_2",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "duct_static",
+                    role: "duct_static",
+                },
+                RoleCol {
+                    csv_col: "duct_static_sp",
+                    role: "duct_static_sp",
+                },
+                RoleCol {
+                    csv_col: "fan_status",
+                    role: "fan_status",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(&building, "ahu_ducthi.sql", 300.0, 600, &[]).await;
+
+        let raw = [true, true, true, true, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.4166666666666667, "pandas reference");
+        assert_hours_close(got, expected, "AHU-DUCTHI fan-on SQL");
+    }
+
+    #[tokio::test]
+    async fn ducthi_fan_off_high_static_does_not_use_pressure_on() {
+        // Pressure-on substitutes only when fan proof is absent, never when proven 0.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_DUCTHI_OFF");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,duct_static,duct_static_sp,fan_status
+2026-01-01T00:00:00Z,2.0,1.0,0
+2026-01-01T00:05:00Z,2.0,1.0,0
+2026-01-01T00:10:00Z,2.0,1.0,0
+2026-01-01T00:15:00Z,2.0,1.0,0
+2026-01-01T00:20:00Z,2.0,1.0,0
+2026-01-01T00:25:00Z,2.0,1.0,0
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_2",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "duct_static",
+                    role: "duct_static",
+                },
+                RoleCol {
+                    csv_col: "duct_static_sp",
+                    role: "duct_static_sp",
+                },
+                RoleCol {
+                    csv_col: "fan_status",
+                    role: "fan_status",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(&building, "ahu_ducthi.sql", 300.0, 600, &[]).await;
+        assert_hours_close(got, 0.0, "AHU-DUCTHI fan proven off");
+    }
+
+    #[tokio::test]
+    async fn ducthi_missing_fan_pressure_on_matches_pandas_confirm() {
+        // No fan cols: SQL pressure-on (fan_on NULL) should match pandas press-only gate.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_DUCTHI_NOFAN");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,duct_static,duct_static_sp
+2026-01-01T00:00:00Z,2.0,1.0
+2026-01-01T00:05:00Z,2.0,1.0
+2026-01-01T00:10:00Z,2.0,1.0
+2026-01-01T00:15:00Z,2.0,1.0
+2026-01-01T00:20:00Z,2.0,1.0
+2026-01-01T00:25:00Z,2.0,1.0
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_2",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "duct_static",
+                    role: "duct_static",
+                },
+                RoleCol {
+                    csv_col: "duct_static_sp",
+                    role: "duct_static_sp",
+                },
+            ],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(&building, "ahu_ducthi.sql", 300.0, 600, &[]).await;
+
+        let raw = [true, true, true, true, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "AHU-DUCTHI missing-fan pressure-on");
+    }
 }

--- a/docs/agent/FAN_ON_ELSE_1_FOLLOWON.md
+++ b/docs/agent/FAN_ON_ELSE_1_FOLLOWON.md
@@ -6,6 +6,6 @@ Same class as the patched four: missing fan proof treated as on.
 
 - ECON-3, ECON-4, ECON-5, ECON-6, ECON-7
 - FC1–FC12, FC14, FC15
-- AHU-SATDEV, AHU-SIMUL
+- AHU-SIMUL (AHU-SATDEV: missing fan = off)
 - VAV-3, VAV-4, VAV-5, VAV-REHEAT, VAV-AHU-LEAVE, VAV-7
 - DMP-1, OA-1, HP-1, VLV-1, TRIM-1

--- a/sql_rules/ahu_satdev.sql
+++ b/sql_rules/ahu_satdev.sql
@@ -1,4 +1,6 @@
 -- ahu_satdev.sql — SAT deviation from setpoint (fan_running + confirm)
+-- Gate: fan-on from fan_status then fan_cmd. Missing fan stays off
+-- (do not ELSE 1 / COALESCE to on — that invents on-hours).
 WITH h AS (
   SELECT
     equipment_id,
@@ -10,7 +12,7 @@ WITH h AS (
     CASE
       WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
       WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
-      ELSE 1
+      ELSE 0
     END AS fan_on
   FROM history
 ),
@@ -19,7 +21,7 @@ base AS (
     equipment_id,
     timestamp_utc,
     CAST(CASE
-      WHEN COALESCE(fan_on, 1) = 0 THEN 0
+      WHEN COALESCE(fan_on, 0) = 0 THEN 0
       WHEN sat IS NULL OR sat_sp IS NULL THEN 0
       WHEN ABS(sat - sat_sp) > {{SAT_DEV_ERR}} THEN 1
       ELSE 0


### PR DESCRIPTION
## Summary
- AHU-SATDEV: missing fan proof is **off** (`ELSE 0`, no COALESCE-to-on). One fan-gate only — not a mass `ELSE 1` edit.
- GHA fixtures (6×5 min, `confirm_rows=2`): SAT off-setpoint with **no fan cols** → **0 h**; fan-on still matches `pandas_confirm_fault_hours`.
- DUCTHI: short fixtures prove fan-on hours already match pandas confirm; fan-off does not use pressure-on; **no SQL patch**. B100 0.5 vs 1.83 h is not isolable at this grain.
- ECON-2 AHU_2 **0.25 h** deferred to cycle 3 (not isolable in ≤6 samples via `pandas_confirm_fault_hours`). No dump accept.

## Test plan
- [ ] GHA Rust CI (`fdd_rules` oracle parity): `satdev_missing_fan_does_not_invent_on_hours`, `satdev_fan_on_off_setpoint_matches_pandas_confirm`, three `ducthi_*` tests
- [ ] Synthetic-59 SATDEV case still has `fan-status` — this change does not ungated-fire that pair (no local soak; do not wait GHCR)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SAT deviation faults are no longer reported when fan status data is unavailable.
  * Fault detection now correctly distinguishes fan-on and proven fan-off conditions.
  * Duct static pressure faults can still be detected from pressure data when fan status is missing.

* **Documentation**
  * Updated AHU follow-on guidance to reflect that missing fan status is treated as off for the applicable rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->