### PR TITLE
Document Railway cloud-lab deployment and GHCR pull requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,26 @@ Aliases: [`docs/migration/vibe19/ROLE_MAPPING_PARITY.md`](docs/migration/vibe19/
 - **Overview layout:** full width beside sidebar (Streamlit-like); named Plotly PNG stems via `downloadFilename` on RCx / Inspect / FDD Plots; Lab rule menu A–Z; FDD series = required∪optional roles.
 - **Mech OAT bins:** status/cmd before amps; prefer web/weather OAT. Analytics envelopes: `scripts/synthetic_59_overview_analytics_soak.py`.
 
+## Deployment
+
+### Railway cloud lab
+
+Railway is an **experimental CSV/package lab/demo path**, not a replacement for the LAN/VPN/OT deployment contract or a claim of production public-internet hardening.
+
+- Minimal cloud stack: `openfdd-central` + `openfdd-web`.
+- Real optional images: `openfdd-fieldbus`, `openfdd-mqtt`, `openfdd-mcp`.
+- Do **not** invent `openfdd-commission`, `openfdd-mcp-rag`, or a Python/Streamlit commissioning runtime.
+- Both central and web currently listen on container port `8080`; local Compose maps web host port `3000` to container `8080`.
+- Central health is `GET /api/health`, not `/health`.
+- Cloud pulls require public GHCR package visibility or explicit registry pull credentials.
+- `OPENFDD_JWT_SECRET` and `OPENFDD_ADMIN_PASSWORD` must be deployment-unique secrets and must never be committed.
+- BACnet/fieldbus generally requires deliberate OT-LAN/VPN/router access; generic Railway networking does not provide BACnet broadcast discovery automatically.
+- Prefer `:nightly` for the latest green `master` channel or `:sha-<7>` for reproducibility.
+
+Full guide: [`docs/operations/RAILWAY_DEPLOYMENT.md`](docs/operations/RAILWAY_DEPLOYMENT.md). Image/tag contract: [`docs/operations/ghcr-images.md`](docs/operations/ghcr-images.md). Local stack entry point remains `./scripts/openfdd_stack_up.sh`.
+
+A Railway one-click template should represent the tested minimal `central + web` cloud-lab topology. Do not add a README deployment button until the real template exists and has been verified.
+
 ## Low-RAM hosts (bensbench)
 
 - **Never** local `docker build` / heavy Rust compile for stack images. Ship via PR → GH Actions → GHCR `nightly` / `sha-*`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Open-FDD maps Haystack-style JSON point roles to live or historical OT/CSV data 
 
 **Ready today — local, behind the firewall:** `./scripts/openfdd_stack_up.sh react` for CSV/zip FDD on your LAN or VPN. Not intended for the public internet.
 
+**Experimental cloud lab:** Railway can run the minimal `openfdd-central` + `openfdd-web` CSV/package stack from GHCR. See [Railway deployment](docs/operations/RAILWAY_DEPLOYMENT.md). This is a lab/demo path, not a production-hardening claim.
+
 **Coming soon:** OT edge (`react-ot` — BACnet, Modbus, Haystack, MQTTS) and managed **cloud hosting**. Internet-facing deployment with production security hardening targets **Fall 2026**.
 
 ---

--- a/docs/operations/RAILWAY_DEPLOYMENT.md
+++ b/docs/operations/RAILWAY_DEPLOYMENT.md
@@ -1,0 +1,157 @@
+---
+title: Railway deployment
+parent: Operations
+nav_order: 4
+---
+
+# Railway deployment
+
+> **Experimental cloud-lab path.** Open-FDD is local-first and currently intended for LAN/VPN/OT networks. The Railway recipe below is for CSV/package labs, demos, and controlled evaluation. It is **not** a claim that Open-FDD is production-hardened for direct public-internet exposure.
+
+Open-FDD publishes a Rust/React container stack to GHCR. Railway can run the cloud-friendly subset without rebuilding the application.
+
+## What to deploy
+
+### Minimal cloud CSV lab
+
+Deploy these two services:
+
+| Railway service | Image | Container port | Exposure |
+| --- | --- | ---: | --- |
+| `openfdd-central` | `ghcr.io/bbartling/openfdd-central:nightly` | `8080` | Private preferred; web must reach it |
+| `openfdd-web` | `ghcr.io/bbartling/openfdd-web:nightly` | `8080` | Public HTTP |
+
+The browser talks to the React web service; the web image proxies `/api` to central in the normal Open-FDD topology. Central owns JWT auth, package import, historian storage, DataFusion FDD, and analytics.
+
+Use `:nightly` for the latest green `master` channel or pin `:sha-<7>` for a reproducible deployment. Do not invent semver tags that are not published.
+
+### Optional services
+
+| Service | Image | Cloud notes |
+| --- | --- | --- |
+| MCP | `ghcr.io/bbartling/openfdd-mcp:nightly` | Optional agent sidecar. Set `OPENFDD_API_BASE` to central. |
+| MQTT | `ghcr.io/bbartling/openfdd-mqtt:nightly` | Useful only when the deployment has a deliberate MQTT/OT topology and certificates. |
+| Fieldbus | `ghcr.io/bbartling/openfdd-fieldbus:nightly` | BACnet/IP discovery normally needs access to the OT LAN/broadcast domain. A naive public Railway deployment cannot provide that. |
+
+The real image set is `openfdd-central`, `openfdd-web`, `openfdd-fieldbus`, `openfdd-mqtt`, and `openfdd-mcp`. There is no `openfdd-commission` or `openfdd-mcp-rag` service in the product stack.
+
+## Prerequisite: GHCR pull access
+
+Railway must be able to pull the selected GHCR images.
+
+For the easiest open-source deployment, make the five Open-FDD GHCR packages public in GitHub package settings. New GHCR packages can default to private, so re-check visibility whenever a new image/package is introduced.
+
+If an unauthenticated pull is blocked, GHCR commonly responds with `401 Unauthorized`:
+
+```bash
+curl -sI https://ghcr.io/v2/bbartling/openfdd-central/manifests/nightly | head -1
+curl -sI https://ghcr.io/v2/bbartling/openfdd-web/manifests/nightly | head -1
+```
+
+A public package should be pullable without a personal GitHub login. If package visibility must remain private, configure Railway with registry credentials instead of embedding credentials in repository files.
+
+See [GHCR images](ghcr-images.md) for the image/tag contract.
+
+## Create the Railway services
+
+1. Create a Railway project.
+2. Add a service from Docker image `ghcr.io/bbartling/openfdd-central:nightly`.
+3. Add a service from Docker image `ghcr.io/bbartling/openfdd-web:nightly`.
+4. Give the web service a public Railway domain.
+5. Keep central private when possible and connect web-to-central over Railway private networking.
+6. Configure persistent storage for central's workspace before relying on imported CSV/package history across redeploys.
+
+Railway configuration should model the container ports, not the host-side ports shown by local Docker Compose. Both current central and web images listen on container port `8080`; local Compose maps web `3000:8080` only for developer convenience.
+
+## Central variables
+
+Set at least:
+
+```text
+OPENFDD_JWT_SECRET=<long deployment-unique random secret>
+OPENFDD_ADMIN_PASSWORD=<strong deployment-unique password>
+OPENFDD_WORKSPACE=/workspace
+OPENFDD_PARQUET_ROOT=/workspace/.cache/parquet
+OPENFDD_REACT_UI=1
+OPENFDD_UI_GENERATION_DEFAULT=react
+```
+
+`OPENFDD_JWT_SECRET` must be unique per deployment. Never commit either secret to Git.
+
+For the minimal CSV lab, do not require the OT MQTT path merely because local `compose.react.yml` includes it. The target cloud recipe is central + web; OT services are optional and topology-dependent.
+
+## Health and verification
+
+Central's health endpoint is:
+
+```text
+GET /api/health
+```
+
+After deployment, verify central from a network location that can reach it:
+
+```bash
+curl -fsS https://<central-host>/api/health
+```
+
+Then open the web domain, log in with the configured admin password, import an `openfdd_package_v1` CSV package, and confirm Overview/Inspect/FDD routes can query the imported building.
+
+Do **not** use bare `/health`; the product route is `/api/health`.
+
+## MCP sidecar
+
+If you add the optional MCP image, point it at central:
+
+```text
+OPENFDD_API_BASE=http://<central-private-host>:8080
+OPENFDD_MCP_TOKEN=<JWT/token appropriate for the deployment>
+```
+
+Keep MCP private unless there is a deliberate authenticated agent gateway around it.
+
+## OT / BACnet warning
+
+Railway is not a substitute for an OT network.
+
+BACnet/IP discovery commonly depends on local broadcast/subnet behavior, interface binding, router configuration, and access to building controls networks. `openfdd-fieldbus` therefore belongs on-site, behind a VPN/tunnel, or in infrastructure deliberately connected to the OT LAN. Do not advertise a one-click public-cloud deployment as automatic BACnet commissioning.
+
+For a cloud CSV/package lab, omit fieldbus and MQTT entirely unless they are genuinely needed.
+
+## Security posture
+
+Open-FDD's current product contract is LAN/VPN/local-first. Internet-facing hardening is still an explicit future target in the project README. Treat Railway as an experimental lab/demo deployment unless your own network controls, authentication, secrets, TLS, persistence, backups, and exposure policy have been reviewed.
+
+Never:
+
+- commit `OPENFDD_JWT_SECRET`, admin passwords, registry tokens, or OT credentials;
+- expose BACnet write paths to the public internet;
+- assume a Railway public domain makes the whole stack production-safe;
+- add Python/Streamlit commissioning services that are not part of the Rust/React product stack.
+
+## Troubleshooting
+
+### `401 Unauthorized` while pulling GHCR
+
+The package is private or Railway lacks registry credentials. Make the package public or configure pull credentials.
+
+### Health check fails
+
+Check the container port (`8080` for central), use `/api/health`, and inspect central startup logs for missing JWT/auth configuration.
+
+### Web loads but `/api` fails
+
+Confirm web can reach central over Railway networking and that the web deployment preserves the normal `/api` proxy topology. Do not point browser JavaScript directly at an unrelated public central URL unless you intentionally redesign the proxy/security model.
+
+### Imported data disappears after redeploy
+
+Attach persistent storage for `/workspace`; central's imported packages, historian artifacts, and related state are not meant to live only on an ephemeral container filesystem.
+
+### BACnet discovery finds nothing
+
+That is expected on a generic cloud network. Run fieldbus where it has routed/broadcast access to the OT LAN or through an explicitly engineered VPN/router topology.
+
+## One-click template target
+
+The intended follow-up is a Railway Template for the **minimal cloud CSV lab** (`openfdd-web` + `openfdd-central`) with generated secrets, private service networking, persistent central storage, and `/api/health` verification. Once a real template is published and tested, the project README can expose Railway's official **Deploy on Railway** button.
+
+Do not add a placeholder button that points to an unpublished or unverified template.

--- a/docs/operations/ghcr-images.md
+++ b/docs/operations/ghcr-images.md
@@ -16,6 +16,8 @@ ghcr.io/bbartling/openfdd-mqtt:${OPENFDD_IMAGE_TAG:-nightly}
 ghcr.io/bbartling/openfdd-mcp:${OPENFDD_IMAGE_TAG:-nightly}
 ```
 
+Cloud platforms such as Railway need pull access to every selected image. For the simplest open-source deployment, make the GHCR packages public; otherwise configure the platform with explicit registry credentials. A `401 Unauthorized` from an unauthenticated manifest request usually means the package is still private. New GHCR packages can default to private, so re-check visibility when adding an image. See [Railway deployment](RAILWAY_DEPLOYMENT.md).
+
 Which images a deployment pulls depends on the recipe — see
 [Build recipes](build-recipes.html). Channel policy:
 [Release channels](release-channels.html).


### PR DESCRIPTION
## Summary
- add `docs/operations/RAILWAY_DEPLOYMENT.md` for the real Rust/React stack
- document minimal Railway cloud lab as `openfdd-central` + `openfdd-web`
- document the real five GHCR images and private-package `401` failure mode
- clarify container port `8080` for both central/web vs local web host mapping `3000:8080`
- document `GET /api/health`, JWT/admin secret requirements, persistence, MCP, and BACnet/OT limitations
- add Railway guidance to `AGENTS.md` and link the experimental cloud-lab path from README
- intentionally do not add a fake Deploy on Railway button until a real tested Railway Template exists

## Guardrails
- Railway is documented as experimental lab/demo infrastructure, not production-hardened public SaaS
- no fictional `openfdd-commission` / `openfdd-mcp-rag` images
- no Python/Streamlit product runtime
- no vendor/campus hardcoding

## Test plan
- GitHub docs/markdown checks green
- verify all intra-repo links resolve in docs build
- confirm branch changes remain docs-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added experimental Railway cloud-lab deployment guidance for the central and web services.
  - Documented supported container images, required configuration, networking, storage, health checks, and troubleshooting.
  - Added GHCR image access and authentication guidance, including `401 Unauthorized` resolution.
  - Clarified security limitations, non-production status, and on-site requirements for fieldbus integrations.
  - Updated the README with a link to the deployment documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->