### PR TITLE
Bind CHW-1 proof and ECON-3/6/7 web weather the way pandas does

### DIFF
--- a/crates/fdd_core/src/columns.rs
+++ b/crates/fdd_core/src/columns.rs
@@ -43,6 +43,10 @@ pub fn load_column_role_map(path: &Path) -> Result<HashMap<String, String>> {
                 (Some("zone_t"), "vav_point") => Some("zone_t".into()),
                 (Some(inferred_role), "vav_point") => Some(inferred_role.to_string()),
                 (Some("min_flow_sp"), "zone_flow") => Some("min_flow_sp".into()),
+                // Historian `other` (CHILLER_2 command/amps) — pandas COL_PATTERN_ROLES
+                // still maps physical names; do not keep a useless `other` parquet col.
+                (Some(inferred_role), "other") => Some(inferred_role.to_string()),
+                (None, "other") => None,
                 _ => Some(normalized),
             }
         };
@@ -128,6 +132,10 @@ pub fn haystack_point_to_role(point: &str) -> String {
         "web-outside-air-dewpoint" => "web_oa_dp".into(),
         "web-outside-air-wetbulb" => "web_wb_t".into(),
         "web-outside-air-humidity" => "web_oa_h".into(),
+        "chiller-power" | "power" => "chiller_power".into(),
+        "chiller-amps" => "chiller_amps".into(),
+        "chiller-current" => "chiller_current".into(),
+        "pump-status" => "pump_status".into(),
         other => normalize_role(&other.replace('-', "_")),
     }
 }
@@ -188,6 +196,10 @@ pub fn normalize_role(role: &str) -> String {
         "loop_enabled" | "pid_enable" => "loop_enabled".into(),
         "chws_t" | "chw_supply" | "chwst" | "chws_t_f" | "chw_supply_t" => "chw_supply_t".into(),
         "chwr_t" | "chw_return" | "chwrt" | "chwr_t_f" | "chw_return_t" => "chw_return_t".into(),
+        "power" | "chiller_power" => "chiller_power".into(),
+        "chiller_amps" | "chiller_amp" => "chiller_amps".into(),
+        "chiller_current" => "chiller_current".into(),
+        "pump_status" => "pump_status".into(),
         "hws_t" | "hw_supply" | "hwst" | "hws_t_f" | "hw_supply_t" => "hw_supply_t".into(),
         "hwr_t" | "hw_return" | "hwrt" | "hwr_t_f" | "hw_return_t" => "hw_return_t".into(),
         "oa_humidity" | "oa_h" | "relative_humidity_pct" | "oa_rh_pct" => "oa_h".into(),
@@ -227,6 +239,10 @@ pub const COOKBOOK_ROLES: &[&str] = &[
     "building_ahu_load_satisfied",
     "chw_supply_t",
     "chw_return_t",
+    "chiller_power",
+    "chiller_amps",
+    "chiller_current",
+    "pump_status",
     "hw_supply_t",
     "hw_return_t",
     "oa_h",
@@ -259,6 +275,10 @@ pub fn is_known_cookbook_role(role: &str) -> bool {
             | "min_flow_sp"
             | "chw_supply_t"
             | "chw_return_t"
+            | "chiller_power"
+            | "chiller_amps"
+            | "chiller_current"
+            | "pump_status"
             | "hw_supply_t"
             | "hw_return_t"
             | "oa_h"
@@ -405,6 +425,19 @@ fn infer_role_from_column_name(column: &str) -> Option<String> {
     }
     if c.contains("chwr") || c.contains("chw_return") {
         return Some("chw_return_t".into());
+    }
+    if c.contains("dew_point") || c.contains("dewpoint") {
+        return Some("web_oa_dp".into());
+    }
+    // Pandas COL_PATTERN_ROLES: chiller_N_command → status, chiller_N_amps → amps.
+    if c.contains("chiller") && c.contains("command") {
+        return Some("chiller_status".into());
+    }
+    if (c.contains("chiller") && c.contains("amps")) || c.ends_with("amps_a") {
+        return Some("chiller_amps".into());
+    }
+    if c.contains("power_demand_this_interval") || c.contains("meter_power_sum") {
+        return Some("chiller_power".into());
     }
     None
 }
@@ -638,5 +671,58 @@ mod tests {
         );
         assert_eq!(map.get("actflow"), Some(&"zone_flow".to_string()));
         assert_eq!(map.get("minflowsp"), Some(&"min_flow_sp".to_string()));
+    }
+
+    #[test]
+    fn chiller_other_and_power_roles_match_pandas() {
+        assert_eq!(haystack_point_to_role("power"), "chiller_power");
+        assert_eq!(
+            infer_role_from_column_name("chiller_2_command").as_deref(),
+            Some("chiller_status")
+        );
+        assert_eq!(
+            infer_role_from_column_name("chiller_2_amps_a").as_deref(),
+            Some("chiller_amps")
+        );
+        assert_eq!(
+            infer_role_from_column_name(
+                "meter_chiller2_chiller2_power_demand_this_interval_element_h_kw"
+            )
+            .as_deref(),
+            Some("chiller_power")
+        );
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("columns.csv");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            "col,point_role\n\
+             chiller_2_command,other\n\
+             chiller_2_amps_a,other\n\
+             meter_chiller2_chiller2_power_demand_this_interval_element_h_kw,power\n\
+             meter_chiller2_chiller2_power_demand_peak_element_h_kw,power\n\
+             chwr_t_f,other\n\
+             chws_t_f,other"
+        )
+        .unwrap();
+        let map = load_column_role_map(&path).unwrap();
+        assert_eq!(
+            map.get("chiller_2_command"),
+            Some(&"chiller_status".to_string())
+        );
+        assert_eq!(
+            map.get("chiller_2_amps_a"),
+            Some(&"chiller_amps".to_string())
+        );
+        assert_eq!(
+            map.get("meter_chiller2_chiller2_power_demand_this_interval_element_h_kw"),
+            Some(&"chiller_power".to_string())
+        );
+        assert_eq!(
+            map.get("meter_chiller2_chiller2_power_demand_peak_element_h_kw"),
+            Some(&"chiller_power".to_string())
+        );
+        assert_eq!(map.get("chws_t_f"), Some(&"chw_supply_t".to_string()));
+        assert_eq!(map.get("chwr_t_f"), Some(&"chw_return_t".to_string()));
     }
 }

--- a/crates/fdd_core/src/role_rank.rs
+++ b/crates/fdd_core/src/role_rank.rs
@@ -113,6 +113,32 @@ pub fn score_column_for_role(role: &str, column: &str) -> i32 {
                 0
             }
         }
+        "chiller_power" => {
+            // Pandas ROLE_COLUMN_RANK: this_interval > meter_power_sum > generic power.
+            // Peak / kVA meters stay on when the chiller is off (B100 CHW-1 hours).
+            if c.contains("peak") || c.contains("kva") || c.contains("va_demand") {
+                -100
+            } else if c.contains("this_interval") {
+                100
+            } else if c.contains("meter_power_sum") {
+                90
+            } else if c.contains("chiller_power") {
+                80
+            } else {
+                0
+            }
+        }
+        "chiller_status" => {
+            if c.contains("override") || c.contains("tstat") {
+                -100
+            } else if c.contains("command") {
+                100
+            } else if c.contains("chiller_status") {
+                90
+            } else {
+                0
+            }
+        }
         _ => 0,
     }
 }
@@ -206,5 +232,21 @@ mod tests {
         assert!(act > input, "actflow={act} flow_input={input}");
         assert!(act > min_sp, "actflow={act} minflowsp={min_sp}");
         assert!(min_sp < 0);
+    }
+
+    #[test]
+    fn chiller_power_prefers_this_interval_over_peak() {
+        let interval = score_column_for_role(
+            "chiller_power",
+            "meter_chiller2_chiller2_power_demand_this_interval_element_h_kw",
+        );
+        let peak = score_column_for_role(
+            "chiller_power",
+            "meter_chiller2_chiller2_power_demand_peak_element_h_kw",
+        );
+        let sum = score_column_for_role("chiller_power", "meter_power_sum_kw");
+        assert!(interval > sum, "interval={interval} sum={sum}");
+        assert!(interval > peak, "interval={interval} peak={peak}");
+        assert!(peak < 0);
     }
 }

--- a/crates/fdd_rules/src/oracle_harness.rs
+++ b/crates/fdd_rules/src/oracle_harness.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use datafusion::prelude::SessionContext;
-use fdd_sql::{register_parquet_tree, run_sql};
+use fdd_sql::{register_parquet_tree, register_weather_if_present, run_sql};
 use fdd_store::ingest_building;
 
 use crate::params::{rule_params, substitute_sql};
@@ -62,6 +62,24 @@ pub async fn run_rule_fault_hours(
 
     let ctx = SessionContext::new();
     register_parquet_tree(&ctx, &tmp_parquet).await.unwrap();
+    let wx_ok = register_weather_if_present(&ctx, &tmp_parquet)
+        .await
+        .unwrap();
+    if !wx_ok {
+        ctx.sql(
+            "CREATE OR REPLACE VIEW weather AS \
+             SELECT CAST(NULL AS TIMESTAMP) AS timestamp_utc, \
+                    CAST(NULL AS DOUBLE) AS oa_t, \
+                    CAST(NULL AS DOUBLE) AS web_oa_t, \
+                    CAST(NULL AS DOUBLE) AS web_oa_dp \
+             WHERE 1=0",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    }
 
     let sql_path = repo_sql_rules().join(sql_file);
     let raw_sql = std::fs::read_to_string(&sql_path)
@@ -162,7 +180,11 @@ async fn inject_optional_fan_cols(
         "duct_static_sp",
         "static_reset_request",
         "web_oa_t",
+        "web_oa_dp",
         "clg_available",
+        "chiller_power",
+        "chiller_amps",
+        "chiller_current",
     ];
     let missing: Vec<&str> = needed.into_iter().filter(|c| !have.contains(*c)).collect();
     if missing.is_empty() {

--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -1644,4 +1644,343 @@ timestamp_utc,duct_static,duct_static_sp
         let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
         assert_hours_close(got, expected, "VAV-6 reheat+OAT vs competing flow");
     }
+
+    #[tokio::test]
+    async fn chw1_missing_proof_is_zero_hours() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_CHW1_NOPROOF");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,chw_supply_t,chw_return_t
+2026-01-01T00:00:00Z,44,45
+2026-01-01T00:05:00Z,44,45
+2026-01-01T00:10:00Z,44,45
+2026-01-01T00:15:00Z,44,45
+2026-01-01T00:20:00Z,44,45
+2026-01-01T00:25:00Z,44,45
+";
+        write_equipment_fixture(
+            &building,
+            "CHILLER_2",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "chw_supply_t",
+                    role: "chw_supply_t",
+                },
+                RoleCol {
+                    csv_col: "chw_return_t",
+                    role: "chw_return_t",
+                },
+            ],
+            rows,
+        );
+
+        let got =
+            run_rule_fault_hours(&building, "chw1_low_dt.sql", 300.0, 600, &[("MIN_DT", "4")])
+                .await;
+        assert_hours_close(got, 0.0, "CHW-1 missing proof");
+    }
+
+    #[tokio::test]
+    async fn chw1_proven_on_low_dt_matches_pandas_confirm() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_CHW1_ON");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,chw_supply_t,chw_return_t,chiller_status
+2026-01-01T00:00:00Z,44,45,1
+2026-01-01T00:05:00Z,44,45,1
+2026-01-01T00:10:00Z,44,45,1
+2026-01-01T00:15:00Z,44,45,1
+2026-01-01T00:20:00Z,44,45,1
+2026-01-01T00:25:00Z,44,45,1
+";
+        write_equipment_fixture(
+            &building,
+            "CHILLER_2",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "chw_supply_t",
+                    role: "chw_supply_t",
+                },
+                RoleCol {
+                    csv_col: "chw_return_t",
+                    role: "chw_return_t",
+                },
+                RoleCol {
+                    csv_col: "chiller_status",
+                    role: "chiller_status",
+                },
+            ],
+            rows,
+        );
+
+        let got =
+            run_rule_fault_hours(&building, "chw1_low_dt.sql", 300.0, 600, &[("MIN_DT", "4")])
+                .await;
+        let raw = [true, true, true, true, true, true];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(expected, 0.4166666666666667, "pandas reference");
+        assert_hours_close(got, expected, "CHW-1 proven-on SQL");
+    }
+
+    #[tokio::test]
+    async fn chw1_competing_peak_uses_this_interval() {
+        // Peak kW stays high while this_interval is 0 → pandas rank → proof off.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_CHW1_PEAK");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let eq = building.join("CHILLER_2");
+        std::fs::create_dir_all(&eq).unwrap();
+        std::fs::write(
+            eq.join("columns.csv"),
+            "col,point_role\n\
+             chws_t_f,other\n\
+             chwr_t_f,other\n\
+             meter_chiller2_chiller2_power_demand_peak_element_h_kw,power\n\
+             meter_chiller2_chiller2_power_demand_this_interval_element_h_kw,power\n",
+        )
+        .unwrap();
+        std::fs::write(
+            eq.join("history_wide.csv"),
+            "timestamp_utc,chws_t_f,chwr_t_f,\
+meter_chiller2_chiller2_power_demand_peak_element_h_kw,\
+meter_chiller2_chiller2_power_demand_this_interval_element_h_kw\n\
+2026-01-01T00:00:00Z,44,45,100,0\n\
+2026-01-01T00:05:00Z,44,45,100,0\n\
+2026-01-01T00:10:00Z,44,45,100,0\n\
+2026-01-01T00:15:00Z,44,45,100,0\n\
+2026-01-01T00:20:00Z,44,45,100,0\n\
+2026-01-01T00:25:00Z,44,45,100,0\n",
+        )
+        .unwrap();
+
+        let got =
+            run_rule_fault_hours(&building, "chw1_low_dt.sql", 300.0, 600, &[("MIN_DT", "4")])
+                .await;
+        assert_hours_close(got, 0.0, "CHW-1 this_interval over peak");
+    }
+
+    #[tokio::test]
+    async fn chw1_command_off_ignores_peak_power() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_CHW1_CMDOFF");
+        std::fs::create_dir_all(&building).unwrap();
+        std::fs::write(building.join("manifest.json"), r#"{"grid_minutes":5}"#).unwrap();
+        let eq = building.join("CHILLER_2");
+        std::fs::create_dir_all(&eq).unwrap();
+        std::fs::write(
+            eq.join("columns.csv"),
+            "col,point_role\n\
+             chws_t_f,other\n\
+             chwr_t_f,other\n\
+             chiller_2_command,other\n\
+             meter_chiller2_chiller2_power_demand_peak_element_h_kw,power\n",
+        )
+        .unwrap();
+        std::fs::write(
+            eq.join("history_wide.csv"),
+            "timestamp_utc,chws_t_f,chwr_t_f,chiller_2_command,\
+meter_chiller2_chiller2_power_demand_peak_element_h_kw\n\
+2026-01-01T00:00:00Z,44,45,0,100\n\
+2026-01-01T00:05:00Z,44,45,0,100\n\
+2026-01-01T00:10:00Z,44,45,0,100\n\
+2026-01-01T00:15:00Z,44,45,0,100\n\
+2026-01-01T00:20:00Z,44,45,0,100\n\
+2026-01-01T00:25:00Z,44,45,0,100\n",
+        )
+        .unwrap();
+
+        let got =
+            run_rule_fault_hours(&building, "chw1_low_dt.sql", 300.0, 600, &[("MIN_DT", "4")])
+                .await;
+        assert_hours_close(got, 0.0, "CHW-1 command off vs peak");
+    }
+
+    fn write_weather_sidecar(data_root: &std::path::Path, rows: &str) {
+        let wx = data_root.join("weather");
+        std::fs::create_dir_all(&wx).unwrap();
+        std::fs::write(
+            wx.join("columns.csv"),
+            "col,point_role\n\
+             web-outside-air-temp,web-outside-air-temp\n\
+             web-outside-air-dewpoint,web-outside-air-dewpoint\n",
+        )
+        .unwrap();
+        std::fs::write(wx.join("history_wide.csv"), rows).unwrap();
+    }
+
+    #[tokio::test]
+    async fn econ3_weather_sidecar_matches_pandas_confirm() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON3_WX");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,oa_d,clg_col
+2026-01-01T00:00:00Z,0.2,50
+2026-01-01T00:05:00Z,0.2,0
+2026-01-01T00:10:00Z,0.2,50
+2026-01-01T00:15:00Z,0.3,50
+2026-01-01T00:20:00Z,0.4,50
+2026-01-01T00:25:00Z,0.95,50
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "oa_d",
+                    role: "oa_damper_pct",
+                },
+                RoleCol {
+                    csv_col: "clg_col",
+                    role: "clg_valve_pct",
+                },
+            ],
+            rows,
+        );
+        write_weather_sidecar(
+            tmp.path(),
+            "timestamp_utc,web-outside-air-temp,web-outside-air-dewpoint\n\
+2026-01-01T00:00:00Z,50,50\n\
+2026-01-01T00:05:00Z,65,50\n\
+2026-01-01T00:10:00Z,65,50\n\
+2026-01-01T00:15:00Z,68,55\n\
+2026-01-01T00:20:00Z,70,58\n\
+2026-01-01T00:25:00Z,65,50\n",
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "econ3_mech_without_econ.sql",
+            300.0,
+            600,
+            &[
+                ("ECON3_DB_MIN", "60"),
+                ("ECON3_DB_MAX", "72"),
+                ("ECON3_DP_MAX", "60"),
+                ("ECON3_DAMPER_HI", "0.9"),
+            ],
+        )
+        .await;
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "ECON-3 weather join");
+    }
+
+    #[tokio::test]
+    async fn econ6_weather_sidecar_matches_pandas_confirm() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON6_WX");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,oa_d
+2026-01-01T00:00:00Z,0.5
+2026-01-01T00:05:00Z,0.1
+2026-01-01T00:10:00Z,0.5
+2026-01-01T00:15:00Z,0.4
+2026-01-01T00:20:00Z,0.6
+2026-01-01T00:25:00Z,0.1
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[RoleCol {
+                csv_col: "oa_d",
+                role: "oa_damper_pct",
+            }],
+            rows,
+        );
+        write_weather_sidecar(
+            tmp.path(),
+            "timestamp_utc,web-outside-air-temp,web-outside-air-dewpoint\n\
+2026-01-01T00:00:00Z,30,10\n\
+2026-01-01T00:05:00Z,20,10\n\
+2026-01-01T00:10:00Z,20,10\n\
+2026-01-01T00:15:00Z,15,10\n\
+2026-01-01T00:20:00Z,10,10\n\
+2026-01-01T00:25:00Z,20,10\n",
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "econ6_econ_freezing.sql",
+            300.0,
+            600,
+            &[("ECON6_OAT_MAX_F", "25"), ("ECON6_DAMPER_MAX", "0.25")],
+        )
+        .await;
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "ECON-6 weather join");
+    }
+
+    #[tokio::test]
+    async fn econ7_weather_sidecar_matches_pandas_confirm() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_ECON7_WX");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,oa_d,clg_col
+2026-01-01T00:00:00Z,0.2,50
+2026-01-01T00:05:00Z,0.2,0
+2026-01-01T00:10:00Z,0.2,50
+2026-01-01T00:15:00Z,0.3,50
+2026-01-01T00:20:00Z,0.4,50
+2026-01-01T00:25:00Z,0.8,50
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[
+                RoleCol {
+                    csv_col: "oa_d",
+                    role: "oa_damper_pct",
+                },
+                RoleCol {
+                    csv_col: "clg_col",
+                    role: "clg_valve_pct",
+                },
+            ],
+            rows,
+        );
+        write_weather_sidecar(
+            tmp.path(),
+            "timestamp_utc,web-outside-air-temp,web-outside-air-dewpoint\n\
+2026-01-01T00:00:00Z,30,50\n\
+2026-01-01T00:05:00Z,50,50\n\
+2026-01-01T00:10:00Z,50,50\n\
+2026-01-01T00:15:00Z,55,55\n\
+2026-01-01T00:20:00Z,60,58\n\
+2026-01-01T00:25:00Z,50,50\n",
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "econ7_ok_not_economizing.sql",
+            300.0,
+            600,
+            &[
+                ("ECON7_DB_MIN", "35"),
+                ("ECON7_DB_MAX", "72"),
+                ("ECON7_DP_MAX", "60"),
+                ("ECON7_DAMPER_MIN", "0.5"),
+            ],
+        )
+        .await;
+        let raw = [false, false, true, true, true, false];
+        let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
+        assert_hours_close(got, expected, "ECON-7 weather join");
+    }
 }

--- a/crates/fdd_store/src/ingest.rs
+++ b/crates/fdd_store/src/ingest.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
-use arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
+use arrow::array::{Array, ArrayRef, Float64Array, StringArray, TimestampNanosecondArray};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
@@ -281,6 +282,99 @@ fn write_parquet(path: &Path, batch: &RecordBatch) -> Result<()> {
     Ok(())
 }
 
+fn weather_has_col(batch: &RecordBatch, name: &str) -> bool {
+    batch.schema().index_of(name).is_ok()
+}
+
+fn weather_clone_col(batch: &RecordBatch, src: &str, dest: &str) -> Option<(Arc<Field>, ArrayRef)> {
+    let i = batch.schema().index_of(src).ok()?;
+    let col = batch.column(i).clone();
+    Some((
+        Arc::new(Field::new(dest, col.data_type().clone(), true)),
+        col,
+    ))
+}
+
+fn weather_f64<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a Float64Array> {
+    let i = batch.schema().index_of(name).ok()?;
+    batch.column(i).as_any().downcast_ref::<Float64Array>()
+}
+
+fn dewpoint_f_from_db_rh(db_f: f64, rh_pct: f64) -> Option<f64> {
+    if !db_f.is_finite() || !rh_pct.is_finite() || rh_pct <= 0.0 {
+        return None;
+    }
+    let t_c = (db_f - 32.0) * 5.0 / 9.0;
+    let rh = rh_pct.clamp(0.1, 100.0);
+    let a = 17.625_f64;
+    let b = 243.04_f64;
+    let gamma = (rh / 100.0).ln() + (a * t_c) / (b + t_c);
+    if (a - gamma).abs() < 1e-12 {
+        return None;
+    }
+    let dp_c = (b * gamma) / (a - gamma);
+    Some(dp_c * 9.0 / 5.0 + 32.0)
+}
+
+fn null_f64(n: usize) -> ArrayRef {
+    Arc::new(Float64Array::from(vec![None; n])) as ArrayRef
+}
+
+/// Pandas `enrich_weather_frame` twin: weather parquet always exposes `oa_t`,
+/// `web_oa_t`, and `web_oa_dp` so ECON-3/6/7 can JOIN without schema misses.
+fn ensure_weather_web_roles(batch: RecordBatch) -> Result<RecordBatch> {
+    let n = batch.num_rows();
+    let mut fields: Vec<Arc<Field>> = batch.schema().fields().iter().cloned().collect();
+    let mut arrays: Vec<ArrayRef> = batch.columns().to_vec();
+
+    if !weather_has_col(&batch, "web_oa_t") {
+        if let Some((f, a)) = weather_clone_col(&batch, "oa_t", "web_oa_t") {
+            fields.push(f);
+            arrays.push(a);
+        } else {
+            fields.push(Arc::new(Field::new("web_oa_t", DataType::Float64, true)));
+            arrays.push(null_f64(n));
+        }
+    }
+    if !weather_has_col(&batch, "oa_t") {
+        if let Some((f, a)) = weather_clone_col(&batch, "web_oa_t", "oa_t") {
+            fields.push(f);
+            arrays.push(a);
+        } else {
+            fields.push(Arc::new(Field::new("oa_t", DataType::Float64, true)));
+            arrays.push(null_f64(n));
+        }
+    }
+    if !weather_has_col(&batch, "web_oa_dp") {
+        if let Some((f, a)) = weather_clone_col(&batch, "oa_dp", "web_oa_dp") {
+            fields.push(f);
+            arrays.push(a);
+        } else {
+            let db = weather_f64(&batch, "web_oa_t").or_else(|| weather_f64(&batch, "oa_t"));
+            let rh = weather_f64(&batch, "oa_h").or_else(|| weather_f64(&batch, "web_oa_h"));
+            let dp = match (db, rh) {
+                (Some(db), Some(rh)) => Float64Array::from(
+                    (0..n)
+                        .map(|i| {
+                            if db.is_null(i) || rh.is_null(i) {
+                                None
+                            } else {
+                                dewpoint_f_from_db_rh(db.value(i), rh.value(i))
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                ),
+                _ => Float64Array::from(vec![None; n]),
+            };
+            fields.push(Arc::new(Field::new("web_oa_dp", DataType::Float64, true)));
+            arrays.push(Arc::new(dp) as ArrayRef);
+        }
+    }
+
+    let schema = Schema::new(fields);
+    Ok(RecordBatch::try_new(Arc::new(schema), arrays)?)
+}
+
 /// Ingest Open-Meteo / weather historian CSV tree into `out_dir/weather/`.
 pub fn ingest_weather_tree(weather_root: &Path, out_dir: &Path) -> Result<usize> {
     let mut written = 0usize;
@@ -312,6 +406,7 @@ pub fn ingest_weather_tree(weather_root: &Path, out_dir: &Path) -> Result<usize>
     std::fs::create_dir_all(&dest)?;
     if let Some((history, columns)) = bundles.into_iter().next() {
         let (batch, _rows) = read_csv_batch(&history, &columns)?;
+        let batch = ensure_weather_web_roles(batch)?;
         let parquet_path = dest.join("history.parquet");
         write_parquet(&parquet_path, &batch)?;
         written += 1;
@@ -350,6 +445,48 @@ mod tests {
             .map(|f| f.name().clone())
             .collect();
         assert!(names.iter().any(|n| n == "oa_t"), "fields: {names:?}");
+    }
+
+    #[test]
+    fn ingest_weather_tree_aliases_web_oa_roles() {
+        let tmp = TempDir::new().unwrap();
+        let wx = tmp.path().join("wx_src");
+        std::fs::create_dir_all(&wx).unwrap();
+        let mut f = std::fs::File::create(wx.join("columns.csv")).unwrap();
+        writeln!(
+            f,
+            "col,point_role\noutside_air_temp_f,outside_air_temp\nrelative_humidity_pct,oa_humidity"
+        )
+        .unwrap();
+        let mut h = std::fs::File::create(wx.join("history_wide.csv")).unwrap();
+        writeln!(h, "timestamp_utc,outside_air_temp_f,relative_humidity_pct").unwrap();
+        writeln!(h, "2026-01-01T00:00:00Z,65.0,41.0").unwrap();
+        let out = tmp.path().join("parquet");
+        let n = ingest_weather_tree(&wx, &out).unwrap();
+        assert_eq!(n, 1);
+        let pq = out.join("weather/history.parquet");
+        let file = std::fs::File::open(&pq).unwrap();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let batch = reader.into_iter().next().unwrap().unwrap();
+        let names: Vec<_> = batch
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert!(names.iter().any(|n| n == "oa_t"), "fields: {names:?}");
+        assert!(names.iter().any(|n| n == "web_oa_t"), "fields: {names:?}");
+        assert!(names.iter().any(|n| n == "web_oa_dp"), "fields: {names:?}");
+        let dp_idx = batch.schema().index_of("web_oa_dp").unwrap();
+        let dp = batch
+            .column(dp_idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!(dp.value(0).is_finite(), "magnus dewpoint {}", dp.value(0));
     }
 
     #[test]

--- a/scripts/wattlab_parity_diff.py
+++ b/scripts/wattlab_parity_diff.py
@@ -226,6 +226,19 @@ def _intentional_accepted(
             True,
             "FAULT∩FAULT after mad_c damper fix; ≤1 confirm-hour residual (326.08 vs 327.08).",
         )
+    if (
+        rule_id == "ECON-2"
+        and o_status.upper() == "FAULT"
+        and r_status.upper() == "FAULT"
+        and o_hours is not None
+        and r_hours is not None
+        and abs(r_hours - o_hours) <= 0.26
+    ):
+        return (
+            True,
+            "FAULT∩FAULT last-interval grain: pandas hours_true vs SQL SUM*poll "
+            "(AHU_2 140.58 vs 140.83 = one 15-min sample). Not isolable in ≤6 GHA rows.",
+        )
     return False, ""
 
 

--- a/sql_rules/econ3_mech_without_econ.sql
+++ b/sql_rules/econ3_mech_without_econ.sql
@@ -1,20 +1,32 @@
 -- econ3_mech_without_econ.sql — Mech cooling without integrated economizer
-WITH h AS (
+-- Web DB+DP: prefer equipment web_oa_* (pandas); else weather sidecar (OAT-METEO join).
+-- Never substitute BAS oa_t.
+WITH wx AS (
   SELECT
-    equipment_id,
     timestamp_utc,
-    web_oa_t, web_oa_dp,
-    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
-    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
-    fan_cmd,
-    fan_status,
+    MAX(web_oa_t) AS wx_web_oa_t,
+    MAX(web_oa_dp) AS wx_web_oa_dp
+  FROM weather
+  GROUP BY timestamp_utc
+),
+h AS (
+  SELECT
+    h.equipment_id,
+    h.timestamp_utc,
+    COALESCE(h.web_oa_t, wx.wx_web_oa_t) AS web_oa_t,
+    COALESCE(h.web_oa_dp, wx.wx_web_oa_dp) AS web_oa_dp,
+    CASE WHEN h.oa_damper_pct IS NULL THEN NULL WHEN h.oa_damper_pct > 1.0 THEN h.oa_damper_pct / 100.0 ELSE h.oa_damper_pct END AS oa_d,
+    CASE WHEN h.clg_valve_pct IS NULL THEN NULL WHEN h.clg_valve_pct > 1.0 THEN h.clg_valve_pct / 100.0 ELSE h.clg_valve_pct END AS clg,
+    h.fan_cmd,
+    h.fan_status,
     CASE
-      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
-      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      WHEN h.fan_status IS NOT NULL THEN CASE WHEN h.fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN h.fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN h.fan_cmd > 1.0 THEN h.fan_cmd / 100.0 ELSE h.fan_cmd END) > 0.01 THEN 1 ELSE 0 END
       ELSE 1
     END AS fan_on
-
-  FROM history
+  FROM history h
+  LEFT JOIN wx
+    ON h.timestamp_utc = wx.timestamp_utc
 ),
 base AS (
   SELECT

--- a/sql_rules/econ6_econ_freezing.sql
+++ b/sql_rules/econ6_econ_freezing.sql
@@ -1,19 +1,28 @@
 -- econ6_econ_freezing.sql — Economizing in freezing weather
-WITH h AS (
+-- Web dry-bulb: prefer equipment web_oa_t; else weather sidecar. Never BAS oa_t.
+WITH wx AS (
   SELECT
-    equipment_id,
     timestamp_utc,
-    web_oa_t,
-    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
-    fan_cmd,
-    fan_status,
+    MAX(web_oa_t) AS wx_web_oa_t
+  FROM weather
+  GROUP BY timestamp_utc
+),
+h AS (
+  SELECT
+    h.equipment_id,
+    h.timestamp_utc,
+    COALESCE(h.web_oa_t, wx.wx_web_oa_t) AS web_oa_t,
+    CASE WHEN h.oa_damper_pct IS NULL THEN NULL WHEN h.oa_damper_pct > 1.0 THEN h.oa_damper_pct / 100.0 ELSE h.oa_damper_pct END AS oa_d,
+    h.fan_cmd,
+    h.fan_status,
     CASE
-      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
-      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      WHEN h.fan_status IS NOT NULL THEN CASE WHEN h.fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN h.fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN h.fan_cmd > 1.0 THEN h.fan_cmd / 100.0 ELSE h.fan_cmd END) > 0.01 THEN 1 ELSE 0 END
       ELSE 1
     END AS fan_on
-
-  FROM history
+  FROM history h
+  LEFT JOIN wx
+    ON h.timestamp_utc = wx.timestamp_utc
 ),
 base AS (
   SELECT

--- a/sql_rules/econ7_ok_not_economizing.sql
+++ b/sql_rules/econ7_ok_not_economizing.sql
@@ -1,20 +1,31 @@
 -- econ7_ok_not_economizing.sql — Economizer OK but not economizing
-WITH h AS (
+-- Web DB+DP: prefer equipment web_oa_*; else weather sidecar. Never BAS oa_t.
+WITH wx AS (
   SELECT
-    equipment_id,
     timestamp_utc,
-    web_oa_t, web_oa_dp,
-    CASE WHEN oa_damper_pct IS NULL THEN NULL WHEN oa_damper_pct > 1.0 THEN oa_damper_pct / 100.0 ELSE oa_damper_pct END AS oa_d,
-    CASE WHEN clg_valve_pct IS NULL THEN NULL WHEN clg_valve_pct > 1.0 THEN clg_valve_pct / 100.0 ELSE clg_valve_pct END AS clg,
-    fan_cmd,
-    fan_status,
+    MAX(web_oa_t) AS wx_web_oa_t,
+    MAX(web_oa_dp) AS wx_web_oa_dp
+  FROM weather
+  GROUP BY timestamp_utc
+),
+h AS (
+  SELECT
+    h.equipment_id,
+    h.timestamp_utc,
+    COALESCE(h.web_oa_t, wx.wx_web_oa_t) AS web_oa_t,
+    COALESCE(h.web_oa_dp, wx.wx_web_oa_dp) AS web_oa_dp,
+    CASE WHEN h.oa_damper_pct IS NULL THEN NULL WHEN h.oa_damper_pct > 1.0 THEN h.oa_damper_pct / 100.0 ELSE h.oa_damper_pct END AS oa_d,
+    CASE WHEN h.clg_valve_pct IS NULL THEN NULL WHEN h.clg_valve_pct > 1.0 THEN h.clg_valve_pct / 100.0 ELSE h.clg_valve_pct END AS clg,
+    h.fan_cmd,
+    h.fan_status,
     CASE
-      WHEN fan_status IS NOT NULL THEN CASE WHEN fan_status > 0.05 THEN 1 ELSE 0 END
-      WHEN fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN fan_cmd > 1.0 THEN fan_cmd / 100.0 ELSE fan_cmd END) > 0.01 THEN 1 ELSE 0 END
+      WHEN h.fan_status IS NOT NULL THEN CASE WHEN h.fan_status > 0.05 THEN 1 ELSE 0 END
+      WHEN h.fan_cmd IS NOT NULL THEN CASE WHEN (CASE WHEN h.fan_cmd > 1.0 THEN h.fan_cmd / 100.0 ELSE h.fan_cmd END) > 0.01 THEN 1 ELSE 0 END
       ELSE 1
     END AS fan_on
-
-  FROM history
+  FROM history h
+  LEFT JOIN wx
+    ON h.timestamp_utc = wx.timestamp_utc
 ),
 base AS (
   SELECT

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -1154,8 +1154,8 @@ rules:
     sql_file: econ3_mech_without_econ.sql
     pandas_function: null
     description: Mech cooling without integrated economizer
-    required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
-    optional_roles: [fan_status, fan_cmd]
+    required_roles: [oa_damper_pct, clg_valve_pct]
+    optional_roles: [web_oa_t, web_oa_dp, fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1247,8 +1247,8 @@ rules:
     sql_file: econ6_econ_freezing.sql
     pandas_function: null
     description: Economizing in freezing weather
-    required_roles: [web_oa_t, oa_damper_pct]
-    optional_roles: [fan_status, fan_cmd]
+    required_roles: [oa_damper_pct]
+    optional_roles: [web_oa_t, fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening
@@ -1289,8 +1289,8 @@ rules:
     sql_file: econ7_ok_not_economizing.sql
     pandas_function: null
     description: Economizer OK but not economizing
-    required_roles: [web_oa_t, web_oa_dp, oa_damper_pct, clg_valve_pct]
-    optional_roles: [fan_status, fan_cmd]
+    required_roles: [oa_damper_pct, clg_valve_pct]
+    optional_roles: [web_oa_t, web_oa_dp, fan_status, fan_cmd]
     output_columns: [equipment_id, fault_hours]
     priority: P0
     parity_status: sql_screening

--- a/tests/test_wattlab_parity_diff.py
+++ b/tests/test_wattlab_parity_diff.py
@@ -27,6 +27,14 @@ def test_other_rule_status_mismatch_not_intentional():
     assert not ok
 
 
+def test_econ2_last_interval_quarter_hour_is_accepted():
+    ok, why = _intentional_accepted("ECON-2", "FAULT", "FAULT", 140.58, 140.83)
+    assert ok
+    assert "15-min" in why
+    ok, _ = _intentional_accepted("ECON-2", "FAULT", "FAULT", 140.58, 141.58)
+    assert not ok
+
+
 def test_fault_intersection_hours_are_blockers():
     ok, _ = _sql_screening_pair("FC1", "FAULT", "FAULT", 10.0, 200.0)
     assert not ok


### PR DESCRIPTION
## Summary

Cycle 3 leftover dump blockers after a written proof pack. One mapping/SQL PR. CAST `>= 1.5` unchanged. No pandas threshold edits. No mass `ELSE 1`. Frozen synthetic-59 stays 59/59. Do not wait GHCR / `:nightly`.

### Proof pack

| Pair | Pandas inputs | SQL `AS` / rank | One sentence |
| --- | --- | --- | --- |
| **CHW-1 / CHILLER_2** 217 vs 767 h | `chilled-water-supply-temp` / `chilled-water-return-temp` (`chws_t_f`, `chwr_t_f`). Hydronic gate: `chiller_2_command` → `chiller-status`, then amps/power. Pandas `ROLE_COLUMN_RANK` prefers `power_demand_this_interval` over peak kW. 900 s startup is a no-op at Liberty 15 min (`ceil(900/900)=1`). | Required `chw_supply_t`, `chw_return_t`. Proof COALESCE `pump_status` → `chiller_status` → current/amps/`chiller_power`. Historian tagged command/amps as `other` (dropped). All `power` meters competed with score 0, so peak/kVA could win. | **Competing column** (peak vs this-interval) plus **missing column** (`other` command/amps never became `chiller_status` / `chiller_amps`). Not CAST/`ELSE 1`. Do not streak-tune 217 vs 767. |
| **ECON-3/6/7 AHU_1/2** pandas FAULT, SQL missing | Pandas `resolve_web_drybulb_dewpoint` on Open-Meteo `web-outside-air-temp` / dewpoint (RH Magnus if needed), plus `mad_c` damper and `chw_valve`. Never BAS `oa_t`. | Required `web_oa_t` (+ `web_oa_dp` for 3/7) **on AHU history**. Preflight skipped the rule. Weather sidecar already exists (OAT-METEO FAULT∩FAULT). Ingest mapped weather dry-bulb to `oa_t`, not `web_oa_t`. | **Missing column**: web analog lives on the weather sidecar, not on the AHU. Same join class as OAT-METEO. Not a mad_c damper miss (already `#734`). |
| **ECON-4 AHU_1/2** 659 vs 663 h, 519 vs 521 h | MAT/RAT/OAT OA-fraction; `mad_c` already OA damper. | Same analog roles; both FAULT. | **Confirm / last-interval grain** (~15 extra 15-min samples). Not isolable in ≤6 GHA rows. **No SQL patch.** Not `semantic_gap`. |
| **ECON-2 AHU_2** 140.58 vs 140.83 h | Cycle 1 deferred. | Same damper CAST path. | **Confirm / last-interval** (one 15-min sample). Accept with that rationale; not a mapping bug. |

No leftover pair is a **semantic_gap**. CHW-1 hours are not a confirm-window fake-match.

### Code

- Map historian `other` command/amps and `power` → `chiller_status` / `chiller_amps` / `chiller_power`; rank this-interval over peak.
- Weather ingest dual-writes `web_oa_t` / `web_oa_dp` (Magnus from RH when needed).
- ECON-3/6/7 SQL `LEFT JOIN weather` (never BAS `oa_t`). Registry: `web_oa_*` optional so preflight does not skip.
- GHA tiny `pandas_confirm_fault_hours` fixtures (6×5 min, `confirm_rows=2`). Not 217 vs 767.
- ECON-2 ≤0.26 h FAULT∩FAULT accept in `wattlab_parity_diff.py`.

## Test plan

- [x] `cargo test -p fdd_rules oracle_parity_test` (42)
- [x] `cargo test -p fdd_core` column/rank tests; `cargo test -p fdd_store` weather alias
- [x] `cargo clippy -p fdd_core -p fdd_store -p fdd_sql -p fdd_rules -- -D warnings`
- [ ] GitHub **Rust CI** green (squash after that; do not wait GHCR/nightly)
- [ ] Synthetic-59 remains **59/59** (untouched)


Made with [Cursor](https://cursor.com)