### PR TITLE
Harden UTC timestamp ingest and ISO8601 pandas parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:808
 - **Synthetic-59:** soak via `scripts/synthetic_59_*.py` under `reports/wattlab-parity/fixtures/synthetic_59/`. Do not greenwash `expected_faults.csv`. B100 dump-parity is **active** (`wattlab_parity_*.py` vs vibe19 `:latest` 4.4.1).
 - **Units:** FDD SQL is °F canonical. Metric CSVs convert at query (`unit_system=metric|si`). Lab sliders show °C when metric is selected; Run all rules after switching.
 - **Hourly append:** seed with `POST /api/csv/import/package`, then `POST /api/csv/import/package/append` (JWT, `confirm:true`). Custom appenders stay outside the repo.
+- **Package timestamps + maps:** `timestamp_utc` accepts ISO-8601 `Z` and `+00:00`. Unparseable rows are skipped (never epoch 0 / now). String `"equip": "AHU_1"` on a sidecar is metadata; package maps need object `equip`/`equipment`. Site vendor names belong in zip preprocess — not product code. See [`docs/RUST_DATAFUSION_ENGINE.md`](docs/RUST_DATAFUSION_ENGINE.md) and [`docs/mcp-agents/roles/package-mapping.md`](docs/mcp-agents/roles/package-mapping.md).
 - **Overview layout:** full width beside sidebar (Streamlit-like); named Plotly PNG stems via `downloadFilename`; Lab rule menu A–Z; FDD series = required∪optional roles.
 - **Mech OAT bins:** status/cmd before amps; prefer web/weather OAT. Analytics envelopes: `scripts/synthetic_59_overview_analytics_soak.py`.
 

--- a/crates/fdd_store/src/ingest.rs
+++ b/crates/fdd_store/src/ingest.rs
@@ -13,6 +13,20 @@ use fdd_core::{load_column_role_map, validate_building};
 
 use crate::meta::{meta_path_for, source_fingerprint, write_meta, SidecarMeta};
 
+/// Parse `timestamp_utc` to UTC nanoseconds.
+///
+/// Accepts RFC3339 with `Z` or numeric offsets (`+00:00`). Returns `None` on
+/// empty / unparseable input — callers must skip the row (never invent epoch 0).
+pub fn parse_timestamp_utc_nanos(raw: &str) -> Option<i64> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    chrono::DateTime::parse_from_rfc3339(trimmed)
+        .ok()
+        .and_then(|dt| dt.with_timezone(&chrono::Utc).timestamp_nanos_opt())
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct IngestTiming {
     pub equipment_id: String,
@@ -186,15 +200,12 @@ fn read_csv_batch(path: &Path, columns_path: &Path) -> Result<(RecordBatch, u64)
 
     for rec in rdr.records() {
         let rec = rec?;
+        let raw_ts = rec.get(ts_idx).unwrap_or("").trim();
+        // Never invent epoch-0 / "now" for bad stamps — skip the row.
+        let Some(ts) = parse_timestamp_utc_nanos(raw_ts) else {
+            continue;
+        };
         rows += 1;
-        let raw_ts = rec.get(ts_idx).unwrap_or("");
-        let ts: i64 = chrono::DateTime::parse_from_rfc3339(raw_ts)
-            .map(|dt| {
-                dt.with_timezone(&chrono::Utc)
-                    .timestamp_nanos_opt()
-                    .unwrap_or(0)
-            })
-            .unwrap_or(0);
         ts_vals.push(ts);
         for (j, (i, _)) in included.iter().enumerate() {
             let cell = rec.get(*i).unwrap_or("").trim();
@@ -419,6 +430,45 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::TempDir;
+
+    #[test]
+    fn parse_accepts_z_and_plus00_as_same_utc() {
+        let z = parse_timestamp_utc_nanos("2026-05-21T20:20:00Z").unwrap();
+        let plus = parse_timestamp_utc_nanos("2026-05-21T20:20:00+00:00").unwrap();
+        assert_eq!(z, plus);
+        assert!(parse_timestamp_utc_nanos("not-a-timestamp").is_none());
+        assert!(parse_timestamp_utc_nanos("").is_none());
+        assert!(parse_timestamp_utc_nanos("   ").is_none());
+    }
+
+    #[test]
+    fn mixed_z_and_offset_suffixes_ingest_without_epoch_zero() {
+        use arrow::array::Array;
+        let tmp = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(tmp.path().join("columns.csv")).unwrap();
+        writeln!(f, "col,point_role\noat,outside_air_temp").unwrap();
+        let mut h = std::fs::File::create(tmp.path().join("history_wide.csv")).unwrap();
+        writeln!(h, "timestamp_utc,oat").unwrap();
+        writeln!(h, "2026-05-21T20:20:00Z,70").unwrap();
+        writeln!(h, "2026-05-21T20:25:00+00:00,71").unwrap();
+        writeln!(h, "bogus,72").unwrap();
+        writeln!(h, ",73").unwrap();
+        let (batch, rows) = read_csv_batch(
+            &tmp.path().join("history_wide.csv"),
+            &tmp.path().join("columns.csv"),
+        )
+        .unwrap();
+        assert_eq!(rows, 2, "unparseable rows must be skipped, not epoch-0");
+        let ts_idx = batch.schema().index_of("timestamp_utc").unwrap();
+        let ts = batch
+            .column(ts_idx)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .unwrap();
+        assert_ne!(ts.value(0), 0);
+        assert_ne!(ts.value(1), 0);
+        assert!(ts.value(1) > ts.value(0));
+    }
 
     #[test]
     fn weather_flat_csv_maps_oa_t() {

--- a/docs/RUST_DATAFUSION_ENGINE.md
+++ b/docs/RUST_DATAFUSION_ENGINE.md
@@ -24,6 +24,18 @@ Production-direction deterministic FDD analytics for Open-FDD.
 
 Optional weather: `{data_root}/weather/` (staged for OAT-METEO rules).
 
+### `timestamp_utc` contract
+
+- ISO-8601 UTC with **`Z` or numeric offset** (`+00:00`) — both accepted.
+- Unparseable or empty stamps are **skipped** (never written as epoch 0 / wall-clock now).
+- Mixed suffixes in one CSV are fine; gold fixtures and BAS exports both appear in the wild.
+
+### Map JSON shapes
+
+- Package map: `equip` / `equipment` / `devices` must be an **object** of equipment blocks.
+- Single-equip Haystack sidecars may set `"equip": "AHU_1"` as a **string** device id — that is metadata; roles come from `points` / `column_roles`.
+- Site-specific vendor point names belong in the package preprocess, not in Rust equations.
+
 ## CLI
 
 ```powershell

--- a/docs/agent/WINDOWS_VIBE19_STREAMLIT_TS_PACKAGE_PROMPT.md
+++ b/docs/agent/WINDOWS_VIBE19_STREAMLIT_TS_PACKAGE_PROMPT.md
@@ -1,0 +1,175 @@
+# Cursor agent prompt — Vibe19 UI deprecations, pandas timestamps, ANY-BAS package contract
+
+Paste this entire file as the first message in a **new Cursor agent chat** whose workspace is:
+
+`C:\Users\ben\Documents\py-bacnet-stacks-playground\vibe_code_apps_19`
+
+Repo: `https://github.com/bbartling/py-bacnet-stacks-playground`. Prefer branch work from **`origin/develop`** (or the vibe19 app path’s default product branch — confirm with `git status` / remote).
+
+Do **not** open or hard-code the Central Heights / Metasys (`sp_jci`) job. This app must stay vendor-agnostic.
+
+---
+
+## Machine split (read this)
+
+| Machine | Owns |
+| --- | --- |
+| **Windows** (this chat) | Vibe App 19 Streamlit UI, package loaders, Haystack sidecar JSON, AGENTS/mapping docs, playground GH Actions / vibe19 GHCR |
+| **Bensbench / open-fdd** | DataFusion Rust ingest, SQL rules, `open_fdd` PyPI oracle, MCP docs — **separate plan** `~/.cursor/plans/openfdd_ts_package_contract_a7c3e91f.plan.md` |
+
+**Do not** patch Open-FDD Rust/SQL/DataFusion from this Windows session. **Do not** `docker build` Open-FDD on bensbench. After vibe19 GHCR publish, Linux only `docker pull`.
+
+Cycles 1–5 FDD leftover dump work is **done on open-fdd**. Do not reopen those SQL PRs here.
+
+You are patching **Vibe App 19** so Streamlit/pandas stop yelling, so Haystack sidecars parse real-world JSON, and so **AGENTS.md + mapping docs** give the next AI agent enough context to preprocess **any** BAS historian into an `openfdd_package_v1` zip.
+
+Charts, FDD plots, RCx, motor hours, mixing scatter, and OAT-METEO are **data-model driven**. If roles are missing, the UI warns. The app must **not** invent vendor point names (no `SF-O`, no `GLYCOL_SYSTEM`, no Madison lat/lon) in Python. Site-specific mapping belongs in the **package** the agent builds offline.
+
+Read first: root [`AGENTS.md`](../AGENTS.md), [`docs/PACKAGE_SPEC.md`](PACKAGE_SPEC.md), [`docs/HAYSTACK_LIKE_MAPPING_GUIDE.md`](HAYSTACK_LIKE_MAPPING_GUIDE.md), [`docs/DATA_MODEL_DRIVEN.md`](DATA_MODEL_DRIVEN.md), [`docs/COLUMN_MAP_JSON.md`](COLUMN_MAP_JSON.md).
+
+## Non-negotiable
+
+1. **No site/vendor hardcoding** in `app/` — not Johnson Controls, ALC, Niagara, BACnet, a school name, a city, or a single equipment id. Lat/lon for Open-Meteo stays a **caller argument** (`app/open_meteo.py` already works that way).
+2. **Do not fork OpenFDD equations.** Do not add Rust/DataFusion.
+3. Gold fixtures must still load: `tests/fixtures/`, Building 100 style maps, synthetic 59-rule zip if present on disk. Add tests; do not weaken existing ones.
+4. `python -m pytest -q` (or `.\scripts\run_tests_local.ps1`) before claiming done.
+5. **Do not commit** unless the human asks. When asked to land: squash-merge to `develop`, delete the branch, leave CI green.
+
+## Phase A — Streamlit `use_container_width` deprecation
+
+Streamlit will remove `use_container_width` after **2025-12-31**.
+
+- `True` → `width="stretch"`
+- `False` → `width="content"`
+
+Grep the **whole repo** (`*.py`), not only the three files that already warned:
+
+- `streamlit_app.py`
+- `app/ui_vav_health.py`
+- `app/report_downloads.py` (`report_download_button` kwarg + `st.download_button`)
+
+Replace every `use_container_width=...` on Streamlit widgets. If a helper still takes `use_container_width: bool`, rename it to `width` or map bool → `"stretch"` / `"content"` so callers stay clean.
+
+`requirements.txt` is `streamlit>=1.28`. If `width=` is too new for 1.28, gate with `hasattr` / version check **or** bump the Streamlit floor in requirements to a version that documents `width=` (prefer bump + one comment in AGENTS.md). Do not leave deprecation spam on current Streamlit 1.4x/1.5x.
+
+## Phase B — Pandas `Could not infer format` on `timestamp_utc`
+
+`pd.to_datetime(..., utc=True)` without `format=` warns on ISO-8601 **`Z`** suffixes (`2026-05-21T20:20:00Z`) and on mixed `Z` vs `+00:00`. Both are valid UTC. Gold fixtures often use `+00:00`; many BAS exports use `Z`.
+
+Fix the **loader**, not a single building’s CSV:
+
+- `app/package_io.py` (~line 878, `_validate_equipment_csv`)
+- `app/data_loader.py` (~line 30, `normalize_timestamp`)
+- Also grep: `app/data_contract.py`, `app/source_profile.py`, `app/open_meteo.py`, `shared/validate_hvac_data.py`, `scripts/gen_openfdd_building_maps.py`
+
+Use `format="ISO8601"` (pandas 2.x) with `utc=True`, `errors="coerce"`. If a frame still fails, fall back to `format="mixed"` then dateutil — **once**, not per-row warnings.
+
+Add a tiny unit test: parse a Series containing **both** `...Z` and `...+00:00` with **zero** `UserWarning` from pandas (use `pytest.warns` / `warnings.catch_warnings`). Do not require packages to rewrite timestamps; the app must accept both.
+
+Note: Open-FDD PyPI / Rust ingest may get a parallel ISO8601 + no-epoch-zero patch on bensbench — **do not duplicate that work here**. Keep Vibe19 loaders self-contained.
+
+## Phase C — Sidecar JSON robustness (any Haystack-shaped map)
+
+`app/sidecar_maps.py` `_points_from_payload` treats **any** key named `equip` as a **full package map**. Haystack-style single-equip JSON often has `"equip": "AHU_1"` as a **string device id**. That currently raises:
+
+`package-style map has no points/column_roles for this equipment`
+
+Fix: only take the package-map branch when `equip` / `equipment` / `devices` is a **dict** (or list of blocks). If `equip` is a string, ignore it as metadata and read `points` / `column_roles` like a single-equip sidecar.
+
+Add a test with `{equipType, equipment_type, device, equip: "<string>", points: {...}}`.
+
+(Open-FDD Rust `points_from_map_json` already requires an object — do not “port” Rust; just fix Python.)
+
+## Phase D — Butter up agent docs (this is the product)
+
+Expand **root `AGENTS.md`**, [`docs/HAYSTACK_LIKE_MAPPING_GUIDE.md`](HAYSTACK_LIKE_MAPPING_GUIDE.md), and [`docs/DATA_MODEL_DRIVEN.md`](DATA_MODEL_DRIVEN.md) so an AI agent can author a zip for **any** BAS job without reading this chat.
+
+Write as **generic rules**, with examples that use `AHU_1` / `VAV_1` / `CHW_1` / `weather/` — never a real campus.
+
+Must include all of the following.
+
+### D1. Analytics are role-driven
+
+If a chart is empty, the package is missing Haystack **roles**, not “the app is broken.” Empty motors / mixing / VAV / compressor bins are expected when roles are absent. The agent’s job is to map or synthesize columns **in the zip**.
+
+### D2. Stamp types — do not rely on folder names
+
+`equipType` / `equipment_type` is canonical (`ahu` `vav` `chwPlant` `boiler` `heatPump` `weather`; `rtu`→AHU). Folder `JRH-RM717-VMA-…` will be **UNKNOWN** if unstamped. Unit ventilators / FCUs with air-side points should be typed **`ahu`** unless a cookbook type exists. Chillers → **`chwPlant`**.
+
+### D3. Web weather (Open-Meteo) — package sidecar, not app config
+
+- Put `weather/history_wide.csv` **inside the building root** (never treated as equipment).
+- Required analysis column: **`web-outside-air-temp`** (°F). Optional: `web-outside-air-humidity`, dewpoint (app can derive wet-bulb).
+- Align to the same UTC grid as HVAC (`timestamp_utc`).
+- Fetch with **job lat/lon** (geocode the site). Do not bake a city into Vibe19.
+- `session_config.prefer_web_oat: true` — web OAT is primary for economizer / RCx / physics; BAS `outside-air-temp` is for OAT-METEO overlay **only when both exist**.
+- BAS OA is often **one site-global sensor** (boiler/plant). Copy that series onto air handlers as `outside-air-temp` in the **package**. The app will not guess which boiler owns OA.
+
+### D4. Fan / pump / tower motor proof
+
+Motors need **`fan-status`** (or pump/tower status), not speed-only leftovers.
+
+When the BAS has **no binary status**:
+
+- Map analog speed/command as **`fan-cmd`** (0–100% or 0–1).
+- **Synthesize** a 0/1 column in the wide CSV (e.g. `fan_s = 1` when speed ≥ documented threshold, typically 5% or 0.05).
+- Map `fan-status` → that column.
+- Same pattern for pumps/towers from VFD % or proven loop DP — **document the rule in the site preprocess repo**, not in Vibe19 source.
+- Never invent motor hours from leave temperature.
+
+### D5. Compressor proof ≠ valve ≠ pump
+
+Mech-cooling OAT bins accept `chiller-status` / `compressor-status` / verified cmd / amps / power. **Never** CHW pump or AHU `cooling-valve`. Optional inferred CHW leave-temp is a **sidebar** on the app, not a silent default.
+
+If the plant only has % cooling output, synthesize `chiller-status` in the package (threshold documented). Map CHW supply/return temps to `chilled-water-supply-temp` / `chilled-water-return-temp`.
+
+### D6. VAV / zone
+
+`zone-airflow` must be **actual CFM**, never the airflow **setpoint**. `zone-air-temp` from the zone sensor. Box damper → `damper`. Reheat → `reheat-valve`. Stamp `vav`.
+
+### D7. Mixing scatter
+
+Needs an AHU/RTU with `fan-status` (or cmd-derived status) **on**, plus `outside-air-temp`, `return-air-temp`, `mixed-air-temp`, and enough `|OAT−RAT|≥10°F` samples. Missing any role → skip, don’t crash.
+
+### D8. Pandas-happy zip hygiene
+
+- `timestamp_utc` ISO-8601 UTC (`Z` or `+00:00` — both OK after Phase B)
+- UTF-8 wide CSV, one point per column
+- Sibling Haystack JSON **without** using string `equip` as a nested package map (or after Phase C either shape works)
+- Forward-slash zip arcnames (Python `zipfile`, never `Compress-Archive`)
+- `weather/` nested under the building folder
+- Stay under `OPENFDD_MAX_EQUIPMENT` (default 100) or split packages
+
+### D9. What Vibe19 must never grow
+
+No `if building == …`, no Metasys suffix table in `app/`, no default Madison weather, no “glycol” special case. Vendor dictionaries live in **per-job preprocess** (the agent that builds the zip).
+
+## Phase E — Verify
+
+- Grep: no remaining `use_container_width` on Streamlit calls (helpers OK only if they translate to `width=`).
+- Tests: datetime Z/+00:00; sidecar `equip` string; existing package/load tests.
+- Docs: AGENTS.md section “Package authoring (any BAS job)” plus mapping-guide subsections for weather, synthetic motor proof, compressor vs pump, VAV airflow vs SP.
+- `python -m pytest -q`
+
+## Phase F — Turnkey playground closeout (required before “done”)
+
+Do this **after** Phases A–E are green locally. Goal: no stale product debt left for the next agent.
+
+```powershell
+cd C:\Users\ben\Documents\py-bacnet-stacks-playground
+git fetch origin --prune
+git checkout develop
+git pull origin develop
+gh pr list --state open --limit 30
+gh run list --status failure --limit 40
+git branch -r
+```
+
+1. Land **this** vibe19 patch on `develop` only when the human asks to commit/PR — squash-merge, **delete the branch**.
+2. Triage other open playground PRs (`gh pr list`): merge if already green and in-scope, or close with a one-line reason if superseded. Known prior noise: vibe22 RL/docs PRs — do not expand into long RL campaigns unless the human asks; prefer close or park.
+3. Rerun or fix **failed** Actions on `develop` / the merge SHA until the product workflows that matter for vibe19 are green (or explicitly waived in the summary).
+4. Delete merged remote branches (`git push origin --delete …` / `gh pr view --json headRefName`).
+5. If vibe19 GHCR publish is part of your workflow, confirm `ghcr.io/bbartling/vibe19:latest` (or the repo’s documented tag) is pullable — **do not** build Open-FDD images here.
+6. Summarize: files changed, PR URL(s), remaining open PRs (ideally zero for vibe19), failed runs cleared.
+
+When done, summarize files changed. Do not commit unless asked — then follow Phase F.

--- a/docs/agent/openfdd-mcp-tool-contract.md
+++ b/docs/agent/openfdd-mcp-tool-contract.md
@@ -101,6 +101,12 @@ Requires **`OPENFDD_MCP_ALLOW_WRITES=1`** and **`confirm: true`** on each tool c
 | Haystack write | `POST /api/haystack/write` | Station write |
 | Site restore | backup/restore scripts | Data loss |
 
+## Package / CSV ingest notes
+
+- `timestamp_utc` must be RFC3339 UTC (`Z` or `+00:00`). Preflight and ingest skip unparseable rows — they do **not** invent epoch 0 or wall-clock now.
+- Haystack sidecar `"equip": "<string>"` is device metadata; nested package maps use object `equip`/`equipment`/`devices`.
+- Empty analytics after import usually mean missing roles in the zip, not a broken MCP tool.
+
 ## Forbidden
 
 - Exposing `auth.env.local`, password hashes, or JWTs in tool output

--- a/docs/mcp-agents/roles/package-mapping.md
+++ b/docs/mcp-agents/roles/package-mapping.md
@@ -50,6 +50,12 @@ labeled points.
 | `confidence` | number 0–1 | no | agent-suggested only; humans may omit |
 | `evidence` | string | no | why this mapping (name/unit/range) |
 
+### Package hygiene (agents)
+
+- `timestamp_utc` is RFC3339 UTC: **`Z` or `+00:00`** — both OK. Do not invent vendor clocks in the app.
+- String `"equip": "AHU_1"` on a single-equip sidecar is **metadata**, not a nested package map. Nested maps use object `equip`/`equipment`/`devices`.
+- Empty charts mean **missing roles** in the zip, not a broken FDD engine. Do not invent site/vendor point names in product code.
+
 ## MCP tools
 
 All entries also live in [`tool-catalog.v1.json`](tool-catalog.v1.json).

--- a/edge/src/csv_ingest/package.rs
+++ b/edge/src/csv_ingest/package.rs
@@ -1386,6 +1386,28 @@ mod tests {
     }
 
     #[test]
+    fn string_equip_metadata_still_reads_points() {
+        // Haystack single-equip sidecars often set "equip": "AHU_1" (string).
+        // Only dict equip/equipment/devices is a package map.
+        let map = serde_json::json!({
+            "equipType": "ahu",
+            "equipment_type": "ahu",
+            "device": "AHU_1",
+            "equip": "AHU_1",
+            "points": {
+                "fan-cmd": "SF_SPD",
+                "discharge-air-temp": "SAT"
+            }
+        });
+        let roles = points_from_map_json(&map, "AHU_1").expect("roles");
+        assert_eq!(roles.get("fan-cmd").map(String::as_str), Some("SF_SPD"));
+        assert_eq!(
+            roles.get("discharge-air-temp").map(String::as_str),
+            Some("SAT")
+        );
+    }
+
+    #[test]
     fn rejects_wrong_schema_and_traversal() {
         let zip = build_zip(&[(
             "manifest.json",

--- a/edge/src/csv_ingest/timestamp.rs
+++ b/edge/src/csv_ingest/timestamp.rs
@@ -306,4 +306,17 @@ mod tests {
             .with_timezone(&Utc);
         assert_eq!(pt.ts_utc, Some(expected));
     }
+
+    #[test]
+    fn rfc3339_z_and_plus00_parse_to_same_utc() {
+        let tz: Tz = "America/Chicago".parse().unwrap();
+        let z = parse_row_timestamp("2026-05-21T20:20:00Z", tz, "first");
+        let plus = parse_row_timestamp("2026-05-21T20:20:00+00:00", tz, "first");
+        assert_eq!(z.status, ParseStatus::Ok);
+        assert_eq!(plus.status, ParseStatus::Ok);
+        assert_eq!(z.ts_utc, plus.ts_utc);
+        let bad = parse_row_timestamp("not-a-timestamp", tz, "first");
+        assert_eq!(bad.status, ParseStatus::Failed);
+        assert!(bad.ts_utc.is_none());
+    }
 }

--- a/edge/src/fdd/execution.rs
+++ b/edge/src/fdd/execution.rs
@@ -204,7 +204,11 @@ fn historian_pivot_to_telemetry_batch(
     let mut devices = Vec::new();
     let mut simulated = Vec::new();
     for row in rows {
-        let ts_ms = store::parse_ts_ms(row.get("timestamp").and_then(|v| v.as_str()).unwrap_or(""));
+        let Some(ts_ms) =
+            store::parse_ts_ms(row.get("timestamp").and_then(|v| v.as_str()).unwrap_or(""))
+        else {
+            continue;
+        };
         let equip = row
             .get("equipment_id")
             .and_then(|v| v.as_str())

--- a/edge/src/historian/feather_store.rs
+++ b/edge/src/historian/feather_store.rs
@@ -41,10 +41,14 @@ fn safe_path_part(part: &str) -> String {
     }
 }
 
-fn parse_ts_ms(ts: &str) -> i64 {
-    DateTime::parse_from_rfc3339(ts)
-        .map(|d| d.timestamp_millis())
-        .unwrap_or_else(|_| Utc::now().timestamp_millis())
+fn parse_ts_ms(ts: &str) -> Option<i64> {
+    let trimmed = ts.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    DateTime::parse_from_rfc3339(trimmed)
+        .ok()
+        .map(|d| d.with_timezone(&Utc).timestamp_millis())
 }
 
 fn shard_name() -> String {
@@ -84,7 +88,12 @@ pub fn write_wide_shard(
     }
     let schema = Arc::new(Schema::new(fields));
 
-    let ts_arr = TimestampMillisecondArray::from(vec![parse_ts_ms(timestamp)]);
+    let Some(ts_ms) = parse_ts_ms(timestamp) else {
+        return Err(format!(
+            "unparseable timestamp (need RFC3339 UTC Z or offset): {timestamp}"
+        ));
+    };
+    let ts_arr = TimestampMillisecondArray::from(vec![ts_ms]);
     let site_arr = StringArray::from(vec![site_id.to_string()]);
     let mut arrays: Vec<Arc<dyn arrow::array::Array>> = vec![Arc::new(ts_arr), Arc::new(site_arr)];
     for name in &col_names {

--- a/edge/src/historian/store.rs
+++ b/edge/src/historian/store.rs
@@ -286,9 +286,11 @@ pub fn pivot_rows_to_batch(rows: &[Value]) -> Result<RecordBatch, String> {
     let mut fan_cmd = Vec::new();
     let mut occ = Vec::new();
     for row in rows {
-        ts.push(parse_ts_ms(
-            row.get("timestamp").and_then(|v| v.as_str()).unwrap_or(""),
-        ));
+        let Some(ts_ms) = parse_ts_ms(row.get("timestamp").and_then(|v| v.as_str()).unwrap_or(""))
+        else {
+            continue;
+        };
+        ts.push(ts_ms);
         equip.push(
             row.get("equipment_id")
                 .and_then(|v| v.as_str())
@@ -349,9 +351,13 @@ fn pivot_schema() -> Schema {
     ])
 }
 
-pub fn parse_ts_ms(s: &str) -> i64 {
-    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
-        return dt.with_timezone(&Utc).timestamp_millis();
+pub fn parse_ts_ms(s: &str) -> Option<i64> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(trimmed) {
+        return Some(dt.with_timezone(&Utc).timestamp_millis());
     }
     for fmt in [
         "%m/%d/%Y %H:%M",
@@ -360,11 +366,12 @@ pub fn parse_ts_ms(s: &str) -> i64 {
         "%Y-%m-%d %H:%M",
         "%Y-%m-%dT%H:%M:%S",
     ] {
-        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s.trim(), fmt) {
-            return DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).timestamp_millis();
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(trimmed, fmt) {
+            return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).timestamp_millis());
         }
     }
-    Utc::now().timestamp_millis()
+    // Never invent Utc::now() — callers must skip the row.
+    None
 }
 
 pub struct PivotSample<'a> {

--- a/open_fdd/__init__.py
+++ b/open_fdd/__init__.py
@@ -9,7 +9,7 @@ Production FDD runs as DataFusion SQL in the GHCR container stack.
 from open_fdd.ecm_engineering import ECMJob
 from open_fdd.compat import maybe_warn_vibe19_from_env
 
-__version__ = "4.4.1"
+__version__ = "4.4.2"
 
 maybe_warn_vibe19_from_env()
 

--- a/open_fdd/analytics/open_meteo.py
+++ b/open_fdd/analytics/open_meteo.py
@@ -123,9 +123,11 @@ def fetch_open_meteo(
         reason = payload.get("reason") or payload.get("error") or "no data"
         raise ValueError(f"Open-Meteo returned no {block_key} data: {reason}")
 
+    from open_fdd.timestamps import to_utc_datetime
+
     raw = pd.DataFrame(
         {
-            "timestamp_utc": pd.to_datetime(block["time"], utc=True),
+            "timestamp_utc": to_utc_datetime(block["time"]),
             "dry_bulb_f": block.get("temperature_2m"),
             "relative_humidity_pct": block.get("relative_humidity_2m"),
             "dew_point_f": block.get("dew_point_2m"),
@@ -179,7 +181,9 @@ def align_to_index(weather: pd.DataFrame, grid: pd.DatetimeIndex) -> pd.DataFram
     src = weather.copy()
     if not isinstance(src.index, pd.DatetimeIndex):
         if "timestamp_utc" in src.columns:
-            src = src.set_index(pd.to_datetime(src["timestamp_utc"], utc=True))
+            from open_fdd.timestamps import to_utc_datetime
+
+            src = src.set_index(to_utc_datetime(src["timestamp_utc"]))
             src = src.drop(columns=["timestamp_utc"], errors="ignore")
         else:
             raise ValueError("weather must have DatetimeIndex or timestamp_utc column")

--- a/open_fdd/analytics/vav_health.py
+++ b/open_fdd/analytics/vav_health.py
@@ -109,7 +109,9 @@ def vav_health_matrix(
         if not isinstance(df.index, pd.DatetimeIndex):
             ts = df.get("timestamp_utc")
             if ts is not None:
-                df = df.set_index(pd.to_datetime(ts, utc=True))
+                from open_fdd.timestamps import to_utc_datetime
+
+                df = df.set_index(to_utc_datetime(ts))
         idx = df.index
         n = len(df)
         coverage = 100.0 if n else 0.0

--- a/open_fdd/reporting/day_zoom.py
+++ b/open_fdd/reporting/day_zoom.py
@@ -71,7 +71,9 @@ def worst_fault_day(fault: pd.Series | None) -> date | None:
         numeric = s.map(lambda v: 1.0 if bool(v) else 0.0)
     if not isinstance(s.index, pd.DatetimeIndex):
         try:
-            idx = pd.to_datetime(s.index)
+            from open_fdd.timestamps import to_utc_datetime
+
+            idx = to_utc_datetime(s.index)
             numeric.index = idx
         except Exception:
             return None
@@ -123,7 +125,9 @@ def render_day_zoom_png(
         s = ser.copy()
         if not isinstance(s.index, pd.DatetimeIndex):
             try:
-                s.index = pd.to_datetime(s.index)
+                from open_fdd.timestamps import to_utc_datetime
+
+                s.index = to_utc_datetime(s.index)
             except Exception:
                 return None
         day_start, day_end = _day_bounds(day, s.index)

--- a/open_fdd/rules/cookbook_catalog.py
+++ b/open_fdd/rules/cookbook_catalog.py
@@ -650,7 +650,9 @@ def fc4(d, p, poll):
     if isinstance(d.index, pd.DatetimeIndex):
         ts = pd.DatetimeIndex(d.index)
     elif "timestamp" in d.columns:
-        ts = pd.DatetimeIndex(pd.to_datetime(d["timestamp"], utc=True, errors="coerce"))
+        from open_fdd.timestamps import to_utc_datetime
+
+        ts = pd.DatetimeIndex(to_utc_datetime(d["timestamp"], errors="coerce"))
     else:
         return _false(d.index)
     entries = (modes.eq(1) & modes.shift().ne(1))

--- a/open_fdd/rules/sensor_rate.py
+++ b/open_fdd/rules/sensor_rate.py
@@ -55,8 +55,10 @@ def _ensure_dt_index(d: pd.DataFrame) -> pd.DataFrame:
     if isinstance(d.index, pd.DatetimeIndex):
         return d
     if "timestamp" in d.columns:
+        from open_fdd.timestamps import to_utc_datetime
+
         out = d.copy()
-        out.index = pd.DatetimeIndex(pd.to_datetime(out["timestamp"], utc=True, errors="coerce"))
+        out.index = pd.DatetimeIndex(to_utc_datetime(out["timestamp"], errors="coerce"))
         return out
     raise ValueError("SV-RATE requires a DatetimeIndex or timestamp column")
 

--- a/open_fdd/timestamps.py
+++ b/open_fdd/timestamps.py
@@ -1,0 +1,23 @@
+"""UTC datetime parsing that accepts ISO-8601 ``Z`` and ``+00:00`` without warnings.
+
+BAS packages and gold fixtures mix both suffixes. Bare ``pd.to_datetime(..., utc=True)``
+emits ``Could not infer format`` UserWarnings on pandas 2.x — prefer this helper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def to_utc_datetime(values: Any, *, errors: str = "coerce") -> pd.Series | pd.DatetimeIndex:
+    """Parse timestamps to UTC.
+
+    Tries ``format="ISO8601"`` first (pandas 2.x), then ``format="mixed"``.
+    Does not invent wall-clock times for garbage input when ``errors="coerce"``.
+    """
+    try:
+        return pd.to_datetime(values, utc=True, format="ISO8601", errors=errors)
+    except (ValueError, TypeError, OverflowError):
+        return pd.to_datetime(values, utc=True, format="mixed", errors=errors)

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -28,6 +28,8 @@ retest. Do not confuse those with this engineering OS.
 | `openfdd_agent_spec/` | Agent law, Milestone A, skills, session log |
 | Playground vibe19/20 | External demos; consumers of PyPI |
 
+**Package / timestamp contract (product + PyPI):** `timestamp_utc` is RFC3339 UTC (`Z` or `+00:00`). Rust ingest skips bad rows (no epoch 0 / now). Pandas oracle uses `open_fdd.timestamps.to_utc_datetime`. String `"equip"` on a Haystack sidecar is metadata. Details: [`../docs/RUST_DATAFUSION_ENGINE.md`](../docs/RUST_DATAFUSION_ENGINE.md).
+
 **Naming (code truth):**
 
 | Concept | Module / extra |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-fdd"
-version = "4.4.1"
+version = "4.4.2"
 description = "Open-FDD libraries: ECM engineering workbooks plus pandas oracle rules, analytics, and Engineering Findings reporting. Production FDD remains the DataFusion/GHCR stack."
 readme = "docs/ecm/README.md"
 license = { text = "MIT" }

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -1,0 +1,30 @@
+"""UTC timestamp helper — Z and +00:00 without pandas format warnings."""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+
+from open_fdd.timestamps import to_utc_datetime
+
+
+def test_mixed_z_and_offset_no_userwarning():
+    series = pd.Series(
+        [
+            "2026-05-21T20:20:00Z",
+            "2026-05-21T20:25:00+00:00",
+            "2026-05-21T20:30:00Z",
+        ]
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        out = to_utc_datetime(series)
+    assert not any(
+        issubclass(w.category, UserWarning) and "infer format" in str(w.message).lower()
+        for w in caught
+    ), [str(w.message) for w in caught]
+    assert len(out) == 3
+    assert out.notna().all()
+    assert out.dt.tz is not None
+    assert out.iloc[0].value == out.iloc[0].tz_convert("UTC").value


### PR DESCRIPTION
## Summary
- Rust \`fdd_store\` / edge historian: never invent epoch 0 or \`Utc::now()\` on bad \`timestamp_utc\`; skip (or Err) instead. Mixed \`Z\` / \`+00:00\` accepted.
- Lock string \`"equip": "AHU_1"\` sidecar map shape with a unit test; document package timestamp + map contract (AGENTS, DataFusion engine, MCP package-mapping).
- PyPI \`open_fdd.timestamps.to_utc_datetime\` (ISO8601 → mixed) wired through analytics/rules/reporting; version **4.4.2**.
- Windows vibe19 Streamlit prompt checked in under \`docs/agent/\` (separate machine).

## Test plan
- [ ] Rust CI: format, clippy, and tests
- [ ] FDD engine CI: synthetic-59 59/59
- [ ] Python package tests (timestamps)
- [ ] Do not wait GHCR mid-PR; turnkey master after merge