### PR TITLE
Simplify README and clarify deployment readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,32 +37,17 @@
 </p>
 
 
-> **Open-source semantic building analytics and HVAC supervisory fault detection. Local-first. On-premises. Vendor-neutral. Free to run at the edge or offline.**
+> **Semantic building analytics and HVAC fault detection — local-first, on-premises, vendor-neutral.**
 
-Open-FDD is an open-source analytics platform for building automation that combines **Haystack-style semantic point roles** (JSON site/equipment maps), **live or historical OT/CSV data**, and **high-performance columnar analytics**.
+Open-FDD maps Haystack-style JSON point roles to live or historical OT/CSV data and runs fault detection with **DataFusion SQL** over an **Apache Arrow** historian. The operator stack is **Rust central** and **React web**; the SPA talks to central `/api` only.
 
-The product stack is **Rust central + React SPA + fieldbus/MQTT**. Browser traffic goes to central `/api` only. Production FDD and Overview analytics run on **Apache DataFusion** SQL over the Arrow historian; the SPA renders Plotly in the browser. **PyPI `open-fdd`** (pandas cookbooks, ECM helpers) is a library for notebooks and third-party tooling — not the product request path.
+- **62** cookbook rules (**66** SQL registry ids) — FDD, RCx, Overview, findings
+- GHCR images: `central`, `web`, `fieldbus`, `mqtt`, `mcp`
+- [PyPI `open-fdd`](https://pypi.org/project/open-fdd/) — pandas cookbooks and ECM for notebooks; not the product runtime
 
-The platform includes:
+**Ready today — local, behind the firewall:** `./scripts/openfdd_stack_up.sh react` for CSV/zip FDD on your LAN or VPN. Not intended for the public internet.
 
-- Haystack-style point roles in JSON (`column_map`) — not RDF-first
-- React SPA (`openfdd-web`) for CSV / zip FDD, RCx, Overview, and findings
-- Arrow historian + DataFusion SQL fault detection (62 cookbook rules; **66** SQL registry ids)
-- ECM / industry helpers on **PyPI**; EnergyPlus remains a stack companion (MCP/DinD)
-- Docker compose images on GHCR (`central`, `web`, `fieldbus`, `mqtt`, `mcp`)
-
-### CSV / lab (ready today)
-
-`central` + `web` — bulk CSV / zip packages, historian, DataFusion FDD, React SPA.
-No MQTT or fieldbus required. Prefer this for lab soaks and agent workflows.
-
-`./scripts/openfdd_stack_up.sh react` (or `react-ot` with fieldbus) is the supported product recipe.
-
-### OT edge / MQTTS
-
-Remote edges speak **JSON API**, **BACnet**, **Modbus**, and **Haystack**, publishing to
-Mosquitto **MQTTS** (`openfdd-mqtt`); central consumes from the broker. Use
-`react-ot` when exercising the fieldbus path on a bench.
+**Coming soon:** OT edge (`react-ot` — BACnet, Modbus, Haystack, MQTTS) and managed **cloud hosting**. Internet-facing deployment with production security hardening targets **Fall 2026**.
 
 ---
 
@@ -87,30 +72,30 @@ The **[HVAC FDD Rule Cookbook](https://bbartling.github.io/open-fdd/rules/cookbo
 | [`ghcr.io/bbartling/openfdd-mqtt`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mqtt) | Mosquitto MQTTS broker |
 | [`ghcr.io/bbartling/openfdd-mcp`](https://github.com/bbartling/open-fdd/pkgs/container/openfdd-mcp) | Optional slim MCP stdio sidecar → central API |
 
-Open-FDD does **not** ship an embedded AI chatbot. External agents connect via MCP or REST — see [docs/examples/external-agents.md](docs/examples/external-agents.md).
-
-### Quick start (standalone)
+### Run
 
 ```bash
 git clone https://github.com/bbartling/open-fdd.git && cd open-fdd
 export OPENFDD_IMAGE_TAG=nightly
 export OPENFDD_JWT_SECRET='change-me'
 export OPENFDD_ADMIN_PASSWORD='change-me'
-./scripts/openfdd_stack_up.sh react
-# SPA http://127.0.0.1:3000  API http://127.0.0.1:8080
+
+./scripts/openfdd_stack_up.sh react       # local CSV lab (ready today)
+./scripts/openfdd_stack_up.sh csv         # central + web only
+# react-ot (OT edge) — coming soon; bench preview only
 ```
 
-### Other recipes
+Update a running stack (pull, backup, rollback if health fails):
 
 ```bash
-./scripts/openfdd_stack_up.sh react        # mqtt + central + React web
-./scripts/openfdd_stack_up.sh react-ot     # react + fieldbus (OT bench)
-./scripts/openfdd_stack_up.sh csv          # central + web (CSV lab)
+./scripts/openfdd_maint_update_resume.sh react nightly
 ```
 
-See [Build recipes](docs/operations/build-recipes.md) and [docker/VERSION_MANIFEST.md](docker/VERSION_MANIFEST.md).
+UI `http://127.0.0.1:3000` · API `http://127.0.0.1:8080` · [build recipes](docs/operations/build-recipes.md)
 
-### MCP (external agents)
+### MCP
+
+Open-FDD does **not** ship an embedded AI chatbot. External agents connect via MCP or REST — see [external agents](docs/examples/external-agents.md).
 
 ```bash
 docker run -i --rm --network host \
@@ -119,26 +104,17 @@ docker run -i --rm --network host \
   ghcr.io/bbartling/openfdd-mcp:nightly
 ```
 
-Full tool list: [mcp/README.md](mcp/README.md).
+Tool list: [mcp/README.md](mcp/README.md).
 
 ---
 
-## PyPI package (`pip install open-fdd`)
+## PyPI package
 
-The [PyPI package](https://pypi.org/project/open-fdd/) is a **library** surface — not a substitute for the operator stack.
+```bash
+pip install open-fdd
+```
 
-| Install | What you get |
-|---------|----------------|
-| `pip install open-fdd` | ECM engineering helpers / workbook builders |
-| `pip install "open-fdd[oracle]"` | Optional pandas oracle for rule screening |
-| `pip install "open-fdd[analytics]"` | Analytics helpers (same deps as `oracle`) |
-| `pip install "open-fdd[reporting]"` | Engineering findings / report writers |
-
-The extra `vibe19` remains a deprecated alias of `reporting` through the 4.3 series and is removed in 5.0.
-
-**FDD (DataFusion SQL)** — historian, registry, React SPA, BACnet/Modbus — ships in the **GHCR container stack** (`openfdd-central` / `openfdd-web` / …), not as the default PyPI runtime. Use `./scripts/openfdd_stack_up.sh react` (above) for that path.
-
-Docs: [ECM](docs/ecm/README.md) · [pandas cookbook](docs/rules/cookbook/pandas-cookbook.md) · [DataFusion SQL cookbook](docs/rules/cookbook/datafusion-sql-cookbook.md)
+Library for notebooks and ECM helpers — not the operator stack. See [PyPI](https://pypi.org/project/open-fdd/) and [docs](https://bbartling.github.io/open-fdd/).
 
 ---
 
@@ -146,35 +122,20 @@ Docs: [ECM](docs/ecm/README.md) · [pandas cookbook](docs/rules/cookbook/pandas-
 
 ```bash
 git clone https://github.com/bbartling/open-fdd.git && cd open-fdd
-./scripts/openfdd_stack_up.sh react --build   # or: cargo run -p openfdd-central
-cd frontend/web && npm ci && npm run dev      # React SPA → central API :8080
+./scripts/openfdd_stack_up.sh react --build
+cd frontend/web && npm ci && npm run dev
 ```
 
-The production operator UI is **React** (`frontend/web` / `ghcr.io/bbartling/openfdd-web`).
-
-Native Rust: `cargo test --workspace`
+Rust: `cargo test --workspace`
 
 ## Releases
 
-**What we run day-to-day:** GHCR **`:nightly`** and immutable **`:sha-<7>`** (every
-`master` merge). Health reports Cargo **`3.3.1+<sha>`** (e.g. `3.3.1+f9047154dab6`).
-The SPA sidebar shows `3.3.1+shortsha` from `GET /api/health`.
+GHCR images build on every `master` merge. Set **`OPENFDD_IMAGE_TAG=nightly`** (or `sha-<7>` to pin). Beta/stable are not published yet — [release policy](https://bbartling.github.io/open-fdd/operations/release-channels.html).
 
-| Channel | Tag | Status today |
-|---------|-----|----------------|
-| **Nightly** | `:nightly` / `:sha-*` | **Default** — bench, agents, soaks |
-| **Semver alias** | `:3.3.1` / `:3.3.1-n<run>` | Nightly also stamps an extra run tag; **not** a signed-off stable cut |
-| **Beta** | `:beta` / `3.3.0-beta.N` | **Not published yet** — next candidate in repo `VERSION` is `3.3.0-beta.1` |
-| **Stable** | `:latest` / promoted semver | **Not published yet** |
-
-**Maintainers:** Actions → **Rust Release** → set `VERSION` match + channel `beta` or `stable` when promoting off nightly.
-
-Prefer `OPENFDD_IMAGE_TAG=sha-*` (or `nightly`) until a real beta/stable promotion exists. Full policy: [Release channels](https://bbartling.github.io/open-fdd/operations/release-channels.html) · [GHCR images](https://bbartling.github.io/open-fdd/operations/ghcr-images.html)
-
-Open-FDD is for **LAN / VPN / OT networks**, not public internet hosting.
+Intended for **LAN / VPN / OT networks**, not public internet hosting.
 
 ## License
 
 MIT — see [LICENSE](LICENSE).
 
-Version: Cargo **`3.3.1`** on `master` · PyPI `open-fdd` **4.4.2** · repo `VERSION` next candidate **`3.3.0-beta.1`** · run **`:nightly` / `:sha-*`** (see [release channels](https://bbartling.github.io/open-fdd/operations/release-channels.html))
+Version **3.3.1** on `master` · PyPI **4.4.2**

--- a/docs/rules/cookbook/generated-parity-report.md
+++ b/docs/rules/cookbook/generated-parity-report.md
@@ -30,68 +30,68 @@ Do not edit by hand. Run `python3 scripts/generate_cookbook_report.py`.
 
 | rule_id | title | pandas | SQL | parity | class |
 | --- | --- | --- | --- | --- | --- |
-| `SV-RANGE` | Sensor out of hard range | `sv_range` | `sv_range.sql` | `sql_screening` | `none` |
-| `SV-FLATLINE` | Sensor flatline (stuck) | `sv_flatline` | `sv_flatline.sql` | `sql_screening` | `none` |
-| `SV-SPIKE` | Sensor rate-of-change spike | `sv_spike` | `sv_spike.sql` | `sql_screening` | `none` |
-| `SV-STALE` | Stale data (no fresh samples) | `sv_stale` | `sv_stale.sql` | `sql_screening` | `none` |
-| `SV-RATE` | Context-aware sensor rate of change | `sv_rate` | `sv_rate.sql` | `sql_screening` | `semantic_gap` |
-| `PID-HUNT-1` | Suspected control-output hunting | `pid_hunt_1` | `pid_hunt_1.sql` | `sql_screening` | `none` |
-| `FC1` | Duct static below SP at full fan | `fc1` | `fc1_duct_static_low.sql` | `sql_screening` | `none` |
-| `FC2` | Mixed air below envelope | `fc2` | `fc2_mat_low.sql` | `sql_screening` | `none` |
-| `FC3` | Mixed air above envelope | `fc3` | `fc3_mat_high.sql` | `sql_screening` | `none` |
+| `SV-RANGE` | Sensor out of hard range | `_sweep_range` | `sv_range.sql` | `sql_screening` | `none` |
+| `SV-FLATLINE` | Sensor flatline (stuck) | `_sweep_flatline` | `sv_flatline.sql` | `sql_screening` | `none` |
+| `SV-SPIKE` | Sensor rate-of-change spike | `_sweep_spike` | `sv_spike.sql` | `sql_screening` | `none` |
+| `SV-STALE` | Stale data (no fresh samples) | `_sweep_stale` | `sv_stale.sql` | `sql_screening` | `none` |
+| `SV-RATE` | Context-aware sensor rate of change | `_sv_rate_compute` | `sv_rate.sql` | `sql_screening` | `semantic_gap` |
+| `PID-HUNT-1` | Suspected control-output hunting | `_pid_hunt_1` | `pid_hunt_1.sql` | `sql_screening` | `none` |
+| `FC1` | Duct static below SP at full fan (GL36 A) | `fc1` | `fc1_duct_static_low.sql` | `sql_screening` | `none` |
+| `FC2` | MAT below OAT/RAT envelope (GL36 B) | `fc2` | `fc2_mat_low.sql` | `sql_screening` | `none` |
+| `FC3` | MAT above OAT/RAT envelope (GL36 C) | `fc3` | `fc3_mat_high.sql` | `sql_screening` | `none` |
 | `FC4` | PID hunting (operating-state oscillation) | `fc4` | `fc4_os_hunting.sql` | `sql_screening` | `none` |
 | `FC5` | SAT cold when heating commanded (GL36 D) | `fc5` | `fc5_sat_cold_heating.sql` | `sql_screening` | `none` |
 | `FC6` | Estimated OA fraction mismatch | `fc6` | `fc6_oa_frac_mismatch.sql` | `sql_screening` | `none` |
-| `FC7` | SAT low while heating at full | `fc7` | `fc7_sat_low_heating.sql` | `sql_screening` | `missing_implementation` |
-| `FC8` | SAT vs MAT while economizing | `fc8` | `fc8_sat_mat_econ.sql` | `sql_screening` | `none` |
-| `FC9` | OAT high vs SAT SP while economizing | `fc9` | `fc9_oa_sat_sp_econ.sql` | `sql_screening` | `none` |
-| `FC10` | MAT-OAT delta while cooling and economizing | `fc10` | `fc10_mat_oa_clg.sql` | `sql_screening` | `none` |
-| `FC11` | OAT low vs SAT SP while cooling and economizing | `fc11` | `fc11_oa_sat_sp_clg.sql` | `sql_screening` | `none` |
-| `FC12` | SAT above MAT while cooling | `fc12` | `fc12_sat_mat_clg.sql` | `sql_screening` | `none` |
-| `FC13` | SAT above setpoint at full cooling | `fc13` | `sat_high_fault.sql` | `sql_screening` | `alias` |
+| `FC7` | SAT low with full heating (GL36 E) | `fc7` | `fc7_sat_low_heating.sql` | `sql_screening` | `missing_implementation` |
+| `FC8` | SAT/MAT mismatch in economizer (GL36 F) | `fc8` | `fc8_sat_mat_econ.sql` | `sql_screening` | `none` |
+| `FC9` | OAT too warm for free cooling (GL36 G) | `fc9` | `fc9_oa_sat_sp_econ.sql` | `sql_screening` | `none` |
+| `FC10` | OAT/MAT mismatch + mech cooling (GL36 H) | `fc10` | `fc10_mat_oa_clg.sql` | `sql_screening` | `none` |
+| `FC11` | OAT/MAT mismatch economizer-only (GL36 I) | `fc11` | `fc11_oa_sat_sp_clg.sql` | `sql_screening` | `none` |
+| `FC12` | SAT above blend in cooling (GL36 J) | `fc12` | `fc12_sat_mat_clg.sql` | `sql_screening` | `none` |
+| `FC13` | SAT above SP at full cooling (GL36 K) | `fc13` | `sat_high_fault.sql` | `sql_screening` | `alias` |
 | `FC14` | CHW coil ΔT when inactive (GL36 L) | `fc14` | `fc14_chw_coil_dt_inactive.sql` | `sql_screening` | `none` |
 | `FC15` | HW coil ΔT when inactive (GL36 M) | `fc15` | `fc15_hw_coil_dt_inactive.sql` | `sql_screening` | `none` |
-| `AHU-SATDEV` | SAT deviation from setpoint | `ahu_satdev` | `ahu_satdev.sql` | `sql_screening` | `none` |
-| `AHU-DUCTHI` | Duct static pressure high | `ahu_ducthi` | `ahu_ducthi.sql` | `sql_screening` | `none` |
-| `AHU-SIMUL` | Heating and cooling simultaneous | `ahu_simul` | `ahu_simul.sql` | `sql_screening` | `none` |
-| `OAT-METEO` | Equipment OAT vs weather-staged wx OAT | `oat_vs_meteo` | `oat_meteo_fault.sql` | `sql_screening` | `none` |
-| `ECON-1` | Economizer stuck closed when OAT favorable | `econ1` | `econ1_stuck_closed.sql` | `sql_screening` | `none` |
-| `ECON-2` | Economizing when outdoor air unfavorable | `econ2` | `economizer_fault.sql` | `sql_screening` | `none` |
-| `ECON-3` | Mech cooling without integrated economizer | `econ_3` | `econ3_mech_without_econ.sql` | `sql_screening` | `none` |
+| `AHU-SATDEV` | SAT deviation from setpoint | `ahu_sat_dev` | `ahu_satdev.sql` | `sql_screening` | `none` |
+| `AHU-DUCTHI` | Duct static pressure high | `ahu_duct_high` | `ahu_ducthi.sql` | `sql_screening` | `none` |
+| `AHU-SIMUL` | Heating and cooling simultaneous | `ahu_simul_heat_cool` | `ahu_simul.sql` | `sql_screening` | `none` |
+| `OAT-METEO` | BAS outdoor-air sensor vs Open-Meteo | `oat_vs_meteo` | `oat_meteo_fault.sql` | `sql_screening` | `none` |
+| `ECON-1` | Economizer stuck closed | `econ1` | `econ1_stuck_closed.sql` | `sql_screening` | `none` |
+| `ECON-2` | Economizing when outdoor unfavorable | `econ2` | `economizer_fault.sql` | `sql_screening` | `none` |
+| `ECON-3` | Mech cooling without integrated economizer | `econ2` | `econ3_mech_without_econ.sql` | `sql_screening` | `none` |
 | `ECON-4` | Low estimated OA fraction | `econ4` | `econ4_low_oa_frac.sql` | `sql_screening` | `none` |
-| `ECON-5` | Preheat over-conditioning | `econ_5` | `econ5_preheat_over.sql` | `sql_screening` | `none` |
-| `ECON-6` | Economizing in freezing weather | `econ_6` | `econ6_econ_freezing.sql` | `sql_screening` | `none` |
-| `ECON-7` | Economizer OK but not economizing | `econ_7` | `econ7_ok_not_economizing.sql` | `sql_screening` | `none` |
-| `MECH-OAT-1` | Mechanical cooling below 60°F web OAT | `mech_oat_1` | `mech_oat_1.sql` | `sql_screening` | `none` |
-| `CHW-NOLOAD-1` | Chiller running with no building load | `chw_noload_1` | `chw_noload_1.sql` | `sql_screening` | `none` |
-| `VAV-1` | Zone comfort band violation hours with confirm window | `vav1` | `vav1_comfort_fault.sql` | `sql_screening` | `none` |
-| `VAV-2` | Night setback miss — unoccupied zone above heating setback | `vav2` | `vav2_night_setback.sql` | `sql_screening` | `none` |
-| `VAV-3` | Excessive reheat during warm weather | `vav_3` | `vav3_excessive_reheat.sql` | `sql_screening` | `none` |
-| `VAV-4` | Damper stuck at full open | `vav_4` | `vav4_damper_full_open.sql` | `sql_screening` | `none` |
-| `VAV-5` | Airflow sensor bias | `vav_5` | `vav5_airflow_bias.sql` | `sql_screening` | `none` |
+| `ECON-5` | Preheat over-conditioning | `econ5` | `econ5_preheat_over.sql` | `sql_screening` | `none` |
+| `ECON-6` | Economizing in freezing weather | `econ6_compute` | `econ6_econ_freezing.sql` | `sql_screening` | `none` |
+| `ECON-7` | Economizer OK but not economizing | `econ7_compute` | `econ7_ok_not_economizing.sql` | `sql_screening` | `none` |
+| `MECH-OAT-1` | Mechanical cooling below 60°F web OAT | `mech_oat1_compute` | `mech_oat_1.sql` | `sql_screening` | `none` |
+| `CHW-NOLOAD-1` | Chiller running with no building load | `chw_noload1_compute` | `chw_noload_1.sql` | `sql_screening` | `none` |
+| `VAV-1` | Zone comfort band | `vav1` | `vav1_comfort_fault.sql` | `sql_screening` | `none` |
+| `VAV-2` | Night setback miss | `vav2` | `vav2_night_setback.sql` | `sql_screening` | `none` |
+| `VAV-3` | Excessive reheat during warm weather | `vav3` | `vav3_excessive_reheat.sql` | `sql_screening` | `none` |
+| `VAV-4` | Damper stuck at full open | `vav4` | `vav4_damper_full_open.sql` | `sql_screening` | `none` |
+| `VAV-5` | Airflow sensor bias | `vav5` | `vav5_airflow_bias.sql` | `sql_screening` | `none` |
 | `VAV-6` | Reheat when cooling available | `vav6` | `vav6_reheat_free_cool.sql` | `sql_screening` | `none` |
-| `VAV-REHEAT` | Reheat valve stuck / no temp rise | `vav_reheat` | `vav_reheat.sql` | `sql_screening` | `none` |
-| `VAV-AHU-LEAVE` | VAV leave vs parent AHU SAT (fedBy) | `vav_ahu_leave` | `vav_ahu_leave.sql` | `sql_screening` | `none` |
-| `VAV-7` | Min airflow / fixed high flow | `vav_7` | `vav7_min_airflow.sql` | `sql_screening` | `none` |
+| `VAV-REHEAT` | Reheat valve stuck / no temp rise | `vav_reheat_stuck` | `vav_reheat.sql` | `sql_screening` | `none` |
+| `VAV-AHU-LEAVE` | VAV leave vs parent AHU SAT (fedBy) | `vav_vs_ahu_leave` | `vav_ahu_leave.sql` | `sql_screening` | `none` |
+| `VAV-7` | Min airflow / fixed high flow | `vav7` | `vav7_min_airflow.sql` | `sql_screening` | `none` |
 | `CHW-1` | Low chilled-water ΔT | `chw1` | `chw1_low_dt.sql` | `sql_screening` | `none` |
-| `CHW-2` | DP below SP at max pump speed | `chw_2` | `chw2_dp_low.sql` | `sql_screening` | `none` |
-| `CHW-3` | Plant supply temp outside deadband | `chw_3` | `chw3_supply_band.sql` | `sql_screening` | `none` |
-| `CHW-4` | Flow high at max pump | `chw_4` | `chw4_flow_high.sql` | `sql_screening` | `none` |
-| `HP-1` | Discharge cold when heating | `hp_1` | `hp1_discharge_cold.sql` | `sql_screening` | `none` |
-| `WX-1` | OA temperature spike | `wx_1` | `wx1_oa_spike.sql` | `sql_screening` | `none` |
-| `CW-OPT-1` | Condenser water not optimized vs wet-bulb | `cw_opt_1` | `cw_opt_1.sql` | `sql_screening` | `none` |
-| `CW-APR-1` | High CW approach at full tower fan | `cw_apr_1` | `cw_apr_1.sql` | `sql_screening` | `none` |
-| `CW-FAN-1` | Excess tower fan energy vs wet-bulb limit | `cw_fan_1` | `cw_fan_1.sql` | `sql_screening` | `none` |
-| `TRIM-1` | Duct static trim advisory | `trim_1` | `trim1_duct_static.sql` | `sql_screening` | `none` |
-| `TRIM-3` | HWST trim advisory | `trim_3` | `trim3_hwst.sql` | `sql_screening` | `none` |
-| `TRIM-4` | CHW plant reset advisory | `trim_4` | `trim4_chw_reset.sql` | `sql_screening` | `none` |
-| `SCHED-1` | Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base). | `sched1` | `sched1_unoccupied_runtime.sql` | `sql_screening` | `alias` |
+| `CHW-2` | DP below SP at max pump speed | `chw2` | `chw2_dp_low.sql` | `sql_screening` | `none` |
+| `CHW-3` | Plant supply temp outside deadband | `chw3` | `chw3_supply_band.sql` | `sql_screening` | `none` |
+| `CHW-4` | Flow high at max pump | `chw4` | `chw4_flow_high.sql` | `sql_screening` | `none` |
+| `HP-1` | Discharge cold when heating | `hp1` | `hp1_discharge_cold.sql` | `sql_screening` | `none` |
+| `WX-1` | OA temperature spike | `wx1` | `wx1_oa_spike.sql` | `sql_screening` | `none` |
+| `CW-OPT-1` | Condenser water not optimized vs wet-bulb | `cw_opt` | `cw_opt_1.sql` | `sql_screening` | `none` |
+| `CW-APR-1` | High CW approach at full tower fan | `cw_apr` | `cw_apr_1.sql` | `sql_screening` | `none` |
+| `CW-FAN-1` | Excess tower fan energy vs wet-bulb limit | `cw_fan_excess` | `cw_fan_1.sql` | `sql_screening` | `none` |
+| `TRIM-1` | Duct static trim advisory | `trim1` | `trim1_duct_static.sql` | `sql_screening` | `none` |
+| `TRIM-3` | HWST trim advisory | `trim3` | `trim3_hwst.sql` | `sql_screening` | `none` |
+| `TRIM-4` | CHW plant reset advisory | `trim4` | `trim4_chw_reset.sql` | `sql_screening` | `none` |
+| `SCHED-1` | Unoccupied runtime | `sched1` | `sched1_unoccupied_runtime.sql` | `sql_screening` | `alias` |
 | `SCHED-247` | Always-on fan or pump runtime | `_sched247` | `sched247_always_on.sql` | `sql_screening` | `none` |
 | `RESET-1` | SAT reset not tracking outdoor air | `reset1` | `reset1_sat_oa_reset.sql` | `sql_screening` | `none` |
-| `CMD-1` | Fan cmd/status mismatch | `cmd_1` | `cmd1_fan_mismatch.sql` | `sql_screening` | `none` |
-| `OA-1` | Low OA fraction | `oa_1` | `oa1_low_oa_frac.sql` | `sql_screening` | `none` |
-| `DMP-1` | OA damper leakage | `dmp_1` | `dmp1_oa_damper_leak.sql` | `sql_screening` | `none` |
-| `VLV-1` | Cooling valve leakage | `vlv_1` | `vlv1_clg_valve_leak.sql` | `sql_screening` | `none` |
+| `CMD-1` | Fan cmd/status mismatch | `cmd1` | `cmd1_fan_mismatch.sql` | `sql_screening` | `none` |
+| `OA-1` | Low OA fraction | `oa1` | `oa1_low_oa_frac.sql` | `sql_screening` | `none` |
+| `DMP-1` | OA damper leakage | `dmp1` | `dmp1_oa_damper_leak.sql` | `sql_screening` | `none` |
+| `VLV-1` | Cooling valve leakage | `vlv1` | `vlv1_clg_valve_leak.sql` | `sql_screening` | `none` |
 | `AVG-ZONE-TEMP` | Average zone temperature per equipment | `—` | `avg_zone_temp.sql` | `sql_screening` | `intentional_non_applicability` |
 | `FAN-RUNTIME-HOURS` | Fan running hours where fan_cmd > 5% (normalized 0-1) | `—` | `fan_runtime_hours.sql` | `sql_screening` | `intentional_non_applicability` |
 | `FAULT-ELAPSED-HOURS` | Comfort fault sample count → hours | `—` | `fault_elapsed_hours.sql` | `sql_screening` | `intentional_non_applicability` |

--- a/docs/rules/cookbook/generated-parity-report.md
+++ b/docs/rules/cookbook/generated-parity-report.md
@@ -30,68 +30,68 @@ Do not edit by hand. Run `python3 scripts/generate_cookbook_report.py`.
 
 | rule_id | title | pandas | SQL | parity | class |
 | --- | --- | --- | --- | --- | --- |
-| `SV-RANGE` | Sensor out of hard range | `_sweep_range` | `sv_range.sql` | `sql_screening` | `none` |
-| `SV-FLATLINE` | Sensor flatline (stuck) | `_sweep_flatline` | `sv_flatline.sql` | `sql_screening` | `none` |
-| `SV-SPIKE` | Sensor rate-of-change spike | `_sweep_spike` | `sv_spike.sql` | `sql_screening` | `none` |
-| `SV-STALE` | Stale data (no fresh samples) | `_sweep_stale` | `sv_stale.sql` | `sql_screening` | `none` |
-| `SV-RATE` | Context-aware sensor rate of change | `_sv_rate_compute` | `sv_rate.sql` | `sql_screening` | `semantic_gap` |
-| `PID-HUNT-1` | Suspected control-output hunting | `_pid_hunt_1` | `pid_hunt_1.sql` | `sql_screening` | `none` |
-| `FC1` | Duct static below SP at full fan (GL36 A) | `fc1` | `fc1_duct_static_low.sql` | `sql_screening` | `none` |
-| `FC2` | MAT below OAT/RAT envelope (GL36 B) | `fc2` | `fc2_mat_low.sql` | `sql_screening` | `none` |
-| `FC3` | MAT above OAT/RAT envelope (GL36 C) | `fc3` | `fc3_mat_high.sql` | `sql_screening` | `none` |
+| `SV-RANGE` | Sensor out of hard range | `sv_range` | `sv_range.sql` | `sql_screening` | `none` |
+| `SV-FLATLINE` | Sensor flatline (stuck) | `sv_flatline` | `sv_flatline.sql` | `sql_screening` | `none` |
+| `SV-SPIKE` | Sensor rate-of-change spike | `sv_spike` | `sv_spike.sql` | `sql_screening` | `none` |
+| `SV-STALE` | Stale data (no fresh samples) | `sv_stale` | `sv_stale.sql` | `sql_screening` | `none` |
+| `SV-RATE` | Context-aware sensor rate of change | `sv_rate` | `sv_rate.sql` | `sql_screening` | `semantic_gap` |
+| `PID-HUNT-1` | Suspected control-output hunting | `pid_hunt_1` | `pid_hunt_1.sql` | `sql_screening` | `none` |
+| `FC1` | Duct static below SP at full fan | `fc1` | `fc1_duct_static_low.sql` | `sql_screening` | `none` |
+| `FC2` | Mixed air below envelope | `fc2` | `fc2_mat_low.sql` | `sql_screening` | `none` |
+| `FC3` | Mixed air above envelope | `fc3` | `fc3_mat_high.sql` | `sql_screening` | `none` |
 | `FC4` | PID hunting (operating-state oscillation) | `fc4` | `fc4_os_hunting.sql` | `sql_screening` | `none` |
 | `FC5` | SAT cold when heating commanded (GL36 D) | `fc5` | `fc5_sat_cold_heating.sql` | `sql_screening` | `none` |
 | `FC6` | Estimated OA fraction mismatch | `fc6` | `fc6_oa_frac_mismatch.sql` | `sql_screening` | `none` |
-| `FC7` | SAT low with full heating (GL36 E) | `fc7` | `fc7_sat_low_heating.sql` | `sql_screening` | `missing_implementation` |
-| `FC8` | SAT/MAT mismatch in economizer (GL36 F) | `fc8` | `fc8_sat_mat_econ.sql` | `sql_screening` | `none` |
-| `FC9` | OAT too warm for free cooling (GL36 G) | `fc9` | `fc9_oa_sat_sp_econ.sql` | `sql_screening` | `none` |
-| `FC10` | OAT/MAT mismatch + mech cooling (GL36 H) | `fc10` | `fc10_mat_oa_clg.sql` | `sql_screening` | `none` |
-| `FC11` | OAT/MAT mismatch economizer-only (GL36 I) | `fc11` | `fc11_oa_sat_sp_clg.sql` | `sql_screening` | `none` |
-| `FC12` | SAT above blend in cooling (GL36 J) | `fc12` | `fc12_sat_mat_clg.sql` | `sql_screening` | `none` |
-| `FC13` | SAT above SP at full cooling (GL36 K) | `fc13` | `sat_high_fault.sql` | `sql_screening` | `alias` |
+| `FC7` | SAT low while heating at full | `fc7` | `fc7_sat_low_heating.sql` | `sql_screening` | `missing_implementation` |
+| `FC8` | SAT vs MAT while economizing | `fc8` | `fc8_sat_mat_econ.sql` | `sql_screening` | `none` |
+| `FC9` | OAT high vs SAT SP while economizing | `fc9` | `fc9_oa_sat_sp_econ.sql` | `sql_screening` | `none` |
+| `FC10` | MAT-OAT delta while cooling and economizing | `fc10` | `fc10_mat_oa_clg.sql` | `sql_screening` | `none` |
+| `FC11` | OAT low vs SAT SP while cooling and economizing | `fc11` | `fc11_oa_sat_sp_clg.sql` | `sql_screening` | `none` |
+| `FC12` | SAT above MAT while cooling | `fc12` | `fc12_sat_mat_clg.sql` | `sql_screening` | `none` |
+| `FC13` | SAT above setpoint at full cooling | `fc13` | `sat_high_fault.sql` | `sql_screening` | `alias` |
 | `FC14` | CHW coil ΔT when inactive (GL36 L) | `fc14` | `fc14_chw_coil_dt_inactive.sql` | `sql_screening` | `none` |
 | `FC15` | HW coil ΔT when inactive (GL36 M) | `fc15` | `fc15_hw_coil_dt_inactive.sql` | `sql_screening` | `none` |
-| `AHU-SATDEV` | SAT deviation from setpoint | `ahu_sat_dev` | `ahu_satdev.sql` | `sql_screening` | `none` |
-| `AHU-DUCTHI` | Duct static pressure high | `ahu_duct_high` | `ahu_ducthi.sql` | `sql_screening` | `none` |
-| `AHU-SIMUL` | Heating and cooling simultaneous | `ahu_simul_heat_cool` | `ahu_simul.sql` | `sql_screening` | `none` |
-| `OAT-METEO` | BAS outdoor-air sensor vs Open-Meteo | `oat_vs_meteo` | `oat_meteo_fault.sql` | `sql_screening` | `none` |
-| `ECON-1` | Economizer stuck closed | `econ1` | `econ1_stuck_closed.sql` | `sql_screening` | `none` |
-| `ECON-2` | Economizing when outdoor unfavorable | `econ2` | `economizer_fault.sql` | `sql_screening` | `none` |
-| `ECON-3` | Mech cooling without integrated economizer | `econ2` | `econ3_mech_without_econ.sql` | `sql_screening` | `none` |
+| `AHU-SATDEV` | SAT deviation from setpoint | `ahu_satdev` | `ahu_satdev.sql` | `sql_screening` | `none` |
+| `AHU-DUCTHI` | Duct static pressure high | `ahu_ducthi` | `ahu_ducthi.sql` | `sql_screening` | `none` |
+| `AHU-SIMUL` | Heating and cooling simultaneous | `ahu_simul` | `ahu_simul.sql` | `sql_screening` | `none` |
+| `OAT-METEO` | Equipment OAT vs weather-staged wx OAT | `oat_vs_meteo` | `oat_meteo_fault.sql` | `sql_screening` | `none` |
+| `ECON-1` | Economizer stuck closed when OAT favorable | `econ1` | `econ1_stuck_closed.sql` | `sql_screening` | `none` |
+| `ECON-2` | Economizing when outdoor air unfavorable | `econ2` | `economizer_fault.sql` | `sql_screening` | `none` |
+| `ECON-3` | Mech cooling without integrated economizer | `econ_3` | `econ3_mech_without_econ.sql` | `sql_screening` | `none` |
 | `ECON-4` | Low estimated OA fraction | `econ4` | `econ4_low_oa_frac.sql` | `sql_screening` | `none` |
-| `ECON-5` | Preheat over-conditioning | `econ5` | `econ5_preheat_over.sql` | `sql_screening` | `none` |
-| `ECON-6` | Economizing in freezing weather | `econ6_compute` | `econ6_econ_freezing.sql` | `sql_screening` | `none` |
-| `ECON-7` | Economizer OK but not economizing | `econ7_compute` | `econ7_ok_not_economizing.sql` | `sql_screening` | `none` |
-| `MECH-OAT-1` | Mechanical cooling below 60°F web OAT | `mech_oat1_compute` | `mech_oat_1.sql` | `sql_screening` | `none` |
-| `CHW-NOLOAD-1` | Chiller running with no building load | `chw_noload1_compute` | `chw_noload_1.sql` | `sql_screening` | `none` |
-| `VAV-1` | Zone comfort band | `vav1` | `vav1_comfort_fault.sql` | `sql_screening` | `none` |
-| `VAV-2` | Night setback miss | `vav2` | `vav2_night_setback.sql` | `sql_screening` | `none` |
-| `VAV-3` | Excessive reheat during warm weather | `vav3` | `vav3_excessive_reheat.sql` | `sql_screening` | `none` |
-| `VAV-4` | Damper stuck at full open | `vav4` | `vav4_damper_full_open.sql` | `sql_screening` | `none` |
-| `VAV-5` | Airflow sensor bias | `vav5` | `vav5_airflow_bias.sql` | `sql_screening` | `none` |
+| `ECON-5` | Preheat over-conditioning | `econ_5` | `econ5_preheat_over.sql` | `sql_screening` | `none` |
+| `ECON-6` | Economizing in freezing weather | `econ_6` | `econ6_econ_freezing.sql` | `sql_screening` | `none` |
+| `ECON-7` | Economizer OK but not economizing | `econ_7` | `econ7_ok_not_economizing.sql` | `sql_screening` | `none` |
+| `MECH-OAT-1` | Mechanical cooling below 60°F web OAT | `mech_oat_1` | `mech_oat_1.sql` | `sql_screening` | `none` |
+| `CHW-NOLOAD-1` | Chiller running with no building load | `chw_noload_1` | `chw_noload_1.sql` | `sql_screening` | `none` |
+| `VAV-1` | Zone comfort band violation hours with confirm window | `vav1` | `vav1_comfort_fault.sql` | `sql_screening` | `none` |
+| `VAV-2` | Night setback miss — unoccupied zone above heating setback | `vav2` | `vav2_night_setback.sql` | `sql_screening` | `none` |
+| `VAV-3` | Excessive reheat during warm weather | `vav_3` | `vav3_excessive_reheat.sql` | `sql_screening` | `none` |
+| `VAV-4` | Damper stuck at full open | `vav_4` | `vav4_damper_full_open.sql` | `sql_screening` | `none` |
+| `VAV-5` | Airflow sensor bias | `vav_5` | `vav5_airflow_bias.sql` | `sql_screening` | `none` |
 | `VAV-6` | Reheat when cooling available | `vav6` | `vav6_reheat_free_cool.sql` | `sql_screening` | `none` |
-| `VAV-REHEAT` | Reheat valve stuck / no temp rise | `vav_reheat_stuck` | `vav_reheat.sql` | `sql_screening` | `none` |
-| `VAV-AHU-LEAVE` | VAV leave vs parent AHU SAT (fedBy) | `vav_vs_ahu_leave` | `vav_ahu_leave.sql` | `sql_screening` | `none` |
-| `VAV-7` | Min airflow / fixed high flow | `vav7` | `vav7_min_airflow.sql` | `sql_screening` | `none` |
+| `VAV-REHEAT` | Reheat valve stuck / no temp rise | `vav_reheat` | `vav_reheat.sql` | `sql_screening` | `none` |
+| `VAV-AHU-LEAVE` | VAV leave vs parent AHU SAT (fedBy) | `vav_ahu_leave` | `vav_ahu_leave.sql` | `sql_screening` | `none` |
+| `VAV-7` | Min airflow / fixed high flow | `vav_7` | `vav7_min_airflow.sql` | `sql_screening` | `none` |
 | `CHW-1` | Low chilled-water ΔT | `chw1` | `chw1_low_dt.sql` | `sql_screening` | `none` |
-| `CHW-2` | DP below SP at max pump speed | `chw2` | `chw2_dp_low.sql` | `sql_screening` | `none` |
-| `CHW-3` | Plant supply temp outside deadband | `chw3` | `chw3_supply_band.sql` | `sql_screening` | `none` |
-| `CHW-4` | Flow high at max pump | `chw4` | `chw4_flow_high.sql` | `sql_screening` | `none` |
-| `HP-1` | Discharge cold when heating | `hp1` | `hp1_discharge_cold.sql` | `sql_screening` | `none` |
-| `WX-1` | OA temperature spike | `wx1` | `wx1_oa_spike.sql` | `sql_screening` | `none` |
-| `CW-OPT-1` | Condenser water not optimized vs wet-bulb | `cw_opt` | `cw_opt_1.sql` | `sql_screening` | `none` |
-| `CW-APR-1` | High CW approach at full tower fan | `cw_apr` | `cw_apr_1.sql` | `sql_screening` | `none` |
-| `CW-FAN-1` | Excess tower fan energy vs wet-bulb limit | `cw_fan_excess` | `cw_fan_1.sql` | `sql_screening` | `none` |
-| `TRIM-1` | Duct static trim advisory | `trim1` | `trim1_duct_static.sql` | `sql_screening` | `none` |
-| `TRIM-3` | HWST trim advisory | `trim3` | `trim3_hwst.sql` | `sql_screening` | `none` |
-| `TRIM-4` | CHW plant reset advisory | `trim4` | `trim4_chw_reset.sql` | `sql_screening` | `none` |
-| `SCHED-1` | Unoccupied runtime | `sched1` | `sched1_unoccupied_runtime.sql` | `sql_screening` | `alias` |
+| `CHW-2` | DP below SP at max pump speed | `chw_2` | `chw2_dp_low.sql` | `sql_screening` | `none` |
+| `CHW-3` | Plant supply temp outside deadband | `chw_3` | `chw3_supply_band.sql` | `sql_screening` | `none` |
+| `CHW-4` | Flow high at max pump | `chw_4` | `chw4_flow_high.sql` | `sql_screening` | `none` |
+| `HP-1` | Discharge cold when heating | `hp_1` | `hp1_discharge_cold.sql` | `sql_screening` | `none` |
+| `WX-1` | OA temperature spike | `wx_1` | `wx1_oa_spike.sql` | `sql_screening` | `none` |
+| `CW-OPT-1` | Condenser water not optimized vs wet-bulb | `cw_opt_1` | `cw_opt_1.sql` | `sql_screening` | `none` |
+| `CW-APR-1` | High CW approach at full tower fan | `cw_apr_1` | `cw_apr_1.sql` | `sql_screening` | `none` |
+| `CW-FAN-1` | Excess tower fan energy vs wet-bulb limit | `cw_fan_1` | `cw_fan_1.sql` | `sql_screening` | `none` |
+| `TRIM-1` | Duct static trim advisory | `trim_1` | `trim1_duct_static.sql` | `sql_screening` | `none` |
+| `TRIM-3` | HWST trim advisory | `trim_3` | `trim3_hwst.sql` | `sql_screening` | `none` |
+| `TRIM-4` | CHW plant reset advisory | `trim_4` | `trim4_chw_reset.sql` | `sql_screening` | `none` |
+| `SCHED-1` | Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base). | `sched1` | `sched1_unoccupied_runtime.sql` | `sql_screening` | `alias` |
 | `SCHED-247` | Always-on fan or pump runtime | `_sched247` | `sched247_always_on.sql` | `sql_screening` | `none` |
 | `RESET-1` | SAT reset not tracking outdoor air | `reset1` | `reset1_sat_oa_reset.sql` | `sql_screening` | `none` |
-| `CMD-1` | Fan cmd/status mismatch | `cmd1` | `cmd1_fan_mismatch.sql` | `sql_screening` | `none` |
-| `OA-1` | Low OA fraction | `oa1` | `oa1_low_oa_frac.sql` | `sql_screening` | `none` |
-| `DMP-1` | OA damper leakage | `dmp1` | `dmp1_oa_damper_leak.sql` | `sql_screening` | `none` |
-| `VLV-1` | Cooling valve leakage | `vlv1` | `vlv1_clg_valve_leak.sql` | `sql_screening` | `none` |
+| `CMD-1` | Fan cmd/status mismatch | `cmd_1` | `cmd1_fan_mismatch.sql` | `sql_screening` | `none` |
+| `OA-1` | Low OA fraction | `oa_1` | `oa1_low_oa_frac.sql` | `sql_screening` | `none` |
+| `DMP-1` | OA damper leakage | `dmp_1` | `dmp1_oa_damper_leak.sql` | `sql_screening` | `none` |
+| `VLV-1` | Cooling valve leakage | `vlv_1` | `vlv1_clg_valve_leak.sql` | `sql_screening` | `none` |
 | `AVG-ZONE-TEMP` | Average zone temperature per equipment | `—` | `avg_zone_temp.sql` | `sql_screening` | `intentional_non_applicability` |
 | `FAN-RUNTIME-HOURS` | Fan running hours where fan_cmd > 5% (normalized 0-1) | `—` | `fan_runtime_hours.sql` | `sql_screening` | `intentional_non_applicability` |
 | `FAULT-ELAPSED-HOURS` | Comfort fault sample count → hours | `—` | `fault_elapsed_hours.sql` | `sql_screening` | `intentional_non_applicability` |

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -43,7 +43,15 @@
     {
       "rule_id": "SV-RANGE",
       "title": "Sensor out of hard range",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -63,16 +71,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -80,9 +94,37 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
+        },
+        "range_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Humidity range scale"
+        },
+        "range_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Pressure range scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_range",
+      "pandas_implementation": "_sweep_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
       "test_coverage": [
@@ -96,7 +138,15 @@
     {
       "rule_id": "SV-FLATLINE",
       "title": "Sensor flatline (stuck)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -117,17 +167,9 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
@@ -136,13 +178,25 @@
         "flatline_hours": {
           "default": 1.0,
           "unit": "h",
-          "min": 0.25,
-          "max": 12.0,
-          "step": 0.25,
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
           "label": "Flatline window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_flatline",
+      "pandas_implementation": "_sweep_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
       "test_coverage": [
@@ -155,7 +209,15 @@
     {
       "rule_id": "SV-SPIKE",
       "title": "Sensor rate-of-change spike",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -175,16 +237,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -192,9 +260,45 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
+        },
+        "spike_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Temp spike scale"
+        },
+        "spike_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Humidity spike scale"
+        },
+        "spike_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Pressure spike scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_spike",
+      "pandas_implementation": "_sweep_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
       "test_coverage": [
@@ -207,7 +311,15 @@
     {
       "rule_id": "SV-STALE",
       "title": "Stale data (no fresh samples)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -223,14 +335,6 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -239,16 +343,20 @@
           "step": 0.5,
           "label": "Stale window"
         },
-        "stale_tol": {
-          "default": 0.05,
-          "unit": "degF",
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
           "min": 0.0,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Stale tolerance"
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_stale",
+      "pandas_implementation": "_sweep_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
       "test_coverage": [
@@ -261,7 +369,15 @@
     {
       "rule_id": "SV-RATE",
       "title": "Context-aware sensor rate of change",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -272,14 +388,6 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -288,16 +396,52 @@
           "step": 1.0,
           "label": "Fault persistence"
         },
-        "steady_fault_per_hour": {
-          "default": 6.0,
-          "unit": "degF_per_h",
-          "min": 1.0,
+        "transition_window_min": {
+          "default": 20.0,
+          "unit": "min",
+          "min": 5.0,
           "max": 60.0,
-          "step": 0.5,
-          "label": "Steady-state slew limit"
+          "step": 5.0,
+          "label": "Transition window"
+        },
+        "max_gap_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Max sample gap"
+        },
+        "design_flow": {
+          "default": 0.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 100.0,
+          "label": "Design flow (flow profiles)"
+        },
+        "sensor_span": {
+          "default": 0.0,
+          "unit": "eng",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 10.0,
+          "label": "Sensor span (flow/pressure)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_rate",
+      "pandas_implementation": "_sv_rate_compute",
       "datafusion_sql_implementation": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
       "test_coverage": [
@@ -312,38 +456,30 @@
     {
       "rule_id": "PID-HUNT-1",
       "title": "Suspected control-output hunting",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct",
-        "htg_valve_pct",
-        "damper_pct",
-        "loop_enabled",
-        "fan_status",
-        "fan_cmd"
+        "loop-enabled"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 0.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "window_hours": {
-          "default": 1.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 4.0,
-          "step": 0.25,
-          "label": "Hunting lookback window"
-        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -351,7 +487,7 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
@@ -359,38 +495,50 @@
         },
         "total_variation_fault_pct": {
           "default": 500.0,
-          "unit": "pct",
+          "unit": "%/h",
           "min": 50.0,
           "max": 2000.0,
           "step": 50.0,
-          "label": "Total variation fault threshold"
+          "label": "Total travel threshold"
         },
         "minimum_equivalent_cycles": {
           "default": 2.5,
-          "unit": "count",
+          "unit": "cyc/h",
           "min": 0.5,
-          "max": 10.0,
+          "max": 20.0,
           "step": 0.5,
           "label": "Min equivalent cycles"
         },
         "minimum_reversals": {
-          "default": 4.0,
+          "default": 4,
           "unit": "count",
-          "min": 1.0,
-          "max": 20.0,
-          "step": 1.0,
+          "min": 1,
+          "max": 40,
+          "step": 1,
           "label": "Min direction reversals"
         },
         "minimum_coverage_pct": {
           "default": 80.0,
-          "unit": "pct",
-          "min": 50.0,
+          "unit": "%",
+          "min": 25.0,
           "max": 100.0,
           "step": 5.0,
-          "label": "Min window sample coverage"
+          "label": "Minimum data coverage"
+        },
+        "confirm_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "pid_hunt_1",
+      "pandas_implementation": "_pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
       "test_coverage": [],
@@ -400,26 +548,35 @@
     },
     {
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan",
-      "equipment_types": [],
+      "title": "Duct static below SP at full fan (GL36 A)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "inwc",
+          "unit": "in. w.c.",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -427,15 +584,43 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
+          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
+        },
+        "duct_static_err": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Legacy duct-static error (sets \u03b5DSP)"
+        },
+        "fan_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc1",
@@ -451,20 +636,90 @@
     },
     {
       "rule_id": "FC2",
-      "title": "Mixed air below envelope",
-      "equipment_types": [],
+      "title": "MAT below OAT/RAT envelope (GL36 B)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc2",
@@ -475,20 +730,90 @@
     },
     {
       "rule_id": "FC3",
-      "title": "Mixed air above envelope",
-      "equipment_types": [],
+      "title": "MAT above OAT/RAT envelope (GL36 C)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc3",
@@ -500,32 +825,54 @@
     {
       "rule_id": "FC4",
       "title": "PID hunting (operating-state oscillation)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct",
-        "fan_cmd"
+        "outside-air-damper",
+        "cooling-valve",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
+        "delta_os_max": {
+          "default": 5,
+          "unit": "count",
+          "min": 1,
+          "max": 30,
+          "step": 1,
+          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "delta_os_max": {
-          "default": 5.0,
-          "unit": "count",
-          "min": 1.0,
-          "max": 30.0,
-          "step": 1.0,
-          "label": "Max operating-state entries per hour"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc4",
@@ -539,34 +886,51 @@
     {
       "rule_id": "FC5",
       "title": "SAT cold when heating commanded (GL36 D)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_sat": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -575,6 +939,42 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -588,27 +988,43 @@
     {
       "rule_id": "FC6",
       "title": "Estimated OA fraction mismatch",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd",
-        "vav_total_flow"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "vav-total-airflow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
+        "eps_airflow": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Airflow error \u03b5F (GL36 default 30%)"
+        },
+        "delta_t_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
           "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
         },
         "airflow_err": {
           "default": 0.15,
@@ -616,23 +1032,51 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Airflow error epsF (GL36 default 30%)"
+          "label": "Legacy OA-fraction error (sets \u03b5F)"
         },
-        "delta_t_min": {
+        "oat_rat_delta_min": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
+          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
         },
         "min_cfm_design": {
-          "default": 5000.0,
+          "default": 5000,
           "unit": "cfm",
+          "min": 500,
+          "max": 20000,
+          "step": 500,
+          "label": "Design min OA CFM"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
           "min": 0.0,
-          "max": 200000.0,
-          "step": 100.0,
-          "label": "Design minimum outdoor airflow"
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc6",
@@ -645,26 +1089,44 @@
     },
     {
       "rule_id": "FC7",
-      "title": "SAT low while heating at full",
-      "equipment_types": [],
+      "title": "SAT low with full heating (GL36 E)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "htg_valve_pct"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_cmd",
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets epsSAT)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -674,13 +1136,33 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc7",
@@ -698,20 +1180,106 @@
     },
     {
       "rule_id": "FC8",
-      "title": "SAT vs MAT while economizing",
-      "equipment_types": [],
+      "title": "SAT/MAT mismatch in economizer (GL36 F)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc8",
@@ -722,20 +1290,98 @@
     },
     {
       "rule_id": "FC9",
-      "title": "OAT high vs SAT SP while economizing",
-      "equipment_types": [],
+      "title": "OAT too warm for free cooling (GL36 G)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc9",
@@ -746,20 +1392,90 @@
     },
     {
       "rule_id": "FC10",
-      "title": "MAT-OAT delta while cooling and economizing",
-      "equipment_types": [],
+      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc10",
@@ -770,20 +1486,98 @@
     },
     {
       "rule_id": "FC11",
-      "title": "OAT low vs SAT SP while cooling and economizing",
-      "equipment_types": [],
+      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc11",
@@ -794,20 +1588,114 @@
     },
     {
       "rule_id": "FC12",
-      "title": "SAT above MAT while cooling",
-      "equipment_types": [],
+      "title": "SAT above blend in cooling (GL36 J)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc12",
@@ -818,59 +1706,88 @@
     },
     {
       "rule_id": "FC13",
-      "title": "SAT above setpoint at full cooling",
-      "equipment_types": [],
+      "title": "SAT above SP at full cooling (GL36 K)",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "clg_valve_pct",
-        "oa_damper_pct"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT high error band"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
         },
-        "clg_valve_min": {
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "clg_full_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
+          "min": 0.5,
+          "max": 1.0,
           "step": 0.01,
-          "label": "Cooling valve open threshold"
+          "label": "Full-cooling threshold (GL36 99%)"
         },
-        "oa_damper_econ_low": {
+        "econ_min_pos": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "OA damper economizer low"
+          "label": "Economizer minimum-position threshold"
         },
-        "oa_damper_econ_high": {
+        "econ_full_open": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "OA damper economizer high"
+          "label": "Economizer full-open threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc13",
@@ -886,9 +1803,14 @@
     {
       "rule_id": "FC14",
       "title": "CHW coil \u0394T when inactive (GL36 L)",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "clg_valve_pct"
+        "cooling-coil-entering-temp",
+        "cooling-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "cooling_coil_entering_temp",
@@ -899,23 +1821,90 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_ccet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Cooling-coil entering sensor error \u03b5CCET"
+        },
+        "eps_cclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc14",
@@ -929,8 +1918,15 @@
     {
       "rule_id": "FC15",
       "title": "HW coil \u0394T when inactive (GL36 M)",
-      "equipment_types": [],
-      "required_roles": [],
+      "equipment_types": [
+        "ahu"
+      ],
+      "required_roles": [
+        "heating-coil-entering-temp",
+        "heating-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
       "optional_roles": [
         "heating_coil_entering_temp",
         "heating_coil_leaving_temp",
@@ -941,23 +1937,98 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_hcet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Heating-coil entering sensor error \u03b5HCET"
+        },
+        "eps_hclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil leaving sensor error \u03b5HCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc15",
@@ -971,35 +2042,48 @@
     {
       "rule_id": "AHU-SATDEV",
       "title": "SAT deviation from setpoint",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp"
+        "discharge-air-temp",
+        "discharge-air-temp-sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_satdev",
+      "pandas_implementation": "ahu_sat_dev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
       "test_coverage": [
@@ -1012,11 +2096,12 @@
     {
       "rule_id": "AHU-DUCTHI",
       "title": "Duct static pressure high",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp"
       ],
       "optional_roles": [
         "fan_status",
@@ -1024,17 +2109,9 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -1042,14 +2119,26 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_ducthi",
+      "pandas_implementation": "ahu_duct_high",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
       "test_coverage": [
@@ -1062,25 +2151,26 @@
     {
       "rule_id": "AHU-SIMUL",
       "title": "Heating and cooling simultaneous",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "htg_valve_pct",
-        "clg_valve_pct"
+        "heating-valve",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -1088,9 +2178,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul",
+      "pandas_implementation": "ahu_simul_heat_cool",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
       "test_coverage": [],
@@ -1100,10 +2202,13 @@
     },
     {
       "rule_id": "OAT-METEO",
-      "title": "Equipment OAT vs weather-staged wx OAT",
-      "equipment_types": [],
+      "title": "BAS outdoor-air sensor vs Open-Meteo",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp",
+        "web-outside-air-temp"
       ],
       "optional_roles": [
         "web_oa_t"
@@ -1112,19 +2217,23 @@
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "OAT vs meteo tolerance"
+          "label": "Max OAT disagreement"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -1137,34 +2246,47 @@
     },
     {
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed when OAT favorable",
-      "equipment_types": [],
+      "title": "Economizer stuck closed",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "oa_damper_pct",
-        "oa_t"
+        "fan-cmd",
+        "outside-air-damper",
+        "outside-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
         },
-        "econ1_damper_max": {
-          "default": 0.05,
-          "unit": "frac",
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
           "min": 0.0,
-          "max": 0.2,
-          "step": 0.01,
-          "label": "Stuck-closed damper frac"
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ1",
@@ -1177,21 +2299,30 @@
     },
     {
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor air unfavorable",
-      "equipment_types": [],
+      "title": "Economizing when outdoor unfavorable",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "oa_damper_pct"
+        "outside-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -1205,13 +2336,17 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ2",
@@ -1227,30 +2362,30 @@
     {
       "rule_id": "ECON-3",
       "title": "Mech cooling without integrated economizer",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -1258,7 +2393,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -1266,7 +2401,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -1279,9 +2414,21 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_3",
+      "pandas_implementation": "econ2",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
       "test_coverage": [],
@@ -1292,34 +2439,47 @@
     {
       "rule_id": "ECON-4",
       "title": "Low estimated OA fraction",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "pct",
+          "unit": "%",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ4",
@@ -1333,37 +2493,50 @@
     {
       "rule_id": "ECON-5",
       "title": "Preheat over-conditioning",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "preheat_leave_t",
-        "sat_sp",
-        "oa_t",
-        "htg_valve_pct"
+        "preheat-leaving-temp",
+        "discharge-air-temp-sp",
+        "outside-air-temp",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_5",
+      "pandas_implementation": "econ5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
       "test_coverage": [],
@@ -1374,28 +2547,27 @@
     {
       "rule_id": "ECON-6",
       "title": "Economizing in freezing weather",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "web_oa_t",
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -1408,9 +2580,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_6",
+      "pandas_implementation": "econ6_compute",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
       "test_coverage": [],
@@ -1421,30 +2605,32 @@
     {
       "rule_id": "ECON-7",
       "title": "Economizer OK but not economizing",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity",
+        "cooling-valve",
+        "compressor-status",
+        "dx-cool-cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -1452,7 +2638,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -1460,7 +2646,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -1473,9 +2659,21 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_7",
+      "pandas_implementation": "econ7_compute",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
       "test_coverage": [],
@@ -1486,34 +2684,45 @@
     {
       "rule_id": "MECH-OAT-1",
       "title": "Mechanical cooling below 60\u00b0F web OAT",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
       "required_roles": [
         "web_oa_t"
       ],
       "optional_roles": [
-        "clg_valve_pct",
-        "chiller_status"
+        "web-outside-air-temp",
+        "compressor-status",
+        "chiller-status",
+        "chw-pump-status",
+        "dx-cool-cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat_1",
+      "pandas_implementation": "mech_oat1_compute",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
       "test_coverage": [],
@@ -1524,28 +2733,57 @@
     {
       "rule_id": "CHW-NOLOAD-1",
       "title": "Chiller running with no building load",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "chiller_status",
-        "chiller_cmd",
-        "chw_pump_status",
-        "chw_pump_cmd",
-        "building_zone_load_satisfied",
-        "building_ahu_load_satisfied"
+        "chiller-status",
+        "chw-pump-status",
+        "compressor-status",
+        "building-zone-load-satisfied",
+        "building-ahu-load-satisfied"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
+        },
+        "sat_band_f": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "AHU SAT\u2248SP band"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_noload_1",
+      "pandas_implementation": "chw_noload1_compute",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
       "test_coverage": [],
@@ -1555,39 +2793,46 @@
     },
     {
       "rule_id": "VAV-1",
-      "title": "Zone comfort band violation hours with confirm window",
-      "equipment_types": [],
+      "title": "Zone comfort band",
+      "equipment_types": [
+        "vav",
+        "zone"
+      ],
       "required_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "optional_roles": [
         "occ_mode"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_t_lo": {
+        "zone_lo": {
           "default": 70.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_t_hi": {
+        "zone_hi": {
           "default": 75.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav1",
@@ -1603,30 +2848,39 @@
     },
     {
       "rule_id": "VAV-2",
-      "title": "Night setback miss \u2014 unoccupied zone above heating setback",
-      "equipment_types": [],
-      "required_roles": [
-        "zone_t",
-        "occ_mode"
+      "title": "Night setback miss",
+      "equipment_types": [
+        "vav",
+        "zone"
       ],
-      "optional_roles": [],
+      "required_roles": [
+        "zone-air-temp",
+        "occupied"
+      ],
+      "optional_roles": [
+        "occ-mode"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
         "setback_hi": {
           "default": 68.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Setback high"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav2",
@@ -1640,29 +2894,29 @@
     {
       "rule_id": "VAV-3",
       "title": "Excessive reheat during warm weather",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "oa_t",
-        "reheat_valve_pct",
-        "zone_flow"
+        "outside-air-temp",
+        "reheat-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -1683,9 +2937,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_3",
+      "pandas_implementation": "vav3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
       "test_coverage": [],
@@ -1696,25 +2962,26 @@
     {
       "rule_id": "VAV-4",
       "title": "Damper stuck at full open",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "damper_pct",
-        "zone_flow"
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -1722,6 +2989,14 @@
           "max": 1.0,
           "step": 0.005,
           "label": "Full open frac"
+        },
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
         },
         "flow_on_min": {
           "default": 25.0,
@@ -1731,16 +3006,20 @@
           "step": 5.0,
           "label": "Airflow-on min"
         },
-        "sustain_hours": {
-          "default": 1.5,
-          "unit": "h",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "Sustain window"
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_4",
+      "pandas_implementation": "vav4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
       "test_coverage": [],
@@ -1751,27 +3030,40 @@
     {
       "rule_id": "VAV-5",
       "title": "Airflow sensor bias",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "damper_pct"
+        "zone-airflow",
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_5",
+      "pandas_implementation": "vav5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
       "test_coverage": [],
@@ -1782,19 +3074,28 @@
     {
       "rule_id": "VAV-6",
       "title": "Reheat when cooling available",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "oa_t",
-        "reheat_valve_pct"
+        "outside-air-temp",
+        "reheat-valve"
       ],
       "optional_roles": [
-        "clg_available"
+        "cooling-available"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "free_cool_oat": {
           "default": 65.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 75.0,
           "step": 1.0,
@@ -1808,13 +3109,17 @@
           "step": 0.05,
           "label": "Reheat frac"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav6",
@@ -1828,27 +3133,27 @@
     {
       "rule_id": "VAV-REHEAT",
       "title": "Reheat valve stuck / no temp rise",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "reheat_valve_pct",
-        "vav_discharge_t",
-        "vav_inlet_t",
-        "zone_flow"
+        "reheat-valve",
+        "vav-discharge-air-temp",
+        "vav-inlet-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -1859,7 +3164,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -1872,9 +3177,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat",
+      "pandas_implementation": "vav_reheat_stuck",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
       "test_coverage": [],
@@ -1885,29 +3202,29 @@
     {
       "rule_id": "VAV-AHU-LEAVE",
       "title": "VAV leave vs parent AHU SAT (fedBy)",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "vav_discharge_t",
-        "ahu_sat",
-        "zone_flow"
+        "vav-discharge-air-temp",
+        "ahu-discharge-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "delta_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -1920,9 +3237,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_ahu_leave",
+      "pandas_implementation": "vav_vs_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
       "test_coverage": [],
@@ -1933,33 +3262,26 @@
     {
       "rule_id": "VAV-7",
       "title": "Min airflow / fixed high flow",
-      "equipment_types": [],
+      "equipment_types": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow"
+        "zone-airflow"
       ],
       "optional_roles": [
         "min_flow_sp",
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "high_min_flow_sp": {
-          "default": 250.0,
-          "unit": "cfm",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 10.0,
-          "label": "High min-flow SP"
-        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -1967,14 +3289,6 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "fixed_flow_hours": {
-          "default": 1.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 6.0,
-          "step": 0.25,
-          "label": "Fixed-flow rolling window"
         },
         "fixed_flow_max_std": {
           "default": 15.0,
@@ -1991,9 +3305,29 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "Fixed-flow min mean"
+        },
+        "high_min_flow_sp": {
+          "default": 250.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "High min-flow SP"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_7",
+      "pandas_implementation": "vav7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
       "test_coverage": [
@@ -2006,10 +3340,12 @@
     {
       "rule_id": "CHW-1",
       "title": "Low chilled-water \u0394T",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_return_t"
+        "chilled-water-supply-temp",
+        "chilled-water-return-temp"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -2020,23 +3356,41 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_dt": {
           "default": 4.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Minimum delta-T"
+          "label": "Min \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "chw1",
@@ -2055,23 +3409,31 @@
     {
       "rule_id": "CHW-2",
       "title": "DP below SP at max pump speed",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_dp",
-        "chw_dp_sp",
-        "chw_pump_cmd"
+        "chw-diff-pressure",
+        "chw-diff-pressure-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -2087,9 +3449,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_2",
+      "pandas_implementation": "chw2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
       "test_coverage": [],
@@ -2100,33 +3474,53 @@
     {
       "rule_id": "CHW-3",
       "title": "Plant supply temp outside deadband",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_supply_sp",
-        "chw_pump_cmd"
+        "chilled-water-supply-temp",
+        "chilled-water-supply-temp-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sp_band": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_3",
+      "pandas_implementation": "chw3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
       "test_coverage": [],
@@ -2137,28 +3531,36 @@
     {
       "rule_id": "CHW-4",
       "title": "Flow high at max pump",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_flow",
-        "chw_pump_cmd"
+        "chw-flow",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flow_hi": {
-          "default": 1100.0,
+          "default": 1100,
           "unit": "gpm",
-          "min": 200.0,
-          "max": 3000.0,
-          "step": 50.0,
+          "min": 200,
+          "max": 3000,
+          "step": 50,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -2168,9 +3570,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_4",
+      "pandas_implementation": "chw4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
       "test_coverage": [],
@@ -2181,44 +3595,55 @@
     {
       "rule_id": "HP-1",
       "title": "Discharge cold when heating",
-      "equipment_types": [],
+      "equipment_types": [
+        "heatpump"
+      ],
       "required_roles": [
-        "sat",
-        "zone_t",
-        "fan_cmd"
+        "discharge-air-temp",
+        "zone-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "compressor_status",
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "compressor-status",
+        "equipment-enable",
+        "fan-status",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_sat": {
           "default": 85.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min discharge SAT"
+          "label": "Min heating SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold threshold"
+          "label": "Zone cold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "hp_1",
+      "pandas_implementation": "hp1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
       "test_coverage": [],
@@ -2229,31 +3654,37 @@
     {
       "rule_id": "WX-1",
       "title": "OA temperature spike",
-      "equipment_types": [],
+      "equipment_types": [
+        "weather"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx_1",
+      "pandas_implementation": "wx1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
       "test_coverage": [],
@@ -2264,10 +3695,12 @@
     {
       "rule_id": "CW-OPT-1",
       "title": "Condenser water not optimized vs wet-bulb",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
         "pump_status",
@@ -2275,19 +3708,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -2295,14 +3734,26 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt_1",
+      "pandas_implementation": "cw_opt",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
       "test_coverage": [],
@@ -2313,31 +3764,38 @@
     {
       "rule_id": "CW-APR-1",
       "title": "High CW approach at full tower fan",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -2350,9 +3808,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr_1",
+      "pandas_implementation": "cw_apr",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
       "test_coverage": [],
@@ -2363,31 +3833,38 @@
     {
       "rule_id": "CW-FAN-1",
       "title": "Excess tower fan energy vs wet-bulb limit",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -2395,7 +3872,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -2408,9 +3885,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_1",
+      "pandas_implementation": "cw_fan_excess",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
       "test_coverage": [],
@@ -2421,9 +3910,12 @@
     {
       "rule_id": "TRIM-1",
       "title": "Duct static trim advisory",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static"
+        "duct-static-pressure",
+        "vav-pressure-request-sum"
       ],
       "optional_roles": [
         "duct_static_sp",
@@ -2431,19 +3923,18 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -2456,9 +3947,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_1",
+      "pandas_implementation": "trim1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
       "test_coverage": [],
@@ -2469,9 +3972,12 @@
     {
       "rule_id": "TRIM-3",
       "title": "HWST trim advisory",
-      "equipment_types": [],
+      "equipment_types": [
+        "boiler"
+      ],
       "required_roles": [
-        "hw_supply_t"
+        "hot-water-supply-temp",
+        "hw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -2479,19 +3985,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -2504,9 +4016,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_3",
+      "pandas_implementation": "trim3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
       "test_coverage": [],
@@ -2517,9 +4041,12 @@
     {
       "rule_id": "TRIM-4",
       "title": "CHW plant reset advisory",
-      "equipment_types": [],
+      "equipment_types": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t"
+        "chilled-water-supply-temp",
+        "chw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -2527,19 +4054,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -2552,9 +4085,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_4",
+      "pandas_implementation": "trim4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
       "test_coverage": [],
@@ -2564,40 +4109,46 @@
     },
     {
       "rule_id": "SCHED-1",
-      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
-      "equipment_types": [],
+      "title": "Unoccupied runtime",
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "occ_mode",
-        "fan_status"
+        "occupied",
+        "fan-status"
       ],
       "optional_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 50.0,
-          "max": 80.0,
+          "min": 60.0,
+          "max": 78.0,
           "step": 0.5,
-          "label": "Zone comfort low"
+          "label": "Comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 55.0,
-          "max": 90.0,
+          "min": 68.0,
+          "max": 85.0,
           "step": 0.5,
-          "label": "Zone comfort high"
+          "label": "Comfort high"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "sched1",
@@ -2615,24 +4166,31 @@
     {
       "rule_id": "SCHED-247",
       "title": "Always-on fan or pump runtime",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "fan_status",
-        "pump_status",
-        "chiller_status",
-        "fan_cmd"
+        "fan-status",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "chiller-status",
+        "compressor-status",
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd",
+        "duct-static-pressure",
+        "chw-diff-pressure"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "always_on_pct": {
           "default": 0.95,
           "unit": "frac",
@@ -2640,6 +4198,26 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Always-on fraction"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "eng",
+          "min": 0.05,
+          "max": 2.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "_sched247",
@@ -2657,20 +4235,29 @@
     {
       "rule_id": "RESET-1",
       "title": "SAT reset not tracking outdoor air",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat_sp",
-        "oa_t"
+        "discharge-air-temp-sp",
+        "outside-air-temp"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "fan-status",
+        "fan-cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "reset_err_f": {
           "default": 3.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 10.0,
           "step": 0.5,
@@ -2678,15 +4265,15 @@
         },
         "reset_sat_at_65": {
           "default": 52.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 65.0,
           "step": 0.5,
-          "label": "SAT SP at 65F OAT"
+          "label": "SAT SP at 65\u00b0F OAT"
         },
         "reset_slope": {
           "default": 0.25,
-          "unit": "frac",
+          "unit": "\u00b0F/\u00b0F",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -2694,19 +4281,23 @@
         },
         "reset_oat_ref": {
           "default": 65.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 50.0,
           "max": 80.0,
           "step": 1.0,
           "label": "Reset OAT ref"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "reset1",
@@ -2720,24 +4311,30 @@
     {
       "rule_id": "CMD-1",
       "title": "Fan cmd/status mismatch",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "fan_status"
+        "fan-cmd",
+        "fan-status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cmd_1",
+      "pandas_implementation": "cmd1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
       "test_coverage": [],
@@ -2748,27 +4345,28 @@
     {
       "rule_id": "OA-1",
       "title": "Low OA fraction",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-status"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -2779,14 +4377,26 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "OAT/RAT guard"
+          "label": "Min |RAT\u2212OAT| guard"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "oa_1",
+      "pandas_implementation": "oa1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
       "test_coverage": [],
@@ -2797,11 +4407,13 @@
     {
       "rule_id": "DMP-1",
       "title": "OA damper leakage",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "oa_t",
-        "mat"
+        "outside-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
@@ -2809,24 +4421,28 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp_1",
+      "pandas_implementation": "dmp1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
       "test_coverage": [],
@@ -2837,30 +4453,24 @@
     {
       "rule_id": "VLV-1",
       "title": "Cooling valve leakage",
-      "equipment_types": [],
+      "equipment_types": [
+        "ahu"
+      ],
       "required_roles": [
-        "clg_valve_pct",
-        "sat",
-        "sat_sp",
-        "mat"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "mixed-air-temp",
+        "fan-status",
+        "fan-cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_err": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -2868,14 +4478,26 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv_1",
+      "pandas_implementation": "vlv1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
       "test_coverage": [],
@@ -3017,8 +4639,24 @@
       "title": "Sensor out of hard range",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -3038,16 +4676,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -3055,9 +4699,37 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
+        },
+        "range_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Humidity range scale"
+        },
+        "range_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.5,
+          "max": 2.0,
+          "step": 0.1,
+          "label": "Pressure range scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_range",
+      "pandas_implementation": "_sweep_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "sql_file": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
@@ -3070,8 +4742,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "equipment_energized",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -3180,8 +4852,24 @@
       "title": "Sensor flatline (stuck)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -3202,17 +4890,9 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
@@ -3221,13 +4901,25 @@
         "flatline_hours": {
           "default": 1.0,
           "unit": "h",
-          "min": 0.25,
-          "max": 12.0,
-          "step": 0.25,
+          "min": 0.5,
+          "max": 8.0,
+          "step": 0.5,
           "label": "Flatline window"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_flatline",
+      "pandas_implementation": "_sweep_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "sql_file": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
@@ -3239,8 +4931,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -3359,8 +5051,24 @@
       "title": "Sensor rate-of-change spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -3380,16 +5088,22 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-current",
+        "chw-flow",
+        "compressor-status",
+        "equipment-enable"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -3397,9 +5111,45 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
+        },
+        "spike_scale_temperature": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Temp spike scale"
+        },
+        "spike_scale_humidity": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Humidity spike scale"
+        },
+        "spike_scale_pressure": {
+          "default": 1.0,
+          "unit": "x",
+          "min": 0.25,
+          "max": 3.0,
+          "step": 0.25,
+          "label": "Pressure spike scale"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_spike",
+      "pandas_implementation": "_sweep_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "sql_file": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
@@ -3411,8 +5161,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "equipment_energized",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -3521,8 +5271,24 @@
       "title": "Stale data (no fresh samples)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -3538,14 +5304,6 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -3554,16 +5312,20 @@
           "step": 0.5,
           "label": "Stale window"
         },
-        "stale_tol": {
-          "default": 0.05,
-          "unit": "degF",
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
           "min": 0.0,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Stale tolerance"
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_stale",
+      "pandas_implementation": "_sweep_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "sql_file": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
@@ -3575,8 +5337,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -3697,8 +5459,24 @@
         "SV-SLEW"
       ],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "weather",
+        "zone",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -3709,14 +5487,6 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -3725,16 +5495,52 @@
           "step": 1.0,
           "label": "Fault persistence"
         },
-        "steady_fault_per_hour": {
-          "default": 6.0,
-          "unit": "degF_per_h",
-          "min": 1.0,
+        "transition_window_min": {
+          "default": 20.0,
+          "unit": "min",
+          "min": 5.0,
           "max": 60.0,
-          "step": 0.5,
-          "label": "Steady-state slew limit"
+          "step": 5.0,
+          "label": "Transition window"
+        },
+        "max_gap_hours": {
+          "default": 2.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Max sample gap"
+        },
+        "design_flow": {
+          "default": 0.0,
+          "unit": "cfm",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 100.0,
+          "label": "Design flow (flow profiles)"
+        },
+        "sensor_span": {
+          "default": 0.0,
+          "unit": "eng",
+          "min": 0.0,
+          "max": 100000.0,
+          "step": 10.0,
+          "label": "Sensor span (flow/pressure)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "sv_rate",
+      "pandas_implementation": "_sv_rate_compute",
       "datafusion_sql_implementation": "sv_rate.sql",
       "sql_file": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
@@ -3748,8 +5554,8 @@
       "parity_level": "sql_screening",
       "difference_class": "semantic_gap",
       "known_semantic_differences": "Pandas ROLE_TO_PROFILE has 30+ quantity/location slew limits; SQL windows five air temps against one STEADY_FAULT_PER_HOUR. Leave sql_screening; do not mark proven from B100 hours. Alias SV-SLEW is not an extra rule.",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -3868,39 +5674,37 @@
       "title": "Suspected control-output hunting",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct",
-        "htg_valve_pct",
-        "damper_pct",
-        "loop_enabled",
-        "fan_status",
-        "fan_cmd"
+        "loop-enabled"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 0.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "window_hours": {
-          "default": 1.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 4.0,
-          "step": 0.25,
-          "label": "Hunting lookback window"
-        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -3908,7 +5712,7 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "pct",
+          "unit": "% out",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
@@ -3916,38 +5720,50 @@
         },
         "total_variation_fault_pct": {
           "default": 500.0,
-          "unit": "pct",
+          "unit": "%/h",
           "min": 50.0,
           "max": 2000.0,
           "step": 50.0,
-          "label": "Total variation fault threshold"
+          "label": "Total travel threshold"
         },
         "minimum_equivalent_cycles": {
           "default": 2.5,
-          "unit": "count",
+          "unit": "cyc/h",
           "min": 0.5,
-          "max": 10.0,
+          "max": 20.0,
           "step": 0.5,
           "label": "Min equivalent cycles"
         },
         "minimum_reversals": {
-          "default": 4.0,
+          "default": 4,
           "unit": "count",
-          "min": 1.0,
-          "max": 20.0,
-          "step": 1.0,
+          "min": 1,
+          "max": 40,
+          "step": 1,
           "label": "Min direction reversals"
         },
         "minimum_coverage_pct": {
           "default": 80.0,
-          "unit": "pct",
-          "min": 50.0,
+          "unit": "%",
+          "min": 25.0,
           "max": 100.0,
           "step": 5.0,
-          "label": "Min window sample coverage"
+          "label": "Minimum data coverage"
+        },
+        "confirm_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "pid_hunt_1",
+      "pandas_implementation": "_pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "sql_file": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
@@ -3957,8 +5773,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 0,
       "parameters": {
         "confirm_seconds": {
@@ -4124,29 +5940,40 @@
       "canonical_id": "FC1",
       "pandas_id": "FC1",
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan",
+      "title": "Duct static below SP at full fan (GL36 A)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "inwc",
+          "unit": "in. w.c.",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -4154,15 +5981,43 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
+          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
+        },
+        "duct_static_err": {
+          "default": 0.12,
+          "unit": "in. w.c.",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Legacy duct-static error (sets \u03b5DSP)"
+        },
+        "fan_hi": {
+          "default": 0.87,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc1",
@@ -4178,8 +6033,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "eps_dsp": {
@@ -4295,23 +6150,95 @@
       "canonical_id": "FC2",
       "pandas_id": "FC2",
       "rule_id": "FC2",
-      "title": "Mixed air below envelope",
+      "title": "MAT below OAT/RAT envelope (GL36 B)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "sql_file": "fc2_mat_low.sql",
@@ -4322,8 +6249,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -4408,23 +6335,95 @@
       "canonical_id": "FC3",
       "pandas_id": "FC3",
       "rule_id": "FC3",
-      "title": "Mixed air above envelope",
+      "title": "MAT above OAT/RAT envelope (GL36 C)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "rat",
-        "fan_cmd"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_rat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "sql_file": "fc3_mat_high.sql",
@@ -4435,8 +6434,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -4524,33 +6523,57 @@
       "title": "PID hunting (operating-state oscillation)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct",
-        "fan_cmd"
+        "outside-air-damper",
+        "cooling-valve",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
+        "delta_os_max": {
+          "default": 5,
+          "unit": "count",
+          "min": 1,
+          "max": 30,
+          "step": 1,
+          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "delta_os_max": {
-          "default": 5.0,
-          "unit": "count",
-          "min": 1.0,
-          "max": 30.0,
-          "step": 1.0,
-          "label": "Max operating-state entries per hour"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc4",
@@ -4563,8 +6586,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -4673,35 +6696,54 @@
       "title": "SAT cold when heating commanded (GL36 D)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "htg_valve_pct",
-        "fan_cmd"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_sat": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -4710,6 +6752,42 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -4722,8 +6800,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -4842,28 +6920,46 @@
       "title": "Estimated OA fraction mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd",
-        "vav_total_flow"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "return-air-temp",
+        "vav-total-airflow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
+        "eps_airflow": {
+          "default": 0.15,
+          "unit": "frac",
+          "min": 0.05,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Airflow error \u03b5F (GL36 default 30%)"
+        },
+        "delta_t_min": {
+          "default": 5.0,
+          "unit": "\u00b0F",
           "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "max": 30.0,
+          "step": 0.5,
+          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
         },
         "airflow_err": {
           "default": 0.15,
@@ -4871,23 +6967,51 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Airflow error epsF (GL36 default 30%)"
+          "label": "Legacy OA-fraction error (sets \u03b5F)"
         },
-        "delta_t_min": {
+        "oat_rat_delta_min": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
+          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
         },
         "min_cfm_design": {
-          "default": 5000.0,
+          "default": 5000,
           "unit": "cfm",
+          "min": 500,
+          "max": 20000,
+          "step": 500,
+          "label": "Design min OA CFM"
+        },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
           "min": 0.0,
-          "max": 200000.0,
-          "step": 100.0,
-          "label": "Design minimum outdoor airflow"
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc6",
@@ -4900,8 +7024,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -5027,29 +7151,49 @@
       "canonical_id": "FC7",
       "pandas_id": "FC7",
       "rule_id": "FC7",
-      "title": "SAT low while heating at full",
+      "title": "SAT low with full heating (GL36 E)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "htg_valve_pct"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "fan-cmd",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_cmd",
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets epsSAT)"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -5059,13 +7203,33 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
+        "fan_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Fan-on command threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc7",
@@ -5083,8 +7247,8 @@
       "parity_level": "sql_screening",
       "difference_class": "missing_implementation",
       "known_semantic_differences": "concept_only \u2014 SQL file is a placeholder; do not claim twin parity",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -5200,23 +7364,111 @@
       "canonical_id": "FC8",
       "pandas_id": "FC8",
       "rule_id": "FC8",
-      "title": "SAT vs MAT while economizing",
+      "title": "SAT/MAT mismatch in economizer (GL36 F)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "sql_file": "fc8_sat_mat_econ.sql",
@@ -5227,8 +7479,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5313,23 +7565,103 @@
       "canonical_id": "FC9",
       "pandas_id": "FC9",
       "rule_id": "FC9",
-      "title": "OAT high vs SAT SP while economizing",
+      "title": "OAT too warm for free cooling (GL36 G)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "sql_file": "fc9_oa_sat_sp_econ.sql",
@@ -5340,8 +7672,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5426,23 +7758,95 @@
       "canonical_id": "FC10",
       "pandas_id": "FC10",
       "rule_id": "FC10",
-      "title": "MAT-OAT delta while cooling and economizing",
+      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "oa_t",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "mixed-air-temp",
+        "outside-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "sql_file": "fc10_mat_oa_clg.sql",
@@ -5453,8 +7857,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5539,23 +7943,103 @@
       "canonical_id": "FC11",
       "pandas_id": "FC11",
       "rule_id": "FC11",
-      "title": "OAT low vs SAT SP while cooling and economizing",
+      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "sat_sp",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_oat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
+        },
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "sql_file": "fc11_oa_sat_sp_clg.sql",
@@ -5566,8 +8050,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5652,23 +8136,119 @@
       "canonical_id": "FC12",
       "pandas_id": "FC12",
       "rule_id": "FC12",
-      "title": "SAT above MAT while cooling",
+      "title": "SAT above blend in cooling (GL36 J)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "mat",
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "discharge-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
-      "default_thresholds": {},
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
+      "default_thresholds": {
+        "eps_sat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
+        },
+        "eps_mat": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "supply_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
+        }
+      },
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "sql_file": "fc12_sat_mat_clg.sql",
@@ -5679,8 +8259,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -5765,64 +8345,95 @@
       "canonical_id": "FC13-SAT-HIGH",
       "pandas_id": "FC13",
       "rule_id": "FC13",
-      "title": "SAT above setpoint at full cooling",
+      "title": "SAT above SP at full cooling (GL36 K)",
       "aliases": [
         "FC13"
       ],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp",
-        "clg_valve_pct",
-        "oa_damper_pct"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "sat_err": {
+        "eps_sat": {
           "default": 1.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT high error band"
+          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
         },
-        "clg_valve_min": {
+        "sat_err": {
+          "default": 1.0,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy SAT error (sets \u03b5SAT)"
+        },
+        "clg_full_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
+          "min": 0.5,
+          "max": 1.0,
           "step": 0.01,
-          "label": "Cooling valve open threshold"
+          "label": "Full-cooling threshold (GL36 99%)"
         },
-        "oa_damper_econ_low": {
+        "econ_min_pos": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "OA damper economizer low"
+          "label": "Economizer minimum-position threshold"
         },
-        "oa_damper_econ_high": {
+        "econ_full_open": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "OA damper economizer high"
+          "label": "Economizer full-open threshold"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc13",
@@ -5837,8 +8448,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: FC13 (not independent rules)",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -5977,10 +8588,17 @@
       "title": "CHW coil \u0394T when inactive (GL36 L)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "clg_valve_pct"
+        "cooling-coil-entering-temp",
+        "cooling-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
         "cooling_coil_entering_temp",
@@ -5991,23 +8609,90 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_ccet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Cooling-coil entering sensor error \u03b5CCET"
+        },
+        "eps_cclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "htg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Heating-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc14",
@@ -6020,8 +8705,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -6130,9 +8815,18 @@
       "title": "HW coil \u0394T when inactive (GL36 M)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
-      "required_roles": [],
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
+      "required_roles": [
+        "heating-coil-entering-temp",
+        "heating-coil-leaving-temp",
+        "outside-air-damper",
+        "cooling-valve"
+      ],
       "optional_roles": [
         "heating_coil_entering_temp",
         "heating_coil_leaving_temp",
@@ -6143,23 +8837,98 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "mix_tol": {
+        "eps_hcet": {
           "default": 1.15,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all eps values)"
+          "label": "Heating-coil entering sensor error \u03b5HCET"
+        },
+        "eps_hclt": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Heating-coil leaving sensor error \u03b5HCLT"
+        },
+        "delta_supply_fan": {
+          "default": 0.55,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 5.0,
+          "step": 0.05,
+          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+        },
+        "econ_min_pos": {
+          "default": 0.05,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Economizer minimum-position threshold"
+        },
+        "econ_full_open": {
+          "default": 0.9,
+          "unit": "frac",
+          "min": 0.5,
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Economizer full-open threshold"
+        },
+        "clg_inactive_max": {
+          "default": 0.1,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.5,
+          "step": 0.01,
+          "label": "Cooling-command inactive ceiling"
+        },
+        "clg_on_min": {
+          "default": 0.01,
+          "unit": "frac",
+          "min": 0.0,
+          "max": 0.25,
+          "step": 0.01,
+          "label": "Cooling-command ON threshold"
+        },
+        "mix_tol": {
+          "default": 1.15,
+          "unit": "\u00b0F",
+          "min": 0.0,
+          "max": 10.0,
+          "step": 0.25,
+          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
+        },
+        "mode_delay_min": {
+          "default": 0.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Mode-change suspension (GL36 default 30)"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "fc15",
@@ -6172,8 +8941,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -6282,36 +9051,51 @@
       "title": "SAT deviation from setpoint",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat",
-        "sat_sp"
+        "discharge-air-temp",
+        "discharge-air-temp-sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_satdev",
+      "pandas_implementation": "ahu_sat_dev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "sql_file": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
@@ -6323,8 +9107,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -6433,12 +9217,15 @@
       "title": "Duct static pressure high",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static",
-        "duct_static_sp",
-        "fan_cmd"
+        "duct-static-pressure",
+        "duct-static-pressure-sp"
       ],
       "optional_roles": [
         "fan_status",
@@ -6446,17 +9233,9 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -6464,14 +9243,26 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_ducthi",
+      "pandas_implementation": "ahu_duct_high",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "sql_file": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
@@ -6483,8 +9274,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -6603,26 +9394,29 @@
       "title": "Heating and cooling simultaneous",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "htg_valve_pct",
-        "clg_valve_pct"
+        "heating-valve",
+        "cooling-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -6630,9 +9424,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul",
+      "pandas_implementation": "ahu_simul_heat_cool",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "sql_file": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
@@ -6642,8 +9448,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -6749,13 +9555,18 @@
       "canonical_id": "OAT-METEO",
       "pandas_id": "OAT-METEO",
       "rule_id": "OAT-METEO",
-      "title": "Equipment OAT vs weather-staged wx OAT",
+      "title": "BAS outdoor-air sensor vs Open-Meteo",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp",
+        "web-outside-air-temp"
       ],
       "optional_roles": [
         "web_oa_t"
@@ -6764,19 +9575,23 @@
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "OAT vs meteo tolerance"
+          "label": "Max OAT disagreement"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
         },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -6789,8 +9604,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 900,
       "parameters": {
         "oat_err": {
@@ -6897,37 +9712,52 @@
       "canonical_id": "ECON-1",
       "pandas_id": "ECON-1",
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed when OAT favorable",
+      "title": "Economizer stuck closed",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "oa_damper_pct",
-        "oa_t"
+        "fan-cmd",
+        "outside-air-damper",
+        "outside-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
         },
-        "econ1_damper_max": {
-          "default": 0.05,
-          "unit": "frac",
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
           "min": 0.0,
-          "max": 0.2,
-          "step": 0.01,
-          "label": "Stuck-closed damper frac"
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ1",
@@ -6940,8 +9770,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "econ1_oat_min": {
@@ -7047,24 +9877,35 @@
       "canonical_id": "ECON-2",
       "pandas_id": "ECON-2",
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor air unfavorable",
+      "title": "Economizing when outdoor unfavorable",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_t",
-        "oa_damper_pct"
+        "outside-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -7078,13 +9919,17 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 300,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 300.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ2",
@@ -7099,8 +9944,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "econ2_oat_hi": {
@@ -7219,31 +10064,33 @@
       "title": "Mech cooling without integrated economizer",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -7251,7 +10098,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -7259,7 +10106,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -7272,9 +10119,21 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_3",
+      "pandas_implementation": "econ2",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "sql_file": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
@@ -7284,8 +10143,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -7424,35 +10283,50 @@
       "title": "Low estimated OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "pct",
+          "unit": "%",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 600,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "econ4",
@@ -7465,8 +10339,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "oa_min_pct": {
@@ -7575,38 +10449,53 @@
       "title": "Preheat over-conditioning",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "preheat_leave_t",
-        "sat_sp",
-        "oa_t",
-        "htg_valve_pct"
+        "preheat-leaving-temp",
+        "discharge-air-temp-sp",
+        "outside-air-temp",
+        "heating-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_5",
+      "pandas_implementation": "econ5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "sql_file": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
@@ -7616,8 +10505,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -7726,29 +10615,30 @@
       "title": "Economizing in freezing weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "web_oa_t",
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -7761,9 +10651,21 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_6",
+      "pandas_implementation": "econ6_compute",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "sql_file": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
@@ -7773,8 +10675,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -7893,31 +10795,35 @@
       "title": "Economizer OK but not economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "clg_valve_pct"
+        "outside-air-damper"
       ],
       "optional_roles": [
-        "web_oa_t",
-        "web_oa_dp",
-        "fan_status",
-        "fan_cmd"
+        "web-outside-air-temp",
+        "web-outside-air-dewpoint",
+        "web-outside-air-humidity",
+        "cooling-valve",
+        "compressor-status",
+        "dx-cool-cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -7925,7 +10831,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -7933,7 +10839,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -7946,9 +10852,21 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ_7",
+      "pandas_implementation": "econ7_compute",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "sql_file": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
@@ -7958,8 +10876,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -8098,35 +11016,50 @@
       "title": "Mechanical cooling below 60\u00b0F web OAT",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "chiller",
+        "heatpump"
+      ],
       "required_roles": [
         "web_oa_t"
       ],
       "optional_roles": [
-        "clg_valve_pct",
-        "chiller_status"
+        "web-outside-air-temp",
+        "compressor-status",
+        "chiller-status",
+        "chw-pump-status",
+        "dx-cool-cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat_1",
+      "pandas_implementation": "mech_oat1_compute",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "sql_file": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
@@ -8136,8 +11069,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -8246,29 +11179,60 @@
       "title": "Chiller running with no building load",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "chiller_status",
-        "chiller_cmd",
-        "chw_pump_status",
-        "chw_pump_cmd",
-        "building_zone_load_satisfied",
-        "building_ahu_load_satisfied"
+        "chiller-status",
+        "chw-pump-status",
+        "compressor-status",
+        "building-zone-load-satisfied",
+        "building-ahu-load-satisfied"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "comfort_low_f": {
+          "default": 70.0,
+          "unit": "\u00b0F",
+          "min": 60.0,
+          "max": 78.0,
+          "step": 0.5,
+          "label": "Comfort low"
+        },
+        "comfort_high_f": {
+          "default": 75.0,
+          "unit": "\u00b0F",
+          "min": 68.0,
+          "max": 85.0,
+          "step": 0.5,
+          "label": "Comfort high"
+        },
+        "sat_band_f": {
+          "default": 2.0,
+          "unit": "\u00b0F",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "AHU SAT\u2248SP band"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_noload_1",
+      "pandas_implementation": "chw_noload1_compute",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "sql_file": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
@@ -8278,8 +11242,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -8375,42 +11339,52 @@
       "canonical_id": "VAV-1",
       "pandas_id": "VAV-1",
       "rule_id": "VAV-1",
-      "title": "Zone comfort band violation hours with confirm window",
+      "title": "Zone comfort band",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav",
+        "zone"
+      ],
+      "equipment_kinds": [
+        "vav",
+        "zone"
+      ],
       "required_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "optional_roles": [
         "occ_mode"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_t_lo": {
+        "zone_lo": {
           "default": 70.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_t_hi": {
+        "zone_hi": {
           "default": 75.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav1",
@@ -8426,8 +11400,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 900,
       "parameters": {
         "zone_t_lo": {
@@ -8544,33 +11518,45 @@
       "canonical_id": "VAV-2",
       "pandas_id": "VAV-2",
       "rule_id": "VAV-2",
-      "title": "Night setback miss \u2014 unoccupied zone above heating setback",
+      "title": "Night setback miss",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
-      "required_roles": [
-        "zone_t",
-        "occ_mode"
+      "equipment_types": [
+        "vav",
+        "zone"
       ],
-      "optional_roles": [],
+      "equipment_kinds": [
+        "vav",
+        "zone"
+      ],
+      "required_roles": [
+        "zone-air-temp",
+        "occupied"
+      ],
+      "optional_roles": [
+        "occ-mode"
+      ],
       "operational_proof_roles": [],
       "default_thresholds": {
         "setback_hi": {
           "default": 68.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Setback high"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
-          "default": 900,
-          "unit": "sec",
-          "min": 0,
-          "max": 3600,
-          "step": 300,
-          "label": "Confirm time"
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav2",
@@ -8583,8 +11569,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 900,
       "parameters": {
         "setback_hi": {
@@ -8693,30 +11679,32 @@
       "title": "Excessive reheat during warm weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "oa_t",
-        "reheat_valve_pct",
-        "zone_flow"
+        "outside-air-temp",
+        "reheat-valve"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -8737,9 +11725,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_3",
+      "pandas_implementation": "vav3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "sql_file": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
@@ -8749,8 +11749,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -8879,26 +11879,29 @@
       "title": "Damper stuck at full open",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "damper_pct",
-        "zone_flow"
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd",
+        "loop-enabled"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -8906,6 +11909,14 @@
           "max": 1.0,
           "step": 0.005,
           "label": "Full open frac"
+        },
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
         },
         "flow_on_min": {
           "default": 25.0,
@@ -8915,16 +11926,20 @@
           "step": 5.0,
           "label": "Airflow-on min"
         },
-        "sustain_hours": {
-          "default": 1.5,
-          "unit": "h",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "Sustain window"
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_4",
+      "pandas_implementation": "vav4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "sql_file": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
@@ -8934,8 +11949,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "control_loop",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -9064,28 +12079,43 @@
       "title": "Airflow sensor bias",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow",
-        "damper_pct"
+        "zone-airflow",
+        "damper"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_5",
+      "pandas_implementation": "vav5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "sql_file": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
@@ -9095,8 +12125,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -9195,20 +12225,31 @@
       "title": "Reheat when cooling available",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "oa_t",
-        "reheat_valve_pct"
+        "outside-air-temp",
+        "reheat-valve"
       ],
       "optional_roles": [
-        "clg_available"
+        "cooling-available"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "free_cool_oat": {
           "default": 65.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 75.0,
           "step": 1.0,
@@ -9222,13 +12263,17 @@
           "step": 0.05,
           "label": "Reheat frac"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "vav6",
@@ -9241,8 +12286,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "free_cool_oat": {
@@ -9361,28 +12406,30 @@
       "title": "Reheat valve stuck / no temp rise",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "reheat_valve_pct",
-        "vav_discharge_t",
-        "vav_inlet_t",
-        "zone_flow"
+        "reheat-valve",
+        "vav-discharge-air-temp",
+        "vav-inlet-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -9393,7 +12440,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -9406,9 +12453,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat",
+      "pandas_implementation": "vav_reheat_stuck",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "sql_file": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
@@ -9418,8 +12477,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -9548,30 +12607,32 @@
       "title": "VAV leave vs parent AHU SAT (fedBy)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "vav_discharge_t",
-        "ahu_sat",
-        "zone_flow"
+        "vav-discharge-air-temp",
+        "ahu-discharge-air-temp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "delta_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -9584,9 +12645,21 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_ahu_leave",
+      "pandas_implementation": "vav_vs_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "sql_file": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
@@ -9596,8 +12669,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -9716,34 +12789,29 @@
       "title": "Min airflow / fixed high flow",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "vav"
+      ],
+      "equipment_kinds": [
+        "vav"
+      ],
       "required_roles": [
-        "zone_flow"
+        "zone-airflow"
       ],
       "optional_roles": [
         "min_flow_sp",
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
-        "high_min_flow_sp": {
-          "default": 250.0,
-          "unit": "cfm",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 10.0,
-          "label": "High min-flow SP"
-        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -9751,14 +12819,6 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "fixed_flow_hours": {
-          "default": 1.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 6.0,
-          "step": 0.25,
-          "label": "Fixed-flow rolling window"
         },
         "fixed_flow_max_std": {
           "default": 15.0,
@@ -9775,9 +12835,29 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "Fixed-flow min mean"
+        },
+        "high_min_flow_sp": {
+          "default": 250.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "High min-flow SP"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_7",
+      "pandas_implementation": "vav7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "sql_file": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
@@ -9789,8 +12869,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -9939,11 +13019,15 @@
       "title": "Low chilled-water \u0394T",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_return_t"
+        "chilled-water-supply-temp",
+        "chilled-water-return-temp"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -9954,23 +13038,41 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_dt": {
           "default": 4.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Minimum delta-T"
+          "label": "Min \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "chw1",
@@ -9988,8 +13090,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "Missing proof \u2192 pandas SKIPPED_MISSING_ROLES; SQL returns 0 fault hours (optional proof roles). Proven-off zeros do not accumulate \u0394T hours.",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 900,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -10098,24 +13200,34 @@
       "title": "DP below SP at max pump speed",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_dp",
-        "chw_dp_sp",
-        "chw_pump_cmd"
+        "chw-diff-pressure",
+        "chw-diff-pressure-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -10131,9 +13243,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_2",
+      "pandas_implementation": "chw2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "sql_file": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
@@ -10143,8 +13267,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -10263,34 +13387,56 @@
       "title": "Plant supply temp outside deadband",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t",
-        "chw_supply_sp",
-        "chw_pump_cmd"
+        "chilled-water-supply-temp",
+        "chilled-water-supply-temp-sp",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sp_band": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_3",
+      "pandas_implementation": "chw3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "sql_file": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
@@ -10300,8 +13446,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -10410,29 +13556,39 @@
       "title": "Flow high at max pump",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_flow",
-        "chw_pump_cmd"
+        "chw-flow",
+        "chw-pump-cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "flow_hi": {
-          "default": 1100.0,
+          "default": 1100,
           "unit": "gpm",
-          "min": 200.0,
-          "max": 3000.0,
-          "step": 50.0,
+          "min": 200,
+          "max": 3000,
+          "step": 50,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -10442,9 +13598,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw_4",
+      "pandas_implementation": "chw4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "sql_file": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
@@ -10454,8 +13622,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -10574,45 +13742,58 @@
       "title": "Discharge cold when heating",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "heatpump"
+      ],
       "required_roles": [
-        "sat",
-        "zone_t",
-        "fan_cmd"
+        "discharge-air-temp",
+        "zone-air-temp",
+        "fan-cmd"
       ],
       "optional_roles": [
         "compressor_status",
         "fan_status"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "compressor-status",
+        "equipment-enable",
+        "fan-status",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_sat": {
           "default": 85.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min discharge SAT"
+          "label": "Min heating SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold threshold"
+          "label": "Zone cold"
+        },
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "hp_1",
+      "pandas_implementation": "hp1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "sql_file": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
@@ -10622,8 +13803,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "compressor",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -10742,32 +13923,40 @@
       "title": "OA temperature spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "weather"
+      ],
+      "equipment_kinds": [
+        "weather"
+      ],
       "required_roles": [
-        "oa_t"
+        "outside-air-temp"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
+        },
+        "confirm_min": {
+          "default": 5.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx_1",
+      "pandas_implementation": "wx1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "sql_file": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
@@ -10777,8 +13966,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -10887,11 +14076,16 @@
       "title": "Condenser water not optimized vs wet-bulb",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
         "pump_status",
@@ -10899,19 +14093,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -10919,14 +14119,26 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt_1",
+      "pandas_implementation": "cw_opt",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "sql_file": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
@@ -10936,8 +14148,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11056,32 +14268,42 @@
       "title": "High CW approach at full tower fan",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -11094,9 +14316,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr_1",
+      "pandas_implementation": "cw_apr",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "sql_file": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
@@ -11106,8 +14340,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11226,32 +14460,42 @@
       "title": "Excess tower fan energy vs wet-bulb limit",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller",
+        "cooling_tower"
+      ],
+      "equipment_kinds": [
+        "chiller",
+        "cooling_tower"
+      ],
       "required_roles": [
-        "cw_supply_t",
-        "web_wb_t",
-        "tower_fan_cmd"
+        "condenser-water-supply-temp"
       ],
       "optional_roles": [
-        "pump_status",
-        "chiller_status",
-        "chw_flow",
-        "chw_pump_cmd"
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "web-outside-air-wetbulb"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -11259,7 +14503,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -11272,9 +14516,21 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_1",
+      "pandas_implementation": "cw_fan_excess",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "sql_file": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
@@ -11284,8 +14540,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -11414,10 +14670,15 @@
       "title": "Duct static trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "duct_static"
+        "duct-static-pressure",
+        "vav-pressure-request-sum"
       ],
       "optional_roles": [
         "duct_static_sp",
@@ -11425,19 +14686,18 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in_wc",
+          "unit": "in. w.c.",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -11450,9 +14710,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_1",
+      "pandas_implementation": "trim1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "sql_file": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
@@ -11462,8 +14734,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -11582,10 +14854,15 @@
       "title": "HWST trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "boiler"
+      ],
+      "equipment_kinds": [
+        "boiler"
+      ],
       "required_roles": [
-        "hw_supply_t"
+        "hot-water-supply-temp",
+        "hw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -11593,19 +14870,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -11618,9 +14901,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_3",
+      "pandas_implementation": "trim3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "sql_file": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
@@ -11630,8 +14925,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -11750,10 +15045,15 @@
       "title": "CHW plant reset advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "chiller"
+      ],
+      "equipment_kinds": [
+        "chiller"
+      ],
       "required_roles": [
-        "chw_supply_t"
+        "chilled-water-supply-temp",
+        "chw-reset-request-sum"
       ],
       "optional_roles": [
         "pump_status",
@@ -11761,19 +15061,25 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "pump-speed-feedback",
+        "pump-current",
+        "chw-flow",
+        "water-flow",
+        "chiller-status",
+        "chiller-current",
+        "chiller-power",
+        "pump-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -11786,9 +15092,21 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim_4",
+      "pandas_implementation": "trim4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "sql_file": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
@@ -11798,8 +15116,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "hydronic_flow",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -11915,45 +15233,53 @@
       "canonical_id": "SCHED-1",
       "pandas_id": "SCHED-1",
       "rule_id": "SCHED-1",
-      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
+      "title": "Unoccupied runtime",
       "aliases": [
         "excess_runtime"
       ],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "occ_mode",
-        "fan_status"
+        "occupied",
+        "fan-status"
       ],
       "optional_roles": [
-        "zone_t"
+        "zone-air-temp"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 50.0,
-          "max": 80.0,
+          "min": 60.0,
+          "max": 78.0,
           "step": 0.5,
-          "label": "Zone comfort low"
+          "label": "Comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 55.0,
-          "max": 90.0,
+          "min": 68.0,
+          "max": 85.0,
           "step": 0.5,
-          "label": "Zone comfort high"
+          "label": "Comfort high"
+        },
+        "confirm_min": {
+          "default": 30.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "sched1",
@@ -11970,8 +15296,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: excess_runtime (not independent rules)",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -12090,25 +15416,38 @@
       "title": "Always-on fan or pump runtime",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
+      "equipment_kinds": [
+        "ahu",
+        "vav",
+        "chiller",
+        "boiler",
+        "heatpump"
+      ],
       "required_roles": [],
       "optional_roles": [
-        "fan_status",
-        "pump_status",
-        "chiller_status",
-        "fan_cmd"
+        "fan-status",
+        "pump-status",
+        "chw-pump-status",
+        "hw-pump-status",
+        "chiller-status",
+        "compressor-status",
+        "tower-fan-cmd",
+        "cw-fan-cmd",
+        "fan-cmd",
+        "chw-pump-cmd",
+        "hw-pump-cmd",
+        "duct-static-pressure",
+        "chw-diff-pressure"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 3600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "always_on_pct": {
           "default": 0.95,
           "unit": "frac",
@@ -12116,6 +15455,26 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Always-on fraction"
+        },
+        "pressure_on_min": {
+          "default": 0.2,
+          "unit": "eng",
+          "min": 0.05,
+          "max": 2.0,
+          "step": 0.05,
+          "label": "Pressure-on evidence"
+        },
+        "confirm_min": {
+          "default": 60.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec"
         }
       },
       "pandas_implementation": "_sched247",
@@ -12132,8 +15491,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "4.3 ranked proof (status/current > command; pressure inferred only). SQL mean(on) >= always_on_pct over the analysis window matches pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -12242,21 +15601,32 @@
       "title": "SAT reset not tracking outdoor air",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "sat_sp",
-        "oa_t"
+        "discharge-air-temp-sp",
+        "outside-air-temp"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "fan-status",
+        "fan-cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
         "reset_err_f": {
           "default": 3.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 10.0,
           "step": 0.5,
@@ -12264,15 +15634,15 @@
         },
         "reset_sat_at_65": {
           "default": 52.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 45.0,
           "max": 65.0,
           "step": 0.5,
-          "label": "SAT SP at 65F OAT"
+          "label": "SAT SP at 65\u00b0F OAT"
         },
         "reset_slope": {
           "default": 0.25,
-          "unit": "frac",
+          "unit": "\u00b0F/\u00b0F",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -12280,19 +15650,23 @@
         },
         "reset_oat_ref": {
           "default": 65.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 50.0,
           "max": 80.0,
           "step": 1.0,
           "label": "Reset OAT ref"
         },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
       "pandas_implementation": "reset1",
@@ -12305,8 +15679,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "reset_err_f": {
@@ -12445,25 +15819,33 @@
       "title": "Fan cmd/status mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "fan_cmd",
-        "fan_status"
+        "fan-cmd",
+        "fan-status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_min": {
+          "default": 10.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "cmd_1",
+      "pandas_implementation": "cmd1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "sql_file": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
@@ -12473,8 +15855,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "always",
+      "startup_delay_seconds": 0.0,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -12573,28 +15955,31 @@
       "title": "Low OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "mat",
-        "rat",
-        "oa_t",
-        "fan_cmd"
+        "mixed-air-temp",
+        "return-air-temp",
+        "outside-air-temp",
+        "fan-status"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [],
+      "operational_proof_roles": [
+        "fan-status",
+        "fan-speed-feedback",
+        "fan-current",
+        "fan-power",
+        "airflow-proof",
+        "fan-cmd"
+      ],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -12605,14 +15990,26 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "OAT/RAT guard"
+          "label": "Min |RAT\u2212OAT| guard"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "oa_1",
+      "pandas_implementation": "oa1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "sql_file": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
@@ -12622,8 +16019,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "fan_running",
+      "startup_delay_seconds": 600,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12742,12 +16139,16 @@
       "title": "OA damper leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "oa_damper_pct",
-        "oa_t",
-        "mat"
+        "outside-air-temp",
+        "mixed-air-temp",
+        "outside-air-damper"
       ],
       "optional_roles": [
         "fan_status",
@@ -12755,24 +16156,28 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp_1",
+      "pandas_implementation": "dmp1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "sql_file": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
@@ -12782,8 +16187,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12892,31 +16297,27 @@
       "title": "Cooling valve leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [],
-      "equipment_kinds": null,
+      "equipment_types": [
+        "ahu"
+      ],
+      "equipment_kinds": [
+        "ahu"
+      ],
       "required_roles": [
-        "clg_valve_pct",
-        "sat",
-        "sat_sp",
-        "mat"
+        "discharge-air-temp",
+        "discharge-air-temp-sp",
+        "cooling-valve"
       ],
       "optional_roles": [
-        "fan_status",
-        "fan_cmd"
+        "mixed-air-temp",
+        "fan-status",
+        "fan-cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec",
-          "min": 0.0,
-          "max": 3600.0,
-          "step": 300.0,
-          "label": "Confirm time"
-        },
         "sat_err": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -12924,14 +16325,26 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "degF",
+          "unit": "\u00b0F",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
+        },
+        "confirm_min": {
+          "default": 15.0,
+          "unit": "min",
+          "min": 0.0,
+          "max": 60.0,
+          "step": 1.0,
+          "label": "Fault confirm delay"
+        },
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv_1",
+      "pandas_implementation": "vlv1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "sql_file": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
@@ -12941,8 +16354,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_or_occupied_when_declared",
-      "startup_delay_seconds": null,
+      "operational_gate": "conditional",
+      "startup_delay_seconds": 300,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {

--- a/sql_rules/generated/parity_inventory.json
+++ b/sql_rules/generated/parity_inventory.json
@@ -43,15 +43,7 @@
     {
       "rule_id": "SV-RANGE",
       "title": "Sensor out of hard range",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -71,22 +63,16 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -94,37 +80,9 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
-        },
-        "range_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Humidity range scale"
-        },
-        "range_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Pressure range scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_range",
+      "pandas_implementation": "sv_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
       "test_coverage": [
@@ -138,15 +96,7 @@
     {
       "rule_id": "SV-FLATLINE",
       "title": "Sensor flatline (stuck)",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -167,9 +117,17 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
@@ -178,25 +136,13 @@
         "flatline_hours": {
           "default": 1.0,
           "unit": "h",
-          "min": 0.5,
-          "max": 8.0,
-          "step": 0.5,
+          "min": 0.25,
+          "max": 12.0,
+          "step": 0.25,
           "label": "Flatline window"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_flatline",
+      "pandas_implementation": "sv_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
       "test_coverage": [
@@ -209,15 +155,7 @@
     {
       "rule_id": "SV-SPIKE",
       "title": "Sensor rate-of-change spike",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -237,22 +175,16 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -260,45 +192,9 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
-        },
-        "spike_scale_temperature": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Temp spike scale"
-        },
-        "spike_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Humidity spike scale"
-        },
-        "spike_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Pressure spike scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_spike",
+      "pandas_implementation": "sv_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
       "test_coverage": [
@@ -311,15 +207,7 @@
     {
       "rule_id": "SV-STALE",
       "title": "Stale data (no fresh samples)",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -335,6 +223,14 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -343,20 +239,16 @@
           "step": 0.5,
           "label": "Stale window"
         },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
+        "stale_tol": {
+          "default": 0.05,
+          "unit": "degF",
           "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Stale tolerance"
         }
       },
-      "pandas_implementation": "_sweep_stale",
+      "pandas_implementation": "sv_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
       "test_coverage": [
@@ -369,15 +261,7 @@
     {
       "rule_id": "SV-RATE",
       "title": "Context-aware sensor rate of change",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -388,6 +272,14 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -396,52 +288,16 @@
           "step": 1.0,
           "label": "Fault persistence"
         },
-        "transition_window_min": {
-          "default": 20.0,
-          "unit": "min",
-          "min": 5.0,
+        "steady_fault_per_hour": {
+          "default": 6.0,
+          "unit": "degF_per_h",
+          "min": 1.0,
           "max": 60.0,
-          "step": 5.0,
-          "label": "Transition window"
-        },
-        "max_gap_hours": {
-          "default": 2.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 6.0,
-          "step": 0.25,
-          "label": "Max sample gap"
-        },
-        "design_flow": {
-          "default": 0.0,
-          "unit": "cfm",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 100.0,
-          "label": "Design flow (flow profiles)"
-        },
-        "sensor_span": {
-          "default": 0.0,
-          "unit": "eng",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 10.0,
-          "label": "Sensor span (flow/pressure)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "step": 0.5,
+          "label": "Steady-state slew limit"
         }
       },
-      "pandas_implementation": "_sv_rate_compute",
+      "pandas_implementation": "sv_rate",
       "datafusion_sql_implementation": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
       "test_coverage": [
@@ -456,30 +312,38 @@
     {
       "rule_id": "PID-HUNT-1",
       "title": "Suspected control-output hunting",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
-        "loop-enabled"
+        "oa_damper_pct",
+        "clg_valve_pct",
+        "htg_valve_pct",
+        "damper_pct",
+        "loop_enabled",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 0.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "window_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 4.0,
+          "step": 0.25,
+          "label": "Hunting lookback window"
+        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -487,7 +351,7 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
@@ -495,50 +359,38 @@
         },
         "total_variation_fault_pct": {
           "default": 500.0,
-          "unit": "%/h",
+          "unit": "pct",
           "min": 50.0,
           "max": 2000.0,
           "step": 50.0,
-          "label": "Total travel threshold"
+          "label": "Total variation fault threshold"
         },
         "minimum_equivalent_cycles": {
           "default": 2.5,
-          "unit": "cyc/h",
+          "unit": "count",
           "min": 0.5,
-          "max": 20.0,
+          "max": 10.0,
           "step": 0.5,
           "label": "Min equivalent cycles"
         },
         "minimum_reversals": {
-          "default": 4,
+          "default": 4.0,
           "unit": "count",
-          "min": 1,
-          "max": 40,
-          "step": 1,
+          "min": 1.0,
+          "max": 20.0,
+          "step": 1.0,
           "label": "Min direction reversals"
         },
         "minimum_coverage_pct": {
           "default": 80.0,
-          "unit": "%",
-          "min": 25.0,
+          "unit": "pct",
+          "min": 50.0,
           "max": 100.0,
           "step": 5.0,
-          "label": "Minimum data coverage"
-        },
-        "confirm_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "label": "Min window sample coverage"
         }
       },
-      "pandas_implementation": "_pid_hunt_1",
+      "pandas_implementation": "pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
       "test_coverage": [],
@@ -548,35 +400,26 @@
     },
     {
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan (GL36 A)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Duct static below SP at full fan",
+      "equipment_types": [],
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp",
-        "fan-cmd"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "in. w.c.",
+          "unit": "inwc",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -584,43 +427,15 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
-        },
-        "duct_static_err": {
-          "default": 0.12,
-          "unit": "in. w.c.",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Legacy duct-static error (sets \u03b5DSP)"
-        },
-        "fan_hi": {
-          "default": 0.87,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
         },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc1",
@@ -636,90 +451,20 @@
     },
     {
       "rule_id": "FC2",
-      "title": "MAT below OAT/RAT envelope (GL36 B)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Mixed air below envelope",
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc2",
@@ -730,90 +475,20 @@
     },
     {
       "rule_id": "FC3",
-      "title": "MAT above OAT/RAT envelope (GL36 C)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Mixed air above envelope",
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc3",
@@ -825,54 +500,32 @@
     {
       "rule_id": "FC4",
       "title": "PID hunting (operating-state oscillation)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve",
-        "fan-cmd"
+        "oa_damper_pct",
+        "clg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "delta_os_max": {
-          "default": 5,
-          "unit": "count",
-          "min": 1,
-          "max": 30,
-          "step": 1,
-          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "delta_os_max": {
+          "default": 5.0,
+          "unit": "count",
+          "min": 1.0,
+          "max": 30.0,
+          "step": 1.0,
+          "label": "Max operating-state entries per hour"
         }
       },
       "pandas_implementation": "fc4",
@@ -886,51 +539,34 @@
     {
       "rule_id": "FC5",
       "title": "SAT cold when heating commanded (GL36 D)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "mat",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -939,42 +575,6 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -988,43 +588,27 @@
     {
       "rule_id": "FC6",
       "title": "Estimated OA fraction mismatch",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "vav-total-airflow"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd",
+        "vav_total_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_airflow": {
-          "default": 0.15,
-          "unit": "frac",
-          "min": 0.05,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Airflow error \u03b5F (GL36 default 30%)"
-        },
-        "delta_t_min": {
-          "default": 5.0,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 30.0,
-          "step": 0.5,
-          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "airflow_err": {
           "default": 0.15,
@@ -1032,51 +616,23 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Legacy OA-fraction error (sets \u03b5F)"
+          "label": "Airflow error epsF (GL36 default 30%)"
         },
-        "oat_rat_delta_min": {
+        "delta_t_min": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
+          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
         },
         "min_cfm_design": {
-          "default": 5000,
+          "default": 5000.0,
           "unit": "cfm",
-          "min": 500,
-          "max": 20000,
-          "step": 500,
-          "label": "Design min OA CFM"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
           "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "max": 200000.0,
+          "step": 100.0,
+          "label": "Design minimum outdoor airflow"
         }
       },
       "pandas_implementation": "fc6",
@@ -1089,44 +645,26 @@
     },
     {
       "rule_id": "FC7",
-      "title": "SAT low with full heating (GL36 E)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT low while heating at full",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "sat_sp",
+        "htg_valve_pct"
       ],
       "optional_roles": [
         "fan_cmd",
         "fan_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "Legacy SAT error (sets epsSAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -1136,40 +674,19 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc7",
       "datafusion_sql_implementation": "fc7_sat_low_heating.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc7",
       "test_coverage": [
-        "scripts/materialize_vav_oracle_fixtures.py",
         "tests/analytics/test_wattlab_engine.py",
         "tests/rules/test_golden_parity.py",
         "tests/rules/test_parity_inventory.py",
@@ -1181,106 +698,20 @@
     },
     {
       "rule_id": "FC8",
-      "title": "SAT/MAT mismatch in economizer (GL36 F)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT vs MAT while economizing",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc8",
@@ -1291,98 +722,20 @@
     },
     {
       "rule_id": "FC9",
-      "title": "OAT too warm for free cooling (GL36 G)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "OAT high vs SAT SP while economizing",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc9",
@@ -1393,90 +746,20 @@
     },
     {
       "rule_id": "FC10",
-      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "MAT-OAT delta while cooling and economizing",
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "oa_t",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc10",
@@ -1487,98 +770,20 @@
     },
     {
       "rule_id": "FC11",
-      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "OAT low vs SAT SP while cooling and economizing",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc11",
@@ -1589,114 +794,20 @@
     },
     {
       "rule_id": "FC12",
-      "title": "SAT above blend in cooling (GL36 J)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT above MAT while cooling",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc12",
@@ -1707,88 +818,59 @@
     },
     {
       "rule_id": "FC13",
-      "title": "SAT above SP at full cooling (GL36 K)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "SAT above setpoint at full cooling",
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "sat_sp",
+        "clg_valve_pct",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "SAT high error band"
         },
-        "clg_full_min": {
+        "clg_valve_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
+          "min": 0.0,
+          "max": 0.5,
           "step": 0.01,
-          "label": "Full-cooling threshold (GL36 99%)"
+          "label": "Cooling valve open threshold"
         },
-        "econ_min_pos": {
+        "oa_damper_econ_low": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Economizer minimum-position threshold"
+          "label": "OA damper economizer low"
         },
-        "econ_full_open": {
+        "oa_damper_econ_high": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OA damper economizer high"
         },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc13",
@@ -1804,14 +886,9 @@
     {
       "rule_id": "FC14",
       "title": "CHW coil \u0394T when inactive (GL36 L)",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "cooling-coil-entering-temp",
-        "cooling-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "cooling_coil_entering_temp",
@@ -1822,90 +899,23 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_ccet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil entering sensor error \u03b5CCET"
-        },
-        "eps_cclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "htg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Heating-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc14",
@@ -1919,15 +929,8 @@
     {
       "rule_id": "FC15",
       "title": "HW coil \u0394T when inactive (GL36 M)",
-      "equipment_types": [
-        "ahu"
-      ],
-      "required_roles": [
-        "heating-coil-entering-temp",
-        "heating-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
-      ],
+      "equipment_types": [],
+      "required_roles": [],
       "optional_roles": [
         "heating_coil_entering_temp",
         "heating_coil_leaving_temp",
@@ -1938,98 +941,23 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_hcet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil entering sensor error \u03b5HCET"
-        },
-        "eps_hclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil leaving sensor error \u03b5HCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc15",
@@ -2043,48 +971,35 @@
     {
       "rule_id": "AHU-SATDEV",
       "title": "SAT deviation from setpoint",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp"
+        "sat",
+        "sat_sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_sat_dev",
+      "pandas_implementation": "ahu_satdev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
       "test_coverage": [
@@ -2097,12 +1012,11 @@
     {
       "rule_id": "AHU-DUCTHI",
       "title": "Duct static pressure high",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
@@ -2110,9 +1024,17 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -2120,26 +1042,14 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_duct_high",
+      "pandas_implementation": "ahu_ducthi",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
       "test_coverage": [
@@ -2152,26 +1062,25 @@
     {
       "rule_id": "AHU-SIMUL",
       "title": "Heating and cooling simultaneous",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "heating-valve",
-        "cooling-valve"
+        "htg_valve_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -2179,21 +1088,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul_heat_cool",
+      "pandas_implementation": "ahu_simul",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
       "test_coverage": [],
@@ -2203,13 +1100,10 @@
     },
     {
       "rule_id": "OAT-METEO",
-      "title": "BAS outdoor-air sensor vs Open-Meteo",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Equipment OAT vs weather-staged wx OAT",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "web-outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [
         "web_oa_t"
@@ -2218,23 +1112,19 @@
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "Max OAT disagreement"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OAT vs meteo tolerance"
         },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -2247,47 +1137,34 @@
     },
     {
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Economizer stuck closed when OAT favorable",
+      "equipment_types": [],
       "required_roles": [
-        "fan-cmd",
-        "outside-air-damper",
-        "outside-air-temp"
+        "fan_cmd",
+        "oa_damper_pct",
+        "oa_t"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
         },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
+        "econ1_damper_max": {
+          "default": 0.05,
+          "unit": "frac",
           "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "max": 0.2,
+          "step": 0.01,
+          "label": "Stuck-closed damper frac"
         }
       },
       "pandas_implementation": "econ1",
@@ -2300,30 +1177,21 @@
     },
     {
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor unfavorable",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Economizing when outdoor air unfavorable",
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "outside-air-damper"
+        "oa_t",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -2337,17 +1205,13 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ2",
@@ -2363,30 +1227,30 @@
     {
       "rule_id": "ECON-3",
       "title": "Mech cooling without integrated economizer",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity"
+        "web_oa_t",
+        "web_oa_dp",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -2394,7 +1258,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -2402,7 +1266,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -2415,21 +1279,9 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ2",
+      "pandas_implementation": "econ_3",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
       "test_coverage": [],
@@ -2440,47 +1292,34 @@
     {
       "rule_id": "ECON-4",
       "title": "Low estimated OA fraction",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-cmd"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "%",
+          "unit": "pct",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ4",
@@ -2494,50 +1333,37 @@
     {
       "rule_id": "ECON-5",
       "title": "Preheat over-conditioning",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "preheat-leaving-temp",
-        "discharge-air-temp-sp",
-        "outside-air-temp",
-        "heating-valve"
+        "preheat_leave_t",
+        "sat_sp",
+        "oa_t",
+        "htg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ5",
+      "pandas_implementation": "econ_5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
       "test_coverage": [],
@@ -2548,27 +1374,28 @@
     {
       "rule_id": "ECON-6",
       "title": "Economizing in freezing weather",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper"
+        "oa_damper_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp"
+        "web_oa_t",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -2581,21 +1408,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ6_compute",
+      "pandas_implementation": "econ_6",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
       "test_coverage": [],
@@ -2606,32 +1421,30 @@
     {
       "rule_id": "ECON-7",
       "title": "Economizer OK but not economizing",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-damper"
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity",
-        "cooling-valve",
-        "compressor-status",
-        "dx-cool-cmd"
+        "web_oa_t",
+        "web_oa_dp",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -2639,7 +1452,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -2647,7 +1460,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -2660,21 +1473,9 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ7_compute",
+      "pandas_implementation": "econ_7",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
       "test_coverage": [],
@@ -2685,45 +1486,34 @@
     {
       "rule_id": "MECH-OAT-1",
       "title": "Mechanical cooling below 60\u00b0F web OAT",
-      "equipment_types": [
-        "ahu",
-        "chiller",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
         "web_oa_t"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "compressor-status",
-        "chiller-status",
-        "chw-pump-status",
-        "dx-cool-cmd"
+        "clg_valve_pct",
+        "chiller_status"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat1_compute",
+      "pandas_implementation": "mech_oat_1",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
       "test_coverage": [],
@@ -2734,57 +1524,28 @@
     {
       "rule_id": "CHW-NOLOAD-1",
       "title": "Chiller running with no building load",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
-        "chiller-status",
-        "chw-pump-status",
-        "compressor-status",
-        "building-zone-load-satisfied",
-        "building-ahu-load-satisfied"
+        "chiller_status",
+        "chiller_cmd",
+        "chw_pump_status",
+        "chw_pump_cmd",
+        "building_zone_load_satisfied",
+        "building_ahu_load_satisfied"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "comfort_low_f": {
-          "default": 70.0,
-          "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
-          "step": 0.5,
-          "label": "Comfort low"
-        },
-        "comfort_high_f": {
-          "default": 75.0,
-          "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
-          "step": 0.5,
-          "label": "Comfort high"
-        },
-        "sat_band_f": {
-          "default": 2.0,
-          "unit": "\u00b0F",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "AHU SAT\u2248SP band"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 1800.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "chw_noload1_compute",
+      "pandas_implementation": "chw_noload_1",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
       "test_coverage": [],
@@ -2794,46 +1555,39 @@
     },
     {
       "rule_id": "VAV-1",
-      "title": "Zone comfort band",
-      "equipment_types": [
-        "vav",
-        "zone"
-      ],
+      "title": "Zone comfort band violation hours with confirm window",
+      "equipment_types": [],
       "required_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
       "optional_roles": [
         "occ_mode"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_lo": {
+        "zone_t_lo": {
           "default": 70.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_hi": {
+        "zone_t_hi": {
           "default": 75.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav1",
@@ -2849,39 +1603,30 @@
     },
     {
       "rule_id": "VAV-2",
-      "title": "Night setback miss",
-      "equipment_types": [
-        "vav",
-        "zone"
-      ],
+      "title": "Night setback miss \u2014 unoccupied zone above heating setback",
+      "equipment_types": [],
       "required_roles": [
-        "zone-air-temp",
-        "occupied"
+        "zone_t",
+        "occ_mode"
       ],
-      "optional_roles": [
-        "occ-mode"
-      ],
+      "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
         "setback_hi": {
           "default": 68.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Setback high"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav2",
@@ -2895,29 +1640,29 @@
     {
       "rule_id": "VAV-3",
       "title": "Excessive reheat during warm weather",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "reheat-valve"
+        "oa_t",
+        "reheat_valve_pct",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -2938,21 +1683,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav3",
+      "pandas_implementation": "vav_3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
       "test_coverage": [],
@@ -2963,26 +1696,25 @@
     {
       "rule_id": "VAV-4",
       "title": "Damper stuck at full open",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "damper"
+        "damper_pct",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -2990,14 +1722,6 @@
           "max": 1.0,
           "step": 0.005,
           "label": "Full open frac"
-        },
-        "sustain_hours": {
-          "default": 1.5,
-          "unit": "h",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "Sustain window"
         },
         "flow_on_min": {
           "default": 25.0,
@@ -3007,25 +1731,19 @@
           "step": 5.0,
           "label": "Airflow-on min"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
         }
       },
-      "pandas_implementation": "vav4",
+      "pandas_implementation": "vav_4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
-      "test_coverage": [
-        "scripts/materialize_vav_oracle_fixtures.py"
-      ],
+      "test_coverage": [],
       "parity_status": "sql_screening",
       "known_semantic_differences": "",
       "difference_class": "none"
@@ -3033,40 +1751,27 @@
     {
       "rule_id": "VAV-5",
       "title": "Airflow sensor bias",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "zone-airflow",
-        "damper"
+        "zone_flow",
+        "damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "vav5",
+      "pandas_implementation": "vav_5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
       "test_coverage": [],
@@ -3077,28 +1782,19 @@
     {
       "rule_id": "VAV-6",
       "title": "Reheat when cooling available",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "reheat-valve"
+        "oa_t",
+        "reheat_valve_pct"
       ],
       "optional_roles": [
-        "cooling-available"
+        "clg_available"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "free_cool_oat": {
           "default": 65.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 75.0,
           "step": 1.0,
@@ -3112,17 +1808,13 @@
           "step": 0.05,
           "label": "Reheat frac"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav6",
@@ -3136,27 +1828,27 @@
     {
       "rule_id": "VAV-REHEAT",
       "title": "Reheat valve stuck / no temp rise",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "reheat-valve",
-        "vav-discharge-air-temp",
-        "vav-inlet-air-temp"
+        "reheat_valve_pct",
+        "vav_discharge_t",
+        "vav_inlet_t",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -3167,7 +1859,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -3180,21 +1872,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat_stuck",
+      "pandas_implementation": "vav_reheat",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
       "test_coverage": [],
@@ -3205,29 +1885,29 @@
     {
       "rule_id": "VAV-AHU-LEAVE",
       "title": "VAV leave vs parent AHU SAT (fedBy)",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "vav-discharge-air-temp",
-        "ahu-discharge-air-temp"
+        "vav_discharge_t",
+        "ahu_sat",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "delta_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -3240,21 +1920,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_vs_ahu_leave",
+      "pandas_implementation": "vav_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
       "test_coverage": [],
@@ -3265,26 +1933,33 @@
     {
       "rule_id": "VAV-7",
       "title": "Min airflow / fixed high flow",
-      "equipment_types": [
-        "vav"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "zone-airflow"
+        "zone_flow"
       ],
       "optional_roles": [
         "min_flow_sp",
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "high_min_flow_sp": {
+          "default": 250.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "High min-flow SP"
+        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -3292,6 +1967,14 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "fixed_flow_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Fixed-flow rolling window"
         },
         "fixed_flow_max_std": {
           "default": 15.0,
@@ -3308,33 +1991,12 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "Fixed-flow min mean"
-        },
-        "high_min_flow_sp": {
-          "default": 250.0,
-          "unit": "cfm",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 10.0,
-          "label": "High min-flow SP"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav7",
+      "pandas_implementation": "vav_7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
       "test_coverage": [
-        "scripts/materialize_vav_oracle_fixtures.py",
         "tests/analytics/test_vav_health.py"
       ],
       "parity_status": "sql_screening",
@@ -3344,12 +2006,10 @@
     {
       "rule_id": "CHW-1",
       "title": "Low chilled-water \u0394T",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-return-temp"
+        "chw_supply_t",
+        "chw_return_t"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -3360,41 +2020,23 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_dt": {
           "default": 4.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Min \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "Minimum delta-T"
         }
       },
       "pandas_implementation": "chw1",
@@ -3413,31 +2055,23 @@
     {
       "rule_id": "CHW-2",
       "title": "DP below SP at max pump speed",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chw-diff-pressure",
-        "chw-diff-pressure-sp",
-        "chw-pump-cmd"
+        "chw_dp",
+        "chw_dp_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -3453,21 +2087,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw2",
+      "pandas_implementation": "chw_2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
       "test_coverage": [],
@@ -3478,53 +2100,33 @@
     {
       "rule_id": "CHW-3",
       "title": "Plant supply temp outside deadband",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-supply-temp-sp",
-        "chw-pump-cmd"
+        "chw_supply_t",
+        "chw_supply_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sp_band": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw3",
+      "pandas_implementation": "chw_3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
       "test_coverage": [],
@@ -3535,36 +2137,28 @@
     {
       "rule_id": "CHW-4",
       "title": "Flow high at max pump",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chw-flow",
-        "chw-pump-cmd"
+        "chw_flow",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flow_hi": {
-          "default": 1100,
+          "default": 1100.0,
           "unit": "gpm",
-          "min": 200,
-          "max": 3000,
-          "step": 50,
+          "min": 200.0,
+          "max": 3000.0,
+          "step": 50.0,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -3574,21 +2168,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw4",
+      "pandas_implementation": "chw_4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
       "test_coverage": [],
@@ -3599,55 +2181,44 @@
     {
       "rule_id": "HP-1",
       "title": "Discharge cold when heating",
-      "equipment_types": [
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "zone-air-temp",
-        "fan-cmd"
+        "sat",
+        "zone_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "compressor_status",
         "fan_status"
       ],
-      "operational_proof_roles": [
-        "compressor-status",
-        "equipment-enable",
-        "fan-status",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_sat": {
           "default": 85.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min heating SAT"
+          "label": "Min discharge SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Zone cold threshold"
         }
       },
-      "pandas_implementation": "hp1",
+      "pandas_implementation": "hp_1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
       "test_coverage": [],
@@ -3658,37 +2229,31 @@
     {
       "rule_id": "WX-1",
       "title": "OA temperature spike",
-      "equipment_types": [
-        "weather"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx1",
+      "pandas_implementation": "wx_1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
       "test_coverage": [],
@@ -3699,12 +2264,10 @@
     {
       "rule_id": "CW-OPT-1",
       "title": "Condenser water not optimized vs wet-bulb",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t"
       ],
       "optional_roles": [
         "pump_status",
@@ -3712,25 +2275,19 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -3738,26 +2295,14 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt",
+      "pandas_implementation": "cw_opt_1",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
       "test_coverage": [],
@@ -3768,38 +2313,31 @@
     {
       "rule_id": "CW-APR-1",
       "title": "High CW approach at full tower fan",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -3812,21 +2350,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr",
+      "pandas_implementation": "cw_apr_1",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
       "test_coverage": [],
@@ -3837,38 +2363,31 @@
     {
       "rule_id": "CW-FAN-1",
       "title": "Excess tower fan energy vs wet-bulb limit",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -3876,7 +2395,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -3889,21 +2408,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_excess",
+      "pandas_implementation": "cw_fan_1",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
       "test_coverage": [],
@@ -3914,12 +2421,9 @@
     {
       "rule_id": "TRIM-1",
       "title": "Duct static trim advisory",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "duct-static-pressure",
-        "vav-pressure-request-sum"
+        "duct_static"
       ],
       "optional_roles": [
         "duct_static_sp",
@@ -3927,18 +2431,19 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -3951,21 +2456,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim1",
+      "pandas_implementation": "trim_1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
       "test_coverage": [],
@@ -3976,12 +2469,9 @@
     {
       "rule_id": "TRIM-3",
       "title": "HWST trim advisory",
-      "equipment_types": [
-        "boiler"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "hot-water-supply-temp",
-        "hw-reset-request-sum"
+        "hw_supply_t"
       ],
       "optional_roles": [
         "pump_status",
@@ -3989,25 +2479,19 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -4020,21 +2504,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim3",
+      "pandas_implementation": "trim_3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
       "test_coverage": [],
@@ -4045,12 +2517,9 @@
     {
       "rule_id": "TRIM-4",
       "title": "CHW plant reset advisory",
-      "equipment_types": [
-        "chiller"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chw-reset-request-sum"
+        "chw_supply_t"
       ],
       "optional_roles": [
         "pump_status",
@@ -4058,25 +2527,19 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -4089,21 +2552,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim4",
+      "pandas_implementation": "trim_4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
       "test_coverage": [],
@@ -4113,46 +2564,40 @@
     },
     {
       "rule_id": "SCHED-1",
-      "title": "Unoccupied runtime",
-      "equipment_types": [
-        "ahu"
-      ],
+      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
+      "equipment_types": [],
       "required_roles": [
-        "occupied",
-        "fan-status"
+        "occ_mode",
+        "fan_status"
       ],
       "optional_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
+          "min": 50.0,
+          "max": 80.0,
           "step": 0.5,
-          "label": "Comfort low"
+          "label": "Zone comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
+          "min": 55.0,
+          "max": 90.0,
           "step": 0.5,
-          "label": "Comfort high"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
+          "label": "Zone comfort high"
         }
       },
       "pandas_implementation": "sched1",
@@ -4170,31 +2615,24 @@
     {
       "rule_id": "SCHED-247",
       "title": "Always-on fan or pump runtime",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
       "required_roles": [],
       "optional_roles": [
-        "fan-status",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "chiller-status",
-        "compressor-status",
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd",
-        "duct-static-pressure",
-        "chw-diff-pressure"
+        "fan_status",
+        "pump_status",
+        "chiller_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "always_on_pct": {
           "default": 0.95,
           "unit": "frac",
@@ -4202,26 +2640,6 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Always-on fraction"
-        },
-        "pressure_on_min": {
-          "default": 0.2,
-          "unit": "eng",
-          "min": 0.05,
-          "max": 2.0,
-          "step": 0.05,
-          "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 3600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "_sched247",
@@ -4239,29 +2657,20 @@
     {
       "rule_id": "RESET-1",
       "title": "SAT reset not tracking outdoor air",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp-sp",
-        "outside-air-temp"
+        "sat_sp",
+        "oa_t"
       ],
       "optional_roles": [
-        "fan-status",
-        "fan-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "reset_err_f": {
           "default": 3.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 10.0,
           "step": 0.5,
@@ -4269,15 +2678,15 @@
         },
         "reset_sat_at_65": {
           "default": 52.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 65.0,
           "step": 0.5,
-          "label": "SAT SP at 65\u00b0F OAT"
+          "label": "SAT SP at 65F OAT"
         },
         "reset_slope": {
           "default": 0.25,
-          "unit": "\u00b0F/\u00b0F",
+          "unit": "frac",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -4285,23 +2694,19 @@
         },
         "reset_oat_ref": {
           "default": 65.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 50.0,
           "max": 80.0,
           "step": 1.0,
           "label": "Reset OAT ref"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "reset1",
@@ -4315,30 +2720,24 @@
     {
       "rule_id": "CMD-1",
       "title": "Fan cmd/status mismatch",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "fan-cmd",
-        "fan-status"
+        "fan_cmd",
+        "fan_status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "cmd1",
+      "pandas_implementation": "cmd_1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
       "test_coverage": [],
@@ -4349,28 +2748,27 @@
     {
       "rule_id": "OA-1",
       "title": "Low OA fraction",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-status"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -4381,26 +2779,14 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "Min |RAT\u2212OAT| guard"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "OAT/RAT guard"
         }
       },
-      "pandas_implementation": "oa1",
+      "pandas_implementation": "oa_1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
       "test_coverage": [],
@@ -4411,13 +2797,11 @@
     {
       "rule_id": "DMP-1",
       "title": "OA damper leakage",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "outside-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper"
+        "oa_damper_pct",
+        "oa_t",
+        "mat"
       ],
       "optional_roles": [
         "fan_status",
@@ -4425,28 +2809,24 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp1",
+      "pandas_implementation": "dmp_1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
       "test_coverage": [],
@@ -4457,24 +2837,30 @@
     {
       "rule_id": "VLV-1",
       "title": "Cooling valve leakage",
-      "equipment_types": [
-        "ahu"
-      ],
+      "equipment_types": [],
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "cooling-valve"
+        "clg_valve_pct",
+        "sat",
+        "sat_sp",
+        "mat"
       ],
       "optional_roles": [
-        "mixed-air-temp",
-        "fan-status",
-        "fan-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_err": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -4482,26 +2868,14 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv1",
+      "pandas_implementation": "vlv_1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
       "test_coverage": [],
@@ -4643,24 +3017,8 @@
       "title": "Sensor out of hard range",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -4680,22 +3038,16 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "range_scale_temperature": {
           "default": 1.0,
           "unit": "x",
@@ -4703,37 +3055,9 @@
           "max": 2.0,
           "step": 0.1,
           "label": "Temp range scale"
-        },
-        "range_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Humidity range scale"
-        },
-        "range_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.5,
-          "max": 2.0,
-          "step": 0.1,
-          "label": "Pressure range scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_range",
+      "pandas_implementation": "sv_range",
       "datafusion_sql_implementation": "sv_range.sql",
       "sql_file": "sv_range.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-range",
@@ -4746,8 +3070,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "equipment_energized",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -4856,24 +3180,8 @@
       "title": "Sensor flatline (stuck)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -4894,9 +3202,17 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flatline_tol": {
           "default": 0.1,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.02,
           "max": 1.0,
           "step": 0.02,
@@ -4905,25 +3221,13 @@
         "flatline_hours": {
           "default": 1.0,
           "unit": "h",
-          "min": 0.5,
-          "max": 8.0,
-          "step": 0.5,
+          "min": 0.25,
+          "max": 12.0,
+          "step": 0.25,
           "label": "Flatline window"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_flatline",
+      "pandas_implementation": "sv_flatline",
       "datafusion_sql_implementation": "sv_flatline.sql",
       "sql_file": "sv_flatline.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-flatline",
@@ -4935,8 +3239,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5055,24 +3359,8 @@
       "title": "Sensor rate-of-change spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -5092,22 +3380,16 @@
         "chw_pump_cmd",
         "chiller_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-current",
-        "chw-flow",
-        "compressor-status",
-        "equipment-enable"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_scale": {
           "default": 1.0,
           "unit": "x",
@@ -5115,45 +3397,9 @@
           "max": 3.0,
           "step": 0.25,
           "label": "Spike limit scale (global)"
-        },
-        "spike_scale_temperature": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Temp spike scale"
-        },
-        "spike_scale_humidity": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Humidity spike scale"
-        },
-        "spike_scale_pressure": {
-          "default": 1.0,
-          "unit": "x",
-          "min": 0.25,
-          "max": 3.0,
-          "step": 0.25,
-          "label": "Pressure spike scale"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "_sweep_spike",
+      "pandas_implementation": "sv_spike",
       "datafusion_sql_implementation": "sv_spike.sql",
       "sql_file": "sv_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-spike",
@@ -5165,8 +3411,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "equipment_energized",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5275,24 +3521,8 @@
       "title": "Stale data (no fresh samples)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -5308,6 +3538,14 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "stale_hours": {
           "default": 2.0,
           "unit": "h",
@@ -5316,20 +3554,16 @@
           "step": 0.5,
           "label": "Stale window"
         },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
+        "stale_tol": {
+          "default": 0.05,
+          "unit": "degF",
           "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "max": 1.0,
+          "step": 0.01,
+          "label": "Stale tolerance"
         }
       },
-      "pandas_implementation": "_sweep_stale",
+      "pandas_implementation": "sv_stale",
       "datafusion_sql_implementation": "sv_stale.sql",
       "sql_file": "sv_stale.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-stale",
@@ -5341,8 +3575,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -5463,24 +3697,8 @@
         "SV-SLEW"
       ],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "weather",
-        "zone",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
         "oa_t",
@@ -5491,6 +3709,14 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "persistence_min": {
           "default": 10.0,
           "unit": "min",
@@ -5499,52 +3725,16 @@
           "step": 1.0,
           "label": "Fault persistence"
         },
-        "transition_window_min": {
-          "default": 20.0,
-          "unit": "min",
-          "min": 5.0,
+        "steady_fault_per_hour": {
+          "default": 6.0,
+          "unit": "degF_per_h",
+          "min": 1.0,
           "max": 60.0,
-          "step": 5.0,
-          "label": "Transition window"
-        },
-        "max_gap_hours": {
-          "default": 2.0,
-          "unit": "h",
-          "min": 0.25,
-          "max": 6.0,
-          "step": 0.25,
-          "label": "Max sample gap"
-        },
-        "design_flow": {
-          "default": 0.0,
-          "unit": "cfm",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 100.0,
-          "label": "Design flow (flow profiles)"
-        },
-        "sensor_span": {
-          "default": 0.0,
-          "unit": "eng",
-          "min": 0.0,
-          "max": 100000.0,
-          "step": 10.0,
-          "label": "Sensor span (flow/pressure)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "step": 0.5,
+          "label": "Steady-state slew limit"
         }
       },
-      "pandas_implementation": "_sv_rate_compute",
+      "pandas_implementation": "sv_rate",
       "datafusion_sql_implementation": "sv_rate.sql",
       "sql_file": "sv_rate.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#sv-rate",
@@ -5558,8 +3748,8 @@
       "parity_level": "sql_screening",
       "difference_class": "semantic_gap",
       "known_semantic_differences": "Pandas ROLE_TO_PROFILE has 30+ quantity/location slew limits; SQL windows five air temps against one STEADY_FAULT_PER_HOUR. Leave sql_screening; do not mark proven from B100 hours. Alias SV-SLEW is not an extra rule.",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -5678,37 +3868,39 @@
       "title": "Suspected control-output hunting",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
-        "loop-enabled"
+        "oa_damper_pct",
+        "clg_valve_pct",
+        "htg_valve_pct",
+        "damper_pct",
+        "loop_enabled",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 0.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "window_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 4.0,
+          "step": 0.25,
+          "label": "Hunting lookback window"
+        },
         "change_deadband_pct": {
           "default": 1.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 0.0,
           "max": 10.0,
           "step": 0.5,
@@ -5716,7 +3908,7 @@
         },
         "minimum_span_pct": {
           "default": 20.0,
-          "unit": "% out",
+          "unit": "pct",
           "min": 5.0,
           "max": 100.0,
           "step": 5.0,
@@ -5724,50 +3916,38 @@
         },
         "total_variation_fault_pct": {
           "default": 500.0,
-          "unit": "%/h",
+          "unit": "pct",
           "min": 50.0,
           "max": 2000.0,
           "step": 50.0,
-          "label": "Total travel threshold"
+          "label": "Total variation fault threshold"
         },
         "minimum_equivalent_cycles": {
           "default": 2.5,
-          "unit": "cyc/h",
+          "unit": "count",
           "min": 0.5,
-          "max": 20.0,
+          "max": 10.0,
           "step": 0.5,
           "label": "Min equivalent cycles"
         },
         "minimum_reversals": {
-          "default": 4,
+          "default": 4.0,
           "unit": "count",
-          "min": 1,
-          "max": 40,
-          "step": 1,
+          "min": 1.0,
+          "max": 20.0,
+          "step": 1.0,
           "label": "Min direction reversals"
         },
         "minimum_coverage_pct": {
           "default": 80.0,
-          "unit": "%",
-          "min": 25.0,
+          "unit": "pct",
+          "min": 50.0,
           "max": 100.0,
           "step": 5.0,
-          "label": "Minimum data coverage"
-        },
-        "confirm_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "label": "Min window sample coverage"
         }
       },
-      "pandas_implementation": "_pid_hunt_1",
+      "pandas_implementation": "pid_hunt_1",
       "datafusion_sql_implementation": "pid_hunt_1.sql",
       "sql_file": "pid_hunt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1",
@@ -5777,8 +3957,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "control_loop",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 0,
       "parameters": {
         "confirm_seconds": {
@@ -5944,40 +4124,29 @@
       "canonical_id": "FC1",
       "pandas_id": "FC1",
       "rule_id": "FC1",
-      "title": "Duct static below SP at full fan (GL36 A)",
+      "title": "Duct static below SP at full fan",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp",
-        "fan-cmd"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "eps_dsp": {
           "default": 0.12,
-          "unit": "in. w.c.",
+          "unit": "inwc",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Duct-static error \u03b5DSP (GL36 default 0.1 in.w.c.)"
+          "label": "Duct-static error epsDSP (GL36 default 0.1 in.w.c.)"
         },
         "eps_vfd_spd": {
           "default": 0.13,
@@ -5985,43 +4154,15 @@
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "VFD speed error \u03b5VFDSPD (GL36 default 5%)"
-        },
-        "duct_static_err": {
-          "default": 0.12,
-          "unit": "in. w.c.",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Legacy duct-static error (sets \u03b5DSP)"
-        },
-        "fan_hi": {
-          "default": 0.87,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Legacy fan-high threshold (sets \u03b5VFDSPD)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "VFD speed error epsVFDSPD (GL36 default 5%)"
         },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc1",
@@ -6037,8 +4178,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "eps_dsp": {
@@ -6154,95 +4295,23 @@
       "canonical_id": "FC2",
       "pandas_id": "FC2",
       "rule_id": "FC2",
-      "title": "MAT below OAT/RAT envelope (GL36 B)",
+      "title": "Mixed air below envelope",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc2",
       "datafusion_sql_implementation": "fc2_mat_low.sql",
       "sql_file": "fc2_mat_low.sql",
@@ -6253,8 +4322,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -6339,95 +4408,23 @@
       "canonical_id": "FC3",
       "pandas_id": "FC3",
       "rule_id": "FC3",
-      "title": "MAT above OAT/RAT envelope (GL36 C)",
+      "title": "Mixed air above envelope",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "fan-cmd"
+        "mat",
+        "oa_t",
+        "rat",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_rat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "RAT sensor error \u03b5RAT (GL36 default 2\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc3",
       "datafusion_sql_implementation": "fc3_mat_high.sql",
       "sql_file": "fc3_mat_high.sql",
@@ -6438,8 +4435,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -6527,57 +4524,33 @@
       "title": "PID hunting (operating-state oscillation)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve",
-        "fan-cmd"
+        "oa_damper_pct",
+        "clg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "delta_os_max": {
-          "default": 5,
-          "unit": "count",
-          "min": 1,
-          "max": 30,
-          "step": 1,
-          "label": "Max mode changes/hr \u0394OSmax (GL36 default 7)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 3600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "delta_os_max": {
+          "default": 5.0,
+          "unit": "count",
+          "min": 1.0,
+          "max": 30.0,
+          "step": 1.0,
+          "label": "Max operating-state entries per hour"
         }
       },
       "pandas_implementation": "fc4",
@@ -6590,8 +4563,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "control_loop",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -6700,54 +4673,35 @@
       "title": "SAT cold when heating commanded (GL36 D)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "mat",
+        "htg_valve_pct",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         },
         "htg_on_min": {
           "default": 0.01,
@@ -6756,42 +4710,6 @@
           "max": 0.25,
           "step": 0.01,
           "label": "Heating-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "fc5",
@@ -6804,8 +4722,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -6924,46 +4842,28 @@
       "title": "Estimated OA fraction mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "return-air-temp",
-        "vav-total-airflow"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd",
+        "vav_total_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_airflow": {
-          "default": 0.15,
-          "unit": "frac",
-          "min": 0.05,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Airflow error \u03b5F (GL36 default 30%)"
-        },
-        "delta_t_min": {
-          "default": 5.0,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 30.0,
-          "step": 0.5,
-          "label": "Minimum |OAT\u2212RAT| \u0394Tmin (GL36 default 10\u00b0F)"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "airflow_err": {
           "default": 0.15,
@@ -6971,51 +4871,23 @@
           "min": 0.05,
           "max": 1.0,
           "step": 0.01,
-          "label": "Legacy OA-fraction error (sets \u03b5F)"
+          "label": "Airflow error epsF (GL36 default 30%)"
         },
-        "oat_rat_delta_min": {
+        "delta_t_min": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 30.0,
           "step": 0.5,
-          "label": "Legacy OAT/RAT guard (sets \u0394Tmin)"
+          "label": "Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)"
         },
         "min_cfm_design": {
-          "default": 5000,
+          "default": 5000.0,
           "unit": "cfm",
-          "min": 500,
-          "max": 20000,
-          "step": 500,
-          "label": "Design min OA CFM"
-        },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
           "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "max": 200000.0,
+          "step": 100.0,
+          "label": "Design minimum outdoor airflow"
         }
       },
       "pandas_implementation": "fc6",
@@ -7028,8 +4900,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -7155,49 +5027,29 @@
       "canonical_id": "FC7",
       "pandas_id": "FC7",
       "rule_id": "FC7",
-      "title": "SAT low with full heating (GL36 E)",
+      "title": "SAT low while heating at full",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "fan-cmd",
-        "heating-valve"
+        "sat",
+        "sat_sp",
+        "htg_valve_pct"
       ],
       "optional_roles": [
         "fan_cmd",
         "fan_status"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "Legacy SAT error (sets epsSAT)"
         },
         "htg_full_min": {
           "default": 0.9,
@@ -7207,33 +5059,13 @@
           "step": 0.01,
           "label": "Full-heating threshold (GL36 99%)"
         },
-        "fan_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Fan-on command threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc7",
@@ -7242,7 +5074,6 @@
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#fc7",
       "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#fc7",
       "test_coverage": [
-        "scripts/materialize_vav_oracle_fixtures.py",
         "tests/analytics/test_wattlab_engine.py",
         "tests/rules/test_golden_parity.py",
         "tests/rules/test_parity_inventory.py",
@@ -7252,8 +5083,8 @@
       "parity_level": "sql_screening",
       "difference_class": "missing_implementation",
       "known_semantic_differences": "concept_only \u2014 SQL file is a placeholder; do not claim twin parity",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -7369,111 +5200,23 @@
       "canonical_id": "FC8",
       "pandas_id": "FC8",
       "rule_id": "FC8",
-      "title": "SAT/MAT mismatch in economizer (GL36 F)",
+      "title": "SAT vs MAT while economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc8",
       "datafusion_sql_implementation": "fc8_sat_mat_econ.sql",
       "sql_file": "fc8_sat_mat_econ.sql",
@@ -7484,8 +5227,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7570,103 +5313,23 @@
       "canonical_id": "FC9",
       "pandas_id": "FC9",
       "rule_id": "FC9",
-      "title": "OAT too warm for free cooling (GL36 G)",
+      "title": "OAT high vs SAT SP while economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc9",
       "datafusion_sql_implementation": "fc9_oa_sat_sp_econ.sql",
       "sql_file": "fc9_oa_sat_sp_econ.sql",
@@ -7677,8 +5340,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7763,95 +5426,23 @@
       "canonical_id": "FC10",
       "pandas_id": "FC10",
       "rule_id": "FC10",
-      "title": "OAT/MAT mismatch + mech cooling (GL36 H)",
+      "title": "MAT-OAT delta while cooling and economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "outside-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "mat",
+        "oa_t",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc10",
       "datafusion_sql_implementation": "fc10_mat_oa_clg.sql",
       "sql_file": "fc10_mat_oa_clg.sql",
@@ -7862,8 +5453,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -7948,103 +5539,23 @@
       "canonical_id": "FC11",
       "pandas_id": "FC11",
       "rule_id": "FC11",
-      "title": "OAT/MAT mismatch economizer-only (GL36 I)",
+      "title": "OAT low vs SAT SP while cooling and economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_t",
+        "sat_sp",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_oat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "OAT sensor error \u03b5OAT (GL36 default 2\u00b0F local / 5\u00b0F global)"
-        },
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc11",
       "datafusion_sql_implementation": "fc11_oa_sat_sp_clg.sql",
       "sql_file": "fc11_oa_sat_sp_clg.sql",
@@ -8055,8 +5566,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -8141,119 +5652,23 @@
       "canonical_id": "FC12",
       "pandas_id": "FC12",
       "rule_id": "FC12",
-      "title": "SAT above blend in cooling (GL36 J)",
+      "title": "SAT above MAT while cooling",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "mat",
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
-      "default_thresholds": {
-        "eps_sat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
-        "eps_mat": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "MAT sensor error \u03b5MAT (GL36 default 5\u00b0F)"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
-        },
-        "mix_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "supply_tol": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Legacy SAT tolerance master (sets \u03b5SAT)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
-        }
-      },
+      "operational_proof_roles": [],
+      "default_thresholds": {},
       "pandas_implementation": "fc12",
       "datafusion_sql_implementation": "fc12_sat_mat_clg.sql",
       "sql_file": "fc12_sat_mat_clg.sql",
@@ -8264,8 +5679,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {},
       "time_semantics": "row_or_interval_per_sql_file",
@@ -8350,95 +5765,64 @@
       "canonical_id": "FC13-SAT-HIGH",
       "pandas_id": "FC13",
       "rule_id": "FC13",
-      "title": "SAT above SP at full cooling (GL36 K)",
+      "title": "SAT above setpoint at full cooling",
       "aliases": [
         "FC13"
       ],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "outside-air-damper",
-        "cooling-valve"
+        "sat",
+        "sat_sp",
+        "clg_valve_pct",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_sat": {
-          "default": 1.0,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "SAT sensor error \u03b5SAT (GL36 default 2\u00b0F)"
-        },
         "sat_err": {
           "default": 1.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy SAT error (sets \u03b5SAT)"
+          "label": "SAT high error band"
         },
-        "clg_full_min": {
+        "clg_valve_min": {
           "default": 0.01,
           "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
+          "min": 0.0,
+          "max": 0.5,
           "step": 0.01,
-          "label": "Full-cooling threshold (GL36 99%)"
+          "label": "Cooling valve open threshold"
         },
-        "econ_min_pos": {
+        "oa_damper_econ_low": {
           "default": 0.05,
           "unit": "frac",
           "min": 0.0,
           "max": 0.5,
           "step": 0.01,
-          "label": "Economizer minimum-position threshold"
+          "label": "OA damper economizer low"
         },
-        "econ_full_open": {
+        "oa_damper_econ_high": {
           "default": 0.9,
           "unit": "frac",
           "min": 0.5,
           "max": 1.0,
           "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OA damper economizer high"
         },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "fc13",
@@ -8453,8 +5837,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: FC13 (not independent rules)",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "sat_err": {
@@ -8593,17 +5977,10 @@
       "title": "CHW coil \u0394T when inactive (GL36 L)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "cooling-coil-entering-temp",
-        "cooling-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "cooling_coil_entering_temp",
@@ -8614,90 +5991,23 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_ccet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil entering sensor error \u03b5CCET"
-        },
-        "eps_cclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Cooling-coil leaving sensor error \u03b5CCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "htg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Heating-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc14",
@@ -8710,8 +6020,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -8820,18 +6130,9 @@
       "title": "HW coil \u0394T when inactive (GL36 M)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
-      "required_roles": [
-        "heating-coil-entering-temp",
-        "heating-coil-leaving-temp",
-        "outside-air-damper",
-        "cooling-valve"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
+      "required_roles": [],
       "optional_roles": [
         "heating_coil_entering_temp",
         "heating_coil_leaving_temp",
@@ -8842,98 +6143,23 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "eps_hcet": {
-          "default": 1.15,
-          "unit": "\u00b0F",
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
           "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil entering sensor error \u03b5HCET"
-        },
-        "eps_hclt": {
-          "default": 1.15,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 10.0,
-          "step": 0.25,
-          "label": "Heating-coil leaving sensor error \u03b5HCLT"
-        },
-        "delta_supply_fan": {
-          "default": 0.55,
-          "unit": "\u00b0F",
-          "min": 0.0,
-          "max": 5.0,
-          "step": 0.05,
-          "label": "Supply-fan heat rise \u0394TSF (GL36 default 2\u00b0F)"
-        },
-        "econ_min_pos": {
-          "default": 0.05,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Economizer minimum-position threshold"
-        },
-        "econ_full_open": {
-          "default": 0.9,
-          "unit": "frac",
-          "min": 0.5,
-          "max": 1.0,
-          "step": 0.01,
-          "label": "Economizer full-open threshold"
-        },
-        "clg_inactive_max": {
-          "default": 0.1,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.5,
-          "step": 0.01,
-          "label": "Cooling-command inactive ceiling"
-        },
-        "clg_on_min": {
-          "default": 0.01,
-          "unit": "frac",
-          "min": 0.0,
-          "max": 0.25,
-          "step": 0.01,
-          "label": "Cooling-command ON threshold"
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         },
         "mix_tol": {
           "default": 1.15,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.0,
           "max": 10.0,
           "step": 0.25,
-          "label": "Legacy master sensor tolerance (sets all \u03b5 values)"
-        },
-        "mode_delay_min": {
-          "default": 0.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Mode-change suspension (GL36 default 30)"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Legacy master sensor tolerance (sets all eps values)"
         }
       },
       "pandas_implementation": "fc15",
@@ -8946,8 +6172,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -9056,51 +6282,36 @@
       "title": "SAT deviation from setpoint",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp"
+        "sat",
+        "sat_sp"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_dev_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 15.0,
           "step": 0.5,
           "label": "SAT deviation"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_sat_dev",
+      "pandas_implementation": "ahu_satdev",
       "datafusion_sql_implementation": "ahu_satdev.sql",
       "sql_file": "ahu_satdev.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-satdev",
@@ -9112,8 +6323,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -9222,15 +6433,12 @@
       "title": "Duct static pressure high",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "duct-static-pressure",
-        "duct-static-pressure-sp"
+        "duct_static",
+        "duct_static_sp",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
@@ -9238,9 +6446,17 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_high_margin": {
           "default": 0.25,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -9248,26 +6464,14 @@
         },
         "pressure_on_min": {
           "default": 0.2,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
           "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_duct_high",
+      "pandas_implementation": "ahu_ducthi",
       "datafusion_sql_implementation": "ahu_ducthi.sql",
       "sql_file": "ahu_ducthi.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi",
@@ -9279,8 +6483,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9399,29 +6603,26 @@
       "title": "Heating and cooling simultaneous",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "heating-valve",
-        "cooling-valve"
+        "htg_valve_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "valve_open_pct": {
           "default": 0.1,
           "unit": "frac",
@@ -9429,21 +6630,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Valve open threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "ahu_simul_heat_cool",
+      "pandas_implementation": "ahu_simul",
       "datafusion_sql_implementation": "ahu_simul.sql",
       "sql_file": "ahu_simul.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#ahu-simul",
@@ -9453,8 +6642,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -9560,18 +6749,13 @@
       "canonical_id": "OAT-METEO",
       "pandas_id": "OAT-METEO",
       "rule_id": "OAT-METEO",
-      "title": "BAS outdoor-air sensor vs Open-Meteo",
+      "title": "Equipment OAT vs weather-staged wx OAT",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "web-outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [
         "web_oa_t"
@@ -9580,23 +6764,19 @@
       "default_thresholds": {
         "oat_err": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
-          "label": "Max OAT disagreement"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
+          "label": "OAT vs meteo tolerance"
         },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "oat_vs_meteo",
@@ -9609,8 +6789,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "oat_err": {
@@ -9717,52 +6897,37 @@
       "canonical_id": "ECON-1",
       "pandas_id": "ECON-1",
       "rule_id": "ECON-1",
-      "title": "Economizer stuck closed",
+      "title": "Economizer stuck closed when OAT favorable",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "fan-cmd",
-        "outside-air-damper",
-        "outside-air-temp"
+        "fan_cmd",
+        "oa_damper_pct",
+        "oa_t"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ1_oat_min": {
           "default": 55.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 70.0,
           "step": 1.0,
           "label": "Favorable OAT"
         },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
+        "econ1_damper_max": {
+          "default": 0.05,
+          "unit": "frac",
           "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "max": 0.2,
+          "step": 0.01,
+          "label": "Stuck-closed damper frac"
         }
       },
       "pandas_implementation": "econ1",
@@ -9775,8 +6940,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "econ1_oat_min": {
@@ -9882,35 +7047,24 @@
       "canonical_id": "ECON-2",
       "pandas_id": "ECON-2",
       "rule_id": "ECON-2",
-      "title": "Economizing when outdoor unfavorable",
+      "title": "Economizing when outdoor air unfavorable",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "outside-air-damper"
+        "oa_t",
+        "oa_damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "econ2_oat_hi": {
           "default": 63.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 80.0,
           "step": 1.0,
@@ -9924,17 +7078,13 @@
           "step": 0.02,
           "label": "Damper open frac"
         },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
+          "default": 300,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ2",
@@ -9949,8 +7099,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "econ2_oat_hi": {
@@ -10069,33 +7219,31 @@
       "title": "Mech cooling without integrated economizer",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper",
-        "cooling-valve"
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity"
+        "web_oa_t",
+        "web_oa_dp",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ3_db_min": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 50.0,
           "max": 68.0,
           "step": 1.0,
@@ -10103,7 +7251,7 @@
         },
         "econ3_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -10111,7 +7259,7 @@
         },
         "econ3_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -10124,21 +7272,9 @@
           "max": 1.0,
           "step": 0.02,
           "label": "Integrated economizer damper"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ2",
+      "pandas_implementation": "econ_3",
       "datafusion_sql_implementation": "econ3_mech_without_econ.sql",
       "sql_file": "econ3_mech_without_econ.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-3",
@@ -10148,8 +7284,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -10288,50 +7424,35 @@
       "title": "Low estimated OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-cmd"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "oa_min_pct": {
           "default": 21.0,
-          "unit": "%",
+          "unit": "pct",
           "min": 5.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Min OA fraction"
         },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "default": 600,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "econ4",
@@ -10344,8 +7465,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "oa_min_pct": {
@@ -10454,53 +7575,38 @@
       "title": "Preheat over-conditioning",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "preheat-leaving-temp",
-        "discharge-air-temp-sp",
-        "outside-air-temp",
-        "heating-valve"
+        "preheat_leave_t",
+        "sat_sp",
+        "oa_t",
+        "htg_valve_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "preheat_over_f": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.1,
           "label": "Preheat over \u0394T"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ5",
+      "pandas_implementation": "econ_5",
       "datafusion_sql_implementation": "econ5_preheat_over.sql",
       "sql_file": "econ5_preheat_over.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-5",
@@ -10510,8 +7616,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -10620,30 +7726,29 @@
       "title": "Economizing in freezing weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper"
+        "oa_damper_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp"
+        "web_oa_t",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ6_oat_max_f": {
           "default": 25.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 15.0,
           "max": 40.0,
           "step": 1.0,
@@ -10656,21 +7761,9 @@
           "max": 0.5,
           "step": 0.01,
           "label": "Winter min-OA damper"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ6_compute",
+      "pandas_implementation": "econ_6",
       "datafusion_sql_implementation": "econ6_econ_freezing.sql",
       "sql_file": "econ6_econ_freezing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-6",
@@ -10680,8 +7773,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -10800,35 +7893,31 @@
       "title": "Economizer OK but not economizing",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-damper"
+        "oa_damper_pct",
+        "clg_valve_pct"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "web-outside-air-dewpoint",
-        "web-outside-air-humidity",
-        "cooling-valve",
-        "compressor-status",
-        "dx-cool-cmd"
+        "web_oa_t",
+        "web_oa_dp",
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "econ7_db_min": {
           "default": 35.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 20.0,
           "max": 50.0,
           "step": 1.0,
@@ -10836,7 +7925,7 @@
         },
         "econ7_db_max": {
           "default": 72.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 80.0,
           "step": 1.0,
@@ -10844,7 +7933,7 @@
         },
         "econ7_dp_max": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 68.0,
           "step": 1.0,
@@ -10857,21 +7946,9 @@
           "max": 0.9,
           "step": 0.02,
           "label": "Economizing damper threshold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "econ7_compute",
+      "pandas_implementation": "econ_7",
       "datafusion_sql_implementation": "econ7_ok_not_economizing.sql",
       "sql_file": "econ7_ok_not_economizing.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#econ-7",
@@ -10881,8 +7958,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -11021,50 +8098,35 @@
       "title": "Mechanical cooling below 60\u00b0F web OAT",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "chiller",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "chiller",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
         "web_oa_t"
       ],
       "optional_roles": [
-        "web-outside-air-temp",
-        "compressor-status",
-        "chiller-status",
-        "chw-pump-status",
-        "dx-cool-cmd"
+        "clg_valve_pct",
+        "chiller_status"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "mech_oat_max_f": {
           "default": 60.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 65.0,
           "step": 1.0,
           "label": "Mech-cool OAT ceiling"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "mech_oat1_compute",
+      "pandas_implementation": "mech_oat_1",
       "datafusion_sql_implementation": "mech_oat_1.sql",
       "sql_file": "mech_oat_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#mech-oat-1",
@@ -11074,8 +8136,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -11184,60 +8246,29 @@
       "title": "Chiller running with no building load",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
-        "chiller-status",
-        "chw-pump-status",
-        "compressor-status",
-        "building-zone-load-satisfied",
-        "building-ahu-load-satisfied"
+        "chiller_status",
+        "chiller_cmd",
+        "chw_pump_status",
+        "chw_pump_cmd",
+        "building_zone_load_satisfied",
+        "building_ahu_load_satisfied"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "comfort_low_f": {
-          "default": 70.0,
-          "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
-          "step": 0.5,
-          "label": "Comfort low"
-        },
-        "comfort_high_f": {
-          "default": 75.0,
-          "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
-          "step": 0.5,
-          "label": "Comfort high"
-        },
-        "sat_band_f": {
-          "default": 2.0,
-          "unit": "\u00b0F",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "AHU SAT\u2248SP band"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 1800.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "chw_noload1_compute",
+      "pandas_implementation": "chw_noload_1",
       "datafusion_sql_implementation": "chw_noload_1.sql",
       "sql_file": "chw_noload_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-noload-1",
@@ -11247,8 +8278,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -11344,52 +8375,42 @@
       "canonical_id": "VAV-1",
       "pandas_id": "VAV-1",
       "rule_id": "VAV-1",
-      "title": "Zone comfort band",
+      "title": "Zone comfort band violation hours with confirm window",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav",
-        "zone"
-      ],
-      "equipment_kinds": [
-        "vav",
-        "zone"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
       "optional_roles": [
         "occ_mode"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "zone_lo": {
+        "zone_t_lo": {
           "default": 70.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Zone low"
         },
-        "zone_hi": {
+        "zone_t_hi": {
           "default": 75.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 72.0,
           "max": 85.0,
           "step": 0.5,
           "label": "Zone high"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav1",
@@ -11405,8 +8426,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "zone_t_lo": {
@@ -11523,45 +8544,33 @@
       "canonical_id": "VAV-2",
       "pandas_id": "VAV-2",
       "rule_id": "VAV-2",
-      "title": "Night setback miss",
+      "title": "Night setback miss \u2014 unoccupied zone above heating setback",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav",
-        "zone"
-      ],
-      "equipment_kinds": [
-        "vav",
-        "zone"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "zone-air-temp",
-        "occupied"
+        "zone_t",
+        "occ_mode"
       ],
-      "optional_roles": [
-        "occ-mode"
-      ],
+      "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
         "setback_hi": {
           "default": 68.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 55.0,
           "max": 72.0,
           "step": 0.5,
           "label": "Setback high"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "default": 900,
+          "unit": "sec",
+          "min": 0,
+          "max": 3600,
+          "step": 300,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav2",
@@ -11574,8 +8583,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "setback_hi": {
@@ -11684,32 +8693,30 @@
       "title": "Excessive reheat during warm weather",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "reheat-valve"
+        "oa_t",
+        "reheat_valve_pct",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_oat": {
           "default": 78.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 65.0,
           "max": 90.0,
           "step": 1.0,
@@ -11730,21 +8737,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav3",
+      "pandas_implementation": "vav_3",
       "datafusion_sql_implementation": "vav3_excessive_reheat.sql",
       "sql_file": "vav3_excessive_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-3",
@@ -11754,8 +8749,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -11884,29 +8879,26 @@
       "title": "Damper stuck at full open",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "damper"
+        "damper_pct",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd",
-        "loop-enabled"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "full_open_pct": {
           "default": 0.975,
           "unit": "frac",
@@ -11914,14 +8906,6 @@
           "max": 1.0,
           "step": 0.005,
           "label": "Full open frac"
-        },
-        "sustain_hours": {
-          "default": 1.5,
-          "unit": "h",
-          "min": 0.5,
-          "max": 6.0,
-          "step": 0.5,
-          "label": "Sustain window"
         },
         "flow_on_min": {
           "default": 25.0,
@@ -11931,33 +8915,27 @@
           "step": 5.0,
           "label": "Airflow-on min"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+        "sustain_hours": {
+          "default": 1.5,
+          "unit": "h",
+          "min": 0.5,
+          "max": 6.0,
+          "step": 0.5,
+          "label": "Sustain window"
         }
       },
-      "pandas_implementation": "vav4",
+      "pandas_implementation": "vav_4",
       "datafusion_sql_implementation": "vav4_damper_full_open.sql",
       "sql_file": "vav4_damper_full_open.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-4",
       "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-4",
-      "test_coverage": [
-        "scripts/materialize_vav_oracle_fixtures.py"
-      ],
+      "test_coverage": [],
       "parity_status": "sql_screening",
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "control_loop",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12086,43 +9064,28 @@
       "title": "Airflow sensor bias",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "zone-airflow",
-        "damper"
+        "zone_flow",
+        "damper_pct"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "vav5",
+      "pandas_implementation": "vav_5",
       "datafusion_sql_implementation": "vav5_airflow_bias.sql",
       "sql_file": "vav5_airflow_bias.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-5",
@@ -12132,8 +9095,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12232,31 +9195,20 @@
       "title": "Reheat when cooling available",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "reheat-valve"
+        "oa_t",
+        "reheat_valve_pct"
       ],
       "optional_roles": [
-        "cooling-available"
+        "clg_available"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "free_cool_oat": {
           "default": 65.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 75.0,
           "step": 1.0,
@@ -12270,17 +9222,13 @@
           "step": 0.05,
           "label": "Reheat frac"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "vav6",
@@ -12293,8 +9241,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "free_cool_oat": {
@@ -12413,30 +9361,28 @@
       "title": "Reheat valve stuck / no temp rise",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "reheat-valve",
-        "vav-discharge-air-temp",
-        "vav-inlet-air-temp"
+        "reheat_valve_pct",
+        "vav_discharge_t",
+        "vav_inlet_t",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "reheat_cmd": {
           "default": 0.3,
           "unit": "frac",
@@ -12447,7 +9393,7 @@
         },
         "min_rise": {
           "default": 3.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 15.0,
           "step": 0.5,
@@ -12460,21 +9406,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_reheat_stuck",
+      "pandas_implementation": "vav_reheat",
       "datafusion_sql_implementation": "vav_reheat.sql",
       "sql_file": "vav_reheat.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-reheat",
@@ -12484,8 +9418,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12614,32 +9548,30 @@
       "title": "VAV leave vs parent AHU SAT (fedBy)",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "vav-discharge-air-temp",
-        "ahu-discharge-air-temp"
+        "vav_discharge_t",
+        "ahu_sat",
+        "zone_flow"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "delta_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 25.0,
           "step": 0.5,
@@ -12652,21 +9584,9 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav_vs_ahu_leave",
+      "pandas_implementation": "vav_ahu_leave",
       "datafusion_sql_implementation": "vav_ahu_leave.sql",
       "sql_file": "vav_ahu_leave.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave",
@@ -12676,8 +9596,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -12796,29 +9716,34 @@
       "title": "Min airflow / fixed high flow",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "vav"
-      ],
-      "equipment_kinds": [
-        "vav"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "zone-airflow"
+        "zone_flow"
       ],
       "optional_roles": [
         "min_flow_sp",
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
+        "high_min_flow_sp": {
+          "default": 250.0,
+          "unit": "cfm",
+          "min": 50.0,
+          "max": 2000.0,
+          "step": 10.0,
+          "label": "High min-flow SP"
+        },
         "flow_on_min": {
           "default": 25.0,
           "unit": "cfm",
@@ -12826,6 +9751,14 @@
           "max": 200.0,
           "step": 5.0,
           "label": "Airflow-on min"
+        },
+        "fixed_flow_hours": {
+          "default": 1.0,
+          "unit": "h",
+          "min": 0.25,
+          "max": 6.0,
+          "step": 0.25,
+          "label": "Fixed-flow rolling window"
         },
         "fixed_flow_max_std": {
           "default": 15.0,
@@ -12842,43 +9775,22 @@
           "max": 2000.0,
           "step": 10.0,
           "label": "Fixed-flow min mean"
-        },
-        "high_min_flow_sp": {
-          "default": 250.0,
-          "unit": "cfm",
-          "min": 50.0,
-          "max": 2000.0,
-          "step": 10.0,
-          "label": "High min-flow SP"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vav7",
+      "pandas_implementation": "vav_7",
       "datafusion_sql_implementation": "vav7_min_airflow.sql",
       "sql_file": "vav7_min_airflow.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vav-7",
       "sql_documentation_link": "docs/rules/cookbook/datafusion-sql-cookbook.md#vav-7",
       "test_coverage": [
-        "scripts/materialize_vav_oracle_fixtures.py",
         "tests/analytics/test_vav_health.py"
       ],
       "parity_status": "sql_screening",
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -13027,15 +9939,11 @@
       "title": "Low chilled-water \u0394T",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-return-temp"
+        "chw_supply_t",
+        "chw_return_t"
       ],
       "optional_roles": [
         "chw_pump_cmd",
@@ -13046,41 +9954,23 @@
         "chiller_power",
         "chw_flow"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_dt": {
           "default": 4.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 1.0,
           "max": 12.0,
           "step": 0.5,
-          "label": "Min \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "Minimum delta-T"
         }
       },
       "pandas_implementation": "chw1",
@@ -13098,8 +9988,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "Missing proof \u2192 pandas SKIPPED_MISSING_ROLES; SQL returns 0 fault hours (optional proof roles). Proven-off zeros do not accumulate \u0394T hours.",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 900,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -13208,34 +10098,24 @@
       "title": "DP below SP at max pump speed",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chw-diff-pressure",
-        "chw-diff-pressure-sp",
-        "chw-pump-cmd"
+        "chw_dp",
+        "chw_dp_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "dp_margin": {
           "default": 2.2,
           "unit": "psi",
@@ -13251,21 +10131,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw2",
+      "pandas_implementation": "chw_2",
       "datafusion_sql_implementation": "chw2_dp_low.sql",
       "sql_file": "chw2_dp_low.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-2",
@@ -13275,8 +10143,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -13395,56 +10263,34 @@
       "title": "Plant supply temp outside deadband",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chilled-water-supply-temp-sp",
-        "chw-pump-cmd"
+        "chw_supply_t",
+        "chw_supply_sp",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sp_band": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
           "label": "SP band"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw3",
+      "pandas_implementation": "chw_3",
       "datafusion_sql_implementation": "chw3_supply_band.sql",
       "sql_file": "chw3_supply_band.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-3",
@@ -13454,8 +10300,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -13564,39 +10410,29 @@
       "title": "Flow high at max pump",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chw-flow",
-        "chw-pump-cmd"
+        "chw_flow",
+        "chw_pump_cmd"
       ],
       "optional_roles": [],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "flow_hi": {
-          "default": 1100,
+          "default": 1100.0,
           "unit": "gpm",
-          "min": 200,
-          "max": 3000,
-          "step": 50,
+          "min": 200.0,
+          "max": 3000.0,
+          "step": 50.0,
           "label": "Flow high"
         },
         "pump_hi": {
@@ -13606,21 +10442,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Pump high-speed threshold"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "chw4",
+      "pandas_implementation": "chw_4",
       "datafusion_sql_implementation": "chw4_flow_high.sql",
       "sql_file": "chw4_flow_high.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#chw-4",
@@ -13630,8 +10454,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -13750,58 +10574,45 @@
       "title": "Discharge cold when heating",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "zone-air-temp",
-        "fan-cmd"
+        "sat",
+        "zone_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "compressor_status",
         "fan_status"
       ],
-      "operational_proof_roles": [
-        "compressor-status",
-        "equipment-enable",
-        "fan-status",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_sat": {
           "default": 85.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 70.0,
           "max": 110.0,
           "step": 1.0,
-          "label": "Min heating SAT"
+          "label": "Min discharge SAT"
         },
         "zone_cold": {
           "default": 69.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 60.0,
           "max": 72.0,
           "step": 0.5,
-          "label": "Zone cold"
-        },
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 600.0,
-          "unit": "sec"
+          "label": "Zone cold threshold"
         }
       },
-      "pandas_implementation": "hp1",
+      "pandas_implementation": "hp_1",
       "datafusion_sql_implementation": "hp1_discharge_cold.sql",
       "sql_file": "hp1_discharge_cold.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#hp-1",
@@ -13811,8 +10622,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "compressor",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -13931,40 +10742,32 @@
       "title": "OA temperature spike",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "weather"
-      ],
-      "equipment_kinds": [
-        "weather"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp"
+        "oa_t"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 300.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "spike_limit": {
           "default": 16.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 4.0,
           "max": 40.0,
           "step": 1.0,
           "label": "Spike limit"
-        },
-        "confirm_min": {
-          "default": 5.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 300.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "wx1",
+      "pandas_implementation": "wx_1",
       "datafusion_sql_implementation": "wx1_oa_spike.sql",
       "sql_file": "wx1_oa_spike.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#wx-1",
@@ -13974,8 +10777,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 300,
       "parameters": {
         "confirm_seconds": {
@@ -14084,16 +10887,11 @@
       "title": "Condenser water not optimized vs wet-bulb",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
-      "equipment_kinds": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t"
       ],
       "optional_roles": [
         "pump_status",
@@ -14101,25 +10899,19 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -14127,26 +10919,14 @@
         },
         "cw_slack": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Slack below target"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_opt",
+      "pandas_implementation": "cw_opt_1",
       "datafusion_sql_implementation": "cw_opt_1.sql",
       "sql_file": "cw_opt_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-opt-1",
@@ -14156,8 +10936,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -14276,42 +11056,32 @@
       "title": "High CW approach at full tower fan",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
-      "equipment_kinds": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "approach_max_f": {
           "default": 8.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 5.0,
           "max": 15.0,
           "step": 0.5,
@@ -14324,21 +11094,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_apr",
+      "pandas_implementation": "cw_apr_1",
       "datafusion_sql_implementation": "cw_apr_1.sql",
       "sql_file": "cw_apr_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-apr-1",
@@ -14348,8 +11106,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -14468,42 +11226,32 @@
       "title": "Excess tower fan energy vs wet-bulb limit",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller",
-        "cooling_tower"
-      ],
-      "equipment_kinds": [
-        "chiller",
-        "cooling_tower"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "condenser-water-supply-temp"
+        "cw_supply_t",
+        "web_wb_t",
+        "tower_fan_cmd"
       ],
       "optional_roles": [
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "web-outside-air-wetbulb"
+        "pump_status",
+        "chiller_status",
+        "chw_flow",
+        "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "cw_approach": {
           "default": 7.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 3.0,
           "max": 15.0,
           "step": 0.5,
@@ -14511,7 +11259,7 @@
         },
         "excess_beyond_approach_f": {
           "default": 5.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 2.0,
           "max": 20.0,
           "step": 0.5,
@@ -14524,21 +11272,9 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Tower fan full-speed threshold"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "cw_fan_excess",
+      "pandas_implementation": "cw_fan_1",
       "datafusion_sql_implementation": "cw_fan_1.sql",
       "sql_file": "cw_fan_1.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cw-fan-1",
@@ -14548,8 +11284,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -14678,15 +11414,10 @@
       "title": "Duct static trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "duct-static-pressure",
-        "vav-pressure-request-sum"
+        "duct_static"
       ],
       "optional_roles": [
         "duct_static_sp",
@@ -14694,18 +11425,19 @@
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "duct_hi": {
           "default": 1.35,
-          "unit": "in. w.c.",
+          "unit": "in_wc",
           "min": 0.5,
           "max": 3.0,
           "step": 0.05,
@@ -14718,21 +11450,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim1",
+      "pandas_implementation": "trim_1",
       "datafusion_sql_implementation": "trim1_duct_static.sql",
       "sql_file": "trim1_duct_static.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-1",
@@ -14742,8 +11462,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -14862,15 +11582,10 @@
       "title": "HWST trim advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "boiler"
-      ],
-      "equipment_kinds": [
-        "boiler"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "hot-water-supply-temp",
-        "hw-reset-request-sum"
+        "hw_supply_t"
       ],
       "optional_roles": [
         "pump_status",
@@ -14878,25 +11593,19 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "hwst_hi": {
           "default": 160.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 120.0,
           "max": 200.0,
           "step": 1.0,
@@ -14909,21 +11618,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim3",
+      "pandas_implementation": "trim_3",
       "datafusion_sql_implementation": "trim3_hwst.sql",
       "sql_file": "trim3_hwst.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-3",
@@ -14933,8 +11630,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -15053,15 +11750,10 @@
       "title": "CHW plant reset advisory",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "chiller"
-      ],
-      "equipment_kinds": [
-        "chiller"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "chilled-water-supply-temp",
-        "chw-reset-request-sum"
+        "chw_supply_t"
       ],
       "optional_roles": [
         "pump_status",
@@ -15069,25 +11761,19 @@
         "chw_flow",
         "chw_pump_cmd"
       ],
-      "operational_proof_roles": [
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "pump-speed-feedback",
-        "pump-current",
-        "chw-flow",
-        "water-flow",
-        "chiller-status",
-        "chiller-current",
-        "chiller-power",
-        "pump-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "chw_lo": {
           "default": 45.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 35.0,
           "max": 55.0,
           "step": 0.5,
@@ -15100,21 +11786,9 @@
           "max": 10.0,
           "step": 0.5,
           "label": "Request sum low"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "trim4",
+      "pandas_implementation": "trim_4",
       "datafusion_sql_implementation": "trim4_chw_reset.sql",
       "sql_file": "trim4_chw_reset.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#trim-4",
@@ -15124,8 +11798,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "hydronic_flow",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -15241,53 +11915,45 @@
       "canonical_id": "SCHED-1",
       "pandas_id": "SCHED-1",
       "rule_id": "SCHED-1",
-      "title": "Unoccupied runtime",
+      "title": "Excess / wasted unoccupied fan runtime when the zone is already in the comfort band (optimal-start / schedule misconfig signal). Without zone_t, falls back to unoccupied + fan_on (pandas sched1 base).",
       "aliases": [
         "excess_runtime"
       ],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "occupied",
-        "fan-status"
+        "occ_mode",
+        "fan_status"
       ],
       "optional_roles": [
-        "zone-air-temp"
+        "zone_t"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 1800.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "comfort_low_f": {
           "default": 70.0,
           "unit": "\u00b0F",
-          "min": 60.0,
-          "max": 78.0,
+          "min": 50.0,
+          "max": 80.0,
           "step": 0.5,
-          "label": "Comfort low"
+          "label": "Zone comfort low"
         },
         "comfort_high_f": {
           "default": 75.0,
           "unit": "\u00b0F",
-          "min": 68.0,
-          "max": 85.0,
+          "min": 55.0,
+          "max": 90.0,
           "step": 0.5,
-          "label": "Comfort high"
-        },
-        "confirm_min": {
-          "default": 30.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 1800.0,
-          "unit": "sec"
+          "label": "Zone comfort high"
         }
       },
       "pandas_implementation": "sched1",
@@ -15304,8 +11970,8 @@
       "parity_level": "sql_screening",
       "difference_class": "alias",
       "known_semantic_differences": "aliases: excess_runtime (not independent rules)",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 1800,
       "parameters": {
         "confirm_seconds": {
@@ -15424,38 +12090,25 @@
       "title": "Always-on fan or pump runtime",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
-      "equipment_kinds": [
-        "ahu",
-        "vav",
-        "chiller",
-        "boiler",
-        "heatpump"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [],
       "optional_roles": [
-        "fan-status",
-        "pump-status",
-        "chw-pump-status",
-        "hw-pump-status",
-        "chiller-status",
-        "compressor-status",
-        "tower-fan-cmd",
-        "cw-fan-cmd",
-        "fan-cmd",
-        "chw-pump-cmd",
-        "hw-pump-cmd",
-        "duct-static-pressure",
-        "chw-diff-pressure"
+        "fan_status",
+        "pump_status",
+        "chiller_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 3600.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "always_on_pct": {
           "default": 0.95,
           "unit": "frac",
@@ -15463,26 +12116,6 @@
           "max": 1.0,
           "step": 0.01,
           "label": "Always-on fraction"
-        },
-        "pressure_on_min": {
-          "default": 0.2,
-          "unit": "eng",
-          "min": 0.05,
-          "max": 2.0,
-          "step": 0.05,
-          "label": "Pressure-on evidence"
-        },
-        "confirm_min": {
-          "default": 60.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 3600.0,
-          "unit": "sec"
         }
       },
       "pandas_implementation": "_sched247",
@@ -15499,8 +12132,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "4.3 ranked proof (status/current > command; pressure inferred only). SQL mean(on) >= always_on_pct over the analysis window matches pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 3600,
       "parameters": {
         "confirm_seconds": {
@@ -15609,32 +12242,21 @@
       "title": "SAT reset not tracking outdoor air",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp-sp",
-        "outside-air-temp"
+        "sat_sp",
+        "oa_t"
       ],
       "optional_roles": [
-        "fan-status",
-        "fan-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
         "reset_err_f": {
           "default": 3.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 10.0,
           "step": 0.5,
@@ -15642,15 +12264,15 @@
         },
         "reset_sat_at_65": {
           "default": 52.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 45.0,
           "max": 65.0,
           "step": 0.5,
-          "label": "SAT SP at 65\u00b0F OAT"
+          "label": "SAT SP at 65F OAT"
         },
         "reset_slope": {
           "default": 0.25,
-          "unit": "\u00b0F/\u00b0F",
+          "unit": "frac",
           "min": 0.05,
           "max": 1.0,
           "step": 0.05,
@@ -15658,23 +12280,19 @@
         },
         "reset_oat_ref": {
           "default": 65.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 50.0,
           "max": 80.0,
           "step": 1.0,
           "label": "Reset OAT ref"
         },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 900.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
       "pandas_implementation": "reset1",
@@ -15687,8 +12305,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "reset_err_f": {
@@ -15827,33 +12445,25 @@
       "title": "Fan cmd/status mismatch",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "fan-cmd",
-        "fan-status"
+        "fan_cmd",
+        "fan_status"
       ],
       "optional_roles": [],
       "operational_proof_roles": [],
       "default_thresholds": {
-        "confirm_min": {
-          "default": 10.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
         "confirm_seconds": {
           "default": 600.0,
-          "unit": "sec"
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
         }
       },
-      "pandas_implementation": "cmd1",
+      "pandas_implementation": "cmd_1",
       "datafusion_sql_implementation": "cmd1_fan_mismatch.sql",
       "sql_file": "cmd1_fan_mismatch.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#cmd-1",
@@ -15863,8 +12473,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "always",
-      "startup_delay_seconds": 0.0,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 600,
       "parameters": {
         "confirm_seconds": {
@@ -15963,31 +12573,28 @@
       "title": "Low OA fraction",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "mixed-air-temp",
-        "return-air-temp",
-        "outside-air-temp",
-        "fan-status"
+        "mat",
+        "rat",
+        "oa_t",
+        "fan_cmd"
       ],
       "optional_roles": [
         "fan_status",
         "fan_cmd"
       ],
-      "operational_proof_roles": [
-        "fan-status",
-        "fan-speed-feedback",
-        "fan-current",
-        "fan-power",
-        "airflow-proof",
-        "fan-cmd"
-      ],
+      "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "min_oa_frac": {
           "default": 0.15,
           "unit": "frac",
@@ -15998,26 +12605,14 @@
         },
         "oat_rat_guard": {
           "default": 2.2,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.1,
-          "label": "Min |RAT\u2212OAT| guard"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
+          "label": "OAT/RAT guard"
         }
       },
-      "pandas_implementation": "oa1",
+      "pandas_implementation": "oa_1",
       "datafusion_sql_implementation": "oa1_low_oa_frac.sql",
       "sql_file": "oa1_low_oa_frac.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#oa-1",
@@ -16027,8 +12622,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "fan_running",
-      "startup_delay_seconds": 600,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -16147,16 +12742,12 @@
       "title": "OA damper leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "outside-air-temp",
-        "mixed-air-temp",
-        "outside-air-damper"
+        "oa_damper_pct",
+        "oa_t",
+        "mat"
       ],
       "optional_roles": [
         "fan_status",
@@ -16164,28 +12755,24 @@
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 6.0,
           "step": 0.5,
           "label": "Leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "dmp1",
+      "pandas_implementation": "dmp_1",
       "datafusion_sql_implementation": "dmp1_oa_damper_leak.sql",
       "sql_file": "dmp1_oa_damper_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#dmp-1",
@@ -16195,8 +12782,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {
@@ -16305,27 +12892,31 @@
       "title": "Cooling valve leakage",
       "aliases": [],
       "kind": "diagnostic",
-      "equipment_types": [
-        "ahu"
-      ],
-      "equipment_kinds": [
-        "ahu"
-      ],
+      "equipment_types": [],
+      "equipment_kinds": null,
       "required_roles": [
-        "discharge-air-temp",
-        "discharge-air-temp-sp",
-        "cooling-valve"
+        "clg_valve_pct",
+        "sat",
+        "sat_sp",
+        "mat"
       ],
       "optional_roles": [
-        "mixed-air-temp",
-        "fan-status",
-        "fan-cmd"
+        "fan_status",
+        "fan_cmd"
       ],
       "operational_proof_roles": [],
       "default_thresholds": {
+        "confirm_seconds": {
+          "default": 900.0,
+          "unit": "sec",
+          "min": 0.0,
+          "max": 3600.0,
+          "step": 300.0,
+          "label": "Confirm time"
+        },
         "sat_err": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 8.0,
           "step": 0.5,
@@ -16333,26 +12924,14 @@
         },
         "mat_leak_delta": {
           "default": 2.0,
-          "unit": "\u00b0F",
+          "unit": "degF",
           "min": 0.5,
           "max": 12.0,
           "step": 0.5,
           "label": "SAT vs MAT leak \u0394T"
-        },
-        "confirm_min": {
-          "default": 15.0,
-          "unit": "min",
-          "min": 0.0,
-          "max": 60.0,
-          "step": 1.0,
-          "label": "Fault confirm delay"
-        },
-        "confirm_seconds": {
-          "default": 900.0,
-          "unit": "sec"
         }
       },
-      "pandas_implementation": "vlv1",
+      "pandas_implementation": "vlv_1",
       "datafusion_sql_implementation": "vlv1_clg_valve_leak.sql",
       "sql_file": "vlv1_clg_valve_leak.sql",
       "documentation_link": "docs/rules/cookbook/pandas-cookbook.md#vlv-1",
@@ -16362,8 +12941,8 @@
       "parity_level": "sql_screening",
       "difference_class": "none",
       "known_semantic_differences": "",
-      "operational_gate": "conditional",
-      "startup_delay_seconds": 300,
+      "operational_gate": "fan_or_occupied_when_declared",
+      "startup_delay_seconds": null,
       "confirm_seconds": 900,
       "parameters": {
         "confirm_seconds": {

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -38,14 +38,7 @@ aliases_index:
 matrix:
 - rule_id: SV-RANGE
   title: Sensor out of hard range
-  equipment_types: &id001
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id001 []
   required_roles: &id002 []
   optional_roles: &id003
   - oa_t
@@ -64,21 +57,15 @@ matrix:
   - pump_status
   - chw_pump_cmd
   - chiller_status
-  operational_proof_roles: &id004
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-current
-  - chw-flow
-  - compressor-status
-  - equipment-enable
+  operational_proof_roles: &id004 []
   default_thresholds: &id005
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     range_scale_temperature:
       default: 1.0
       unit: x
@@ -86,31 +73,7 @@ matrix:
       max: 2.0
       step: 0.1
       label: Temp range scale
-    range_scale_humidity:
-      default: 1.0
-      unit: x
-      min: 0.5
-      max: 2.0
-      step: 0.1
-      label: Humidity range scale
-    range_scale_pressure:
-      default: 1.0
-      unit: x
-      min: 0.5
-      max: 2.0
-      step: 0.1
-      label: Pressure range scale
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_range
+  pandas_implementation: sv_range
   datafusion_sql_implementation: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
   test_coverage: &id006
@@ -121,14 +84,7 @@ matrix:
   difference_class: none
 - rule_id: SV-FLATLINE
   title: Sensor flatline (stuck)
-  equipment_types: &id007
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id007 []
   required_roles: &id008 []
   optional_roles: &id009
   - oa_t
@@ -148,9 +104,16 @@ matrix:
   - chiller_status
   operational_proof_roles: &id010 []
   default_thresholds: &id011
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     flatline_tol:
       default: 0.1
-      unit: °F
+      unit: degF
       min: 0.02
       max: 1.0
       step: 0.02
@@ -158,21 +121,11 @@ matrix:
     flatline_hours:
       default: 1.0
       unit: h
-      min: 0.5
-      max: 8.0
-      step: 0.5
+      min: 0.25
+      max: 12.0
+      step: 0.25
       label: Flatline window
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_flatline
+  pandas_implementation: sv_flatline
   datafusion_sql_implementation: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
   test_coverage: &id012
@@ -182,14 +135,7 @@ matrix:
   difference_class: none
 - rule_id: SV-SPIKE
   title: Sensor rate-of-change spike
-  equipment_types: &id013
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id013 []
   required_roles: &id014 []
   optional_roles: &id015
   - oa_t
@@ -208,21 +154,15 @@ matrix:
   - pump_status
   - chw_pump_cmd
   - chiller_status
-  operational_proof_roles: &id016
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-current
-  - chw-flow
-  - compressor-status
-  - equipment-enable
+  operational_proof_roles: &id016 []
   default_thresholds: &id017
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     spike_scale:
       default: 1.0
       unit: x
@@ -230,38 +170,7 @@ matrix:
       max: 3.0
       step: 0.25
       label: Spike limit scale (global)
-    spike_scale_temperature:
-      default: 1.0
-      unit: x
-      min: 0.25
-      max: 3.0
-      step: 0.25
-      label: Temp spike scale
-    spike_scale_humidity:
-      default: 1.0
-      unit: x
-      min: 0.25
-      max: 3.0
-      step: 0.25
-      label: Humidity spike scale
-    spike_scale_pressure:
-      default: 1.0
-      unit: x
-      min: 0.25
-      max: 3.0
-      step: 0.25
-      label: Pressure spike scale
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_spike
+  pandas_implementation: sv_spike
   datafusion_sql_implementation: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
   test_coverage: &id018
@@ -271,14 +180,7 @@ matrix:
   difference_class: none
 - rule_id: SV-STALE
   title: Stale data (no fresh samples)
-  equipment_types: &id019
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id019 []
   required_roles: &id020 []
   optional_roles: &id021
   - oa_t
@@ -293,6 +195,13 @@ matrix:
   - oa_h
   operational_proof_roles: &id022 []
   default_thresholds: &id023
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     stale_hours:
       default: 2.0
       unit: h
@@ -300,17 +209,14 @@ matrix:
       max: 12.0
       step: 0.5
       label: Stale window
-    confirm_min:
-      default: 5.0
-      unit: min
+    stale_tol:
+      default: 0.05
+      unit: degF
       min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _sweep_stale
+      max: 1.0
+      step: 0.01
+      label: Stale tolerance
+  pandas_implementation: sv_stale
   datafusion_sql_implementation: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
   test_coverage: &id024
@@ -320,14 +226,7 @@ matrix:
   difference_class: none
 - rule_id: SV-RATE
   title: Context-aware sensor rate of change
-  equipment_types: &id025
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - weather
-  - zone
-  - heatpump
+  equipment_types: &id025 []
   required_roles: &id026 []
   optional_roles: &id027
   - oa_t
@@ -337,6 +236,13 @@ matrix:
   - sat
   operational_proof_roles: &id028 []
   default_thresholds: &id029
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     persistence_min:
       default: 10.0
       unit: min
@@ -344,45 +250,14 @@ matrix:
       max: 60.0
       step: 1.0
       label: Fault persistence
-    transition_window_min:
-      default: 20.0
-      unit: min
-      min: 5.0
+    steady_fault_per_hour:
+      default: 6.0
+      unit: degF_per_h
+      min: 1.0
       max: 60.0
-      step: 5.0
-      label: Transition window
-    max_gap_hours:
-      default: 2.0
-      unit: h
-      min: 0.25
-      max: 6.0
-      step: 0.25
-      label: Max sample gap
-    design_flow:
-      default: 0.0
-      unit: cfm
-      min: 0.0
-      max: 100000.0
-      step: 100.0
-      label: Design flow (flow profiles)
-    sensor_span:
-      default: 0.0
-      unit: eng
-      min: 0.0
-      max: 100000.0
-      step: 10.0
-      label: Sensor span (flow/pressure)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: _sv_rate_compute
+      step: 0.5
+      label: Steady-state slew limit
+  pandas_implementation: sv_rate
   datafusion_sql_implementation: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
   test_coverage: &id030
@@ -396,77 +271,75 @@ matrix:
   difference_class: semantic_gap
 - rule_id: PID-HUNT-1
   title: Suspected control-output hunting
-  equipment_types: &id031
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - heatpump
+  equipment_types: &id031 []
   required_roles: &id032 []
   optional_roles: &id033
-  - loop-enabled
-  operational_proof_roles: &id034
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - loop-enabled
+  - oa_damper_pct
+  - clg_valve_pct
+  - htg_valve_pct
+  - damper_pct
+  - loop_enabled
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id034 []
   default_thresholds: &id035
+    confirm_seconds:
+      default: 0.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    window_hours:
+      default: 1.0
+      unit: h
+      min: 0.25
+      max: 4.0
+      step: 0.25
+      label: Hunting lookback window
     change_deadband_pct:
       default: 1.0
-      unit: '% out'
+      unit: pct
       min: 0.0
       max: 10.0
       step: 0.5
       label: Ignore changes below
     minimum_span_pct:
       default: 20.0
-      unit: '% out'
+      unit: pct
       min: 5.0
       max: 100.0
       step: 5.0
       label: Minimum observed span
     total_variation_fault_pct:
       default: 500.0
-      unit: '%/h'
+      unit: pct
       min: 50.0
       max: 2000.0
       step: 50.0
-      label: Total travel threshold
+      label: Total variation fault threshold
     minimum_equivalent_cycles:
       default: 2.5
-      unit: cyc/h
+      unit: count
       min: 0.5
-      max: 20.0
+      max: 10.0
       step: 0.5
       label: Min equivalent cycles
     minimum_reversals:
-      default: 4
+      default: 4.0
       unit: count
-      min: 1
-      max: 40
-      step: 1
+      min: 1.0
+      max: 20.0
+      step: 1.0
       label: Min direction reversals
     minimum_coverage_pct:
       default: 80.0
-      unit: '%'
-      min: 25.0
+      unit: pct
+      min: 50.0
       max: 100.0
       step: 5.0
-      label: Minimum data coverage
-    confirm_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: _pid_hunt_1
+      label: Min window sample coverage
+  pandas_implementation: pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
   test_coverage: &id036 []
@@ -474,69 +347,38 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC1
-  title: Duct static below SP at full fan (GL36 A)
-  equipment_types: &id037
-  - ahu
+  title: Duct static below SP at full fan
+  equipment_types: &id037 []
   required_roles: &id038
-  - duct-static-pressure
-  - duct-static-pressure-sp
-  - fan-cmd
+  - duct_static
+  - duct_static_sp
+  - fan_cmd
   optional_roles: &id039
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id040
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id040 []
   default_thresholds: &id041
     eps_dsp:
       default: 0.12
-      unit: in. w.c.
+      unit: inwc
       min: 0.0
       max: 0.5
       step: 0.01
-      label: Duct-static error εDSP (GL36 default 0.1 in.w.c.)
+      label: Duct-static error epsDSP (GL36 default 0.1 in.w.c.)
     eps_vfd_spd:
       default: 0.13
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: VFD speed error εVFDSPD (GL36 default 5%)
-    duct_static_err:
-      default: 0.12
-      unit: in. w.c.
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Legacy duct-static error (sets εDSP)
-    fan_hi:
-      default: 0.87
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Legacy fan-high threshold (sets εVFDSPD)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
+      label: VFD speed error epsVFDSPD (GL36 default 5%)
     confirm_seconds:
-      default: 300.0
+      default: 300
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: fc1
   datafusion_sql_implementation: fc1_duct_static_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc1
@@ -547,77 +389,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC2
-  title: MAT below OAT/RAT envelope (GL36 B)
-  equipment_types: &id043
-  - ahu
+  title: Mixed air below envelope
+  equipment_types: &id043 []
   required_roles: &id044
-  - mixed-air-temp
-  - outside-air-temp
-  - return-air-temp
-  - fan-cmd
+  - mat
+  - oa_t
+  - rat
+  - fan_cmd
   optional_roles: &id045
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id046
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id047
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    eps_rat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: RAT sensor error εRAT (GL36 default 2°F)
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id046 []
+  default_thresholds: &id047 {}
   pandas_implementation: fc2
   datafusion_sql_implementation: fc2_mat_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc2
@@ -626,77 +409,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC3
-  title: MAT above OAT/RAT envelope (GL36 C)
-  equipment_types: &id049
-  - ahu
+  title: Mixed air above envelope
+  equipment_types: &id049 []
   required_roles: &id050
-  - mixed-air-temp
-  - outside-air-temp
-  - return-air-temp
-  - fan-cmd
+  - mat
+  - oa_t
+  - rat
+  - fan_cmd
   optional_roles: &id051
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id052
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id053
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    eps_rat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: RAT sensor error εRAT (GL36 default 2°F)
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id052 []
+  default_thresholds: &id053 {}
   pandas_implementation: fc3
   datafusion_sql_implementation: fc3_mat_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc3
@@ -706,47 +430,29 @@ matrix:
   difference_class: none
 - rule_id: FC4
   title: PID hunting (operating-state oscillation)
-  equipment_types: &id055
-  - ahu
+  equipment_types: &id055 []
   required_roles: &id056
-  - outside-air-damper
-  - cooling-valve
-  - fan-cmd
+  - oa_damper_pct
+  - clg_valve_pct
+  - fan_cmd
   optional_roles: &id057
   - fan_status
-  operational_proof_roles: &id058
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - loop-enabled
+  operational_proof_roles: &id058 []
   default_thresholds: &id059
-    delta_os_max:
-      default: 5
-      unit: count
-      min: 1
-      max: 30
-      step: 1
-      label: Max mode changes/hr ΔOSmax (GL36 default 7)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 60.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 3600.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    delta_os_max:
+      default: 5.0
+      unit: count
+      min: 1.0
+      max: 30.0
+      step: 1.0
+      label: Max operating-state entries per hour
   pandas_implementation: fc4
   datafusion_sql_implementation: fc4_os_hunting.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc4
@@ -756,45 +462,31 @@ matrix:
   difference_class: none
 - rule_id: FC5
   title: SAT cold when heating commanded (GL36 D)
-  equipment_types: &id061
-  - ahu
+  equipment_types: &id061 []
   required_roles: &id062
-  - discharge-air-temp
-  - mixed-air-temp
-  - fan-cmd
-  - heating-valve
+  - sat
+  - mat
+  - htg_valve_pct
+  - fan_cmd
   optional_roles: &id063
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id064
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id064 []
   default_thresholds: &id065
-    eps_sat:
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    mix_tol:
       default: 1.15
-      unit: °F
+      unit: degF
       min: 0.0
       max: 10.0
       step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+      label: Legacy master sensor tolerance (sets all eps values)
     htg_on_min:
       default: 0.01
       unit: frac
@@ -802,37 +494,6 @@ matrix:
       max: 0.25
       step: 0.01
       label: Heating-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
   pandas_implementation: fc5
   datafusion_sql_implementation: fc5_sat_cold_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc5
@@ -842,83 +503,46 @@ matrix:
   difference_class: none
 - rule_id: FC6
   title: Estimated OA fraction mismatch
-  equipment_types: &id067
-  - ahu
+  equipment_types: &id067 []
   required_roles: &id068
-  - mixed-air-temp
-  - outside-air-temp
-  - return-air-temp
-  - vav-total-airflow
+  - mat
+  - rat
+  - oa_t
+  - fan_cmd
+  - vav_total_flow
   optional_roles: &id069
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id070
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id070 []
   default_thresholds: &id071
-    eps_airflow:
-      default: 0.15
-      unit: frac
-      min: 0.05
-      max: 1.0
-      step: 0.01
-      label: Airflow error εF (GL36 default 30%)
-    delta_t_min:
-      default: 5.0
-      unit: °F
+    confirm_seconds:
+      default: 600.0
+      unit: sec
       min: 0.0
-      max: 30.0
-      step: 0.5
-      label: Minimum |OAT−RAT| ΔTmin (GL36 default 10°F)
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     airflow_err:
       default: 0.15
       unit: frac
       min: 0.05
       max: 1.0
       step: 0.01
-      label: Legacy OA-fraction error (sets εF)
-    oat_rat_delta_min:
+      label: Airflow error epsF (GL36 default 30%)
+    delta_t_min:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 0.0
       max: 30.0
       step: 0.5
-      label: Legacy OAT/RAT guard (sets ΔTmin)
+      label: Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)
     min_cfm_design:
-      default: 5000
+      default: 5000.0
       unit: cfm
-      min: 500
-      max: 20000
-      step: 500
-      label: Design min OA CFM
-    fan_on_min:
-      default: 0.01
-      unit: frac
       min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+      max: 200000.0
+      step: 100.0
+      label: Design minimum outdoor airflow
   pandas_implementation: fc6
   datafusion_sql_implementation: fc6_oa_frac_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc6
@@ -927,39 +551,24 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC7
-  title: SAT low with full heating (GL36 E)
-  equipment_types: &id073
-  - ahu
+  title: SAT low while heating at full
+  equipment_types: &id073 []
   required_roles: &id074
-  - discharge-air-temp
-  - discharge-air-temp-sp
-  - fan-cmd
-  - heating-valve
+  - sat
+  - sat_sp
+  - htg_valve_pct
   optional_roles: &id075
   - fan_cmd
   - fan_status
-  operational_proof_roles: &id076
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id076 []
   default_thresholds: &id077
-    eps_sat:
-      default: 1.0
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
     sat_err:
       default: 1.0
-      unit: °F
+      unit: degF
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy SAT error (sets εSAT)
+      label: Legacy SAT error (sets epsSAT)
     htg_full_min:
       default: 0.9
       unit: frac
@@ -967,35 +576,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Full-heating threshold (GL36 99%)
-    fan_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Fan-on command threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 600.0
+      default: 600
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: fc7
   datafusion_sql_implementation: fc7_sat_low_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc7
   test_coverage: &id078
-  - scripts/materialize_vav_oracle_fixtures.py
   - tests/analytics/test_wattlab_engine.py
   - tests/rules/test_golden_parity.py
   - tests/rules/test_parity_inventory.py
@@ -1005,91 +596,18 @@ matrix:
     twin parity
   difference_class: missing_implementation
 - rule_id: FC8
-  title: SAT/MAT mismatch in economizer (GL36 F)
-  equipment_types: &id079
-  - ahu
+  title: SAT vs MAT while economizing
+  equipment_types: &id079 []
   required_roles: &id080
-  - discharge-air-temp
-  - mixed-air-temp
-  - outside-air-damper
-  - cooling-valve
+  - sat
+  - mat
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id081
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id082
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id083
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    supply_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy SAT tolerance master (sets εSAT)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id082 []
+  default_thresholds: &id083 {}
   pandas_implementation: fc8
   datafusion_sql_implementation: fc8_sat_mat_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc8
@@ -1098,84 +616,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC9
-  title: OAT too warm for free cooling (GL36 G)
-  equipment_types: &id085
-  - ahu
+  title: OAT high vs SAT SP while economizing
+  equipment_types: &id085 []
   required_roles: &id086
-  - outside-air-temp
-  - discharge-air-temp-sp
-  - outside-air-damper
-  - cooling-valve
+  - oa_t
+  - sat_sp
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id087
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id088
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id089
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id088 []
+  default_thresholds: &id089 {}
   pandas_implementation: fc9
   datafusion_sql_implementation: fc9_oa_sat_sp_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc9
@@ -1184,77 +636,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC10
-  title: OAT/MAT mismatch + mech cooling (GL36 H)
-  equipment_types: &id091
-  - ahu
+  title: MAT-OAT delta while cooling and economizing
+  equipment_types: &id091 []
   required_roles: &id092
-  - mixed-air-temp
-  - outside-air-temp
-  - outside-air-damper
-  - cooling-valve
+  - mat
+  - oa_t
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id093
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id094
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id095
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id094 []
+  default_thresholds: &id095 {}
   pandas_implementation: fc10
   datafusion_sql_implementation: fc10_mat_oa_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc10
@@ -1263,84 +656,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC11
-  title: OAT/MAT mismatch economizer-only (GL36 I)
-  equipment_types: &id097
-  - ahu
+  title: OAT low vs SAT SP while cooling and economizing
+  equipment_types: &id097 []
   required_roles: &id098
-  - outside-air-temp
-  - discharge-air-temp-sp
-  - outside-air-damper
-  - cooling-valve
+  - oa_t
+  - sat_sp
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id099
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id100
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id101
-    eps_oat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id100 []
+  default_thresholds: &id101 {}
   pandas_implementation: fc11
   datafusion_sql_implementation: fc11_oa_sat_sp_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc11
@@ -1349,98 +676,18 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC12
-  title: SAT above blend in cooling (GL36 J)
-  equipment_types: &id103
-  - ahu
+  title: SAT above MAT while cooling
+  equipment_types: &id103 []
   required_roles: &id104
-  - discharge-air-temp
-  - mixed-air-temp
-  - outside-air-damper
-  - cooling-valve
+  - sat
+  - mat
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id105
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id106
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  default_thresholds: &id107
-    eps_sat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
-    eps_mat:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: MAT sensor error εMAT (GL36 default 5°F)
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    supply_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy SAT tolerance master (sets εSAT)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+  operational_proof_roles: &id106 []
+  default_thresholds: &id107 {}
   pandas_implementation: fc12
   datafusion_sql_implementation: fc12_sat_mat_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc12
@@ -1449,77 +696,53 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC13
-  title: SAT above SP at full cooling (GL36 K)
-  equipment_types: &id109
-  - ahu
+  title: SAT above setpoint at full cooling
+  equipment_types: &id109 []
   required_roles: &id110
-  - discharge-air-temp
-  - discharge-air-temp-sp
-  - outside-air-damper
-  - cooling-valve
+  - sat
+  - sat_sp
+  - clg_valve_pct
+  - oa_damper_pct
   optional_roles: &id111
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id112
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id112 []
   default_thresholds: &id113
-    eps_sat:
-      default: 1.0
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: SAT sensor error εSAT (GL36 default 2°F)
     sat_err:
       default: 1.0
-      unit: °F
+      unit: degF
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy SAT error (sets εSAT)
-    clg_full_min:
+      label: SAT high error band
+    clg_valve_min:
       default: 0.01
       unit: frac
-      min: 0.5
-      max: 1.0
+      min: 0.0
+      max: 0.5
       step: 0.01
-      label: Full-cooling threshold (GL36 99%)
-    econ_min_pos:
+      label: Cooling valve open threshold
+    oa_damper_econ_low:
       default: 0.05
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: Economizer minimum-position threshold
-    econ_full_open:
+      label: OA damper economizer low
+    oa_damper_econ_high:
       default: 0.9
       unit: frac
       min: 0.5
       max: 1.0
       step: 0.01
-      label: Economizer full-open threshold
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
+      label: OA damper economizer high
     confirm_seconds:
-      default: 600.0
+      default: 600
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: fc13
   datafusion_sql_implementation: sat_high_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc13
@@ -1530,13 +753,9 @@ matrix:
   difference_class: alias
 - rule_id: FC14
   title: CHW coil ΔT when inactive (GL36 L)
-  equipment_types: &id115
-  - ahu
+  equipment_types: &id115 []
   required_roles: &id116
-  - cooling-coil-entering-temp
-  - cooling-coil-leaving-temp
-  - outside-air-damper
-  - cooling-valve
+  - clg_valve_pct
   optional_roles: &id117
   - cooling_coil_entering_temp
   - cooling_coil_leaving_temp
@@ -1545,80 +764,22 @@ matrix:
   - oa_damper_pct
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id118
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id118 []
   default_thresholds: &id119
-    eps_ccet:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Cooling-coil entering sensor error εCCET
-    eps_cclt:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Cooling-coil leaving sensor error εCCLT
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    htg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Heating-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    mix_tol:
+      default: 1.15
+      unit: degF
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all eps values)
   pandas_implementation: fc14
   datafusion_sql_implementation: fc14_chw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc14
@@ -1628,13 +789,8 @@ matrix:
   difference_class: none
 - rule_id: FC15
   title: HW coil ΔT when inactive (GL36 M)
-  equipment_types: &id121
-  - ahu
-  required_roles: &id122
-  - heating-coil-entering-temp
-  - heating-coil-leaving-temp
-  - outside-air-damper
-  - cooling-valve
+  equipment_types: &id121 []
+  required_roles: &id122 []
   optional_roles: &id123
   - heating_coil_entering_temp
   - heating_coil_leaving_temp
@@ -1644,87 +800,22 @@ matrix:
   - clg_valve_pct
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id124
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id124 []
   default_thresholds: &id125
-    eps_hcet:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Heating-coil entering sensor error εHCET
-    eps_hclt:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Heating-coil leaving sensor error εHCLT
-    delta_supply_fan:
-      default: 0.55
-      unit: °F
-      min: 0.0
-      max: 5.0
-      step: 0.05
-      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
-    econ_min_pos:
-      default: 0.05
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Economizer minimum-position threshold
-    econ_full_open:
-      default: 0.9
-      unit: frac
-      min: 0.5
-      max: 1.0
-      step: 0.01
-      label: Economizer full-open threshold
-    clg_inactive_max:
-      default: 0.1
-      unit: frac
-      min: 0.0
-      max: 0.5
-      step: 0.01
-      label: Cooling-command inactive ceiling
-    clg_on_min:
-      default: 0.01
-      unit: frac
-      min: 0.0
-      max: 0.25
-      step: 0.01
-      label: Cooling-command ON threshold
-    mix_tol:
-      default: 1.15
-      unit: °F
-      min: 0.0
-      max: 10.0
-      step: 0.25
-      label: Legacy master sensor tolerance (sets all ε values)
-    mode_delay_min:
-      default: 0.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Mode-change suspension (GL36 default 30)
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    mix_tol:
+      default: 1.15
+      unit: degF
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all eps values)
   pandas_implementation: fc15
   datafusion_sql_implementation: fc15_hw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc15
@@ -1734,40 +825,30 @@ matrix:
   difference_class: none
 - rule_id: AHU-SATDEV
   title: SAT deviation from setpoint
-  equipment_types: &id127
-  - ahu
+  equipment_types: &id127 []
   required_roles: &id128
-  - discharge-air-temp
-  - discharge-air-temp-sp
+  - sat
+  - sat_sp
   optional_roles: &id129
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id130
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id130 []
   default_thresholds: &id131
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     sat_dev_err:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 1.0
       max: 15.0
       step: 0.5
       label: SAT deviation
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: ahu_sat_dev
+  pandas_implementation: ahu_satdev
   datafusion_sql_implementation: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
   test_coverage: &id132
@@ -1777,41 +858,38 @@ matrix:
   difference_class: none
 - rule_id: AHU-DUCTHI
   title: Duct static pressure high
-  equipment_types: &id133
-  - ahu
+  equipment_types: &id133 []
   required_roles: &id134
-  - duct-static-pressure
-  - duct-static-pressure-sp
+  - duct_static
+  - duct_static_sp
+  - fan_cmd
   optional_roles: &id135
   - fan_status
   - fan_cmd
   operational_proof_roles: &id136 []
   default_thresholds: &id137
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     duct_high_margin:
       default: 0.25
-      unit: in. w.c.
+      unit: in_wc
       min: 0.05
       max: 1.0
       step: 0.05
       label: High margin
     pressure_on_min:
       default: 0.2
-      unit: in. w.c.
+      unit: in_wc
       min: 0.05
       max: 1.0
       step: 0.05
       label: Pressure-on evidence
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: ahu_duct_high
+  pandas_implementation: ahu_ducthi
   datafusion_sql_implementation: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
   test_coverage: &id138
@@ -1821,22 +899,22 @@ matrix:
   difference_class: none
 - rule_id: AHU-SIMUL
   title: Heating and cooling simultaneous
-  equipment_types: &id139
-  - ahu
+  equipment_types: &id139 []
   required_roles: &id140
-  - heating-valve
-  - cooling-valve
+  - htg_valve_pct
+  - clg_valve_pct
   optional_roles: &id141
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id142
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id142 []
   default_thresholds: &id143
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     valve_open_pct:
       default: 0.1
       unit: frac
@@ -1844,17 +922,7 @@ matrix:
       max: 0.5
       step: 0.01
       label: Valve open threshold
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: ahu_simul_heat_cool
+  pandas_implementation: ahu_simul
   datafusion_sql_implementation: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
   test_coverage: &id144 []
@@ -1862,33 +930,28 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: OAT-METEO
-  title: BAS outdoor-air sensor vs Open-Meteo
-  equipment_types: &id145
-  - ahu
+  title: Equipment OAT vs weather-staged wx OAT
+  equipment_types: &id145 []
   required_roles: &id146
-  - outside-air-temp
-  - web-outside-air-temp
+  - oa_t
   optional_roles: &id147
   - web_oa_t
   operational_proof_roles: &id148 []
   default_thresholds: &id149
     oat_err:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 2.0
       max: 20.0
       step: 0.5
-      label: Max OAT disagreement
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
+      label: OAT vs meteo tolerance
     confirm_seconds:
-      default: 900.0
+      default: 900
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: oat_vs_meteo
   datafusion_sql_implementation: oat_meteo_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oat-meteo
@@ -1897,41 +960,31 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-1
-  title: Economizer stuck closed
-  equipment_types: &id151
-  - ahu
+  title: Economizer stuck closed when OAT favorable
+  equipment_types: &id151 []
   required_roles: &id152
-  - fan-cmd
-  - outside-air-damper
-  - outside-air-temp
+  - fan_cmd
+  - oa_damper_pct
+  - oa_t
   optional_roles: &id153
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id154
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id154 []
   default_thresholds: &id155
     econ1_oat_min:
       default: 55.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 70.0
       step: 1.0
       label: Favorable OAT
-    confirm_min:
-      default: 10.0
-      unit: min
+    econ1_damper_max:
+      default: 0.05
+      unit: frac
       min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+      max: 0.2
+      step: 0.01
+      label: Stuck-closed damper frac
   pandas_implementation: econ1
   datafusion_sql_implementation: econ1_stuck_closed.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-1
@@ -1940,26 +993,19 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-2
-  title: Economizing when outdoor unfavorable
-  equipment_types: &id157
-  - ahu
+  title: Economizing when outdoor air unfavorable
+  equipment_types: &id157 []
   required_roles: &id158
-  - outside-air-temp
-  - outside-air-damper
+  - oa_t
+  - oa_damper_pct
   optional_roles: &id159
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id160
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id160 []
   default_thresholds: &id161
     econ2_oat_hi:
       default: 63.0
-      unit: °F
+      unit: degF
       min: 55.0
       max: 80.0
       step: 1.0
@@ -1971,16 +1017,13 @@ matrix:
       max: 0.9
       step: 0.02
       label: Damper open frac
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 300.0
+      default: 300
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: econ2
   datafusion_sql_implementation: economizer_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-2
@@ -1991,40 +1034,41 @@ matrix:
   difference_class: none
 - rule_id: ECON-3
   title: Mech cooling without integrated economizer
-  equipment_types: &id163
-  - ahu
+  equipment_types: &id163 []
   required_roles: &id164
-  - outside-air-damper
-  - cooling-valve
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id165
-  - web-outside-air-temp
-  - web-outside-air-dewpoint
-  - web-outside-air-humidity
-  operational_proof_roles: &id166
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - web_oa_t
+  - web_oa_dp
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id166 []
   default_thresholds: &id167
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     econ3_db_min:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 50.0
       max: 68.0
       step: 1.0
       label: Free-cool OA dry-bulb min
     econ3_db_max:
       default: 72.0
-      unit: °F
+      unit: degF
       min: 65.0
       max: 80.0
       step: 1.0
       label: Free-cool OA dry-bulb max
     econ3_dp_max:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 68.0
       step: 1.0
@@ -2036,17 +1080,7 @@ matrix:
       max: 1.0
       step: 0.02
       label: Integrated economizer damper
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: econ2
+  pandas_implementation: econ_3
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
   test_coverage: &id168 []
@@ -2055,41 +1089,31 @@ matrix:
   difference_class: none
 - rule_id: ECON-4
   title: Low estimated OA fraction
-  equipment_types: &id169
-  - ahu
+  equipment_types: &id169 []
   required_roles: &id170
-  - mixed-air-temp
-  - return-air-temp
-  - outside-air-temp
-  - fan-cmd
+  - mat
+  - rat
+  - oa_t
+  - fan_cmd
   optional_roles: &id171
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id172
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id172 []
   default_thresholds: &id173
     oa_min_pct:
       default: 21.0
-      unit: '%'
+      unit: pct
       min: 5.0
       max: 40.0
       step: 1.0
       label: Min OA fraction
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 600.0
+      default: 600
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: econ4
   datafusion_sql_implementation: econ4_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-4
@@ -2099,42 +1123,32 @@ matrix:
   difference_class: none
 - rule_id: ECON-5
   title: Preheat over-conditioning
-  equipment_types: &id175
-  - ahu
+  equipment_types: &id175 []
   required_roles: &id176
-  - preheat-leaving-temp
-  - discharge-air-temp-sp
-  - outside-air-temp
-  - heating-valve
+  - preheat_leave_t
+  - sat_sp
+  - oa_t
+  - htg_valve_pct
   optional_roles: &id177
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id178
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id178 []
   default_thresholds: &id179
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     preheat_over_f:
       default: 2.2
-      unit: °F
+      unit: degF
       min: 0.5
       max: 8.0
       step: 0.1
       label: Preheat over ΔT
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: econ5
+  pandas_implementation: econ_5
   datafusion_sql_implementation: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
   test_coverage: &id180 []
@@ -2143,23 +1157,25 @@ matrix:
   difference_class: none
 - rule_id: ECON-6
   title: Economizing in freezing weather
-  equipment_types: &id181
-  - ahu
+  equipment_types: &id181 []
   required_roles: &id182
-  - outside-air-damper
+  - oa_damper_pct
   optional_roles: &id183
-  - web-outside-air-temp
-  operational_proof_roles: &id184
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - web_oa_t
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id184 []
   default_thresholds: &id185
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     econ6_oat_max_f:
       default: 25.0
-      unit: °F
+      unit: degF
       min: 15.0
       max: 40.0
       step: 1.0
@@ -2171,17 +1187,7 @@ matrix:
       max: 0.5
       step: 0.01
       label: Winter min-OA damper
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: econ6_compute
+  pandas_implementation: econ_6
   datafusion_sql_implementation: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
   test_coverage: &id186 []
@@ -2190,42 +1196,41 @@ matrix:
   difference_class: none
 - rule_id: ECON-7
   title: Economizer OK but not economizing
-  equipment_types: &id187
-  - ahu
+  equipment_types: &id187 []
   required_roles: &id188
-  - outside-air-damper
+  - oa_damper_pct
+  - clg_valve_pct
   optional_roles: &id189
-  - web-outside-air-temp
-  - web-outside-air-dewpoint
-  - web-outside-air-humidity
-  - cooling-valve
-  - compressor-status
-  - dx-cool-cmd
-  operational_proof_roles: &id190
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - web_oa_t
+  - web_oa_dp
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id190 []
   default_thresholds: &id191
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     econ7_db_min:
       default: 35.0
-      unit: °F
+      unit: degF
       min: 20.0
       max: 50.0
       step: 1.0
       label: Econ-OK dry-bulb floor (freeze guard)
     econ7_db_max:
       default: 72.0
-      unit: °F
+      unit: degF
       min: 65.0
       max: 80.0
       step: 1.0
       label: Econ-OK dry-bulb max
     econ7_dp_max:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 68.0
       step: 1.0
@@ -2237,17 +1242,7 @@ matrix:
       max: 0.9
       step: 0.02
       label: Economizing damper threshold
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: econ7_compute
+  pandas_implementation: econ_7
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
   test_coverage: &id192 []
@@ -2256,38 +1251,29 @@ matrix:
   difference_class: none
 - rule_id: MECH-OAT-1
   title: Mechanical cooling below 60°F web OAT
-  equipment_types: &id193
-  - ahu
-  - chiller
-  - heatpump
+  equipment_types: &id193 []
   required_roles: &id194
   - web_oa_t
   optional_roles: &id195
-  - web-outside-air-temp
-  - compressor-status
-  - chiller-status
-  - chw-pump-status
-  - dx-cool-cmd
+  - clg_valve_pct
+  - chiller_status
   operational_proof_roles: &id196 []
   default_thresholds: &id197
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     mech_oat_max_f:
       default: 60.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 65.0
       step: 1.0
       label: Mech-cool OAT ceiling
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-  pandas_implementation: mech_oat1_compute
+  pandas_implementation: mech_oat_1
   datafusion_sql_implementation: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
   test_coverage: &id198 []
@@ -2296,49 +1282,25 @@ matrix:
   difference_class: none
 - rule_id: CHW-NOLOAD-1
   title: Chiller running with no building load
-  equipment_types: &id199
-  - chiller
+  equipment_types: &id199 []
   required_roles: &id200 []
   optional_roles: &id201
-  - chiller-status
-  - chw-pump-status
-  - compressor-status
-  - building-zone-load-satisfied
-  - building-ahu-load-satisfied
+  - chiller_status
+  - chiller_cmd
+  - chw_pump_status
+  - chw_pump_cmd
+  - building_zone_load_satisfied
+  - building_ahu_load_satisfied
   operational_proof_roles: &id202 []
   default_thresholds: &id203
-    comfort_low_f:
-      default: 70.0
-      unit: °F
-      min: 60.0
-      max: 78.0
-      step: 0.5
-      label: Comfort low
-    comfort_high_f:
-      default: 75.0
-      unit: °F
-      min: 68.0
-      max: 85.0
-      step: 0.5
-      label: Comfort high
-    sat_band_f:
-      default: 2.0
-      unit: °F
-      min: 0.5
-      max: 6.0
-      step: 0.5
-      label: AHU SAT≈SP band
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 1800.0
       unit: sec
-  pandas_implementation: chw_noload1_compute
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+  pandas_implementation: chw_noload_1
   datafusion_sql_implementation: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
   test_coverage: &id204 []
@@ -2346,40 +1308,35 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: VAV-1
-  title: Zone comfort band
-  equipment_types: &id205
-  - vav
-  - zone
+  title: Zone comfort band violation hours with confirm window
+  equipment_types: &id205 []
   required_roles: &id206
-  - zone-air-temp
+  - zone_t
   optional_roles: &id207
   - occ_mode
   operational_proof_roles: &id208 []
   default_thresholds: &id209
-    zone_lo:
+    zone_t_lo:
       default: 70.0
-      unit: °F
+      unit: degF
       min: 55.0
       max: 72.0
       step: 0.5
       label: Zone low
-    zone_hi:
+    zone_t_hi:
       default: 75.0
-      unit: °F
+      unit: degF
       min: 72.0
       max: 85.0
       step: 0.5
       label: Zone high
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 900.0
+      default: 900
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: vav1
   datafusion_sql_implementation: vav1_comfort_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-1
@@ -2390,34 +1347,28 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: VAV-2
-  title: Night setback miss
-  equipment_types: &id211
-  - vav
-  - zone
+  title: Night setback miss — unoccupied zone above heating setback
+  equipment_types: &id211 []
   required_roles: &id212
-  - zone-air-temp
-  - occupied
-  optional_roles: &id213
-  - occ-mode
+  - zone_t
+  - occ_mode
+  optional_roles: &id213 []
   operational_proof_roles: &id214 []
   default_thresholds: &id215
     setback_hi:
       default: 68.0
-      unit: °F
+      unit: degF
       min: 55.0
       max: 72.0
       step: 0.5
       label: Setback high
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
-      default: 900.0
+      default: 900
       unit: sec
+      min: 0
+      max: 3600
+      step: 300
+      label: Confirm time
   pandas_implementation: vav2
   datafusion_sql_implementation: vav2_night_setback.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-2
@@ -2427,25 +1378,26 @@ matrix:
   difference_class: none
 - rule_id: VAV-3
   title: Excessive reheat during warm weather
-  equipment_types: &id217
-  - vav
+  equipment_types: &id217 []
   required_roles: &id218
-  - outside-air-temp
-  - reheat-valve
+  - oa_t
+  - reheat_valve_pct
+  - zone_flow
   optional_roles: &id219
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id220
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id220 []
   default_thresholds: &id221
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     reheat_oat:
       default: 78.0
-      unit: °F
+      unit: degF
       min: 65.0
       max: 90.0
       step: 1.0
@@ -2464,17 +1416,7 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: vav3
+  pandas_implementation: vav_3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
   test_coverage: &id222 []
@@ -2483,22 +1425,22 @@ matrix:
   difference_class: none
 - rule_id: VAV-4
   title: Damper stuck at full open
-  equipment_types: &id223
-  - vav
+  equipment_types: &id223 []
   required_roles: &id224
-  - damper
+  - damper_pct
+  - zone_flow
   optional_roles: &id225
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id226
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
-  - loop-enabled
+  operational_proof_roles: &id226 []
   default_thresholds: &id227
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     full_open_pct:
       default: 0.975
       unit: frac
@@ -2506,13 +1448,6 @@ matrix:
       max: 1.0
       step: 0.005
       label: Full open frac
-    sustain_hours:
-      default: 1.5
-      unit: h
-      min: 0.5
-      max: 6.0
-      step: 0.5
-      label: Sustain window
     flow_on_min:
       default: 25.0
       unit: cfm
@@ -2520,53 +1455,39 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav4
+    sustain_hours:
+      default: 1.5
+      unit: h
+      min: 0.5
+      max: 6.0
+      step: 0.5
+      label: Sustain window
+  pandas_implementation: vav_4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
-  test_coverage: &id228
-  - scripts/materialize_vav_oracle_fixtures.py
+  test_coverage: &id228 []
   parity_status: sql_screening
   known_semantic_differences: ''
   difference_class: none
 - rule_id: VAV-5
   title: Airflow sensor bias
-  equipment_types: &id229
-  - vav
+  equipment_types: &id229 []
   required_roles: &id230
-  - zone-airflow
-  - damper
+  - zone_flow
+  - damper_pct
   optional_roles: &id231
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id232
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id232 []
   default_thresholds: &id233
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
-  pandas_implementation: vav5
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+  pandas_implementation: vav_5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
   test_coverage: &id234 []
@@ -2575,24 +1496,17 @@ matrix:
   difference_class: none
 - rule_id: VAV-6
   title: Reheat when cooling available
-  equipment_types: &id235
-  - vav
+  equipment_types: &id235 []
   required_roles: &id236
-  - outside-air-temp
-  - reheat-valve
+  - oa_t
+  - reheat_valve_pct
   optional_roles: &id237
-  - cooling-available
-  operational_proof_roles: &id238
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - clg_available
+  operational_proof_roles: &id238 []
   default_thresholds: &id239
     free_cool_oat:
       default: 65.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 75.0
       step: 1.0
@@ -2604,16 +1518,13 @@ matrix:
       max: 1.0
       step: 0.05
       label: Reheat frac
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
   pandas_implementation: vav6
   datafusion_sql_implementation: vav6_reheat_free_cool.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-6
@@ -2623,23 +1534,24 @@ matrix:
   difference_class: none
 - rule_id: VAV-REHEAT
   title: Reheat valve stuck / no temp rise
-  equipment_types: &id241
-  - vav
+  equipment_types: &id241 []
   required_roles: &id242
-  - reheat-valve
-  - vav-discharge-air-temp
-  - vav-inlet-air-temp
+  - reheat_valve_pct
+  - vav_discharge_t
+  - vav_inlet_t
+  - zone_flow
   optional_roles: &id243
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id244
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id244 []
   default_thresholds: &id245
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     reheat_cmd:
       default: 0.3
       unit: frac
@@ -2649,7 +1561,7 @@ matrix:
       label: Reheat open frac
     min_rise:
       default: 3.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 15.0
       step: 0.5
@@ -2661,17 +1573,7 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav_reheat_stuck
+  pandas_implementation: vav_reheat
   datafusion_sql_implementation: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
   test_coverage: &id246 []
@@ -2680,25 +1582,26 @@ matrix:
   difference_class: none
 - rule_id: VAV-AHU-LEAVE
   title: VAV leave vs parent AHU SAT (fedBy)
-  equipment_types: &id247
-  - vav
+  equipment_types: &id247 []
   required_roles: &id248
-  - vav-discharge-air-temp
-  - ahu-discharge-air-temp
+  - vav_discharge_t
+  - ahu_sat
+  - zone_flow
   optional_roles: &id249
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id250
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id250 []
   default_thresholds: &id251
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     delta_f:
       default: 8.0
-      unit: °F
+      unit: degF
       min: 2.0
       max: 25.0
       step: 0.5
@@ -2710,17 +1613,7 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav_vs_ahu_leave
+  pandas_implementation: vav_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
   test_coverage: &id252 []
@@ -2729,22 +1622,29 @@ matrix:
   difference_class: none
 - rule_id: VAV-7
   title: Min airflow / fixed high flow
-  equipment_types: &id253
-  - vav
+  equipment_types: &id253 []
   required_roles: &id254
-  - zone-airflow
+  - zone_flow
   optional_roles: &id255
   - min_flow_sp
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id256
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id256 []
   default_thresholds: &id257
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    high_min_flow_sp:
+      default: 250.0
+      unit: cfm
+      min: 50.0
+      max: 2000.0
+      step: 10.0
+      label: High min-flow SP
     flow_on_min:
       default: 25.0
       unit: cfm
@@ -2752,6 +1652,13 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
+    fixed_flow_hours:
+      default: 1.0
+      unit: h
+      min: 0.25
+      max: 6.0
+      step: 0.25
+      label: Fixed-flow rolling window
     fixed_flow_max_std:
       default: 15.0
       unit: cfm
@@ -2766,39 +1673,20 @@ matrix:
       max: 2000.0
       step: 10.0
       label: Fixed-flow min mean
-    high_min_flow_sp:
-      default: 250.0
-      unit: cfm
-      min: 50.0
-      max: 2000.0
-      step: 10.0
-      label: High min-flow SP
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vav7
+  pandas_implementation: vav_7
   datafusion_sql_implementation: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
   test_coverage: &id258
-  - scripts/materialize_vav_oracle_fixtures.py
   - tests/analytics/test_vav_health.py
   parity_status: sql_screening
   known_semantic_differences: ''
   difference_class: none
 - rule_id: CHW-1
   title: Low chilled-water ΔT
-  equipment_types: &id259
-  - chiller
+  equipment_types: &id259 []
   required_roles: &id260
-  - chilled-water-supply-temp
-  - chilled-water-return-temp
+  - chw_supply_t
+  - chw_return_t
   optional_roles: &id261
   - chw_pump_cmd
   - pump_status
@@ -2807,38 +1695,22 @@ matrix:
   - chiller_amps
   - chiller_power
   - chw_flow
-  operational_proof_roles: &id262
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id262 []
   default_thresholds: &id263
-    min_dt:
-      default: 4.0
-      unit: °F
-      min: 1.0
-      max: 12.0
-      step: 0.5
-      label: Min ΔT
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    min_dt:
+      default: 4.0
+      unit: degF
+      min: 1.0
+      max: 12.0
+      step: 0.5
+      label: Minimum delta-T
   pandas_implementation: chw1
   datafusion_sql_implementation: chw1_low_dt.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-1
@@ -2853,28 +1725,21 @@ matrix:
   difference_class: none
 - rule_id: CHW-2
   title: DP below SP at max pump speed
-  equipment_types: &id265
-  - chiller
+  equipment_types: &id265 []
   required_roles: &id266
-  - chw-diff-pressure
-  - chw-diff-pressure-sp
-  - chw-pump-cmd
+  - chw_dp
+  - chw_dp_sp
+  - chw_pump_cmd
   optional_roles: &id267 []
-  operational_proof_roles: &id268
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id268 []
   default_thresholds: &id269
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     dp_margin:
       default: 2.2
       unit: psi
@@ -2889,17 +1754,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: chw2
+  pandas_implementation: chw_2
   datafusion_sql_implementation: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
   test_coverage: &id270 []
@@ -2908,46 +1763,29 @@ matrix:
   difference_class: none
 - rule_id: CHW-3
   title: Plant supply temp outside deadband
-  equipment_types: &id271
-  - chiller
+  equipment_types: &id271 []
   required_roles: &id272
-  - chilled-water-supply-temp
-  - chilled-water-supply-temp-sp
-  - chw-pump-cmd
+  - chw_supply_t
+  - chw_supply_sp
+  - chw_pump_cmd
   optional_roles: &id273 []
-  operational_proof_roles: &id274
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id274 []
   default_thresholds: &id275
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     sp_band:
       default: 2.2
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.1
       label: SP band
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: chw3
+  pandas_implementation: chw_3
   datafusion_sql_implementation: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
   test_coverage: &id276 []
@@ -2956,33 +1794,26 @@ matrix:
   difference_class: none
 - rule_id: CHW-4
   title: Flow high at max pump
-  equipment_types: &id277
-  - chiller
+  equipment_types: &id277 []
   required_roles: &id278
-  - chw-flow
-  - chw-pump-cmd
+  - chw_flow
+  - chw_pump_cmd
   optional_roles: &id279 []
-  operational_proof_roles: &id280
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id280 []
   default_thresholds: &id281
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     flow_hi:
-      default: 1100
+      default: 1100.0
       unit: gpm
-      min: 200
-      max: 3000
-      step: 50
+      min: 200.0
+      max: 3000.0
+      step: 50.0
       label: Flow high
     pump_hi:
       default: 0.87
@@ -2991,17 +1822,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: chw4
+  pandas_implementation: chw_4
   datafusion_sql_implementation: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
   test_coverage: &id282 []
@@ -3010,46 +1831,38 @@ matrix:
   difference_class: none
 - rule_id: HP-1
   title: Discharge cold when heating
-  equipment_types: &id283
-  - heatpump
+  equipment_types: &id283 []
   required_roles: &id284
-  - discharge-air-temp
-  - zone-air-temp
-  - fan-cmd
+  - sat
+  - zone_t
+  - fan_cmd
   optional_roles: &id285
   - compressor_status
   - fan_status
-  operational_proof_roles: &id286
-  - compressor-status
-  - equipment-enable
-  - fan-status
-  - fan-cmd
+  operational_proof_roles: &id286 []
   default_thresholds: &id287
-    min_sat:
-      default: 85.0
-      unit: °F
-      min: 70.0
-      max: 110.0
-      step: 1.0
-      label: Min heating SAT
-    zone_cold:
-      default: 69.0
-      unit: °F
-      min: 60.0
-      max: 72.0
-      step: 0.5
-      label: Zone cold
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
-  pandas_implementation: hp1
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    min_sat:
+      default: 85.0
+      unit: degF
+      min: 70.0
+      max: 110.0
+      step: 1.0
+      label: Min discharge SAT
+    zone_cold:
+      default: 69.0
+      unit: degF
+      min: 60.0
+      max: 72.0
+      step: 0.5
+      label: Zone cold threshold
+  pandas_implementation: hp_1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
   test_coverage: &id288 []
@@ -3058,31 +1871,27 @@ matrix:
   difference_class: none
 - rule_id: WX-1
   title: OA temperature spike
-  equipment_types: &id289
-  - weather
+  equipment_types: &id289 []
   required_roles: &id290
-  - outside-air-temp
+  - oa_t
   optional_roles: &id291 []
   operational_proof_roles: &id292 []
   default_thresholds: &id293
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     spike_limit:
       default: 16.0
-      unit: °F
+      unit: degF
       min: 4.0
       max: 40.0
       step: 1.0
       label: Spike limit
-    confirm_min:
-      default: 5.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-  pandas_implementation: wx1
+  pandas_implementation: wx_1
   datafusion_sql_implementation: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
   test_coverage: &id294 []
@@ -3091,56 +1900,39 @@ matrix:
   difference_class: none
 - rule_id: CW-OPT-1
   title: Condenser water not optimized vs wet-bulb
-  equipment_types: &id295
-  - chiller
-  - cooling_tower
+  equipment_types: &id295 []
   required_roles: &id296
-  - condenser-water-supply-temp
+  - cw_supply_t
+  - web_wb_t
   optional_roles: &id297
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id298
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id298 []
   default_thresholds: &id299
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: °F
+      unit: degF
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     cw_slack:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.5
       label: Slack below target
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: cw_opt
+  pandas_implementation: cw_opt_1
   datafusion_sql_implementation: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
   test_coverage: &id300 []
@@ -3149,34 +1941,28 @@ matrix:
   difference_class: none
 - rule_id: CW-APR-1
   title: High CW approach at full tower fan
-  equipment_types: &id301
-  - chiller
-  - cooling_tower
+  equipment_types: &id301 []
   required_roles: &id302
-  - condenser-water-supply-temp
+  - cw_supply_t
+  - web_wb_t
+  - tower_fan_cmd
   optional_roles: &id303
-  - tower-fan-cmd
-  - cw-fan-cmd
-  - fan-cmd
-  - web-outside-air-wetbulb
-  operational_proof_roles: &id304
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  - pump_status
+  - chiller_status
+  - chw_flow
+  - chw_pump_cmd
+  operational_proof_roles: &id304 []
   default_thresholds: &id305
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     approach_max_f:
       default: 8.0
-      unit: °F
+      unit: degF
       min: 5.0
       max: 15.0
       step: 0.5
@@ -3188,17 +1974,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: cw_apr
+  pandas_implementation: cw_apr_1
   datafusion_sql_implementation: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
   test_coverage: &id306 []
@@ -3207,41 +1983,35 @@ matrix:
   difference_class: none
 - rule_id: CW-FAN-1
   title: Excess tower fan energy vs wet-bulb limit
-  equipment_types: &id307
-  - chiller
-  - cooling_tower
+  equipment_types: &id307 []
   required_roles: &id308
-  - condenser-water-supply-temp
+  - cw_supply_t
+  - web_wb_t
+  - tower_fan_cmd
   optional_roles: &id309
-  - tower-fan-cmd
-  - cw-fan-cmd
-  - fan-cmd
-  - web-outside-air-wetbulb
-  operational_proof_roles: &id310
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  - pump_status
+  - chiller_status
+  - chw_flow
+  - chw_pump_cmd
+  operational_proof_roles: &id310 []
   default_thresholds: &id311
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: °F
+      unit: degF
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     excess_beyond_approach_f:
       default: 5.0
-      unit: °F
+      unit: degF
       min: 2.0
       max: 20.0
       step: 0.5
@@ -3253,17 +2023,7 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: cw_fan_excess
+  pandas_implementation: cw_fan_1
   datafusion_sql_implementation: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
   test_coverage: &id312 []
@@ -3272,27 +2032,26 @@ matrix:
   difference_class: none
 - rule_id: TRIM-1
   title: Duct static trim advisory
-  equipment_types: &id313
-  - ahu
+  equipment_types: &id313 []
   required_roles: &id314
-  - duct-static-pressure
-  - vav-pressure-request-sum
+  - duct_static
   optional_roles: &id315
   - duct_static_sp
   - static_reset_request
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id316
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id316 []
   default_thresholds: &id317
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     duct_hi:
       default: 1.35
-      unit: in. w.c.
+      unit: in_wc
       min: 0.5
       max: 3.0
       step: 0.05
@@ -3304,17 +2063,7 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-  pandas_implementation: trim1
+  pandas_implementation: trim_1
   datafusion_sql_implementation: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
   test_coverage: &id318 []
@@ -3323,34 +2072,26 @@ matrix:
   difference_class: none
 - rule_id: TRIM-3
   title: HWST trim advisory
-  equipment_types: &id319
-  - boiler
+  equipment_types: &id319 []
   required_roles: &id320
-  - hot-water-supply-temp
-  - hw-reset-request-sum
+  - hw_supply_t
   optional_roles: &id321
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id322
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id322 []
   default_thresholds: &id323
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     hwst_hi:
       default: 160.0
-      unit: °F
+      unit: degF
       min: 120.0
       max: 200.0
       step: 1.0
@@ -3362,17 +2103,7 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-  pandas_implementation: trim3
+  pandas_implementation: trim_3
   datafusion_sql_implementation: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
   test_coverage: &id324 []
@@ -3381,34 +2112,26 @@ matrix:
   difference_class: none
 - rule_id: TRIM-4
   title: CHW plant reset advisory
-  equipment_types: &id325
-  - chiller
+  equipment_types: &id325 []
   required_roles: &id326
-  - chilled-water-supply-temp
-  - chw-reset-request-sum
+  - chw_supply_t
   optional_roles: &id327
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id328
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - pump-speed-feedback
-  - pump-current
-  - chw-flow
-  - water-flow
-  - chiller-status
-  - chiller-current
-  - chiller-power
-  - pump-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
+  operational_proof_roles: &id328 []
   default_thresholds: &id329
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     chw_lo:
       default: 45.0
-      unit: °F
+      unit: degF
       min: 35.0
       max: 55.0
       step: 0.5
@@ -3420,17 +2143,7 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-  pandas_implementation: trim4
+  pandas_implementation: trim_4
   datafusion_sql_implementation: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
   test_coverage: &id330 []
@@ -3438,40 +2151,38 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: SCHED-1
-  title: Unoccupied runtime
-  equipment_types: &id331
-  - ahu
+  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
+    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
+    unoccupied + fan_on (pandas sched1 base).
+  equipment_types: &id331 []
   required_roles: &id332
-  - occupied
-  - fan-status
+  - occ_mode
+  - fan_status
   optional_roles: &id333
-  - zone-air-temp
+  - zone_t
   operational_proof_roles: &id334 []
   default_thresholds: &id335
-    comfort_low_f:
-      default: 70.0
-      unit: °F
-      min: 60.0
-      max: 78.0
-      step: 0.5
-      label: Comfort low
-    comfort_high_f:
-      default: 75.0
-      unit: °F
-      min: 68.0
-      max: 85.0
-      step: 0.5
-      label: Comfort high
-    confirm_min:
-      default: 30.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 1800.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+    comfort_low_f:
+      default: 70.0
+      unit: °F
+      min: 50.0
+      max: 80.0
+      step: 0.5
+      label: Zone comfort low
+    comfort_high_f:
+      default: 75.0
+      unit: °F
+      min: 55.0
+      max: 90.0
+      step: 0.5
+      label: Zone comfort high
   pandas_implementation: sched1
   datafusion_sql_implementation: sched1_unoccupied_runtime.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-1
@@ -3484,29 +2195,22 @@ matrix:
   difference_class: alias
 - rule_id: SCHED-247
   title: Always-on fan or pump runtime
-  equipment_types: &id337
-  - ahu
-  - vav
-  - chiller
-  - boiler
-  - heatpump
+  equipment_types: &id337 []
   required_roles: &id338 []
   optional_roles: &id339
-  - fan-status
-  - pump-status
-  - chw-pump-status
-  - hw-pump-status
-  - chiller-status
-  - compressor-status
-  - tower-fan-cmd
-  - cw-fan-cmd
-  - fan-cmd
-  - chw-pump-cmd
-  - hw-pump-cmd
-  - duct-static-pressure
-  - chw-diff-pressure
+  - fan_status
+  - pump_status
+  - chiller_status
+  - fan_cmd
   operational_proof_roles: &id340 []
   default_thresholds: &id341
+    confirm_seconds:
+      default: 3600.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     always_on_pct:
       default: 0.95
       unit: frac
@@ -3514,23 +2218,6 @@ matrix:
       max: 1.0
       step: 0.01
       label: Always-on fraction
-    pressure_on_min:
-      default: 0.2
-      unit: eng
-      min: 0.05
-      max: 2.0
-      step: 0.05
-      label: Pressure-on evidence
-    confirm_min:
-      default: 60.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 3600.0
-      unit: sec
   pandas_implementation: _sched247
   datafusion_sql_implementation: sched247_always_on.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-247
@@ -3545,60 +2232,50 @@ matrix:
   difference_class: none
 - rule_id: RESET-1
   title: SAT reset not tracking outdoor air
-  equipment_types: &id343
-  - ahu
+  equipment_types: &id343 []
   required_roles: &id344
-  - discharge-air-temp-sp
-  - outside-air-temp
+  - sat_sp
+  - oa_t
   optional_roles: &id345
-  - fan-status
-  - fan-cmd
-  operational_proof_roles: &id346
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  - fan_status
+  - fan_cmd
+  operational_proof_roles: &id346 []
   default_thresholds: &id347
     reset_err_f:
       default: 3.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 10.0
       step: 0.5
       label: Reset error
     reset_sat_at_65:
       default: 52.0
-      unit: °F
+      unit: degF
       min: 45.0
       max: 65.0
       step: 0.5
-      label: SAT SP at 65°F OAT
+      label: SAT SP at 65F OAT
     reset_slope:
       default: 0.25
-      unit: °F/°F
+      unit: frac
       min: 0.05
       max: 1.0
       step: 0.05
       label: Reset slope
     reset_oat_ref:
       default: 65.0
-      unit: °F
+      unit: degF
       min: 50.0
       max: 80.0
       step: 1.0
       label: Reset OAT ref
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
   pandas_implementation: reset1
   datafusion_sql_implementation: reset1_sat_oa_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#reset-1
@@ -3608,25 +2285,21 @@ matrix:
   difference_class: none
 - rule_id: CMD-1
   title: Fan cmd/status mismatch
-  equipment_types: &id349
-  - ahu
+  equipment_types: &id349 []
   required_roles: &id350
-  - fan-cmd
-  - fan-status
+  - fan_cmd
+  - fan_status
   optional_roles: &id351 []
   operational_proof_roles: &id352 []
   default_thresholds: &id353
-    confirm_min:
-      default: 10.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
-  pandas_implementation: cmd1
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
+  pandas_implementation: cmd_1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
   test_coverage: &id354 []
@@ -3635,24 +2308,24 @@ matrix:
   difference_class: none
 - rule_id: OA-1
   title: Low OA fraction
-  equipment_types: &id355
-  - ahu
+  equipment_types: &id355 []
   required_roles: &id356
-  - mixed-air-temp
-  - return-air-temp
-  - outside-air-temp
-  - fan-status
+  - mat
+  - rat
+  - oa_t
+  - fan_cmd
   optional_roles: &id357
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id358
-  - fan-status
-  - fan-speed-feedback
-  - fan-current
-  - fan-power
-  - airflow-proof
-  - fan-cmd
+  operational_proof_roles: &id358 []
   default_thresholds: &id359
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     min_oa_frac:
       default: 0.15
       unit: frac
@@ -3662,22 +2335,12 @@ matrix:
       label: Min OA fraction
     oat_rat_guard:
       default: 2.2
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.1
-      label: Min |RAT−OAT| guard
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: oa1
+      label: OAT/RAT guard
+  pandas_implementation: oa_1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
   test_coverage: &id360 []
@@ -3686,35 +2349,31 @@ matrix:
   difference_class: none
 - rule_id: DMP-1
   title: OA damper leakage
-  equipment_types: &id361
-  - ahu
+  equipment_types: &id361 []
   required_roles: &id362
-  - outside-air-temp
-  - mixed-air-temp
-  - outside-air-damper
+  - oa_damper_pct
+  - oa_t
+  - mat
   optional_roles: &id363
   - fan_status
   - fan_cmd
   operational_proof_roles: &id364 []
   default_thresholds: &id365
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     leak_delta:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 6.0
       step: 0.5
       label: Leak ΔT
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: dmp1
+  pandas_implementation: dmp_1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
   test_coverage: &id366 []
@@ -3723,43 +2382,39 @@ matrix:
   difference_class: none
 - rule_id: VLV-1
   title: Cooling valve leakage
-  equipment_types: &id367
-  - ahu
+  equipment_types: &id367 []
   required_roles: &id368
-  - discharge-air-temp
-  - discharge-air-temp-sp
-  - cooling-valve
+  - clg_valve_pct
+  - sat
+  - sat_sp
+  - mat
   optional_roles: &id369
-  - mixed-air-temp
-  - fan-status
-  - fan-cmd
+  - fan_status
+  - fan_cmd
   operational_proof_roles: &id370 []
   default_thresholds: &id371
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+      min: 0.0
+      max: 3600.0
+      step: 300.0
+      label: Confirm time
     sat_err:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 8.0
       step: 0.5
       label: SAT vs SP leak ΔT
     mat_leak_delta:
       default: 2.0
-      unit: °F
+      unit: degF
       min: 0.5
       max: 12.0
       step: 0.5
       label: SAT vs MAT leak ΔT
-    confirm_min:
-      default: 15.0
-      unit: min
-      min: 0.0
-      max: 60.0
-      step: 1.0
-      label: Fault confirm delay
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-  pandas_implementation: vlv1
+  pandas_implementation: vlv_1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
   test_coverage: &id372 []
@@ -3877,12 +2532,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id001
-  equipment_kinds: *id001
+  equipment_kinds: null
   required_roles: *id002
   optional_roles: *id003
   operational_proof_roles: *id004
   default_thresholds: *id005
-  pandas_implementation: _sweep_range
+  pandas_implementation: sv_range
   datafusion_sql_implementation: sv_range.sql
   sql_file: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
@@ -3892,8 +2547,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: equipment_energized
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -3976,12 +2631,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id007
-  equipment_kinds: *id007
+  equipment_kinds: null
   required_roles: *id008
   optional_roles: *id009
   operational_proof_roles: *id010
   default_thresholds: *id011
-  pandas_implementation: _sweep_flatline
+  pandas_implementation: sv_flatline
   datafusion_sql_implementation: sv_flatline.sql
   sql_file: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
@@ -3991,8 +2646,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4084,12 +2739,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id013
-  equipment_kinds: *id013
+  equipment_kinds: null
   required_roles: *id014
   optional_roles: *id015
   operational_proof_roles: *id016
   default_thresholds: *id017
-  pandas_implementation: _sweep_spike
+  pandas_implementation: sv_spike
   datafusion_sql_implementation: sv_spike.sql
   sql_file: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
@@ -4099,8 +2754,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: equipment_energized
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4183,12 +2838,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id019
-  equipment_kinds: *id019
+  equipment_kinds: null
   required_roles: *id020
   optional_roles: *id021
   operational_proof_roles: *id022
   default_thresholds: *id023
-  pandas_implementation: _sweep_stale
+  pandas_implementation: sv_stale
   datafusion_sql_implementation: sv_stale.sql
   sql_file: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
@@ -4198,8 +2853,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4292,12 +2947,12 @@ concepts:
   - SV-SLEW
   kind: diagnostic
   equipment_types: *id025
-  equipment_kinds: *id025
+  equipment_kinds: null
   required_roles: *id026
   optional_roles: *id027
   operational_proof_roles: *id028
   default_thresholds: *id029
-  pandas_implementation: _sv_rate_compute
+  pandas_implementation: sv_rate
   datafusion_sql_implementation: sv_rate.sql
   sql_file: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
@@ -4309,8 +2964,8 @@ concepts:
   known_semantic_differences: Pandas ROLE_TO_PROFILE has 30+ quantity/location slew
     limits; SQL windows five air temps against one STEADY_FAULT_PER_HOUR. Leave sql_screening;
     do not mark proven from B100 hours. Alias SV-SLEW is not an extra rule.
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4402,12 +3057,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id031
-  equipment_kinds: *id031
+  equipment_kinds: null
   required_roles: *id032
   optional_roles: *id033
   operational_proof_roles: *id034
   default_thresholds: *id035
-  pandas_implementation: _pid_hunt_1
+  pandas_implementation: pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   sql_file: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
@@ -4417,8 +3072,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: control_loop
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 0
   parameters:
     confirm_seconds:
@@ -4551,11 +3206,11 @@ concepts:
 - canonical_id: FC1
   pandas_id: FC1
   rule_id: FC1
-  title: Duct static below SP at full fan (GL36 A)
+  title: Duct static below SP at full fan
   aliases: []
   kind: diagnostic
   equipment_types: *id037
-  equipment_kinds: *id037
+  equipment_kinds: null
   required_roles: *id038
   optional_roles: *id039
   operational_proof_roles: *id040
@@ -4570,8 +3225,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     eps_dsp:
@@ -4659,11 +3314,11 @@ concepts:
 - canonical_id: FC2
   pandas_id: FC2
   rule_id: FC2
-  title: MAT below OAT/RAT envelope (GL36 B)
+  title: Mixed air below envelope
   aliases: []
   kind: diagnostic
   equipment_types: *id043
-  equipment_kinds: *id043
+  equipment_kinds: null
   required_roles: *id044
   optional_roles: *id045
   operational_proof_roles: *id046
@@ -4678,8 +3333,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4740,11 +3395,11 @@ concepts:
 - canonical_id: FC3
   pandas_id: FC3
   rule_id: FC3
-  title: MAT above OAT/RAT envelope (GL36 C)
+  title: Mixed air above envelope
   aliases: []
   kind: diagnostic
   equipment_types: *id049
-  equipment_kinds: *id049
+  equipment_kinds: null
   required_roles: *id050
   optional_roles: *id051
   operational_proof_roles: *id052
@@ -4759,8 +3414,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4825,7 +3480,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id055
-  equipment_kinds: *id055
+  equipment_kinds: null
   required_roles: *id056
   optional_roles: *id057
   operational_proof_roles: *id058
@@ -4840,8 +3495,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: control_loop
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -4924,7 +3579,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id061
-  equipment_kinds: *id061
+  equipment_kinds: null
   required_roles: *id062
   optional_roles: *id063
   operational_proof_roles: *id064
@@ -4939,8 +3594,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5032,7 +3687,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id067
-  equipment_kinds: *id067
+  equipment_kinds: null
   required_roles: *id068
   optional_roles: *id069
   operational_proof_roles: *id070
@@ -5047,8 +3702,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5145,11 +3800,11 @@ concepts:
 - canonical_id: FC7
   pandas_id: FC7
   rule_id: FC7
-  title: SAT low with full heating (GL36 E)
+  title: SAT low while heating at full
   aliases: []
   kind: diagnostic
   equipment_types: *id073
-  equipment_kinds: *id073
+  equipment_kinds: null
   required_roles: *id074
   optional_roles: *id075
   operational_proof_roles: *id076
@@ -5165,8 +3820,8 @@ concepts:
   difference_class: missing_implementation
   known_semantic_differences: concept_only — SQL file is a placeholder; do not claim
     twin parity
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -5254,11 +3909,11 @@ concepts:
 - canonical_id: FC8
   pandas_id: FC8
   rule_id: FC8
-  title: SAT/MAT mismatch in economizer (GL36 F)
+  title: SAT vs MAT while economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id079
-  equipment_kinds: *id079
+  equipment_kinds: null
   required_roles: *id080
   optional_roles: *id081
   operational_proof_roles: *id082
@@ -5273,8 +3928,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5335,11 +3990,11 @@ concepts:
 - canonical_id: FC9
   pandas_id: FC9
   rule_id: FC9
-  title: OAT too warm for free cooling (GL36 G)
+  title: OAT high vs SAT SP while economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id085
-  equipment_kinds: *id085
+  equipment_kinds: null
   required_roles: *id086
   optional_roles: *id087
   operational_proof_roles: *id088
@@ -5354,8 +4009,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5416,11 +4071,11 @@ concepts:
 - canonical_id: FC10
   pandas_id: FC10
   rule_id: FC10
-  title: OAT/MAT mismatch + mech cooling (GL36 H)
+  title: MAT-OAT delta while cooling and economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id091
-  equipment_kinds: *id091
+  equipment_kinds: null
   required_roles: *id092
   optional_roles: *id093
   operational_proof_roles: *id094
@@ -5435,8 +4090,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5497,11 +4152,11 @@ concepts:
 - canonical_id: FC11
   pandas_id: FC11
   rule_id: FC11
-  title: OAT/MAT mismatch economizer-only (GL36 I)
+  title: OAT low vs SAT SP while cooling and economizing
   aliases: []
   kind: diagnostic
   equipment_types: *id097
-  equipment_kinds: *id097
+  equipment_kinds: null
   required_roles: *id098
   optional_roles: *id099
   operational_proof_roles: *id100
@@ -5516,8 +4171,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5578,11 +4233,11 @@ concepts:
 - canonical_id: FC12
   pandas_id: FC12
   rule_id: FC12
-  title: SAT above blend in cooling (GL36 J)
+  title: SAT above MAT while cooling
   aliases: []
   kind: diagnostic
   equipment_types: *id103
-  equipment_kinds: *id103
+  equipment_kinds: null
   required_roles: *id104
   optional_roles: *id105
   operational_proof_roles: *id106
@@ -5597,8 +4252,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -5659,12 +4314,12 @@ concepts:
 - canonical_id: FC13-SAT-HIGH
   pandas_id: FC13
   rule_id: FC13
-  title: SAT above SP at full cooling (GL36 K)
+  title: SAT above setpoint at full cooling
   aliases:
   - FC13
   kind: diagnostic
   equipment_types: *id109
-  equipment_kinds: *id109
+  equipment_kinds: null
   required_roles: *id110
   optional_roles: *id111
   operational_proof_roles: *id112
@@ -5679,8 +4334,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: FC13 (not independent rules)'
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -5790,7 +4445,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id115
-  equipment_kinds: *id115
+  equipment_kinds: null
   required_roles: *id116
   optional_roles: *id117
   operational_proof_roles: *id118
@@ -5805,8 +4460,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5889,7 +4544,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id121
-  equipment_kinds: *id121
+  equipment_kinds: null
   required_roles: *id122
   optional_roles: *id123
   operational_proof_roles: *id124
@@ -5904,8 +4559,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5988,12 +4643,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id127
-  equipment_kinds: *id127
+  equipment_kinds: null
   required_roles: *id128
   optional_roles: *id129
   operational_proof_roles: *id130
   default_thresholds: *id131
-  pandas_implementation: ahu_sat_dev
+  pandas_implementation: ahu_satdev
   datafusion_sql_implementation: ahu_satdev.sql
   sql_file: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
@@ -6003,8 +4658,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -6087,12 +4742,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id133
-  equipment_kinds: *id133
+  equipment_kinds: null
   required_roles: *id134
   optional_roles: *id135
   operational_proof_roles: *id136
   default_thresholds: *id137
-  pandas_implementation: ahu_duct_high
+  pandas_implementation: ahu_ducthi
   datafusion_sql_implementation: ahu_ducthi.sql
   sql_file: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
@@ -6102,8 +4757,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6195,12 +4850,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id139
-  equipment_kinds: *id139
+  equipment_kinds: null
   required_roles: *id140
   optional_roles: *id141
   operational_proof_roles: *id142
   default_thresholds: *id143
-  pandas_implementation: ahu_simul_heat_cool
+  pandas_implementation: ahu_simul
   datafusion_sql_implementation: ahu_simul.sql
   sql_file: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
@@ -6210,8 +4865,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6290,11 +4945,11 @@ concepts:
 - canonical_id: OAT-METEO
   pandas_id: OAT-METEO
   rule_id: OAT-METEO
-  title: BAS outdoor-air sensor vs Open-Meteo
+  title: Equipment OAT vs weather-staged wx OAT
   aliases: []
   kind: diagnostic
   equipment_types: *id145
-  equipment_kinds: *id145
+  equipment_kinds: null
   required_roles: *id146
   optional_roles: *id147
   operational_proof_roles: *id148
@@ -6309,8 +4964,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     oat_err:
@@ -6390,11 +5045,11 @@ concepts:
 - canonical_id: ECON-1
   pandas_id: ECON-1
   rule_id: ECON-1
-  title: Economizer stuck closed
+  title: Economizer stuck closed when OAT favorable
   aliases: []
   kind: diagnostic
   equipment_types: *id151
-  equipment_kinds: *id151
+  equipment_kinds: null
   required_roles: *id152
   optional_roles: *id153
   operational_proof_roles: *id154
@@ -6409,8 +5064,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     econ1_oat_min:
@@ -6489,11 +5144,11 @@ concepts:
 - canonical_id: ECON-2
   pandas_id: ECON-2
   rule_id: ECON-2
-  title: Economizing when outdoor unfavorable
+  title: Economizing when outdoor air unfavorable
   aliases: []
   kind: diagnostic
   equipment_types: *id157
-  equipment_kinds: *id157
+  equipment_kinds: null
   required_roles: *id158
   optional_roles: *id159
   operational_proof_roles: *id160
@@ -6508,8 +5163,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     econ2_oat_hi:
@@ -6601,12 +5256,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id163
-  equipment_kinds: *id163
+  equipment_kinds: null
   required_roles: *id164
   optional_roles: *id165
   operational_proof_roles: *id166
   default_thresholds: *id167
-  pandas_implementation: econ2
+  pandas_implementation: econ_3
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   sql_file: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
@@ -6616,8 +5271,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6727,7 +5382,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id169
-  equipment_kinds: *id169
+  equipment_kinds: null
   required_roles: *id170
   optional_roles: *id171
   operational_proof_roles: *id172
@@ -6742,8 +5397,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     oa_min_pct:
@@ -6826,12 +5481,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id175
-  equipment_kinds: *id175
+  equipment_kinds: null
   required_roles: *id176
   optional_roles: *id177
   operational_proof_roles: *id178
   default_thresholds: *id179
-  pandas_implementation: econ5
+  pandas_implementation: econ_5
   datafusion_sql_implementation: econ5_preheat_over.sql
   sql_file: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
@@ -6841,8 +5496,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -6925,12 +5580,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id181
-  equipment_kinds: *id181
+  equipment_kinds: null
   required_roles: *id182
   optional_roles: *id183
   operational_proof_roles: *id184
   default_thresholds: *id185
-  pandas_implementation: econ6_compute
+  pandas_implementation: econ_6
   datafusion_sql_implementation: econ6_econ_freezing.sql
   sql_file: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
@@ -6940,8 +5595,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -7033,12 +5688,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id187
-  equipment_kinds: *id187
+  equipment_kinds: null
   required_roles: *id188
   optional_roles: *id189
   operational_proof_roles: *id190
   default_thresholds: *id191
-  pandas_implementation: econ7_compute
+  pandas_implementation: econ_7
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   sql_file: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
@@ -7048,8 +5703,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -7159,12 +5814,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id193
-  equipment_kinds: *id193
+  equipment_kinds: null
   required_roles: *id194
   optional_roles: *id195
   operational_proof_roles: *id196
   default_thresholds: *id197
-  pandas_implementation: mech_oat1_compute
+  pandas_implementation: mech_oat_1
   datafusion_sql_implementation: mech_oat_1.sql
   sql_file: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
@@ -7174,8 +5829,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -7258,12 +5913,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id199
-  equipment_kinds: *id199
+  equipment_kinds: null
   required_roles: *id200
   optional_roles: *id201
   operational_proof_roles: *id202
   default_thresholds: *id203
-  pandas_implementation: chw_noload1_compute
+  pandas_implementation: chw_noload_1
   datafusion_sql_implementation: chw_noload_1.sql
   sql_file: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
@@ -7273,8 +5928,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -7344,11 +5999,11 @@ concepts:
 - canonical_id: VAV-1
   pandas_id: VAV-1
   rule_id: VAV-1
-  title: Zone comfort band
+  title: Zone comfort band violation hours with confirm window
   aliases: []
   kind: diagnostic
   equipment_types: *id205
-  equipment_kinds: *id205
+  equipment_kinds: null
   required_roles: *id206
   optional_roles: *id207
   operational_proof_roles: *id208
@@ -7363,8 +6018,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     zone_t_lo:
@@ -7453,11 +6108,11 @@ concepts:
 - canonical_id: VAV-2
   pandas_id: VAV-2
   rule_id: VAV-2
-  title: Night setback miss
+  title: Night setback miss — unoccupied zone above heating setback
   aliases: []
   kind: diagnostic
   equipment_types: *id211
-  equipment_kinds: *id211
+  equipment_kinds: null
   required_roles: *id212
   optional_roles: *id213
   operational_proof_roles: *id214
@@ -7472,8 +6127,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     setback_hi:
@@ -7556,12 +6211,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id217
-  equipment_kinds: *id217
+  equipment_kinds: null
   required_roles: *id218
   optional_roles: *id219
   operational_proof_roles: *id220
   default_thresholds: *id221
-  pandas_implementation: vav3
+  pandas_implementation: vav_3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   sql_file: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
@@ -7571,8 +6226,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -7673,12 +6328,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id223
-  equipment_kinds: *id223
+  equipment_kinds: null
   required_roles: *id224
   optional_roles: *id225
   operational_proof_roles: *id226
   default_thresholds: *id227
-  pandas_implementation: vav4
+  pandas_implementation: vav_4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   sql_file: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
@@ -7688,8 +6343,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: control_loop
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7790,12 +6445,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id229
-  equipment_kinds: *id229
+  equipment_kinds: null
   required_roles: *id230
   optional_roles: *id231
   operational_proof_roles: *id232
   default_thresholds: *id233
-  pandas_implementation: vav5
+  pandas_implementation: vav_5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   sql_file: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
@@ -7805,8 +6460,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7880,7 +6535,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id235
-  equipment_kinds: *id235
+  equipment_kinds: null
   required_roles: *id236
   optional_roles: *id237
   operational_proof_roles: *id238
@@ -7895,8 +6550,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     free_cool_oat:
@@ -7988,12 +6643,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id241
-  equipment_kinds: *id241
+  equipment_kinds: null
   required_roles: *id242
   optional_roles: *id243
   operational_proof_roles: *id244
   default_thresholds: *id245
-  pandas_implementation: vav_reheat_stuck
+  pandas_implementation: vav_reheat
   datafusion_sql_implementation: vav_reheat.sql
   sql_file: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
@@ -8003,8 +6658,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8105,12 +6760,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id247
-  equipment_kinds: *id247
+  equipment_kinds: null
   required_roles: *id248
   optional_roles: *id249
   operational_proof_roles: *id250
   default_thresholds: *id251
-  pandas_implementation: vav_vs_ahu_leave
+  pandas_implementation: vav_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   sql_file: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
@@ -8120,8 +6775,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8213,12 +6868,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id253
-  equipment_kinds: *id253
+  equipment_kinds: null
   required_roles: *id254
   optional_roles: *id255
   operational_proof_roles: *id256
   default_thresholds: *id257
-  pandas_implementation: vav7
+  pandas_implementation: vav_7
   datafusion_sql_implementation: vav7_min_airflow.sql
   sql_file: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
@@ -8228,8 +6883,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8348,7 +7003,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id259
-  equipment_kinds: *id259
+  equipment_kinds: null
   required_roles: *id260
   optional_roles: *id261
   operational_proof_roles: *id262
@@ -8364,8 +7019,8 @@ concepts:
   difference_class: none
   known_semantic_differences: Missing proof → pandas SKIPPED_MISSING_ROLES; SQL returns
     0 fault hours (optional proof roles). Proven-off zeros do not accumulate ΔT hours.
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 900
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8448,12 +7103,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id265
-  equipment_kinds: *id265
+  equipment_kinds: null
   required_roles: *id266
   optional_roles: *id267
   operational_proof_roles: *id268
   default_thresholds: *id269
-  pandas_implementation: chw2
+  pandas_implementation: chw_2
   datafusion_sql_implementation: chw2_dp_low.sql
   sql_file: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
@@ -8463,8 +7118,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -8556,12 +7211,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id271
-  equipment_kinds: *id271
+  equipment_kinds: null
   required_roles: *id272
   optional_roles: *id273
   operational_proof_roles: *id274
   default_thresholds: *id275
-  pandas_implementation: chw3
+  pandas_implementation: chw_3
   datafusion_sql_implementation: chw3_supply_band.sql
   sql_file: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
@@ -8571,8 +7226,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -8655,12 +7310,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id277
-  equipment_kinds: *id277
+  equipment_kinds: null
   required_roles: *id278
   optional_roles: *id279
   operational_proof_roles: *id280
   default_thresholds: *id281
-  pandas_implementation: chw4
+  pandas_implementation: chw_4
   datafusion_sql_implementation: chw4_flow_high.sql
   sql_file: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
@@ -8670,8 +7325,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -8763,12 +7418,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id283
-  equipment_kinds: *id283
+  equipment_kinds: null
   required_roles: *id284
   optional_roles: *id285
   operational_proof_roles: *id286
   default_thresholds: *id287
-  pandas_implementation: hp1
+  pandas_implementation: hp_1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   sql_file: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
@@ -8778,8 +7433,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: compressor
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -8871,12 +7526,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id289
-  equipment_kinds: *id289
+  equipment_kinds: null
   required_roles: *id290
   optional_roles: *id291
   operational_proof_roles: *id292
   default_thresholds: *id293
-  pandas_implementation: wx1
+  pandas_implementation: wx_1
   datafusion_sql_implementation: wx1_oa_spike.sql
   sql_file: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
@@ -8886,8 +7541,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -8970,12 +7625,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id295
-  equipment_kinds: *id295
+  equipment_kinds: null
   required_roles: *id296
   optional_roles: *id297
   operational_proof_roles: *id298
   default_thresholds: *id299
-  pandas_implementation: cw_opt
+  pandas_implementation: cw_opt_1
   datafusion_sql_implementation: cw_opt_1.sql
   sql_file: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
@@ -8985,8 +7640,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -9078,12 +7733,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id301
-  equipment_kinds: *id301
+  equipment_kinds: null
   required_roles: *id302
   optional_roles: *id303
   operational_proof_roles: *id304
   default_thresholds: *id305
-  pandas_implementation: cw_apr
+  pandas_implementation: cw_apr_1
   datafusion_sql_implementation: cw_apr_1.sql
   sql_file: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
@@ -9093,8 +7748,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -9186,12 +7841,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id307
-  equipment_kinds: *id307
+  equipment_kinds: null
   required_roles: *id308
   optional_roles: *id309
   operational_proof_roles: *id310
   default_thresholds: *id311
-  pandas_implementation: cw_fan_excess
+  pandas_implementation: cw_fan_1
   datafusion_sql_implementation: cw_fan_1.sql
   sql_file: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
@@ -9201,8 +7856,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -9303,12 +7958,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id313
-  equipment_kinds: *id313
+  equipment_kinds: null
   required_roles: *id314
   optional_roles: *id315
   operational_proof_roles: *id316
   default_thresholds: *id317
-  pandas_implementation: trim1
+  pandas_implementation: trim_1
   datafusion_sql_implementation: trim1_duct_static.sql
   sql_file: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
@@ -9318,8 +7973,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -9411,12 +8066,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id319
-  equipment_kinds: *id319
+  equipment_kinds: null
   required_roles: *id320
   optional_roles: *id321
   operational_proof_roles: *id322
   default_thresholds: *id323
-  pandas_implementation: trim3
+  pandas_implementation: trim_3
   datafusion_sql_implementation: trim3_hwst.sql
   sql_file: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
@@ -9426,8 +8081,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -9519,12 +8174,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id325
-  equipment_kinds: *id325
+  equipment_kinds: null
   required_roles: *id326
   optional_roles: *id327
   operational_proof_roles: *id328
   default_thresholds: *id329
-  pandas_implementation: trim4
+  pandas_implementation: trim_4
   datafusion_sql_implementation: trim4_chw_reset.sql
   sql_file: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
@@ -9534,8 +8189,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: hydronic_flow
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -9623,12 +8278,14 @@ concepts:
 - canonical_id: SCHED-1
   pandas_id: SCHED-1
   rule_id: SCHED-1
-  title: Unoccupied runtime
+  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
+    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
+    unoccupied + fan_on (pandas sched1 base).
   aliases:
   - excess_runtime
   kind: diagnostic
   equipment_types: *id331
-  equipment_kinds: *id331
+  equipment_kinds: null
   required_roles: *id332
   optional_roles: *id333
   operational_proof_roles: *id334
@@ -9643,8 +8300,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: excess_runtime (not independent rules)'
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -9736,7 +8393,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id337
-  equipment_kinds: *id337
+  equipment_kinds: null
   required_roles: *id338
   optional_roles: *id339
   operational_proof_roles: *id340
@@ -9753,8 +8410,8 @@ concepts:
   known_semantic_differences: 4.3 ranked proof (status/current > command; pressure
     inferred only). SQL mean(on) >= always_on_pct over the analysis window matches
     pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -9837,7 +8494,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id343
-  equipment_kinds: *id343
+  equipment_kinds: null
   required_roles: *id344
   optional_roles: *id345
   operational_proof_roles: *id346
@@ -9852,8 +8509,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     reset_err_f:
@@ -9963,12 +8620,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id349
-  equipment_kinds: *id349
+  equipment_kinds: null
   required_roles: *id350
   optional_roles: *id351
   operational_proof_roles: *id352
   default_thresholds: *id353
-  pandas_implementation: cmd1
+  pandas_implementation: cmd_1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   sql_file: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
@@ -9978,8 +8635,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: always
-  startup_delay_seconds: 0.0
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -10053,12 +8710,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id355
-  equipment_kinds: *id355
+  equipment_kinds: null
   required_roles: *id356
   optional_roles: *id357
   operational_proof_roles: *id358
   default_thresholds: *id359
-  pandas_implementation: oa1
+  pandas_implementation: oa_1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   sql_file: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
@@ -10068,8 +8725,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_running
-  startup_delay_seconds: 600
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -10161,12 +8818,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id361
-  equipment_kinds: *id361
+  equipment_kinds: null
   required_roles: *id362
   optional_roles: *id363
   operational_proof_roles: *id364
   default_thresholds: *id365
-  pandas_implementation: dmp1
+  pandas_implementation: dmp_1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   sql_file: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
@@ -10176,8 +8833,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -10260,12 +8917,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id367
-  equipment_kinds: *id367
+  equipment_kinds: null
   required_roles: *id368
   optional_roles: *id369
   operational_proof_roles: *id370
   default_thresholds: *id371
-  pandas_implementation: vlv1
+  pandas_implementation: vlv_1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   sql_file: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
@@ -10275,8 +8932,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: conditional
-  startup_delay_seconds: 300
+  operational_gate: fan_or_occupied_when_declared
+  startup_delay_seconds: null
   confirm_seconds: 900
   parameters:
     confirm_seconds:

--- a/sql_rules/generated/parity_inventory.yaml
+++ b/sql_rules/generated/parity_inventory.yaml
@@ -38,7 +38,14 @@ aliases_index:
 matrix:
 - rule_id: SV-RANGE
   title: Sensor out of hard range
-  equipment_types: &id001 []
+  equipment_types: &id001
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id002 []
   optional_roles: &id003
   - oa_t
@@ -57,15 +64,21 @@ matrix:
   - pump_status
   - chw_pump_cmd
   - chiller_status
-  operational_proof_roles: &id004 []
+  operational_proof_roles: &id004
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-current
+  - chw-flow
+  - compressor-status
+  - equipment-enable
   default_thresholds: &id005
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     range_scale_temperature:
       default: 1.0
       unit: x
@@ -73,7 +86,31 @@ matrix:
       max: 2.0
       step: 0.1
       label: Temp range scale
-  pandas_implementation: sv_range
+    range_scale_humidity:
+      default: 1.0
+      unit: x
+      min: 0.5
+      max: 2.0
+      step: 0.1
+      label: Humidity range scale
+    range_scale_pressure:
+      default: 1.0
+      unit: x
+      min: 0.5
+      max: 2.0
+      step: 0.1
+      label: Pressure range scale
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_range
   datafusion_sql_implementation: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
   test_coverage: &id006
@@ -84,7 +121,14 @@ matrix:
   difference_class: none
 - rule_id: SV-FLATLINE
   title: Sensor flatline (stuck)
-  equipment_types: &id007 []
+  equipment_types: &id007
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id008 []
   optional_roles: &id009
   - oa_t
@@ -104,16 +148,9 @@ matrix:
   - chiller_status
   operational_proof_roles: &id010 []
   default_thresholds: &id011
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     flatline_tol:
       default: 0.1
-      unit: degF
+      unit: °F
       min: 0.02
       max: 1.0
       step: 0.02
@@ -121,11 +158,21 @@ matrix:
     flatline_hours:
       default: 1.0
       unit: h
-      min: 0.25
-      max: 12.0
-      step: 0.25
+      min: 0.5
+      max: 8.0
+      step: 0.5
       label: Flatline window
-  pandas_implementation: sv_flatline
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_flatline
   datafusion_sql_implementation: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
   test_coverage: &id012
@@ -135,7 +182,14 @@ matrix:
   difference_class: none
 - rule_id: SV-SPIKE
   title: Sensor rate-of-change spike
-  equipment_types: &id013 []
+  equipment_types: &id013
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id014 []
   optional_roles: &id015
   - oa_t
@@ -154,15 +208,21 @@ matrix:
   - pump_status
   - chw_pump_cmd
   - chiller_status
-  operational_proof_roles: &id016 []
+  operational_proof_roles: &id016
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-current
+  - chw-flow
+  - compressor-status
+  - equipment-enable
   default_thresholds: &id017
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     spike_scale:
       default: 1.0
       unit: x
@@ -170,7 +230,38 @@ matrix:
       max: 3.0
       step: 0.25
       label: Spike limit scale (global)
-  pandas_implementation: sv_spike
+    spike_scale_temperature:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Temp spike scale
+    spike_scale_humidity:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Humidity spike scale
+    spike_scale_pressure:
+      default: 1.0
+      unit: x
+      min: 0.25
+      max: 3.0
+      step: 0.25
+      label: Pressure spike scale
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_spike
   datafusion_sql_implementation: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
   test_coverage: &id018
@@ -180,7 +271,14 @@ matrix:
   difference_class: none
 - rule_id: SV-STALE
   title: Stale data (no fresh samples)
-  equipment_types: &id019 []
+  equipment_types: &id019
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id020 []
   optional_roles: &id021
   - oa_t
@@ -195,13 +293,6 @@ matrix:
   - oa_h
   operational_proof_roles: &id022 []
   default_thresholds: &id023
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     stale_hours:
       default: 2.0
       unit: h
@@ -209,14 +300,17 @@ matrix:
       max: 12.0
       step: 0.5
       label: Stale window
-    stale_tol:
-      default: 0.05
-      unit: degF
+    confirm_min:
+      default: 5.0
+      unit: min
       min: 0.0
-      max: 1.0
-      step: 0.01
-      label: Stale tolerance
-  pandas_implementation: sv_stale
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _sweep_stale
   datafusion_sql_implementation: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
   test_coverage: &id024
@@ -226,7 +320,14 @@ matrix:
   difference_class: none
 - rule_id: SV-RATE
   title: Context-aware sensor rate of change
-  equipment_types: &id025 []
+  equipment_types: &id025
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - weather
+  - zone
+  - heatpump
   required_roles: &id026 []
   optional_roles: &id027
   - oa_t
@@ -236,13 +337,6 @@ matrix:
   - sat
   operational_proof_roles: &id028 []
   default_thresholds: &id029
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     persistence_min:
       default: 10.0
       unit: min
@@ -250,14 +344,45 @@ matrix:
       max: 60.0
       step: 1.0
       label: Fault persistence
-    steady_fault_per_hour:
-      default: 6.0
-      unit: degF_per_h
-      min: 1.0
+    transition_window_min:
+      default: 20.0
+      unit: min
+      min: 5.0
       max: 60.0
-      step: 0.5
-      label: Steady-state slew limit
-  pandas_implementation: sv_rate
+      step: 5.0
+      label: Transition window
+    max_gap_hours:
+      default: 2.0
+      unit: h
+      min: 0.25
+      max: 6.0
+      step: 0.25
+      label: Max sample gap
+    design_flow:
+      default: 0.0
+      unit: cfm
+      min: 0.0
+      max: 100000.0
+      step: 100.0
+      label: Design flow (flow profiles)
+    sensor_span:
+      default: 0.0
+      unit: eng
+      min: 0.0
+      max: 100000.0
+      step: 10.0
+      label: Sensor span (flow/pressure)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: _sv_rate_compute
   datafusion_sql_implementation: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
   test_coverage: &id030
@@ -271,75 +396,77 @@ matrix:
   difference_class: semantic_gap
 - rule_id: PID-HUNT-1
   title: Suspected control-output hunting
-  equipment_types: &id031 []
+  equipment_types: &id031
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - heatpump
   required_roles: &id032 []
   optional_roles: &id033
-  - oa_damper_pct
-  - clg_valve_pct
-  - htg_valve_pct
-  - damper_pct
-  - loop_enabled
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id034 []
+  - loop-enabled
+  operational_proof_roles: &id034
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
   default_thresholds: &id035
-    confirm_seconds:
-      default: 0.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    window_hours:
-      default: 1.0
-      unit: h
-      min: 0.25
-      max: 4.0
-      step: 0.25
-      label: Hunting lookback window
     change_deadband_pct:
       default: 1.0
-      unit: pct
+      unit: '% out'
       min: 0.0
       max: 10.0
       step: 0.5
       label: Ignore changes below
     minimum_span_pct:
       default: 20.0
-      unit: pct
+      unit: '% out'
       min: 5.0
       max: 100.0
       step: 5.0
       label: Minimum observed span
     total_variation_fault_pct:
       default: 500.0
-      unit: pct
+      unit: '%/h'
       min: 50.0
       max: 2000.0
       step: 50.0
-      label: Total variation fault threshold
+      label: Total travel threshold
     minimum_equivalent_cycles:
       default: 2.5
-      unit: count
+      unit: cyc/h
       min: 0.5
-      max: 10.0
+      max: 20.0
       step: 0.5
       label: Min equivalent cycles
     minimum_reversals:
-      default: 4.0
+      default: 4
       unit: count
-      min: 1.0
-      max: 20.0
-      step: 1.0
+      min: 1
+      max: 40
+      step: 1
       label: Min direction reversals
     minimum_coverage_pct:
       default: 80.0
-      unit: pct
-      min: 50.0
+      unit: '%'
+      min: 25.0
       max: 100.0
       step: 5.0
-      label: Min window sample coverage
-  pandas_implementation: pid_hunt_1
+      label: Minimum data coverage
+    confirm_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: _pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
   test_coverage: &id036 []
@@ -347,38 +474,69 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC1
-  title: Duct static below SP at full fan
-  equipment_types: &id037 []
+  title: Duct static below SP at full fan (GL36 A)
+  equipment_types: &id037
+  - ahu
   required_roles: &id038
-  - duct_static
-  - duct_static_sp
-  - fan_cmd
+  - duct-static-pressure
+  - duct-static-pressure-sp
+  - fan-cmd
   optional_roles: &id039
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id040 []
+  operational_proof_roles: &id040
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id041
     eps_dsp:
       default: 0.12
-      unit: inwc
+      unit: in. w.c.
       min: 0.0
       max: 0.5
       step: 0.01
-      label: Duct-static error epsDSP (GL36 default 0.1 in.w.c.)
+      label: Duct-static error εDSP (GL36 default 0.1 in.w.c.)
     eps_vfd_spd:
       default: 0.13
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: VFD speed error epsVFDSPD (GL36 default 5%)
+      label: VFD speed error εVFDSPD (GL36 default 5%)
+    duct_static_err:
+      default: 0.12
+      unit: in. w.c.
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Legacy duct-static error (sets εDSP)
+    fan_hi:
+      default: 0.87
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Legacy fan-high threshold (sets εVFDSPD)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 300
+      default: 300.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: fc1
   datafusion_sql_implementation: fc1_duct_static_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc1
@@ -389,18 +547,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC2
-  title: Mixed air below envelope
-  equipment_types: &id043 []
+  title: MAT below OAT/RAT envelope (GL36 B)
+  equipment_types: &id043
+  - ahu
   required_roles: &id044
-  - mat
-  - oa_t
-  - rat
-  - fan_cmd
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - fan-cmd
   optional_roles: &id045
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id046 []
-  default_thresholds: &id047 {}
+  operational_proof_roles: &id046
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id047
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_rat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: RAT sensor error εRAT (GL36 default 2°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc2
   datafusion_sql_implementation: fc2_mat_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc2
@@ -409,18 +626,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC3
-  title: Mixed air above envelope
-  equipment_types: &id049 []
+  title: MAT above OAT/RAT envelope (GL36 C)
+  equipment_types: &id049
+  - ahu
   required_roles: &id050
-  - mat
-  - oa_t
-  - rat
-  - fan_cmd
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - fan-cmd
   optional_roles: &id051
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id052 []
-  default_thresholds: &id053 {}
+  operational_proof_roles: &id052
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id053
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_rat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: RAT sensor error εRAT (GL36 default 2°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc3
   datafusion_sql_implementation: fc3_mat_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc3
@@ -430,29 +706,47 @@ matrix:
   difference_class: none
 - rule_id: FC4
   title: PID hunting (operating-state oscillation)
-  equipment_types: &id055 []
+  equipment_types: &id055
+  - ahu
   required_roles: &id056
-  - oa_damper_pct
-  - clg_valve_pct
-  - fan_cmd
+  - outside-air-damper
+  - cooling-valve
+  - fan-cmd
   optional_roles: &id057
   - fan_status
-  operational_proof_roles: &id058 []
+  operational_proof_roles: &id058
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
   default_thresholds: &id059
+    delta_os_max:
+      default: 5
+      unit: count
+      min: 1
+      max: 30
+      step: 1
+      label: Max mode changes/hr ΔOSmax (GL36 default 7)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 60.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 3600.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    delta_os_max:
-      default: 5.0
-      unit: count
-      min: 1.0
-      max: 30.0
-      step: 1.0
-      label: Max operating-state entries per hour
   pandas_implementation: fc4
   datafusion_sql_implementation: fc4_os_hunting.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc4
@@ -462,31 +756,45 @@ matrix:
   difference_class: none
 - rule_id: FC5
   title: SAT cold when heating commanded (GL36 D)
-  equipment_types: &id061 []
+  equipment_types: &id061
+  - ahu
   required_roles: &id062
-  - sat
-  - mat
-  - htg_valve_pct
-  - fan_cmd
+  - discharge-air-temp
+  - mixed-air-temp
+  - fan-cmd
+  - heating-valve
   optional_roles: &id063
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id064 []
+  operational_proof_roles: &id064
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id065
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    mix_tol:
+    eps_sat:
       default: 1.15
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy master sensor tolerance (sets all eps values)
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
     htg_on_min:
       default: 0.01
       unit: frac
@@ -494,6 +802,37 @@ matrix:
       max: 0.25
       step: 0.01
       label: Heating-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc5
   datafusion_sql_implementation: fc5_sat_cold_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc5
@@ -503,46 +842,83 @@ matrix:
   difference_class: none
 - rule_id: FC6
   title: Estimated OA fraction mismatch
-  equipment_types: &id067 []
+  equipment_types: &id067
+  - ahu
   required_roles: &id068
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
-  - vav_total_flow
+  - mixed-air-temp
+  - outside-air-temp
+  - return-air-temp
+  - vav-total-airflow
   optional_roles: &id069
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id070 []
+  operational_proof_roles: &id070
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id071
-    confirm_seconds:
-      default: 600.0
-      unit: sec
+    eps_airflow:
+      default: 0.15
+      unit: frac
+      min: 0.05
+      max: 1.0
+      step: 0.01
+      label: Airflow error εF (GL36 default 30%)
+    delta_t_min:
+      default: 5.0
+      unit: °F
       min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
+      max: 30.0
+      step: 0.5
+      label: Minimum |OAT−RAT| ΔTmin (GL36 default 10°F)
     airflow_err:
       default: 0.15
       unit: frac
       min: 0.05
       max: 1.0
       step: 0.01
-      label: Airflow error epsF (GL36 default 30%)
-    delta_t_min:
+      label: Legacy OA-fraction error (sets εF)
+    oat_rat_delta_min:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 0.0
       max: 30.0
       step: 0.5
-      label: Minimum |OAT-RAT| deltaTmin (GL36 default 10degF)
+      label: Legacy OAT/RAT guard (sets ΔTmin)
     min_cfm_design:
-      default: 5000.0
+      default: 5000
       unit: cfm
+      min: 500
+      max: 20000
+      step: 500
+      label: Design min OA CFM
+    fan_on_min:
+      default: 0.01
+      unit: frac
       min: 0.0
-      max: 200000.0
-      step: 100.0
-      label: Design minimum outdoor airflow
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc6
   datafusion_sql_implementation: fc6_oa_frac_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc6
@@ -551,24 +927,39 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC7
-  title: SAT low while heating at full
-  equipment_types: &id073 []
+  title: SAT low with full heating (GL36 E)
+  equipment_types: &id073
+  - ahu
   required_roles: &id074
-  - sat
-  - sat_sp
-  - htg_valve_pct
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - fan-cmd
+  - heating-valve
   optional_roles: &id075
   - fan_cmd
   - fan_status
-  operational_proof_roles: &id076 []
+  operational_proof_roles: &id076
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id077
-    sat_err:
+    eps_sat:
       default: 1.0
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy SAT error (sets epsSAT)
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    sat_err:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT error (sets εSAT)
     htg_full_min:
       default: 0.9
       unit: frac
@@ -576,13 +967,30 @@ matrix:
       max: 1.0
       step: 0.01
       label: Full-heating threshold (GL36 99%)
+    fan_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Fan-on command threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 600
+      default: 600.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: fc7
   datafusion_sql_implementation: fc7_sat_low_heating.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc7
@@ -596,18 +1004,91 @@ matrix:
     twin parity
   difference_class: missing_implementation
 - rule_id: FC8
-  title: SAT vs MAT while economizing
-  equipment_types: &id079 []
+  title: SAT/MAT mismatch in economizer (GL36 F)
+  equipment_types: &id079
+  - ahu
   required_roles: &id080
-  - sat
-  - mat
-  - oa_damper_pct
-  - clg_valve_pct
+  - discharge-air-temp
+  - mixed-air-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id081
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id082 []
-  default_thresholds: &id083 {}
+  operational_proof_roles: &id082
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id083
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    supply_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT tolerance master (sets εSAT)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc8
   datafusion_sql_implementation: fc8_sat_mat_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc8
@@ -616,18 +1097,84 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC9
-  title: OAT high vs SAT SP while economizing
-  equipment_types: &id085 []
+  title: OAT too warm for free cooling (GL36 G)
+  equipment_types: &id085
+  - ahu
   required_roles: &id086
-  - oa_t
-  - sat_sp
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id087
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id088 []
-  default_thresholds: &id089 {}
+  operational_proof_roles: &id088
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id089
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc9
   datafusion_sql_implementation: fc9_oa_sat_sp_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc9
@@ -636,18 +1183,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC10
-  title: MAT-OAT delta while cooling and economizing
-  equipment_types: &id091 []
+  title: OAT/MAT mismatch + mech cooling (GL36 H)
+  equipment_types: &id091
+  - ahu
   required_roles: &id092
-  - mat
-  - oa_t
-  - oa_damper_pct
-  - clg_valve_pct
+  - mixed-air-temp
+  - outside-air-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id093
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id094 []
-  default_thresholds: &id095 {}
+  operational_proof_roles: &id094
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id095
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc10
   datafusion_sql_implementation: fc10_mat_oa_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc10
@@ -656,18 +1262,84 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC11
-  title: OAT low vs SAT SP while cooling and economizing
-  equipment_types: &id097 []
+  title: OAT/MAT mismatch economizer-only (GL36 I)
+  equipment_types: &id097
+  - ahu
   required_roles: &id098
-  - oa_t
-  - sat_sp
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id099
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id100 []
-  default_thresholds: &id101 {}
+  operational_proof_roles: &id100
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id101
+    eps_oat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: OAT sensor error εOAT (GL36 default 2°F local / 5°F global)
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc11
   datafusion_sql_implementation: fc11_oa_sat_sp_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc11
@@ -676,18 +1348,98 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC12
-  title: SAT above MAT while cooling
-  equipment_types: &id103 []
+  title: SAT above blend in cooling (GL36 J)
+  equipment_types: &id103
+  - ahu
   required_roles: &id104
-  - sat
-  - mat
-  - oa_damper_pct
-  - clg_valve_pct
+  - discharge-air-temp
+  - mixed-air-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id105
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id106 []
-  default_thresholds: &id107 {}
+  operational_proof_roles: &id106
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  default_thresholds: &id107
+    eps_sat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    eps_mat:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: MAT sensor error εMAT (GL36 default 5°F)
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    supply_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT tolerance master (sets εSAT)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc12
   datafusion_sql_implementation: fc12_sat_mat_clg.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc12
@@ -696,53 +1448,77 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: FC13
-  title: SAT above setpoint at full cooling
-  equipment_types: &id109 []
+  title: SAT above SP at full cooling (GL36 K)
+  equipment_types: &id109
+  - ahu
   required_roles: &id110
-  - sat
-  - sat_sp
-  - clg_valve_pct
-  - oa_damper_pct
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id111
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id112 []
+  operational_proof_roles: &id112
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id113
-    sat_err:
+    eps_sat:
       default: 1.0
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: SAT high error band
-    clg_valve_min:
+      label: SAT sensor error εSAT (GL36 default 2°F)
+    sat_err:
+      default: 1.0
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy SAT error (sets εSAT)
+    clg_full_min:
       default: 0.01
       unit: frac
-      min: 0.0
-      max: 0.5
+      min: 0.5
+      max: 1.0
       step: 0.01
-      label: Cooling valve open threshold
-    oa_damper_econ_low:
+      label: Full-cooling threshold (GL36 99%)
+    econ_min_pos:
       default: 0.05
       unit: frac
       min: 0.0
       max: 0.5
       step: 0.01
-      label: OA damper economizer low
-    oa_damper_econ_high:
+      label: Economizer minimum-position threshold
+    econ_full_open:
       default: 0.9
       unit: frac
       min: 0.5
       max: 1.0
       step: 0.01
-      label: OA damper economizer high
+      label: Economizer full-open threshold
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 600
+      default: 600.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: fc13
   datafusion_sql_implementation: sat_high_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc13
@@ -753,9 +1529,13 @@ matrix:
   difference_class: alias
 - rule_id: FC14
   title: CHW coil ΔT when inactive (GL36 L)
-  equipment_types: &id115 []
+  equipment_types: &id115
+  - ahu
   required_roles: &id116
-  - clg_valve_pct
+  - cooling-coil-entering-temp
+  - cooling-coil-leaving-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id117
   - cooling_coil_entering_temp
   - cooling_coil_leaving_temp
@@ -764,22 +1544,80 @@ matrix:
   - oa_damper_pct
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id118 []
+  operational_proof_roles: &id118
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id119
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    mix_tol:
+    eps_ccet:
       default: 1.15
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy master sensor tolerance (sets all eps values)
+      label: Cooling-coil entering sensor error εCCET
+    eps_cclt:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Cooling-coil leaving sensor error εCCLT
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    htg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Heating-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc14
   datafusion_sql_implementation: fc14_chw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc14
@@ -789,8 +1627,13 @@ matrix:
   difference_class: none
 - rule_id: FC15
   title: HW coil ΔT when inactive (GL36 M)
-  equipment_types: &id121 []
-  required_roles: &id122 []
+  equipment_types: &id121
+  - ahu
+  required_roles: &id122
+  - heating-coil-entering-temp
+  - heating-coil-leaving-temp
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id123
   - heating_coil_entering_temp
   - heating_coil_leaving_temp
@@ -800,22 +1643,87 @@ matrix:
   - clg_valve_pct
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id124 []
+  operational_proof_roles: &id124
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id125
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    mix_tol:
+    eps_hcet:
       default: 1.15
-      unit: degF
+      unit: °F
       min: 0.0
       max: 10.0
       step: 0.25
-      label: Legacy master sensor tolerance (sets all eps values)
+      label: Heating-coil entering sensor error εHCET
+    eps_hclt:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Heating-coil leaving sensor error εHCLT
+    delta_supply_fan:
+      default: 0.55
+      unit: °F
+      min: 0.0
+      max: 5.0
+      step: 0.05
+      label: Supply-fan heat rise ΔTSF (GL36 default 2°F)
+    econ_min_pos:
+      default: 0.05
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Economizer minimum-position threshold
+    econ_full_open:
+      default: 0.9
+      unit: frac
+      min: 0.5
+      max: 1.0
+      step: 0.01
+      label: Economizer full-open threshold
+    clg_inactive_max:
+      default: 0.1
+      unit: frac
+      min: 0.0
+      max: 0.5
+      step: 0.01
+      label: Cooling-command inactive ceiling
+    clg_on_min:
+      default: 0.01
+      unit: frac
+      min: 0.0
+      max: 0.25
+      step: 0.01
+      label: Cooling-command ON threshold
+    mix_tol:
+      default: 1.15
+      unit: °F
+      min: 0.0
+      max: 10.0
+      step: 0.25
+      label: Legacy master sensor tolerance (sets all ε values)
+    mode_delay_min:
+      default: 0.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Mode-change suspension (GL36 default 30)
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: fc15
   datafusion_sql_implementation: fc15_hw_coil_dt_inactive.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#fc15
@@ -825,30 +1733,40 @@ matrix:
   difference_class: none
 - rule_id: AHU-SATDEV
   title: SAT deviation from setpoint
-  equipment_types: &id127 []
+  equipment_types: &id127
+  - ahu
   required_roles: &id128
-  - sat
-  - sat_sp
+  - discharge-air-temp
+  - discharge-air-temp-sp
   optional_roles: &id129
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id130 []
+  operational_proof_roles: &id130
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id131
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     sat_dev_err:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 1.0
       max: 15.0
       step: 0.5
       label: SAT deviation
-  pandas_implementation: ahu_satdev
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: ahu_sat_dev
   datafusion_sql_implementation: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
   test_coverage: &id132
@@ -858,38 +1776,41 @@ matrix:
   difference_class: none
 - rule_id: AHU-DUCTHI
   title: Duct static pressure high
-  equipment_types: &id133 []
+  equipment_types: &id133
+  - ahu
   required_roles: &id134
-  - duct_static
-  - duct_static_sp
-  - fan_cmd
+  - duct-static-pressure
+  - duct-static-pressure-sp
   optional_roles: &id135
   - fan_status
   - fan_cmd
   operational_proof_roles: &id136 []
   default_thresholds: &id137
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     duct_high_margin:
       default: 0.25
-      unit: in_wc
+      unit: in. w.c.
       min: 0.05
       max: 1.0
       step: 0.05
       label: High margin
     pressure_on_min:
       default: 0.2
-      unit: in_wc
+      unit: in. w.c.
       min: 0.05
       max: 1.0
       step: 0.05
       label: Pressure-on evidence
-  pandas_implementation: ahu_ducthi
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: ahu_duct_high
   datafusion_sql_implementation: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
   test_coverage: &id138
@@ -899,22 +1820,22 @@ matrix:
   difference_class: none
 - rule_id: AHU-SIMUL
   title: Heating and cooling simultaneous
-  equipment_types: &id139 []
+  equipment_types: &id139
+  - ahu
   required_roles: &id140
-  - htg_valve_pct
-  - clg_valve_pct
+  - heating-valve
+  - cooling-valve
   optional_roles: &id141
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id142 []
+  operational_proof_roles: &id142
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id143
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     valve_open_pct:
       default: 0.1
       unit: frac
@@ -922,7 +1843,17 @@ matrix:
       max: 0.5
       step: 0.01
       label: Valve open threshold
-  pandas_implementation: ahu_simul
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: ahu_simul_heat_cool
   datafusion_sql_implementation: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
   test_coverage: &id144 []
@@ -930,28 +1861,33 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: OAT-METEO
-  title: Equipment OAT vs weather-staged wx OAT
-  equipment_types: &id145 []
+  title: BAS outdoor-air sensor vs Open-Meteo
+  equipment_types: &id145
+  - ahu
   required_roles: &id146
-  - oa_t
+  - outside-air-temp
+  - web-outside-air-temp
   optional_roles: &id147
   - web_oa_t
   operational_proof_roles: &id148 []
   default_thresholds: &id149
     oat_err:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 2.0
       max: 20.0
       step: 0.5
-      label: OAT vs meteo tolerance
+      label: Max OAT disagreement
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 900
+      default: 900.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: oat_vs_meteo
   datafusion_sql_implementation: oat_meteo_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oat-meteo
@@ -960,31 +1896,41 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-1
-  title: Economizer stuck closed when OAT favorable
-  equipment_types: &id151 []
+  title: Economizer stuck closed
+  equipment_types: &id151
+  - ahu
   required_roles: &id152
-  - fan_cmd
-  - oa_damper_pct
-  - oa_t
+  - fan-cmd
+  - outside-air-damper
+  - outside-air-temp
   optional_roles: &id153
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id154 []
+  operational_proof_roles: &id154
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id155
     econ1_oat_min:
       default: 55.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 70.0
       step: 1.0
       label: Favorable OAT
-    econ1_damper_max:
-      default: 0.05
-      unit: frac
+    confirm_min:
+      default: 10.0
+      unit: min
       min: 0.0
-      max: 0.2
-      step: 0.01
-      label: Stuck-closed damper frac
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
   pandas_implementation: econ1
   datafusion_sql_implementation: econ1_stuck_closed.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-1
@@ -993,19 +1939,26 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: ECON-2
-  title: Economizing when outdoor air unfavorable
-  equipment_types: &id157 []
+  title: Economizing when outdoor unfavorable
+  equipment_types: &id157
+  - ahu
   required_roles: &id158
-  - oa_t
-  - oa_damper_pct
+  - outside-air-temp
+  - outside-air-damper
   optional_roles: &id159
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id160 []
+  operational_proof_roles: &id160
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id161
     econ2_oat_hi:
       default: 63.0
-      unit: degF
+      unit: °F
       min: 55.0
       max: 80.0
       step: 1.0
@@ -1017,13 +1970,16 @@ matrix:
       max: 0.9
       step: 0.02
       label: Damper open frac
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 300
+      default: 300.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: econ2
   datafusion_sql_implementation: economizer_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-2
@@ -1034,41 +1990,40 @@ matrix:
   difference_class: none
 - rule_id: ECON-3
   title: Mech cooling without integrated economizer
-  equipment_types: &id163 []
+  equipment_types: &id163
+  - ahu
   required_roles: &id164
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-damper
+  - cooling-valve
   optional_roles: &id165
-  - web_oa_t
-  - web_oa_dp
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id166 []
+  - web-outside-air-temp
+  - web-outside-air-dewpoint
+  - web-outside-air-humidity
+  operational_proof_roles: &id166
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id167
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     econ3_db_min:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 50.0
       max: 68.0
       step: 1.0
       label: Free-cool OA dry-bulb min
     econ3_db_max:
       default: 72.0
-      unit: degF
+      unit: °F
       min: 65.0
       max: 80.0
       step: 1.0
       label: Free-cool OA dry-bulb max
     econ3_dp_max:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 68.0
       step: 1.0
@@ -1080,7 +2035,17 @@ matrix:
       max: 1.0
       step: 0.02
       label: Integrated economizer damper
-  pandas_implementation: econ_3
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: econ2
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
   test_coverage: &id168 []
@@ -1089,31 +2054,41 @@ matrix:
   difference_class: none
 - rule_id: ECON-4
   title: Low estimated OA fraction
-  equipment_types: &id169 []
+  equipment_types: &id169
+  - ahu
   required_roles: &id170
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
+  - mixed-air-temp
+  - return-air-temp
+  - outside-air-temp
+  - fan-cmd
   optional_roles: &id171
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id172 []
+  operational_proof_roles: &id172
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id173
     oa_min_pct:
       default: 21.0
-      unit: pct
+      unit: '%'
       min: 5.0
       max: 40.0
       step: 1.0
       label: Min OA fraction
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 600
+      default: 600.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: econ4
   datafusion_sql_implementation: econ4_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-4
@@ -1123,32 +2098,42 @@ matrix:
   difference_class: none
 - rule_id: ECON-5
   title: Preheat over-conditioning
-  equipment_types: &id175 []
+  equipment_types: &id175
+  - ahu
   required_roles: &id176
-  - preheat_leave_t
-  - sat_sp
-  - oa_t
-  - htg_valve_pct
+  - preheat-leaving-temp
+  - discharge-air-temp-sp
+  - outside-air-temp
+  - heating-valve
   optional_roles: &id177
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id178 []
+  operational_proof_roles: &id178
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id179
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     preheat_over_f:
       default: 2.2
-      unit: degF
+      unit: °F
       min: 0.5
       max: 8.0
       step: 0.1
       label: Preheat over ΔT
-  pandas_implementation: econ_5
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ5
   datafusion_sql_implementation: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
   test_coverage: &id180 []
@@ -1157,25 +2142,23 @@ matrix:
   difference_class: none
 - rule_id: ECON-6
   title: Economizing in freezing weather
-  equipment_types: &id181 []
+  equipment_types: &id181
+  - ahu
   required_roles: &id182
-  - oa_damper_pct
+  - outside-air-damper
   optional_roles: &id183
-  - web_oa_t
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id184 []
+  - web-outside-air-temp
+  operational_proof_roles: &id184
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id185
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     econ6_oat_max_f:
       default: 25.0
-      unit: degF
+      unit: °F
       min: 15.0
       max: 40.0
       step: 1.0
@@ -1187,7 +2170,17 @@ matrix:
       max: 0.5
       step: 0.01
       label: Winter min-OA damper
-  pandas_implementation: econ_6
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ6_compute
   datafusion_sql_implementation: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
   test_coverage: &id186 []
@@ -1196,41 +2189,42 @@ matrix:
   difference_class: none
 - rule_id: ECON-7
   title: Economizer OK but not economizing
-  equipment_types: &id187 []
+  equipment_types: &id187
+  - ahu
   required_roles: &id188
-  - oa_damper_pct
-  - clg_valve_pct
+  - outside-air-damper
   optional_roles: &id189
-  - web_oa_t
-  - web_oa_dp
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id190 []
+  - web-outside-air-temp
+  - web-outside-air-dewpoint
+  - web-outside-air-humidity
+  - cooling-valve
+  - compressor-status
+  - dx-cool-cmd
+  operational_proof_roles: &id190
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id191
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     econ7_db_min:
       default: 35.0
-      unit: degF
+      unit: °F
       min: 20.0
       max: 50.0
       step: 1.0
       label: Econ-OK dry-bulb floor (freeze guard)
     econ7_db_max:
       default: 72.0
-      unit: degF
+      unit: °F
       min: 65.0
       max: 80.0
       step: 1.0
       label: Econ-OK dry-bulb max
     econ7_dp_max:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 68.0
       step: 1.0
@@ -1242,7 +2236,17 @@ matrix:
       max: 0.9
       step: 0.02
       label: Economizing damper threshold
-  pandas_implementation: econ_7
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: econ7_compute
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
   test_coverage: &id192 []
@@ -1251,29 +2255,38 @@ matrix:
   difference_class: none
 - rule_id: MECH-OAT-1
   title: Mechanical cooling below 60°F web OAT
-  equipment_types: &id193 []
+  equipment_types: &id193
+  - ahu
+  - chiller
+  - heatpump
   required_roles: &id194
   - web_oa_t
   optional_roles: &id195
-  - clg_valve_pct
-  - chiller_status
+  - web-outside-air-temp
+  - compressor-status
+  - chiller-status
+  - chw-pump-status
+  - dx-cool-cmd
   operational_proof_roles: &id196 []
   default_thresholds: &id197
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     mech_oat_max_f:
       default: 60.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 65.0
       step: 1.0
       label: Mech-cool OAT ceiling
-  pandas_implementation: mech_oat_1
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: mech_oat1_compute
   datafusion_sql_implementation: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
   test_coverage: &id198 []
@@ -1282,25 +2295,49 @@ matrix:
   difference_class: none
 - rule_id: CHW-NOLOAD-1
   title: Chiller running with no building load
-  equipment_types: &id199 []
+  equipment_types: &id199
+  - chiller
   required_roles: &id200 []
   optional_roles: &id201
-  - chiller_status
-  - chiller_cmd
-  - chw_pump_status
-  - chw_pump_cmd
-  - building_zone_load_satisfied
-  - building_ahu_load_satisfied
+  - chiller-status
+  - chw-pump-status
+  - compressor-status
+  - building-zone-load-satisfied
+  - building-ahu-load-satisfied
   operational_proof_roles: &id202 []
   default_thresholds: &id203
+    comfort_low_f:
+      default: 70.0
+      unit: °F
+      min: 60.0
+      max: 78.0
+      step: 0.5
+      label: Comfort low
+    comfort_high_f:
+      default: 75.0
+      unit: °F
+      min: 68.0
+      max: 85.0
+      step: 0.5
+      label: Comfort high
+    sat_band_f:
+      default: 2.0
+      unit: °F
+      min: 0.5
+      max: 6.0
+      step: 0.5
+      label: AHU SAT≈SP band
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 1800.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-  pandas_implementation: chw_noload_1
+  pandas_implementation: chw_noload1_compute
   datafusion_sql_implementation: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
   test_coverage: &id204 []
@@ -1308,35 +2345,40 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: VAV-1
-  title: Zone comfort band violation hours with confirm window
-  equipment_types: &id205 []
+  title: Zone comfort band
+  equipment_types: &id205
+  - vav
+  - zone
   required_roles: &id206
-  - zone_t
+  - zone-air-temp
   optional_roles: &id207
   - occ_mode
   operational_proof_roles: &id208 []
   default_thresholds: &id209
-    zone_t_lo:
+    zone_lo:
       default: 70.0
-      unit: degF
+      unit: °F
       min: 55.0
       max: 72.0
       step: 0.5
       label: Zone low
-    zone_t_hi:
+    zone_hi:
       default: 75.0
-      unit: degF
+      unit: °F
       min: 72.0
       max: 85.0
       step: 0.5
       label: Zone high
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 900
+      default: 900.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: vav1
   datafusion_sql_implementation: vav1_comfort_fault.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-1
@@ -1347,28 +2389,34 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: VAV-2
-  title: Night setback miss — unoccupied zone above heating setback
-  equipment_types: &id211 []
+  title: Night setback miss
+  equipment_types: &id211
+  - vav
+  - zone
   required_roles: &id212
-  - zone_t
-  - occ_mode
-  optional_roles: &id213 []
+  - zone-air-temp
+  - occupied
+  optional_roles: &id213
+  - occ-mode
   operational_proof_roles: &id214 []
   default_thresholds: &id215
     setback_hi:
       default: 68.0
-      unit: degF
+      unit: °F
       min: 55.0
       max: 72.0
       step: 0.5
       label: Setback high
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
-      default: 900
+      default: 900.0
       unit: sec
-      min: 0
-      max: 3600
-      step: 300
-      label: Confirm time
   pandas_implementation: vav2
   datafusion_sql_implementation: vav2_night_setback.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-2
@@ -1378,26 +2426,25 @@ matrix:
   difference_class: none
 - rule_id: VAV-3
   title: Excessive reheat during warm weather
-  equipment_types: &id217 []
+  equipment_types: &id217
+  - vav
   required_roles: &id218
-  - oa_t
-  - reheat_valve_pct
-  - zone_flow
+  - outside-air-temp
+  - reheat-valve
   optional_roles: &id219
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id220 []
+  operational_proof_roles: &id220
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id221
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     reheat_oat:
       default: 78.0
-      unit: degF
+      unit: °F
       min: 65.0
       max: 90.0
       step: 1.0
@@ -1416,7 +2463,17 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-  pandas_implementation: vav_3
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: vav3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
   test_coverage: &id222 []
@@ -1425,22 +2482,22 @@ matrix:
   difference_class: none
 - rule_id: VAV-4
   title: Damper stuck at full open
-  equipment_types: &id223 []
+  equipment_types: &id223
+  - vav
   required_roles: &id224
-  - damper_pct
-  - zone_flow
+  - damper
   optional_roles: &id225
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id226 []
+  operational_proof_roles: &id226
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
+  - loop-enabled
   default_thresholds: &id227
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     full_open_pct:
       default: 0.975
       unit: frac
@@ -1448,13 +2505,6 @@ matrix:
       max: 1.0
       step: 0.005
       label: Full open frac
-    flow_on_min:
-      default: 25.0
-      unit: cfm
-      min: 0.0
-      max: 200.0
-      step: 5.0
-      label: Airflow-on min
     sustain_hours:
       default: 1.5
       unit: h
@@ -1462,7 +2512,24 @@ matrix:
       max: 6.0
       step: 0.5
       label: Sustain window
-  pandas_implementation: vav_4
+    flow_on_min:
+      default: 25.0
+      unit: cfm
+      min: 0.0
+      max: 200.0
+      step: 5.0
+      label: Airflow-on min
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
   test_coverage: &id228 []
@@ -1471,23 +2538,33 @@ matrix:
   difference_class: none
 - rule_id: VAV-5
   title: Airflow sensor bias
-  equipment_types: &id229 []
+  equipment_types: &id229
+  - vav
   required_roles: &id230
-  - zone_flow
-  - damper_pct
+  - zone-airflow
+  - damper
   optional_roles: &id231
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id232 []
+  operational_proof_roles: &id232
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id233
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-  pandas_implementation: vav_5
+  pandas_implementation: vav5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
   test_coverage: &id234 []
@@ -1496,17 +2573,24 @@ matrix:
   difference_class: none
 - rule_id: VAV-6
   title: Reheat when cooling available
-  equipment_types: &id235 []
+  equipment_types: &id235
+  - vav
   required_roles: &id236
-  - oa_t
-  - reheat_valve_pct
+  - outside-air-temp
+  - reheat-valve
   optional_roles: &id237
-  - clg_available
-  operational_proof_roles: &id238 []
+  - cooling-available
+  operational_proof_roles: &id238
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id239
     free_cool_oat:
       default: 65.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 75.0
       step: 1.0
@@ -1518,13 +2602,16 @@ matrix:
       max: 1.0
       step: 0.05
       label: Reheat frac
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
   pandas_implementation: vav6
   datafusion_sql_implementation: vav6_reheat_free_cool.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-6
@@ -1534,24 +2621,23 @@ matrix:
   difference_class: none
 - rule_id: VAV-REHEAT
   title: Reheat valve stuck / no temp rise
-  equipment_types: &id241 []
+  equipment_types: &id241
+  - vav
   required_roles: &id242
-  - reheat_valve_pct
-  - vav_discharge_t
-  - vav_inlet_t
-  - zone_flow
+  - reheat-valve
+  - vav-discharge-air-temp
+  - vav-inlet-air-temp
   optional_roles: &id243
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id244 []
+  operational_proof_roles: &id244
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id245
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     reheat_cmd:
       default: 0.3
       unit: frac
@@ -1561,7 +2647,7 @@ matrix:
       label: Reheat open frac
     min_rise:
       default: 3.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 15.0
       step: 0.5
@@ -1573,7 +2659,17 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-  pandas_implementation: vav_reheat
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav_reheat_stuck
   datafusion_sql_implementation: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
   test_coverage: &id246 []
@@ -1582,26 +2678,25 @@ matrix:
   difference_class: none
 - rule_id: VAV-AHU-LEAVE
   title: VAV leave vs parent AHU SAT (fedBy)
-  equipment_types: &id247 []
+  equipment_types: &id247
+  - vav
   required_roles: &id248
-  - vav_discharge_t
-  - ahu_sat
-  - zone_flow
+  - vav-discharge-air-temp
+  - ahu-discharge-air-temp
   optional_roles: &id249
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id250 []
+  operational_proof_roles: &id250
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id251
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     delta_f:
       default: 8.0
-      unit: degF
+      unit: °F
       min: 2.0
       max: 25.0
       step: 0.5
@@ -1613,7 +2708,17 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-  pandas_implementation: vav_ahu_leave
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav_vs_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
   test_coverage: &id252 []
@@ -1622,29 +2727,22 @@ matrix:
   difference_class: none
 - rule_id: VAV-7
   title: Min airflow / fixed high flow
-  equipment_types: &id253 []
+  equipment_types: &id253
+  - vav
   required_roles: &id254
-  - zone_flow
+  - zone-airflow
   optional_roles: &id255
   - min_flow_sp
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id256 []
+  operational_proof_roles: &id256
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id257
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-    high_min_flow_sp:
-      default: 250.0
-      unit: cfm
-      min: 50.0
-      max: 2000.0
-      step: 10.0
-      label: High min-flow SP
     flow_on_min:
       default: 25.0
       unit: cfm
@@ -1652,13 +2750,6 @@ matrix:
       max: 200.0
       step: 5.0
       label: Airflow-on min
-    fixed_flow_hours:
-      default: 1.0
-      unit: h
-      min: 0.25
-      max: 6.0
-      step: 0.25
-      label: Fixed-flow rolling window
     fixed_flow_max_std:
       default: 15.0
       unit: cfm
@@ -1673,7 +2764,24 @@ matrix:
       max: 2000.0
       step: 10.0
       label: Fixed-flow min mean
-  pandas_implementation: vav_7
+    high_min_flow_sp:
+      default: 250.0
+      unit: cfm
+      min: 50.0
+      max: 2000.0
+      step: 10.0
+      label: High min-flow SP
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vav7
   datafusion_sql_implementation: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
   test_coverage: &id258
@@ -1683,10 +2791,11 @@ matrix:
   difference_class: none
 - rule_id: CHW-1
   title: Low chilled-water ΔT
-  equipment_types: &id259 []
+  equipment_types: &id259
+  - chiller
   required_roles: &id260
-  - chw_supply_t
-  - chw_return_t
+  - chilled-water-supply-temp
+  - chilled-water-return-temp
   optional_roles: &id261
   - chw_pump_cmd
   - pump_status
@@ -1695,22 +2804,38 @@ matrix:
   - chiller_amps
   - chiller_power
   - chw_flow
-  operational_proof_roles: &id262 []
+  operational_proof_roles: &id262
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id263
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     min_dt:
       default: 4.0
-      unit: degF
+      unit: °F
       min: 1.0
       max: 12.0
       step: 0.5
-      label: Minimum delta-T
+      label: Min ΔT
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
   pandas_implementation: chw1
   datafusion_sql_implementation: chw1_low_dt.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-1
@@ -1725,21 +2850,28 @@ matrix:
   difference_class: none
 - rule_id: CHW-2
   title: DP below SP at max pump speed
-  equipment_types: &id265 []
+  equipment_types: &id265
+  - chiller
   required_roles: &id266
-  - chw_dp
-  - chw_dp_sp
-  - chw_pump_cmd
+  - chw-diff-pressure
+  - chw-diff-pressure-sp
+  - chw-pump-cmd
   optional_roles: &id267 []
-  operational_proof_roles: &id268 []
+  operational_proof_roles: &id268
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id269
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     dp_margin:
       default: 2.2
       unit: psi
@@ -1754,7 +2886,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-  pandas_implementation: chw_2
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw2
   datafusion_sql_implementation: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
   test_coverage: &id270 []
@@ -1763,29 +2905,46 @@ matrix:
   difference_class: none
 - rule_id: CHW-3
   title: Plant supply temp outside deadband
-  equipment_types: &id271 []
+  equipment_types: &id271
+  - chiller
   required_roles: &id272
-  - chw_supply_t
-  - chw_supply_sp
-  - chw_pump_cmd
+  - chilled-water-supply-temp
+  - chilled-water-supply-temp-sp
+  - chw-pump-cmd
   optional_roles: &id273 []
-  operational_proof_roles: &id274 []
+  operational_proof_roles: &id274
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id275
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     sp_band:
       default: 2.2
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.1
       label: SP band
-  pandas_implementation: chw_3
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw3
   datafusion_sql_implementation: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
   test_coverage: &id276 []
@@ -1794,26 +2953,33 @@ matrix:
   difference_class: none
 - rule_id: CHW-4
   title: Flow high at max pump
-  equipment_types: &id277 []
+  equipment_types: &id277
+  - chiller
   required_roles: &id278
-  - chw_flow
-  - chw_pump_cmd
+  - chw-flow
+  - chw-pump-cmd
   optional_roles: &id279 []
-  operational_proof_roles: &id280 []
+  operational_proof_roles: &id280
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id281
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     flow_hi:
-      default: 1100.0
+      default: 1100
       unit: gpm
-      min: 200.0
-      max: 3000.0
-      step: 50.0
+      min: 200
+      max: 3000
+      step: 50
       label: Flow high
     pump_hi:
       default: 0.87
@@ -1822,7 +2988,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Pump high-speed threshold
-  pandas_implementation: chw_4
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: chw4
   datafusion_sql_implementation: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
   test_coverage: &id282 []
@@ -1831,38 +3007,46 @@ matrix:
   difference_class: none
 - rule_id: HP-1
   title: Discharge cold when heating
-  equipment_types: &id283 []
+  equipment_types: &id283
+  - heatpump
   required_roles: &id284
-  - sat
-  - zone_t
-  - fan_cmd
+  - discharge-air-temp
+  - zone-air-temp
+  - fan-cmd
   optional_roles: &id285
   - compressor_status
   - fan_status
-  operational_proof_roles: &id286 []
+  operational_proof_roles: &id286
+  - compressor-status
+  - equipment-enable
+  - fan-status
+  - fan-cmd
   default_thresholds: &id287
-    confirm_seconds:
-      default: 600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     min_sat:
       default: 85.0
-      unit: degF
+      unit: °F
       min: 70.0
       max: 110.0
       step: 1.0
-      label: Min discharge SAT
+      label: Min heating SAT
     zone_cold:
       default: 69.0
-      unit: degF
+      unit: °F
       min: 60.0
       max: 72.0
       step: 0.5
-      label: Zone cold threshold
-  pandas_implementation: hp_1
+      label: Zone cold
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 600.0
+      unit: sec
+  pandas_implementation: hp1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
   test_coverage: &id288 []
@@ -1871,27 +3055,31 @@ matrix:
   difference_class: none
 - rule_id: WX-1
   title: OA temperature spike
-  equipment_types: &id289 []
+  equipment_types: &id289
+  - weather
   required_roles: &id290
-  - oa_t
+  - outside-air-temp
   optional_roles: &id291 []
   operational_proof_roles: &id292 []
   default_thresholds: &id293
-    confirm_seconds:
-      default: 300.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     spike_limit:
       default: 16.0
-      unit: degF
+      unit: °F
       min: 4.0
       max: 40.0
       step: 1.0
       label: Spike limit
-  pandas_implementation: wx_1
+    confirm_min:
+      default: 5.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 300.0
+      unit: sec
+  pandas_implementation: wx1
   datafusion_sql_implementation: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
   test_coverage: &id294 []
@@ -1900,39 +3088,56 @@ matrix:
   difference_class: none
 - rule_id: CW-OPT-1
   title: Condenser water not optimized vs wet-bulb
-  equipment_types: &id295 []
+  equipment_types: &id295
+  - chiller
+  - cooling_tower
   required_roles: &id296
-  - cw_supply_t
-  - web_wb_t
+  - condenser-water-supply-temp
   optional_roles: &id297
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id298 []
+  operational_proof_roles: &id298
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id299
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: degF
+      unit: °F
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     cw_slack:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.5
       label: Slack below target
-  pandas_implementation: cw_opt_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_opt
   datafusion_sql_implementation: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
   test_coverage: &id300 []
@@ -1941,28 +3146,34 @@ matrix:
   difference_class: none
 - rule_id: CW-APR-1
   title: High CW approach at full tower fan
-  equipment_types: &id301 []
+  equipment_types: &id301
+  - chiller
+  - cooling_tower
   required_roles: &id302
-  - cw_supply_t
-  - web_wb_t
-  - tower_fan_cmd
+  - condenser-water-supply-temp
   optional_roles: &id303
-  - pump_status
-  - chiller_status
-  - chw_flow
-  - chw_pump_cmd
-  operational_proof_roles: &id304 []
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - web-outside-air-wetbulb
+  operational_proof_roles: &id304
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id305
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     approach_max_f:
       default: 8.0
-      unit: degF
+      unit: °F
       min: 5.0
       max: 15.0
       step: 0.5
@@ -1974,7 +3185,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-  pandas_implementation: cw_apr_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_apr
   datafusion_sql_implementation: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
   test_coverage: &id306 []
@@ -1983,35 +3204,41 @@ matrix:
   difference_class: none
 - rule_id: CW-FAN-1
   title: Excess tower fan energy vs wet-bulb limit
-  equipment_types: &id307 []
+  equipment_types: &id307
+  - chiller
+  - cooling_tower
   required_roles: &id308
-  - cw_supply_t
-  - web_wb_t
-  - tower_fan_cmd
+  - condenser-water-supply-temp
   optional_roles: &id309
-  - pump_status
-  - chiller_status
-  - chw_flow
-  - chw_pump_cmd
-  operational_proof_roles: &id310 []
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - web-outside-air-wetbulb
+  operational_proof_roles: &id310
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id311
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     cw_approach:
       default: 7.0
-      unit: degF
+      unit: °F
       min: 3.0
       max: 15.0
       step: 0.5
       label: Design approach
     excess_beyond_approach_f:
       default: 5.0
-      unit: degF
+      unit: °F
       min: 2.0
       max: 20.0
       step: 0.5
@@ -2023,7 +3250,17 @@ matrix:
       max: 1.0
       step: 0.01
       label: Tower fan full-speed threshold
-  pandas_implementation: cw_fan_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: cw_fan_excess
   datafusion_sql_implementation: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
   test_coverage: &id312 []
@@ -2032,26 +3269,27 @@ matrix:
   difference_class: none
 - rule_id: TRIM-1
   title: Duct static trim advisory
-  equipment_types: &id313 []
+  equipment_types: &id313
+  - ahu
   required_roles: &id314
-  - duct_static
+  - duct-static-pressure
+  - vav-pressure-request-sum
   optional_roles: &id315
   - duct_static_sp
   - static_reset_request
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id316 []
+  operational_proof_roles: &id316
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id317
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     duct_hi:
       default: 1.35
-      unit: in_wc
+      unit: in. w.c.
       min: 0.5
       max: 3.0
       step: 0.05
@@ -2063,7 +3301,17 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-  pandas_implementation: trim_1
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim1
   datafusion_sql_implementation: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
   test_coverage: &id318 []
@@ -2072,26 +3320,34 @@ matrix:
   difference_class: none
 - rule_id: TRIM-3
   title: HWST trim advisory
-  equipment_types: &id319 []
+  equipment_types: &id319
+  - boiler
   required_roles: &id320
-  - hw_supply_t
+  - hot-water-supply-temp
+  - hw-reset-request-sum
   optional_roles: &id321
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id322 []
+  operational_proof_roles: &id322
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id323
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     hwst_hi:
       default: 160.0
-      unit: degF
+      unit: °F
       min: 120.0
       max: 200.0
       step: 1.0
@@ -2103,7 +3359,17 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-  pandas_implementation: trim_3
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim3
   datafusion_sql_implementation: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
   test_coverage: &id324 []
@@ -2112,26 +3378,34 @@ matrix:
   difference_class: none
 - rule_id: TRIM-4
   title: CHW plant reset advisory
-  equipment_types: &id325 []
+  equipment_types: &id325
+  - chiller
   required_roles: &id326
-  - chw_supply_t
+  - chilled-water-supply-temp
+  - chw-reset-request-sum
   optional_roles: &id327
   - pump_status
   - chiller_status
   - chw_flow
   - chw_pump_cmd
-  operational_proof_roles: &id328 []
+  operational_proof_roles: &id328
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - pump-speed-feedback
+  - pump-current
+  - chw-flow
+  - water-flow
+  - chiller-status
+  - chiller-current
+  - chiller-power
+  - pump-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
   default_thresholds: &id329
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     chw_lo:
       default: 45.0
-      unit: degF
+      unit: °F
       min: 35.0
       max: 55.0
       step: 0.5
@@ -2143,7 +3417,17 @@ matrix:
       max: 10.0
       step: 0.5
       label: Request sum low
-  pandas_implementation: trim_4
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
+  pandas_implementation: trim4
   datafusion_sql_implementation: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
   test_coverage: &id330 []
@@ -2151,38 +3435,40 @@ matrix:
   known_semantic_differences: ''
   difference_class: none
 - rule_id: SCHED-1
-  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
-    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
-    unoccupied + fan_on (pandas sched1 base).
-  equipment_types: &id331 []
+  title: Unoccupied runtime
+  equipment_types: &id331
+  - ahu
   required_roles: &id332
-  - occ_mode
-  - fan_status
+  - occupied
+  - fan-status
   optional_roles: &id333
-  - zone_t
+  - zone-air-temp
   operational_proof_roles: &id334 []
   default_thresholds: &id335
-    confirm_seconds:
-      default: 1800.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     comfort_low_f:
       default: 70.0
       unit: °F
-      min: 50.0
-      max: 80.0
+      min: 60.0
+      max: 78.0
       step: 0.5
-      label: Zone comfort low
+      label: Comfort low
     comfort_high_f:
       default: 75.0
       unit: °F
-      min: 55.0
-      max: 90.0
+      min: 68.0
+      max: 85.0
       step: 0.5
-      label: Zone comfort high
+      label: Comfort high
+    confirm_min:
+      default: 30.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 1800.0
+      unit: sec
   pandas_implementation: sched1
   datafusion_sql_implementation: sched1_unoccupied_runtime.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-1
@@ -2195,22 +3481,29 @@ matrix:
   difference_class: alias
 - rule_id: SCHED-247
   title: Always-on fan or pump runtime
-  equipment_types: &id337 []
+  equipment_types: &id337
+  - ahu
+  - vav
+  - chiller
+  - boiler
+  - heatpump
   required_roles: &id338 []
   optional_roles: &id339
-  - fan_status
-  - pump_status
-  - chiller_status
-  - fan_cmd
+  - fan-status
+  - pump-status
+  - chw-pump-status
+  - hw-pump-status
+  - chiller-status
+  - compressor-status
+  - tower-fan-cmd
+  - cw-fan-cmd
+  - fan-cmd
+  - chw-pump-cmd
+  - hw-pump-cmd
+  - duct-static-pressure
+  - chw-diff-pressure
   operational_proof_roles: &id340 []
   default_thresholds: &id341
-    confirm_seconds:
-      default: 3600.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     always_on_pct:
       default: 0.95
       unit: frac
@@ -2218,6 +3511,23 @@ matrix:
       max: 1.0
       step: 0.01
       label: Always-on fraction
+    pressure_on_min:
+      default: 0.2
+      unit: eng
+      min: 0.05
+      max: 2.0
+      step: 0.05
+      label: Pressure-on evidence
+    confirm_min:
+      default: 60.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 3600.0
+      unit: sec
   pandas_implementation: _sched247
   datafusion_sql_implementation: sched247_always_on.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sched-247
@@ -2232,50 +3542,60 @@ matrix:
   difference_class: none
 - rule_id: RESET-1
   title: SAT reset not tracking outdoor air
-  equipment_types: &id343 []
+  equipment_types: &id343
+  - ahu
   required_roles: &id344
-  - sat_sp
-  - oa_t
+  - discharge-air-temp-sp
+  - outside-air-temp
   optional_roles: &id345
-  - fan_status
-  - fan_cmd
-  operational_proof_roles: &id346 []
+  - fan-status
+  - fan-cmd
+  operational_proof_roles: &id346
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id347
     reset_err_f:
       default: 3.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 10.0
       step: 0.5
       label: Reset error
     reset_sat_at_65:
       default: 52.0
-      unit: degF
+      unit: °F
       min: 45.0
       max: 65.0
       step: 0.5
-      label: SAT SP at 65F OAT
+      label: SAT SP at 65°F OAT
     reset_slope:
       default: 0.25
-      unit: frac
+      unit: °F/°F
       min: 0.05
       max: 1.0
       step: 0.05
       label: Reset slope
     reset_oat_ref:
       default: 65.0
-      unit: degF
+      unit: °F
       min: 50.0
       max: 80.0
       step: 1.0
       label: Reset OAT ref
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 900.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
   pandas_implementation: reset1
   datafusion_sql_implementation: reset1_sat_oa_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#reset-1
@@ -2285,21 +3605,25 @@ matrix:
   difference_class: none
 - rule_id: CMD-1
   title: Fan cmd/status mismatch
-  equipment_types: &id349 []
+  equipment_types: &id349
+  - ahu
   required_roles: &id350
-  - fan_cmd
-  - fan_status
+  - fan-cmd
+  - fan-status
   optional_roles: &id351 []
   operational_proof_roles: &id352 []
   default_thresholds: &id353
+    confirm_min:
+      default: 10.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
     confirm_seconds:
       default: 600.0
       unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
-  pandas_implementation: cmd_1
+  pandas_implementation: cmd1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
   test_coverage: &id354 []
@@ -2308,24 +3632,24 @@ matrix:
   difference_class: none
 - rule_id: OA-1
   title: Low OA fraction
-  equipment_types: &id355 []
+  equipment_types: &id355
+  - ahu
   required_roles: &id356
-  - mat
-  - rat
-  - oa_t
-  - fan_cmd
+  - mixed-air-temp
+  - return-air-temp
+  - outside-air-temp
+  - fan-status
   optional_roles: &id357
   - fan_status
   - fan_cmd
-  operational_proof_roles: &id358 []
+  operational_proof_roles: &id358
+  - fan-status
+  - fan-speed-feedback
+  - fan-current
+  - fan-power
+  - airflow-proof
+  - fan-cmd
   default_thresholds: &id359
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     min_oa_frac:
       default: 0.15
       unit: frac
@@ -2335,12 +3659,22 @@ matrix:
       label: Min OA fraction
     oat_rat_guard:
       default: 2.2
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.1
-      label: OAT/RAT guard
-  pandas_implementation: oa_1
+      label: Min |RAT−OAT| guard
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: oa1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
   test_coverage: &id360 []
@@ -2349,31 +3683,35 @@ matrix:
   difference_class: none
 - rule_id: DMP-1
   title: OA damper leakage
-  equipment_types: &id361 []
+  equipment_types: &id361
+  - ahu
   required_roles: &id362
-  - oa_damper_pct
-  - oa_t
-  - mat
+  - outside-air-temp
+  - mixed-air-temp
+  - outside-air-damper
   optional_roles: &id363
   - fan_status
   - fan_cmd
   operational_proof_roles: &id364 []
   default_thresholds: &id365
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     leak_delta:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 6.0
       step: 0.5
       label: Leak ΔT
-  pandas_implementation: dmp_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: dmp1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
   test_coverage: &id366 []
@@ -2382,39 +3720,43 @@ matrix:
   difference_class: none
 - rule_id: VLV-1
   title: Cooling valve leakage
-  equipment_types: &id367 []
+  equipment_types: &id367
+  - ahu
   required_roles: &id368
-  - clg_valve_pct
-  - sat
-  - sat_sp
-  - mat
+  - discharge-air-temp
+  - discharge-air-temp-sp
+  - cooling-valve
   optional_roles: &id369
-  - fan_status
-  - fan_cmd
+  - mixed-air-temp
+  - fan-status
+  - fan-cmd
   operational_proof_roles: &id370 []
   default_thresholds: &id371
-    confirm_seconds:
-      default: 900.0
-      unit: sec
-      min: 0.0
-      max: 3600.0
-      step: 300.0
-      label: Confirm time
     sat_err:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 8.0
       step: 0.5
       label: SAT vs SP leak ΔT
     mat_leak_delta:
       default: 2.0
-      unit: degF
+      unit: °F
       min: 0.5
       max: 12.0
       step: 0.5
       label: SAT vs MAT leak ΔT
-  pandas_implementation: vlv_1
+    confirm_min:
+      default: 15.0
+      unit: min
+      min: 0.0
+      max: 60.0
+      step: 1.0
+      label: Fault confirm delay
+    confirm_seconds:
+      default: 900.0
+      unit: sec
+  pandas_implementation: vlv1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
   test_coverage: &id372 []
@@ -2532,12 +3874,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id001
-  equipment_kinds: null
+  equipment_kinds: *id001
   required_roles: *id002
   optional_roles: *id003
   operational_proof_roles: *id004
   default_thresholds: *id005
-  pandas_implementation: sv_range
+  pandas_implementation: _sweep_range
   datafusion_sql_implementation: sv_range.sql
   sql_file: sv_range.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-range
@@ -2547,8 +3889,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: equipment_energized
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2631,12 +3973,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id007
-  equipment_kinds: null
+  equipment_kinds: *id007
   required_roles: *id008
   optional_roles: *id009
   operational_proof_roles: *id010
   default_thresholds: *id011
-  pandas_implementation: sv_flatline
+  pandas_implementation: _sweep_flatline
   datafusion_sql_implementation: sv_flatline.sql
   sql_file: sv_flatline.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-flatline
@@ -2646,8 +3988,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2739,12 +4081,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id013
-  equipment_kinds: null
+  equipment_kinds: *id013
   required_roles: *id014
   optional_roles: *id015
   operational_proof_roles: *id016
   default_thresholds: *id017
-  pandas_implementation: sv_spike
+  pandas_implementation: _sweep_spike
   datafusion_sql_implementation: sv_spike.sql
   sql_file: sv_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-spike
@@ -2754,8 +4096,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: equipment_energized
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2838,12 +4180,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id019
-  equipment_kinds: null
+  equipment_kinds: *id019
   required_roles: *id020
   optional_roles: *id021
   operational_proof_roles: *id022
   default_thresholds: *id023
-  pandas_implementation: sv_stale
+  pandas_implementation: _sweep_stale
   datafusion_sql_implementation: sv_stale.sql
   sql_file: sv_stale.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-stale
@@ -2853,8 +4195,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -2947,12 +4289,12 @@ concepts:
   - SV-SLEW
   kind: diagnostic
   equipment_types: *id025
-  equipment_kinds: null
+  equipment_kinds: *id025
   required_roles: *id026
   optional_roles: *id027
   operational_proof_roles: *id028
   default_thresholds: *id029
-  pandas_implementation: sv_rate
+  pandas_implementation: _sv_rate_compute
   datafusion_sql_implementation: sv_rate.sql
   sql_file: sv_rate.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#sv-rate
@@ -2964,8 +4306,8 @@ concepts:
   known_semantic_differences: Pandas ROLE_TO_PROFILE has 30+ quantity/location slew
     limits; SQL windows five air temps against one STEADY_FAULT_PER_HOUR. Leave sql_screening;
     do not mark proven from B100 hours. Alias SV-SLEW is not an extra rule.
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -3057,12 +4399,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id031
-  equipment_kinds: null
+  equipment_kinds: *id031
   required_roles: *id032
   optional_roles: *id033
   operational_proof_roles: *id034
   default_thresholds: *id035
-  pandas_implementation: pid_hunt_1
+  pandas_implementation: _pid_hunt_1
   datafusion_sql_implementation: pid_hunt_1.sql
   sql_file: pid_hunt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#pid-hunt-1
@@ -3072,8 +4414,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 0
   parameters:
     confirm_seconds:
@@ -3206,11 +4548,11 @@ concepts:
 - canonical_id: FC1
   pandas_id: FC1
   rule_id: FC1
-  title: Duct static below SP at full fan
+  title: Duct static below SP at full fan (GL36 A)
   aliases: []
   kind: diagnostic
   equipment_types: *id037
-  equipment_kinds: null
+  equipment_kinds: *id037
   required_roles: *id038
   optional_roles: *id039
   operational_proof_roles: *id040
@@ -3225,8 +4567,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     eps_dsp:
@@ -3314,11 +4656,11 @@ concepts:
 - canonical_id: FC2
   pandas_id: FC2
   rule_id: FC2
-  title: Mixed air below envelope
+  title: MAT below OAT/RAT envelope (GL36 B)
   aliases: []
   kind: diagnostic
   equipment_types: *id043
-  equipment_kinds: null
+  equipment_kinds: *id043
   required_roles: *id044
   optional_roles: *id045
   operational_proof_roles: *id046
@@ -3333,8 +4675,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3395,11 +4737,11 @@ concepts:
 - canonical_id: FC3
   pandas_id: FC3
   rule_id: FC3
-  title: Mixed air above envelope
+  title: MAT above OAT/RAT envelope (GL36 C)
   aliases: []
   kind: diagnostic
   equipment_types: *id049
-  equipment_kinds: null
+  equipment_kinds: *id049
   required_roles: *id050
   optional_roles: *id051
   operational_proof_roles: *id052
@@ -3414,8 +4756,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3480,7 +4822,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id055
-  equipment_kinds: null
+  equipment_kinds: *id055
   required_roles: *id056
   optional_roles: *id057
   operational_proof_roles: *id058
@@ -3495,8 +4837,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -3579,7 +4921,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id061
-  equipment_kinds: null
+  equipment_kinds: *id061
   required_roles: *id062
   optional_roles: *id063
   operational_proof_roles: *id064
@@ -3594,8 +4936,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -3687,7 +5029,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id067
-  equipment_kinds: null
+  equipment_kinds: *id067
   required_roles: *id068
   optional_roles: *id069
   operational_proof_roles: *id070
@@ -3702,8 +5044,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -3800,11 +5142,11 @@ concepts:
 - canonical_id: FC7
   pandas_id: FC7
   rule_id: FC7
-  title: SAT low while heating at full
+  title: SAT low with full heating (GL36 E)
   aliases: []
   kind: diagnostic
   equipment_types: *id073
-  equipment_kinds: null
+  equipment_kinds: *id073
   required_roles: *id074
   optional_roles: *id075
   operational_proof_roles: *id076
@@ -3820,8 +5162,8 @@ concepts:
   difference_class: missing_implementation
   known_semantic_differences: concept_only — SQL file is a placeholder; do not claim
     twin parity
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -3909,11 +5251,11 @@ concepts:
 - canonical_id: FC8
   pandas_id: FC8
   rule_id: FC8
-  title: SAT vs MAT while economizing
+  title: SAT/MAT mismatch in economizer (GL36 F)
   aliases: []
   kind: diagnostic
   equipment_types: *id079
-  equipment_kinds: null
+  equipment_kinds: *id079
   required_roles: *id080
   optional_roles: *id081
   operational_proof_roles: *id082
@@ -3928,8 +5270,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -3990,11 +5332,11 @@ concepts:
 - canonical_id: FC9
   pandas_id: FC9
   rule_id: FC9
-  title: OAT high vs SAT SP while economizing
+  title: OAT too warm for free cooling (GL36 G)
   aliases: []
   kind: diagnostic
   equipment_types: *id085
-  equipment_kinds: null
+  equipment_kinds: *id085
   required_roles: *id086
   optional_roles: *id087
   operational_proof_roles: *id088
@@ -4009,8 +5351,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4071,11 +5413,11 @@ concepts:
 - canonical_id: FC10
   pandas_id: FC10
   rule_id: FC10
-  title: MAT-OAT delta while cooling and economizing
+  title: OAT/MAT mismatch + mech cooling (GL36 H)
   aliases: []
   kind: diagnostic
   equipment_types: *id091
-  equipment_kinds: null
+  equipment_kinds: *id091
   required_roles: *id092
   optional_roles: *id093
   operational_proof_roles: *id094
@@ -4090,8 +5432,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4152,11 +5494,11 @@ concepts:
 - canonical_id: FC11
   pandas_id: FC11
   rule_id: FC11
-  title: OAT low vs SAT SP while cooling and economizing
+  title: OAT/MAT mismatch economizer-only (GL36 I)
   aliases: []
   kind: diagnostic
   equipment_types: *id097
-  equipment_kinds: null
+  equipment_kinds: *id097
   required_roles: *id098
   optional_roles: *id099
   operational_proof_roles: *id100
@@ -4171,8 +5513,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4233,11 +5575,11 @@ concepts:
 - canonical_id: FC12
   pandas_id: FC12
   rule_id: FC12
-  title: SAT above MAT while cooling
+  title: SAT above blend in cooling (GL36 J)
   aliases: []
   kind: diagnostic
   equipment_types: *id103
-  equipment_kinds: null
+  equipment_kinds: *id103
   required_roles: *id104
   optional_roles: *id105
   operational_proof_roles: *id106
@@ -4252,8 +5594,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters: {}
   time_semantics: row_or_interval_per_sql_file
@@ -4314,12 +5656,12 @@ concepts:
 - canonical_id: FC13-SAT-HIGH
   pandas_id: FC13
   rule_id: FC13
-  title: SAT above setpoint at full cooling
+  title: SAT above SP at full cooling (GL36 K)
   aliases:
   - FC13
   kind: diagnostic
   equipment_types: *id109
-  equipment_kinds: null
+  equipment_kinds: *id109
   required_roles: *id110
   optional_roles: *id111
   operational_proof_roles: *id112
@@ -4334,8 +5676,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: FC13 (not independent rules)'
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     sat_err:
@@ -4445,7 +5787,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id115
-  equipment_kinds: null
+  equipment_kinds: *id115
   required_roles: *id116
   optional_roles: *id117
   operational_proof_roles: *id118
@@ -4460,8 +5802,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4544,7 +5886,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id121
-  equipment_kinds: null
+  equipment_kinds: *id121
   required_roles: *id122
   optional_roles: *id123
   operational_proof_roles: *id124
@@ -4559,8 +5901,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4643,12 +5985,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id127
-  equipment_kinds: null
+  equipment_kinds: *id127
   required_roles: *id128
   optional_roles: *id129
   operational_proof_roles: *id130
   default_thresholds: *id131
-  pandas_implementation: ahu_satdev
+  pandas_implementation: ahu_sat_dev
   datafusion_sql_implementation: ahu_satdev.sql
   sql_file: ahu_satdev.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-satdev
@@ -4658,8 +6000,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -4742,12 +6084,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id133
-  equipment_kinds: null
+  equipment_kinds: *id133
   required_roles: *id134
   optional_roles: *id135
   operational_proof_roles: *id136
   default_thresholds: *id137
-  pandas_implementation: ahu_ducthi
+  pandas_implementation: ahu_duct_high
   datafusion_sql_implementation: ahu_ducthi.sql
   sql_file: ahu_ducthi.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-ducthi
@@ -4757,8 +6099,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4850,12 +6192,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id139
-  equipment_kinds: null
+  equipment_kinds: *id139
   required_roles: *id140
   optional_roles: *id141
   operational_proof_roles: *id142
   default_thresholds: *id143
-  pandas_implementation: ahu_simul
+  pandas_implementation: ahu_simul_heat_cool
   datafusion_sql_implementation: ahu_simul.sql
   sql_file: ahu_simul.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#ahu-simul
@@ -4865,8 +6207,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -4945,11 +6287,11 @@ concepts:
 - canonical_id: OAT-METEO
   pandas_id: OAT-METEO
   rule_id: OAT-METEO
-  title: Equipment OAT vs weather-staged wx OAT
+  title: BAS outdoor-air sensor vs Open-Meteo
   aliases: []
   kind: diagnostic
   equipment_types: *id145
-  equipment_kinds: null
+  equipment_kinds: *id145
   required_roles: *id146
   optional_roles: *id147
   operational_proof_roles: *id148
@@ -4964,8 +6306,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 900
   parameters:
     oat_err:
@@ -5045,11 +6387,11 @@ concepts:
 - canonical_id: ECON-1
   pandas_id: ECON-1
   rule_id: ECON-1
-  title: Economizer stuck closed when OAT favorable
+  title: Economizer stuck closed
   aliases: []
   kind: diagnostic
   equipment_types: *id151
-  equipment_kinds: null
+  equipment_kinds: *id151
   required_roles: *id152
   optional_roles: *id153
   operational_proof_roles: *id154
@@ -5064,8 +6406,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     econ1_oat_min:
@@ -5144,11 +6486,11 @@ concepts:
 - canonical_id: ECON-2
   pandas_id: ECON-2
   rule_id: ECON-2
-  title: Economizing when outdoor air unfavorable
+  title: Economizing when outdoor unfavorable
   aliases: []
   kind: diagnostic
   equipment_types: *id157
-  equipment_kinds: null
+  equipment_kinds: *id157
   required_roles: *id158
   optional_roles: *id159
   operational_proof_roles: *id160
@@ -5163,8 +6505,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     econ2_oat_hi:
@@ -5256,12 +6598,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id163
-  equipment_kinds: null
+  equipment_kinds: *id163
   required_roles: *id164
   optional_roles: *id165
   operational_proof_roles: *id166
   default_thresholds: *id167
-  pandas_implementation: econ_3
+  pandas_implementation: econ2
   datafusion_sql_implementation: econ3_mech_without_econ.sql
   sql_file: econ3_mech_without_econ.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-3
@@ -5271,8 +6613,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -5382,7 +6724,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id169
-  equipment_kinds: null
+  equipment_kinds: *id169
   required_roles: *id170
   optional_roles: *id171
   operational_proof_roles: *id172
@@ -5397,8 +6739,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     oa_min_pct:
@@ -5481,12 +6823,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id175
-  equipment_kinds: null
+  equipment_kinds: *id175
   required_roles: *id176
   optional_roles: *id177
   operational_proof_roles: *id178
   default_thresholds: *id179
-  pandas_implementation: econ_5
+  pandas_implementation: econ5
   datafusion_sql_implementation: econ5_preheat_over.sql
   sql_file: econ5_preheat_over.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-5
@@ -5496,8 +6838,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5580,12 +6922,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id181
-  equipment_kinds: null
+  equipment_kinds: *id181
   required_roles: *id182
   optional_roles: *id183
   operational_proof_roles: *id184
   default_thresholds: *id185
-  pandas_implementation: econ_6
+  pandas_implementation: econ6_compute
   datafusion_sql_implementation: econ6_econ_freezing.sql
   sql_file: econ6_econ_freezing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-6
@@ -5595,8 +6937,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5688,12 +7030,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id187
-  equipment_kinds: null
+  equipment_kinds: *id187
   required_roles: *id188
   optional_roles: *id189
   operational_proof_roles: *id190
   default_thresholds: *id191
-  pandas_implementation: econ_7
+  pandas_implementation: econ7_compute
   datafusion_sql_implementation: econ7_ok_not_economizing.sql
   sql_file: econ7_ok_not_economizing.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#econ-7
@@ -5703,8 +7045,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5814,12 +7156,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id193
-  equipment_kinds: null
+  equipment_kinds: *id193
   required_roles: *id194
   optional_roles: *id195
   operational_proof_roles: *id196
   default_thresholds: *id197
-  pandas_implementation: mech_oat_1
+  pandas_implementation: mech_oat1_compute
   datafusion_sql_implementation: mech_oat_1.sql
   sql_file: mech_oat_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#mech-oat-1
@@ -5829,8 +7171,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -5913,12 +7255,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id199
-  equipment_kinds: null
+  equipment_kinds: *id199
   required_roles: *id200
   optional_roles: *id201
   operational_proof_roles: *id202
   default_thresholds: *id203
-  pandas_implementation: chw_noload_1
+  pandas_implementation: chw_noload1_compute
   datafusion_sql_implementation: chw_noload_1.sql
   sql_file: chw_noload_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-noload-1
@@ -5928,8 +7270,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -5999,11 +7341,11 @@ concepts:
 - canonical_id: VAV-1
   pandas_id: VAV-1
   rule_id: VAV-1
-  title: Zone comfort band violation hours with confirm window
+  title: Zone comfort band
   aliases: []
   kind: diagnostic
   equipment_types: *id205
-  equipment_kinds: null
+  equipment_kinds: *id205
   required_roles: *id206
   optional_roles: *id207
   operational_proof_roles: *id208
@@ -6018,8 +7360,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 0.0
   confirm_seconds: 900
   parameters:
     zone_t_lo:
@@ -6108,11 +7450,11 @@ concepts:
 - canonical_id: VAV-2
   pandas_id: VAV-2
   rule_id: VAV-2
-  title: Night setback miss — unoccupied zone above heating setback
+  title: Night setback miss
   aliases: []
   kind: diagnostic
   equipment_types: *id211
-  equipment_kinds: null
+  equipment_kinds: *id211
   required_roles: *id212
   optional_roles: *id213
   operational_proof_roles: *id214
@@ -6127,8 +7469,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 900
   parameters:
     setback_hi:
@@ -6211,12 +7553,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id217
-  equipment_kinds: null
+  equipment_kinds: *id217
   required_roles: *id218
   optional_roles: *id219
   operational_proof_roles: *id220
   default_thresholds: *id221
-  pandas_implementation: vav_3
+  pandas_implementation: vav3
   datafusion_sql_implementation: vav3_excessive_reheat.sql
   sql_file: vav3_excessive_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-3
@@ -6226,8 +7568,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -6328,12 +7670,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id223
-  equipment_kinds: null
+  equipment_kinds: *id223
   required_roles: *id224
   optional_roles: *id225
   operational_proof_roles: *id226
   default_thresholds: *id227
-  pandas_implementation: vav_4
+  pandas_implementation: vav4
   datafusion_sql_implementation: vav4_damper_full_open.sql
   sql_file: vav4_damper_full_open.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-4
@@ -6343,8 +7685,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: control_loop
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6445,12 +7787,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id229
-  equipment_kinds: null
+  equipment_kinds: *id229
   required_roles: *id230
   optional_roles: *id231
   operational_proof_roles: *id232
   default_thresholds: *id233
-  pandas_implementation: vav_5
+  pandas_implementation: vav5
   datafusion_sql_implementation: vav5_airflow_bias.sql
   sql_file: vav5_airflow_bias.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-5
@@ -6460,8 +7802,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6535,7 +7877,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id235
-  equipment_kinds: null
+  equipment_kinds: *id235
   required_roles: *id236
   optional_roles: *id237
   operational_proof_roles: *id238
@@ -6550,8 +7892,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     free_cool_oat:
@@ -6643,12 +7985,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id241
-  equipment_kinds: null
+  equipment_kinds: *id241
   required_roles: *id242
   optional_roles: *id243
   operational_proof_roles: *id244
   default_thresholds: *id245
-  pandas_implementation: vav_reheat
+  pandas_implementation: vav_reheat_stuck
   datafusion_sql_implementation: vav_reheat.sql
   sql_file: vav_reheat.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-reheat
@@ -6658,8 +8000,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6760,12 +8102,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id247
-  equipment_kinds: null
+  equipment_kinds: *id247
   required_roles: *id248
   optional_roles: *id249
   operational_proof_roles: *id250
   default_thresholds: *id251
-  pandas_implementation: vav_ahu_leave
+  pandas_implementation: vav_vs_ahu_leave
   datafusion_sql_implementation: vav_ahu_leave.sql
   sql_file: vav_ahu_leave.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-ahu-leave
@@ -6775,8 +8117,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -6868,12 +8210,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id253
-  equipment_kinds: null
+  equipment_kinds: *id253
   required_roles: *id254
   optional_roles: *id255
   operational_proof_roles: *id256
   default_thresholds: *id257
-  pandas_implementation: vav_7
+  pandas_implementation: vav7
   datafusion_sql_implementation: vav7_min_airflow.sql
   sql_file: vav7_min_airflow.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vav-7
@@ -6883,8 +8225,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7003,7 +8345,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id259
-  equipment_kinds: null
+  equipment_kinds: *id259
   required_roles: *id260
   optional_roles: *id261
   operational_proof_roles: *id262
@@ -7019,8 +8361,8 @@ concepts:
   difference_class: none
   known_semantic_differences: Missing proof → pandas SKIPPED_MISSING_ROLES; SQL returns
     0 fault hours (optional proof roles). Proven-off zeros do not accumulate ΔT hours.
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 900
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7103,12 +8445,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id265
-  equipment_kinds: null
+  equipment_kinds: *id265
   required_roles: *id266
   optional_roles: *id267
   operational_proof_roles: *id268
   default_thresholds: *id269
-  pandas_implementation: chw_2
+  pandas_implementation: chw2
   datafusion_sql_implementation: chw2_dp_low.sql
   sql_file: chw2_dp_low.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-2
@@ -7118,8 +8460,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -7211,12 +8553,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id271
-  equipment_kinds: null
+  equipment_kinds: *id271
   required_roles: *id272
   optional_roles: *id273
   operational_proof_roles: *id274
   default_thresholds: *id275
-  pandas_implementation: chw_3
+  pandas_implementation: chw3
   datafusion_sql_implementation: chw3_supply_band.sql
   sql_file: chw3_supply_band.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-3
@@ -7226,8 +8568,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -7310,12 +8652,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id277
-  equipment_kinds: null
+  equipment_kinds: *id277
   required_roles: *id278
   optional_roles: *id279
   operational_proof_roles: *id280
   default_thresholds: *id281
-  pandas_implementation: chw_4
+  pandas_implementation: chw4
   datafusion_sql_implementation: chw4_flow_high.sql
   sql_file: chw4_flow_high.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#chw-4
@@ -7325,8 +8667,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 300
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -7418,12 +8760,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id283
-  equipment_kinds: null
+  equipment_kinds: *id283
   required_roles: *id284
   optional_roles: *id285
   operational_proof_roles: *id286
   default_thresholds: *id287
-  pandas_implementation: hp_1
+  pandas_implementation: hp1
   datafusion_sql_implementation: hp1_discharge_cold.sql
   sql_file: hp1_discharge_cold.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#hp-1
@@ -7433,8 +8775,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: compressor
+  startup_delay_seconds: 600
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -7526,12 +8868,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id289
-  equipment_kinds: null
+  equipment_kinds: *id289
   required_roles: *id290
   optional_roles: *id291
   operational_proof_roles: *id292
   default_thresholds: *id293
-  pandas_implementation: wx_1
+  pandas_implementation: wx1
   datafusion_sql_implementation: wx1_oa_spike.sql
   sql_file: wx1_oa_spike.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#wx-1
@@ -7541,8 +8883,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 300
   parameters:
     confirm_seconds:
@@ -7625,12 +8967,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id295
-  equipment_kinds: null
+  equipment_kinds: *id295
   required_roles: *id296
   optional_roles: *id297
   operational_proof_roles: *id298
   default_thresholds: *id299
-  pandas_implementation: cw_opt_1
+  pandas_implementation: cw_opt
   datafusion_sql_implementation: cw_opt_1.sql
   sql_file: cw_opt_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-opt-1
@@ -7640,8 +8982,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7733,12 +9075,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id301
-  equipment_kinds: null
+  equipment_kinds: *id301
   required_roles: *id302
   optional_roles: *id303
   operational_proof_roles: *id304
   default_thresholds: *id305
-  pandas_implementation: cw_apr_1
+  pandas_implementation: cw_apr
   datafusion_sql_implementation: cw_apr_1.sql
   sql_file: cw_apr_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-apr-1
@@ -7748,8 +9090,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7841,12 +9183,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id307
-  equipment_kinds: null
+  equipment_kinds: *id307
   required_roles: *id308
   optional_roles: *id309
   operational_proof_roles: *id310
   default_thresholds: *id311
-  pandas_implementation: cw_fan_1
+  pandas_implementation: cw_fan_excess
   datafusion_sql_implementation: cw_fan_1.sql
   sql_file: cw_fan_1.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cw-fan-1
@@ -7856,8 +9198,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -7958,12 +9300,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id313
-  equipment_kinds: null
+  equipment_kinds: *id313
   required_roles: *id314
   optional_roles: *id315
   operational_proof_roles: *id316
   default_thresholds: *id317
-  pandas_implementation: trim_1
+  pandas_implementation: trim1
   datafusion_sql_implementation: trim1_duct_static.sql
   sql_file: trim1_duct_static.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-1
@@ -7973,8 +9315,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -8066,12 +9408,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id319
-  equipment_kinds: null
+  equipment_kinds: *id319
   required_roles: *id320
   optional_roles: *id321
   operational_proof_roles: *id322
   default_thresholds: *id323
-  pandas_implementation: trim_3
+  pandas_implementation: trim3
   datafusion_sql_implementation: trim3_hwst.sql
   sql_file: trim3_hwst.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-3
@@ -8081,8 +9423,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -8174,12 +9516,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id325
-  equipment_kinds: null
+  equipment_kinds: *id325
   required_roles: *id326
   optional_roles: *id327
   operational_proof_roles: *id328
   default_thresholds: *id329
-  pandas_implementation: trim_4
+  pandas_implementation: trim4
   datafusion_sql_implementation: trim4_chw_reset.sql
   sql_file: trim4_chw_reset.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#trim-4
@@ -8189,8 +9531,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: hydronic_flow
+  startup_delay_seconds: 600
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -8278,14 +9620,12 @@ concepts:
 - canonical_id: SCHED-1
   pandas_id: SCHED-1
   rule_id: SCHED-1
-  title: Excess / wasted unoccupied fan runtime when the zone is already in the comfort
-    band (optimal-start / schedule misconfig signal). Without zone_t, falls back to
-    unoccupied + fan_on (pandas sched1 base).
+  title: Unoccupied runtime
   aliases:
   - excess_runtime
   kind: diagnostic
   equipment_types: *id331
-  equipment_kinds: null
+  equipment_kinds: *id331
   required_roles: *id332
   optional_roles: *id333
   operational_proof_roles: *id334
@@ -8300,8 +9640,8 @@ concepts:
   parity_level: sql_screening
   difference_class: alias
   known_semantic_differences: 'aliases: excess_runtime (not independent rules)'
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 1800
   parameters:
     confirm_seconds:
@@ -8393,7 +9733,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id337
-  equipment_kinds: null
+  equipment_kinds: *id337
   required_roles: *id338
   optional_roles: *id339
   operational_proof_roles: *id340
@@ -8410,8 +9750,8 @@ concepts:
   known_semantic_differences: 4.3 ranked proof (status/current > command; pressure
     inferred only). SQL mean(on) >= always_on_pct over the analysis window matches
     pandas _sched247. Keep sql_screening; do not mark proven from B100 hours.
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 3600
   parameters:
     confirm_seconds:
@@ -8494,7 +9834,7 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id343
-  equipment_kinds: null
+  equipment_kinds: *id343
   required_roles: *id344
   optional_roles: *id345
   operational_proof_roles: *id346
@@ -8509,8 +9849,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     reset_err_f:
@@ -8620,12 +9960,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id349
-  equipment_kinds: null
+  equipment_kinds: *id349
   required_roles: *id350
   optional_roles: *id351
   operational_proof_roles: *id352
   default_thresholds: *id353
-  pandas_implementation: cmd_1
+  pandas_implementation: cmd1
   datafusion_sql_implementation: cmd1_fan_mismatch.sql
   sql_file: cmd1_fan_mismatch.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#cmd-1
@@ -8635,8 +9975,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: always
+  startup_delay_seconds: 0.0
   confirm_seconds: 600
   parameters:
     confirm_seconds:
@@ -8710,12 +10050,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id355
-  equipment_kinds: null
+  equipment_kinds: *id355
   required_roles: *id356
   optional_roles: *id357
   operational_proof_roles: *id358
   default_thresholds: *id359
-  pandas_implementation: oa_1
+  pandas_implementation: oa1
   datafusion_sql_implementation: oa1_low_oa_frac.sql
   sql_file: oa1_low_oa_frac.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#oa-1
@@ -8725,8 +10065,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: fan_running
+  startup_delay_seconds: 600
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8818,12 +10158,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id361
-  equipment_kinds: null
+  equipment_kinds: *id361
   required_roles: *id362
   optional_roles: *id363
   operational_proof_roles: *id364
   default_thresholds: *id365
-  pandas_implementation: dmp_1
+  pandas_implementation: dmp1
   datafusion_sql_implementation: dmp1_oa_damper_leak.sql
   sql_file: dmp1_oa_damper_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#dmp-1
@@ -8833,8 +10173,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:
@@ -8917,12 +10257,12 @@ concepts:
   aliases: []
   kind: diagnostic
   equipment_types: *id367
-  equipment_kinds: null
+  equipment_kinds: *id367
   required_roles: *id368
   optional_roles: *id369
   operational_proof_roles: *id370
   default_thresholds: *id371
-  pandas_implementation: vlv_1
+  pandas_implementation: vlv1
   datafusion_sql_implementation: vlv1_clg_valve_leak.sql
   sql_file: vlv1_clg_valve_leak.sql
   documentation_link: docs/rules/cookbook/pandas-cookbook.md#vlv-1
@@ -8932,8 +10272,8 @@ concepts:
   parity_level: sql_screening
   difference_class: none
   known_semantic_differences: ''
-  operational_gate: fan_or_occupied_when_declared
-  startup_delay_seconds: null
+  operational_gate: conditional
+  startup_delay_seconds: 300
   confirm_seconds: 900
   parameters:
     confirm_seconds:


### PR DESCRIPTION
## Summary
- Shorten intro, PyPI, develop, and releases sections for a cleaner first read
- Consolidate install into **Run** with validated `openfdd_stack_up.sh` recipes and `openfdd_maint_update_resume.sh`
- State what is **ready today** (local CSV lab behind the firewall) vs **coming soon** (OT edge, cloud hosting; internet security hardening Fall 2026)
- Move the no-chatbot / external-agents note next to MCP

## Test plan
- [ ] Proofread rendered README on GitHub
- [ ] Confirm stack script names match `scripts/openfdd_stack_up.sh --help`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized and condensed the README for easier navigation.
  * Clarified local deployment, CSV usage, maintenance commands, UI/API endpoints, and MCP guidance.
  * Updated installation, PyPI, development, release, licensing, and version information.
  * Added clearer details about current capabilities, image names, and planned hosting options.
  * Updated the generated parity report with clearer rule descriptions, normalized naming, and revised pandas mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->