### PR TITLE
Map VAV damper and airflow the way pandas does

### DIFF
--- a/crates/fdd_core/src/columns.rs
+++ b/crates/fdd_core/src/columns.rs
@@ -41,6 +41,8 @@ pub fn load_column_role_map(path: &Path) -> Result<HashMap<String, String>> {
                     Some("clg_valve_pct".into())
                 }
                 (Some("zone_t"), "vav_point") => Some("zone_t".into()),
+                (Some(inferred_role), "vav_point") => Some(inferred_role.to_string()),
+                (Some("min_flow_sp"), "zone_flow") => Some("min_flow_sp".into()),
                 _ => Some(normalized),
             }
         };
@@ -48,7 +50,7 @@ pub fn load_column_role_map(path: &Path) -> Result<HashMap<String, String>> {
         if role == "zone_t" && is_zone_t_limit_or_alarm_column(&column) {
             continue;
         }
-        if role == "ahu_point" || role == "ignore" {
+        if role == "ahu_point" || role == "ignore" || role == "vav_point" {
             continue;
         }
         // Prefer first mapping per role (supply fan before return fan, etc.)
@@ -95,7 +97,7 @@ pub fn haystack_point_to_role(point: &str) -> String {
         "chiller-status" => "chiller_status".into(),
         "loop-enabled" => "loop_enabled".into(),
         "zone-air-temp" => "zone_t".into(),
-        "zone-airflow" => "zone_flow".into(),
+        "zone-airflow" | "airflow" => "zone_flow".into(),
         "vav-total-airflow" => "vav_total_flow".into(),
         "min-flow-sp" => "min_flow_sp".into(),
         "chw-pump-status" => "chw_pump_status".into(),
@@ -157,12 +159,16 @@ pub fn normalize_role(role: &str) -> String {
         | "supply_fan_speed"
         | "supply_fan_speed_pct" => "fan_cmd".into(),
         "fan_status" | "fan_proof" | "supply_fan_status" | "supply_fan_stat" => "fan_status".into(),
-        "oa_damper" | "outside_air_damper" | "damper" | "oa_damper_pct" | "oa_damper_cmd"
+        "oa_damper" | "outside_air_damper" | "oa_damper_pct" | "oa_damper_cmd"
         | "oa_damper_pos" => "oa_damper_pct".into(),
+        "damper" | "zone_damper" | "vav_damper" | "damper_pct" | "damper_pos" => {
+            "damper_pct".into()
+        }
         "cooling_valve" | "cooling_cmd" | "clg_valve" | "chw_valve" | "clg_valve_pct"
         | "chw_valve_pct" | "cooling_valve_pct" => "clg_valve_pct".into(),
         "heating_valve" | "heating_cmd" | "htg_valve" | "htg_valve_pct" | "heating_valve_pct"
-        | "hw_valve_pct" | "reheat_valve" => "htg_valve_pct".into(),
+        | "hw_valve_pct" => "htg_valve_pct".into(),
+        "reheat_valve" | "reheat_valve_pct" | "rht_valve" => "reheat_valve_pct".into(),
         "sat_setpoint" | "sat_sp" | "dat_reset" | "dat_reset_f" | "sat_sp_f" | "sat_setpoint_f" => {
             "sat_sp".into()
         }
@@ -177,6 +183,8 @@ pub fn normalize_role(role: &str) -> String {
         "vav_total_airflow" | "vav_total_flow" | "total_airflow" | "ahu_total_airflow" => {
             "vav_total_flow".into()
         }
+        "airflow" | "actflow" | "flow_input" | "zone_flow" | "zone_airflow" => "zone_flow".into(),
+        "min_flow_sp" | "minflowsp" | "min_airflow" => "min_flow_sp".into(),
         "loop_enabled" | "pid_enable" => "loop_enabled".into(),
         "chws_t" | "chw_supply" | "chwst" | "chws_t_f" | "chw_supply_t" => "chw_supply_t".into(),
         "chwr_t" | "chw_return" | "chwrt" | "chwr_t_f" | "chw_return_t" => "chw_return_t".into(),
@@ -204,8 +212,10 @@ pub const COOKBOOK_ROLES: &[&str] = &[
     "duct_static",
     "duct_static_sp",
     "oa_damper_pct",
+    "damper_pct",
     "clg_valve_pct",
     "htg_valve_pct",
+    "reheat_valve_pct",
     "zone_t",
     "zone_flow",
     "vav_total_flow",
@@ -240,9 +250,13 @@ pub fn is_known_cookbook_role(role: &str) -> bool {
             | "duct_static"
             | "duct_static_sp"
             | "oa_damper_pct"
+            | "damper_pct"
             | "clg_valve_pct"
             | "htg_valve_pct"
+            | "reheat_valve_pct"
             | "zone_t"
+            | "zone_flow"
+            | "min_flow_sp"
             | "chw_supply_t"
             | "chw_return_t"
             | "hw_supply_t"
@@ -332,8 +346,9 @@ fn infer_role_from_column_name(column: &str) -> Option<String> {
     if c.contains("htg_valve") || c.contains("heating_valve") || c.contains("hhw_valve") {
         return Some("htg_valve_pct".into());
     }
-    if c.contains("damper") || c.contains("dmpr") {
-        // Fan-enable / min-OA setpoints are not the economizer damper command.
+    if c.contains("damper") || c.contains("dmpr") || c.contains("dpr_pos") || c.contains("vavactuator")
+    {
+        // Fan-enable / min-OA setpoints are not a damper command.
         if c.contains("enable")
             || c.contains("minimum")
             || c.contains("min_pos")
@@ -341,7 +356,26 @@ fn infer_role_from_column_name(column: &str) -> Option<String> {
         {
             return None;
         }
-        return Some("oa_damper_pct".into());
+        // OA / mixed-air damper stays oa_damper_pct (mad_c handled above).
+        if c.contains("ex_dmpr")
+            || c.contains("oa_damper")
+            || c.contains("outdoor_air")
+            || c.contains("mixed_air_damper")
+            || c.contains("oad_")
+        {
+            return Some("oa_damper_pct".into());
+        }
+        // Zone / VAV damper — never treat generic damper as OA (pandas role_map).
+        return Some("damper_pct".into());
+    }
+    if c.contains("actflow")
+        || c.contains("flow_input")
+        || (c.contains("airflow") && !c.contains("min") && !c.contains("max") && !c.contains("sp"))
+    {
+        return Some("zone_flow".into());
+    }
+    if c.contains("minflowsp") || (c.contains("min") && c.contains("airflow")) {
+        return Some("min_flow_sp".into());
     }
     if c.contains("zone_t") || c.contains("spacetemp") {
         if is_zone_t_limit_or_alarm_column(column) {
@@ -552,5 +586,51 @@ mod tests {
         assert_eq!(map.get("mixed_air_temp_f"), Some(&"mat".to_string()));
         assert!(!map.contains_key("ex_dmpr_pos_fan_enable_pct"));
         assert!(!map.contains_key("oa_minimum_position_pct"));
+    }
+
+    #[test]
+    fn b100_vav_damper_and_airflow_roles() {
+        assert_eq!(haystack_point_to_role("damper"), "damper_pct");
+        assert_eq!(haystack_point_to_role("airflow"), "zone_flow");
+        assert_eq!(normalize_role("damper"), "damper_pct");
+        assert_eq!(normalize_role("reheat_valve"), "reheat_valve_pct");
+        assert_eq!(
+            infer_role_from_column_name("vav_1_vavactuatorcommand_pct").as_deref(),
+            Some("damper_pct")
+        );
+        assert_eq!(
+            infer_role_from_column_name("vav_1_dpr_pos_pct").as_deref(),
+            Some("damper_pct")
+        );
+        assert_eq!(
+            infer_role_from_column_name("damper_pct_40").as_deref(),
+            Some("damper_pct")
+        );
+        assert_eq!(infer_role_from_column_name("actflow").as_deref(), Some("zone_flow"));
+        assert_eq!(
+            infer_role_from_column_name("minflowsp").as_deref(),
+            Some("min_flow_sp")
+        );
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("columns.csv");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            "column,role\n\
+             damper_pct_40,damper\n\
+             vav_1_vavactuatorcommand_pct,vav_point\n\
+             actflow,airflow\n\
+             minflowsp,airflow"
+        )
+        .unwrap();
+        let map = load_column_role_map(&path).unwrap();
+        assert_eq!(map.get("damper_pct_40"), Some(&"damper_pct".to_string()));
+        assert_eq!(
+            map.get("vav_1_vavactuatorcommand_pct"),
+            Some(&"damper_pct".to_string())
+        );
+        assert_eq!(map.get("actflow"), Some(&"zone_flow".to_string()));
+        assert_eq!(map.get("minflowsp"), Some(&"min_flow_sp".to_string()));
     }
 }

--- a/crates/fdd_core/src/columns.rs
+++ b/crates/fdd_core/src/columns.rs
@@ -346,7 +346,10 @@ fn infer_role_from_column_name(column: &str) -> Option<String> {
     if c.contains("htg_valve") || c.contains("heating_valve") || c.contains("hhw_valve") {
         return Some("htg_valve_pct".into());
     }
-    if c.contains("damper") || c.contains("dmpr") || c.contains("dpr_pos") || c.contains("vavactuator")
+    if c.contains("damper")
+        || c.contains("dmpr")
+        || c.contains("dpr_pos")
+        || c.contains("vavactuator")
     {
         // Fan-enable / min-OA setpoints are not a damper command.
         if c.contains("enable")
@@ -606,7 +609,10 @@ mod tests {
             infer_role_from_column_name("damper_pct_40").as_deref(),
             Some("damper_pct")
         );
-        assert_eq!(infer_role_from_column_name("actflow").as_deref(), Some("zone_flow"));
+        assert_eq!(
+            infer_role_from_column_name("actflow").as_deref(),
+            Some("zone_flow")
+        );
         assert_eq!(
             infer_role_from_column_name("minflowsp").as_deref(),
             Some("min_flow_sp")

--- a/crates/fdd_core/src/role_rank.rs
+++ b/crates/fdd_core/src/role_rank.rs
@@ -51,6 +51,49 @@ pub fn score_column_for_role(role: &str, column: &str) -> i32 {
                 0
             }
         }
+        "damper_pct" => {
+            // Pandas ROLE_COLUMN_RANK: vavactuatorcommand > actuatorcommand > damper_pct > dpr_pos.
+            // Do not let OA / heating-damper analogs steal the VAV damper.
+            if c.contains("ex_dmpr")
+                || c.contains("oa_damper")
+                || c.contains("outdoor_air")
+                || c.contains("mad_c")
+                || c.contains("oad_")
+                || c.contains("heatingdamper")
+                || c.contains("heating_damper")
+            {
+                -100
+            } else if c.contains("vavactuatorcommand") || c.contains("actuatorcommand") {
+                100
+            } else if c.contains("damper_pct") || c.contains("damper_pos") {
+                80
+            } else if c.contains("dpr_pos") || c.contains("vavactuator") {
+                70
+            } else {
+                0
+            }
+        }
+        "zone_flow" => {
+            if c.contains("setpoint")
+                || c.contains("minflow")
+                || c.contains("maxflow")
+                || c.contains("min_flow")
+                || c.contains("max_flow")
+                || c.contains("_sp")
+                || c.contains("stby")
+                || c.contains("unocc")
+            {
+                -100
+            } else if c.contains("actflow") {
+                100
+            } else if c.contains("flow_input") {
+                90
+            } else if c.contains("airflow") {
+                50
+            } else {
+                0
+            }
+        }
         "fan_cmd" => {
             if c.contains("supply_fan") && !c.contains("status") {
                 100
@@ -140,5 +183,28 @@ mod tests {
         assert!(enable < 0);
         assert_eq!(score_column_for_role("mat", "mad_c"), -100);
         assert_eq!(score_column_for_role("mat", "mixed_air_temp_f"), 100);
+    }
+
+    #[test]
+    fn vav_damper_prefers_actuator_command_over_heating_damper() {
+        let cmd = score_column_for_role("damper_pct", "vav_1_vavactuatorcommand_pct");
+        let heat = score_column_for_role("damper_pct", "damper_pct_40");
+        let dpr = score_column_for_role("damper_pct", "vav_1_dpr_pos_pct");
+        assert!(cmd > heat, "actuator={cmd} heating_damper={heat}");
+        assert!(cmd > dpr, "actuator={cmd} dpr_pos={dpr}");
+        assert_eq!(
+            score_column_for_role("damper_pct", "ex_dmpr_pos_fan_enable_pct"),
+            -100
+        );
+    }
+
+    #[test]
+    fn zone_flow_prefers_actflow_over_minflow_sp() {
+        let act = score_column_for_role("zone_flow", "actflow");
+        let input = score_column_for_role("zone_flow", "flow_input");
+        let min_sp = score_column_for_role("zone_flow", "minflowsp");
+        assert!(act > input, "actflow={act} flow_input={input}");
+        assert!(act > min_sp, "actflow={act} minflowsp={min_sp}");
+        assert!(min_sp < 0);
     }
 }

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -162,6 +162,7 @@ async fn inject_optional_fan_cols(
         "duct_static_sp",
         "static_reset_request",
         "web_oa_t",
+        "clg_available",
     ];
     let missing: Vec<&str> = needed.into_iter().filter(|c| !have.contains(*c)).collect();
     if missing.is_empty() {

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1522,4 +1522,125 @@ timestamp_utc,duct_static,duct_static_sp
         let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
         assert_hours_close(got, expected, "AHU-DUCTHI missing-fan pressure-on");
     }
+
+    #[tokio::test]
+    async fn vav4_competing_damper_uses_actuator_not_heating() {
+        // B100: HeatingDamper (damper_pct_40) vs VAVActuatorCommand (vav_point).
+        // SQL must use the actuator analog or VAV-4 is PASS 0.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_VAV4_DMP");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let eq = building.join("VAV_1");
+        std::fs::create_dir_all(&eq).unwrap();
+        std::fs::write(
+            eq.join("columns.csv"),
+            "column,role\n\
+             damper_pct_40,damper\n\
+             vav_1_vavactuatorcommand_pct,vav_point\n\
+             actflow,airflow\n",
+        )
+        .unwrap();
+        std::fs::write(
+            eq.join("history_wide.csv"),
+            "timestamp_utc,damper_pct_40,vav_1_vavactuatorcommand_pct,actflow\n\
+2026-01-01T00:00:00Z,0,100,200\n\
+2026-01-01T00:05:00Z,0,100,200\n\
+2026-01-01T00:10:00Z,0,100,200\n\
+2026-01-01T00:15:00Z,0,100,200\n\
+2026-01-01T00:20:00Z,0,100,200\n\
+2026-01-01T00:25:00Z,0,100,200\n",
+        )
+        .unwrap();
+
+        let got = run_rule_fault_hours(
+            &building,
+            "vav4_damper_full_open.sql",
+            300.0,
+            600,
+            &[("SUSTAIN_HOURS", "0.05")],
+        )
+        .await;
+        let raw = [true, true, true, true, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "VAV-4 actuator vs heating damper");
+    }
+
+    #[tokio::test]
+    async fn vav4_competing_flow_uses_actflow_not_minflow_sp() {
+        // Same class as mad_c: MinFlowSP as zone_flow is ~0 vs ActFlow live.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_VAV4_FLOW");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let eq = building.join("VAV_1");
+        std::fs::create_dir_all(&eq).unwrap();
+        std::fs::write(
+            eq.join("columns.csv"),
+            "column,role\n\
+             vavactuatorcommand_pct,damper\n\
+             actflow,airflow\n\
+             minflowsp,airflow\n",
+        )
+        .unwrap();
+        std::fs::write(
+            eq.join("history_wide.csv"),
+            "timestamp_utc,vavactuatorcommand_pct,actflow,minflowsp\n\
+2026-01-01T00:00:00Z,100,200,0\n\
+2026-01-01T00:05:00Z,100,200,0\n\
+2026-01-01T00:10:00Z,100,200,0\n\
+2026-01-01T00:15:00Z,100,200,0\n\
+2026-01-01T00:20:00Z,100,200,0\n\
+2026-01-01T00:25:00Z,100,200,0\n",
+        )
+        .unwrap();
+
+        let got = run_rule_fault_hours(
+            &building,
+            "vav4_damper_full_open.sql",
+            300.0,
+            600,
+            &[("SUSTAIN_HOURS", "0.05")],
+        )
+        .await;
+        let raw = [true, true, true, true, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "VAV-4 actflow vs minflowsp");
+    }
+
+    #[tokio::test]
+    async fn vav6_reheat_free_cool_matches_pandas_confirm() {
+        // VAV-6 SQL is reheat+OAT (not flow). Competing airflow must not zero this rule.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_VAV6");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let eq = building.join("VAV_1");
+        std::fs::create_dir_all(&eq).unwrap();
+        std::fs::write(
+            eq.join("columns.csv"),
+            "column,role\n\
+             oa_t,outside-air-temp\n\
+             reheat_valve_pct,reheat_valve\n\
+             actflow,airflow\n\
+             minflowsp,airflow\n",
+        )
+        .unwrap();
+        std::fs::write(
+            eq.join("history_wide.csv"),
+            "timestamp_utc,oa_t,reheat_valve_pct,actflow,minflowsp\n\
+2026-01-01T00:00:00Z,55,0.6,200,0\n\
+2026-01-01T00:05:00Z,55,0.6,200,0\n\
+2026-01-01T00:10:00Z,55,0.6,200,0\n\
+2026-01-01T00:15:00Z,55,0.6,200,0\n\
+2026-01-01T00:20:00Z,55,0.6,200,0\n\
+2026-01-01T00:25:00Z,55,0.6,200,0\n",
+        )
+        .unwrap();
+
+        let got = run_rule_fault_hours(&building, "vav6_reheat_free_cool.sql", 300.0, 600, &[]).await;
+        let raw = [true, true, true, true, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "VAV-6 reheat+OAT vs competing flow");
+    }
 }

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1638,7 +1638,8 @@ timestamp_utc,duct_static,duct_static_sp
         )
         .unwrap();
 
-        let got = run_rule_fault_hours(&building, "vav6_reheat_free_cool.sql", 300.0, 600, &[]).await;
+        let got =
+            run_rule_fault_hours(&building, "vav6_reheat_free_cool.sql", 300.0, 600, &[]).await;
         let raw = [true, true, true, true, true, true];
         let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
         assert_hours_close(got, expected, "VAV-6 reheat+OAT vs competing flow");


### PR DESCRIPTION
## Summary
- B100 VAV-4 PASS 0: historian `airflow` never became `zone_flow`, and `vav_point` actuator/dpr columns never became `damper_pct` (generic damper was OA). Same shape as the mad_c miss.
- Ingest: `airflow` → `zone_flow`; generic damper → `damper_pct`; `vav_point` uses physical-name inference; rank VAVActuatorCommand over HeatingDamper and ActFlow over MinFlowSP.
- GHA competing-column fixtures (6×5 min, confirm_rows=2): VAV-4 must FAULT tiny `pandas_confirm_fault_hours`, not PASS 0. VAV-6 SQL is reheat+OAT — competing flow must not zero it. No VAV-4 `ELSE 1` change.

## Test plan
- [ ] Rust CI: `b100_vav_damper_and_airflow_roles`, rank unit tests, `vav4_competing_damper_uses_actuator_not_heating`, `vav4_competing_flow_uses_actflow_not_minflow_sp`, `vav6_reheat_free_cool_matches_pandas_confirm`
- [ ] Synthetic-59 VAV cases still use haystack `damper` / `zone-airflow` — do not wait GHCR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identification of VAV airflow, damper, reheat valve, and minimum-flow signals.
  * More accurately distinguishes zone dampers from outdoor-air and heating dampers.
  * Prioritizes actuator and active airflow readings over setpoints or competing signals.
  * Improved VAV-4 and VAV-6 fault detection, including reheat and outdoor-air temperature analysis.
  * Prevents valid diagnostics from being suppressed by unrelated or ambiguous airflow columns.
  * Improved handling of missing cooling-availability history data during diagnostic processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->