### PR TITLE
H9: AFDD scheduler and MQTT operations UX

### DIFF
--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -14,6 +14,7 @@ import { AuthPage } from "./pages/AuthPage";
 import { TwinPage } from "./pages/TwinPage";
 import { SitesPage } from "./pages/SitesPage";
 import { RcxPage } from "./pages/RcxPage";
+import { OperationsPage } from "./pages/OperationsPage";
 
 function gated(element: React.ReactNode) {
   return <AuthGate>{element}</AuthGate>;
@@ -39,6 +40,7 @@ export default function App() {
         <Route path="/metering" element={gated(<MeteringPage />)} />
         <Route path="/wattlab" element={gated(<WattLabPage />)} />
         <Route path="/twin" element={gated(<TwinPage />)} />
+        <Route path="/operations" element={gated(<OperationsPage />)} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/web/src/components/AppShell.test.tsx
+++ b/frontend/web/src/components/AppShell.test.tsx
@@ -100,6 +100,7 @@ describe("AppShell layout parity", () => {
       "Metering",
       "WattLab",
       "Sites",
+      "Operations",
     ]);
   });
 

--- a/frontend/web/src/nav/sections.test.ts
+++ b/frontend/web/src/nav/sections.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { MAIN_SECTIONS } from "./sections";
 
-/** Product main sections — Sites after WattLab; Run Rules removed (Overview + left rail). */
+/** Product main sections — H9 adds Operations after Sites; Run Rules remains on Overview + left rail. */
 const ORACLE_MAIN_SECTIONS = [
   "Overview",
   "Inspect",
@@ -13,6 +13,7 @@ const ORACLE_MAIN_SECTIONS = [
   "Metering",
   "WattLab",
   "Sites",
+  "Operations",
 ] as const;
 
 describe("MAIN_SECTIONS navigation contract", () => {

--- a/frontend/web/src/nav/sections.ts
+++ b/frontend/web/src/nav/sections.ts
@@ -10,6 +10,7 @@ export const MAIN_SECTIONS = [
   { id: "metering", label: "Metering", path: "/metering" },
   { id: "wattlab", label: "WattLab", path: "/wattlab" },
   { id: "sites", label: "Sites", path: "/sites" },
+  { id: "operations", label: "Operations", path: "/operations" },
 ] as const;
 
 /** Secondary App pages (collapsed sidebar details). */
@@ -25,4 +26,5 @@ export const SIDEBAR_NAV = [
   { to: "/metering", label: "Metering", short: "E", testId: "nav-metering" },
   { to: "/wattlab", label: "WattLab", short: "W", testId: "nav-wattlab" },
   { to: "/twin", label: "Twin", short: "T", testId: "nav-twin" },
+  { to: "/operations", label: "Operations", short: "O", testId: "nav-operations" },
 ] as const;

--- a/frontend/web/src/pages/OperationsPage.tsx
+++ b/frontend/web/src/pages/OperationsPage.tsx
@@ -4,7 +4,6 @@ import { AppShell } from "../components/AppShell";
 import { Button } from "../components/widgets";
 
 type OperationsView = "afdd" | "mqtt";
-
 type AfddMode = "bulk" | "continuous";
 
 interface AfddConfig {
@@ -49,6 +48,36 @@ interface AfddRunNowResponse {
   ok: boolean;
   cycle?: AfddCycleRecord;
   error?: string;
+}
+
+interface MqttObservedMessage {
+  received_at_utc: string;
+  topic: string;
+  qos: string;
+  retain: boolean;
+  payload_bytes: number;
+  payload_encoding: "json" | "text" | "hex" | string;
+  payload_preview: string;
+  truncated: boolean;
+}
+
+interface MqttMonitorEvent {
+  at_utc: string;
+  kind: string;
+  message: string;
+}
+
+interface MqttMonitorSnapshot {
+  connected: boolean;
+  client_id?: string | null;
+  subscriptions: string[];
+  received_messages: number;
+  reconnects: number;
+  errors: number;
+  buffer_capacity: number;
+  recent_messages: MqttObservedMessage[];
+  recent_events: MqttMonitorEvent[];
+  test_publish_enabled: boolean;
 }
 
 function formatTime(value?: string | null): string {
@@ -144,14 +173,7 @@ function AfddPanel() {
       <div className="table-wrap">
         <table className="data-table">
           <thead>
-            <tr>
-              <th>Finished</th>
-              <th>Scope</th>
-              <th>Trigger</th>
-              <th>Window</th>
-              <th>Rules</th>
-              <th>Status</th>
-            </tr>
+            <tr><th>Finished</th><th>Scope</th><th>Trigger</th><th>Window</th><th>Rules</th><th>Status</th></tr>
           </thead>
           <tbody>
             {recent.length === 0 ? (
@@ -183,22 +205,79 @@ function validTopicFilter(value: string): boolean {
   });
 }
 
+function topicMatchesFilter(topic: string, filter: string): boolean {
+  if (!validTopicFilter(filter)) return false;
+  const topicLevels = topic.split("/");
+  const filterLevels = filter.split("/");
+  for (let index = 0; index < filterLevels.length; index += 1) {
+    const expected = filterLevels[index];
+    if (expected === "#") return true;
+    if (index >= topicLevels.length) return false;
+    if (expected !== "+" && expected !== topicLevels[index]) return false;
+  }
+  return topicLevels.length === filterLevels.length;
+}
+
 function MqttPanel() {
-  const [topicFilter, setTopicFilter] = useState("openfdd/+/+/telemetry/#");
+  const [topicFilter, setTopicFilter] = useState("openfdd/#");
+  const [snapshot, setSnapshot] = useState<MqttMonitorSnapshot | null>(null);
+  const [paused, setPaused] = useState(false);
+  const [clearedAt, setClearedAt] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const filterOk = useMemo(() => validTopicFilter(topicFilter), [topicFilter]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await apiFetch<MqttMonitorSnapshot>("/api/mqtt/monitor");
+      setSnapshot(next);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (paused) return undefined;
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 2000);
+    return () => window.clearInterval(timer);
+  }, [paused, refresh]);
+
+  const messages = useMemo(() => {
+    const cutoff = clearedAt ?? Number.NEGATIVE_INFINITY;
+    return (snapshot?.recent_messages ?? []).filter((message) => {
+      const received = Date.parse(message.received_at_utc);
+      return received > cutoff && filterOk && topicMatchesFilter(message.topic, topicFilter);
+    });
+  }, [clearedAt, filterOk, snapshot?.recent_messages, topicFilter]);
 
   return (
     <section aria-labelledby="mqtt-config-heading" data-testid="mqtt-config-panel">
-      <h2 id="mqtt-config-heading">MQTT Test Monitor</h2>
-      <p className="muted">
-        Read-only operator monitor by default. The browser never receives broker passwords, private keys, or raw deployment credentials and never connects directly to the broker.
-      </p>
+      <div className="section-heading-row">
+        <div>
+          <h2 id="mqtt-config-heading">MQTT Test Monitor</h2>
+          <p className="muted">
+            Read-only operator monitor. The browser receives only bounded observation data from authenticated Central API calls; broker credentials and private keys never leave Central.
+          </p>
+        </div>
+        <div className="button-row">
+          <Button id="mqtt-pause" label={paused ? "Resume display" : "Pause display"} variant="secondary" onClick={() => setPaused((value) => !value)} />
+          <Button id="mqtt-clear" label="Clear local view" variant="secondary" onClick={() => setClearedAt(Date.now())} />
+          <Button id="mqtt-refresh" label="Refresh" variant="secondary" onClick={() => void refresh()} />
+        </div>
+      </div>
+
+      {error ? <div className="inline-alert inline-alert--error" role="alert">{error}</div> : null}
 
       <div className="summary-grid">
-        {metric("Broker state", "Central monitor backend pending")}
-        {metric("Publish capability", "Disabled by default")}
-        {metric("Observation buffer", "Bounded")}
-        {metric("Transport", "Authenticated Central API")}
+        {metric("Broker state", snapshot?.connected ? "Connected" : "Disconnected")}
+        {metric("Client identity", snapshot?.client_id ?? "—")}
+        {metric("Messages observed", String(snapshot?.received_messages ?? 0))}
+        {metric("Reconnects", String(snapshot?.reconnects ?? 0))}
+        {metric("Errors", String(snapshot?.errors ?? 0))}
+        {metric("Observation buffer", snapshot ? `${snapshot.recent_messages.length}/${snapshot.buffer_capacity}` : "—")}
+        {metric("Subscriptions", String(snapshot?.subscriptions.length ?? 0))}
+        {metric("Publish capability", snapshot?.test_publish_enabled ? "Enabled" : "Disabled")}
       </div>
 
       <div className="form-row">
@@ -208,10 +287,17 @@ function MqttPanel() {
           value={topicFilter}
           onChange={(event) => setTopicFilter(event.target.value)}
           aria-invalid={!filterOk}
-          placeholder="openfdd/+/+/telemetry/#"
+          placeholder="openfdd/#"
         />
-        <span>{filterOk ? "Valid MQTT topic filter" : "Use + for one level and # only as the final level"}</span>
+        <span>{filterOk ? `${messages.length} buffered messages match` : "Use + for one level and # only as the final level"}</span>
       </div>
+
+      <details>
+        <summary>Central subscriptions</summary>
+        <ul>
+          {(snapshot?.subscriptions ?? []).map((subscription) => <li key={subscription}><code>{subscription}</code></li>)}
+        </ul>
+      </details>
 
       <div className="table-wrap">
         <table className="data-table">
@@ -219,7 +305,39 @@ function MqttPanel() {
             <tr><th>Received</th><th>Topic</th><th>QoS</th><th>Retain</th><th>Bytes</th><th>Payload</th></tr>
           </thead>
           <tbody>
-            <tr><td colSpan={6}>Live bounded message observation wiring is the next H9 backend slice.</td></tr>
+            {messages.length === 0 ? (
+              <tr><td colSpan={6}>{paused ? "Display paused." : "No buffered messages match the current filter."}</td></tr>
+            ) : messages.map((message) => (
+              <tr key={`${message.received_at_utc}-${message.topic}-${message.payload_bytes}`}>
+                <td>{formatTime(message.received_at_utc)}</td>
+                <td><code>{message.topic}</code></td>
+                <td>{message.qos}</td>
+                <td>{message.retain ? "Yes" : "No"}</td>
+                <td>{message.payload_bytes}</td>
+                <td>
+                  <details>
+                    <summary>{message.payload_encoding}{message.truncated ? " · truncated" : ""}</summary>
+                    <pre>{message.payload_preview}</pre>
+                  </details>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Connection and error events</h3>
+      <div className="table-wrap">
+        <table className="data-table">
+          <thead><tr><th>Time</th><th>Kind</th><th>Event</th></tr></thead>
+          <tbody>
+            {(snapshot?.recent_events ?? []).length === 0 ? (
+              <tr><td colSpan={3}>No connection events recorded yet.</td></tr>
+            ) : snapshot?.recent_events.map((event) => (
+              <tr key={`${event.at_utc}-${event.kind}-${event.message}`}>
+                <td>{formatTime(event.at_utc)}</td><td>{event.kind}</td><td>{event.message}</td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
@@ -231,11 +349,7 @@ export function OperationsPage() {
   const [view, setView] = useState<OperationsView>("afdd");
 
   return (
-    <AppShell
-      title="Operations"
-      caption="AFDD scheduler and MQTT operator tooling"
-      activeSectionId="operations"
-    >
+    <AppShell title="Operations" caption="AFDD scheduler and MQTT operator tooling" activeSectionId="operations">
       <fieldset className="section-tabs" aria-label="Operations configuration">
         <legend className="sr-only">Operations configuration</legend>
         <label>

--- a/frontend/web/src/pages/OperationsPage.tsx
+++ b/frontend/web/src/pages/OperationsPage.tsx
@@ -50,6 +50,22 @@ interface AfddRunNowResponse {
   error?: string;
 }
 
+interface FddContinuityRow {
+  rule_id?: string;
+  equipment_id?: string;
+  first_seen_utc?: string;
+  first_seen?: string;
+  last_seen_utc?: string;
+  last_seen?: string;
+  continuity_count?: number;
+  occurrences?: number;
+}
+
+interface FddResultsResponse {
+  ok?: boolean;
+  results?: FddContinuityRow[];
+}
+
 interface MqttObservedMessage {
   received_at_utc: string;
   topic: string;
@@ -95,8 +111,42 @@ function metric(label: string, value: string) {
   );
 }
 
+function findScalar(root: unknown, names: string[]): string | null {
+  const wanted = new Set(names.map((name) => name.toLowerCase()));
+  const visit = (value: unknown, depth: number): string | null => {
+    if (depth > 4 || value == null || typeof value !== "object") return null;
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (wanted.has(key.toLowerCase()) && ["string", "number", "boolean"].includes(typeof child)) {
+        return String(child);
+      }
+    }
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      const found = visit(child, depth + 1);
+      if (found != null) return found;
+    }
+    return null;
+  };
+  return visit(root, 0);
+}
+
+function basFreshness(value?: string | null): string {
+  if (!value) return "No persisted sample";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return "Unknown";
+  const ageMinutes = Math.max(0, Math.round((Date.now() - parsed) / 60000));
+  return ageMinutes > 15 ? `Stale · ${ageMinutes} min old` : `Fresh · ${ageMinutes} min old`;
+}
+
+function cycleState(cycle: AfddCycleRecord): string {
+  if (!cycle.ok) return cycle.error ?? "Failed";
+  if ((cycle.rules_failed ?? 0) > 0) return "Partial";
+  return "Success";
+}
+
 function AfddPanel() {
   const [status, setStatus] = useState<AfddSchedulerStatus | null>(null);
+  const [historian, setHistorian] = useState<Record<string, unknown> | null>(null);
+  const [continuity, setContinuity] = useState<FddContinuityRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -104,8 +154,14 @@ function AfddPanel() {
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const next = await apiFetch<AfddSchedulerStatus>("/api/afdd/scheduler/status");
+      const [next, historianSummary, results] = await Promise.all([
+        apiFetch<AfddSchedulerStatus>("/api/afdd/scheduler/status"),
+        apiFetch<Record<string, unknown>>("/api/data-management/summary").catch(() => null),
+        apiFetch<FddResultsResponse>("/api/fdd/results").catch(() => null),
+      ]);
       setStatus(next);
+      setHistorian(historianSummary);
+      setContinuity(results?.results ?? []);
       setError(next.ok ? null : next.error ?? "AFDD scheduler status unavailable");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -141,6 +197,12 @@ function AfddPanel() {
   const recent = status?.recent_cycles ?? [];
   const latestCycle = recent[0];
   const config = status?.config;
+  const historianBackend = findScalar(historian, ["backend", "storage_backend", "storage", "scheme"]);
+  const historianFiles = findScalar(historian, ["file_count", "files", "part_count", "parts"]);
+  const historianBytes = findScalar(historian, ["total_bytes", "bytes", "size_bytes"]);
+  const smallFiles = findScalar(historian, ["small_file_count", "small_files"]);
+  const compaction = findScalar(historian, ["compaction_status", "compaction", "compaction_health"]);
+  const continuityRows = continuity.filter((row) => row.first_seen_utc || row.first_seen || row.last_seen_utc || row.last_seen);
 
   return (
     <section aria-labelledby="afdd-config-heading" data-testid="afdd-config-panel">
@@ -158,18 +220,31 @@ function AfddPanel() {
       </div>
 
       {error ? <div className="inline-alert inline-alert--error" role="alert">{error}</div> : null}
+      {status?.last_error ? <div className="inline-alert inline-alert--error" role="status">Last scheduler error: {status.last_error}</div> : null}
 
       <div className="summary-grid">
         {metric("Mode", config?.mode ?? "—")}
         {metric("Frequency", config ? `${config.interval_minutes} min` : "—")}
         {metric("Rolling lookback", config ? `${config.lookback_value} ${config.lookback_unit}` : "—")}
         {metric("Latest historian sample", formatTime(status?.latest_persisted_telemetry_utc))}
+        {metric("BAS freshness", basFreshness(status?.latest_persisted_telemetry_utc))}
         {metric("Analyzed through", formatTime(status?.checkpoint?.analyzed_through_utc))}
         {metric("Last completed", formatTime(status?.checkpoint?.last_completed_at_utc))}
         {metric("Next due", config?.mode === "continuous" ? formatTime(status?.next_due_at_utc) : "Bulk mode")}
         {metric("Catch-up", latestCycle?.catch_up ? "Yes" : "No")}
       </div>
 
+      <h3>Historian health</h3>
+      <p className="muted">Read-only values from Central data-management health. Missing values are reported as unavailable rather than synthesized.</p>
+      <div className="summary-grid">
+        {metric("Backend", historianBackend ?? "Not reported")}
+        {metric("Files / parts", historianFiles ?? "Not reported")}
+        {metric("Bytes", historianBytes ?? "Not reported")}
+        {metric("Small files", smallFiles ?? "Not reported")}
+        {metric("Compaction", compaction ?? "Not reported")}
+      </div>
+
+      <h3>Recent AFDD cycles</h3>
       <div className="table-wrap">
         <table className="data-table">
           <thead>
@@ -185,7 +260,28 @@ function AfddPanel() {
                 <td>{cycle.trigger}{cycle.catch_up ? " · catch-up" : ""}</td>
                 <td>{formatTime(cycle.start_utc)} → {formatTime(cycle.end_utc)}</td>
                 <td>{cycle.rules_succeeded ?? 0}✓ / {cycle.rules_failed ?? 0}✗ / {cycle.rules_skipped ?? 0} skipped</td>
-                <td>{cycle.ok ? "Success" : cycle.error ?? "Failed"}</td>
+                <td>{cycleState(cycle)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Finding continuity</h3>
+      <p className="muted">First/last-seen values are shown only when the current findings contract exposes them; the UI never invents continuity timestamps.</p>
+      <div className="table-wrap">
+        <table className="data-table">
+          <thead><tr><th>Rule</th><th>Equipment</th><th>First seen</th><th>Last seen</th><th>Occurrences</th></tr></thead>
+          <tbody>
+            {continuityRows.length === 0 ? (
+              <tr><td colSpan={5}>Current findings do not expose first/last-seen continuity fields.</td></tr>
+            ) : continuityRows.map((row, index) => (
+              <tr key={`${row.rule_id ?? "rule"}-${row.equipment_id ?? "equipment"}-${index}`}>
+                <td>{row.rule_id ?? "—"}</td>
+                <td>{row.equipment_id ?? "—"}</td>
+                <td>{formatTime(row.first_seen_utc ?? row.first_seen)}</td>
+                <td>{formatTime(row.last_seen_utc ?? row.last_seen)}</td>
+                <td>{row.continuity_count ?? row.occurrences ?? "—"}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/web/src/pages/OperationsPage.tsx
+++ b/frontend/web/src/pages/OperationsPage.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { apiFetch } from "../api/client";
+import { AppShell } from "../components/AppShell";
+import { Button } from "../components/widgets";
+
+type OperationsView = "afdd" | "mqtt";
+
+type AfddMode = "bulk" | "continuous";
+
+interface AfddConfig {
+  mode: AfddMode;
+  interval_minutes: number;
+  lookback_value: number;
+  lookback_unit: "minutes" | "hours" | "days";
+}
+
+interface AfddCheckpoint {
+  last_completed_at_utc: string;
+  analyzed_through_utc: string;
+}
+
+interface AfddCycleRecord {
+  scope: string;
+  trigger: string;
+  started_at_utc: string;
+  finished_at_utc: string;
+  start_utc: string;
+  end_utc: string;
+  catch_up: boolean;
+  ok: boolean;
+  error?: string;
+  rules_succeeded?: number;
+  rules_failed?: number;
+  rules_skipped?: number;
+}
+
+interface AfddSchedulerStatus {
+  ok: boolean;
+  config: AfddConfig;
+  checkpoint?: AfddCheckpoint | null;
+  latest_persisted_telemetry_utc?: string | null;
+  next_due_at_utc?: string | null;
+  last_error?: string | null;
+  recent_cycles: AfddCycleRecord[];
+  error?: string;
+}
+
+interface AfddRunNowResponse {
+  ok: boolean;
+  cycle?: AfddCycleRecord;
+  error?: string;
+}
+
+function formatTime(value?: string | null): string {
+  if (!value) return "—";
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toLocaleString() : value;
+}
+
+function metric(label: string, value: string) {
+  return (
+    <div className="summary-card" key={label}>
+      <div className="summary-card__label">{label}</div>
+      <div className="summary-card__value">{value}</div>
+    </div>
+  );
+}
+
+function AfddPanel() {
+  const [status, setStatus] = useState<AfddSchedulerStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await apiFetch<AfddSchedulerStatus>("/api/afdd/scheduler/status");
+      setStatus(next);
+      setError(next.ok ? null : next.error ?? "AFDD scheduler status unavailable");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const runNow = useCallback(async () => {
+    setRunning(true);
+    setError(null);
+    try {
+      const result = await apiFetch<AfddRunNowResponse>("/api/afdd/scheduler/run-now", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!result.ok) {
+        setError(result.error ?? result.cycle?.error ?? "AFDD run failed");
+      }
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRunning(false);
+    }
+  }, [refresh]);
+
+  const recent = status?.recent_cycles ?? [];
+  const latestCycle = recent[0];
+  const config = status?.config;
+
+  return (
+    <section aria-labelledby="afdd-config-heading" data-testid="afdd-config-panel">
+      <div className="section-heading-row">
+        <div>
+          <h2 id="afdd-config-heading">AFDD Scheduler</h2>
+          <p className="muted">
+            Deployment-backed scheduler settings are read-only here. Run Now uses the same H8 execution engine as scheduled cycles.
+          </p>
+        </div>
+        <div className="button-row">
+          <Button id="afdd-refresh" label="Refresh" variant="secondary" loading={loading} onClick={() => void refresh()} />
+          <Button id="afdd-run-now" label="Run AFDD now" loading={running} onClick={() => void runNow()} />
+        </div>
+      </div>
+
+      {error ? <div className="inline-alert inline-alert--error" role="alert">{error}</div> : null}
+
+      <div className="summary-grid">
+        {metric("Mode", config?.mode ?? "—")}
+        {metric("Frequency", config ? `${config.interval_minutes} min` : "—")}
+        {metric("Rolling lookback", config ? `${config.lookback_value} ${config.lookback_unit}` : "—")}
+        {metric("Latest historian sample", formatTime(status?.latest_persisted_telemetry_utc))}
+        {metric("Analyzed through", formatTime(status?.checkpoint?.analyzed_through_utc))}
+        {metric("Last completed", formatTime(status?.checkpoint?.last_completed_at_utc))}
+        {metric("Next due", config?.mode === "continuous" ? formatTime(status?.next_due_at_utc) : "Bulk mode")}
+        {metric("Catch-up", latestCycle?.catch_up ? "Yes" : "No")}
+      </div>
+
+      <div className="table-wrap">
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Finished</th>
+              <th>Scope</th>
+              <th>Trigger</th>
+              <th>Window</th>
+              <th>Rules</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recent.length === 0 ? (
+              <tr><td colSpan={6}>No AFDD cycles recorded in this Central process yet.</td></tr>
+            ) : recent.map((cycle) => (
+              <tr key={`${cycle.finished_at_utc}-${cycle.scope}-${cycle.trigger}`}>
+                <td>{formatTime(cycle.finished_at_utc)}</td>
+                <td>{cycle.scope}</td>
+                <td>{cycle.trigger}{cycle.catch_up ? " · catch-up" : ""}</td>
+                <td>{formatTime(cycle.start_utc)} → {formatTime(cycle.end_utc)}</td>
+                <td>{cycle.rules_succeeded ?? 0}✓ / {cycle.rules_failed ?? 0}✗ / {cycle.rules_skipped ?? 0} skipped</td>
+                <td>{cycle.ok ? "Success" : cycle.error ?? "Failed"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function validTopicFilter(value: string): boolean {
+  if (!value.trim()) return false;
+  const levels = value.split("/");
+  return levels.every((level, index) => {
+    if (level.includes("#")) return level === "#" && index === levels.length - 1;
+    if (level.includes("+")) return level === "+";
+    return true;
+  });
+}
+
+function MqttPanel() {
+  const [topicFilter, setTopicFilter] = useState("openfdd/+/+/telemetry/#");
+  const filterOk = useMemo(() => validTopicFilter(topicFilter), [topicFilter]);
+
+  return (
+    <section aria-labelledby="mqtt-config-heading" data-testid="mqtt-config-panel">
+      <h2 id="mqtt-config-heading">MQTT Test Monitor</h2>
+      <p className="muted">
+        Read-only operator monitor by default. The browser never receives broker passwords, private keys, or raw deployment credentials and never connects directly to the broker.
+      </p>
+
+      <div className="summary-grid">
+        {metric("Broker state", "Central monitor backend pending")}
+        {metric("Publish capability", "Disabled by default")}
+        {metric("Observation buffer", "Bounded")}
+        {metric("Transport", "Authenticated Central API")}
+      </div>
+
+      <div className="form-row">
+        <label htmlFor="mqtt-topic-filter">Topic filter</label>
+        <input
+          id="mqtt-topic-filter"
+          value={topicFilter}
+          onChange={(event) => setTopicFilter(event.target.value)}
+          aria-invalid={!filterOk}
+          placeholder="openfdd/+/+/telemetry/#"
+        />
+        <span>{filterOk ? "Valid MQTT topic filter" : "Use + for one level and # only as the final level"}</span>
+      </div>
+
+      <div className="table-wrap">
+        <table className="data-table">
+          <thead>
+            <tr><th>Received</th><th>Topic</th><th>QoS</th><th>Retain</th><th>Bytes</th><th>Payload</th></tr>
+          </thead>
+          <tbody>
+            <tr><td colSpan={6}>Live bounded message observation wiring is the next H9 backend slice.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export function OperationsPage() {
+  const [view, setView] = useState<OperationsView>("afdd");
+
+  return (
+    <AppShell
+      title="Operations"
+      caption="AFDD scheduler and MQTT operator tooling"
+      activeSectionId="operations"
+    >
+      <fieldset className="section-tabs" aria-label="Operations configuration">
+        <legend className="sr-only">Operations configuration</legend>
+        <label>
+          <input type="radio" name="operations-view" value="afdd" checked={view === "afdd"} onChange={() => setView("afdd")} />
+          AFDD Config
+        </label>
+        <label>
+          <input type="radio" name="operations-view" value="mqtt" checked={view === "mqtt"} onChange={() => setView("mqtt")} />
+          MQTT Config
+        </label>
+      </fieldset>
+      {view === "afdd" ? <AfddPanel /> : <MqttPanel />}
+    </AppShell>
+  );
+}

--- a/openfdd_agent_spec/HISTORIAN_PROGRAM.md
+++ b/openfdd_agent_spec/HISTORIAN_PROGRAM.md
@@ -151,17 +151,17 @@ H7 uses explicit `OPENFDD_BUILDING_ID` plus configured device/point metadata at 
 
 ### H8 — Continuous AFDD scheduler / findings / API
 
-- [~] explicit `bulk` vs `continuous` modes
-- [~] interval independent from rolling lookback
-- [ ] rolling end time = latest successfully persisted eligible telemetry
-- [ ] overlapping windows for late arrivals
-- [ ] persisted scheduler checkpoint
-- [ ] no overlapping cycle for same scope
-- [ ] one restart catch-up when due, no missed-tick storm
-- [ ] run-now uses same engine
-- [ ] explicit chunked historical backfill
-- [ ] finding continuity/dedup preserves existing contracts
-- [ ] building/rule failure isolation where safe
+- [x] explicit `bulk` vs `continuous` modes
+- [x] interval independent from rolling lookback
+- [x] rolling end time = latest successfully persisted eligible telemetry
+- [x] overlapping rolling windows support late arrivals when lookback exceeds cadence
+- [x] persisted scheduler checkpoint on the canonical local/S3 backend
+- [x] no overlapping cycle for same scope
+- [x] one restart catch-up when due, no missed-tick storm
+- [x] run-now uses the same execution engine as scheduled cycles
+- [x] explicit bounded historical backfill chunk planner
+- [~] finding continuity/dedup preserves existing contracts; H8 does not fabricate first/last-seen fields when the current findings contract does not expose them
+- [x] building/rule failure isolation remains in the registry engine and cycle status exposes succeeded/failed/skipped counts
 
 Target configuration:
 
@@ -172,39 +172,43 @@ OPENFDD_AFDD_LOOKBACK_VALUE=24
 OPENFDD_AFDD_LOOKBACK_UNIT=hours
 ```
 
+H8 Central owns the continuous timer, reads the H7 persisted telemetry watermark, persists `state/afdd/scheduler-checkpoint.json`, serializes same-scope runs, and exposes authenticated scheduler status and run-now APIs.
+
 ### H9 — AFDD / historian / MQTT React operations UX
 
 The operations page gains two additional radio-selectable configuration surfaces alongside the existing views: **AFDD Config** and **MQTT Config**. These are operator tools, not a public cloud console.
 
 #### AFDD Config / Scheduler
 
-- [ ] radio/navigation entry for `AFDD Config`
-- [ ] scheduler widget with operating mode (`bulk` / `continuous`)
-- [ ] frequency and rolling lookback shown as separate concepts and controls when deployment permits mutation
-- [ ] last run / analyzed-through / latest historian sample / next run
-- [ ] persisted scheduler checkpoint and catch-up state
-- [ ] historian backend/size/files/small-files/compaction health
-- [ ] run AFDD now through the same H8 execution engine used by scheduled cycles
-- [ ] recent AFDD cycles with success/partial/failure state
-- [ ] stale BAS data health independent of scheduler health
-- [ ] finding first/last seen and continuity fields
-- [ ] deployment-backed values render read-only when runtime configuration cannot safely be changed from the UI; never show fake controls
+- [x] radio/navigation entry for `AFDD Config`
+- [x] scheduler widget with operating mode (`bulk` / `continuous`)
+- [x] frequency and rolling lookback shown as separate concepts; deployment-owned values remain read-only when runtime mutation is not supported
+- [x] last run / analyzed-through / latest historian sample / next run
+- [x] persisted scheduler checkpoint and catch-up state
+- [x] historian backend/size/files/small-files/compaction health surface reads Central data-management health and reports unavailable fields honestly rather than synthesizing values
+- [x] run AFDD now through the same H8 execution engine used by scheduled cycles
+- [x] recent AFDD cycles with success/partial/failure state
+- [x] stale BAS data health independent of scheduler health using persisted telemetry freshness
+- [x] finding first/last-seen and continuity fields are rendered when exposed by the current findings response; unavailable contract fields are explicitly identified rather than fabricated
+- [x] deployment-backed values render read-only when runtime configuration cannot safely be changed from the UI; never show fake controls
 
 #### MQTT Config / Test Monitor
 
-- [ ] radio/navigation entry for `MQTT Config`
-- [ ] AWS IoT Core test-client-style monitor layout without copying AWS branding or cloud assumptions
-- [ ] show broker connection state, client/runtime identity, subscriptions, and message counters without exposing credentials
-- [ ] topic-filter input supporting normal MQTT topic filters (`+` and `#`) with validation
-- [ ] bounded live/recent message list with receive timestamp, topic, payload size, QoS/retain metadata when available
-- [ ] expandable payload viewer with pretty JSON when valid and safe text/hex fallback for non-JSON payloads
-- [ ] pause/resume display and clear-local-view actions that do not interrupt broker ingestion
-- [ ] bounded in-memory/server-side observation buffer; monitoring must not become a second historian
-- [ ] reconnect/error events visible separately from telemetry messages
-- [ ] test publish UI only when an explicit backend capability/config flag allows it; otherwise monitor remains read-only
-- [ ] any allowed test publish requires authenticated operator access, topic validation, payload size limits, audit/event logging, and a clear non-production/testing label
-- [ ] browser never receives MQTT passwords, private keys, S3 secrets, or raw deployment credentials
-- [ ] MQTT monitor traffic is exposed through authenticated Central API/SSE/WebSocket plumbing rather than opening the broker directly to the browser
+- [x] radio/navigation entry for `MQTT Config`
+- [x] AWS IoT Core test-client-style conceptual monitor layout without copying AWS branding or cloud assumptions
+- [x] show broker connection state, client/runtime identity, subscriptions, and message counters without exposing credentials
+- [x] topic-filter input supporting normal MQTT topic filters (`+` and `#`) with validation and local buffered-message matching
+- [x] bounded live/recent message list with receive timestamp, topic, payload size, QoS/retain metadata
+- [x] expandable payload viewer with pretty JSON when valid and safe text/hex fallback for non-JSON payloads
+- [x] pause/resume display and clear-local-view actions that do not interrupt broker ingestion
+- [x] bounded in-memory/server-side observation buffer; monitoring is not a second historian
+- [x] reconnect/error events visible separately from telemetry messages
+- [x] test publish remains disabled/read-only unless a future explicit backend capability/config flag enables it
+- [x] because test publish is disabled in H9, no browser publish path bypasses authenticated operator controls, topic validation, payload limits, or audit requirements
+- [x] browser never receives MQTT passwords, private keys, S3 secrets, or raw deployment credentials
+- [x] MQTT monitor traffic is exposed through authenticated Central API plumbing rather than opening the broker directly to the browser
+
+H9 is gated on the exact final PR head passing frontend/Rust/security/docs workflows with zero unresolved review threads before merge.
 
 ### H10 — Scale benchmarks and release qualification
 

--- a/services/central/src/ingest.rs
+++ b/services/central/src/ingest.rs
@@ -61,9 +61,8 @@ fn spawn_mqtt_ingest_inner(
                 Some(historian)
             }
             Err(err) => {
-                // Canonical history is now the durability path. Do not keep
-                // accepting MQTT solely into the legacy Feather/JSONL mirror.
                 warn!(%err, "canonical live historian unavailable; refusing durability downgrade");
+                state.mqtt_record_error("canonical live historian unavailable");
                 return;
             }
         };
@@ -98,6 +97,7 @@ fn spawn_mqtt_ingest_inner(
         loop {
             let connection = tokio::select! {
                 _ = wait_for_shutdown(&mut shutdown) => {
+                    state.mqtt_mark_disconnected("Central shutting down");
                     drain_live_historian(&mut live_historian);
                     return;
                 }
@@ -116,9 +116,11 @@ fn spawn_mqtt_ingest_inner(
                     for topic in &topics {
                         if let Err(err) = handle.subscribe(topic).await {
                             warn!(%err, topic, "subscribe failed");
+                            state.mqtt_record_error(format!("subscription failed for {topic}"));
                         }
                     }
 
+                    state.mqtt_mark_connected(cfg.client_id.clone(), topics.to_vec());
                     let (publisher, mut events) = handle.split();
                     state.set_mqtt_publisher(publisher);
                     info!("central MQTT ingest connected; publisher ready for commands");
@@ -127,6 +129,7 @@ fn spawn_mqtt_ingest_inner(
                         tokio::select! {
                             _ = wait_for_shutdown(&mut shutdown) => {
                                 *state.mqtt_publisher.lock().unwrap() = None;
+                                state.mqtt_mark_disconnected("Central shutting down");
                                 drain_live_historian(&mut live_historian);
                                 return;
                             }
@@ -136,6 +139,12 @@ fn spawn_mqtt_ingest_inner(
                                 };
                                 if let Incoming::Publish(p) = ev {
                                     let topic = p.topic.clone();
+                                    state.mqtt_observe(
+                                        &topic,
+                                        &p.payload,
+                                        format!("{:?}", p.qos),
+                                        p.retain,
+                                    );
                                     handle_payload(
                                         &state,
                                         live_historian.as_mut(),
@@ -164,11 +173,14 @@ fn spawn_mqtt_ingest_inner(
                     }
                     warn!("central mqtt event stream ended; reconnecting");
                     *state.mqtt_publisher.lock().unwrap() = None;
+                    state.mqtt_mark_disconnected("MQTT event stream ended; reconnecting");
                 }
                 Err(err) => {
                     warn!(%err, "central mqtt connect failed; retrying");
+                    state.mqtt_record_error("MQTT connect failed; retrying");
                     tokio::select! {
                         _ = wait_for_shutdown(&mut shutdown) => {
+                            state.mqtt_mark_disconnected("Central shutting down");
                             drain_live_historian(&mut live_historian);
                             return;
                         }
@@ -362,9 +374,6 @@ fn handle_telemetry(
                 }
             }
 
-            // The compatibility mirror is no longer durability-critical. It is
-            // available only for audited migration/interchange consumers that
-            // explicitly opt in during the H7 cutover period.
             if legacy_compatibility_mirror_enabled() {
                 persist_legacy_compatibility(&env);
             }

--- a/services/central/src/main.rs
+++ b/services/central/src/main.rs
@@ -13,6 +13,7 @@ mod ingest;
 mod jobs;
 mod live_historian;
 mod models;
+mod mqtt_monitor;
 mod openapi;
 mod routes;
 mod state;
@@ -60,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
             Arc::clone(&state),
             Arc::clone(&afdd_runtime),
         ))
+        .merge(mqtt_monitor::router(Arc::clone(&state)))
         .merge(cutover::router())
         .merge(vibe21::router())
         .merge(openapi::router())

--- a/services/central/src/mqtt_monitor.rs
+++ b/services/central/src/mqtt_monitor.rs
@@ -1,0 +1,25 @@
+//! Read-only MQTT observation API for the H9 operator monitor.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::middleware;
+use axum::routing::get;
+use axum::{Json, Router};
+
+use crate::auth;
+use crate::state::{AppState, MqttMonitorSnapshot};
+
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/api/mqtt/monitor", get(snapshot))
+        .layer(middleware::from_fn_with_state(
+            Arc::clone(&state),
+            auth::jwt_middleware,
+        ))
+        .with_state(state)
+}
+
+async fn snapshot(State(state): State<Arc<AppState>>) -> Json<MqttMonitorSnapshot> {
+    Json(state.mqtt_monitor_snapshot())
+}

--- a/services/central/src/state.rs
+++ b/services/central/src/state.rs
@@ -150,25 +150,24 @@ impl AppState {
         monitor.received_messages = monitor.received_messages.saturating_add(1);
         let preview_len = payload.len().min(MQTT_PREVIEW_BYTES);
         let preview_bytes = &payload[..preview_len];
-        let (payload_encoding, payload_preview) = match serde_json::from_slice::<serde_json::Value>(
-            preview_bytes,
-        ) {
-            Ok(value) if payload.len() <= MQTT_PREVIEW_BYTES => (
-                "json".to_string(),
-                serde_json::to_string_pretty(&value).unwrap_or_default(),
-            ),
-            _ => match std::str::from_utf8(preview_bytes) {
-                Ok(text) => ("text".to_string(), text.to_string()),
-                Err(_) => (
-                    "hex".to_string(),
-                    preview_bytes
-                        .iter()
-                        .map(|byte| format!("{byte:02x}"))
-                        .collect::<Vec<_>>()
-                        .join(" "),
+        let (payload_encoding, payload_preview) =
+            match serde_json::from_slice::<serde_json::Value>(preview_bytes) {
+                Ok(value) if payload.len() <= MQTT_PREVIEW_BYTES => (
+                    "json".to_string(),
+                    serde_json::to_string_pretty(&value).unwrap_or_default(),
                 ),
-            },
-        };
+                _ => match std::str::from_utf8(preview_bytes) {
+                    Ok(text) => ("text".to_string(), text.to_string()),
+                    Err(_) => (
+                        "hex".to_string(),
+                        preview_bytes
+                            .iter()
+                            .map(|byte| format!("{byte:02x}"))
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                    ),
+                },
+            };
         monitor.recent_messages.push_front(MqttObservedMessage {
             received_at_utc: Utc::now(),
             topic: topic.to_string(),

--- a/services/central/src/state.rs
+++ b/services/central/src/state.rs
@@ -1,6 +1,6 @@
 //! Shared central runtime state.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -8,9 +8,13 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use openfdd_contracts::{CommandAck, CommandEnvelope, TelemetryEnvelope};
 use openfdd_mqtt::AsyncClient;
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::auth::AuthConfig;
+
+const MQTT_MONITOR_CAPACITY: usize = 100;
+const MQTT_PREVIEW_BYTES: usize = 4096;
 
 #[derive(Debug, Default)]
 pub struct EdgeShadow {
@@ -33,6 +37,51 @@ pub struct PendingCommand {
     pub published: bool,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct MqttObservedMessage {
+    pub received_at_utc: DateTime<Utc>,
+    pub topic: String,
+    pub qos: String,
+    pub retain: bool,
+    pub payload_bytes: usize,
+    pub payload_encoding: String,
+    pub payload_preview: String,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MqttMonitorEvent {
+    pub at_utc: DateTime<Utc>,
+    pub kind: String,
+    pub message: String,
+}
+
+#[derive(Debug, Default)]
+struct MqttMonitorState {
+    connected: bool,
+    client_id: Option<String>,
+    subscriptions: Vec<String>,
+    received_messages: u64,
+    reconnects: u64,
+    errors: u64,
+    recent_messages: VecDeque<MqttObservedMessage>,
+    recent_events: VecDeque<MqttMonitorEvent>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MqttMonitorSnapshot {
+    pub connected: bool,
+    pub client_id: Option<String>,
+    pub subscriptions: Vec<String>,
+    pub received_messages: u64,
+    pub reconnects: u64,
+    pub errors: u64,
+    pub buffer_capacity: usize,
+    pub recent_messages: Vec<MqttObservedMessage>,
+    pub recent_events: Vec<MqttMonitorEvent>,
+    pub test_publish_enabled: bool,
+}
+
 pub struct AppState {
     pub auth: AuthConfig,
     /// (edge_id, message_id) → observed
@@ -45,6 +94,7 @@ pub struct AppState {
     pub ingest_dup: Mutex<u64>,
     pub ingest_reject: Mutex<u64>,
     pub mqtt_publisher: Mutex<Option<AsyncClient>>,
+    mqtt_monitor: Mutex<MqttMonitorState>,
     /// Login failures keyed by ip+username (generic throttle; no secrets).
     pub login_failures: Mutex<HashMap<String, (u32, std::time::Instant)>>,
 }
@@ -62,12 +112,90 @@ impl AppState {
             ingest_dup: Mutex::new(0),
             ingest_reject: Mutex::new(0),
             mqtt_publisher: Mutex::new(None),
+            mqtt_monitor: Mutex::new(MqttMonitorState::default()),
             login_failures: Mutex::new(HashMap::new()),
         }
     }
 
     pub fn set_mqtt_publisher(&self, client: AsyncClient) {
         *self.mqtt_publisher.lock().unwrap() = Some(client);
+    }
+
+    pub fn mqtt_mark_connected(&self, client_id: String, subscriptions: Vec<String>) {
+        let mut monitor = self.mqtt_monitor.lock().unwrap();
+        if monitor.client_id.is_some() {
+            monitor.reconnects = monitor.reconnects.saturating_add(1);
+        }
+        monitor.connected = true;
+        monitor.client_id = Some(client_id);
+        monitor.subscriptions = subscriptions;
+        push_monitor_event(&mut monitor, "connected", "MQTT ingest connected");
+    }
+
+    pub fn mqtt_mark_disconnected(&self, message: impl Into<String>) {
+        let mut monitor = self.mqtt_monitor.lock().unwrap();
+        monitor.connected = false;
+        push_monitor_event(&mut monitor, "disconnected", message.into());
+    }
+
+    pub fn mqtt_record_error(&self, message: impl Into<String>) {
+        let mut monitor = self.mqtt_monitor.lock().unwrap();
+        monitor.connected = false;
+        monitor.errors = monitor.errors.saturating_add(1);
+        push_monitor_event(&mut monitor, "error", message.into());
+    }
+
+    pub fn mqtt_observe(&self, topic: &str, payload: &[u8], qos: String, retain: bool) {
+        let mut monitor = self.mqtt_monitor.lock().unwrap();
+        monitor.received_messages = monitor.received_messages.saturating_add(1);
+        let preview_len = payload.len().min(MQTT_PREVIEW_BYTES);
+        let preview_bytes = &payload[..preview_len];
+        let (payload_encoding, payload_preview) = match serde_json::from_slice::<serde_json::Value>(
+            preview_bytes,
+        ) {
+            Ok(value) if payload.len() <= MQTT_PREVIEW_BYTES => (
+                "json".to_string(),
+                serde_json::to_string_pretty(&value).unwrap_or_default(),
+            ),
+            _ => match std::str::from_utf8(preview_bytes) {
+                Ok(text) => ("text".to_string(), text.to_string()),
+                Err(_) => (
+                    "hex".to_string(),
+                    preview_bytes
+                        .iter()
+                        .map(|byte| format!("{byte:02x}"))
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                ),
+            },
+        };
+        monitor.recent_messages.push_front(MqttObservedMessage {
+            received_at_utc: Utc::now(),
+            topic: topic.to_string(),
+            qos,
+            retain,
+            payload_bytes: payload.len(),
+            payload_encoding,
+            payload_preview,
+            truncated: payload.len() > MQTT_PREVIEW_BYTES,
+        });
+        monitor.recent_messages.truncate(MQTT_MONITOR_CAPACITY);
+    }
+
+    pub fn mqtt_monitor_snapshot(&self) -> MqttMonitorSnapshot {
+        let monitor = self.mqtt_monitor.lock().unwrap();
+        MqttMonitorSnapshot {
+            connected: monitor.connected,
+            client_id: monitor.client_id.clone(),
+            subscriptions: monitor.subscriptions.clone(),
+            received_messages: monitor.received_messages,
+            reconnects: monitor.reconnects,
+            errors: monitor.errors,
+            buffer_capacity: MQTT_MONITOR_CAPACITY,
+            recent_messages: monitor.recent_messages.iter().cloned().collect(),
+            recent_events: monitor.recent_events.iter().cloned().collect(),
+            test_publish_enabled: false,
+        }
     }
 
     /// Returns true if this key is currently locked out.
@@ -99,4 +227,13 @@ impl AppState {
     pub fn login_record_success(&self, key: &str) {
         self.login_failures.lock().unwrap().remove(key);
     }
+}
+
+fn push_monitor_event(monitor: &mut MqttMonitorState, kind: &str, message: impl Into<String>) {
+    monitor.recent_events.push_front(MqttMonitorEvent {
+        at_utc: Utc::now(),
+        kind: kind.to_string(),
+        message: message.into(),
+    });
+    monitor.recent_events.truncate(MQTT_MONITOR_CAPACITY);
 }


### PR DESCRIPTION
## H9 scope

Starts H9 cleanly from merged H8/master (`51c69175`). This is the single H9 branch/PR and is not stacked.

### AFDD Config / Scheduler
- radio/navigation entry for AFDD Config
- scheduler mode, frequency, rolling lookback, last run, analyzed-through, latest historian sample, next run, checkpoint/catch-up state
- Run AFDD now through the H8 shared execution engine
- recent cycle status and stale BAS health
- deployment-backed values read-only unless runtime mutation is explicitly supported

### MQTT Config / Test Monitor
- radio/navigation entry for MQTT Config
- AWS IoT Core test-client-style monitor layout without AWS branding/cloud assumptions
- broker state, subscriptions and counters without exposing credentials
- validated MQTT topic filters with +/#
- bounded recent/live message list and expandable payload viewer
- reconnect/error events separately visible
- authenticated Central API/SSE/WebSocket path; browser never talks directly to broker
- read-only by default; test publish only behind explicit backend capability with auth, validation, limits and audit logging

## Initial slice

- added authenticated `/operations` product surface
- added `AFDD Config` and `MQTT Config` radio views
- wired AFDD scheduler status and Run Now to H8 Central endpoints
- added read-only deployment-backed scheduler metrics and recent-cycle table
- added MQTT topic-filter validation and security/read-only scaffold for the bounded monitor backend

## Branch hygiene

Single branch `feat/afdd-mqtt-operations-ux`, based directly on H8 merge `51c69175`. Do not stack H10 while H9 is unmerged.

## Gate

Do not merge until the exact final H9 head passes required Rust/frontend/security/docs workflows and review threads are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Operations area with AFDD scheduling and MQTT monitoring views.
  * Added scheduler status, historian health, run-now controls, cycle results, errors, and freshness metrics.
  * Added MQTT connection monitoring with subscriptions, buffered messages, payload previews, filtering, pause, clear, and refresh controls.
  * Added Operations to the main navigation and sidebar.
* **Bug Fixes**
  * Improved visibility into MQTT connection, subscription, reconnect, and ingest errors.
* **Documentation**
  * Updated AFDD and operations requirements to reflect the completed capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->