### PR TITLE
Expand React Overview health UX

### DIFF
--- a/frontend/web/src/api/overviewHealthApi.ts
+++ b/frontend/web/src/api/overviewHealthApi.ts
@@ -1,0 +1,24 @@
+import { postAnalytics } from "./analyticsApi";
+import type { AnalyticsEnvelope, AnalyticsRequest } from "./analyticsApi";
+
+function postHealth(path: string, body: AnalyticsRequest): Promise<AnalyticsEnvelope> {
+  return postAnalytics(path, body);
+}
+
+export const postAhuTemperatureHealth = (body: AnalyticsRequest) =>
+  postHealth("/api/analytics/ahu-temperature-health", body);
+
+export const postAhuPressureHealth = (body: AnalyticsRequest) =>
+  postHealth("/api/analytics/ahu-pressure-health", body);
+
+export const postAhuEconomizerHealth = (body: AnalyticsRequest) =>
+  postHealth("/api/analytics/ahu-economizer-health", body);
+
+export const postCoolingTowerHealth = (body: AnalyticsRequest) =>
+  postHealth("/api/analytics/cooling-tower-health", body);
+
+export const postPidHunting = (body: AnalyticsRequest) =>
+  postHealth("/api/analytics/pid-hunting", body);
+
+export const postSensorFaults = (body: AnalyticsRequest) =>
+  postHealth("/api/analytics/sensor-faults", body);

--- a/frontend/web/src/components/HealthMatrixSection.test.tsx
+++ b/frontend/web/src/components/HealthMatrixSection.test.tsx
@@ -1,7 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { DataTable } from "./widgets/DataTable";
-import { healthRowClass, healthRowClassBroken3Only, tri } from "./HealthMatrixSection";
+import {
+  HealthMatrixSection,
+  healthRowClass,
+  healthRowClassBroken3Only,
+  healthRowClassFullyBroken,
+  tri,
+} from "./HealthMatrixSection";
+import type { AnalyticsEnvelope } from "../api/analyticsApi";
+
+function emptyEnvelope(): AnalyticsEnvelope {
+  return {
+    schema_version: "sensor_fault_matrix_v1",
+    query_version: "sensor-faults-v1",
+    generated_at: "2026-08-20T00:00:00Z",
+    engine: "datafusion",
+    warnings: [],
+    rows: [],
+    equipment: [],
+    points: [],
+    skipped: [],
+  };
+}
 
 describe("health matrix tint", () => {
   it("maps score to broken-N classes and skips unknown", () => {
@@ -14,11 +35,13 @@ describe("health matrix tint", () => {
     expect(tri(true)).toBe("true");
   });
 
-  it("overview matrix tints only fully broken 3/3 rows", () => {
+  it("overview matrix highlights fully faulted arbitrary-width rows", () => {
+    expect(healthRowClassFullyBroken("3/3")).toBe("health-row--broken-3");
+    expect(healthRowClassFullyBroken("5/5")).toBe("health-row--broken-3");
+    expect(healthRowClassFullyBroken("7/7")).toBe("health-row--broken-3");
+    expect(healthRowClassFullyBroken("4/5")).toBeUndefined();
+    expect(healthRowClassFullyBroken("?/7")).toBeUndefined();
     expect(healthRowClassBroken3Only("3/3")).toBe("health-row--broken-3");
-    expect(healthRowClassBroken3Only("2/3")).toBeUndefined();
-    expect(healthRowClassBroken3Only("1/3")).toBeUndefined();
-    expect(healthRowClassBroken3Only("0/3")).toBeUndefined();
     render(
       <DataTable
         id="h3"
@@ -29,10 +52,10 @@ describe("health matrix tint", () => {
           { key: "sat_dev", header: "flag" },
         ]}
         rows={[
-          { score_label: "2/3", equipment_id: "AHU_2", sat_dev: "true" },
-          { score_label: "3/3", equipment_id: "AHU_3", sat_dev: "true" },
+          { score_label: "4/5", equipment_id: "AHU_2", sat_dev: "true" },
+          { score_label: "5/5", equipment_id: "AHU_3", sat_dev: "true" },
         ]}
-        rowClassName={(row) => healthRowClassBroken3Only(row.score_label)}
+        rowClassName={(row) => healthRowClassFullyBroken(row.score_label)}
       />,
     );
     const rows = screen.getByTestId("health-table-3only").querySelectorAll("tbody tr");
@@ -67,5 +90,25 @@ describe("health matrix tint", () => {
     expect(rows[1].className).toContain("health-row--broken-1");
     expect(rows[2].getAttribute("data-broken")).toBe("3");
     expect(rows[3].getAttribute("data-broken")).toBeNull();
+  });
+
+  it("keeps the clean sensor table shell visible", async () => {
+    render(
+      <HealthMatrixSection
+        family="sensor"
+        title="Sensor faults"
+        caption="Sensor validation faults."
+        buildingId="B1"
+        refreshToken={0}
+        fetchHealth={async () => emptyEnvelope()}
+        flagColumns={[{ key: "flatline", ruleId: "SV-FLATLINE" }]}
+        emptyMessage="No sensor faults in window"
+        renderEmptyTable
+      />,
+    );
+
+    expect(await screen.findByText("No sensor faults in window")).toBeTruthy();
+    expect(screen.getByTestId("sensor-health-table")).toBeTruthy();
+    expect(screen.getByText("SV-FLATLINE fault_h")).toBeTruthy();
   });
 });

--- a/frontend/web/src/components/HealthMatrixSection.tsx
+++ b/frontend/web/src/components/HealthMatrixSection.tsx
@@ -17,14 +17,18 @@ function fmtHours(v: unknown): string {
   return n.toFixed(1);
 }
 
-function healthRowClassBroken3Only(score: unknown): string | undefined {
-  return String(score ?? "") === "3/3" ? "health-row--broken-3" : undefined;
+export function healthRowClassFullyBroken(score: unknown): string | undefined {
+  const match = String(score ?? "").match(/^(\d+)\/(\d+)$/);
+  if (!match) return undefined;
+  const hit = Number(match[1]);
+  const total = Number(match[2]);
+  return total > 0 && hit === total ? "health-row--broken-3" : undefined;
 }
 
-/** @internal test export */
-export { healthRowClassBroken3Only };
+/** @internal compatibility export for existing tests/callers. */
+export const healthRowClassBroken3Only = healthRowClassFullyBroken;
 
-/** @deprecated use healthRowClassBroken3Only — kept for unit tests */
+/** @deprecated retained for legacy 3-dimension table tests. */
 export function healthRowClass(score: unknown): string | undefined {
   switch (String(score ?? "")) {
     case "1/3":
@@ -54,6 +58,10 @@ export interface HealthMatrixSectionProps {
   refreshToken: number;
   fetchHealth: (buildingId: string) => Promise<AnalyticsEnvelope>;
   flagColumns: HealthFlagColumn[];
+  /** Custom clean/empty state copy. */
+  emptyMessage?: string;
+  /** Keep the table headers visible when rows are empty. */
+  renderEmptyTable?: boolean;
 }
 
 export function HealthMatrixSection({
@@ -64,6 +72,8 @@ export function HealthMatrixSection({
   refreshToken,
   fetchHealth,
   flagColumns,
+  emptyMessage,
+  renderEmptyTable = false,
 }: HealthMatrixSectionProps) {
   const [env, setEnv] = useState<AnalyticsEnvelope | null>(null);
   const [err, setErr] = useState<string | null>(null);
@@ -103,7 +113,7 @@ export function HealthMatrixSection({
     [env?.rows],
   );
 
-  const stale = !loading && !err && rows.length === 0;
+  const empty = !loading && !err && env !== null && rows.length === 0;
 
   const tableColumns = useMemo(() => {
     const cols: Array<{ key: string; header: string }> = [
@@ -137,6 +147,8 @@ export function HealthMatrixSection({
     return out;
   });
 
+  const showTable = matrixRows.length > 0 || (empty && renderEmptyTable);
+
   return (
     <section
       className={`overview-${family}-health`}
@@ -147,7 +159,7 @@ export function HealthMatrixSection({
       <p className="oracle-sidebar__caption">{caption}</p>
       {loading ? (
         <InlineAlert id={`${family}-health-loading`} variant="info" testId={test("loading")}>
-          Loading {family.toUpperCase()} health…
+          Loading {title}…
         </InlineAlert>
       ) : null}
       {err ? (
@@ -155,21 +167,24 @@ export function HealthMatrixSection({
           {err}
         </InlineAlert>
       ) : null}
-      {stale ? (
-        <InlineAlert id={`${family}-health-stale`} variant="warning" testId={test("stale")}>
-          No {family.toUpperCase()} equipment in this data model. Section hidden when the
-          package has no matching equip refs — run <strong>Update analytics</strong> /{" "}
-          <strong>Run all rules</strong> after mapping.
+      {empty ? (
+        <InlineAlert id={`${family}-health-empty`} variant="info" testId={test("empty")}>
+          {emptyMessage ?? (
+            <>
+              No {family.toUpperCase()} equipment in this data model. Run{" "}
+              <strong>Update analytics</strong> / <strong>Run all rules</strong> after mapping.
+            </>
+          )}
         </InlineAlert>
       ) : null}
-      {matrixRows.length ? (
+      {showTable ? (
         <DataTable
           id={`${family}-health-table`}
-          label={`${family.toUpperCase()} health matrix`}
+          label={`${title} matrix`}
           columns={tableColumns}
           rows={matrixRows}
           rowClassName={(row) =>
-            healthRowClassBroken3Only((row as { score_label?: unknown }).score_label)
+            healthRowClassFullyBroken((row as { score_label?: unknown }).score_label)
           }
           testId={test("table")}
         />

--- a/frontend/web/src/components/OverviewPopulated.test.tsx
+++ b/frontend/web/src/components/OverviewPopulated.test.tsx
@@ -44,6 +44,19 @@ const emptyOverview = {
   error: null,
 };
 
+const emptyAnalytics = {
+  schema_version: "analytics-envelope-v1",
+  query_version: "test-v1",
+  generated_at: "",
+  engine: "datafusion",
+  warnings: [],
+  rows: [],
+  equipment: [],
+  points: [],
+  skipped: [],
+  coverage: {},
+};
+
 const { fetchCentralOverview } = vi.hoisted(() => ({
   fetchCentralOverview: vi.fn(async () => emptyOverview),
 }));
@@ -108,17 +121,15 @@ vi.mock("../api/centralOverview", () => ({
 }));
 
 vi.mock("../api/analyticsApi", () => ({
+  postAnalytics: vi.fn(async () => emptyAnalytics),
   postInspect: vi.fn(async () => ({
     coverage: {},
     points: [],
     warnings: [],
   })),
   postVavHealth: vi.fn(async () => ({
-    schema_version: "analytics-envelope-v1",
+    ...emptyAnalytics,
     query_version: "vav-health-v1",
-    generated_at: "",
-    engine: "datafusion",
-    warnings: [],
     rows: [
       {
         equipment_id: "VAV_1",
@@ -130,70 +141,21 @@ vi.mock("../api/analyticsApi", () => ({
         parent_ahu: "AHU_1",
       },
     ],
-    equipment: [],
-    points: [],
-    skipped: [],
     coverage: { groups: { "3/3": 0, "2/3": 0, "1/3": 0, "0/3": 1, "?/3": 0 } },
   })),
-  postAhuHealth: vi.fn(async () => ({
-    schema_version: "analytics-envelope-v1",
-    query_version: "ahu-health-v1",
-    generated_at: "",
-    engine: "datafusion",
-    warnings: [],
-    rows: [],
-    equipment: [],
-    points: [],
-    skipped: [],
-    coverage: { groups: {} },
-  })),
+  postAhuHealth: vi.fn(async () => ({ ...emptyAnalytics, query_version: "ahu-health-v1" })),
   postChillerHealth: vi.fn(async () => ({
-    schema_version: "analytics-envelope-v1",
-    query_version: "chiller-health-v1",
-    generated_at: "",
-    engine: "datafusion",
-    warnings: [],
-    rows: [],
-    equipment: [],
-    points: [],
-    skipped: [],
-    coverage: { groups: {} },
+    ...emptyAnalytics,
+    query_version: "chiller-health-v2",
   })),
   postBoilerHealth: vi.fn(async () => ({
-    schema_version: "analytics-envelope-v1",
+    ...emptyAnalytics,
     query_version: "boiler-health-v1",
-    generated_at: "",
-    engine: "datafusion",
-    warnings: [],
-    rows: [],
-    equipment: [],
-    points: [],
-    skipped: [],
-    coverage: { groups: {} },
   })),
-  postHpHealth: vi.fn(async () => ({
-    schema_version: "analytics-envelope-v1",
-    query_version: "hp-health-v1",
-    generated_at: "",
-    engine: "datafusion",
-    warnings: [],
-    rows: [],
-    equipment: [],
-    points: [],
-    skipped: [],
-    coverage: { groups: {} },
-  })),
+  postHpHealth: vi.fn(async () => ({ ...emptyAnalytics, query_version: "hp-health-v1" })),
   postBasVsWebOat: vi.fn(async () => ({
-    schema_version: "analytics-envelope-v1",
+    ...emptyAnalytics,
     query_version: "bas-vs-web-oat-v2",
-    generated_at: "",
-    engine: "datafusion",
-    warnings: [],
-    rows: [],
-    equipment: [],
-    points: [],
-    skipped: [],
-    coverage: {},
   })),
 }));
 
@@ -284,8 +246,13 @@ describe("OverviewPopulated metric isolation", () => {
     ]) {
       expect(screen.queryByTestId(id)).toBeNull();
     }
-    expect(screen.getByTestId("overview-ahu-health")).toBeTruthy();
+    expect(screen.getByTestId("overview-ahu-temperature-health")).toBeTruthy();
+    expect(screen.getByTestId("overview-ahu-pressure-health")).toBeTruthy();
+    expect(screen.getByTestId("overview-ahu-economizer-health")).toBeTruthy();
+    expect(screen.getByTestId("overview-pid-health")).toBeTruthy();
+    expect(screen.getByTestId("overview-sensor-health")).toBeTruthy();
     expect(screen.queryByTestId("overview-chiller-health")).toBeNull();
+    expect(screen.queryByTestId("overview-cooling-tower-health")).toBeNull();
     expect(screen.queryByTestId("overview-boiler-health")).toBeNull();
     expect(screen.queryByTestId("overview-hp-health")).toBeNull();
     expect(screen.queryByTestId("overview-vav-health")).toBeNull();

--- a/frontend/web/src/components/PlantHealthSections.tsx
+++ b/frontend/web/src/components/PlantHealthSections.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useMemo } from "react";
 import { HealthMatrixSection } from "./HealthMatrixSection";
-import {
-  postAhuHealth,
-  postChillerHealth,
-  postHpHealth,
-} from "../api/analyticsApi";
+import { postChillerHealth, postHpHealth } from "../api/analyticsApi";
 import type { FddEquipmentItem } from "../api/analyticsApi";
+import {
+  postAhuEconomizerHealth,
+  postAhuPressureHealth,
+  postAhuTemperatureHealth,
+  postCoolingTowerHealth,
+  postPidHunting,
+  postSensorFaults,
+} from "../api/overviewHealthApi";
 import { plantEquipmentFamilies } from "../lib/plantEquipment";
 
 export function PlantHealthSections({
@@ -19,80 +23,212 @@ export function PlantHealthSections({
 }) {
   const families = useMemo(() => plantEquipmentFamilies(equipment), [equipment]);
 
-  const fetchAhu = useCallback(
-    (id: string) => postAhuHealth({ building_id: id }),
+  const fetchAhuTemperature = useCallback(
+    (id: string) => postAhuTemperatureHealth({ building_id: id }),
+    [],
+  );
+  const fetchAhuPressure = useCallback(
+    (id: string) => postAhuPressureHealth({ building_id: id }),
+    [],
+  );
+  const fetchAhuEconomizer = useCallback(
+    (id: string) => postAhuEconomizerHealth({ building_id: id }),
     [],
   );
   const fetchChiller = useCallback(
     (id: string) => postChillerHealth({ building_id: id }),
     [],
   );
+  const fetchCoolingTower = useCallback(
+    (id: string) => postCoolingTowerHealth({ building_id: id }),
+    [],
+  );
   const fetchHp = useCallback(
     (id: string) => postHpHealth({ building_id: id }),
+    [],
+  );
+  const fetchPid = useCallback(
+    (id: string) => postPidHunting({ building_id: id }),
+    [],
+  );
+  const fetchSensors = useCallback(
+    (id: string) => postSensorFaults({ building_id: id }),
     [],
   );
 
   return (
     <>
       {families.hasAhu ? (
-        <HealthMatrixSection
-          family="ahu"
-          title="AHU health"
-          caption="Data-model scoped to AHU equip refs. Red = all cookbook flags faulted (3/3)."
-          buildingId={buildingId}
-          refreshToken={refreshToken}
-          fetchHealth={fetchAhu}
-          flagColumns={[
-            {
-              key: "sat_dev",
-              ruleId: "AHU-SATDEV",
-              haystackTags: ["dischargeAir", "dischargeAirSp"],
-            },
-            {
-              key: "duct_high",
-              ruleId: "AHU-DUCTHI",
-              haystackTags: ["ductStatic", "ductStaticSp", "fan"],
-            },
-            {
-              key: "economizer",
-              ruleId: "ECON-1",
-              haystackTags: ["outsideAir", "outsideAirDamper", "fan"],
-            },
-          ]}
-        />
+        <>
+          <HealthMatrixSection
+            family="ahu-temperature"
+            title="AHU temperature health"
+            caption="Supply and mixed-air temperature diagnostics. Fully faulted rows are highlighted regardless of matrix width."
+            buildingId={buildingId}
+            refreshToken={refreshToken}
+            fetchHealth={fetchAhuTemperature}
+            flagColumns={[
+              {
+                key: "sat_dev",
+                ruleId: "AHU-SATDEV",
+                haystackTags: ["dischargeAir", "dischargeAirSp"],
+              },
+              { key: "mat_low", ruleId: "FC2", haystackTags: ["mixedAir"] },
+              { key: "mat_high", ruleId: "FC3", haystackTags: ["mixedAir"] },
+              {
+                key: "sat_low_heating",
+                ruleId: "FC7",
+                haystackTags: ["dischargeAir", "heating"],
+              },
+              {
+                key: "sat_high_cooling",
+                ruleId: "FC13-SAT-HIGH",
+                haystackTags: ["dischargeAir", "cooling"],
+              },
+            ]}
+          />
+          <HealthMatrixSection
+            family="ahu-pressure"
+            title="AHU pressure / fan health"
+            caption="Duct static, fan command, and static-pressure reset diagnostics."
+            buildingId={buildingId}
+            refreshToken={refreshToken}
+            fetchHealth={fetchAhuPressure}
+            flagColumns={[
+              {
+                key: "duct_high",
+                ruleId: "AHU-DUCTHI",
+                haystackTags: ["ductStatic", "ductStaticSp", "fan"],
+              },
+              {
+                key: "duct_low",
+                ruleId: "FC1",
+                haystackTags: ["ductStatic", "ductStaticSp"],
+              },
+              {
+                key: "fan_mismatch",
+                ruleId: "CMD-1",
+                haystackTags: ["fan", "cmd"],
+              },
+              {
+                key: "static_trim",
+                ruleId: "TRIM-1",
+                haystackTags: ["ductStatic", "ductStaticSp"],
+              },
+            ]}
+          />
+          <HealthMatrixSection
+            family="ahu-economizer"
+            title="AHU economizer health"
+            caption="Economizer sequence diagnostics from the canonical ECON rule family."
+            buildingId={buildingId}
+            refreshToken={refreshToken}
+            fetchHealth={fetchAhuEconomizer}
+            flagColumns={[
+              {
+                key: "stuck_closed",
+                ruleId: "ECON-1",
+                haystackTags: ["outsideAir", "outsideAirDamper", "fan"],
+              },
+              {
+                key: "unfavorable",
+                ruleId: "ECON-2",
+                haystackTags: ["outsideAir", "returnAir"],
+              },
+              {
+                key: "mech_without_econ",
+                ruleId: "ECON-3",
+                haystackTags: ["outsideAir", "cooling"],
+              },
+              {
+                key: "low_oa_fraction",
+                ruleId: "ECON-4",
+                haystackTags: ["outsideAir", "mixedAir"],
+              },
+              {
+                key: "preheat_over",
+                ruleId: "ECON-5",
+                haystackTags: ["preheat", "outsideAir"],
+              },
+              {
+                key: "freeze_risk",
+                ruleId: "ECON-6",
+                haystackTags: ["outsideAir", "mixedAir"],
+              },
+              {
+                key: "not_economizing",
+                ruleId: "ECON-7",
+                haystackTags: ["outsideAir", "outsideAirDamper"],
+              },
+            ]}
+          />
+        </>
       ) : null}
+
       {families.hasChiller ? (
         <HealthMatrixSection
           family="chiller"
           title="Chiller plant health"
-          caption="Compressor-plant flags only. Heat pumps (HP_*) use the heat-pump matrix."
+          caption="Expanded chilled-water plant diagnostics. Heat pumps and cooling towers use separate matrices."
           buildingId={buildingId}
           refreshToken={refreshToken}
           fetchHealth={fetchChiller}
           flagColumns={[
             {
-              key: "chw_1",
+              key: "low_delta_t",
               ruleId: "CHW-1",
               haystackTags: ["chilledWaterSupply", "chilledWaterReturn"],
             },
             {
-              key: "chw_2",
+              key: "dp_low",
               ruleId: "CHW-2",
               haystackTags: ["chilledWaterDiffPressure", "chilledWaterDiffPressureSp"],
             },
             {
-              key: "chw_3",
+              key: "supply_band",
               ruleId: "CHW-3",
-              haystackTags: ["condenserWaterSupply", "condenserWaterReturn"],
+              haystackTags: ["chilledWaterSupply", "chilledWaterSupplySp"],
+            },
+            { key: "flow_high", ruleId: "CHW-4", haystackTags: ["chilledWater", "flow"] },
+            { key: "no_load", ruleId: "CHW-NOLOAD-1", haystackTags: ["chilledWater", "load"] },
+            {
+              key: "chw_reset",
+              ruleId: "TRIM-4",
+              haystackTags: ["chilledWaterSupply", "chilledWaterSupplySp"],
             },
           ]}
         />
       ) : null}
+
+      {families.hasCoolingTower ? (
+        <HealthMatrixSection
+          family="cooling-tower"
+          title="Cooling-tower health"
+          caption="Condenser-water approach, fan, and optimization diagnostics."
+          buildingId={buildingId}
+          refreshToken={refreshToken}
+          fetchHealth={fetchCoolingTower}
+          flagColumns={[
+            {
+              key: "approach_high",
+              ruleId: "CW-APR-1",
+              haystackTags: ["condenserWater", "outsideAirWetBulb"],
+            },
+            { key: "fan_energy", ruleId: "CW-FAN-1", haystackTags: ["fan", "condenserWater"] },
+            {
+              key: "cw_optimization",
+              ruleId: "CW-OPT-1",
+              haystackTags: ["condenserWater", "setpoint"],
+            },
+          ]}
+        />
+      ) : null}
+
       {families.hasHeatPump ? (
         <HealthMatrixSection
           family="hp"
           title="Heat-pump health"
-          caption="HP_* equip refs only."
+          caption="Heat-pump equipment only."
           buildingId={buildingId}
           refreshToken={refreshToken}
           fetchHealth={fetchHp}
@@ -115,6 +251,37 @@ export function PlantHealthSections({
           ]}
         />
       ) : null}
+
+      <HealthMatrixSection
+        family="pid"
+        title="PID Hunting"
+        caption="Operating-state and control-output hunting evidence across applicable equipment."
+        buildingId={buildingId}
+        refreshToken={refreshToken}
+        fetchHealth={fetchPid}
+        flagColumns={[
+          { key: "operating_state_hunt", ruleId: "FC4" },
+          { key: "control_output_hunt", ruleId: "PID-HUNT-1" },
+        ]}
+      />
+
+      <HealthMatrixSection
+        family="sensor"
+        title="Sensor faults"
+        caption="Sensor validation faults across the current Overview window."
+        buildingId={buildingId}
+        refreshToken={refreshToken}
+        fetchHealth={fetchSensors}
+        flagColumns={[
+          { key: "flatline", ruleId: "SV-FLATLINE" },
+          { key: "range", ruleId: "SV-RANGE" },
+          { key: "rate", ruleId: "SV-RATE" },
+          { key: "spike", ruleId: "SV-SPIKE" },
+          { key: "stale", ruleId: "SV-STALE" },
+        ]}
+        emptyMessage="No sensor faults in window"
+        renderEmptyTable
+      />
     </>
   );
 }

--- a/frontend/web/src/lib/plantEquipment.test.ts
+++ b/frontend/web/src/lib/plantEquipment.test.ts
@@ -11,10 +11,31 @@ describe("plantEquipmentFamilies", () => {
     ]);
     expect(f.hasAhu).toBe(true);
     expect(f.hasChiller).toBe(true);
+    expect(f.hasCoolingTower).toBe(false);
     expect(f.hasVav).toBe(true);
     expect(f.hasWeather).toBe(true);
     expect(f.hasHeatPump).toBe(false);
     expect(f.hasBoiler).toBe(false);
+  });
+
+  it("separates cooling towers from chillers", () => {
+    const f = plantEquipmentFamilies([
+      {
+        equipment_id: "CT_opaque",
+        equipment_type: "PLANT",
+        equipment_type_raw: "cooling_tower",
+      },
+    ]);
+    expect(f.hasCoolingTower).toBe(true);
+    expect(f.hasChiller).toBe(false);
+  });
+
+  it("recognizes generic tower ids without making them chillers", () => {
+    const f = plantEquipmentFamilies([
+      { equipment_id: "TOWER_1", equipment_type: "PLANT" },
+    ]);
+    expect(f.hasCoolingTower).toBe(true);
+    expect(f.hasChiller).toBe(false);
   });
 
   it("hides heat pump matrix when no HP refs", () => {

--- a/frontend/web/src/lib/plantEquipment.ts
+++ b/frontend/web/src/lib/plantEquipment.ts
@@ -16,6 +16,29 @@ export function isHeatPumpId(equipmentId: string): boolean {
   );
 }
 
+function normalizedType(equipment: FddEquipmentItem): string {
+  const raw = String(
+    equipment.equipment_type_raw ??
+      equipment.equipType ??
+      equipment.equipment_type ??
+      "",
+  );
+  return raw.trim().toUpperCase().replace(/[\s-]+/g, "_");
+}
+
+export function isCoolingTowerEquipment(equipment: FddEquipmentItem): boolean {
+  const kind = normalizedType(equipment);
+  if (
+    kind === "COOLING_TOWER" ||
+    kind === "COOLINGTOWER" ||
+    kind === "TOWER"
+  ) {
+    return true;
+  }
+  const id = String(equipment.equipment_id ?? "").trim().toUpperCase();
+  return id.includes("TOWER") || id.startsWith("CT_") || id.includes("/CT_");
+}
+
 /** Rough plant group from equipment id (historian `plant_group_for`). */
 export function plantGroupFor(equipmentId: string): "air" | "chiller" | "boiler" | null {
   const u = equipmentId.trim().toUpperCase().replace(/\\/g, "/");
@@ -47,6 +70,7 @@ function isZoneTerminalId(id: string): boolean {
 export interface PlantEquipmentFamilies {
   hasAhu: boolean;
   hasChiller: boolean;
+  hasCoolingTower: boolean;
   hasBoiler: boolean;
   hasHeatPump: boolean;
   hasVav: boolean;
@@ -60,6 +84,7 @@ export function plantEquipmentFamilies(
   const items = equipment.filter((e) => !isWeatherEquipment(e));
   let hasAhu = false;
   let hasChiller = false;
+  let hasCoolingTower = false;
   let hasBoiler = false;
   let hasHeatPump = false;
   let hasVav = false;
@@ -68,16 +93,26 @@ export function plantEquipmentFamilies(
   for (const e of items) {
     const id = String(e.equipment_id ?? "");
     const kind = String(e.equipment_type ?? "").trim().toUpperCase();
+    const tower = isCoolingTowerEquipment(e);
     if (kind === "VAV" || isZoneTerminalEquipment(e)) hasVav = true;
     if (kind === "AHU" || plantGroupFor(id) === "air") hasAhu = true;
+    if (tower) hasCoolingTower = true;
     if (kind === "PLANT" && plantGroupFor(id) === "boiler") hasBoiler = true;
-    if (kind === "PLANT" && plantGroupFor(id) === "chiller") hasChiller = true;
+    if (kind === "PLANT" && plantGroupFor(id) === "chiller" && !tower) hasChiller = true;
     if (isHeatPumpId(id) || kind === "HEAT_PUMP" || kind === "HEATPUMP") {
       hasHeatPump = true;
     }
-    if (plantGroupFor(id) === "chiller" && !isHeatPumpId(id)) hasChiller = true;
+    if (plantGroupFor(id) === "chiller" && !isHeatPumpId(id) && !tower) hasChiller = true;
     if (plantGroupFor(id) === "boiler") hasBoiler = true;
   }
 
-  return { hasAhu, hasChiller, hasBoiler, hasHeatPump, hasVav, hasWeather };
+  return {
+    hasAhu,
+    hasChiller,
+    hasCoolingTower,
+    hasBoiler,
+    hasHeatPump,
+    hasVav,
+    hasWeather,
+  };
 }


### PR DESCRIPTION
## Summary
- replace the single AHU Overview matrix with temperature, pressure/fan, and economizer tables
- render expanded chiller and separate cooling-tower matrices
- add PID Hunting and Sensor sections at the bottom of Overview health
- deliberately keep the Sensor table shell visible with `No sensor faults in window` when the backend returns `rows: []`
- generalize fully-faulted row highlighting from fixed `3/3` to arbitrary `n/n`
- preserve existing heat-pump behavior and leave VAV/weather flows untouched

## Guardrails
- frontend-only: no Rust/backend changes
- consume PR3 health endpoints as-is
- cooling towers are not folded back into chiller presence detection

## Tests
- arbitrary-width full-fault highlighting (`5/5`, `7/7`)
- clean sensor empty-shell rendering
- cooling-tower inventory separation
- existing React typecheck/lint/test/build and repo-wide CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed plant health views for AHU temperature, pressure, economizer, cooling towers, PID hunting, and sensor faults.
  - Expanded chiller and cooling-tower diagnostics with clearer equipment separation.
  - Added configurable empty states for health tables, including optional headers and informative messages.

- **Bug Fixes**
  - Improved detection of cooling-tower equipment.
  - Health status rows now correctly identify fully affected equipment regardless of the number of checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->