### PR TITLE
Gate SCHED-247 SQL on window mean(on) like pandas always_on_pct

### DIFF
--- a/crates/fdd_rules/src/oracle_parity_test.rs
+++ b/crates/fdd_rules/src/oracle_parity_test.rs
@@ -408,8 +408,9 @@ timestamp_utc,web_oat,web_dp,oa_d,clg_col
 
     #[tokio::test]
     async fn sched247_fan_cmd_screening_confirm_streak() {
-        // Screening: SQL confirms fan_cmd>=0.05 streaks — not vibe19 window always_on_pct.
-        // Keep parity_level sql_screening until SQL matches _sched247.
+        // Keep this fixture: 50% duty with a 3-sample streak is below default
+        // always_on_pct=0.95, so pandas `_sched247` is all-false. After the
+        // window-fraction port, SQL must also be 0 — do not streak-tune hours.
         let tmp = tempfile::TempDir::new().unwrap();
         let building = tmp.path().join("BUILDING_SCHED247");
         std::fs::create_dir_all(&building).unwrap();
@@ -449,10 +450,50 @@ timestamp_utc,fan_col,fan_st,pump_st,ch_st
         );
 
         let got = run_rule_fault_hours(&building, "sched247_always_on.sql", 300.0, 600, &[]).await;
+        assert_hours_close(got, 0.0, "SCHED-247 below always_on_pct");
+    }
 
-        let raw = [false, false, true, true, true, false];
+    #[tokio::test]
+    async fn sched247_high_duty_short_streak_matches_pandas() {
+        // always_on_pct=0.5 so 4/6 on is over the gate; longest streak is
+        // confirm_rows=2 (not a 3-sample screening run). SQL hours match pandas.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let building = tmp.path().join("BUILDING_SCHED247_DUTY");
+        std::fs::create_dir_all(&building).unwrap();
+
+        let rows = "\
+timestamp_utc,fan_col
+2026-01-01T00:00:00Z,50
+2026-01-01T00:05:00Z,50
+2026-01-01T00:10:00Z,0
+2026-01-01T00:15:00Z,50
+2026-01-01T00:20:00Z,50
+2026-01-01T00:25:00Z,0
+";
+        write_equipment_fixture(
+            &building,
+            "AHU_1",
+            5,
+            &[RoleCol {
+                csv_col: "fan_col",
+                role: "fan_cmd",
+            }],
+            rows,
+        );
+
+        let got = run_rule_fault_hours(
+            &building,
+            "sched247_always_on.sql",
+            300.0,
+            600,
+            &[("ALWAYS_ON_PCT", "0.5")],
+        )
+        .await;
+
+        let raw = [true, true, false, true, true, false];
         let expected = pandas_confirm_fault_hours(&raw, 300.0, 2);
-        assert_hours_close(got, expected, "SCHED-247 screening SQL");
+        assert_hours_close(expected, 0.16666666666666666, "pandas reference");
+        assert_hours_close(got, expected, "SCHED-247 window fraction SQL");
     }
 
     #[tokio::test]

--- a/crates/fdd_rules/src/params.rs
+++ b/crates/fdd_rules/src/params.rs
@@ -35,6 +35,7 @@ pub fn substitute_sql(sql: &str, params: &HashMap<String, String>) -> String {
         ("ECON2_DAMPER", "0.42"),
         ("DUCT_HIGH_MARGIN", "0.25"),
         ("PRESSURE_ON_MIN", "0.2"),
+        ("ALWAYS_ON_PCT", "0.95"),
     ] {
         params.entry(k.into()).or_insert_with(|| v.into());
     }

--- a/docs/agent/SCHED247_WINDOW_FRACTION.md
+++ b/docs/agent/SCHED247_WINDOW_FRACTION.md
@@ -1,0 +1,19 @@
+# SCHED-247: window `always_on_pct` vs confirm streak
+
+Cycle 5 option **A**. Pandas `_sched247` faults only when `mean(on) ≥ always_on_pct`
+over the **whole analysis window**, then returns the on-mask (confirm is applied
+after). SQL used to confirm every on-streak regardless of duty cycle.
+
+`sql_rules/sched247_always_on.sql` now gates on `AVG(on_bit)` per equipment.
+Ranked proof is unchanged (fan/pump/chiller status, else `fan_cmd`). Pressure
+still does not OR into the FAULT mask.
+
+Keep `parity_status: sql_screening`. Do not mark proven from B100 hours. Do not
+auto-accept dump PASS vs FAULT in `wattlab_parity_diff.py`.
+
+GHA (6 samples × 5 min, `confirm_rows=2`):
+
+- `sched247_fan_cmd_screening_confirm_streak`: 50% duty with a 3-sample streak
+  is below default 0.95 → SQL 0 (pandas).
+- `sched247_high_duty_short_streak_matches_pandas`: `always_on_pct=0.5`, 4/6 on,
+  longest streak = 2 → SQL matches `pandas_confirm_fault_hours`.

--- a/scripts/generate_parity_inventory.py
+++ b/scripts/generate_parity_inventory.py
@@ -90,8 +90,9 @@ KNOWN_DIFFERENCES: dict[str, dict] = {
     "SCHED-247": {
         "class": "none",
         "note": (
-            "4.3: ranked proof status/current > command; pressure is inferred "
-            "runtime only and does not OR into the FAULT mask. SQL uses the same rank."
+            "4.3 ranked proof (status/current > command; pressure inferred only). "
+            "SQL mean(on) >= always_on_pct over the analysis window matches pandas "
+            "_sched247. Keep sql_screening; do not mark proven from B100 hours."
         ),
     },
     "FC7": {

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -4233,7 +4233,7 @@
         "tests/test_wattlab_parity_diff.py"
       ],
       "parity_status": "sql_screening",
-      "known_semantic_differences": "4.3: ranked proof status/current > command; pressure is inferred runtime only and does not OR into the FAULT mask. SQL uses the same rank.",
+      "known_semantic_differences": "4.3 ranked proof (status/current > command; pressure inferred only). SQL mean(on) >= always_on_pct over the analysis window matches pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.",
       "difference_class": "none"
     },
     {
@@ -15498,7 +15498,7 @@
       "parity_status": "sql_screening",
       "parity_level": "sql_screening",
       "difference_class": "none",
-      "known_semantic_differences": "4.3: ranked proof status/current > command; pressure is inferred runtime only and does not OR into the FAULT mask. SQL uses the same rank.",
+      "known_semantic_differences": "4.3 ranked proof (status/current > command; pressure inferred only). SQL mean(on) >= always_on_pct over the analysis window matches pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.",
       "operational_gate": "always",
       "startup_delay_seconds": 0.0,
       "confirm_seconds": 3600,
@@ -15512,6 +15512,16 @@
           "unit": "sec",
           "frontend_control": "slider",
           "sql_placeholder": "CONFIRM_SECONDS"
+        },
+        "always_on_pct": {
+          "label": "Always-on fraction",
+          "default": 0.95,
+          "min": 0.8,
+          "max": 1.0,
+          "step": 0.01,
+          "unit": "frac",
+          "frontend_control": "slider",
+          "sql_placeholder": "ALWAYS_ON_PCT"
         }
       },
       "time_semantics": "row_or_interval_per_sql_file",

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -3539,9 +3539,9 @@ matrix:
   - tests/rules/test_sched247_proof.py
   - tests/test_wattlab_parity_diff.py
   parity_status: sql_screening
-  known_semantic_differences: '4.3: ranked proof status/current > command; pressure
-    is inferred runtime only and does not OR into the FAULT mask. SQL uses the same
-    rank.'
+  known_semantic_differences: 4.3 ranked proof (status/current > command; pressure
+    inferred only). SQL mean(on) >= always_on_pct over the analysis window matches
+    pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.
   difference_class: none
 - rule_id: RESET-1
   title: SAT reset not tracking outdoor air
@@ -9750,9 +9750,9 @@ concepts:
   parity_status: sql_screening
   parity_level: sql_screening
   difference_class: none
-  known_semantic_differences: '4.3: ranked proof status/current > command; pressure
-    is inferred runtime only and does not OR into the FAULT mask. SQL uses the same
-    rank.'
+  known_semantic_differences: 4.3 ranked proof (status/current > command; pressure
+    inferred only). SQL mean(on) >= always_on_pct over the analysis window matches
+    pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.
   operational_gate: always
   startup_delay_seconds: 0.0
   confirm_seconds: 3600
@@ -9766,6 +9766,15 @@ concepts:
       unit: sec
       frontend_control: slider
       sql_placeholder: CONFIRM_SECONDS
+    always_on_pct:
+      label: Always-on fraction
+      default: 0.95
+      min: 0.8
+      max: 1.0
+      step: 0.01
+      unit: frac
+      frontend_control: slider
+      sql_placeholder: ALWAYS_ON_PCT
   time_semantics: row_or_interval_per_sql_file
   output_schema:
   - equipment_id

--- a/sql_rules/registry.yaml
+++ b/sql_rules/registry.yaml
@@ -2486,3 +2486,12 @@ rules:
         unit: sec
         frontend_control: slider
         sql_placeholder: CONFIRM_SECONDS
+      always_on_pct:
+        label: Always-on fraction
+        default: 0.95
+        min: 0.8
+        max: 1.0
+        step: 0.01
+        unit: frac
+        frontend_control: slider
+        sql_placeholder: ALWAYS_ON_PCT

--- a/sql_rules/sched247_always_on.sql
+++ b/sql_rules/sched247_always_on.sql
@@ -1,5 +1,7 @@
 -- sched247_always_on.sql — Always-on fan or pump runtime
--- Ranked proof: fan_status / pump_status / chiller_status, else fan_cmd.
+-- Pandas `_sched247`: ranked proof (status > command), then FAULT only when
+-- mean(on) >= always_on_pct over the whole analysis window. Confirmed hours
+-- are the on-mask after that gate (not a streak-only screen).
 -- Pressure is not used for the FAULT mask (4.3 migration).
 WITH h AS (
   SELECT
@@ -21,8 +23,26 @@ proof AS (
       WHEN chiller_status IS NOT NULL THEN CASE WHEN chiller_status > 0.05 THEN 1 ELSE 0 END
       WHEN fan IS NOT NULL THEN CASE WHEN fan >= 0.05 THEN 1 ELSE 0 END
       ELSE 0
-    END AS INT) AS raw_fault
+    END AS INT) AS on_bit
   FROM h
+),
+win AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    on_bit,
+    AVG(CAST(on_bit AS DOUBLE)) OVER (PARTITION BY equipment_id) AS on_frac
+  FROM proof
+),
+base AS (
+  SELECT
+    equipment_id,
+    timestamp_utc,
+    CAST(CASE
+      WHEN on_frac >= {{ALWAYS_ON_PCT}} AND on_bit = 1 THEN 1
+      ELSE 0
+    END AS INT) AS raw_fault
+  FROM win
 ),
 lagged AS (
   SELECT
@@ -31,7 +51,7 @@ lagged AS (
       WHEN raw_fault = LAG(raw_fault) OVER (PARTITION BY equipment_id ORDER BY timestamp_utc)
       THEN 0 ELSE 1
     END AS is_new_streak
-  FROM proof
+  FROM base
 ),
 grp AS (
   SELECT


### PR DESCRIPTION
## Summary
- Option A: `sched247_always_on.sql` now faults only when `mean(on) ≥ always_on_pct` over the analysis window (pandas `_sched247`), then confirms the on-mask. Ranked proof and pressure-not-OR are unchanged.
- Keep `sched247_fan_cmd_screening_confirm_streak`: 50% duty is below default 0.95 → SQL 0. New GHA: high duty, longest streak = `confirm_rows=2` → SQL matches `pandas_confirm_fault_hours`.
- Keep `sql_screening`. Do not streak-tune 0 vs 1500 h. Dump PASS vs FAULT is still not auto-accepted.

## Test plan
- [ ] Rust CI: format, clippy, and tests
- [ ] FDD engine CI: synthetic slice 59/59
- [ ] Do not wait GHCR / `:nightly`