### PR TITLE
Overview UX: drop VAV from weekly motors, include CH-1 chillers

### DIFF
--- a/frontend/web/src/api/centralOverview.test.ts
+++ b/frontend/web/src/api/centralOverview.test.ts
@@ -72,11 +72,21 @@ vi.mock("./analyticsApi", () => ({
         run_hours: 85,
         avg_oat_f: 51,
       },
+      {
+        kind: "weekly_equipment",
+        plant_group: "air",
+        equipment_id: "AHU_1_VAV_12",
+        label: "AHU_1_VAV_12 · damper",
+        week_label: "2026-03-23",
+        run_hours: 40,
+        avg_oat_f: 45,
+      },
     ],
     equipment: [
       { equipment_id: "AHU_1", run_hours: 170, coverage_pct: 40, plant_group: "air" },
       { equipment_id: "AHU_2", run_hours: 155, coverage_pct: 38, plant_group: "air" },
       { equipment_id: "VAV_1", run_hours: 3, coverage_pct: 10 },
+      { equipment_id: "AHU_1_VAV_12", run_hours: 9, coverage_pct: 12, plant_group: "air" },
     ],
     points: [],
     skipped: [],
@@ -277,6 +287,10 @@ describe("fetchCentralOverview", () => {
     expect(bars.map((t) => t.name)).toEqual(
       expect.arrayContaining(["AHU_1 · fan-status", "AHU_2 · fan-status"]),
     );
+    expect(bars.map((t) => t.name).join(" ")).not.toMatch(/VAV/);
+    expect(
+      out.motor_weekly.table.map((r) => String(r.equipment_id ?? "")),
+    ).toEqual(["AHU_1", "AHU_2"]);
     expect(bars[0]?.marker?.color).toBe(RAINBOW_PALETTE[0]);
     const oat = (air!.figure?.data ?? []).find((t) =>
       String(t.name).includes("Avg OAT"),

--- a/frontend/web/src/api/centralOverview.ts
+++ b/frontend/web/src/api/centralOverview.ts
@@ -30,6 +30,7 @@ import {
   datasetTimeSpan,
   isWeatherEquipment,
   isWeatherEquipmentId,
+  isZoneTerminalEquipment,
 } from "../lib/overviewMetrics";
 import { naturalCompare } from "../lib/naturalSort";
 
@@ -53,7 +54,9 @@ function groupByType(
 }
 
 function motorFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null {
-  const usable = rows.filter((r) => num(r.run_hours) != null);
+  const usable = rows.filter(
+    (r) => num(r.run_hours) != null && !isZoneTerminalEquipment(r),
+  );
   if (!usable.length) return null;
   return rowsToBarFigure(usable, {
     xKey: "equipment_id",
@@ -71,13 +74,16 @@ function motorFigure(rows: Array<Record<string, unknown>>): PlotlyFigure | null 
 function weeklyPlantFigures(
   rows: Array<Record<string, unknown>>,
 ): OverviewPlantFig[] {
-  const weekly = rows.filter(
-    (r) => r.kind === "weekly_equipment" || r.kind === "weekly_plant",
-  );
+  const weekly = rows.filter((r) => {
+    if (r.kind !== "weekly_equipment" && r.kind !== "weekly_plant") return false;
+    if (isZoneTerminalEquipment(r)) return false;
+    const g = String(r.plant_group ?? "");
+    return g === "air" || g === "boiler" || g === "chiller";
+  });
   if (!weekly.length) return [];
   const byPlant = new Map<string, Array<Record<string, unknown>>>();
   for (const r of weekly) {
-    const g = String(r.plant_group || "other");
+    const g = String(r.plant_group);
     const list = byPlant.get(g) ?? [];
     list.push(r);
     byPlant.set(g, list);
@@ -738,14 +744,14 @@ export async function fetchCentralOverview(opts: {
       );
 
   const weeklyPlants = weeklyPlantFigures(runtimeRows);
-  const motorFig = motorFigure(
-    equipmentTotals.filter(
-      (r) =>
-        r.kind !== "weekly_plant" &&
-        r.kind !== "weekly_equipment" &&
-        !isWeatherEquipmentId(String(r.equipment_id ?? "")),
-    ),
+  const plantMotorTotals = equipmentTotals.filter(
+    (r) =>
+      r.kind !== "weekly_plant" &&
+      r.kind !== "weekly_equipment" &&
+      !isWeatherEquipmentId(String(r.equipment_id ?? "")) &&
+      !isZoneTerminalEquipment(r),
   );
+  const motorFig = motorFigure(plantMotorTotals);
   const plants: OverviewPlantFig[] =
     weeklyPlants.length > 0
       ? weeklyPlants
@@ -791,20 +797,20 @@ export async function fetchCentralOverview(opts: {
       caption: warnCaption(
         runtime,
         weeklyPlants.length
-          ? "Weekly plant run hours (DataFusion historian Δt)"
-          : "Run hours by equipment (DataFusion historian Δt)",
+          ? "Weekly plant motors (AHU fans, boilers, chillers/CHW pumps). VAV terminals are excluded."
+          : "Plant motor run hours (AHU fans, boilers, chillers). VAV terminals are excluded.",
       ),
       plants,
-      table: equipmentTotals.slice(0, 200),
+      table: plantMotorTotals.slice(0, 200),
     },
     mech_cooling: {
       caption: warnCaption(
         mech,
         mechBins.length
-          ? "Mechanical cooling OAT bin hours from DataFusion"
+          ? "Chiller / DX / VRF compressor hours by site OAT (5°F bins). VAV boxes and CHW valves are not cooling proof."
           : mechFig
             ? "Mechanical cooling evidence from DataFusion"
-            : "No compressor×OAT intervals in historian (need chiller proof + site OAT)",
+            : "No compressor×OAT intervals. Need a chiller/DX status (or CH-1 / CHILLER_* id) plus site web OAT on the historian.",
       ),
       figure: mechFig,
       bins: mechBins,

--- a/frontend/web/src/components/OverviewPopulated.tsx
+++ b/frontend/web/src/components/OverviewPopulated.tsx
@@ -899,7 +899,7 @@ export function OverviewPopulated({
         <h3>Motor / equipment run hours</h3>
         <p className="oracle-sidebar__caption">
           {overview?.motor_weekly.caption ??
-            "Air side — both AHUs as series (building-wide; not filtered by Equipment)."}
+            "Weekly plant motors (AHU fans, boilers, chillers). VAV terminals are excluded."}
         </p>
         {(overview?.motor_weekly.plants ?? []).map((plant) => (
           <div key={plant.plant_group} data-testid={`overview-motor-${plant.plant_group}`}>
@@ -980,6 +980,11 @@ export function OverviewPopulated({
           downloadFilename="mech_cooling_oat_bins"
           testId="overview-mech-plot"
         />
+        {overview && !overview.mech_cooling.figure && !loadingOverview ? (
+          <p className="oracle-sidebar__caption" data-testid="overview-mech-empty">
+            {overview.mech_cooling.caption}
+          </p>
+        ) : null}
         {overview?.mech_cooling.bins?.length ? (
           <Expander
             id="mech-bins-exp"

--- a/frontend/web/src/lib/overviewMetrics.test.ts
+++ b/frontend/web/src/lib/overviewMetrics.test.ts
@@ -6,6 +6,8 @@ import {
   formatOverviewTs,
   inventoryWithoutWeather,
   isWeatherEquipment,
+  isZoneTerminalEquipment,
+  isZoneTerminalId,
   SQL_ROLLUP_RULE_IDS,
 } from "./overviewMetrics";
 
@@ -18,6 +20,17 @@ describe("overviewMetrics", () => {
     ]);
     expect(items.map((e) => e.equipment_id)).toEqual(["AHU_2", "AHU_10"]);
     expect(isWeatherEquipment({ equipment_id: "weather" })).toBe(true);
+  });
+
+  it("treats VAV/zone ids as terminals even when prefixed with AHU", () => {
+    expect(isZoneTerminalId("VAV_1")).toBe(true);
+    expect(isZoneTerminalId("AHU_1_VAV_12")).toBe(true);
+    expect(isZoneTerminalEquipment({ equipment_id: "AHU-1-VAV-03" })).toBe(
+      true,
+    );
+    expect(isZoneTerminalEquipment({ equipment_type: "VAV" })).toBe(true);
+    expect(isZoneTerminalId("AHU_1")).toBe(false);
+    expect(isZoneTerminalId("CH-1")).toBe(false);
   });
 
   it("formats timestamps like vibe19 and lowercases kind", () => {

--- a/frontend/web/src/lib/overviewMetrics.ts
+++ b/frontend/web/src/lib/overviewMetrics.ts
@@ -13,6 +13,33 @@ export function isWeatherEquipmentId(id: string): boolean {
   return s === "weather" || s === "(weather)";
 }
 
+/** Zone terminals — never plant weekly motors or compressor OAT bins. */
+export function isZoneTerminalId(id: string): boolean {
+  const u = id.trim().toUpperCase().replace(/\\/g, "/");
+  if (!u) return false;
+  return (
+    u.includes("VAV") ||
+    u.includes("ZONE") ||
+    u.includes("VAVFC") ||
+    u.includes("VAVH")
+  );
+}
+
+export function isZoneTerminalEquipment(e: {
+  equipment_id?: unknown;
+  equipment_type?: unknown;
+  label?: unknown;
+}): boolean {
+  const et = String(e.equipment_type ?? "")
+    .trim()
+    .toUpperCase();
+  if (et === "VAV" || et === "ZONE") return true;
+  return (
+    isZoneTerminalId(String(e.equipment_id ?? "")) ||
+    isZoneTerminalId(String(e.label ?? ""))
+  );
+}
+
 export function isWeatherEquipment(e: {
   equipment_id?: string;
   equipment_type?: string;

--- a/open_fdd/analytics/core.py
+++ b/open_fdd/analytics/core.py
@@ -247,13 +247,18 @@ def _equipment_plant_group(
 
     # Id fallback only when type is unknown / untyped
     eq = (equipment_id or "").upper().replace("\\", "/")
-    if "/VAV" in eq or eq.startswith("VAV"):
+    if "VAV" in eq or "ZONE" in eq:
         return None
     if eq.startswith("AHU") or "/AHU" in eq or "RTU" in eq:
         return PLANT_AIR
     if "TOWER" in eq or re.search(r"(^|/)CT\d", eq) or eq.startswith("CT_"):
         return PLANT_CHILLER
-    if "CHILLER" in eq or eq.startswith("CHW"):
+    if (
+        "CHILLER" in eq
+        or "CHLR" in eq
+        or eq.startswith("CHW")
+        or re.search(r"(^|/)CH[-_]?[0-9]", eq)
+    ):
         return PLANT_CHILLER
     if "BOILER" in eq:
         return PLANT_BOILER

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -314,10 +314,10 @@ fn round2(x: f64) -> f64 {
 }
 
 /// Map equipment_id → Overview plant chart group (air / boiler / chiller).
-/// VAVs and unknown meters return `None` (excluded from plant weekly charts).
+/// Zone terminals (VAV / ZONE) and unknown meters return `None`.
 pub fn plant_group_for(equipment_id: &str) -> Option<&'static str> {
     let eq = equipment_id.to_ascii_uppercase().replace('\\', "/");
-    if eq.contains("/VAV") || eq.starts_with("VAV") || eq.contains("VAVFC") || eq.contains("VAVH") {
+    if is_zone_terminal_id(&eq) {
         return None;
     }
     if eq.starts_with("AHU")
@@ -333,6 +333,8 @@ pub fn plant_group_for(equipment_id: &str) -> Option<&'static str> {
         || eq.contains("/CT")
         || (eq.starts_with("CT") && eq.chars().nth(2).is_some_and(|c| c.is_ascii_digit()))
         || eq.contains("CHILLER")
+        || eq.contains("CHLR")
+        || is_short_chiller_id(&eq)
         || eq.starts_with("CHW")
         || eq.contains("CWP")
         || eq.contains("_DX")
@@ -351,6 +353,31 @@ pub fn plant_group_for(equipment_id: &str) -> Option<&'static str> {
     }
     // Do not catch bare FAN/SUPPLY — too broad (exhaust/return/etc.).
     None
+}
+
+fn is_zone_terminal_id(eq: &str) -> bool {
+    eq.contains("/VAV")
+        || eq.starts_with("VAV")
+        || eq.contains("VAVFC")
+        || eq.contains("VAVH")
+        || eq.contains("VAV")
+        || eq.contains("ZONE")
+}
+
+/// Building-100 style ids: CH-1, CH_1, CH1 — not CHANNEL / CHECK / CHW_*.
+fn is_short_chiller_id(eq: &str) -> bool {
+    eq.split('/').any(|part| {
+        let p = part.trim();
+        if p.starts_with("CHW") || p.starts_with("CHECK") || p.starts_with("CHAN") {
+            return false;
+        }
+        if p.starts_with("CH-") || p.starts_with("CH_") {
+            return p.chars().nth(3).is_some_and(|c| c.is_ascii_digit());
+        }
+        p.len() >= 3
+            && p.starts_with("CH")
+            && p.as_bytes().get(2).is_some_and(|b| b.is_ascii_digit())
+    })
 }
 
 /// OAT for mech-cooling bins: prefer web/meteo OAT (pandas Overview default).
@@ -414,8 +441,10 @@ fn equipment_filter_sql(equipment_filter: Option<&[String]>) -> String {
 /// SQL fragment restricting to chiller/DX/tower-like equipment ids.
 /// Kept aligned with [`plant_group_for`] (no bare `CT%` — that matches CTRL_*).
 fn chiller_like_equipment_sql() -> &'static str {
+    // LIKE `_` is a wildcard — do not use `CH_%` (matches CHANNEL / CHW…).
     " AND (\
         UPPER(equipment_id) LIKE '%CHILLER%' \
+        OR UPPER(equipment_id) LIKE '%CHLR%' \
         OR UPPER(equipment_id) LIKE '%TOWER%' \
         OR UPPER(equipment_id) LIKE 'CT_%' \
         OR UPPER(equipment_id) LIKE '%/CT_%' \
@@ -424,7 +453,9 @@ fn chiller_like_equipment_sql() -> &'static str {
         OR UPPER(equipment_id) LIKE 'HP_%' \
         OR UPPER(equipment_id) LIKE '%CWP%' \
         OR UPPER(equipment_id) LIKE 'CHW%' \
-     )"
+        OR UPPER(equipment_id) LIKE 'CH-%' \
+        OR UPPER(equipment_id) LIKE '%/CH-%' \
+     ) AND UPPER(equipment_id) NOT LIKE '%VAV%'"
 }
 
 /// Load runtime hours from historian Parquet via DataFusion.
@@ -3132,6 +3163,12 @@ mod tests {
         assert_eq!(plant_group_for("BOILER_1"), Some("boiler"));
         assert_eq!(plant_group_for("VAV_101"), None);
         assert_eq!(plant_group_for("BUILDING/VAVFC_2"), None);
+        assert_eq!(plant_group_for("AHU_1_VAV_12"), None);
+        assert_eq!(plant_group_for("AHU-1-VAV-03"), None);
+        assert_eq!(plant_group_for("CH-1"), Some("chiller"));
+        assert_eq!(plant_group_for("CH_1"), Some("chiller"));
+        assert_eq!(plant_group_for("CHLR_2"), Some("chiller"));
+        assert_eq!(plant_group_for("CHANNEL_1"), None);
         // Bare FAN/SUPPLY must not swallow unrelated motors.
         assert_eq!(plant_group_for("EXHAUST_FAN_1"), None);
         assert_eq!(plant_group_for("SUPPLY_METER"), None);


### PR DESCRIPTION
## Summary
- Weekly motor hours on Overview no longer plot or table **VAV / zone terminals**, including ids like `AHU_1_VAV_12` that previously matched the AHU plant group.
- Mechanical cooling OAT bins include short chiller ids (`CH-1`, `CHLR_*`) and skip VAV ids; empty state copy says what is missing (compressor proof + site web OAT).
- Captions state the product contract: plant motors vs compressor×OAT, not every fan-status point.

## Test plan
- [ ] `npm test` Overview + overviewMetrics (VAV traces/table excluded)
- [ ] Rust `plant_group_for` tests: `AHU_1_VAV_12` none, `CH-1` chiller
- [ ] BUILDING_100 Overview: air weekly is AHUs only; mech cooling bins populate when chillers have status + `web_oa_t`
- [ ] Re-ingest BUILDING_100 if weather `dry_bulb_f` is not mapped to `web_oa_t`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved central overview equipment classification for VAV and zone-terminal devices.
  * Excluded VAV terminals from motor runtime, weekly plant figures, charts, and tables.
  * Improved recognition of chiller equipment across common naming formats.
  * Added a clear empty state when mechanical cooling data is unavailable.
  * Updated captions and totals to accurately reflect included plant equipment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->