### PR TITLE
Add historian migration and operator tooling

### DIFF
--- a/crates/fdd_cli/src/main.rs
+++ b/crates/fdd_cli/src/main.rs
@@ -11,13 +11,16 @@ use fdd_sql::{
     new_historian_session, register_parquet_tree, run_sql_file_bounded,
     DEFAULT_INTERACTIVE_MAX_ROWS,
 };
-use fdd_store::{ingest_building, HistorianConfig};
+use fdd_store::{
+    discover_legacy_historian, ingest_building, local_historian_stats, migrate_legacy_parquet,
+    HistorianConfig, LocalStorage,
+};
 use inventory::write_inventory;
 
 #[derive(Parser)]
 #[command(
     name = "fdd_cli",
-    about = "Open-FDD CLI — validate, ingest, query, run-rules, compare, benchmark"
+    about = "Open-FDD CLI — validate, ingest, query, historian ops, run-rules, compare, benchmark"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -48,6 +51,26 @@ enum Commands {
         building: String,
         #[arg(long, default_value = ".cache/parquet")]
         out: PathBuf,
+    },
+    /// Inventory legacy historian files without writing canonical data
+    HistorianDryRun {
+        #[arg(long)]
+        legacy_root: PathBuf,
+    },
+    /// Migrate eligible legacy history.parquet files into canonical monthly parts
+    HistorianMigrate {
+        #[arg(long)]
+        legacy_root: PathBuf,
+        #[arg(long)]
+        canonical_root: PathBuf,
+    },
+    /// Report lightweight local canonical historian health/statistics as JSON
+    HistorianStats {
+        #[arg(long)]
+        canonical_root: PathBuf,
+        /// Small-file threshold in MiB; defaults to OPENFDD_PARQUET_TARGET_FILE_MB's default.
+        #[arg(long)]
+        target_file_mb: Option<u64>,
     },
     /// Run a DataFusion SQL file against Parquet
     Query {
@@ -124,6 +147,28 @@ async fn main() -> Result<()> {
             out,
         } => {
             let report = ingest_building(&data_root, &building, &out)?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        Commands::HistorianDryRun { legacy_root } => {
+            let report = discover_legacy_historian(&legacy_root)?.dry_run_report();
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        Commands::HistorianMigrate {
+            legacy_root,
+            canonical_root,
+        } => {
+            let storage = LocalStorage::new(canonical_root);
+            let report = migrate_legacy_parquet(&legacy_root, &storage)?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        Commands::HistorianStats {
+            canonical_root,
+            target_file_mb,
+        } => {
+            let storage = LocalStorage::new(canonical_root);
+            let target_file_mb =
+                target_file_mb.unwrap_or(fdd_store::historian::DEFAULT_TARGET_FILE_MB);
+            let report = local_historian_stats(&storage, target_file_mb)?;
             println!("{}", serde_json::to_string_pretty(&report)?);
         }
         Commands::Query { parquet, sql_file } => {

--- a/crates/fdd_cli/src/main.rs
+++ b/crates/fdd_cli/src/main.rs
@@ -12,7 +12,7 @@ use fdd_sql::{
     DEFAULT_INTERACTIVE_MAX_ROWS,
 };
 use fdd_store::{
-    discover_legacy_historian, ingest_building, local_historian_stats, migrate_legacy_parquet,
+    discover_legacy_historian, ingest_building, local_historian_stats, migrate_legacy_historian,
     HistorianConfig, LocalStorage,
 };
 use inventory::write_inventory;
@@ -57,7 +57,7 @@ enum Commands {
         #[arg(long)]
         legacy_root: PathBuf,
     },
-    /// Migrate eligible legacy history.parquet files into canonical monthly parts
+    /// Migrate eligible legacy Parquet/JSONL/Arrow files into canonical monthly parts
     HistorianMigrate {
         #[arg(long)]
         legacy_root: PathBuf,
@@ -158,7 +158,7 @@ async fn main() -> Result<()> {
             canonical_root,
         } => {
             let storage = LocalStorage::new(canonical_root);
-            let report = migrate_legacy_parquet(&legacy_root, &storage)?;
+            let report = migrate_legacy_historian(&legacy_root, &storage)?;
             println!("{}", serde_json::to_string_pretty(&report)?);
         }
         Commands::HistorianStats {

--- a/crates/fdd_sql/src/lib.rs
+++ b/crates/fdd_sql/src/lib.rs
@@ -39,13 +39,11 @@ pub async fn register_parquet_tree(ctx: &SessionContext, parquet_root: &Path) ->
         if matches!(StorageUrl::parse(&raw)?, StorageUrl::S3 { .. }) {
             let config = HistorianConfig::from_env()?;
             let building_id = object_store::building_scope_from_compat_path(parquet_root)
-                .ok_or_else(|| anyhow!("S3 historian compatibility registration requires a building scope"))?;
-            object_store::register_configured_historian_scoped(
-                ctx,
-                &config,
-                Some(building_id),
-            )
-            .await?;
+                .ok_or_else(|| {
+                    anyhow!("S3 historian compatibility registration requires a building scope")
+                })?;
+            object_store::register_configured_historian_scoped(ctx, &config, Some(building_id))
+                .await?;
             return Ok(1);
         }
     }

--- a/crates/fdd_sql/src/lib.rs
+++ b/crates/fdd_sql/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use datafusion::prelude::SessionContext;
 use fdd_store::{HistorianConfig, StorageUrl};
 
@@ -31,13 +31,21 @@ pub use tuning::{historian_session_config_from_env, DataFusionTuning};
 /// Existing local callers remain path-driven. When `OPENFDD_STORAGE_URL`
 /// explicitly selects S3, an existing `building=<id>` compatibility marker is
 /// translated into a canonical object-store prefix before DataFusion discovers
-/// files, avoiding unrelated-building object listings.
+/// files, avoiding unrelated-building object listings. Compatibility callers may
+/// not fall back to unscoped whole-bucket history; explicit global/operator S3
+/// queries must use `register_configured_historian` directly.
 pub async fn register_parquet_tree(ctx: &SessionContext, parquet_root: &Path) -> Result<usize> {
     if let Ok(raw) = std::env::var("OPENFDD_STORAGE_URL") {
         if matches!(StorageUrl::parse(&raw)?, StorageUrl::S3 { .. }) {
             let config = HistorianConfig::from_env()?;
-            let building_id = object_store::building_scope_from_compat_path(parquet_root);
-            object_store::register_configured_historian_scoped(ctx, &config, building_id).await?;
+            let building_id = object_store::building_scope_from_compat_path(parquet_root)
+                .ok_or_else(|| anyhow!("S3 historian compatibility registration requires a building scope"))?;
+            object_store::register_configured_historian_scoped(
+                ctx,
+                &config,
+                Some(building_id),
+            )
+            .await?;
             return Ok(1);
         }
     }

--- a/crates/fdd_store/src/legacy_formats.rs
+++ b/crates/fdd_store/src/legacy_formats.rs
@@ -1,0 +1,436 @@
+//! Bounded readers for legacy historian formats eligible for H6 migration.
+//!
+//! Path identity is established by `migration`; this module only converts file
+//! contents into Arrow batches. Ambiguous timestamps, mixed JSON scalar types,
+//! nested JSON values, and non-timestamp IPC schemas fail closed rather than
+//! silently dropping or inventing data.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, StringArray, TimestampNanosecondArray,
+};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::ipc::reader::FileReader;
+use arrow::record_batch::RecordBatch;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use serde_json::{Map, Value};
+
+use crate::migration::LegacyHistorianFormat;
+use crate::parquet_parts::DEFAULT_ROW_GROUP_ROWS;
+
+const JSON_BATCH_ROWS: usize = 5_000;
+
+pub(crate) fn for_each_legacy_batch<F>(
+    path: &Path,
+    format: LegacyHistorianFormat,
+    mut on_batch: F,
+) -> Result<u64>
+where
+    F: FnMut(RecordBatch) -> Result<()>,
+{
+    match format {
+        LegacyHistorianFormat::Parquet => for_each_parquet_batch(path, &mut on_batch),
+        LegacyHistorianFormat::Jsonl => for_each_jsonl_batch(path, &mut on_batch),
+        LegacyHistorianFormat::Feather => for_each_ipc_batch(path, &mut on_batch),
+    }
+}
+
+fn for_each_parquet_batch<F>(path: &Path, on_batch: &mut F) -> Result<u64>
+where
+    F: FnMut(RecordBatch) -> Result<()>,
+{
+    let file =
+        fs::File::open(path).with_context(|| format!("open legacy Parquet {}", path.display()))?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        .context("read legacy Parquet metadata")?
+        .with_batch_size(DEFAULT_ROW_GROUP_ROWS)
+        .build()
+        .context("build legacy Parquet batch reader")?;
+    let mut rows = 0u64;
+    for batch in reader {
+        let batch = batch.context("read legacy Parquet batch")?;
+        rows = checked_add_rows(rows, batch.num_rows())?;
+        on_batch(batch)?;
+    }
+    Ok(rows)
+}
+
+fn for_each_ipc_batch<F>(path: &Path, on_batch: &mut F) -> Result<u64>
+where
+    F: FnMut(RecordBatch) -> Result<()>,
+{
+    let file = fs::File::open(path)
+        .with_context(|| format!("open legacy Arrow/Feather {}", path.display()))?;
+    let reader = FileReader::try_new(file, None).context("open legacy Arrow IPC/Feather file")?;
+    let mut rows = 0u64;
+    for batch in reader {
+        let batch = normalize_ipc_timestamp(batch.context("read legacy Arrow IPC batch")?)?;
+        rows = checked_add_rows(rows, batch.num_rows())?;
+        on_batch(batch)?;
+    }
+    Ok(rows)
+}
+
+fn normalize_ipc_timestamp(batch: RecordBatch) -> Result<RecordBatch> {
+    let schema = batch.schema();
+    let timestamp_utc = schema.index_of("timestamp_utc").ok();
+    let timestamp = schema.index_of("timestamp").ok();
+    match (timestamp_utc, timestamp) {
+        (Some(_), Some(_)) => bail!(
+            "legacy Arrow IPC cannot contain both timestamp and timestamp_utc"
+        ),
+        (Some(index), None) => {
+            ensure_arrow_timestamp(batch.column(index).data_type())?;
+            Ok(batch)
+        }
+        (None, Some(index)) => {
+            ensure_arrow_timestamp(batch.column(index).data_type())?;
+            let fields = schema
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(field_index, field)| {
+                    if field_index == index {
+                        Arc::new(Field::new(
+                            "timestamp_utc",
+                            field.data_type().clone(),
+                            field.is_nullable(),
+                        ))
+                    } else {
+                        field.clone()
+                    }
+                })
+                .collect::<Vec<_>>();
+            Ok(RecordBatch::try_new(
+                Arc::new(Schema::new(fields)),
+                batch.columns().to_vec(),
+            )?)
+        }
+        (None, None) => bail!("legacy Arrow IPC requires timestamp or timestamp_utc"),
+    }
+}
+
+fn ensure_arrow_timestamp(data_type: &DataType) -> Result<()> {
+    if matches!(data_type, DataType::Timestamp(_, _)) {
+        return Ok(());
+    }
+    bail!("legacy Arrow IPC timestamp must be an Arrow Timestamp, got {data_type:?}")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JsonKind {
+    Float64,
+    Utf8,
+    Boolean,
+}
+
+fn for_each_jsonl_batch<F>(path: &Path, on_batch: &mut F) -> Result<u64>
+where
+    F: FnMut(RecordBatch) -> Result<()>,
+{
+    let schema = infer_json_schema(path)?;
+    let file =
+        fs::File::open(path).with_context(|| format!("open legacy JSONL {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut pending = Vec::with_capacity(JSON_BATCH_ROWS);
+    let mut rows = 0u64;
+
+    for (line_index, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let row = parse_json_object(&line, line_index + 1)?;
+        validate_json_timestamp(&row, line_index + 1)?;
+        pending.push(row);
+        if pending.len() >= JSON_BATCH_ROWS {
+            rows = checked_add_rows(rows, pending.len())?;
+            on_batch(json_batch(&schema, &pending)?)?;
+            pending.clear();
+        }
+    }
+    if !pending.is_empty() {
+        rows = checked_add_rows(rows, pending.len())?;
+        on_batch(json_batch(&schema, &pending)?)?;
+    }
+    Ok(rows)
+}
+
+fn infer_json_schema(path: &Path) -> Result<BTreeMap<String, JsonKind>> {
+    let file =
+        fs::File::open(path).with_context(|| format!("open legacy JSONL {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut schema = BTreeMap::new();
+    for (line_index, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let row = parse_json_object(&line, line_index + 1)?;
+        validate_json_timestamp(&row, line_index + 1)?;
+        for (name, value) in &row {
+            if matches!(name.as_str(), "timestamp" | "timestamp_utc") || value.is_null() {
+                continue;
+            }
+            let kind = match value {
+                Value::Number(number) if number.as_f64().is_some() => JsonKind::Float64,
+                Value::String(_) => JsonKind::Utf8,
+                Value::Bool(_) => JsonKind::Boolean,
+                Value::Number(_) => bail!(
+                    "legacy JSONL numeric value is outside Float64 range at line {}",
+                    line_index + 1
+                ),
+                Value::Array(_) | Value::Object(_) => bail!(
+                    "legacy JSONL nested value for {name} is not supported at line {}",
+                    line_index + 1
+                ),
+                Value::Null => continue,
+            };
+            if let Some(existing) = schema.get(name) {
+                if *existing != kind {
+                    bail!(
+                        "legacy JSONL field {name} changes scalar type at line {}",
+                        line_index + 1
+                    );
+                }
+            } else {
+                schema.insert(name.clone(), kind);
+            }
+        }
+    }
+    Ok(schema)
+}
+
+fn parse_json_object(line: &str, line_number: usize) -> Result<Map<String, Value>> {
+    let value: Value = serde_json::from_str(line)
+        .with_context(|| format!("parse legacy JSONL line {line_number}"))?;
+    value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| anyhow!("legacy JSONL line {line_number} must be an object"))
+}
+
+fn validate_json_timestamp(row: &Map<String, Value>, line_number: usize) -> Result<i64> {
+    let timestamp_utc =
+        json_timestamp_value(row.get("timestamp_utc"), "timestamp_utc", line_number)?;
+    let timestamp = json_timestamp_value(row.get("timestamp"), "timestamp", line_number)?;
+    match (timestamp_utc, timestamp) {
+        (Some(left), Some(right)) if left != right => {
+            bail!("legacy JSONL timestamp and timestamp_utc conflict at line {line_number}")
+        }
+        (Some(value), _) | (_, Some(value)) => Ok(value),
+        (None, None) => bail!("legacy JSONL line {line_number} has no timestamp"),
+    }
+}
+
+fn json_timestamp_value(
+    value: Option<&Value>,
+    name: &str,
+    line_number: usize,
+) -> Result<Option<i64>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let raw = value
+        .as_str()
+        .ok_or_else(|| anyhow!("legacy JSONL {name} must be a string at line {line_number}"))?;
+    parse_timestamp_nanos(raw)
+        .map(Some)
+        .ok_or_else(|| anyhow!("invalid legacy JSONL {name} at line {line_number}"))
+}
+
+fn parse_timestamp_nanos(raw: &str) -> Option<i64> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(raw) {
+        return timestamp.with_timezone(&Utc).timestamp_nanos_opt();
+    }
+    for format in [
+        "%m/%d/%Y %H:%M",
+        "%m/%d/%Y %H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%dT%H:%M:%S",
+    ] {
+        if let Ok(timestamp) = NaiveDateTime::parse_from_str(raw, format) {
+            return DateTime::<Utc>::from_naive_utc_and_offset(timestamp, Utc).timestamp_nanos_opt();
+        }
+    }
+    None
+}
+
+fn json_batch(
+    schema: &BTreeMap<String, JsonKind>,
+    rows: &[Map<String, Value>],
+) -> Result<RecordBatch> {
+    let timestamps = rows
+        .iter()
+        .enumerate()
+        .map(|(index, row)| validate_json_timestamp(row, index + 1))
+        .collect::<Result<Vec<_>>>()?;
+    let mut fields = vec![Field::new(
+        "timestamp_utc",
+        DataType::Timestamp(TimeUnit::Nanosecond, None),
+        false,
+    )];
+    let mut arrays: Vec<ArrayRef> = vec![Arc::new(TimestampNanosecondArray::from(timestamps))];
+
+    for (name, kind) in schema {
+        match kind {
+            JsonKind::Float64 => {
+                fields.push(Field::new(name, DataType::Float64, true));
+                let values = rows
+                    .iter()
+                    .map(|row| match row.get(name) {
+                        None | Some(Value::Null) => Ok(None),
+                        Some(Value::Number(number)) => number.as_f64().map(Some).ok_or_else(|| {
+                            anyhow!("legacy JSONL field {name} is outside Float64 range")
+                        }),
+                        Some(_) => bail!("legacy JSONL field {name} changed scalar type"),
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                arrays.push(Arc::new(Float64Array::from(values)));
+            }
+            JsonKind::Utf8 => {
+                fields.push(Field::new(name, DataType::Utf8, true));
+                let values = rows
+                    .iter()
+                    .map(|row| match row.get(name) {
+                        None | Some(Value::Null) => Ok(None),
+                        Some(Value::String(value)) => Ok(Some(value.as_str())),
+                        Some(_) => bail!("legacy JSONL field {name} changed scalar type"),
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                arrays.push(Arc::new(StringArray::from(values)));
+            }
+            JsonKind::Boolean => {
+                fields.push(Field::new(name, DataType::Boolean, true));
+                let values = rows
+                    .iter()
+                    .map(|row| match row.get(name) {
+                        None | Some(Value::Null) => Ok(None),
+                        Some(Value::Bool(value)) => Ok(Some(*value)),
+                        Some(_) => bail!("legacy JSONL field {name} changed scalar type"),
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                arrays.push(Arc::new(BooleanArray::from(values)));
+            }
+        }
+    }
+
+    Ok(RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)?)
+}
+
+fn checked_add_rows(current: u64, rows: usize) -> Result<u64> {
+    current
+        .checked_add(u64::try_from(rows).context("legacy batch row count overflow")?)
+        .ok_or_else(|| anyhow!("legacy source row count overflow"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+    use arrow::ipc::writer::FileWriter;
+    use tempfile::TempDir;
+
+    #[test]
+    fn jsonl_conversion_preserves_scalar_columns_and_normalizes_timestamp() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("history.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"timestamp\":\"2026-08-20T12:00:00Z\",\"equipment_id\":\"AHU_1\",\"sat\":55.0,\"source\":\"bacnet\",\"is_simulated\":false}\n",
+                "{\"timestamp\":\"2026-08-20T12:05:00Z\",\"equipment_id\":\"AHU_1\",\"sat\":56.0,\"source\":\"bacnet\",\"is_simulated\":false}\n"
+            ),
+        )
+        .unwrap();
+        let mut batches = Vec::new();
+        let rows = for_each_legacy_batch(&path, LegacyHistorianFormat::Jsonl, |batch| {
+            batches.push(batch);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(rows, 2);
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 2);
+        assert!(matches!(
+            batch
+                .schema()
+                .field_with_name("timestamp_utc")
+                .unwrap()
+                .data_type(),
+            DataType::Timestamp(_, _)
+        ));
+        assert_eq!(batch.column_by_name("sat").unwrap().len(), 2);
+        assert_eq!(batch.column_by_name("source").unwrap().len(), 2);
+        assert_eq!(batch.column_by_name("is_simulated").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn mixed_json_scalar_type_fails_closed() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("history.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"timestamp\":\"2026-08-20T12:00:00Z\",\"sat\":55.0}\n",
+                "{\"timestamp\":\"2026-08-20T12:05:00Z\",\"sat\":\"bad\"}\n"
+            ),
+        )
+        .unwrap();
+        let error = for_each_legacy_batch(&path, LegacyHistorianFormat::Jsonl, |_| Ok(()))
+            .unwrap_err();
+        assert!(error.to_string().contains("changes scalar type"));
+    }
+
+    #[test]
+    fn arrow_ipc_timestamp_is_renamed_without_row_loss() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("history.arrow");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("equipment_id", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(arrow::array::TimestampMillisecondArray::from(vec![
+                    1_i64, 2_i64,
+                ])),
+                Arc::new(StringArray::from(vec!["AHU_1", "AHU_1"])),
+            ],
+        )
+        .unwrap();
+        let file = fs::File::create(&path).unwrap();
+        let mut writer = FileWriter::try_new(file, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+
+        let mut output = Vec::new();
+        let rows = for_each_legacy_batch(&path, LegacyHistorianFormat::Feather, |batch| {
+            output.push(batch);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(rows, 2);
+        assert_eq!(output.len(), 1);
+        assert!(output[0].schema().index_of("timestamp_utc").is_ok());
+        assert!(output[0].schema().index_of("timestamp").is_err());
+    }
+}

--- a/crates/fdd_store/src/legacy_formats.rs
+++ b/crates/fdd_store/src/legacy_formats.rs
@@ -12,9 +12,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
-use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, StringArray, TimestampNanosecondArray,
-};
+use arrow::array::{ArrayRef, BooleanArray, Float64Array, StringArray, TimestampNanosecondArray};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::ipc::reader::FileReader;
 use arrow::record_batch::RecordBatch;
@@ -83,9 +81,9 @@ fn normalize_ipc_timestamp(batch: RecordBatch) -> Result<RecordBatch> {
     let timestamp_utc = schema.index_of("timestamp_utc").ok();
     let timestamp = schema.index_of("timestamp").ok();
     match (timestamp_utc, timestamp) {
-        (Some(_), Some(_)) => bail!(
-            "legacy Arrow IPC cannot contain both timestamp and timestamp_utc"
-        ),
+        (Some(_), Some(_)) => {
+            bail!("legacy Arrow IPC cannot contain both timestamp and timestamp_utc")
+        }
         (Some(index), None) => {
             ensure_arrow_timestamp(batch.column(index).data_type())?;
             Ok(batch)
@@ -262,7 +260,8 @@ fn parse_timestamp_nanos(raw: &str) -> Option<i64> {
         "%Y-%m-%dT%H:%M:%S",
     ] {
         if let Ok(timestamp) = NaiveDateTime::parse_from_str(raw, format) {
-            return DateTime::<Utc>::from_naive_utc_and_offset(timestamp, Utc).timestamp_nanos_opt();
+            return DateTime::<Utc>::from_naive_utc_and_offset(timestamp, Utc)
+                .timestamp_nanos_opt();
         }
     }
     None
@@ -390,8 +389,8 @@ mod tests {
             ),
         )
         .unwrap();
-        let error = for_each_legacy_batch(&path, LegacyHistorianFormat::Jsonl, |_| Ok(()))
-            .unwrap_err();
+        let error =
+            for_each_legacy_batch(&path, LegacyHistorianFormat::Jsonl, |_| Ok(())).unwrap_err();
         assert!(error.to_string().contains("changes scalar type"));
     }
 

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ingest;
 pub mod meta;
 pub mod micro_batch;
 pub mod migration;
+pub mod migration_exec;
 pub mod parquet_parts;
 
 pub use append::{merge_history_wide_csv, merge_history_wide_text, MergeReport};
@@ -21,5 +22,9 @@ pub use micro_batch::{FlushReason, HistorianBatchKey, MicroBatchFlush, MicroBatc
 pub use migration::{
     discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat,
     MigrationDryRunReport, MigrationInventory,
+};
+pub use migration_exec::{
+    migrate_legacy_parquet, MigrationPart, MigrationRunReport, MigrationSourceReport,
+    MigrationSourceStatus,
 };
 pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -9,6 +9,7 @@ pub mod micro_batch;
 pub mod migration;
 pub mod migration_exec;
 pub mod parquet_parts;
+pub mod stats;
 
 pub use append::{merge_history_wide_csv, merge_history_wide_text, MergeReport};
 pub use compaction::{CompactionPlan, CompactionResult, CompactionSummary, ParquetCompactor};
@@ -28,3 +29,4 @@ pub use migration_exec::{
     MigrationSourceStatus,
 };
 pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};
+pub use stats::{local_historian_stats, local_historian_stats_from_config, HistorianStats};

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -6,6 +6,7 @@ pub mod historian;
 pub mod ingest;
 pub mod meta;
 pub mod micro_batch;
+pub mod migration;
 pub mod parquet_parts;
 
 pub use append::{merge_history_wide_csv, merge_history_wide_text, MergeReport};
@@ -17,4 +18,8 @@ pub use historian::{
 pub use ingest::{ingest_building, ingest_building_with_batch_hook, IngestReport, IngestTiming};
 pub use meta::SidecarMeta;
 pub use micro_batch::{FlushReason, HistorianBatchKey, MicroBatchFlush, MicroBatchHistorian};
+pub use migration::{
+    discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat, MigrationDryRunReport,
+    MigrationInventory,
+};
 pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -19,7 +19,7 @@ pub use ingest::{ingest_building, ingest_building_with_batch_hook, IngestReport,
 pub use meta::SidecarMeta;
 pub use micro_batch::{FlushReason, HistorianBatchKey, MicroBatchFlush, MicroBatchHistorian};
 pub use migration::{
-    discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat, MigrationDryRunReport,
-    MigrationInventory,
+    discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat,
+    MigrationDryRunReport, MigrationInventory,
 };
 pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -4,6 +4,7 @@ pub mod append;
 pub mod compaction;
 pub mod historian;
 pub mod ingest;
+pub(crate) mod legacy_formats;
 pub mod meta;
 pub mod micro_batch;
 pub mod migration;
@@ -25,8 +26,8 @@ pub use migration::{
     MigrationDryRunReport, MigrationInventory,
 };
 pub use migration_exec::{
-    migrate_legacy_parquet, MigrationPart, MigrationRunReport, MigrationSourceReport,
-    MigrationSourceStatus,
+    migrate_legacy_historian, migrate_legacy_parquet, MigrationPart, MigrationRunReport,
+    MigrationSourceReport, MigrationSourceStatus,
 };
 pub use parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};
 pub use stats::{local_historian_stats, local_historian_stats_from_config, HistorianStats};

--- a/crates/fdd_store/src/migration.rs
+++ b/crates/fdd_store/src/migration.rs
@@ -7,7 +7,7 @@
 //! and pass the same partition-value validation used by the canonical writer.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde::Serialize;

--- a/crates/fdd_store/src/migration.rs
+++ b/crates/fdd_store/src/migration.rs
@@ -1,0 +1,293 @@
+//! Legacy historian migration discovery and dry-run planning.
+//!
+//! H6 must never invent building/equipment identity while converting old
+//! historian artifacts into the canonical monthly Hive layout. This module is
+//! deliberately conservative: a source is eligible only when both identities
+//! are present as trusted legacy path segments (`building=<id>/equipment=<id>`)
+//! and pass the same partition-value validation used by the canonical writer.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::safe_partition_value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacyHistorianFormat {
+    Parquet,
+    Jsonl,
+    Feather,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LegacyHistorianCandidate {
+    pub path: String,
+    pub format: LegacyHistorianFormat,
+    pub building_id: Option<String>,
+    pub equipment_id: Option<String>,
+    pub eligible: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MigrationInventory {
+    pub root: String,
+    pub candidates: Vec<LegacyHistorianCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MigrationDryRunReport {
+    pub root: String,
+    pub recognized_files: usize,
+    pub eligible_files: usize,
+    pub parquet_files: usize,
+    pub jsonl_files: usize,
+    pub feather_files: usize,
+    pub candidates: Vec<LegacyHistorianCandidate>,
+}
+
+impl MigrationInventory {
+    pub fn dry_run_report(&self) -> MigrationDryRunReport {
+        let mut parquet_files = 0usize;
+        let mut jsonl_files = 0usize;
+        let mut feather_files = 0usize;
+        let mut eligible_files = 0usize;
+        for candidate in &self.candidates {
+            match candidate.format {
+                LegacyHistorianFormat::Parquet => parquet_files += 1,
+                LegacyHistorianFormat::Jsonl => jsonl_files += 1,
+                LegacyHistorianFormat::Feather => feather_files += 1,
+            }
+            if candidate.eligible {
+                eligible_files += 1;
+            }
+        }
+        MigrationDryRunReport {
+            root: self.root.clone(),
+            recognized_files: self.candidates.len(),
+            eligible_files,
+            parquet_files,
+            jsonl_files,
+            feather_files,
+            candidates: self.candidates.clone(),
+        }
+    }
+}
+
+/// Discover legacy historian artifacts recursively without reading their data.
+///
+/// Recognized source formats are Parquet, JSONL/NDJSON, and Feather/Arrow IPC.
+/// Eligibility is intentionally stricter than recognition: both trusted legacy
+/// identity path segments must be present and safe, and legacy Parquet must use
+/// the historical `history.parquet` filename. JSONL/Feather sources are merely
+/// classified here; their content conversion is a later H6 step.
+pub fn discover_legacy_historian(root: &Path) -> Result<MigrationInventory> {
+    let mut candidates = Vec::new();
+    if root.exists() {
+        walk(root, &mut candidates)?;
+    }
+    candidates.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(MigrationInventory {
+        root: root.display().to_string(),
+        candidates,
+    })
+}
+
+fn walk(dir: &Path, out: &mut Vec<LegacyHistorianCandidate>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            walk(&path, out)?;
+            continue;
+        }
+        if let Some(candidate) = classify_file(&path) {
+            out.push(candidate);
+        }
+    }
+    Ok(())
+}
+
+fn classify_file(path: &Path) -> Option<LegacyHistorianCandidate> {
+    let format = format_from_path(path)?;
+    let (building_id, equipment_id, identity_reason) = legacy_identity(path);
+    let parquet_name_ok = format != LegacyHistorianFormat::Parquet
+        || path.file_name().and_then(|v| v.to_str()) == Some("history.parquet");
+
+    let reason = if let Some(reason) = identity_reason {
+        Some(reason)
+    } else if !parquet_name_ok {
+        Some("legacy Parquet candidate must be named history.parquet".to_string())
+    } else {
+        None
+    };
+
+    Some(LegacyHistorianCandidate {
+        path: path.display().to_string(),
+        format,
+        building_id,
+        equipment_id,
+        eligible: reason.is_none(),
+        reason,
+    })
+}
+
+fn format_from_path(path: &Path) -> Option<LegacyHistorianFormat> {
+    let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+    match extension.as_str() {
+        "parquet" => Some(LegacyHistorianFormat::Parquet),
+        "jsonl" | "ndjson" => Some(LegacyHistorianFormat::Jsonl),
+        "feather" | "arrow" | "ipc" => Some(LegacyHistorianFormat::Feather),
+        _ => None,
+    }
+}
+
+fn legacy_identity(path: &Path) -> (Option<String>, Option<String>, Option<String>) {
+    let mut building: Option<String> = None;
+    let mut equipment: Option<String> = None;
+    for component in path.ancestors().flat_map(Path::file_name) {
+        let Some(segment) = component.to_str() else {
+            continue;
+        };
+        if let Some(value) = segment.strip_prefix("building=") {
+            match safe_partition_value(value, "building_id") {
+                Ok(value) => {
+                    if building.as_deref().is_some_and(|existing| existing != value) {
+                        return (
+                            None,
+                            None,
+                            Some("conflicting legacy building path identity".to_string()),
+                        );
+                    }
+                    building = Some(value);
+                }
+                Err(_) => {
+                    return (
+                        None,
+                        None,
+                        Some("unsafe legacy building path identity".to_string()),
+                    )
+                }
+            }
+        }
+        if let Some(value) = segment.strip_prefix("equipment=") {
+            match safe_partition_value(value, "equipment_id") {
+                Ok(value) => {
+                    if equipment.as_deref().is_some_and(|existing| existing != value) {
+                        return (
+                            None,
+                            None,
+                            Some("conflicting legacy equipment path identity".to_string()),
+                        );
+                    }
+                    equipment = Some(value);
+                }
+                Err(_) => {
+                    return (
+                        None,
+                        None,
+                        Some("unsafe legacy equipment path identity".to_string()),
+                    )
+                }
+            }
+        }
+    }
+
+    if building.is_none() || equipment.is_none() {
+        return (
+            building,
+            equipment,
+            Some("missing trusted building/equipment legacy path identity".to_string()),
+        );
+    }
+    (building, equipment, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn touch(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"").unwrap();
+    }
+
+    #[test]
+    fn discovers_trusted_legacy_parquet_identity() {
+        let tmp = TempDir::new().unwrap();
+        let history = tmp
+            .path()
+            .join("building=BLDG_1/equipment=AHU_1/history.parquet");
+        touch(&history);
+
+        let inventory = discover_legacy_historian(tmp.path()).unwrap();
+        assert_eq!(inventory.candidates.len(), 1);
+        let candidate = &inventory.candidates[0];
+        assert_eq!(candidate.format, LegacyHistorianFormat::Parquet);
+        assert_eq!(candidate.building_id.as_deref(), Some("BLDG_1"));
+        assert_eq!(candidate.equipment_id.as_deref(), Some("AHU_1"));
+        assert!(candidate.eligible);
+    }
+
+    #[test]
+    fn jsonl_and_feather_are_classified_only_with_path_identity() {
+        let tmp = TempDir::new().unwrap();
+        touch(&tmp.path().join("building=BLDG_1/equipment=AHU_1/history.jsonl"));
+        touch(&tmp.path().join("orphan/history.feather"));
+
+        let report = discover_legacy_historian(tmp.path())
+            .unwrap()
+            .dry_run_report();
+        assert_eq!(report.recognized_files, 2);
+        assert_eq!(report.jsonl_files, 1);
+        assert_eq!(report.feather_files, 1);
+        assert_eq!(report.eligible_files, 1);
+        assert!(report
+            .candidates
+            .iter()
+            .any(|candidate| !candidate.eligible && candidate.equipment_id.is_none()));
+    }
+
+    #[test]
+    fn unsafe_or_conflicting_identity_never_becomes_eligible() {
+        let tmp = TempDir::new().unwrap();
+        touch(
+            &tmp.path()
+                .join("building=BLDG_1/building=BLDG_2/equipment=AHU_1/history.parquet"),
+        );
+        touch(
+            &tmp.path()
+                .join("building=BLDG=BAD/equipment=AHU_2/history.parquet"),
+        );
+
+        let inventory = discover_legacy_historian(tmp.path()).unwrap();
+        assert_eq!(inventory.candidates.len(), 2);
+        assert!(inventory.candidates.iter().all(|candidate| !candidate.eligible));
+    }
+
+    #[test]
+    fn non_history_parquet_is_not_eligible_for_legacy_migration() {
+        let tmp = TempDir::new().unwrap();
+        touch(
+            &tmp.path()
+                .join("building=BLDG_1/equipment=AHU_1/other.parquet"),
+        );
+        let inventory = discover_legacy_historian(tmp.path()).unwrap();
+        assert_eq!(inventory.candidates.len(), 1);
+        assert!(!inventory.candidates[0].eligible);
+        assert!(inventory.candidates[0]
+            .reason
+            .as_deref()
+            .unwrap()
+            .contains("history.parquet"));
+    }
+}

--- a/crates/fdd_store/src/migration.rs
+++ b/crates/fdd_store/src/migration.rs
@@ -160,7 +160,10 @@ fn legacy_identity(path: &Path) -> (Option<String>, Option<String>, Option<Strin
         if let Some(value) = segment.strip_prefix("building=") {
             match safe_partition_value(value, "building_id") {
                 Ok(value) => {
-                    if building.as_deref().is_some_and(|existing| existing != value) {
+                    if building
+                        .as_deref()
+                        .is_some_and(|existing| existing != value)
+                    {
                         return (
                             None,
                             None,
@@ -181,7 +184,10 @@ fn legacy_identity(path: &Path) -> (Option<String>, Option<String>, Option<Strin
         if let Some(value) = segment.strip_prefix("equipment=") {
             match safe_partition_value(value, "equipment_id") {
                 Ok(value) => {
-                    if equipment.as_deref().is_some_and(|existing| existing != value) {
+                    if equipment
+                        .as_deref()
+                        .is_some_and(|existing| existing != value)
+                    {
                         return (
                             None,
                             None,
@@ -241,7 +247,10 @@ mod tests {
     #[test]
     fn jsonl_and_feather_are_classified_only_with_path_identity() {
         let tmp = TempDir::new().unwrap();
-        touch(&tmp.path().join("building=BLDG_1/equipment=AHU_1/history.jsonl"));
+        touch(
+            &tmp.path()
+                .join("building=BLDG_1/equipment=AHU_1/history.jsonl"),
+        );
         touch(&tmp.path().join("orphan/history.feather"));
 
         let report = discover_legacy_historian(tmp.path())
@@ -271,7 +280,10 @@ mod tests {
 
         let inventory = discover_legacy_historian(tmp.path()).unwrap();
         assert_eq!(inventory.candidates.len(), 2);
-        assert!(inventory.candidates.iter().all(|candidate| !candidate.eligible));
+        assert!(inventory
+            .candidates
+            .iter()
+            .all(|candidate| !candidate.eligible));
     }
 
     #[test]

--- a/crates/fdd_store/src/migration_exec.rs
+++ b/crates/fdd_store/src/migration_exec.rs
@@ -1,0 +1,631 @@
+//! Restart-safe execution for H6 legacy historian migration.
+//!
+//! Eligible legacy Parquet sources are read in bounded Arrow batches and written
+//! into a staging tree that is not query-visible. An atomic receipt records the
+//! exact canonical publish plan before any staged part is renamed into `history/`.
+//! If migration stops mid-publish, rerunning resumes that exact plan instead of
+//! producing duplicate canonical parts.
+
+use std::fs;
+use std::io::{BufReader, Read};
+use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::historian::LocalStorage;
+use crate::migration::{discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat};
+use crate::parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};
+
+const RECEIPT_VERSION: u32 = 1;
+const METADATA_DIR: &str = ".openfdd-migration";
+const HASH_BUFFER_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationSourceStatus {
+    Migrated,
+    Resumed,
+    AlreadyMigrated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationPart {
+    pub relative_path: String,
+    pub rows: usize,
+    pub bytes: usize,
+    pub year: i32,
+    pub month: u32,
+    pub first_timestamp_utc: String,
+    pub last_timestamp_utc: String,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MigrationSourceReport {
+    pub source_path: String,
+    pub source_relative_path: String,
+    pub building_id: String,
+    pub equipment_id: String,
+    pub source_sha256: String,
+    pub source_size_bytes: u64,
+    pub source_rows: u64,
+    pub canonical_rows: u64,
+    pub status: MigrationSourceStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_timestamp_utc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_timestamp_utc: Option<String>,
+    pub parts: Vec<MigrationPart>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MigrationRunReport {
+    pub source_root: String,
+    pub destination_root: String,
+    pub eligible_parquet_sources: usize,
+    pub migrated_sources: usize,
+    pub resumed_sources: usize,
+    pub already_migrated_sources: usize,
+    pub source_rows_verified: u64,
+    pub canonical_rows_verified: u64,
+    pub parts_verified: usize,
+    pub sources: Vec<MigrationSourceReport>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ReceiptState {
+    Staged,
+    Complete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Receipt {
+    version: u32,
+    state: ReceiptState,
+    source_relative_path: String,
+    source_sha256: String,
+    source_size_bytes: u64,
+    source_modified_unix_seconds: u64,
+    building_id: String,
+    equipment_id: String,
+    source_rows: u64,
+    canonical_rows: u64,
+    parts: Vec<MigrationPart>,
+}
+
+#[derive(Debug, Clone)]
+struct SourceFingerprint {
+    size_bytes: u64,
+    modified: SystemTime,
+    modified_unix_seconds: u64,
+    sha256: String,
+}
+
+/// Migrate every eligible legacy `building=<id>/equipment=<id>/history.parquet`
+/// source under `source_root` into canonical monthly Parquet parts.
+///
+/// The destination must be local canonical storage. This command is intended for
+/// explicit operator/offline migration, not concurrent live ingest.
+pub fn migrate_legacy_parquet(
+    source_root: &Path,
+    destination: &LocalStorage,
+) -> Result<MigrationRunReport> {
+    let inventory = discover_legacy_historian(source_root)?;
+    let candidates: Vec<_> = inventory
+        .candidates
+        .into_iter()
+        .filter(|candidate| {
+            candidate.eligible && candidate.format == LegacyHistorianFormat::Parquet
+        })
+        .collect();
+
+    let mut sources = Vec::with_capacity(candidates.len());
+    for candidate in &candidates {
+        sources.push(migrate_candidate(source_root, destination, candidate)?);
+    }
+
+    Ok(MigrationRunReport {
+        source_root: source_root.display().to_string(),
+        destination_root: destination.root().display().to_string(),
+        eligible_parquet_sources: candidates.len(),
+        migrated_sources: count_status(&sources, MigrationSourceStatus::Migrated),
+        resumed_sources: count_status(&sources, MigrationSourceStatus::Resumed),
+        already_migrated_sources: count_status(
+            &sources,
+            MigrationSourceStatus::AlreadyMigrated,
+        ),
+        source_rows_verified: sources.iter().map(|source| source.source_rows).sum(),
+        canonical_rows_verified: sources.iter().map(|source| source.canonical_rows).sum(),
+        parts_verified: sources.iter().map(|source| source.parts.len()).sum(),
+        sources,
+    })
+}
+
+fn count_status(sources: &[MigrationSourceReport], status: MigrationSourceStatus) -> usize {
+    sources.iter().filter(|source| source.status == status).count()
+}
+
+fn migrate_candidate(
+    source_root: &Path,
+    destination: &LocalStorage,
+    candidate: &LegacyHistorianCandidate,
+) -> Result<MigrationSourceReport> {
+    let building_id = candidate
+        .building_id
+        .as_deref()
+        .ok_or_else(|| anyhow!("eligible migration candidate is missing building identity"))?;
+    let equipment_id = candidate
+        .equipment_id
+        .as_deref()
+        .ok_or_else(|| anyhow!("eligible migration candidate is missing equipment identity"))?;
+    let source_path = PathBuf::from(&candidate.path);
+    let source_relative_path = slash_path(
+        source_path
+            .strip_prefix(source_root)
+            .context("legacy migration candidate escaped discovery root")?,
+    );
+    let migration_id = migration_id(&source_relative_path, building_id, equipment_id);
+    let receipt_path = receipt_path(&migration_id);
+    let fingerprint = fingerprint_source(&source_path)?;
+
+    if destination.exists(&receipt_path)? {
+        let mut receipt: Receipt = serde_json::from_slice(&destination.read(&receipt_path)?)
+            .context("parse historian migration receipt")?;
+        validate_receipt(
+            &receipt,
+            &source_relative_path,
+            building_id,
+            equipment_id,
+            &fingerprint,
+        )?;
+        return match receipt.state {
+            ReceiptState::Complete => {
+                verify_published_parts(destination, &receipt.parts)?;
+                Ok(report_from_receipt(
+                    &source_path,
+                    receipt,
+                    MigrationSourceStatus::AlreadyMigrated,
+                ))
+            }
+            ReceiptState::Staged => {
+                let staging_root = staging_root(destination, &migration_id);
+                publish_staged_parts(destination, &staging_root, &receipt.parts)?;
+                receipt.state = ReceiptState::Complete;
+                write_receipt(destination, &receipt_path, &receipt)?;
+                verify_published_parts(destination, &receipt.parts)?;
+                Ok(report_from_receipt(
+                    &source_path,
+                    receipt,
+                    MigrationSourceStatus::Resumed,
+                ))
+            }
+        };
+    }
+
+    let staging_root = staging_root(destination, &migration_id);
+    if staging_root.exists() {
+        fs::remove_dir_all(&staging_root)
+            .with_context(|| format!("clear stale migration staging {}", staging_root.display()))?;
+    }
+    fs::create_dir_all(&staging_root)?;
+
+    let writer = ParquetPartWriter::new(LocalStorage::new(&staging_root));
+    let source_file = fs::File::open(&source_path)
+        .with_context(|| format!("open legacy Parquet {}", source_path.display()))?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(source_file)
+        .context("read legacy Parquet metadata")?
+        .with_batch_size(DEFAULT_ROW_GROUP_ROWS)
+        .build()
+        .context("build legacy Parquet batch reader")?;
+
+    let mut source_rows = 0u64;
+    let mut canonical_rows = 0u64;
+    let mut parts = Vec::new();
+    for batch in reader {
+        let batch = batch.context("read legacy Parquet batch")?;
+        source_rows += batch.num_rows() as u64;
+        let written = writer
+            .write_history_batch(building_id, equipment_id, &batch)
+            .with_context(|| format!("migrate legacy batch from {}", source_path.display()))?;
+        let batch_rows = written.iter().map(|part| part.rows as u64).sum::<u64>();
+        if batch_rows != batch.num_rows() as u64 {
+            bail!(
+                "legacy migration row mismatch for {}: source batch {} != canonical {}",
+                source_relative_path,
+                batch.num_rows(),
+                batch_rows
+            );
+        }
+        canonical_rows += batch_rows;
+        for part in written {
+            parts.push(migration_part(&staging_root, part)?);
+        }
+    }
+
+    if source_rows != canonical_rows {
+        bail!(
+            "legacy migration row mismatch for {}: source {} != canonical {}",
+            source_relative_path,
+            source_rows,
+            canonical_rows
+        );
+    }
+    ensure_source_unchanged(&source_path, &fingerprint)?;
+
+    let mut receipt = Receipt {
+        version: RECEIPT_VERSION,
+        state: ReceiptState::Staged,
+        source_relative_path,
+        source_sha256: fingerprint.sha256.clone(),
+        source_size_bytes: fingerprint.size_bytes,
+        source_modified_unix_seconds: fingerprint.modified_unix_seconds,
+        building_id: building_id.to_string(),
+        equipment_id: equipment_id.to_string(),
+        source_rows,
+        canonical_rows,
+        parts,
+    };
+
+    write_receipt(destination, &receipt_path, &receipt)?;
+    publish_staged_parts(destination, &staging_root, &receipt.parts)?;
+    receipt.state = ReceiptState::Complete;
+    write_receipt(destination, &receipt_path, &receipt)?;
+    verify_published_parts(destination, &receipt.parts)?;
+
+    Ok(report_from_receipt(
+        &source_path,
+        receipt,
+        MigrationSourceStatus::Migrated,
+    ))
+}
+
+fn fingerprint_source(path: &Path) -> Result<SourceFingerprint> {
+    let before = fs::metadata(path).with_context(|| format!("stat {}", path.display()))?;
+    let modified = before.modified()?;
+    let sha256 = file_sha256(path)?;
+    let after = fs::metadata(path).with_context(|| format!("restat {}", path.display()))?;
+    if before.len() != after.len() || modified != after.modified()? {
+        bail!("legacy source changed while fingerprinting {}", path.display());
+    }
+    Ok(SourceFingerprint {
+        size_bytes: before.len(),
+        modified,
+        modified_unix_seconds: modified.duration_since(UNIX_EPOCH)?.as_secs(),
+        sha256,
+    })
+}
+
+fn ensure_source_unchanged(path: &Path, fingerprint: &SourceFingerprint) -> Result<()> {
+    let metadata = fs::metadata(path).with_context(|| format!("restat {}", path.display()))?;
+    if metadata.len() != fingerprint.size_bytes || metadata.modified()? != fingerprint.modified {
+        bail!("legacy source changed during migration {}", path.display());
+    }
+    Ok(())
+}
+
+fn migration_id(source_relative_path: &str, building_id: &str, equipment_id: &str) -> String {
+    let mut hash = Sha256::new();
+    hash.update(b"openfdd-h6-migration\0");
+    hash.update(source_relative_path.as_bytes());
+    hash.update(b"\0");
+    hash.update(building_id.as_bytes());
+    hash.update(b"\0");
+    hash.update(equipment_id.as_bytes());
+    format!("{:x}", hash.finalize())
+}
+
+fn receipt_path(migration_id: &str) -> PathBuf {
+    PathBuf::from(METADATA_DIR)
+        .join("receipts")
+        .join(format!("{migration_id}.json"))
+}
+
+fn staging_root(destination: &LocalStorage, migration_id: &str) -> PathBuf {
+    destination
+        .root()
+        .join(METADATA_DIR)
+        .join("staging")
+        .join(migration_id)
+}
+
+fn migration_part(staging_root: &Path, part: ParquetPart) -> Result<MigrationPart> {
+    let staged_path = validated_part_path(staging_root, &part.relative_path)?;
+    Ok(MigrationPart {
+        relative_path: part.relative_path,
+        rows: part.rows,
+        bytes: part.bytes,
+        year: part.year,
+        month: part.month,
+        first_timestamp_utc: part.first_timestamp_utc,
+        last_timestamp_utc: part.last_timestamp_utc,
+        sha256: file_sha256(&staged_path)?,
+    })
+}
+
+fn validate_receipt(
+    receipt: &Receipt,
+    source_relative_path: &str,
+    building_id: &str,
+    equipment_id: &str,
+    fingerprint: &SourceFingerprint,
+) -> Result<()> {
+    if receipt.version != RECEIPT_VERSION {
+        bail!("unsupported historian migration receipt version");
+    }
+    if receipt.source_relative_path != source_relative_path
+        || receipt.building_id != building_id
+        || receipt.equipment_id != equipment_id
+    {
+        bail!("historian migration receipt identity mismatch");
+    }
+    if receipt.source_size_bytes != fingerprint.size_bytes
+        || receipt.source_sha256 != fingerprint.sha256
+    {
+        bail!(
+            "legacy source changed since migration receipt was created: {}",
+            source_relative_path
+        );
+    }
+    if receipt.source_rows != receipt.canonical_rows {
+        bail!("historian migration receipt contains a row preservation mismatch");
+    }
+    Ok(())
+}
+
+fn write_receipt(destination: &LocalStorage, path: &Path, receipt: &Receipt) -> Result<()> {
+    destination.write_atomic(path, &serde_json::to_vec_pretty(receipt)?)
+}
+
+fn publish_staged_parts(
+    destination: &LocalStorage,
+    staging_root: &Path,
+    parts: &[MigrationPart],
+) -> Result<()> {
+    for part in parts {
+        let canonical = validated_part_path(destination.root(), &part.relative_path)?;
+        let staged = validated_part_path(staging_root, &part.relative_path)?;
+        if canonical.exists() {
+            verify_file(&canonical, part)?;
+            if staged.exists() {
+                verify_file(&staged, part)?;
+                fs::remove_file(&staged)?;
+            }
+            continue;
+        }
+        if !staged.is_file() {
+            bail!("migration publish plan lost staged part {}", part.relative_path);
+        }
+        verify_file(&staged, part)?;
+        let parent = canonical
+            .parent()
+            .ok_or_else(|| anyhow!("canonical migration part has no parent"))?;
+        fs::create_dir_all(parent)?;
+        fs::rename(&staged, &canonical).with_context(|| {
+            format!(
+                "publish staged historian part {} -> {}",
+                staged.display(),
+                canonical.display()
+            )
+        })?;
+    }
+    if staging_root.exists() {
+        fs::remove_dir_all(staging_root)?;
+    }
+    Ok(())
+}
+
+fn verify_published_parts(destination: &LocalStorage, parts: &[MigrationPart]) -> Result<()> {
+    for part in parts {
+        let path = validated_part_path(destination.root(), &part.relative_path)?;
+        if !path.is_file() {
+            bail!("migrated historian part is missing: {}", part.relative_path);
+        }
+        verify_file(&path, part)?;
+    }
+    Ok(())
+}
+
+fn verify_file(path: &Path, part: &MigrationPart) -> Result<()> {
+    if fs::metadata(path)?.len() != part.bytes as u64 {
+        bail!("migrated historian part size mismatch: {}", path.display());
+    }
+    if file_sha256(path)? != part.sha256 {
+        bail!("migrated historian part hash mismatch: {}", path.display());
+    }
+    Ok(())
+}
+
+fn validated_part_path(root: &Path, relative_path: &str) -> Result<PathBuf> {
+    let relative = Path::new(relative_path);
+    if relative.is_absolute() {
+        bail!("migration part path must be relative");
+    }
+    let mut components = relative.components();
+    match components.next() {
+        Some(Component::Normal(first)) if first.to_str() == Some("history") => {}
+        _ => bail!("migration part must remain inside canonical history/"),
+    }
+    if components.any(|component| !matches!(component, Component::Normal(_))) {
+        bail!("migration part contains unsafe path components");
+    }
+    Ok(root.join(relative))
+}
+
+fn file_sha256(path: &Path) -> Result<String> {
+    let file = fs::File::open(path).with_context(|| format!("open {} for hashing", path.display()))?;
+    let mut reader = BufReader::with_capacity(HASH_BUFFER_BYTES, file);
+    let mut buffer = vec![0u8; HASH_BUFFER_BYTES];
+    let mut hash = Sha256::new();
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hash.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hash.finalize()))
+}
+
+fn report_from_receipt(
+    source_path: &Path,
+    receipt: Receipt,
+    status: MigrationSourceStatus,
+) -> MigrationSourceReport {
+    let first_timestamp_utc = receipt
+        .parts
+        .iter()
+        .map(|part| part.first_timestamp_utc.as_str())
+        .min()
+        .map(ToOwned::to_owned);
+    let last_timestamp_utc = receipt
+        .parts
+        .iter()
+        .map(|part| part.last_timestamp_utc.as_str())
+        .max()
+        .map(ToOwned::to_owned);
+    MigrationSourceReport {
+        source_path: source_path.display().to_string(),
+        source_relative_path: receipt.source_relative_path,
+        building_id: receipt.building_id,
+        equipment_id: receipt.equipment_id,
+        source_sha256: receipt.source_sha256,
+        source_size_bytes: receipt.source_size_bytes,
+        source_rows: receipt.source_rows,
+        canonical_rows: receipt.canonical_rows,
+        status,
+        first_timestamp_utc,
+        last_timestamp_utc,
+        parts: receipt.parts,
+    }
+}
+
+fn slash_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use arrow::array::{Float64Array, TimestampNanosecondArray};
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow::record_batch::RecordBatch;
+    use chrono::{DateTime, Utc};
+    use parquet::arrow::ArrowWriter;
+    use tempfile::TempDir;
+
+    fn write_legacy_parquet(path: &Path, times: &[&str]) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let timestamps = times
+            .iter()
+            .map(|raw| {
+                DateTime::parse_from_rfc3339(raw)
+                    .unwrap()
+                    .with_timezone(&Utc)
+                    .timestamp_nanos_opt()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp_utc",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("sat", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampNanosecondArray::from(timestamps)),
+                Arc::new(Float64Array::from(
+                    (0..times.len())
+                        .map(|index| Some(50.0 + index as f64))
+                        .collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap();
+        let file = fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    fn legacy_path(root: &Path) -> PathBuf {
+        root.join("building=BLDG_1/equipment=AHU_1/history.parquet")
+    }
+
+    #[test]
+    fn preserves_rows_and_month_partitions() {
+        let source = TempDir::new().unwrap();
+        let destination = TempDir::new().unwrap();
+        write_legacy_parquet(
+            &legacy_path(source.path()),
+            &[
+                "2026-08-31T23:55:00Z",
+                "2026-09-01T00:00:00Z",
+                "2026-08-01T00:00:00Z",
+            ],
+        );
+        let storage = LocalStorage::new(destination.path());
+
+        let report = migrate_legacy_parquet(source.path(), &storage).unwrap();
+        assert_eq!(report.migrated_sources, 1);
+        assert_eq!(report.source_rows_verified, 3);
+        assert_eq!(report.canonical_rows_verified, 3);
+        assert_eq!(report.parts_verified, 2);
+        assert!(report.sources[0]
+            .parts
+            .iter()
+            .any(|part| part.relative_path.contains("year=2026/month=08/")));
+        assert!(report.sources[0]
+            .parts
+            .iter()
+            .any(|part| part.relative_path.contains("year=2026/month=09/")));
+    }
+
+    #[test]
+    fn completed_receipt_makes_rerun_idempotent() {
+        let source = TempDir::new().unwrap();
+        let destination = TempDir::new().unwrap();
+        write_legacy_parquet(
+            &legacy_path(source.path()),
+            &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"],
+        );
+        let storage = LocalStorage::new(destination.path());
+
+        let first = migrate_legacy_parquet(source.path(), &storage).unwrap();
+        let files_before = storage.list_recursive(Path::new("history")).unwrap();
+        let second = migrate_legacy_parquet(source.path(), &storage).unwrap();
+        let files_after = storage.list_recursive(Path::new("history")).unwrap();
+
+        assert_eq!(first.migrated_sources, 1);
+        assert_eq!(second.already_migrated_sources, 1);
+        assert_eq!(files_before.len(), files_after.len());
+        assert_eq!(first.sources[0].parts, second.sources[0].parts);
+    }
+
+    #[test]
+    fn changed_source_after_receipt_fails_closed() {
+        let source = TempDir::new().unwrap();
+        let destination = TempDir::new().unwrap();
+        let history = legacy_path(source.path());
+        write_legacy_parquet(&history, &["2026-08-20T12:00:00Z"]);
+        let storage = LocalStorage::new(destination.path());
+        migrate_legacy_parquet(source.path(), &storage).unwrap();
+
+        write_legacy_parquet(
+            &history,
+            &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"],
+        );
+        let error = migrate_legacy_parquet(source.path(), &storage).unwrap_err();
+        assert!(error.to_string().contains("changed since migration receipt"));
+    }
+}

--- a/crates/fdd_store/src/migration_exec.rs
+++ b/crates/fdd_store/src/migration_exec.rs
@@ -553,7 +553,9 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use arrow::array::{Float64Array, StringArray, TimestampMillisecondArray, TimestampNanosecondArray};
+    use arrow::array::{
+        Float64Array, StringArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    };
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use arrow::ipc::writer::FileWriter;
     use arrow::record_batch::RecordBatch;
@@ -696,10 +698,7 @@ mod tests {
         let storage = LocalStorage::new(destination.path());
         migrate_legacy_parquet(source.path(), &storage).unwrap();
 
-        write_legacy_parquet(
-            &history,
-            &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"],
-        );
+        write_legacy_parquet(&history, &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"]);
         let error = migrate_legacy_parquet(source.path(), &storage).unwrap_err();
         assert!(error
             .to_string()

--- a/crates/fdd_store/src/migration_exec.rs
+++ b/crates/fdd_store/src/migration_exec.rs
@@ -1,8 +1,8 @@
 //! Restart-safe execution for H6 legacy historian migration.
 //!
-//! Eligible legacy Parquet sources are read in bounded Arrow batches and written
-//! into a staging tree that is not query-visible. An atomic receipt records the
-//! exact canonical publish plan before any staged part is renamed into `history/`.
+//! Eligible legacy sources are read in bounded Arrow batches and written into a
+//! staging tree that is not query-visible. An atomic receipt records the exact
+//! canonical publish plan before any staged part is renamed into `history/`.
 //! If migration stops mid-publish, rerunning resumes that exact plan instead of
 //! producing duplicate canonical parts.
 
@@ -12,15 +12,15 @@ use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail, Context, Result};
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::historian::LocalStorage;
+use crate::legacy_formats::for_each_legacy_batch;
 use crate::migration::{
     discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat,
 };
-use crate::parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};
+use crate::parquet_parts::{ParquetPart, ParquetPartWriter};
 
 const RECEIPT_VERSION: u32 = 1;
 const METADATA_DIR: &str = ".openfdd-migration";
@@ -68,7 +68,10 @@ pub struct MigrationSourceReport {
 pub struct MigrationRunReport {
     pub source_root: String,
     pub destination_root: String,
+    pub eligible_sources: usize,
     pub eligible_parquet_sources: usize,
+    pub eligible_jsonl_sources: usize,
+    pub eligible_feather_sources: usize,
     pub migrated_sources: usize,
     pub resumed_sources: usize,
     pub already_migrated_sources: usize,
@@ -108,33 +111,58 @@ struct SourceFingerprint {
     sha256: String,
 }
 
-/// Migrate every eligible legacy `building=<id>/equipment=<id>/history.parquet`
-/// source under `source_root` into canonical monthly Parquet parts.
+/// Migrate every eligible legacy historian source under `source_root`.
 ///
-/// The destination must be local canonical storage. This command is intended for
-/// explicit operator/offline migration, not concurrent live ingest.
+/// Parquet, JSONL/NDJSON, and Arrow IPC/Feather candidates all use the same
+/// trusted path identity and restart-safe publish protocol. The destination must
+/// be local canonical storage. This is an explicit offline/operator operation,
+/// not a concurrent live-ingest path.
+pub fn migrate_legacy_historian(
+    source_root: &Path,
+    destination: &LocalStorage,
+) -> Result<MigrationRunReport> {
+    let inventory = discover_legacy_historian(source_root)?;
+    let candidates = inventory
+        .candidates
+        .into_iter()
+        .filter(|candidate| candidate.eligible)
+        .collect::<Vec<_>>();
+    migrate_candidates(source_root, destination, &candidates)
+}
+
+/// Compatibility helper for callers that intentionally want only legacy Parquet.
 pub fn migrate_legacy_parquet(
     source_root: &Path,
     destination: &LocalStorage,
 ) -> Result<MigrationRunReport> {
     let inventory = discover_legacy_historian(source_root)?;
-    let candidates: Vec<_> = inventory
+    let candidates = inventory
         .candidates
         .into_iter()
         .filter(|candidate| {
             candidate.eligible && candidate.format == LegacyHistorianFormat::Parquet
         })
-        .collect();
+        .collect::<Vec<_>>();
+    migrate_candidates(source_root, destination, &candidates)
+}
 
+fn migrate_candidates(
+    source_root: &Path,
+    destination: &LocalStorage,
+    candidates: &[LegacyHistorianCandidate],
+) -> Result<MigrationRunReport> {
     let mut sources = Vec::with_capacity(candidates.len());
-    for candidate in &candidates {
+    for candidate in candidates {
         sources.push(migrate_candidate(source_root, destination, candidate)?);
     }
 
     Ok(MigrationRunReport {
         source_root: source_root.display().to_string(),
         destination_root: destination.root().display().to_string(),
-        eligible_parquet_sources: candidates.len(),
+        eligible_sources: candidates.len(),
+        eligible_parquet_sources: count_format(candidates, LegacyHistorianFormat::Parquet),
+        eligible_jsonl_sources: count_format(candidates, LegacyHistorianFormat::Jsonl),
+        eligible_feather_sources: count_format(candidates, LegacyHistorianFormat::Feather),
         migrated_sources: count_status(&sources, MigrationSourceStatus::Migrated),
         resumed_sources: count_status(&sources, MigrationSourceStatus::Resumed),
         already_migrated_sources: count_status(&sources, MigrationSourceStatus::AlreadyMigrated),
@@ -143,6 +171,13 @@ pub fn migrate_legacy_parquet(
         parts_verified: sources.iter().map(|source| source.parts.len()).sum(),
         sources,
     })
+}
+
+fn count_format(candidates: &[LegacyHistorianCandidate], format: LegacyHistorianFormat) -> usize {
+    candidates
+        .iter()
+        .filter(|candidate| candidate.format == format)
+        .count()
 }
 
 fn count_status(sources: &[MigrationSourceReport], status: MigrationSourceStatus) -> usize {
@@ -217,24 +252,17 @@ fn migrate_candidate(
     fs::create_dir_all(&staging_root)?;
 
     let writer = ParquetPartWriter::new(LocalStorage::new(&staging_root));
-    let source_file = fs::File::open(&source_path)
-        .with_context(|| format!("open legacy Parquet {}", source_path.display()))?;
-    let reader = ParquetRecordBatchReaderBuilder::try_new(source_file)
-        .context("read legacy Parquet metadata")?
-        .with_batch_size(DEFAULT_ROW_GROUP_ROWS)
-        .build()
-        .context("build legacy Parquet batch reader")?;
-
-    let mut source_rows = 0u64;
     let mut canonical_rows = 0u64;
     let mut parts = Vec::new();
-    for batch in reader {
-        let batch = batch.context("read legacy Parquet batch")?;
-        source_rows += batch.num_rows() as u64;
+    let source_rows = for_each_legacy_batch(&source_path, candidate.format, |batch| {
         let written = writer
             .write_history_batch(building_id, equipment_id, &batch)
             .with_context(|| format!("migrate legacy batch from {}", source_path.display()))?;
-        let batch_rows = written.iter().map(|part| part.rows as u64).sum::<u64>();
+        let batch_rows = written.iter().try_fold(0u64, |total, part| {
+            total
+                .checked_add(u64::try_from(part.rows).context("canonical part row overflow")?)
+                .ok_or_else(|| anyhow!("canonical migration row count overflow"))
+        })?;
         if batch_rows != batch.num_rows() as u64 {
             bail!(
                 "legacy migration row mismatch for {}: source batch {} != canonical {}",
@@ -243,11 +271,14 @@ fn migrate_candidate(
                 batch_rows
             );
         }
-        canonical_rows += batch_rows;
+        canonical_rows = canonical_rows
+            .checked_add(batch_rows)
+            .ok_or_else(|| anyhow!("canonical migration row count overflow"))?;
         for part in written {
             parts.push(migration_part(&staging_root, part)?);
         }
-    }
+        Ok(())
+    })?;
 
     if source_rows != canonical_rows {
         bail!(
@@ -522,8 +553,9 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use arrow::array::{Float64Array, TimestampNanosecondArray};
+    use arrow::array::{Float64Array, StringArray, TimestampMillisecondArray, TimestampNanosecondArray};
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow::ipc::writer::FileWriter;
     use arrow::record_batch::RecordBatch;
     use chrono::{DateTime, Utc};
     use parquet::arrow::ArrowWriter;
@@ -567,7 +599,41 @@ mod tests {
         writer.close().unwrap();
     }
 
-    fn legacy_path(root: &Path) -> PathBuf {
+    fn write_legacy_ipc(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("equipment_id", DataType::Utf8, false),
+            Field::new("sat", DataType::Float64, true),
+        ]));
+        let times = [
+            DateTime::parse_from_rfc3339("2026-08-20T12:00:00Z")
+                .unwrap()
+                .timestamp_millis(),
+            DateTime::parse_from_rfc3339("2026-08-20T12:05:00Z")
+                .unwrap()
+                .timestamp_millis(),
+        ];
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(times.to_vec())),
+                Arc::new(StringArray::from(vec!["AHU_1", "AHU_1"])),
+                Arc::new(Float64Array::from(vec![Some(55.0), Some(56.0)])),
+            ],
+        )
+        .unwrap();
+        let file = fs::File::create(path).unwrap();
+        let mut writer = FileWriter::try_new(file, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+    }
+
+    fn legacy_parquet_path(root: &Path) -> PathBuf {
         root.join("building=BLDG_1/equipment=AHU_1/history.parquet")
     }
 
@@ -576,7 +642,7 @@ mod tests {
         let source = TempDir::new().unwrap();
         let destination = TempDir::new().unwrap();
         write_legacy_parquet(
-            &legacy_path(source.path()),
+            &legacy_parquet_path(source.path()),
             &[
                 "2026-08-31T23:55:00Z",
                 "2026-09-01T00:00:00Z",
@@ -605,7 +671,7 @@ mod tests {
         let source = TempDir::new().unwrap();
         let destination = TempDir::new().unwrap();
         write_legacy_parquet(
-            &legacy_path(source.path()),
+            &legacy_parquet_path(source.path()),
             &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"],
         );
         let storage = LocalStorage::new(destination.path());
@@ -625,15 +691,58 @@ mod tests {
     fn changed_source_after_receipt_fails_closed() {
         let source = TempDir::new().unwrap();
         let destination = TempDir::new().unwrap();
-        let history = legacy_path(source.path());
+        let history = legacy_parquet_path(source.path());
         write_legacy_parquet(&history, &["2026-08-20T12:00:00Z"]);
         let storage = LocalStorage::new(destination.path());
         migrate_legacy_parquet(source.path(), &storage).unwrap();
 
-        write_legacy_parquet(&history, &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"]);
+        write_legacy_parquet(
+            &history,
+            &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"],
+        );
         let error = migrate_legacy_parquet(source.path(), &storage).unwrap_err();
         assert!(error
             .to_string()
             .contains("changed since migration receipt"));
+    }
+
+    #[test]
+    fn generic_migration_converts_trusted_jsonl() {
+        let source = TempDir::new().unwrap();
+        let destination = TempDir::new().unwrap();
+        let history = source
+            .path()
+            .join("building=BLDG_1/equipment=AHU_1/history.jsonl");
+        fs::create_dir_all(history.parent().unwrap()).unwrap();
+        fs::write(
+            &history,
+            concat!(
+                "{\"timestamp\":\"2026-08-20T12:00:00Z\",\"equipment_id\":\"AHU_1\",\"sat\":55.0}\n",
+                "{\"timestamp\":\"2026-08-20T12:05:00Z\",\"equipment_id\":\"AHU_1\",\"sat\":56.0}\n"
+            ),
+        )
+        .unwrap();
+        let storage = LocalStorage::new(destination.path());
+        let report = migrate_legacy_historian(source.path(), &storage).unwrap();
+        assert_eq!(report.eligible_jsonl_sources, 1);
+        assert_eq!(report.source_rows_verified, 2);
+        assert_eq!(report.canonical_rows_verified, 2);
+        assert_eq!(report.migrated_sources, 1);
+    }
+
+    #[test]
+    fn generic_migration_converts_trusted_arrow_ipc() {
+        let source = TempDir::new().unwrap();
+        let destination = TempDir::new().unwrap();
+        let history = source
+            .path()
+            .join("building=BLDG_1/equipment=AHU_1/history.arrow");
+        write_legacy_ipc(&history);
+        let storage = LocalStorage::new(destination.path());
+        let report = migrate_legacy_historian(source.path(), &storage).unwrap();
+        assert_eq!(report.eligible_feather_sources, 1);
+        assert_eq!(report.source_rows_verified, 2);
+        assert_eq!(report.canonical_rows_verified, 2);
+        assert_eq!(report.migrated_sources, 1);
     }
 }

--- a/crates/fdd_store/src/migration_exec.rs
+++ b/crates/fdd_store/src/migration_exec.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::historian::LocalStorage;
-use crate::migration::{discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat};
+use crate::migration::{
+    discover_legacy_historian, LegacyHistorianCandidate, LegacyHistorianFormat,
+};
 use crate::parquet_parts::{ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS};
 
 const RECEIPT_VERSION: u32 = 1;
@@ -135,10 +137,7 @@ pub fn migrate_legacy_parquet(
         eligible_parquet_sources: candidates.len(),
         migrated_sources: count_status(&sources, MigrationSourceStatus::Migrated),
         resumed_sources: count_status(&sources, MigrationSourceStatus::Resumed),
-        already_migrated_sources: count_status(
-            &sources,
-            MigrationSourceStatus::AlreadyMigrated,
-        ),
+        already_migrated_sources: count_status(&sources, MigrationSourceStatus::AlreadyMigrated),
         source_rows_verified: sources.iter().map(|source| source.source_rows).sum(),
         canonical_rows_verified: sources.iter().map(|source| source.canonical_rows).sum(),
         parts_verified: sources.iter().map(|source| source.parts.len()).sum(),
@@ -147,7 +146,10 @@ pub fn migrate_legacy_parquet(
 }
 
 fn count_status(sources: &[MigrationSourceReport], status: MigrationSourceStatus) -> usize {
-    sources.iter().filter(|source| source.status == status).count()
+    sources
+        .iter()
+        .filter(|source| source.status == status)
+        .count()
 }
 
 fn migrate_candidate(
@@ -290,7 +292,10 @@ fn fingerprint_source(path: &Path) -> Result<SourceFingerprint> {
     let sha256 = file_sha256(path)?;
     let after = fs::metadata(path).with_context(|| format!("restat {}", path.display()))?;
     if before.len() != after.len() || modified != after.modified()? {
-        bail!("legacy source changed while fingerprinting {}", path.display());
+        bail!(
+            "legacy source changed while fingerprinting {}",
+            path.display()
+        );
     }
     Ok(SourceFingerprint {
         size_bytes: before.len(),
@@ -398,7 +403,10 @@ fn publish_staged_parts(
             continue;
         }
         if !staged.is_file() {
-            bail!("migration publish plan lost staged part {}", part.relative_path);
+            bail!(
+                "migration publish plan lost staged part {}",
+                part.relative_path
+            );
         }
         verify_file(&staged, part)?;
         let parent = canonical
@@ -457,7 +465,8 @@ fn validated_part_path(root: &Path, relative_path: &str) -> Result<PathBuf> {
 }
 
 fn file_sha256(path: &Path) -> Result<String> {
-    let file = fs::File::open(path).with_context(|| format!("open {} for hashing", path.display()))?;
+    let file =
+        fs::File::open(path).with_context(|| format!("open {} for hashing", path.display()))?;
     let mut reader = BufReader::with_capacity(HASH_BUFFER_BYTES, file);
     let mut buffer = vec![0u8; HASH_BUFFER_BYTES];
     let mut hash = Sha256::new();
@@ -621,11 +630,10 @@ mod tests {
         let storage = LocalStorage::new(destination.path());
         migrate_legacy_parquet(source.path(), &storage).unwrap();
 
-        write_legacy_parquet(
-            &history,
-            &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"],
-        );
+        write_legacy_parquet(&history, &["2026-08-20T12:00:00Z", "2026-08-20T12:05:00Z"]);
         let error = migrate_legacy_parquet(source.path(), &storage).unwrap_err();
-        assert!(error.to_string().contains("changed since migration receipt"));
+        assert!(error
+            .to_string()
+            .contains("changed since migration receipt"));
     }
 }

--- a/crates/fdd_store/src/stats.rs
+++ b/crates/fdd_store/src/stats.rs
@@ -35,7 +35,10 @@ pub struct HistorianStats {
     pub invalid_layout_files: usize,
 }
 
-pub fn local_historian_stats(storage: &LocalStorage, target_file_mb: u64) -> Result<HistorianStats> {
+pub fn local_historian_stats(
+    storage: &LocalStorage,
+    target_file_mb: u64,
+) -> Result<HistorianStats> {
     if target_file_mb == 0 {
         bail!("historian stats target file size must be greater than zero");
     }
@@ -75,7 +78,10 @@ pub fn local_historian_stats(storage: &LocalStorage, target_file_mb: u64) -> Res
             continue;
         };
         buildings.insert(identity.building.to_string());
-        equipment.insert((identity.building.to_string(), identity.equipment.to_string()));
+        equipment.insert((
+            identity.building.to_string(),
+            identity.equipment.to_string(),
+        ));
         partitions.insert((
             identity.building.to_string(),
             identity.equipment.to_string(),
@@ -128,7 +134,11 @@ struct CanonicalHistoryIdentity<'a> {
 
 fn canonical_history_identity(path: &Path) -> Option<CanonicalHistoryIdentity<'_>> {
     let components = path.components().collect::<Vec<_>>();
-    if components.len() != 6 || components.iter().any(|c| !matches!(c, Component::Normal(_))) {
+    if components.len() != 6
+        || components
+            .iter()
+            .any(|c| !matches!(c, Component::Normal(_)))
+    {
         return None;
     }
     let text = components
@@ -226,11 +236,7 @@ mod tests {
             )
             .unwrap();
         writer
-            .write_history_batch(
-                "BLDG_1",
-                "VAV_1",
-                &batch(&["2026-09-01T00:05:00Z"]),
-            )
+            .write_history_batch("BLDG_1", "VAV_1", &batch(&["2026-09-01T00:05:00Z"]))
             .unwrap();
 
         let stats = local_historian_stats(&storage, 128).unwrap();

--- a/crates/fdd_store/src/stats.rs
+++ b/crates/fdd_store/src/stats.rs
@@ -1,0 +1,260 @@
+//! Lightweight local historian statistics for operator health reporting.
+//!
+//! The stats pass lists canonical Parquet objects and reads only Parquet footer
+//! metadata for row counts. It does not scan telemetry columns. The small-file
+//! threshold is the same target file size used by H4 compaction.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path};
+
+use anyhow::{anyhow, bail, Context, Result};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use serde::Serialize;
+
+use crate::historian::{HistorianConfig, LocalStorage, StorageUrl};
+
+const BYTES_PER_MIB: u64 = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HistorianStats {
+    pub root: String,
+    pub target_file_mb: u64,
+    pub parquet_files: usize,
+    pub total_bytes: u64,
+    pub rows: u64,
+    pub small_files: usize,
+    pub small_file_bytes: u64,
+    pub partitions: usize,
+    pub buildings: usize,
+    pub equipment: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub earliest_month: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_month: Option<String>,
+    pub invalid_layout_files: usize,
+}
+
+pub fn local_historian_stats(storage: &LocalStorage, target_file_mb: u64) -> Result<HistorianStats> {
+    if target_file_mb == 0 {
+        bail!("historian stats target file size must be greater than zero");
+    }
+    let target_file_bytes = target_file_mb
+        .checked_mul(BYTES_PER_MIB)
+        .ok_or_else(|| anyhow!("historian stats target file size is too large"))?;
+
+    let objects = storage.list_recursive(Path::new("history"))?;
+    let mut parquet_files = 0usize;
+    let mut total_bytes = 0u64;
+    let mut rows = 0u64;
+    let mut small_files = 0usize;
+    let mut small_file_bytes = 0u64;
+    let mut invalid_layout_files = 0usize;
+    let mut partitions = BTreeSet::new();
+    let mut buildings = BTreeSet::new();
+    let mut equipment = BTreeSet::new();
+    let mut months = BTreeSet::new();
+
+    for object in objects {
+        if !object.relative_path.ends_with(".parquet") {
+            continue;
+        }
+        parquet_files += 1;
+        total_bytes = total_bytes
+            .checked_add(object.size_bytes)
+            .ok_or_else(|| anyhow!("historian byte count overflow"))?;
+        if object.size_bytes < target_file_bytes {
+            small_files += 1;
+            small_file_bytes = small_file_bytes
+                .checked_add(object.size_bytes)
+                .ok_or_else(|| anyhow!("historian small-file byte count overflow"))?;
+        }
+
+        let Some(identity) = canonical_history_identity(Path::new(&object.relative_path)) else {
+            invalid_layout_files += 1;
+            continue;
+        };
+        buildings.insert(identity.building.to_string());
+        equipment.insert((identity.building.to_string(), identity.equipment.to_string()));
+        partitions.insert((
+            identity.building.to_string(),
+            identity.equipment.to_string(),
+            identity.year,
+            identity.month,
+        ));
+        months.insert(format!("{:04}-{:02}", identity.year, identity.month));
+
+        let file = fs::File::open(storage.root().join(&object.relative_path))
+            .with_context(|| format!("open historian Parquet {}", object.relative_path))?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+            .with_context(|| format!("read historian Parquet footer {}", object.relative_path))?;
+        let file_rows = builder.metadata().file_metadata().num_rows();
+        rows = rows
+            .checked_add(u64::try_from(file_rows).context("negative Parquet row count")?)
+            .ok_or_else(|| anyhow!("historian row count overflow"))?;
+    }
+
+    Ok(HistorianStats {
+        root: storage.root().display().to_string(),
+        target_file_mb,
+        parquet_files,
+        total_bytes,
+        rows,
+        small_files,
+        small_file_bytes,
+        partitions: partitions.len(),
+        buildings: buildings.len(),
+        equipment: equipment.len(),
+        earliest_month: months.first().cloned(),
+        latest_month: months.last().cloned(),
+        invalid_layout_files,
+    })
+}
+
+pub fn local_historian_stats_from_config(config: &HistorianConfig) -> Result<HistorianStats> {
+    let StorageUrl::File { root } = &config.storage_url else {
+        bail!("local historian stats require file:// storage");
+    };
+    local_historian_stats(&LocalStorage::new(root), config.target_file_mb)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CanonicalHistoryIdentity<'a> {
+    building: &'a str,
+    equipment: &'a str,
+    year: i32,
+    month: u32,
+}
+
+fn canonical_history_identity(path: &Path) -> Option<CanonicalHistoryIdentity<'_>> {
+    let components = path.components().collect::<Vec<_>>();
+    if components.len() != 6 || components.iter().any(|c| !matches!(c, Component::Normal(_))) {
+        return None;
+    }
+    let text = components
+        .iter()
+        .map(|component| component.as_os_str().to_str())
+        .collect::<Option<Vec<_>>>()?;
+    if text[0] != "history" || !text[5].ends_with(".parquet") {
+        return None;
+    }
+    let building = text[1].strip_prefix("building_id=")?;
+    let equipment = text[2].strip_prefix("equipment_id=")?;
+    if building.is_empty()
+        || equipment.is_empty()
+        || building.contains('/')
+        || building.contains('\\')
+        || building.contains('=')
+        || building.contains("..")
+        || equipment.contains('/')
+        || equipment.contains('\\')
+        || equipment.contains('=')
+        || equipment.contains("..")
+    {
+        return None;
+    }
+    let year_raw = text[3].strip_prefix("year=")?;
+    let month_raw = text[4].strip_prefix("month=")?;
+    if year_raw.len() != 4 || month_raw.len() != 2 {
+        return None;
+    }
+    let year = year_raw.parse::<i32>().ok()?;
+    let month = month_raw.parse::<u32>().ok()?;
+    if !(1..=12).contains(&month) {
+        return None;
+    }
+    Some(CanonicalHistoryIdentity {
+        building,
+        equipment,
+        year,
+        month,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use arrow::array::{Float64Array, TimestampNanosecondArray};
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow::record_batch::RecordBatch;
+    use chrono::{DateTime, Utc};
+    use tempfile::TempDir;
+
+    use crate::parquet_parts::ParquetPartWriter;
+
+    fn batch(times: &[&str]) -> RecordBatch {
+        let timestamps = times
+            .iter()
+            .map(|raw| {
+                DateTime::parse_from_rfc3339(raw)
+                    .unwrap()
+                    .with_timezone(&Utc)
+                    .timestamp_nanos_opt()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp_utc",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("sat", DataType::Float64, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampNanosecondArray::from(timestamps)),
+                Arc::new(Float64Array::from(vec![Some(55.0); times.len()])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn stats_use_footer_rows_and_canonical_partitions() {
+        let tmp = TempDir::new().unwrap();
+        let storage = LocalStorage::new(tmp.path());
+        let writer = ParquetPartWriter::new(storage.clone());
+        writer
+            .write_history_batch(
+                "BLDG_1",
+                "AHU_1",
+                &batch(&["2026-08-20T12:00:00Z", "2026-09-01T00:00:00Z"]),
+            )
+            .unwrap();
+        writer
+            .write_history_batch(
+                "BLDG_1",
+                "VAV_1",
+                &batch(&["2026-09-01T00:05:00Z"]),
+            )
+            .unwrap();
+
+        let stats = local_historian_stats(&storage, 128).unwrap();
+        assert_eq!(stats.parquet_files, 3);
+        assert_eq!(stats.rows, 3);
+        assert_eq!(stats.partitions, 3);
+        assert_eq!(stats.buildings, 1);
+        assert_eq!(stats.equipment, 2);
+        assert_eq!(stats.small_files, 3);
+        assert_eq!(stats.earliest_month.as_deref(), Some("2026-08"));
+        assert_eq!(stats.latest_month.as_deref(), Some("2026-09"));
+        assert_eq!(stats.invalid_layout_files, 0);
+    }
+
+    #[test]
+    fn malformed_history_parquet_is_counted_but_not_trusted_as_canonical() {
+        let tmp = TempDir::new().unwrap();
+        let storage = LocalStorage::new(tmp.path());
+        fs::create_dir_all(tmp.path().join("history/junk")).unwrap();
+        fs::write(tmp.path().join("history/junk/bad.parquet"), b"not parquet").unwrap();
+
+        let stats = local_historian_stats(&storage, 128).unwrap();
+        assert_eq!(stats.parquet_files, 1);
+        assert_eq!(stats.invalid_layout_files, 1);
+        assert_eq!(stats.rows, 0);
+    }
+}

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -225,4 +225,6 @@ Product voice = React + DataFusion only. Track deletion / GHCR / agent_spec hone
 
 - [x] P1-M7-00 — H1/H2 merged; H3 DataFusion historian registration/query-safety merged via #758 (`c5974abd`)
 - [x] P1-M7-01 — H4 bounded offline local historian compaction merged via #760 (`32eabc68`) after exact-head CI + review passed
-- [ ] P1-M7-02 — H5 generic S3/object-store + central runtime/Railway/MinIO cutover
+- [x] P1-M7-02 — H5 generic S3/object-store + DataFusion tuning + central scoped runtime/Railway/loopback-MinIO merged via #762 (`9239574a`); canonical S3 bucket remains private and container disk is scratch/spill
+- [~] P1-M7-03 — H6 migration/operator tooling active via #764: trusted Parquet/JSONL/Arrow discovery + bounded restart-safe conversion, preservation receipts/reports, footer-only canonical stats, operator CLI, fail-closed S3 compatibility scope
+- [ ] P1-M7-04 — H7 live-ingest micro-batch cutover: trustworthy equipment/role identity, H2 accumulator wiring, elapsed/shutdown flush, persisted latest timestamp, retire durability-critical JSONL/IPC rewrite

--- a/openfdd_agent_spec/HISTORIAN_PROGRAM.md
+++ b/openfdd_agent_spec/HISTORIAN_PROGRAM.md
@@ -88,19 +88,21 @@ The older stacked PR #759 remains closed historical context only. H4 merged only
 
 ### H5 — S3-compatible backend + Railway
 
-- [ ] direct generic `object_store` integration (same ecosystem used by DataFusion/Parquet)
-- [ ] AWS S3 / MinIO / Railway-compatible endpoint, region and credentials
-- [ ] virtual-hosted/path-style configuration for compatible providers
-- [ ] never log credentials
-- [ ] DataFusion object-store registration
-- [ ] central analytics/runtime cutover from local-only Parquet discovery to configured canonical storage
-- [ ] fail-closed building scoping on canonical object-store history
-- [ ] optional local MinIO Compose recipe
-- [ ] Railway Storage Bucket mapping docs
-- [ ] Railway central uses bucket as canonical historian; container disk is scratch
-- [ ] Railway web remains the only public service in the minimal dashboard recipe
+- [x] PR #762 — `feat/s3-historian-backend`, merged to `master` as `9239574a`
+- [x] direct generic `object_store` integration (same ecosystem used by DataFusion/Parquet)
+- [x] AWS S3 / MinIO / Railway-compatible endpoint, region and credentials
+- [x] virtual-hosted/path-style configuration for compatible providers
+- [x] credential/session-token validation and redacted debug output; secrets are never logged
+- [x] DataFusion object-store registration and canonical Hive partition exposure
+- [x] building-scoped object discovery before DataFusion scans unrelated objects
+- [x] central S3 scope-index refresh with fail-closed building presence checks
+- [x] DataFusion historian tuning contract for Parquet filter pushdown/reordering, metadata hints, memory/spill, partition and batch controls
+- [x] optional loopback-only local MinIO Compose recipe
+- [x] Railway Storage Bucket mapping docs without Railway-specific engine branching
+- [x] Railway central uses the bucket as canonical historian; container disk is scratch/spill only
+- [x] deployment language is LAN/VPN/private-ingress only; H5 does not introduce a public historian or public central API
 
-Railway mapping target (deployment config, never Rust provider branching):
+Railway mapping is deployment configuration, never Rust provider branching:
 
 ```text
 OPENFDD_STORAGE_URL=s3://${{bucket.BUCKET}}
@@ -108,17 +110,29 @@ OPENFDD_S3_ENDPOINT=${{bucket.ENDPOINT}}
 OPENFDD_S3_REGION=${{bucket.REGION}}
 OPENFDD_S3_ACCESS_KEY_ID=${{bucket.ACCESS_KEY_ID}}
 OPENFDD_S3_SECRET_ACCESS_KEY=${{bucket.SECRET_ACCESS_KEY}}
+OPENFDD_S3_URL_STYLE=virtual
+OPENFDD_S3_ALLOW_HTTP=false
 ```
 
-Current Railway Storage Buckets are private S3-compatible buckets; current Railway docs use `BUCKET`, `ENDPOINT`, `REGION`, `ACCESS_KEY_ID`, and `SECRET_ACCESS_KEY`. New buckets use virtual-hosted-style URLs by default; support remains generic because older/other S3-compatible endpoints may use path style.
+Compatible providers may use path style instead. `OPENFDD_S3_ALLOW_HTTP=true` is limited to explicit local/test endpoints such as loopback MinIO. H5 merged only after its exact head passed FDD engine, Rust stack, AppSec, docs, security, and review gates.
 
 ### H6 — Migration + operator historian tooling
 
-- [ ] migrate legacy `building=<id>/equipment=<id>/history.parquet`
-- [ ] classify/migrate eligible legacy JSONL/Feather data without inventing identity
-- [ ] dry-run and restart-safe behavior
-- [ ] row/timestamp/equipment preservation report
-- [ ] historian stats JSON/operator command/API
+- [~] PR #764 — `feat/historian-migration-tooling`, active until exact-head CI/review gates are clean
+- [x] recursively discover and classify legacy Parquet, JSONL/NDJSON, and Feather/Arrow IPC historian artifacts
+- [x] require trusted `building=<id>/equipment=<id>` path identity; never invent identity from point IDs or defaults
+- [x] reject unsafe/conflicting identity and non-canonical/ambiguous migration inputs
+- [x] bounded streamed migration of eligible legacy `history.parquet` into canonical monthly parts
+- [x] bounded JSONL scalar-schema conversion with strict timestamp parsing and mixed/nested type rejection
+- [x] bounded Arrow IPC/Feather conversion with `timestamp` → `timestamp_utc` normalization and timestamp-type validation
+- [x] use the same staging + atomic receipt + part hash verification protocol for every migrated format
+- [x] restart-safe/idempotent reruns resume the exact publish plan; changed sources fail closed
+- [x] row-count preservation plus first/last timestamp and equipment identity reports
+- [x] footer-only local canonical historian stats: files, bytes, rows, partitions, buildings, equipment, month range, invalid layout, and H4-aligned small-file health
+- [x] public serializable `HistorianStats` / migration report API plus operator CLI commands `historian-dry-run`, `historian-migrate`, and `historian-stats`
+- [x] S3 compatibility registration carry-forward is fail-closed when a building scope is absent; explicit global/operator registration remains separate
+
+H6 remains offline/operator migration. It does not delete legacy data and does not make migration concurrent with live ingest. The phase is not complete until PR #764's final changed head has clean FDD, Rust stack, AppSec, docs/security workflows and clean review threads.
 
 ### H7 — Live ingest micro-batch cutover
 
@@ -185,4 +199,5 @@ OPENFDD_AFDD_LOOKBACK_UNIT=hours
 - Do not make bulk CSV import start recurring AFDD.
 - Do not rescan retained history for every continuous AFDD cycle.
 - Do not weaken auth/security or log S3 secrets.
+- Keep historian/central ingress LAN/VPN/private-only; do not describe these services as public.
 - Do not merge a phase until its changed-head CI and review threads are clean.

--- a/openfdd_agent_spec/docs/HISTORIAN_ARCHITECTURE.md
+++ b/openfdd_agent_spec/docs/HISTORIAN_ARCHITECTURE.md
@@ -11,6 +11,7 @@ This file is the software-engineering agent summary for the canonical Open-FDD h
 - No PostgreSQL, TimescaleDB, InfluxDB, ClickHouse, DuckDB, or SQLite as the canonical historian.
 - Do not add Railway-specific historian engine code.
 - Normal local installs must work without MinIO.
+- Historian, central, and dashboard ingress remain LAN/VPN/private-only. Do not describe product services as public.
 
 ## Generic storage contract
 
@@ -28,9 +29,11 @@ OPENFDD_S3_ENDPOINT=https://...
 OPENFDD_S3_REGION=...
 OPENFDD_S3_ACCESS_KEY_ID=...
 OPENFDD_S3_SECRET_ACCESS_KEY=...
+OPENFDD_S3_URL_STYLE=path|virtual
+OPENFDD_S3_ALLOW_HTTP=false
 ```
 
-Never log or return access/secret keys.
+Never log or return access/secret keys or session tokens. `OPENFDD_S3_ALLOW_HTTP=true` is for explicit local/test endpoints such as loopback MinIO only.
 
 Legacy `OPENFDD_PARQUET_ROOT` may be recognized for migration/backwards compatibility, but do not silently pretend the legacy physical layout is the canonical layout.
 
@@ -83,33 +86,50 @@ Do **not** overlap H4 local compaction with DataFusion scans of the same histori
 
 ## DataFusion/query contract
 
-The canonical local `history` table is registered from `<storage_root>/history/`, not from a recursive glob. DataFusion exposes these Hive columns to SQL:
+Canonical `history` registration is rooted at the configured `history/` dataset, never physical part filenames. Local registration uses `<storage_root>/history/`; S3 registration uses the configured `s3://<bucket>/<prefix>/history/` object-store root. DataFusion exposes these Hive columns to SQL:
 
 ```text
 building_id, equipment_id, year, month
 ```
 
-Canonical Hive partition values are UTF-8 path literals. Use zero-padded string predicates such as `year = '2026'` and `month = '08'`; this keeps local and future object-store pruning semantics aligned. H3 physical-plan tests prove unrelated building/equipment/month files are absent from selected scans.
+Canonical Hive partition values are UTF-8 path literals. Use zero-padded string predicates such as `year = '2026'` and `month = '08'`; this keeps local and object-store pruning semantics aligned. Building-scoped S3 callers narrow object discovery to `building_id=<id>/` before DataFusion file discovery rather than registering the whole bucket and filtering afterward.
 
-When no canonical `history/` dataset exists, the compatibility layer may fall back to the legacy recursive Parquet sidecar tree until H6 migration is complete. Do not make that fallback the new abstraction. FDD SQL should never know physical part filenames.
+When no canonical local `history/` dataset exists, the compatibility layer may fall back to the legacy recursive Parquet sidecar tree during migration. S3 compatibility registration is different: it fails closed without a trusted building scope. Explicit whole-dataset S3 registration is reserved for operator/global callers. Do not make compatibility paths the new abstraction. FDD SQL should never know physical part filenames.
 
 Parquet schema inference must tolerate safe nullable-role evolution across immutable parts. Adding an optional role is allowed; old parts surface null for the new column. Incompatible role datatypes must fail rather than be silently reinterpreted.
 
-A large historian must not be collected into RAM. H3 provides two generic execution contracts:
+A large historian must not be collected into RAM. The generic execution contracts are:
 
 - `collect_sql_bounded(ctx, sql, max_rows)` materializes at most `max_rows` and rejects larger interactive results;
 - `stream_sql(ctx, sql)` returns Arrow record batches without materializing the full result in Open-FDD.
 
 `DEFAULT_INTERACTIVE_MAX_ROWS` is 10,000. Deployment/API layers may wire their own explicit limit, but generic interactive callers must not use unbounded `DataFrame::collect()` by default. Existing rule/batch compatibility paths may retain bounded result behavior where FDD parity requires it.
 
-DataFusion query runtime configuration is sourced from the historian config:
+DataFusion historian sessions use bounded memory/spill plus tuning from the generic configuration. Important controls include:
 
 ```text
 OPENFDD_QUERY_MEMORY_MB=512
 OPENFDD_DATAFUSION_SPILL_DIR=...
+OPENFDD_DATAFUSION_PUSHDOWN_FILTERS=true
+OPENFDD_DATAFUSION_REORDER_FILTERS=true
+OPENFDD_DATAFUSION_PARQUET_METADATA_HINT_KB=512
+OPENFDD_DATAFUSION_TARGET_PARTITIONS=...
+OPENFDD_DATAFUSION_BATCH_ROWS=...
+OPENFDD_DATAFUSION_META_FETCH_CONCURRENCY=...
+OPENFDD_DATAFUSION_REPARTITION_FILE_MIN_MB=...
 ```
 
-`new_historian_session` applies the memory pool and optional spill directory. At least the CLI query runtime uses this configured session in H3; new historian query callers should do the same rather than constructing an unconstrained `SessionContext` casually.
+Do not turn every DataFusion option on mechanically. Keep row-group pruning/page index behavior enabled, use late Parquet filter pushdown/reordering where beneficial, keep full statistics collection off by default for large object stores, and benchmark expensive options before changing defaults.
+
+## H6 migration contract
+
+Legacy migration is explicit operator/offline work. Discovery may classify Parquet, JSONL/NDJSON, and Feather/Arrow IPC, but a source is eligible only when trusted `building=<id>/equipment=<id>` path identity is present and safe. Never invent identity from point IDs, active-profile defaults, or filename guesses.
+
+Eligible sources are converted through bounded Arrow batches into the same canonical H2 writer. JSONL requires scalar fields with consistent types and a parseable timestamp; nested/mixed values fail closed. Arrow IPC/Feather requires a real Arrow timestamp; legacy `timestamp` may be normalized to `timestamp_utc`, while ambiguous timestamp columns fail closed.
+
+Every format uses one restart-safe protocol: write invisible staging parts, verify row preservation and part hashes, persist an atomic receipt containing the exact publish plan, then publish the recorded parts. Reruns resume that plan; changed source content fails closed. H6 does not delete legacy source data.
+
+Historian stats are footer/metadata oriented, not a full telemetry scan. Local canonical stats report files, bytes, rows, partitions, buildings, equipment, month range, invalid layout, and H4-aligned small-file health. The serializable Rust API and CLI are operator surfaces; do not enumerate an entire S3 historian on every request merely to display a dashboard counter.
 
 ## Operating modes
 
@@ -154,23 +174,23 @@ Overlapping AFDD windows must continue one fault episode instead of inserting a 
 Railway is deployment configuration only:
 
 ```text
-openfdd-web (public)
+private dashboard / VPN ingress
   -> openfdd-central.railway.internal:8080 (private)
   -> Railway Storage Bucket (private S3-compatible)
 ```
 
 Map Railway bucket variables (`BUCKET`, `ENDPOINT`, `REGION`, `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`) into Open-FDD's generic `OPENFDD_*` variables. Do not read `RAILWAY_*` in historian engine code.
 
-The central container filesystem is ephemeral cloud scratch, not the canonical historian. A volume may still hold small mutable application/session state where needed.
+The central container filesystem is ephemeral cloud scratch/spill, not the canonical historian. A volume may still hold small mutable application/session state where needed.
 
 ## Local VM mapping
 
-IT-hosted VM/dashboard deployments use the same images and `file://` storage, with persistent Docker volume/host disk and central bound privately. MinIO is optional only for testing the S3 path.
+IT-hosted VM/dashboard deployments use the same images and `file://` storage, with persistent Docker volume/host disk and central bound privately. MinIO is optional only for testing the S3 path and binds to loopback in the provided recipe.
 
 ## Validation
 
 Every implementation PR touching this architecture must preserve FDD/weather behavior and run the relevant repo gates. Never weaken tests to get green.
 
-H1 through H4 are merged. H4 merged only after its exact head passed FDD engine, Rust stack, AppSec, docs/security, and review gates. H5 owns the S3-compatible backend and deployment wiring; H6+ own migration, live/runtime cutover, scheduling, UX, and scale qualification.
+H1 through H5 are merged. H5 added provider-neutral S3/object-store registration, fail-closed building scoping, DataFusion tuning, MinIO qualification wiring, and private Railway bucket deployment mapping. H6 owns restart-safe legacy migration and operator stats. H7 owns live micro-batch cutover; H8+ own continuous scheduling, UX, and scale qualification.
 
 Scale target: hundreds of GB to ~1 TB retained history while normal continuous AFDD scans only the configured building/equipment/time window through partition/statistics/column pruning.


### PR DESCRIPTION
## H6 scope
Migration and operator tooling for the canonical historian.

Implemented on this branch:
- recursive legacy historian discovery for Parquet, JSONL/NDJSON, and Feather/Arrow IPC
- trusted `building=<id>/equipment=<id>` path identity only; no invented identity
- dry-run inventory with unsafe/conflicting identity rejection
- bounded streamed migration of eligible Parquet, JSONL/NDJSON, and Arrow IPC/Feather into canonical monthly Parquet
- strict JSONL scalar/timestamp validation and Arrow timestamp normalization; ambiguous/mixed inputs fail closed
- staging + atomic receipts + source/part hash verification for restart-safe/idempotent migration
- row preservation and first/last timestamp reporting per migrated source
- footer-only local historian stats: files/bytes/rows/partitions/buildings/equipment/month range/small-file health
- public serializable migration/stats Rust APIs and operator CLI commands: `historian-dry-run`, `historian-migrate`, `historian-stats`
- S3 compatibility registration fails closed without a trusted building scope
- H5/H6 historian program, build checkpoints, and architecture docs synchronized with LAN/VPN/private-ingress deployment language

H6 remains an explicit offline/operator migration path. It does not delete legacy data and does not make migration concurrent with live ingest.

## Merge gate
Do not merge until this PR's exact current head passes FDD DataFusion Engine CI, Rust Stack CI, AppSec, docs-guard, Stack Security Guards, and has no unresolved review threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI tools to preview and migrate legacy historian data from Parquet, JSONL/NDJSON, and Feather/Arrow formats.
  * Added local historian statistics, including file, row, size, partition, and invalid-layout reporting.
  * Migration supports resumable, restart-safe processing with validation and duplicate protection.
* **Bug Fixes**
  * S3 compatibility now rejects configurations without a valid building scope.
* **Documentation**
  * Updated historian architecture and operational guidance for private deployments and migration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->