### PR TITLE
Write immutable monthly Parquet historian parts

### DIFF
--- a/crates/fdd_store/Cargo.toml
+++ b/crates/fdd_store/Cargo.toml
@@ -15,6 +15,7 @@ parquet = { workspace = true, features = ["arrow"] }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -4,6 +4,7 @@ pub mod append;
 pub mod historian;
 pub mod ingest;
 pub mod meta;
+pub mod micro_batch;
 pub mod parquet_parts;
 
 pub use append::{merge_history_wide_csv, merge_history_wide_text, MergeReport};
@@ -13,4 +14,7 @@ pub use historian::{
 };
 pub use ingest::{ingest_building, ingest_building_with_batch_hook, IngestReport, IngestTiming};
 pub use meta::SidecarMeta;
+pub use micro_batch::{
+    FlushReason, HistorianBatchKey, MicroBatchFlush, MicroBatchHistorian,
+};
 pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -4,6 +4,7 @@ pub mod append;
 pub mod historian;
 pub mod ingest;
 pub mod meta;
+pub mod parquet_parts;
 
 pub use append::{merge_history_wide_csv, merge_history_wide_text, MergeReport};
 pub use historian::{
@@ -12,3 +13,4 @@ pub use historian::{
 };
 pub use ingest::{ingest_building, ingest_building_with_batch_hook, IngestReport, IngestTiming};
 pub use meta::SidecarMeta;
+pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -14,7 +14,5 @@ pub use historian::{
 };
 pub use ingest::{ingest_building, ingest_building_with_batch_hook, IngestReport, IngestTiming};
 pub use meta::SidecarMeta;
-pub use micro_batch::{
-    FlushReason, HistorianBatchKey, MicroBatchFlush, MicroBatchHistorian,
-};
+pub use micro_batch::{FlushReason, HistorianBatchKey, MicroBatchFlush, MicroBatchHistorian};
 pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};

--- a/crates/fdd_store/src/micro_batch.rs
+++ b/crates/fdd_store/src/micro_batch.rs
@@ -1,0 +1,407 @@
+//! Bounded in-memory micro-batching for canonical Parquet historian writes.
+//!
+//! This module is deliberately transport-agnostic. Fieldbus/MQTT integration is
+//! a later cutover phase; callers provide already-normalized Arrow batches plus
+//! trusted building/equipment identity. Pending rows flush when either the row
+//! threshold or elapsed-time threshold is reached, and `shutdown_flush` drains
+//! every remaining batch before a clean process exit.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Result};
+use arrow::compute::concat_batches;
+use arrow::record_batch::RecordBatch;
+use serde::Serialize;
+
+use crate::parquet_parts::{ParquetPart, ParquetPartWriter};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HistorianBatchKey {
+    pub building_id: String,
+    pub equipment_id: String,
+}
+
+impl HistorianBatchKey {
+    pub fn new(building_id: impl Into<String>, equipment_id: impl Into<String>) -> Self {
+        Self {
+            building_id: building_id.into(),
+            equipment_id: equipment_id.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlushReason {
+    RowThreshold,
+    TimeThreshold,
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MicroBatchFlush {
+    pub building_id: String,
+    pub equipment_id: String,
+    pub rows: usize,
+    pub reason: FlushReason,
+    pub parts: Vec<ParquetPart>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingBatch {
+    batches: Vec<RecordBatch>,
+    rows: usize,
+    first_buffered_at: Instant,
+}
+
+/// In-memory bounded accumulator that flushes complete Arrow batches into
+/// immutable Parquet parts.
+///
+/// The accumulator does not spawn timers or background tasks. The owning runtime
+/// calls `flush_due()` from its existing interval loop and `shutdown_flush()`
+/// during graceful shutdown. This keeps lifecycle ownership explicit and avoids
+/// hidden tasks inside the storage crate.
+#[derive(Debug, Clone)]
+pub struct MicroBatchHistorian {
+    writer: ParquetPartWriter,
+    flush_rows: usize,
+    flush_after: Duration,
+    pending: BTreeMap<HistorianBatchKey, PendingBatch>,
+}
+
+impl MicroBatchHistorian {
+    pub fn new(
+        writer: ParquetPartWriter,
+        flush_rows: usize,
+        flush_after: Duration,
+    ) -> Result<Self> {
+        if flush_rows == 0 {
+            bail!("micro-batch flush_rows must be greater than zero");
+        }
+        if flush_after.is_zero() {
+            bail!("micro-batch flush_after must be greater than zero");
+        }
+        Ok(Self {
+            writer,
+            flush_rows,
+            flush_after,
+            pending: BTreeMap::new(),
+        })
+    }
+
+    pub fn writer(&self) -> &ParquetPartWriter {
+        &self.writer
+    }
+
+    pub fn pending_rows(&self) -> usize {
+        self.pending.values().map(|pending| pending.rows).sum()
+    }
+
+    pub fn pending_keys(&self) -> usize {
+        self.pending.len()
+    }
+
+    pub fn push(
+        &mut self,
+        building_id: impl Into<String>,
+        equipment_id: impl Into<String>,
+        batch: RecordBatch,
+    ) -> Result<Vec<MicroBatchFlush>> {
+        self.push_at(building_id, equipment_id, batch, Instant::now())
+    }
+
+    /// Deterministic variant used by runtimes/tests that already own a clock.
+    pub fn push_at(
+        &mut self,
+        building_id: impl Into<String>,
+        equipment_id: impl Into<String>,
+        batch: RecordBatch,
+        now: Instant,
+    ) -> Result<Vec<MicroBatchFlush>> {
+        if batch.num_rows() == 0 {
+            return Ok(Vec::new());
+        }
+
+        let key = HistorianBatchKey::new(building_id, equipment_id);
+        if let Some(existing) = self.pending.get(&key) {
+            if existing
+                .batches
+                .first()
+                .is_some_and(|first| first.schema() != batch.schema())
+            {
+                bail!(
+                    "micro-batch schema changed before flush for {}/{}",
+                    key.building_id,
+                    key.equipment_id
+                );
+            }
+        }
+
+        let rows = batch.num_rows();
+        let pending = self.pending.entry(key.clone()).or_insert_with(|| PendingBatch {
+            batches: Vec::new(),
+            rows: 0,
+            first_buffered_at: now,
+        });
+        pending.rows += rows;
+        pending.batches.push(batch);
+
+        if pending.rows >= self.flush_rows {
+            return Ok(vec![self.flush_key(&key, FlushReason::RowThreshold)?]);
+        }
+        Ok(Vec::new())
+    }
+
+    /// Flush keys whose oldest pending batch has reached the configured time
+    /// threshold. A failed write leaves that key buffered for an explicit retry.
+    pub fn flush_due(&mut self) -> Result<Vec<MicroBatchFlush>> {
+        self.flush_due_at(Instant::now())
+    }
+
+    pub fn flush_due_at(&mut self, now: Instant) -> Result<Vec<MicroBatchFlush>> {
+        let due: Vec<HistorianBatchKey> = self
+            .pending
+            .iter()
+            .filter_map(|(key, pending)| {
+                now.checked_duration_since(pending.first_buffered_at)
+                    .filter(|elapsed| *elapsed >= self.flush_after)
+                    .map(|_| key.clone())
+            })
+            .collect();
+
+        let mut reports = Vec::with_capacity(due.len());
+        for key in due {
+            reports.push(self.flush_key(&key, FlushReason::TimeThreshold)?);
+        }
+        Ok(reports)
+    }
+
+    /// Drain every pending key. The owning service should call this from its
+    /// graceful-shutdown path before terminating the process.
+    pub fn shutdown_flush(&mut self) -> Result<Vec<MicroBatchFlush>> {
+        let keys: Vec<HistorianBatchKey> = self.pending.keys().cloned().collect();
+        let mut reports = Vec::with_capacity(keys.len());
+        for key in keys {
+            reports.push(self.flush_key(&key, FlushReason::Shutdown)?);
+        }
+        Ok(reports)
+    }
+
+    fn flush_key(
+        &mut self,
+        key: &HistorianBatchKey,
+        reason: FlushReason,
+    ) -> Result<MicroBatchFlush> {
+        let pending = self
+            .pending
+            .get(key)
+            .ok_or_else(|| anyhow!("micro-batch key is not pending"))?;
+        let rows = pending.rows;
+        let combined = match pending.batches.as_slice() {
+            [only] => only.clone(),
+            batches => {
+                let schema = batches
+                    .first()
+                    .ok_or_else(|| anyhow!("pending micro-batch has no record batches"))?
+                    .schema();
+                concat_batches(&schema, batches)?
+            }
+        };
+
+        let parts = self.writer.write_history_batch(
+            &key.building_id,
+            &key.equipment_id,
+            &combined,
+        )?;
+
+        // Remove only after every immutable part was successfully published.
+        self.pending.remove(key);
+        Ok(MicroBatchFlush {
+            building_id: key.building_id.clone(),
+            equipment_id: key.equipment_id.clone(),
+            rows,
+            reason,
+            parts,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow::record_batch::RecordBatch;
+    use chrono::{DateTime, Utc};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::historian::LocalStorage;
+
+    fn batch(times: &[&str]) -> RecordBatch {
+        let timestamps: Vec<i64> = times
+            .iter()
+            .map(|raw| {
+                DateTime::parse_from_rfc3339(raw)
+                    .unwrap()
+                    .with_timezone(&Utc)
+                    .timestamp_nanos_opt()
+                    .unwrap()
+            })
+            .collect();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp_utc",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("sat", DataType::Float64, true),
+            Field::new("equipment_id", DataType::Utf8, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampNanosecondArray::from(timestamps)),
+                Arc::new(Float64Array::from(vec![Some(55.0); times.len()])),
+                Arc::new(StringArray::from(vec!["AHU_1"; times.len()])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn historian(tmp: &TempDir, flush_rows: usize, flush_after: Duration) -> MicroBatchHistorian {
+        let writer = ParquetPartWriter::new(LocalStorage::new(tmp.path()));
+        MicroBatchHistorian::new(writer, flush_rows, flush_after).unwrap()
+    }
+
+    #[test]
+    fn row_threshold_flushes_and_clears_pending_rows() {
+        let tmp = TempDir::new().unwrap();
+        let start = Instant::now();
+        let mut historian = historian(&tmp, 2, Duration::from_secs(60));
+        assert!(historian
+            .push_at(
+                "BUILDING_100",
+                "AHU_1",
+                batch(&["2026-08-20T12:00:00Z"]),
+                start,
+            )
+            .unwrap()
+            .is_empty());
+        let flushed = historian
+            .push_at(
+                "BUILDING_100",
+                "AHU_1",
+                batch(&["2026-08-20T12:05:00Z"]),
+                start + Duration::from_secs(1),
+            )
+            .unwrap();
+        assert_eq!(flushed.len(), 1);
+        assert_eq!(flushed[0].reason, FlushReason::RowThreshold);
+        assert_eq!(flushed[0].rows, 2);
+        assert_eq!(historian.pending_rows(), 0);
+        assert_eq!(flushed[0].parts.len(), 1);
+    }
+
+    #[test]
+    fn time_threshold_flushes_small_batch() {
+        let tmp = TempDir::new().unwrap();
+        let start = Instant::now();
+        let mut historian = historian(&tmp, 100, Duration::from_secs(30));
+        historian
+            .push_at(
+                "BUILDING_100",
+                "AHU_1",
+                batch(&["2026-08-20T12:00:00Z"]),
+                start,
+            )
+            .unwrap();
+        assert!(historian
+            .flush_due_at(start + Duration::from_secs(29))
+            .unwrap()
+            .is_empty());
+        let flushed = historian
+            .flush_due_at(start + Duration::from_secs(30))
+            .unwrap();
+        assert_eq!(flushed.len(), 1);
+        assert_eq!(flushed[0].reason, FlushReason::TimeThreshold);
+        assert_eq!(historian.pending_keys(), 0);
+    }
+
+    #[test]
+    fn shutdown_flush_drains_all_keys() {
+        let tmp = TempDir::new().unwrap();
+        let mut historian = historian(&tmp, 100, Duration::from_secs(60));
+        historian
+            .push(
+                "BUILDING_100",
+                "AHU_1",
+                batch(&["2026-08-20T12:00:00Z"]),
+            )
+            .unwrap();
+        historian
+            .push(
+                "BUILDING_100",
+                "AHU_2",
+                batch(&["2026-08-20T12:00:00Z"]),
+            )
+            .unwrap();
+        let flushed = historian.shutdown_flush().unwrap();
+        assert_eq!(flushed.len(), 2);
+        assert!(flushed
+            .iter()
+            .all(|report| report.reason == FlushReason::Shutdown));
+        assert_eq!(historian.pending_rows(), 0);
+    }
+
+    #[test]
+    fn schema_change_is_rejected_without_losing_pending_rows() {
+        let tmp = TempDir::new().unwrap();
+        let mut historian = historian(&tmp, 100, Duration::from_secs(60));
+        historian
+            .push(
+                "BUILDING_100",
+                "AHU_1",
+                batch(&["2026-08-20T12:00:00Z"]),
+            )
+            .unwrap();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp_utc",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("different_role", DataType::Float64, true),
+        ]));
+        let changed = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![0_i64])),
+                Arc::new(Float64Array::from(vec![Some(1.0)])),
+            ],
+        )
+        .unwrap();
+        assert!(historian
+            .push("BUILDING_100", "AHU_1", changed)
+            .is_err());
+        assert_eq!(historian.pending_rows(), 1);
+    }
+
+    #[test]
+    fn failed_flush_keeps_rows_buffered_for_retry() {
+        let tmp = TempDir::new().unwrap();
+        let mut historian = historian(&tmp, 1, Duration::from_secs(60));
+        assert!(historian
+            .push(
+                "../unsafe-building",
+                "AHU_1",
+                batch(&["2026-08-20T12:00:00Z"]),
+            )
+            .is_err());
+        assert_eq!(historian.pending_rows(), 1);
+        assert_eq!(historian.pending_keys(), 1);
+    }
+}

--- a/crates/fdd_store/src/micro_batch.rs
+++ b/crates/fdd_store/src/micro_batch.rs
@@ -242,6 +242,10 @@ mod tests {
     use crate::historian::LocalStorage;
 
     fn batch(times: &[&str]) -> RecordBatch {
+        batch_for_equipment(times, "AHU_1")
+    }
+
+    fn batch_for_equipment(times: &[&str], equipment_id: &str) -> RecordBatch {
         let timestamps: Vec<i64> = times
             .iter()
             .map(|raw| {
@@ -266,7 +270,7 @@ mod tests {
             vec![
                 Arc::new(TimestampNanosecondArray::from(timestamps)),
                 Arc::new(Float64Array::from(vec![Some(55.0); times.len()])),
-                Arc::new(StringArray::from(vec!["AHU_1"; times.len()])),
+                Arc::new(StringArray::from(vec![equipment_id; times.len()])),
             ],
         )
         .unwrap()
@@ -339,7 +343,11 @@ mod tests {
             .push("BUILDING_100", "AHU_1", batch(&["2026-08-20T12:00:00Z"]))
             .unwrap();
         historian
-            .push("BUILDING_100", "AHU_2", batch(&["2026-08-20T12:00:00Z"]))
+            .push(
+                "BUILDING_100",
+                "AHU_2",
+                batch_for_equipment(&["2026-08-20T12:00:00Z"], "AHU_2"),
+            )
             .unwrap();
         let flushed = historian.shutdown_flush().unwrap();
         assert_eq!(flushed.len(), 2);

--- a/crates/fdd_store/src/micro_batch.rs
+++ b/crates/fdd_store/src/micro_batch.rs
@@ -139,11 +139,14 @@ impl MicroBatchHistorian {
         }
 
         let rows = batch.num_rows();
-        let pending = self.pending.entry(key.clone()).or_insert_with(|| PendingBatch {
-            batches: Vec::new(),
-            rows: 0,
-            first_buffered_at: now,
-        });
+        let pending = self
+            .pending
+            .entry(key.clone())
+            .or_insert_with(|| PendingBatch {
+                batches: Vec::new(),
+                rows: 0,
+                first_buffered_at: now,
+            });
         pending.rows += rows;
         pending.batches.push(batch);
 
@@ -209,11 +212,9 @@ impl MicroBatchHistorian {
             }
         };
 
-        let parts = self.writer.write_history_batch(
-            &key.building_id,
-            &key.equipment_id,
-            &combined,
-        )?;
+        let parts =
+            self.writer
+                .write_history_batch(&key.building_id, &key.equipment_id, &combined)?;
 
         // Remove only after every immutable part was successfully published.
         self.pending.remove(key);
@@ -335,18 +336,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut historian = historian(&tmp, 100, Duration::from_secs(60));
         historian
-            .push(
-                "BUILDING_100",
-                "AHU_1",
-                batch(&["2026-08-20T12:00:00Z"]),
-            )
+            .push("BUILDING_100", "AHU_1", batch(&["2026-08-20T12:00:00Z"]))
             .unwrap();
         historian
-            .push(
-                "BUILDING_100",
-                "AHU_2",
-                batch(&["2026-08-20T12:00:00Z"]),
-            )
+            .push("BUILDING_100", "AHU_2", batch(&["2026-08-20T12:00:00Z"]))
             .unwrap();
         let flushed = historian.shutdown_flush().unwrap();
         assert_eq!(flushed.len(), 2);
@@ -361,11 +354,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut historian = historian(&tmp, 100, Duration::from_secs(60));
         historian
-            .push(
-                "BUILDING_100",
-                "AHU_1",
-                batch(&["2026-08-20T12:00:00Z"]),
-            )
+            .push("BUILDING_100", "AHU_1", batch(&["2026-08-20T12:00:00Z"]))
             .unwrap();
 
         let schema = Arc::new(Schema::new(vec![
@@ -384,9 +373,7 @@ mod tests {
             ],
         )
         .unwrap();
-        assert!(historian
-            .push("BUILDING_100", "AHU_1", changed)
-            .is_err());
+        assert!(historian.push("BUILDING_100", "AHU_1", changed).is_err());
         assert_eq!(historian.pending_rows(), 1);
     }
 

--- a/crates/fdd_store/src/parquet_parts.rs
+++ b/crates/fdd_store/src/parquet_parts.rs
@@ -242,7 +242,7 @@ fn timestamp_at(col: &ArrayRef, row: usize) -> Result<DateTime<Utc>> {
                 .as_any()
                 .downcast_ref::<$array_ty>()
                 .ok_or_else(|| anyhow!("timestamp array downcast failed"))?;
-            timestamp_from_units(a.value(row), $scale)?
+            timestamp_from_units(a.value(row), $scale)
         }};
     }
 

--- a/crates/fdd_store/src/parquet_parts.rs
+++ b/crates/fdd_store/src/parquet_parts.rs
@@ -83,7 +83,9 @@ impl ParquetPartWriter {
         validate_identity_column(batch, "equipment_id", equipment_id)?;
         for reserved in ["year", "month"] {
             if batch.schema().index_of(reserved).is_ok() {
-                bail!("canonical historian input cannot contain reserved partition column {reserved}");
+                bail!(
+                    "canonical historian input cannot contain reserved partition column {reserved}"
+                );
             }
         }
 
@@ -395,7 +397,11 @@ mod tests {
         assert!(writer
             .write_history_batch("BUILDING_100", "AHU_1", &wrong)
             .is_err());
-        assert!(writer.storage().list_recursive(Path::new("history")).unwrap().is_empty());
+        assert!(writer
+            .storage()
+            .list_recursive(Path::new("history"))
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/crates/fdd_store/src/parquet_parts.rs
+++ b/crates/fdd_store/src/parquet_parts.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
-use arrow::array::{Array, ArrayRef, UInt32Array};
+use arrow::array::{Array, ArrayRef, LargeStringArray, StringArray, UInt32Array};
 use arrow::compute::take;
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow::record_batch::RecordBatch;
@@ -64,8 +64,12 @@ impl ParquetPartWriter {
     ///
     /// The batch must have a non-null Arrow timestamp column named
     /// `timestamp_utc`. Rows are grouped by UTC year/month even when input is
-    /// unsorted. A complete Parquet byte buffer is built before publication so
-    /// the storage backend never exposes a partially written Parquet file.
+    /// unsorted. If `building_id` or `equipment_id` columns are present, every
+    /// row must agree with the trusted partition identity supplied by the caller.
+    /// Those identity columns are omitted from the physical Parquet payload so
+    /// DataFusion can expose them exactly once as Hive partition columns.
+    /// A complete Parquet byte buffer is built before publication so the storage
+    /// backend never exposes a partially written Parquet file.
     pub fn write_history_batch(
         &self,
         building_id: &str,
@@ -75,6 +79,14 @@ impl ParquetPartWriter {
         if batch.num_rows() == 0 {
             return Ok(Vec::new());
         }
+        validate_identity_column(batch, "building_id", building_id)?;
+        validate_identity_column(batch, "equipment_id", equipment_id)?;
+        for reserved in ["year", "month"] {
+            if batch.schema().index_of(reserved).is_ok() {
+                bail!("canonical historian input cannot contain reserved partition column {reserved}");
+            }
+        }
+
         let ts_idx = batch
             .schema()
             .index_of("timestamp_utc")
@@ -97,6 +109,7 @@ impl ParquetPartWriter {
         let mut out = Vec::with_capacity(groups.len());
         for ((year, month), indices) in groups {
             let subset = take_batch(batch, &indices)?;
+            let payload = partition_payload_batch(&subset)?;
             let first = indices
                 .iter()
                 .map(|i| timestamp_at(ts_col, *i as usize))
@@ -117,7 +130,7 @@ impl ParquetPartWriter {
             debug_assert_eq!(month, first.month());
             let file_name = part_name(first);
             let relative = partition.join(file_name);
-            let bytes = encode_parquet(&subset, self.row_group_rows)?;
+            let bytes = encode_parquet(&payload, self.row_group_rows)?;
             self.storage.write_atomic(&relative, &bytes)?;
             out.push(ParquetPart {
                 relative_path: slash_path(&relative),
@@ -131,6 +144,52 @@ impl ParquetPartWriter {
         }
         Ok(out)
     }
+}
+
+fn validate_identity_column(batch: &RecordBatch, name: &str, expected: &str) -> Result<()> {
+    let Ok(index) = batch.schema().index_of(name) else {
+        return Ok(());
+    };
+    let column = batch.column(index);
+    match column.data_type() {
+        DataType::Utf8 => {
+            let values = column
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| anyhow!("{name} string array downcast failed"))?;
+            for row in 0..values.len() {
+                if values.is_null(row) || values.value(row) != expected {
+                    bail!("{name} does not match canonical partition identity {expected}");
+                }
+            }
+        }
+        DataType::LargeUtf8 => {
+            let values = column
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .ok_or_else(|| anyhow!("{name} large string array downcast failed"))?;
+            for row in 0..values.len() {
+                if values.is_null(row) || values.value(row) != expected {
+                    bail!("{name} does not match canonical partition identity {expected}");
+                }
+            }
+        }
+        other => bail!("{name} must be Utf8 identity metadata when present, got {other:?}"),
+    }
+    Ok(())
+}
+
+fn partition_payload_batch(batch: &RecordBatch) -> Result<RecordBatch> {
+    let schema = batch.schema();
+    let keep: Vec<usize> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, field)| {
+            (!matches!(field.name().as_str(), "building_id" | "equipment_id")).then_some(index)
+        })
+        .collect();
+    Ok(batch.project(&keep)?)
 }
 
 fn part_name(first: DateTime<Utc>) -> String {
@@ -225,6 +284,10 @@ mod tests {
     use tempfile::TempDir;
 
     fn batch(times: &[&str]) -> RecordBatch {
+        batch_for_equipment(times, "AHU_1")
+    }
+
+    fn batch_for_equipment(times: &[&str], equipment_id: &str) -> RecordBatch {
         let ts: Vec<i64> = times
             .iter()
             .map(|raw| {
@@ -253,7 +316,7 @@ mod tests {
                         .map(|i| Some(50.0 + i as f64))
                         .collect::<Vec<_>>(),
                 )),
-                Arc::new(StringArray::from(vec!["AHU_1"; times.len()])),
+                Arc::new(StringArray::from(vec![equipment_id; times.len()])),
             ],
         )
         .unwrap()
@@ -298,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn written_part_roundtrips_timestamp_and_roles() {
+    fn written_part_roundtrips_timestamp_and_roles_without_partition_identity_columns() {
         let tmp = TempDir::new().unwrap();
         let writer = ParquetPartWriter::new(LocalStorage::new(tmp.path()));
         let parts = writer
@@ -309,15 +372,30 @@ mod tests {
             )
             .unwrap();
         let file = std::fs::File::open(tmp.path().join(&parts[0].relative_path)).unwrap();
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
             .unwrap()
             .build()
             .unwrap();
-        let rows: usize = reader.map(|b| b.unwrap().num_rows()).sum();
-        assert_eq!(rows, 2);
+        let persisted = reader.next().unwrap().unwrap();
+        assert_eq!(persisted.num_rows(), 2);
+        assert!(persisted.schema().index_of("timestamp_utc").is_ok());
+        assert!(persisted.schema().index_of("sat").is_ok());
+        assert!(persisted.schema().index_of("equipment_id").is_err());
+        assert!(persisted.schema().index_of("building_id").is_err());
         assert!(parts[0].bytes > 0);
         assert_eq!(parts[0].first_timestamp_utc, "2026-08-20T12:00:00+00:00");
         assert_eq!(parts[0].last_timestamp_utc, "2026-08-20T12:05:00+00:00");
+    }
+
+    #[test]
+    fn mismatched_identity_is_rejected_before_publish() {
+        let tmp = TempDir::new().unwrap();
+        let writer = ParquetPartWriter::new(LocalStorage::new(tmp.path()));
+        let wrong = batch_for_equipment(&["2026-08-20T12:00:00Z"], "AHU_2");
+        assert!(writer
+            .write_history_batch("BUILDING_100", "AHU_1", &wrong)
+            .is_err());
+        assert!(writer.storage().list_recursive(Path::new("history")).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/fdd_store/src/parquet_parts.rs
+++ b/crates/fdd_store/src/parquet_parts.rs
@@ -1,0 +1,355 @@
+//! Immutable canonical Parquet part writer.
+//!
+//! A RecordBatch may span calendar months. Rows are split by the UTC
+//! `timestamp_utc` column and published as complete immutable Parquet objects
+//! under the canonical monthly Hive partition. No existing part is rewritten.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use arrow::array::{Array, ArrayRef, UInt32Array};
+use arrow::compute::take;
+use arrow::datatypes::{DataType, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use chrono::{DateTime, Datelike, TimeZone, Utc};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::{EnabledStatistics, WriterProperties};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::historian::{history_partition_path, LocalStorage};
+
+pub const DEFAULT_ROW_GROUP_ROWS: usize = 65_536;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ParquetPart {
+    pub relative_path: String,
+    pub rows: usize,
+    pub bytes: usize,
+    pub year: i32,
+    pub month: u32,
+    pub first_timestamp_utc: String,
+    pub last_timestamp_utc: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParquetPartWriter {
+    storage: LocalStorage,
+    row_group_rows: usize,
+}
+
+impl ParquetPartWriter {
+    pub fn new(storage: LocalStorage) -> Self {
+        Self {
+            storage,
+            row_group_rows: DEFAULT_ROW_GROUP_ROWS,
+        }
+    }
+
+    pub fn with_row_group_rows(mut self, rows: usize) -> Result<Self> {
+        if rows == 0 {
+            bail!("row group size must be greater than zero");
+        }
+        self.row_group_rows = rows;
+        Ok(self)
+    }
+
+    pub fn storage(&self) -> &LocalStorage {
+        &self.storage
+    }
+
+    /// Write one or more immutable canonical Parquet parts.
+    ///
+    /// The batch must have a non-null Arrow timestamp column named
+    /// `timestamp_utc`. Rows are grouped by UTC year/month even when input is
+    /// unsorted. A complete Parquet byte buffer is built before publication so
+    /// the storage backend never exposes a partially written Parquet file.
+    pub fn write_history_batch(
+        &self,
+        building_id: &str,
+        equipment_id: &str,
+        batch: &RecordBatch,
+    ) -> Result<Vec<ParquetPart>> {
+        if batch.num_rows() == 0 {
+            return Ok(Vec::new());
+        }
+        let ts_idx = batch
+            .schema()
+            .index_of("timestamp_utc")
+            .context("canonical historian batch requires timestamp_utc")?;
+        let ts_col = batch.column(ts_idx);
+        ensure_timestamp_type(ts_col.data_type())?;
+
+        let mut groups: BTreeMap<(i32, u32), Vec<u32>> = BTreeMap::new();
+        for row in 0..batch.num_rows() {
+            if ts_col.is_null(row) {
+                bail!("timestamp_utc cannot be null in canonical historian batch");
+            }
+            let dt = timestamp_at(ts_col, row)?;
+            groups
+                .entry((dt.year(), dt.month()))
+                .or_default()
+                .push(u32::try_from(row).context("record batch exceeds u32 row indexing")?);
+        }
+
+        let mut out = Vec::with_capacity(groups.len());
+        for ((year, month), indices) in groups {
+            let subset = take_batch(batch, &indices)?;
+            let first = indices
+                .iter()
+                .map(|i| timestamp_at(ts_col, *i as usize))
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .min()
+                .ok_or_else(|| anyhow!("empty partition subset"))?;
+            let last = indices
+                .iter()
+                .map(|i| timestamp_at(ts_col, *i as usize))
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .max()
+                .ok_or_else(|| anyhow!("empty partition subset"))?;
+
+            let partition = history_partition_path(building_id, equipment_id, first)?;
+            debug_assert_eq!(year, first.year());
+            debug_assert_eq!(month, first.month());
+            let file_name = part_name(first);
+            let relative = partition.join(file_name);
+            let bytes = encode_parquet(&subset, self.row_group_rows)?;
+            self.storage.write_atomic(&relative, &bytes)?;
+            out.push(ParquetPart {
+                relative_path: slash_path(&relative),
+                rows: subset.num_rows(),
+                bytes: bytes.len(),
+                year,
+                month,
+                first_timestamp_utc: first.to_rfc3339(),
+                last_timestamp_utc: last.to_rfc3339(),
+            });
+        }
+        Ok(out)
+    }
+}
+
+fn part_name(first: DateTime<Utc>) -> String {
+    format!(
+        "part-{}-{}.parquet",
+        first.format("%Y%m%dT%H%M%SZ"),
+        Uuid::new_v4().simple()
+    )
+}
+
+fn slash_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn encode_parquet(batch: &RecordBatch, row_group_rows: usize) -> Result<Vec<u8>> {
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .set_statistics_enabled(EnabledStatistics::Page)
+        .set_max_row_group_size(row_group_rows)
+        .set_created_by(format!("open-fdd/{}", env!("CARGO_PKG_VERSION")))
+        .build();
+    let mut writer = ArrowWriter::try_new(Vec::new(), batch.schema(), Some(props))?;
+    writer.write(batch)?;
+    writer.into_inner().map_err(Into::into)
+}
+
+fn take_batch(batch: &RecordBatch, indices: &[u32]) -> Result<RecordBatch> {
+    let indices = UInt32Array::from(indices.to_vec());
+    let arrays: Vec<ArrayRef> = batch
+        .columns()
+        .iter()
+        .map(|col| take(col.as_ref(), &indices, None))
+        .collect::<arrow::error::Result<Vec<_>>>()?;
+    Ok(RecordBatch::try_new(batch.schema(), arrays)?)
+}
+
+fn ensure_timestamp_type(data_type: &DataType) -> Result<()> {
+    if matches!(data_type, DataType::Timestamp(_, _)) {
+        return Ok(());
+    }
+    bail!("timestamp_utc must be an Arrow Timestamp, got {data_type:?}")
+}
+
+fn timestamp_at(col: &ArrayRef, row: usize) -> Result<DateTime<Utc>> {
+    macro_rules! value {
+        ($array_ty:ty, $scale:expr) => {{
+            let a = col
+                .as_any()
+                .downcast_ref::<$array_ty>()
+                .ok_or_else(|| anyhow!("timestamp array downcast failed"))?;
+            timestamp_from_units(a.value(row), $scale)?
+        }};
+    }
+
+    use arrow::array::{
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray,
+    };
+
+    match col.data_type() {
+        DataType::Timestamp(TimeUnit::Second, _) => value!(TimestampSecondArray, 1_000_000_000_i64),
+        DataType::Timestamp(TimeUnit::Millisecond, _) => {
+            value!(TimestampMillisecondArray, 1_000_000_i64)
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, _) => {
+            value!(TimestampMicrosecondArray, 1_000_i64)
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => value!(TimestampNanosecondArray, 1_i64),
+        other => bail!("timestamp_utc must be an Arrow Timestamp, got {other:?}"),
+    }
+}
+
+fn timestamp_from_units(value: i64, nanos_per_unit: i64) -> Result<DateTime<Utc>> {
+    let nanos = value
+        .checked_mul(nanos_per_unit)
+        .ok_or_else(|| anyhow!("timestamp_utc is outside supported range"))?;
+    let secs = nanos.div_euclid(1_000_000_000);
+    let subsec = nanos.rem_euclid(1_000_000_000) as u32;
+    Utc.timestamp_opt(secs, subsec)
+        .single()
+        .ok_or_else(|| anyhow!("timestamp_utc is outside supported range"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
+    use arrow::datatypes::{Field, Schema};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use tempfile::TempDir;
+
+    fn batch(times: &[&str]) -> RecordBatch {
+        let ts: Vec<i64> = times
+            .iter()
+            .map(|raw| {
+                DateTime::parse_from_rfc3339(raw)
+                    .unwrap()
+                    .with_timezone(&Utc)
+                    .timestamp_nanos_opt()
+                    .unwrap()
+            })
+            .collect();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp_utc",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("sat", DataType::Float64, true),
+            Field::new("equipment_id", DataType::Utf8, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampNanosecondArray::from(ts)),
+                Arc::new(Float64Array::from(
+                    (0..times.len())
+                        .map(|i| Some(50.0 + i as f64))
+                        .collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(vec!["AHU_1"; times.len()])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn append_creates_new_immutable_part_each_time() {
+        let tmp = TempDir::new().unwrap();
+        let writer = ParquetPartWriter::new(LocalStorage::new(tmp.path()));
+        let first = writer
+            .write_history_batch("BUILDING_100", "AHU_1", &batch(&["2026-08-20T12:00:00Z"]))
+            .unwrap();
+        let second = writer
+            .write_history_batch("BUILDING_100", "AHU_1", &batch(&["2026-08-20T12:05:00Z"]))
+            .unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_ne!(first[0].relative_path, second[0].relative_path);
+        assert!(tmp.path().join(&first[0].relative_path).is_file());
+        assert!(tmp.path().join(&second[0].relative_path).is_file());
+    }
+
+    #[test]
+    fn batch_is_split_across_month_partitions() {
+        let tmp = TempDir::new().unwrap();
+        let writer = ParquetPartWriter::new(LocalStorage::new(tmp.path()));
+        let parts = writer
+            .write_history_batch(
+                "BUILDING_100",
+                "AHU_1",
+                &batch(&[
+                    "2026-08-31T23:55:00Z",
+                    "2026-09-01T00:00:00Z",
+                    "2026-08-01T00:00:00Z",
+                ]),
+            )
+            .unwrap();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts.iter().map(|p| p.rows).sum::<usize>(), 3);
+        assert!(parts[0].relative_path.contains("year=2026/month=08/"));
+        assert!(parts[1].relative_path.contains("year=2026/month=09/"));
+    }
+
+    #[test]
+    fn written_part_roundtrips_timestamp_and_roles() {
+        let tmp = TempDir::new().unwrap();
+        let writer = ParquetPartWriter::new(LocalStorage::new(tmp.path()));
+        let parts = writer
+            .write_history_batch(
+                "BUILDING_100",
+                "AHU_1",
+                &batch(&["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"]),
+            )
+            .unwrap();
+        let file = std::fs::File::open(tmp.path().join(&parts[0].relative_path)).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let rows: usize = reader.map(|b| b.unwrap().num_rows()).sum();
+        assert_eq!(rows, 2);
+        assert!(parts[0].bytes > 0);
+        assert_eq!(parts[0].first_timestamp_utc, "2026-08-20T12:00:00+00:00");
+        assert_eq!(parts[0].last_timestamp_utc, "2026-08-20T12:05:00+00:00");
+    }
+
+    #[test]
+    fn rejects_non_timestamp_and_null_timestamp() {
+        let tmp = TempDir::new().unwrap();
+        let writer = ParquetPartWriter::new(LocalStorage::new(tmp.path()));
+        let bad_schema = Arc::new(Schema::new(vec![Field::new(
+            "timestamp_utc",
+            DataType::Utf8,
+            false,
+        )]));
+        let bad = RecordBatch::try_new(
+            bad_schema,
+            vec![Arc::new(StringArray::from(vec!["2026-08-20T12:00:00Z"]))],
+        )
+        .unwrap();
+        assert!(writer
+            .write_history_batch("BUILDING_100", "AHU_1", &bad)
+            .is_err());
+
+        let null_schema = Arc::new(Schema::new(vec![Field::new(
+            "timestamp_utc",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        )]));
+        let null_batch = RecordBatch::try_new(
+            null_schema,
+            vec![Arc::new(TimestampNanosecondArray::from(vec![None]))],
+        )
+        .unwrap();
+        assert!(writer
+            .write_history_batch("BUILDING_100", "AHU_1", &null_batch)
+            .is_err());
+    }
+}

--- a/openfdd_agent_spec/HISTORIAN_PROGRAM.md
+++ b/openfdd_agent_spec/HISTORIAN_PROGRAM.md
@@ -29,19 +29,19 @@ The retained historian may grow toward ~1 TB, while ordinary AFDD cycles query o
 
 ### H1 — Storage contract + architecture audit
 
-- [~] PR #756 — `feat/parquet-object-historian-foundation`
-- [~] generic `OPENFDD_STORAGE_URL` (`file://`, plain local path, `s3://`)
-- [~] canonical monthly Hive partition paths
-- [~] crash-safe local backend and path-traversal guards
-- [~] historian architecture audit/documentation
-- [~] `.env.example` configuration seed
-- [~] agent architecture lock
+- [x] PR #756 — `feat/parquet-object-historian-foundation`, merged to `master` as `6d75b50e`
+- [x] generic `OPENFDD_STORAGE_URL` (`file://`, plain local path, `s3://`)
+- [x] canonical monthly Hive partition paths
+- [x] crash-safe local backend and path-traversal guards
+- [x] historian architecture audit/documentation
+- [x] `.env.example` configuration seed
+- [x] agent architecture lock
 
-Do not claim H1 complete until #756 is merged to `master` with all CI green.
+H1 merged only after its changed-head FDD, Rust stack, AppSec, docs, and security CI were green.
 
 ### H2 — Immutable partitioned Parquet writer
 
-- [~] PR #757 — `feat/partitioned-parquet-writer` (stacked on #756)
+- [~] PR #757 — `feat/partitioned-parquet-writer`, cleanly based on merged H1 / current `master`
 - [~] immutable collision-safe part names
 - [~] UTC month split for RecordBatches
 - [~] explicit Snappy compression + page statistics + bounded row groups

--- a/openfdd_agent_spec/HISTORIAN_PROGRAM.md
+++ b/openfdd_agent_spec/HISTORIAN_PROGRAM.md
@@ -47,8 +47,10 @@ H1 merged only after its changed-head FDD, Rust stack, AppSec, docs, and securit
 - [~] explicit Snappy compression + page statistics + bounded row groups
 - [~] local crash-safe publish
 - [~] append/month-boundary/round-trip/strict timestamp tests
-- [ ] micro-batch accumulator for live ingest
-- [ ] clean shutdown flush
+- [~] bounded micro-batch accumulator with per-equipment schema consistency
+- [~] row-threshold OR elapsed-time flush policy
+- [~] failed-write buffering retained for explicit retry
+- [~] clean shutdown drain through the same immutable writer
 
 ### H3 — Logical DataFusion dataset registration + query safety
 
@@ -104,8 +106,8 @@ Current Railway Storage Buckets are private S3-compatible buckets; current Railw
 
 - [ ] trace trustworthy equipment/role identity from fieldbus/MQTT metadata before mapping live points
 - [ ] no arbitrary parsing of point IDs as canonical equipment roles
-- [ ] accumulate live rows into bounded Arrow micro-batches
-- [ ] flush on row threshold OR time threshold OR shutdown
+- [ ] connect normalized live Arrow batches to the H2 micro-batch primitive
+- [ ] call elapsed-time flush from the owning runtime loop and shutdown drain on graceful exit
 - [ ] latest successfully persisted telemetry timestamp
 - [ ] stop durability-critical dependence on JSONL/Arrow-IPC snapshot rewrite
 - [ ] Feather remains optional compatibility/interchange only

--- a/openfdd_agent_spec/HISTORIAN_PROGRAM.md
+++ b/openfdd_agent_spec/HISTORIAN_PROGRAM.md
@@ -1,0 +1,168 @@
+# Historian / Railway implementation program
+
+Last updated: 2026-08-20
+
+Canonical architecture: [`docs/HISTORIAN_ARCHITECTURE.md`](docs/HISTORIAN_ARCHITECTURE.md)  
+Full audit/design: [`../docs/architecture/historian.md`](../docs/architecture/historian.md)
+
+Legend: `[x]` merged/complete · `[~]` active/partial · `[ ]` not yet merged
+
+## Goal
+
+One Open-FDD application, same FDD SQL and logical historian:
+
+```text
+small PC / IT VM                  Railway / cloud
+        |                               |
+ file:///data/openfdd              s3://<bucket>
+        |                               |
+        +-------- Parquet dataset ------+
+                         |
+                    DataFusion
+                         |
+                      FDD SQL
+```
+
+The retained historian may grow toward ~1 TB, while ordinary AFDD cycles query only relevant building/equipment/month/time windows.
+
+## Phase ledger
+
+### H1 — Storage contract + architecture audit
+
+- [~] PR #756 — `feat/parquet-object-historian-foundation`
+- [~] generic `OPENFDD_STORAGE_URL` (`file://`, plain local path, `s3://`)
+- [~] canonical monthly Hive partition paths
+- [~] crash-safe local backend and path-traversal guards
+- [~] historian architecture audit/documentation
+- [~] `.env.example` configuration seed
+- [~] agent architecture lock
+
+Do not claim H1 complete until #756 is merged to `master` with all CI green.
+
+### H2 — Immutable partitioned Parquet writer
+
+- [~] PR #757 — `feat/partitioned-parquet-writer` (stacked on #756)
+- [~] immutable collision-safe part names
+- [~] UTC month split for RecordBatches
+- [~] explicit Snappy compression + page statistics + bounded row groups
+- [~] local crash-safe publish
+- [~] append/month-boundary/round-trip/strict timestamp tests
+- [ ] micro-batch accumulator for live ingest
+- [ ] clean shutdown flush
+
+### H3 — Logical DataFusion dataset registration + query safety
+
+- [ ] register canonical dataset root instead of making `**/*.parquet` the long-term contract
+- [ ] expose Hive partition columns (`building_id`, `equipment_id`, `year`, `month`)
+- [ ] preserve legacy sidecar fallback during migration
+- [ ] partition/date pruning tests
+- [ ] schema evolution tests
+- [ ] generic interactive query row safeguard / streaming contract
+- [ ] DataFusion memory/spill configuration wiring
+
+### H4 — Compaction
+
+- [ ] identify small files partition-by-partition
+- [ ] bounded-memory replacement writer
+- [ ] publish/validate replacement before deleting inputs
+- [ ] no row loss / schema preservation / failure-safety tests
+- [ ] lightweight compaction metrics/stats
+
+### H5 — S3-compatible backend + Railway
+
+- [ ] direct generic `object_store` integration (same ecosystem used by DataFusion/Parquet)
+- [ ] AWS S3 / MinIO / Railway-compatible endpoint, region and credentials
+- [ ] virtual-hosted/path-style configuration for compatible providers
+- [ ] never log credentials
+- [ ] DataFusion object-store registration
+- [ ] optional local MinIO Compose recipe
+- [ ] Railway Storage Bucket mapping docs
+- [ ] Railway central uses bucket as canonical historian; container disk is scratch
+- [ ] Railway web remains the only public service in the minimal dashboard recipe
+
+Railway mapping target (deployment config, never Rust provider branching):
+
+```text
+OPENFDD_STORAGE_URL=s3://${{bucket.BUCKET}}
+OPENFDD_S3_ENDPOINT=${{bucket.ENDPOINT}}
+OPENFDD_S3_REGION=${{bucket.REGION}}
+OPENFDD_S3_ACCESS_KEY_ID=${{bucket.ACCESS_KEY_ID}}
+OPENFDD_S3_SECRET_ACCESS_KEY=${{bucket.SECRET_ACCESS_KEY}}
+```
+
+Current Railway Storage Buckets are private S3-compatible buckets; current Railway docs use `BUCKET`, `ENDPOINT`, `REGION`, `ACCESS_KEY_ID`, and `SECRET_ACCESS_KEY`. New buckets use virtual-hosted-style URLs by default; support should remain generic because older/other S3-compatible endpoints may use path style.
+
+### H6 — Migration + operator historian tooling
+
+- [ ] migrate legacy `building=<id>/equipment=<id>/history.parquet`
+- [ ] classify/migrate eligible legacy JSONL/Feather data without inventing identity
+- [ ] dry-run and restart-safe behavior
+- [ ] row/timestamp/equipment preservation report
+- [ ] historian stats JSON/operator command/API
+
+### H7 — Live ingest micro-batch cutover
+
+- [ ] trace trustworthy equipment/role identity from fieldbus/MQTT metadata before mapping live points
+- [ ] no arbitrary parsing of point IDs as canonical equipment roles
+- [ ] accumulate live rows into bounded Arrow micro-batches
+- [ ] flush on row threshold OR time threshold OR shutdown
+- [ ] latest successfully persisted telemetry timestamp
+- [ ] stop durability-critical dependence on JSONL/Arrow-IPC snapshot rewrite
+- [ ] Feather remains optional compatibility/interchange only
+
+### H8 — Continuous AFDD scheduler / findings / API
+
+- [ ] explicit `bulk` vs `continuous` modes
+- [ ] interval independent from rolling lookback
+- [ ] rolling end time = latest successfully persisted eligible telemetry
+- [ ] overlapping windows for late arrivals
+- [ ] persisted scheduler checkpoint
+- [ ] no overlapping cycle for same scope
+- [ ] one restart catch-up when due, no missed-tick storm
+- [ ] run-now uses same engine
+- [ ] explicit chunked historical backfill
+- [ ] finding continuity/dedup preserves existing contracts
+- [ ] building/rule failure isolation where safe
+
+Target configuration:
+
+```text
+OPENFDD_AFDD_MODE=bulk|continuous
+OPENFDD_AFDD_INTERVAL_MINUTES=60
+OPENFDD_AFDD_LOOKBACK_VALUE=24
+OPENFDD_AFDD_LOOKBACK_UNIT=hours
+```
+
+### H9 — AFDD / historian React operations UX
+
+- [ ] operating-mode status
+- [ ] frequency vs lookback visibly distinct
+- [ ] last run / analyzed-through / latest historian sample / next run
+- [ ] historian backend/size/files/small-files/compaction health
+- [ ] run AFDD now
+- [ ] recent AFDD cycles
+- [ ] stale BAS data health independent of scheduler health
+- [ ] finding first/last seen and continuity fields
+- [ ] no fake runtime controls when deployment configuration is read-only
+
+### H10 — Scale benchmarks and release qualification
+
+- [ ] deterministic synthetic historian generator
+- [ ] equipment/day, equipment/month, building/hour, monthly aggregation, weather join, representative FDD
+- [ ] continuous append + rolling AFDD workload
+- [ ] report files/partitions/bytes/rows/time/memory and pruning where measurable
+- [ ] scalable manual targets (1 GB / 10 GB / 100 GB / ~1 TB architecture validation)
+- [ ] local Docker qualification
+- [ ] optional MinIO qualification
+- [ ] Railway `:nightly` qualification
+
+## Non-negotiable gates
+
+- Do not add a traditional database as canonical historian.
+- Do not hard-code Railway in historian/FDD logic.
+- Do not produce one Parquet file per telemetry sample.
+- Do not delete legacy Feather/JSONL paths before their consumers and migration needs are audited.
+- Do not make bulk CSV import start recurring AFDD.
+- Do not rescan retained history for every continuous AFDD cycle.
+- Do not weaken auth/security or log S3 secrets.
+- Do not merge a phase until its changed-head CI and review threads are clean.

--- a/openfdd_agent_spec/HISTORIAN_PROGRAM.md
+++ b/openfdd_agent_spec/HISTORIAN_PROGRAM.md
@@ -45,6 +45,8 @@ H1 merged only after its changed-head FDD, Rust stack, AppSec, docs, and securit
 - [~] immutable collision-safe part names
 - [~] UTC month split for RecordBatches
 - [~] explicit Snappy compression + page statistics + bounded row groups
+- [~] validate optional `building_id` / `equipment_id` batch identity against the trusted partition path
+- [~] omit identity columns from physical Parquet so H3 can expose them exactly once as Hive partition columns
 - [~] local crash-safe publish
 - [~] append/month-boundary/round-trip/strict timestamp tests
 - [~] bounded micro-batch accumulator with per-equipment schema consistency


### PR DESCRIPTION
## Scope
Phase 2 on the merged H1 storage foundation (#756).

- add an immutable `ParquetPartWriter` for canonical local historian storage
- split an Arrow `RecordBatch` by UTC year/month even when input rows are unsorted
- publish each complete part under `history/building_id=.../equipment_id=.../year=.../month=...`
- use collision-safe `part-<utc>-<uuid>.parquet` names; never rewrite an existing part
- explicitly use Snappy compression, page statistics, a bounded 65,536-row row-group target, and Open-FDD writer metadata
- validate any `building_id` / `equipment_id` values already present in an input batch against the trusted partition identity
- omit those identity columns from the physical Parquet payload so H3/DataFusion can expose them exactly once as Hive partition columns
- reject reserved `year` / `month` payload columns rather than creating ambiguous duplicate partition metadata
- reject missing/non-Arrow/null canonical timestamps
- reuse the H1 crash-safe local storage publication path
- add a transport-agnostic per-building/equipment Arrow micro-batch accumulator
- flush on row threshold or elapsed-time threshold without spawning hidden tasks
- retain pending rows when a write fails so the caller can retry explicitly
- provide an explicit graceful-shutdown drain through the same immutable writer
- keep `openfdd_agent_spec/HISTORIAN_PROGRAM.md` synchronized with merged/active phase truth

## Tests
- repeated append creates different immutable files
- one batch crossing a month boundary creates two partitions without row loss
- Parquet part round-trips timestamps/roles while keeping Hive identity out of the file payload
- mismatched partition identity is rejected before publish
- invalid/null timestamp batches fail clearly
- row-threshold and time-threshold micro-batch flush
- shutdown flush drains multiple equipment keys
- schema changes are rejected without losing pending rows
- failed writes retain buffered rows

## Non-goals
No live MQTT cutover, no compaction, no DataFusion registration change, no S3 calls. H7 will connect trusted normalized live telemetry to the H2 batching primitive after the storage/query phases are proven.

## Branch hygiene
The branch was rebuilt directly on merged H1/master after #756 squash-merged, so this PR contains only H2 changes rather than replaying H1 history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added historian micro-batching for grouping, validating, and flushing incoming data by building and equipment.
  * Added automatic flushes based on row limits, elapsed time, or shutdown.
  * Added immutable Parquet file writing with timestamp validation, monthly partitioning, compression, and metadata reporting.
  * Added retry-safe handling for failed writes and schema mismatches.
* **Documentation**
  * Added the historian implementation roadmap, including storage, deployment, migration, operations, and scaling plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->