### PR TITLE
H8: Continuous AFDD scheduler, findings, and API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,12 +37,13 @@ OPENFDD_QUERY_MEMORY_MB=512
 # OPENFDD_S3_URL_STYLE=path
 # OPENFDD_S3_ALLOW_HTTP=false
 
-# Continuous AFDD target configuration. Runtime scheduler wiring is introduced
-# incrementally; bulk analysis remains the default until continuous mode is enabled.
+# H8 AFDD scheduler contract. Bulk remains the safe default. In continuous mode,
+# interval controls how often cycles are due and lookback controls how much
+# persisted historian data each rolling cycle analyzes; these are independent.
 OPENFDD_AFDD_MODE=bulk
-# OPENFDD_AFDD_INTERVAL_MINUTES=60
-# OPENFDD_AFDD_LOOKBACK_VALUE=24
-# OPENFDD_AFDD_LOOKBACK_UNIT=hours
+OPENFDD_AFDD_INTERVAL_MINUTES=60
+OPENFDD_AFDD_LOOKBACK_VALUE=24
+OPENFDD_AFDD_LOOKBACK_UNIT=hours
 
 # Set to 1 only when you intentionally compile Rust on this host (needs 12GB+ free disk).
 OPENFDD_ALLOW_LOCAL_BUILD=0

--- a/crates/fdd_store/src/afdd.rs
+++ b/crates/fdd_store/src/afdd.rs
@@ -89,10 +89,8 @@ impl AfddConfig {
             "OPENFDD_AFDD_INTERVAL_MINUTES",
             DEFAULT_AFDD_INTERVAL_MINUTES,
         )?;
-        let lookback_value = env_positive_u64(
-            "OPENFDD_AFDD_LOOKBACK_VALUE",
-            DEFAULT_AFDD_LOOKBACK_VALUE,
-        )?;
+        let lookback_value =
+            env_positive_u64("OPENFDD_AFDD_LOOKBACK_VALUE", DEFAULT_AFDD_LOOKBACK_VALUE)?;
         let lookback_unit = env::var("OPENFDD_AFDD_LOOKBACK_UNIT")
             .map(|raw| AfddLookbackUnit::parse(&raw))
             .unwrap_or(Ok(DEFAULT_AFDD_LOOKBACK_UNIT))?;
@@ -151,10 +149,7 @@ mod tests {
     #[test]
     fn mode_parser_is_strict() {
         assert_eq!(AfddMode::parse("bulk").unwrap(), AfddMode::Bulk);
-        assert_eq!(
-            AfddMode::parse("CONTINUOUS").unwrap(),
-            AfddMode::Continuous
-        );
+        assert_eq!(AfddMode::parse("CONTINUOUS").unwrap(), AfddMode::Continuous);
         assert!(AfddMode::parse("scheduled").is_err());
     }
 

--- a/crates/fdd_store/src/afdd.rs
+++ b/crates/fdd_store/src/afdd.rs
@@ -1,0 +1,194 @@
+//! Continuous AFDD scheduling configuration contract.
+//!
+//! H8 keeps the scheduler policy explicit and provider-neutral. Bulk mode remains
+//! the safe default. Continuous mode has an interval that is independent from
+//! the rolling lookback window; runtime scheduling consumes this validated
+//! contract rather than reparsing environment variables in multiple services.
+
+use std::env;
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+
+pub const DEFAULT_AFDD_INTERVAL_MINUTES: u64 = 60;
+pub const DEFAULT_AFDD_LOOKBACK_VALUE: u64 = 24;
+pub const DEFAULT_AFDD_LOOKBACK_UNIT: AfddLookbackUnit = AfddLookbackUnit::Hours;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AfddMode {
+    Bulk,
+    Continuous,
+}
+
+impl AfddMode {
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "bulk" => Ok(Self::Bulk),
+            "continuous" => Ok(Self::Continuous),
+            _ => bail!("OPENFDD_AFDD_MODE must be 'bulk' or 'continuous'"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AfddLookbackUnit {
+    Minutes,
+    Hours,
+    Days,
+}
+
+impl AfddLookbackUnit {
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "minute" | "minutes" => Ok(Self::Minutes),
+            "hour" | "hours" => Ok(Self::Hours),
+            "day" | "days" => Ok(Self::Days),
+            _ => bail!("OPENFDD_AFDD_LOOKBACK_UNIT must be minutes, hours, or days"),
+        }
+    }
+
+    pub fn seconds(self, value: u64) -> Result<u64> {
+        let multiplier = match self {
+            Self::Minutes => 60,
+            Self::Hours => 60 * 60,
+            Self::Days => 24 * 60 * 60,
+        };
+        value
+            .checked_mul(multiplier)
+            .ok_or_else(|| anyhow::anyhow!("AFDD lookback duration is too large"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AfddConfig {
+    pub mode: AfddMode,
+    pub interval_minutes: u64,
+    pub lookback_value: u64,
+    pub lookback_unit: AfddLookbackUnit,
+}
+
+impl Default for AfddConfig {
+    fn default() -> Self {
+        Self {
+            mode: AfddMode::Bulk,
+            interval_minutes: DEFAULT_AFDD_INTERVAL_MINUTES,
+            lookback_value: DEFAULT_AFDD_LOOKBACK_VALUE,
+            lookback_unit: DEFAULT_AFDD_LOOKBACK_UNIT,
+        }
+    }
+}
+
+impl AfddConfig {
+    pub fn from_env() -> Result<Self> {
+        let mode = env::var("OPENFDD_AFDD_MODE")
+            .map(|raw| AfddMode::parse(&raw))
+            .unwrap_or(Ok(AfddMode::Bulk))?;
+        let interval_minutes = env_positive_u64(
+            "OPENFDD_AFDD_INTERVAL_MINUTES",
+            DEFAULT_AFDD_INTERVAL_MINUTES,
+        )?;
+        let lookback_value = env_positive_u64(
+            "OPENFDD_AFDD_LOOKBACK_VALUE",
+            DEFAULT_AFDD_LOOKBACK_VALUE,
+        )?;
+        let lookback_unit = env::var("OPENFDD_AFDD_LOOKBACK_UNIT")
+            .map(|raw| AfddLookbackUnit::parse(&raw))
+            .unwrap_or(Ok(DEFAULT_AFDD_LOOKBACK_UNIT))?;
+
+        let config = Self {
+            mode,
+            interval_minutes,
+            lookback_value,
+            lookback_unit,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.interval_minutes == 0 {
+            bail!("OPENFDD_AFDD_INTERVAL_MINUTES must be greater than zero");
+        }
+        if self.lookback_value == 0 {
+            bail!("OPENFDD_AFDD_LOOKBACK_VALUE must be greater than zero");
+        }
+        self.lookback_seconds()?;
+        Ok(())
+    }
+
+    pub fn lookback_seconds(&self) -> Result<u64> {
+        self.lookback_unit.seconds(self.lookback_value)
+    }
+}
+
+fn env_positive_u64(name: &str, default: u64) -> Result<u64> {
+    match env::var(name) {
+        Ok(raw) => raw
+            .parse::<u64>()
+            .with_context(|| format!("{name} must be a positive integer"))
+            .and_then(|value| {
+                if value == 0 {
+                    bail!("{name} must be greater than zero");
+                }
+                Ok(value)
+            }),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(err) => Err(err).with_context(|| format!("read {name}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bulk_is_safe_default() {
+        assert_eq!(AfddConfig::default().mode, AfddMode::Bulk);
+    }
+
+    #[test]
+    fn mode_parser_is_strict() {
+        assert_eq!(AfddMode::parse("bulk").unwrap(), AfddMode::Bulk);
+        assert_eq!(
+            AfddMode::parse("CONTINUOUS").unwrap(),
+            AfddMode::Continuous
+        );
+        assert!(AfddMode::parse("scheduled").is_err());
+    }
+
+    #[test]
+    fn lookback_unit_parser_and_seconds_are_explicit() {
+        assert_eq!(
+            AfddLookbackUnit::parse("hours").unwrap(),
+            AfddLookbackUnit::Hours
+        );
+        assert_eq!(AfddLookbackUnit::Hours.seconds(24).unwrap(), 86_400);
+        assert_eq!(AfddLookbackUnit::Days.seconds(2).unwrap(), 172_800);
+        assert!(AfddLookbackUnit::parse("weeks").is_err());
+    }
+
+    #[test]
+    fn interval_and_lookback_are_independent() {
+        let config = AfddConfig {
+            mode: AfddMode::Continuous,
+            interval_minutes: 15,
+            lookback_value: 48,
+            lookback_unit: AfddLookbackUnit::Hours,
+        };
+        config.validate().unwrap();
+        assert_eq!(config.interval_minutes, 15);
+        assert_eq!(config.lookback_seconds().unwrap(), 172_800);
+    }
+
+    #[test]
+    fn zero_values_fail_closed() {
+        let mut config = AfddConfig::default();
+        config.interval_minutes = 0;
+        assert!(config.validate().is_err());
+        config.interval_minutes = 60;
+        config.lookback_value = 0;
+        assert!(config.validate().is_err());
+    }
+}

--- a/crates/fdd_store/src/afdd.rs
+++ b/crates/fdd_store/src/afdd.rs
@@ -179,11 +179,16 @@ mod tests {
 
     #[test]
     fn zero_values_fail_closed() {
-        let mut config = AfddConfig::default();
-        config.interval_minutes = 0;
-        assert!(config.validate().is_err());
-        config.interval_minutes = 60;
-        config.lookback_value = 0;
-        assert!(config.validate().is_err());
+        let zero_interval = AfddConfig {
+            interval_minutes: 0,
+            ..AfddConfig::default()
+        };
+        assert!(zero_interval.validate().is_err());
+
+        let zero_lookback = AfddConfig {
+            lookback_value: 0,
+            ..AfddConfig::default()
+        };
+        assert!(zero_lookback.validate().is_err());
     }
 }

--- a/crates/fdd_store/src/afdd_scheduler.rs
+++ b/crates/fdd_store/src/afdd_scheduler.rs
@@ -160,7 +160,13 @@ mod tests {
             analyzed_through_utc: ts(8),
         };
         assert_eq!(
-            plan_continuous_cycle(Some(&checkpoint), ts(8) + Duration::minutes(30), Some(ts(9)), &config()).unwrap(),
+            plan_continuous_cycle(
+                Some(&checkpoint),
+                ts(8) + Duration::minutes(30),
+                Some(ts(9)),
+                &config(),
+            )
+            .unwrap(),
             None
         );
     }

--- a/crates/fdd_store/src/afdd_scheduler.rs
+++ b/crates/fdd_store/src/afdd_scheduler.rs
@@ -1,0 +1,203 @@
+//! Deterministic continuous-AFDD scheduler planning primitives.
+//!
+//! This module is intentionally runtime-neutral: Central owns timers, locking,
+//! persistence, and execution, while this crate defines the restart-safe policy
+//! for rolling windows, one-shot catch-up, checkpoints, and bounded backfill.
+
+use anyhow::{bail, Result};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::AfddConfig;
+
+pub const AFDD_SCHEDULER_CHECKPOINT_PATH: &str = "state/afdd/scheduler-checkpoint.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AfddSchedulerCheckpoint {
+    pub last_completed_at_utc: DateTime<Utc>,
+    pub analyzed_through_utc: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AfddCycleWindow {
+    pub start_utc: DateTime<Utc>,
+    pub end_utc: DateTime<Utc>,
+    pub scheduled_for_utc: DateTime<Utc>,
+    pub catch_up: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AfddBackfillChunk {
+    pub start_utc: DateTime<Utc>,
+    pub end_utc: DateTime<Utc>,
+}
+
+/// Return the next due time from the last successful scheduler checkpoint.
+pub fn next_due_at(
+    checkpoint: Option<&AfddSchedulerCheckpoint>,
+    now: DateTime<Utc>,
+    config: &AfddConfig,
+) -> Result<DateTime<Utc>> {
+    config.validate()?;
+    let interval = Duration::minutes(i64::try_from(config.interval_minutes)?);
+    Ok(match checkpoint {
+        Some(checkpoint) => checkpoint.last_completed_at_utc + interval,
+        None => now,
+    })
+}
+
+/// Plan at most one continuous cycle.
+///
+/// The rolling end is the latest successfully persisted eligible telemetry,
+/// never wall-clock time. If the process was down for multiple intervals, this
+/// returns one catch-up cycle rather than replaying every missed timer tick.
+pub fn plan_continuous_cycle(
+    checkpoint: Option<&AfddSchedulerCheckpoint>,
+    now: DateTime<Utc>,
+    latest_persisted_telemetry: Option<DateTime<Utc>>,
+    config: &AfddConfig,
+) -> Result<Option<AfddCycleWindow>> {
+    config.validate()?;
+    let Some(end_utc) = latest_persisted_telemetry else {
+        return Ok(None);
+    };
+
+    let due = next_due_at(checkpoint, now, config)?;
+    if checkpoint.is_some() && now < due {
+        return Ok(None);
+    }
+
+    // Do not run again when telemetry has not advanced beyond the last
+    // successfully analyzed watermark.
+    if checkpoint.is_some_and(|cp| end_utc <= cp.analyzed_through_utc) {
+        return Ok(None);
+    }
+
+    let lookback_seconds = i64::try_from(config.lookback_seconds()?)?;
+    let start_utc = end_utc - Duration::seconds(lookback_seconds);
+    let interval = Duration::minutes(i64::try_from(config.interval_minutes)?);
+    let catch_up = checkpoint.is_some_and(|cp| now >= cp.last_completed_at_utc + interval * 2);
+
+    Ok(Some(AfddCycleWindow {
+        start_utc,
+        end_utc,
+        scheduled_for_utc: due,
+        catch_up,
+    }))
+}
+
+/// Split an explicit historical backfill range into bounded chunks.
+///
+/// Backfill is deliberately separate from recurring continuous scheduling so a
+/// large retained history range cannot accidentally turn into a full rescan on
+/// every scheduler tick.
+pub fn plan_backfill_chunks(
+    start_utc: DateTime<Utc>,
+    end_utc: DateTime<Utc>,
+    chunk_hours: u64,
+) -> Result<Vec<AfddBackfillChunk>> {
+    if end_utc <= start_utc {
+        bail!("AFDD backfill end must be after start");
+    }
+    if chunk_hours == 0 {
+        bail!("AFDD backfill chunk_hours must be greater than zero");
+    }
+    let chunk = Duration::hours(i64::try_from(chunk_hours)?);
+    let mut cursor = start_utc;
+    let mut chunks = Vec::new();
+    while cursor < end_utc {
+        let next = (cursor + chunk).min(end_utc);
+        chunks.push(AfddBackfillChunk {
+            start_utc: cursor,
+            end_utc: next,
+        });
+        cursor = next;
+    }
+    Ok(chunks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AfddLookbackUnit, AfddMode};
+    use chrono::TimeZone;
+
+    fn ts(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 22, hour, 0, 0).unwrap()
+    }
+
+    fn config() -> AfddConfig {
+        AfddConfig {
+            mode: AfddMode::Continuous,
+            interval_minutes: 60,
+            lookback_value: 24,
+            lookback_unit: AfddLookbackUnit::Hours,
+        }
+    }
+
+    #[test]
+    fn no_telemetry_means_no_cycle() {
+        assert_eq!(
+            plan_continuous_cycle(None, ts(9), None, &config()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn first_cycle_ends_at_persisted_telemetry_and_overlaps_by_lookback() {
+        let window = plan_continuous_cycle(None, ts(9), Some(ts(8)), &config())
+            .unwrap()
+            .unwrap();
+        assert_eq!(window.end_utc, ts(8));
+        assert_eq!(window.start_utc, ts(8) - Duration::hours(24));
+        assert!(!window.catch_up);
+    }
+
+    #[test]
+    fn not_due_does_not_run() {
+        let checkpoint = AfddSchedulerCheckpoint {
+            last_completed_at_utc: ts(8),
+            analyzed_through_utc: ts(8),
+        };
+        assert_eq!(
+            plan_continuous_cycle(Some(&checkpoint), ts(8) + Duration::minutes(30), Some(ts(9)), &config()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn restart_after_many_ticks_creates_one_catch_up_cycle() {
+        let checkpoint = AfddSchedulerCheckpoint {
+            last_completed_at_utc: ts(3),
+            analyzed_through_utc: ts(3),
+        };
+        let cycle = plan_continuous_cycle(Some(&checkpoint), ts(9), Some(ts(8)), &config())
+            .unwrap()
+            .unwrap();
+        assert!(cycle.catch_up);
+        assert_eq!(cycle.scheduled_for_utc, ts(4));
+        assert_eq!(cycle.end_utc, ts(8));
+    }
+
+    #[test]
+    fn unchanged_telemetry_watermark_does_not_repeat_cycle() {
+        let checkpoint = AfddSchedulerCheckpoint {
+            last_completed_at_utc: ts(7),
+            analyzed_through_utc: ts(8),
+        };
+        assert_eq!(
+            plan_continuous_cycle(Some(&checkpoint), ts(9), Some(ts(8)), &config()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn backfill_is_bounded_and_covers_range_exactly() {
+        let chunks = plan_backfill_chunks(ts(0), ts(8), 3).unwrap();
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].start_utc, ts(0));
+        assert_eq!(chunks[0].end_utc, ts(3));
+        assert_eq!(chunks[2].start_utc, ts(6));
+        assert_eq!(chunks[2].end_utc, ts(8));
+    }
+}

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -1,6 +1,7 @@
 //! Parquet historian and sidecar storage helpers.
 
 pub mod afdd;
+pub mod afdd_scheduler;
 pub mod append;
 pub mod compaction;
 pub mod historian;
@@ -16,6 +17,10 @@ pub mod stats;
 pub use afdd::{
     AfddConfig, AfddLookbackUnit, AfddMode, DEFAULT_AFDD_INTERVAL_MINUTES,
     DEFAULT_AFDD_LOOKBACK_UNIT, DEFAULT_AFDD_LOOKBACK_VALUE,
+};
+pub use afdd_scheduler::{
+    next_due_at, plan_backfill_chunks, plan_continuous_cycle, AfddBackfillChunk, AfddCycleWindow,
+    AfddSchedulerCheckpoint, AFDD_SCHEDULER_CHECKPOINT_PATH,
 };
 pub use append::{merge_history_wide_csv, merge_history_wide_text, MergeReport};
 pub use compaction::{CompactionPlan, CompactionResult, CompactionSummary, ParquetCompactor};

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -1,5 +1,6 @@
 //! Parquet historian and sidecar storage helpers.
 
+pub mod afdd;
 pub mod append;
 pub mod compaction;
 pub mod historian;
@@ -12,6 +13,10 @@ pub mod migration_exec;
 pub mod parquet_parts;
 pub mod stats;
 
+pub use afdd::{
+    AfddConfig, AfddLookbackUnit, AfddMode, DEFAULT_AFDD_INTERVAL_MINUTES,
+    DEFAULT_AFDD_LOOKBACK_UNIT, DEFAULT_AFDD_LOOKBACK_VALUE,
+};
 pub use append::{merge_history_wide_csv, merge_history_wide_text, MergeReport};
 pub use compaction::{CompactionPlan, CompactionResult, CompactionSummary, ParquetCompactor};
 pub use historian::{

--- a/openfdd_agent_spec/H8_CHECKPOINT.md
+++ b/openfdd_agent_spec/H8_CHECKPOINT.md
@@ -1,0 +1,42 @@
+# H8 — Continuous AFDD scheduler / findings / API
+
+Status: active after H7 merge `07f59e98`.
+
+This checkpoint starts H8 from updated `master`; H8 is not stacked on the H7 branch.
+
+## Required contract
+
+- explicit `bulk` vs `continuous` operating modes
+- scheduling interval independent from rolling lookback
+- continuous rolling window ends at the latest successfully persisted eligible telemetry watermark written by H7
+- overlapping windows are intentional for late-arriving telemetry
+- persisted scheduler checkpoint survives restart
+- prevent overlapping AFDD cycles for the same scope
+- after downtime, run one catch-up cycle when due rather than replaying every missed tick
+- manual run-now and scheduled runs share the same execution engine
+- historical backfill is explicit and chunked
+- preserve existing finding contracts while adding episode continuity/dedup where needed
+- isolate building/rule failures where existing execution contracts safely allow it
+
+## Target configuration
+
+```text
+OPENFDD_AFDD_MODE=bulk|continuous
+OPENFDD_AFDD_INTERVAL_MINUTES=60
+OPENFDD_AFDD_LOOKBACK_VALUE=24
+OPENFDD_AFDD_LOOKBACK_UNIT=hours
+```
+
+Bulk CSV/history import must never implicitly enable recurring AFDD.
+
+## First implementation slice
+
+1. Add strict H8 configuration parsing and validation with `bulk` as the safe default.
+2. Load H7's persisted latest-telemetry watermark from the configured canonical storage backend.
+3. Define persisted scheduler checkpoint and deterministic due/catch-up window calculation.
+4. Add per-scope non-overlap guard and one shared cycle execution entry point for scheduled/run-now calls.
+5. Expose read-only scheduler/cycle status API needed by H9 before adding UI controls.
+
+## Gates
+
+Do not merge H8 until its exact final head passes FDD DataFusion Engine CI, Rust Stack CI, AppSec, docs-guard, Stack Security Guards, and has no unresolved review threads. Keep historian/central ingress private-only and do not add a traditional database as canonical historian or scheduler state store.

--- a/openfdd_agent_spec/HISTORIAN_PROGRAM.md
+++ b/openfdd_agent_spec/HISTORIAN_PROGRAM.md
@@ -1,6 +1,6 @@
 # Historian / Railway implementation program
 
-Last updated: 2026-08-21
+Last updated: 2026-08-22
 
 Canonical architecture: [`docs/HISTORIAN_ARCHITECTURE.md`](docs/HISTORIAN_ARCHITECTURE.md)  
 Full audit/design: [`../docs/architecture/historian.md`](../docs/architecture/historian.md)
@@ -136,7 +136,7 @@ H6 remains offline/operator migration. It does not delete legacy data and does n
 
 ### H7 — Live ingest micro-batch cutover
 
-- [~] PR #765 — `feat/live-historian-ingest-cutover`, implementation complete; exact-head CI/review gate pending
+- [x] PR #765 — `feat/live-historian-ingest-cutover`, merged to `master` as `07f59e98`
 - [x] trace trustworthy building/equipment/role identity from fieldbus/MQTT metadata before mapping live points
 - [x] no arbitrary parsing of BACnet/REST point IDs as canonical equipment roles
 - [x] connect normalized live Arrow batches to the H2 `MicroBatchHistorian`
@@ -147,12 +147,12 @@ H6 remains offline/operator migration. It does not delete legacy data and does n
 - [x] Feather/JSONL MQTT mirror is compatibility-only, disabled by default, and requires explicit `OPENFDD_LEGACY_INGEST_MIRROR=1`
 - [x] preserve bad/stale scalar point roles as nullable values without changing an equipment schema mid-batch
 
-H7 uses explicit `OPENFDD_BUILDING_ID` plus configured device/point metadata at the fieldbus publisher. Missing building identity fails closed for canonical persistence; central does not infer building/equipment/role identity from transport IDs or topic strings. H7 is not complete until PR #765's exact final head passes FDD, Rust stack, AppSec, docs/security workflows and has no unresolved review threads.
+H7 uses explicit `OPENFDD_BUILDING_ID` plus configured device/point metadata at the fieldbus publisher. Missing building identity fails closed for canonical persistence; central does not infer building/equipment/role identity from transport IDs or topic strings. H7 merged only after PR #765's exact final head passed FDD, Rust stack, AppSec, docs/security workflows and had no unresolved review threads.
 
 ### H8 — Continuous AFDD scheduler / findings / API
 
-- [ ] explicit `bulk` vs `continuous` modes
-- [ ] interval independent from rolling lookback
+- [~] explicit `bulk` vs `continuous` modes
+- [~] interval independent from rolling lookback
 - [ ] rolling end time = latest successfully persisted eligible telemetry
 - [ ] overlapping windows for late arrivals
 - [ ] persisted scheduler checkpoint
@@ -172,17 +172,39 @@ OPENFDD_AFDD_LOOKBACK_VALUE=24
 OPENFDD_AFDD_LOOKBACK_UNIT=hours
 ```
 
-### H9 — AFDD / historian React operations UX
+### H9 — AFDD / historian / MQTT React operations UX
 
-- [ ] operating-mode status
-- [ ] frequency vs lookback visibly distinct
+The operations page gains two additional radio-selectable configuration surfaces alongside the existing views: **AFDD Config** and **MQTT Config**. These are operator tools, not a public cloud console.
+
+#### AFDD Config / Scheduler
+
+- [ ] radio/navigation entry for `AFDD Config`
+- [ ] scheduler widget with operating mode (`bulk` / `continuous`)
+- [ ] frequency and rolling lookback shown as separate concepts and controls when deployment permits mutation
 - [ ] last run / analyzed-through / latest historian sample / next run
+- [ ] persisted scheduler checkpoint and catch-up state
 - [ ] historian backend/size/files/small-files/compaction health
-- [ ] run AFDD now
-- [ ] recent AFDD cycles
+- [ ] run AFDD now through the same H8 execution engine used by scheduled cycles
+- [ ] recent AFDD cycles with success/partial/failure state
 - [ ] stale BAS data health independent of scheduler health
 - [ ] finding first/last seen and continuity fields
-- [ ] no fake runtime controls when deployment configuration is read-only
+- [ ] deployment-backed values render read-only when runtime configuration cannot safely be changed from the UI; never show fake controls
+
+#### MQTT Config / Test Monitor
+
+- [ ] radio/navigation entry for `MQTT Config`
+- [ ] AWS IoT Core test-client-style monitor layout without copying AWS branding or cloud assumptions
+- [ ] show broker connection state, client/runtime identity, subscriptions, and message counters without exposing credentials
+- [ ] topic-filter input supporting normal MQTT topic filters (`+` and `#`) with validation
+- [ ] bounded live/recent message list with receive timestamp, topic, payload size, QoS/retain metadata when available
+- [ ] expandable payload viewer with pretty JSON when valid and safe text/hex fallback for non-JSON payloads
+- [ ] pause/resume display and clear-local-view actions that do not interrupt broker ingestion
+- [ ] bounded in-memory/server-side observation buffer; monitoring must not become a second historian
+- [ ] reconnect/error events visible separately from telemetry messages
+- [ ] test publish UI only when an explicit backend capability/config flag allows it; otherwise monitor remains read-only
+- [ ] any allowed test publish requires authenticated operator access, topic validation, payload size limits, audit/event logging, and a clear non-production/testing label
+- [ ] browser never receives MQTT passwords, private keys, S3 secrets, or raw deployment credentials
+- [ ] MQTT monitor traffic is exposed through authenticated Central API/SSE/WebSocket plumbing rather than opening the broker directly to the browser
 
 ### H10 — Scale benchmarks and release qualification
 
@@ -194,6 +216,8 @@ OPENFDD_AFDD_LOOKBACK_UNIT=hours
 - [ ] local Docker qualification
 - [ ] optional MinIO qualification
 - [ ] Railway `:nightly` qualification
+- [ ] AFDD scheduler operations UX qualification
+- [ ] MQTT monitor soak with bounded message buffer and payload rendering under sustained telemetry
 
 ## Non-negotiable gates
 
@@ -203,6 +227,7 @@ OPENFDD_AFDD_LOOKBACK_UNIT=hours
 - Do not delete legacy Feather/JSONL paths before their consumers and migration needs are audited.
 - Do not make bulk CSV import start recurring AFDD.
 - Do not rescan retained history for every continuous AFDD cycle.
-- Do not weaken auth/security or log S3 secrets.
-- Keep historian/central ingress LAN/VPN/private-only; do not describe these services as public.
+- Do not weaken auth/security or log S3/MQTT secrets.
+- Do not expose MQTT broker credentials or private keys to the React client.
+- Keep historian/central/MQTT ingress LAN/VPN/private-only; do not describe these services as public.
 - Do not merge a phase until its changed-head CI and review threads are clean.

--- a/services/central/src/afdd_scheduler.rs
+++ b/services/central/src/afdd_scheduler.rs
@@ -1,0 +1,328 @@
+//! Continuous AFDD scheduler runtime owned by Central.
+//!
+//! Scheduled cycles and operator-triggered run-now cycles share `execute_cycle`.
+//! A per-scope Tokio mutex prevents overlapping AFDD runs for the same building,
+//! while failures are recorded without advancing the persisted checkpoint.
+
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration as StdDuration;
+
+use anyhow::{Context, Result};
+use axum::extract::{Extension, State};
+use axum::middleware;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Duration, Utc};
+use dashmap::DashMap;
+use fdd_store::{
+    next_due_at, plan_continuous_cycle, AfddConfig, AfddCycleWindow, AfddMode,
+    AfddSchedulerCheckpoint, AFDD_SCHEDULER_CHECKPOINT_PATH,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
+use tracing::{info, warn};
+
+use crate::auth;
+use crate::canonical_state::CanonicalStateStore;
+use crate::state::AppState;
+
+const LATEST_TELEMETRY_WATERMARK_PATH: &str = "state/live-historian/latest-telemetry.json";
+const MAX_RECENT_CYCLES: usize = 50;
+
+#[derive(Debug, Deserialize)]
+struct LatestTelemetryWatermark {
+    latest_persisted_timestamp_utc: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AfddCycleRecord {
+    pub scope: String,
+    pub trigger: String,
+    pub started_at_utc: DateTime<Utc>,
+    pub finished_at_utc: DateTime<Utc>,
+    pub start_utc: DateTime<Utc>,
+    pub end_utc: DateTime<Utc>,
+    pub catch_up: bool,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules_succeeded: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules_failed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules_skipped: Option<u64>,
+}
+
+#[derive(Debug, Default)]
+struct RuntimeStatus {
+    recent_cycles: VecDeque<AfddCycleRecord>,
+    last_error: Option<String>,
+}
+
+pub struct AfddSchedulerRuntime {
+    config: AfddConfig,
+    store: CanonicalStateStore,
+    scope_locks: DashMap<String, Arc<AsyncMutex<()>>>,
+    status: Mutex<RuntimeStatus>,
+}
+
+impl AfddSchedulerRuntime {
+    pub fn from_env() -> Result<Arc<Self>> {
+        let config = AfddConfig::from_env().context("load AFDD scheduler config")?;
+        let store = CanonicalStateStore::from_env().context("open canonical AFDD state store")?;
+        Ok(Arc::new(Self {
+            config,
+            store,
+            scope_locks: DashMap::new(),
+            status: Mutex::new(RuntimeStatus::default()),
+        }))
+    }
+
+    fn checkpoint(&self) -> Result<Option<AfddSchedulerCheckpoint>> {
+        let Some(bytes) = self
+            .store
+            .read_optional(Path::new(AFDD_SCHEDULER_CHECKPOINT_PATH))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(
+            serde_json::from_slice(&bytes).context("decode AFDD scheduler checkpoint")?,
+        ))
+    }
+
+    fn latest_telemetry(&self) -> Result<Option<DateTime<Utc>>> {
+        let Some(bytes) = self
+            .store
+            .read_optional(Path::new(LATEST_TELEMETRY_WATERMARK_PATH))?
+        else {
+            return Ok(None);
+        };
+        let watermark: LatestTelemetryWatermark =
+            serde_json::from_slice(&bytes).context("decode live telemetry watermark")?;
+        Ok(Some(watermark.latest_persisted_timestamp_utc))
+    }
+
+    fn persist_checkpoint(&self, checkpoint: &AfddSchedulerCheckpoint) -> Result<()> {
+        let bytes = serde_json::to_vec_pretty(checkpoint)?;
+        self.store
+            .write(Path::new(AFDD_SCHEDULER_CHECKPOINT_PATH), &bytes)
+            .context("persist AFDD scheduler checkpoint")
+    }
+
+    fn record_cycle(&self, record: AfddCycleRecord) {
+        let mut status = self.status.lock().unwrap();
+        status.last_error = record.error.clone();
+        status.recent_cycles.push_front(record);
+        status.recent_cycles.truncate(MAX_RECENT_CYCLES);
+    }
+
+    fn scope_lock(&self, scope: &str) -> Arc<AsyncMutex<()>> {
+        self.scope_locks
+            .entry(scope.to_string())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+
+    async fn run_scheduled_cycle(&self, scope: &str) -> Result<Option<AfddCycleRecord>> {
+        if self.config.mode != AfddMode::Continuous {
+            return Ok(None);
+        }
+        let now = Utc::now();
+        let checkpoint = self.checkpoint()?;
+        let latest = self.latest_telemetry()?;
+        let Some(window) =
+            plan_continuous_cycle(checkpoint.as_ref(), now, latest, &self.config)?
+        else {
+            return Ok(None);
+        };
+        self.execute_cycle(scope, "scheduled", window).await.map(Some)
+    }
+
+    async fn run_now(&self, scope: &str) -> Result<AfddCycleRecord> {
+        let end_utc = self
+            .latest_telemetry()?
+            .ok_or_else(|| anyhow::anyhow!("no persisted telemetry watermark is available"))?;
+        let lookback_seconds = i64::try_from(self.config.lookback_seconds()?)?;
+        let now = Utc::now();
+        let window = AfddCycleWindow {
+            start_utc: end_utc - Duration::seconds(lookback_seconds),
+            end_utc,
+            scheduled_for_utc: now,
+            catch_up: false,
+        };
+        self.execute_cycle(scope, "run_now", window).await
+    }
+
+    async fn execute_cycle(
+        &self,
+        scope: &str,
+        trigger: &str,
+        window: AfddCycleWindow,
+    ) -> Result<AfddCycleRecord> {
+        let scope_lock = self.scope_lock(scope);
+        let Ok(_guard) = scope_lock.try_lock() else {
+            anyhow::bail!("AFDD cycle already running for scope {scope}");
+        };
+
+        let started_at_utc = Utc::now();
+        let payload = json!({
+            "mode": "registry",
+            "building_id": if scope == "all" { Value::Null } else { json!(scope) },
+            "params": {
+                "mode": "registry",
+                "start_utc": window.start_utc.to_rfc3339(),
+                "end_utc": window.end_utc.to_rfc3339(),
+                "afdd_trigger": trigger,
+                "afdd_catch_up": window.catch_up,
+            }
+        });
+
+        let result = tokio::task::spawn_blocking(move || {
+            open_fdd_edge_prototype::fdd::registry_api::run_registry(&payload)
+        })
+        .await
+        .unwrap_or_else(|error| {
+            json!({"ok": false, "error": format!("AFDD registry task failed: {error}")})
+        });
+
+        let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+        let error = result
+            .get("error")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .filter(|value| !value.is_empty());
+        let record = AfddCycleRecord {
+            scope: scope.to_string(),
+            trigger: trigger.to_string(),
+            started_at_utc,
+            finished_at_utc: Utc::now(),
+            start_utc: window.start_utc,
+            end_utc: window.end_utc,
+            catch_up: window.catch_up,
+            ok,
+            error: if ok {
+                None
+            } else {
+                error.or_else(|| Some("AFDD registry cycle failed".into()))
+            },
+            rules_succeeded: result.get("rules_succeeded").and_then(Value::as_u64),
+            rules_failed: result.get("rules_failed").and_then(Value::as_u64),
+            rules_skipped: result.get("rules_skipped").and_then(Value::as_u64),
+        };
+
+        if ok {
+            self.persist_checkpoint(&AfddSchedulerCheckpoint {
+                last_completed_at_utc: record.finished_at_utc,
+                analyzed_through_utc: record.end_utc,
+            })?;
+        }
+        self.record_cycle(record.clone());
+        Ok(record)
+    }
+
+    fn status_json(&self) -> Result<Value> {
+        let checkpoint = self.checkpoint()?;
+        let latest_telemetry = self.latest_telemetry()?;
+        let next_due = next_due_at(checkpoint.as_ref(), Utc::now(), &self.config)?;
+        let status = self.status.lock().unwrap();
+        Ok(json!({
+            "ok": true,
+            "config": self.config,
+            "checkpoint": checkpoint,
+            "latest_persisted_telemetry_utc": latest_telemetry,
+            "next_due_at_utc": if self.config.mode == AfddMode::Continuous { Some(next_due) } else { None },
+            "last_error": status.last_error,
+            "recent_cycles": status.recent_cycles,
+        }))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RunNowRequest {
+    #[serde(default)]
+    building_id: Option<String>,
+}
+
+fn normalize_scope(building_id: Option<&str>) -> String {
+    building_id
+        .map(str::trim)
+        .filter(|scope| !scope.is_empty())
+        .unwrap_or("all")
+        .to_string()
+}
+
+pub fn router(state: Arc<AppState>, runtime: Arc<AfddSchedulerRuntime>) -> Router {
+    Router::new()
+        .route("/api/afdd/scheduler/status", get(scheduler_status))
+        .route("/api/afdd/scheduler/run-now", post(scheduler_run_now))
+        .layer(Extension(runtime))
+        .layer(middleware::from_fn_with_state(
+            Arc::clone(&state),
+            auth::jwt_middleware,
+        ))
+        .with_state(state)
+}
+
+async fn scheduler_status(
+    Extension(runtime): Extension<Arc<AfddSchedulerRuntime>>,
+) -> Json<Value> {
+    match runtime.status_json() {
+        Ok(value) => Json(value),
+        Err(error) => Json(json!({"ok": false, "error": error.to_string()})),
+    }
+}
+
+async fn scheduler_run_now(
+    Extension(runtime): Extension<Arc<AfddSchedulerRuntime>>,
+    Json(body): Json<RunNowRequest>,
+) -> Json<Value> {
+    let scope = normalize_scope(body.building_id.as_deref());
+    match runtime.run_now(&scope).await {
+        Ok(record) => Json(json!({"ok": record.ok, "cycle": record})),
+        Err(error) => Json(json!({"ok": false, "error": error.to_string()})),
+    }
+}
+
+pub fn spawn(runtime: Arc<AfddSchedulerRuntime>) -> Option<tokio::task::JoinHandle<()>> {
+    if runtime.config.mode != AfddMode::Continuous {
+        info!("AFDD scheduler is in bulk mode; continuous timer is disabled");
+        return None;
+    }
+    let scope = normalize_scope(std::env::var("OPENFDD_AFDD_BUILDING_ID").ok().as_deref());
+    Some(tokio::spawn(async move {
+        let mut interval = tokio::time::interval(StdDuration::from_secs(30));
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            match runtime.run_scheduled_cycle(&scope).await {
+                Ok(Some(record)) => info!(
+                    scope = %record.scope,
+                    analyzed_through = %record.end_utc,
+                    catch_up = record.catch_up,
+                    "continuous AFDD cycle completed"
+                ),
+                Ok(None) => {}
+                Err(error) => {
+                    warn!(scope = %scope, %error, "continuous AFDD cycle failed");
+                    runtime.status.lock().unwrap().last_error = Some(error.to_string());
+                }
+            }
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_scope_normalizes_to_all() {
+        assert_eq!(normalize_scope(None), "all");
+        assert_eq!(normalize_scope(Some("   ")), "all");
+        assert_eq!(normalize_scope(Some(" building-a ")), "building-a");
+    }
+}

--- a/services/central/src/afdd_scheduler.rs
+++ b/services/central/src/afdd_scheduler.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration as StdDuration;
 
 use anyhow::{Context, Result};
-use axum::extract::{Extension, State};
+use axum::extract::Extension;
 use axum::middleware;
 use axum::routing::{get, post};
 use axum::{Json, Router};

--- a/services/central/src/afdd_scheduler.rs
+++ b/services/central/src/afdd_scheduler.rs
@@ -134,12 +134,13 @@ impl AfddSchedulerRuntime {
         let now = Utc::now();
         let checkpoint = self.checkpoint()?;
         let latest = self.latest_telemetry()?;
-        let Some(window) =
-            plan_continuous_cycle(checkpoint.as_ref(), now, latest, &self.config)?
+        let Some(window) = plan_continuous_cycle(checkpoint.as_ref(), now, latest, &self.config)?
         else {
             return Ok(None);
         };
-        self.execute_cycle(scope, "scheduled", window).await.map(Some)
+        self.execute_cycle(scope, "scheduled", window)
+            .await
+            .map(Some)
     }
 
     async fn run_now(&self, scope: &str) -> Result<AfddCycleRecord> {
@@ -185,9 +186,9 @@ impl AfddSchedulerRuntime {
             open_fdd_edge_prototype::fdd::registry_api::run_registry(&payload)
         })
         .await
-        .unwrap_or_else(|error| {
-            json!({"ok": false, "error": format!("AFDD registry task failed: {error}")})
-        });
+        .unwrap_or_else(
+            |error| json!({"ok": false, "error": format!("AFDD registry task failed: {error}")}),
+        );
 
         let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
         let error = result
@@ -267,9 +268,7 @@ pub fn router(state: Arc<AppState>, runtime: Arc<AfddSchedulerRuntime>) -> Route
         .with_state(state)
 }
 
-async fn scheduler_status(
-    Extension(runtime): Extension<Arc<AfddSchedulerRuntime>>,
-) -> Json<Value> {
+async fn scheduler_status(Extension(runtime): Extension<Arc<AfddSchedulerRuntime>>) -> Json<Value> {
     match runtime.status_json() {
         Ok(value) => Json(value),
         Err(error) => Json(json!({"ok": false, "error": error.to_string()})),

--- a/services/central/src/canonical_state.rs
+++ b/services/central/src/canonical_state.rs
@@ -180,18 +180,16 @@ fn build_s3_store(bucket: &str) -> Result<Arc<dyn ObjectStore>> {
             .host_str()
             .ok_or_else(|| anyhow!("OPENFDD_S3_ENDPOINT requires a host"))?
             .to_string();
-        let endpoint = if virtual_hosted
-            && host != bucket
-            && !host.starts_with(&format!("{bucket}."))
-        {
-            let mut rewritten = parsed;
-            rewritten
-                .set_host(Some(&format!("{bucket}.{host}")))
-                .map_err(|_| anyhow!("cannot apply virtual-hosted S3 bucket to endpoint"))?;
-            rewritten.as_str().trim_end_matches('/').to_string()
-        } else {
-            endpoint.trim_end_matches('/').to_string()
-        };
+        let endpoint =
+            if virtual_hosted && host != bucket && !host.starts_with(&format!("{bucket}.")) {
+                let mut rewritten = parsed;
+                rewritten
+                    .set_host(Some(&format!("{bucket}.{host}")))
+                    .map_err(|_| anyhow!("cannot apply virtual-hosted S3 bucket to endpoint"))?;
+                rewritten.as_str().trim_end_matches('/').to_string()
+            } else {
+                endpoint.trim_end_matches('/').to_string()
+            };
         builder = builder.with_endpoint(endpoint);
     }
     if let (Some(key), Some(secret)) = (access_key_id, secret_access_key) {

--- a/services/central/src/canonical_state.rs
+++ b/services/central/src/canonical_state.rs
@@ -56,7 +56,8 @@ impl CanonicalStateStore {
                     Ok(result) => result,
                     Err(error) if is_not_found(&error) => return Ok(None),
                     Err(error) => {
-                        return Err(error).with_context(|| format!("read S3 state object {location}"));
+                        return Err(error)
+                            .with_context(|| format!("read S3 state object {location}"));
                     }
                 };
                 let bytes = run_object_store(result.bytes())
@@ -84,7 +85,10 @@ fn validate_relative(path: &Path) -> Result<()> {
     if path.is_absolute() {
         bail!("canonical state path must be relative");
     }
-    if path.components().any(|component| matches!(component, std::path::Component::ParentDir)) {
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
         bail!("canonical state path traversal rejected");
     }
     Ok(())
@@ -174,8 +178,12 @@ fn build_s3_store(bucket: &str) -> Result<Arc<dyn ObjectStore>> {
         }
         let host = parsed
             .host_str()
-            .ok_or_else(|| anyhow!("OPENFDD_S3_ENDPOINT requires a host"))?;
-        let endpoint = if virtual_hosted && host != bucket && !host.starts_with(&format!("{bucket}.")) {
+            .ok_or_else(|| anyhow!("OPENFDD_S3_ENDPOINT requires a host"))?
+            .to_string();
+        let endpoint = if virtual_hosted
+            && host != bucket
+            && !host.starts_with(&format!("{bucket}."))
+        {
             let mut rewritten = parsed;
             rewritten
                 .set_host(Some(&format!("{bucket}.{host}")))
@@ -187,12 +195,16 @@ fn build_s3_store(bucket: &str) -> Result<Arc<dyn ObjectStore>> {
         builder = builder.with_endpoint(endpoint);
     }
     if let (Some(key), Some(secret)) = (access_key_id, secret_access_key) {
-        builder = builder.with_access_key_id(key).with_secret_access_key(secret);
+        builder = builder
+            .with_access_key_id(key)
+            .with_secret_access_key(secret);
     }
     if let Some(token) = session_token {
         builder = builder.with_token(token);
     }
-    Ok(Arc::new(builder.build().context("build canonical S3 state store")?))
+    Ok(Arc::new(
+        builder.build().context("build canonical S3 state store")?,
+    ))
 }
 
 fn run_object_store<F, T>(future: F) -> Result<T>

--- a/services/central/src/canonical_state.rs
+++ b/services/central/src/canonical_state.rs
@@ -1,0 +1,224 @@
+//! Small canonical state-object store used by continuous AFDD scheduling.
+//!
+//! State objects live beside the canonical historian so restart behavior is the
+//! same for local disk and S3-compatible deployments. Secrets are read from the
+//! existing OPENFDD_S3_* environment contract and are never returned/logged.
+
+use std::env;
+use std::future::Future;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use bytes::Bytes;
+use fdd_store::{HistorianConfig, LocalStorage, StorageUrl};
+use object_store::aws::AmazonS3Builder;
+use object_store::path::Path as ObjectPath;
+use object_store::ObjectStore;
+use url::Url;
+
+#[derive(Clone)]
+pub enum CanonicalStateStore {
+    Local(LocalStorage),
+    S3 {
+        store: Arc<dyn ObjectStore>,
+        prefix: String,
+    },
+}
+
+impl CanonicalStateStore {
+    pub fn from_env() -> Result<Self> {
+        Self::from_config(&HistorianConfig::from_env()?)
+    }
+
+    pub fn from_config(config: &HistorianConfig) -> Result<Self> {
+        match &config.storage_url {
+            StorageUrl::File { root } => Ok(Self::Local(LocalStorage::new(root))),
+            StorageUrl::S3 { bucket, prefix } => Ok(Self::S3 {
+                store: build_s3_store(bucket)?,
+                prefix: prefix.trim_matches('/').to_string(),
+            }),
+        }
+    }
+
+    pub fn read_optional(&self, relative_path: &Path) -> Result<Option<Vec<u8>>> {
+        validate_relative(relative_path)?;
+        match self {
+            Self::Local(storage) => {
+                if !storage.exists(relative_path)? {
+                    return Ok(None);
+                }
+                Ok(Some(storage.read(relative_path)?))
+            }
+            Self::S3 { store, prefix } => {
+                let location = object_path(prefix, relative_path)?;
+                let result = match run_object_store(store.get(&location)) {
+                    Ok(result) => result,
+                    Err(error) if is_not_found(&error) => return Ok(None),
+                    Err(error) => {
+                        return Err(error).with_context(|| format!("read S3 state object {location}"));
+                    }
+                };
+                let bytes = run_object_store(result.bytes())
+                    .with_context(|| format!("read S3 state object body {location}"))?;
+                Ok(Some(bytes.to_vec()))
+            }
+        }
+    }
+
+    pub fn write(&self, relative_path: &Path, bytes: &[u8]) -> Result<()> {
+        validate_relative(relative_path)?;
+        match self {
+            Self::Local(storage) => storage.write_atomic(relative_path, bytes),
+            Self::S3 { store, prefix } => {
+                let location = object_path(prefix, relative_path)?;
+                run_object_store(store.put(&location, Bytes::copy_from_slice(bytes).into()))
+                    .with_context(|| format!("write S3 state object {location}"))?;
+                Ok(())
+            }
+        }
+    }
+}
+
+fn validate_relative(path: &Path) -> Result<()> {
+    if path.is_absolute() {
+        bail!("canonical state path must be relative");
+    }
+    if path.components().any(|component| matches!(component, std::path::Component::ParentDir)) {
+        bail!("canonical state path traversal rejected");
+    }
+    Ok(())
+}
+
+fn object_path(prefix: &str, relative_path: &Path) -> Result<ObjectPath> {
+    validate_relative(relative_path)?;
+    let relative = relative_path.to_string_lossy().replace('\\', "/");
+    let prefix = prefix.trim_matches('/');
+    let key = if prefix.is_empty() {
+        relative
+    } else {
+        format!("{prefix}/{relative}")
+    };
+    Ok(ObjectPath::from(key))
+}
+
+fn nonempty_env(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_bool(name: &str, raw: &str) -> Result<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => bail!("{name} must be a boolean"),
+    }
+}
+
+fn build_s3_store(bucket: &str) -> Result<Arc<dyn ObjectStore>> {
+    let endpoint = nonempty_env("OPENFDD_S3_ENDPOINT");
+    let region = nonempty_env("OPENFDD_S3_REGION");
+    let access_key_id = nonempty_env("OPENFDD_S3_ACCESS_KEY_ID");
+    let secret_access_key = nonempty_env("OPENFDD_S3_SECRET_ACCESS_KEY");
+    let session_token = nonempty_env("OPENFDD_S3_SESSION_TOKEN");
+    let allow_http = env::var("OPENFDD_S3_ALLOW_HTTP")
+        .ok()
+        .map(|raw| parse_bool("OPENFDD_S3_ALLOW_HTTP", &raw))
+        .transpose()?
+        .unwrap_or(false);
+    let virtual_hosted = match env::var("OPENFDD_S3_URL_STYLE") {
+        Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "path" | "path_style" | "path-style" => false,
+            "virtual" | "virtual_hosted" | "virtual-hosted" => true,
+            _ => bail!("OPENFDD_S3_URL_STYLE must be 'path' or 'virtual'"),
+        },
+        Err(_) => env::var("OPENFDD_S3_VIRTUAL_HOSTED_STYLE")
+            .ok()
+            .map(|raw| parse_bool("OPENFDD_S3_VIRTUAL_HOSTED_STYLE", &raw))
+            .transpose()?
+            .unwrap_or(false),
+    };
+
+    match (&access_key_id, &secret_access_key) {
+        (Some(_), None) | (None, Some(_)) => bail!(
+            "OPENFDD_S3_ACCESS_KEY_ID and OPENFDD_S3_SECRET_ACCESS_KEY must be configured together"
+        ),
+        _ => {}
+    }
+    if session_token.is_some() && access_key_id.is_none() {
+        bail!("OPENFDD_S3_SESSION_TOKEN requires explicit S3 access key credentials");
+    }
+    if session_token.is_some() && allow_http {
+        bail!("OPENFDD_S3_SESSION_TOKEN cannot be combined with OPENFDD_S3_ALLOW_HTTP=true");
+    }
+
+    let mut builder = AmazonS3Builder::from_env()
+        .with_bucket_name(bucket)
+        .with_virtual_hosted_style_request(virtual_hosted)
+        .with_allow_http(allow_http);
+    if let Some(region) = region {
+        builder = builder.with_region(region);
+    }
+    if let Some(endpoint) = endpoint {
+        let parsed = Url::parse(&endpoint).context("parse OPENFDD_S3_ENDPOINT")?;
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            bail!("OPENFDD_S3_ENDPOINT must not embed credentials");
+        }
+        match parsed.scheme() {
+            "https" => {}
+            "http" if allow_http => {}
+            "http" => bail!("HTTP S3 endpoint requires OPENFDD_S3_ALLOW_HTTP=true"),
+            _ => bail!("OPENFDD_S3_ENDPOINT must use http:// or https://"),
+        }
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| anyhow!("OPENFDD_S3_ENDPOINT requires a host"))?;
+        let endpoint = if virtual_hosted && host != bucket && !host.starts_with(&format!("{bucket}.")) {
+            let mut rewritten = parsed;
+            rewritten
+                .set_host(Some(&format!("{bucket}.{host}")))
+                .map_err(|_| anyhow!("cannot apply virtual-hosted S3 bucket to endpoint"))?;
+            rewritten.as_str().trim_end_matches('/').to_string()
+        } else {
+            endpoint.trim_end_matches('/').to_string()
+        };
+        builder = builder.with_endpoint(endpoint);
+    }
+    if let (Some(key), Some(secret)) = (access_key_id, secret_access_key) {
+        builder = builder.with_access_key_id(key).with_secret_access_key(secret);
+    }
+    if let Some(token) = session_token {
+        builder = builder.with_token(token);
+    }
+    Ok(Arc::new(builder.build().context("build canonical S3 state store")?))
+}
+
+fn run_object_store<F, T>(future: F) -> Result<T>
+where
+    F: Future<Output = object_store::Result<T>>,
+{
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::MultiThread => {
+                return tokio::task::block_in_place(|| handle.block_on(future)).map_err(Into::into);
+            }
+            tokio::runtime::RuntimeFlavor::CurrentThread => {
+                bail!("S3 canonical state requires a multi-thread Tokio runtime");
+            }
+            _ => bail!("unsupported Tokio runtime flavor for S3 canonical state"),
+        }
+    }
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build canonical state object-store runtime")?;
+    runtime.block_on(future).map_err(Into::into)
+}
+
+fn is_not_found(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<object_store::Error>()
+        .is_some_and(|error| matches!(error, object_store::Error::NotFound { .. }))
+}

--- a/services/central/src/main.rs
+++ b/services/central/src/main.rs
@@ -1,8 +1,10 @@
 //! Open-FDD Central — MQTTS ingest + REST/OpenAPI control plane.
 
 mod actions;
+mod afdd_scheduler;
 mod analytics;
 mod auth;
+mod canonical_state;
 mod contract;
 mod cutover;
 mod eplus_runner;
@@ -41,6 +43,8 @@ async fn main() -> anyhow::Result<()> {
     initialize_s3_scope_index().await?;
 
     let state = Arc::new(AppState::new());
+    let afdd_runtime = afdd_scheduler::AfddSchedulerRuntime::from_env()?;
+    let afdd_task = afdd_scheduler::spawn(Arc::clone(&afdd_runtime));
     match jobs::recover_interrupted_runs() {
         Ok(n) if n > 0 => info!(recovered = n, "marked interrupted RUNNING jobs as FAILED"),
         Ok(_) => {}
@@ -52,6 +56,10 @@ async fn main() -> anyhow::Result<()> {
 
     let app = Router::new()
         .merge(routes::router(Arc::clone(&state)))
+        .merge(afdd_scheduler::router(
+            Arc::clone(&state),
+            Arc::clone(&afdd_runtime),
+        ))
         .merge(cutover::router())
         .merge(vibe21::router())
         .merge(openapi::router())
@@ -86,6 +94,9 @@ async fn main() -> anyhow::Result<()> {
 
     let server_result = server.await;
     let _ = shutdown_tx.send(true);
+    if let Some(task) = afdd_task {
+        task.abort();
+    }
     if let Err(error) = ingest_task.await {
         warn!(%error, "MQTT ingest task ended unexpectedly during shutdown");
     }


### PR DESCRIPTION
## H8 scope

Starts H8 cleanly from merged H7/master (`07f59e98`). This is the single H8 branch/PR; it is not stacked on H7.

Initial checkpoint locks the required contract for:
- explicit bulk vs continuous modes
- interval independent from rolling lookback
- H7 persisted telemetry watermark as the continuous analyzed-through boundary
- intentional overlap for late arrivals
- persisted scheduler checkpoint and one catch-up cycle after downtime
- per-scope non-overlap
- shared execution engine for scheduled and run-now cycles
- explicit chunked historical backfill
- finding continuity/dedup while preserving existing contracts
- failure isolation where safe

## First implementation slice

1. strict H8 configuration parsing/validation with bulk as safe default
2. load the H7 persisted latest-telemetry watermark from canonical storage
3. deterministic due/catch-up window calculation plus persisted checkpoint
4. per-scope non-overlap and shared cycle execution entry point
5. read-only scheduler/cycle status API needed by H9

## Branch hygiene

Single H8 branch `feat/continuous-afdd-scheduler`, based directly on merged H7 master. Do not stack H9 on this PR while H8 is unmerged.

## Gate

Draft intentionally. Do not merge until the exact final H8 head passes FDD DataFusion Engine CI, Rust Stack CI, AppSec, docs-guard, Stack Security Guards, and review threads are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable AFDD bulk and continuous scheduling modes.
  - Added independent analysis intervals and lookback periods in minutes, hours, or days.
  - Continuous scheduling now supports catch-up processing, historical backfill, checkpointing, and overlap prevention.
  - Added authenticated status and operator-triggered run-now endpoints.
  - Added support for local and S3-compatible canonical state storage.

- **Documentation**
  - Added AFDD scheduling specifications and updated program status and qualification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->