### PR TITLE
H10: Historian scale benchmarks and release qualification

### DIFF
--- a/.github/workflows/historian-scale-qualification.yml
+++ b/.github/workflows/historian-scale-qualification.yml
@@ -1,0 +1,62 @@
+name: H10 Historian scale qualification
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - "scripts/historian_scale_generate.py"
+      - "scripts/historian_scale_check.py"
+      - "scripts/historian_scale_workloads.sql"
+      - "crates/fdd_store/**"
+      - "crates/fdd_sql/**"
+      - "crates/fdd_rules/**"
+      - "crates/fdd_bench/**"
+      - "services/central/**"
+      - "frontend/web/**"
+      - "docker/compose.csv.yml"
+      - "scripts/release/smoke_csv_central_boot.sh"
+      - ".github/workflows/historian-scale-qualification.yml"
+
+concurrency:
+  group: h10-historian-scale-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  synthetic-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Deterministic generator + incremental workload contract
+        run: python3 scripts/historian_scale_check.py
+
+  rust-historian:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Historian / DataFusion / FDD benchmark tests
+        run: cargo test -p fdd_store -p fdd_sql -p fdd_rules -p fdd_bench
+
+  local-container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - name: Local central + React CSV container smoke
+        env:
+          OPENFDD_SMOKE_TIMEOUT_SECS: "300"
+        run: |
+          chmod +x scripts/release/smoke_csv_central_boot.sh
+          ./scripts/release/smoke_csv_central_boot.sh

--- a/docs/operations/HISTORIAN_SCALE_QUALIFICATION.md
+++ b/docs/operations/HISTORIAN_SCALE_QUALIFICATION.md
@@ -1,0 +1,95 @@
+# Historian scale and release qualification
+
+H10 provides a deterministic synthetic workload and a repeatable qualification path for the canonical Parquet/DataFusion historian. It is a test harness, not a second historian or a production data generator.
+
+## Cheap changed-head gate
+
+Run before expensive image or deployment tests:
+
+```bash
+python3 scripts/historian_scale_check.py
+cargo test -p fdd_store -p fdd_sql -p fdd_rules -p fdd_bench
+```
+
+The H10 GitHub Actions workflow also boots the local CSV central + React containers and verifies `/api/health` plus a CSV preview smoke.
+
+## Synthetic source
+
+Generate deterministic JSONL source rows:
+
+```bash
+python3 scripts/historian_scale_generate.py \
+  --buildings 1 \
+  --equipment-per-building 10 \
+  --days 30 \
+  --interval-seconds 300 \
+  --seed 20260822 \
+  --output .cache/h10/source.jsonl
+```
+
+Generate incremental chunks for continuous-ingest/rolling-AFDD exercises without regenerating retained history:
+
+```bash
+python3 scripts/historian_scale_generate.py \
+  --buildings 1 --equipment-per-building 10 \
+  --duration-hours 1 --offset-hours 24 \
+  --interval-seconds 300 --seed 20260822 \
+  --output .cache/h10/source.jsonl --append
+```
+
+The source is intentionally portable. Qualification adapters must feed it through the production historian ingest/writer contract rather than writing ad-hoc Parquet files behind that contract.
+
+## Representative query shapes
+
+`scripts/historian_scale_workloads.sql` defines the stable H10 workload set:
+
+- equipment/day
+- equipment/month
+- building/hour
+- monthly aggregation
+- bounded weather join
+- representative FDD proof query
+
+Production AFDD registry execution remains mandatory; the representative FDD query is only a stable benchmark shape.
+
+## Scale targets
+
+Use the same source/harness at increasing sizes. Do not make the normal PR gate generate multi-GB artifacts.
+
+| Target | Purpose | Expected execution |
+| --- | --- | --- |
+| small | changed-head correctness, pruning/query shape, local container smoke | GitHub Actions / developer machine |
+| ~1 GB | first meaningful storage/query benchmark | manual local or CI runner with adequate disk |
+| ~10 GB | sustained partition/query/rolling-AFDD check | manual benchmark host |
+| ~100 GB | object-count, pruning, compaction and memory behavior | dedicated benchmark host / object store |
+| ~1 TB architecture check | validate retained-history design assumptions | dedicated environment; never ordinary PR CI |
+
+For each run capture at minimum: generated/ingested rows, canonical files, partitions, bytes, query wall time, peak process/container memory where available, AFDD cycle time, and evidence of building/equipment/month/time pruning where measurable.
+
+## Local container qualification
+
+The changed-head H10 workflow runs:
+
+```bash
+./scripts/release/smoke_csv_central_boot.sh
+```
+
+For a candidate GHCR build, prefer an immutable `sha-<shortsha>` tag for reproduction. A floating tag is useful for convenience but should not be the evidence recorded in a qualification result.
+
+## MinIO / S3-compatible qualification
+
+Use the existing S3-compatible historian configuration and local MinIO recipe documented in `docs/operations/historian-s3.md`. H10 does not add a provider-specific storage path. The same canonical layout, DataFusion registration, AFDD execution, and stats expectations apply.
+
+## Railway qualification
+
+Railway qualification is deployment verification, not engine branching. Use `docs/operations/RAILWAY_DEPLOYMENT.md` and pin the exact candidate image SHA while testing. Confirm at minimum:
+
+- central `/api/health`
+- React web reaches central through private Railway DNS
+- persistent canonical storage is configured as documented
+- AFDD Config shows scheduler/watermark/cycle state without fabricated values
+- Run AFDD now uses the H8 execution engine
+- MQTT Config remains bounded/read-only and does not expose broker credentials
+- sustained telemetry does not create an unbounded monitor buffer
+
+Do not describe a Railway trial as production-hardened public SaaS. Central, historian, MQTT, and fieldbus ingress remain private/LAN/VPN-oriented per the repository security contract.

--- a/scripts/historian_scale_check.py
+++ b/scripts/historian_scale_check.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Cheap deterministic checks for the H10 historian scale qualification assets."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GEN = ROOT / "scripts" / "historian_scale_generate.py"
+WORKLOADS = ROOT / "scripts" / "historian_scale_workloads.sql"
+EXPECTED_ROLES = {
+    "outside_air_temperature",
+    "supply_air_temperature",
+    "return_air_temperature",
+    "supply_fan_status",
+    "outside_air_damper_command",
+}
+EXPECTED_WORKLOADS = {
+    "equipment/day",
+    "equipment/month",
+    "building/hour",
+    "monthly aggregation",
+    "weather join",
+    "representative FDD proof query",
+}
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def run_generator(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GEN), *args],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def read_jsonl(path: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            fail(f"{path}:{line_number}: invalid JSON: {exc}")
+        if not isinstance(value, dict):
+            fail(f"{path}:{line_number}: expected JSON object")
+        rows.append(value)
+    return rows
+
+
+def check_determinism(tmp: Path) -> dict[str, object]:
+    a = tmp / "a.jsonl"
+    b = tmp / "b.jsonl"
+    common = [
+        "--buildings",
+        "1",
+        "--equipment-per-building",
+        "2",
+        "--duration-hours",
+        "2",
+        "--interval-seconds",
+        "300",
+        "--seed",
+        "42",
+    ]
+    run_generator(*common, "--output", str(a))
+    run_generator(*common, "--output", str(b))
+    if a.read_bytes() != b.read_bytes():
+        fail("same seed/config did not produce byte-identical JSONL")
+
+    rows = read_jsonl(a)
+    if len(rows) != 48:
+        fail(f"2 equipment x 2 hours x 12 samples/hour should be 48 rows, got {len(rows)}")
+    for row in rows:
+        roles = row.get("roles")
+        if not isinstance(roles, dict) or set(roles) != EXPECTED_ROLES:
+            fail(f"unexpected role set: {roles!r}")
+        if row.get("building_id") != "building-0001":
+            fail(f"unexpected building id: {row.get('building_id')!r}")
+    equipment = sorted({str(row.get("equipment_id")) for row in rows})
+    if equipment != ["ahu-00001", "ahu-00002"]:
+        fail(f"unexpected equipment ids: {equipment}")
+    return {"rows": len(rows), "equipment": equipment}
+
+
+def check_incremental_append(tmp: Path) -> dict[str, object]:
+    out = tmp / "append.jsonl"
+    common = [
+        "--buildings",
+        "1",
+        "--equipment-per-building",
+        "1",
+        "--duration-hours",
+        "1",
+        "--interval-seconds",
+        "300",
+        "--seed",
+        "7",
+        "--output",
+        str(out),
+    ]
+    run_generator(*common, "--offset-hours", "0")
+    run_generator(*common, "--offset-hours", "1", "--append")
+    rows = read_jsonl(out)
+    if len(rows) != 24:
+        fail(f"two appended one-hour chunks should be 24 rows, got {len(rows)}")
+    timestamps = [str(row.get("timestamp_utc")) for row in rows]
+    if len(set(timestamps)) != len(timestamps):
+        fail("incremental chunks overlapped timestamps unexpectedly")
+    if timestamps != sorted(timestamps):
+        fail("incremental append is not monotonic")
+    return {"rows": len(rows), "first": timestamps[0], "last": timestamps[-1]}
+
+
+def check_workloads() -> dict[str, object]:
+    if not WORKLOADS.is_file():
+        fail(f"missing workload suite: {WORKLOADS}")
+    text = WORKLOADS.read_text(encoding="utf-8")
+    found = {
+        line.split(":", 1)[1].strip()
+        for line in text.splitlines()
+        if line.startswith("-- workload:")
+    }
+    missing = EXPECTED_WORKLOADS - found
+    if missing:
+        fail(f"workload suite missing markers: {sorted(missing)}")
+    required_fragments = [
+        "building_id = 'building-0001'",
+        "equipment_id = 'ahu-00001'",
+        "year = '2026'",
+        "month = '01'",
+        "timestamp_utc >=",
+        "timestamp_utc <",
+        "JOIN weather",
+    ]
+    for fragment in required_fragments:
+        if fragment not in text:
+            fail(f"workload suite missing selective/pruning fragment: {fragment}")
+    return {"workloads": sorted(found)}
+
+
+def main() -> int:
+    if not GEN.is_file():
+        fail(f"missing generator: {GEN}")
+    with tempfile.TemporaryDirectory(prefix="openfdd-h10-") as raw_tmp:
+        tmp = Path(raw_tmp)
+        summary = {
+            "determinism": check_determinism(tmp),
+            "incremental_append": check_incremental_append(tmp),
+            "workload_suite": check_workloads(),
+        }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    print("PASS: H10 historian scale assets are deterministic and self-consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/historian_scale_generate.py
+++ b/scripts/historian_scale_generate.py
@@ -5,6 +5,10 @@ The generator intentionally emits a portable JSONL workload rather than writing 
 canonical historian directly. Benchmark/qualification harnesses can feed the same
 rows through the production ingest/writer path, preserving the H1-H9 storage
 contract while keeping the synthetic source deterministic and easy to scale.
+
+Use --duration-hours/--offset-hours/--append to generate repeatable incremental
+chunks for continuous-ingest plus rolling-AFDD qualification without regenerating
+or rescanning the retained synthetic source.
 """
 
 from __future__ import annotations
@@ -31,13 +35,13 @@ def rows(
     *,
     buildings: int,
     equipment_per_building: int,
-    days: int,
+    duration_seconds: int,
     interval_seconds: int,
     start: datetime,
     seed: int,
 ) -> Iterator[dict[str, object]]:
     rng = random.Random(seed)
-    sample_count = (days * 24 * 60 * 60) // interval_seconds
+    sample_count = duration_seconds // interval_seconds
     for building_index in range(buildings):
         building_id = f"building-{building_index + 1:04d}"
         weather_phase = rng.random() * math.tau
@@ -67,14 +71,17 @@ def rows(
                 }
 
 
-def open_output(path: str) -> tuple[TextIO, bool]:
+def open_output(path: str, *, append: bool) -> tuple[TextIO, bool]:
     if path == "-":
+        if append:
+            raise ValueError("--append requires a file --output, not stdout")
         import sys
 
         return sys.stdout, False
     target = Path(path)
     target.parent.mkdir(parents=True, exist_ok=True)
-    return target.open("w", encoding="utf-8"), True
+    mode = "a" if append else "w"
+    return target.open(mode, encoding="utf-8"), True
 
 
 def main() -> int:
@@ -82,25 +89,58 @@ def main() -> int:
     parser.add_argument("--buildings", type=int, default=1)
     parser.add_argument("--equipment-per-building", type=int, default=10)
     parser.add_argument("--days", type=int, default=1)
+    parser.add_argument(
+        "--duration-hours",
+        type=int,
+        help="override --days with an exact chunk duration in hours",
+    )
+    parser.add_argument(
+        "--offset-hours",
+        type=int,
+        default=0,
+        help="advance the requested --start before generating this chunk",
+    )
     parser.add_argument("--interval-seconds", type=int, default=300)
     parser.add_argument("--start", default="2026-01-01T00:00:00Z")
     parser.add_argument("--seed", type=int, default=20260822)
     parser.add_argument("--output", default="-")
+    parser.add_argument(
+        "--append",
+        action="store_true",
+        help="append this deterministic chunk to an existing JSONL source",
+    )
     args = parser.parse_args()
 
     for name in ("buildings", "equipment_per_building", "days", "interval_seconds"):
         if getattr(args, name) <= 0:
             parser.error(f"--{name.replace('_', '-')} must be > 0")
+    if args.duration_hours is not None and args.duration_hours <= 0:
+        parser.error("--duration-hours must be > 0")
+    if args.offset_hours < 0:
+        parser.error("--offset-hours must be >= 0")
 
-    output, should_close = open_output(args.output)
+    duration_seconds = (
+        args.duration_hours * 60 * 60
+        if args.duration_hours is not None
+        else args.days * 24 * 60 * 60
+    )
+    if duration_seconds < args.interval_seconds:
+        parser.error("duration must include at least one sample interval")
+
+    chunk_start = parse_utc(args.start) + timedelta(hours=args.offset_hours)
+    try:
+        output, should_close = open_output(args.output, append=args.append)
+    except ValueError as exc:
+        parser.error(str(exc))
+
     count = 0
     try:
         for row in rows(
             buildings=args.buildings,
             equipment_per_building=args.equipment_per_building,
-            days=args.days,
+            duration_seconds=duration_seconds,
             interval_seconds=args.interval_seconds,
-            start=parse_utc(args.start),
+            start=chunk_start,
             seed=args.seed,
         ):
             output.write(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n")
@@ -111,7 +151,18 @@ def main() -> int:
 
     import sys
 
-    print(f"generated_rows={count}", file=sys.stderr)
+    chunk_end = chunk_start + timedelta(seconds=duration_seconds)
+    print(
+        " ".join(
+            [
+                f"generated_rows={count}",
+                f"chunk_start={chunk_start.isoformat()}",
+                f"chunk_end={chunk_end.isoformat()}",
+                f"append={str(args.append).lower()}",
+            ]
+        ),
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/scripts/historian_scale_generate.py
+++ b/scripts/historian_scale_generate.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Generate deterministic synthetic Open-FDD historian telemetry for H10 scale tests.
+
+The generator intentionally emits a portable JSONL workload rather than writing the
+canonical historian directly. Benchmark/qualification harnesses can feed the same
+rows through the production ingest/writer path, preserving the H1-H9 storage
+contract while keeping the synthetic source deterministic and easy to scale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterator, TextIO
+
+UTC = timezone.utc
+
+
+def parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def rows(
+    *,
+    buildings: int,
+    equipment_per_building: int,
+    days: int,
+    interval_seconds: int,
+    start: datetime,
+    seed: int,
+) -> Iterator[dict[str, object]]:
+    rng = random.Random(seed)
+    sample_count = (days * 24 * 60 * 60) // interval_seconds
+    for building_index in range(buildings):
+        building_id = f"building-{building_index + 1:04d}"
+        weather_phase = rng.random() * math.tau
+        for equipment_index in range(equipment_per_building):
+            equipment_id = f"ahu-{equipment_index + 1:05d}"
+            equipment_bias = rng.uniform(-1.5, 1.5)
+            for sample_index in range(sample_count):
+                timestamp = start + timedelta(seconds=sample_index * interval_seconds)
+                hour = timestamp.hour + timestamp.minute / 60.0
+                daily_wave = math.sin((hour / 24.0) * math.tau + weather_phase)
+                oat = 72.0 + 14.0 * daily_wave
+                sat = 55.0 + equipment_bias + 0.15 * daily_wave
+                rat = 72.0 + equipment_bias + 2.0 * daily_wave
+                fan = 1.0 if 6 <= timestamp.hour < 20 else 0.0
+                damper = max(0.0, min(100.0, 35.0 + 30.0 * daily_wave))
+                yield {
+                    "timestamp_utc": timestamp.isoformat().replace("+00:00", "Z"),
+                    "building_id": building_id,
+                    "equipment_id": equipment_id,
+                    "roles": {
+                        "outside_air_temperature": round(oat, 4),
+                        "supply_air_temperature": round(sat, 4),
+                        "return_air_temperature": round(rat, 4),
+                        "supply_fan_status": fan,
+                        "outside_air_damper_command": round(damper, 4),
+                    },
+                }
+
+
+def open_output(path: str) -> tuple[TextIO, bool]:
+    if path == "-":
+        import sys
+
+        return sys.stdout, False
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target.open("w", encoding="utf-8"), True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--buildings", type=int, default=1)
+    parser.add_argument("--equipment-per-building", type=int, default=10)
+    parser.add_argument("--days", type=int, default=1)
+    parser.add_argument("--interval-seconds", type=int, default=300)
+    parser.add_argument("--start", default="2026-01-01T00:00:00Z")
+    parser.add_argument("--seed", type=int, default=20260822)
+    parser.add_argument("--output", default="-")
+    args = parser.parse_args()
+
+    for name in ("buildings", "equipment_per_building", "days", "interval_seconds"):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be > 0")
+
+    output, should_close = open_output(args.output)
+    count = 0
+    try:
+        for row in rows(
+            buildings=args.buildings,
+            equipment_per_building=args.equipment_per_building,
+            days=args.days,
+            interval_seconds=args.interval_seconds,
+            start=parse_utc(args.start),
+            seed=args.seed,
+        ):
+            output.write(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n")
+            count += 1
+    finally:
+        if should_close:
+            output.close()
+
+    import sys
+
+    print(f"generated_rows={count}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/historian_scale_workloads.sql
+++ b/scripts/historian_scale_workloads.sql
@@ -1,0 +1,104 @@
+-- H10 representative DataFusion historian workload suite.
+--
+-- The production historian is registered as `history` by fdd_sql. Replace the
+-- literal scope/time values in a qualification harness; keep building/equipment
+-- predicates explicit so file/partition pruning can be measured.
+
+-- workload: equipment/day
+SELECT
+  building_id,
+  equipment_id,
+  COUNT(*) AS rows_scanned,
+  MIN(timestamp_utc) AS first_sample,
+  MAX(timestamp_utc) AS last_sample,
+  AVG(supply_air_temperature) AS avg_sat
+FROM history
+WHERE building_id = 'building-0001'
+  AND equipment_id = 'ahu-00001'
+  AND timestamp_utc >= TIMESTAMP '2026-01-05T00:00:00Z'
+  AND timestamp_utc <  TIMESTAMP '2026-01-06T00:00:00Z'
+GROUP BY building_id, equipment_id;
+
+-- workload: equipment/month
+SELECT
+  building_id,
+  equipment_id,
+  COUNT(*) AS rows_scanned,
+  AVG(outside_air_temperature) AS avg_oat,
+  AVG(return_air_temperature) AS avg_rat,
+  AVG(supply_air_temperature) AS avg_sat
+FROM history
+WHERE building_id = 'building-0001'
+  AND equipment_id = 'ahu-00001'
+  AND year = '2026'
+  AND month = '01'
+GROUP BY building_id, equipment_id;
+
+-- workload: building/hour
+SELECT
+  building_id,
+  date_trunc('hour', timestamp_utc) AS hour_utc,
+  COUNT(*) AS rows_scanned,
+  AVG(supply_air_temperature) AS avg_sat,
+  AVG(outside_air_damper_command) AS avg_damper
+FROM history
+WHERE building_id = 'building-0001'
+  AND timestamp_utc >= TIMESTAMP '2026-01-05T12:00:00Z'
+  AND timestamp_utc <  TIMESTAMP '2026-01-05T13:00:00Z'
+GROUP BY building_id, date_trunc('hour', timestamp_utc)
+ORDER BY hour_utc;
+
+-- workload: monthly aggregation
+SELECT
+  building_id,
+  equipment_id,
+  year,
+  month,
+  COUNT(*) AS rows_scanned,
+  AVG(outside_air_temperature) AS avg_oat,
+  AVG(supply_air_temperature) AS avg_sat,
+  AVG(return_air_temperature) AS avg_rat
+FROM history
+WHERE building_id = 'building-0001'
+  AND year = '2026'
+  AND month = '01'
+GROUP BY building_id, equipment_id, year, month
+ORDER BY equipment_id;
+
+-- workload: weather join
+-- H10 harnesses should run this only when the canonical optional `weather` table
+-- is registered. The join intentionally uses a bounded time range and building
+-- scope so weather qualification does not turn into a retained-history scan.
+SELECT
+  h.building_id,
+  h.equipment_id,
+  date_trunc('hour', h.timestamp_utc) AS hour_utc,
+  AVG(h.supply_air_temperature) AS avg_sat,
+  AVG(w.outside_air_temperature) AS avg_weather_oat
+FROM history h
+JOIN weather w
+  ON date_trunc('hour', h.timestamp_utc) = date_trunc('hour', w.timestamp_utc)
+WHERE h.building_id = 'building-0001'
+  AND h.timestamp_utc >= TIMESTAMP '2026-01-05T00:00:00Z'
+  AND h.timestamp_utc <  TIMESTAMP '2026-01-06T00:00:00Z'
+GROUP BY h.building_id, h.equipment_id, date_trunc('hour', h.timestamp_utc)
+ORDER BY h.equipment_id, hour_utc;
+
+-- workload: representative FDD proof query
+-- A deliberately simple economizer-style diagnostic proof workload. This does
+-- not replace the rule registry; release qualification must also execute the
+-- production AFDD registry. It provides a stable SQL benchmark shape that uses
+-- multiple role columns and a selective equipment/time predicate.
+SELECT
+  building_id,
+  equipment_id,
+  COUNT(*) AS suspect_samples
+FROM history
+WHERE building_id = 'building-0001'
+  AND equipment_id = 'ahu-00001'
+  AND timestamp_utc >= TIMESTAMP '2026-01-05T00:00:00Z'
+  AND timestamp_utc <  TIMESTAMP '2026-01-06T00:00:00Z'
+  AND supply_fan_status > 0.5
+  AND outside_air_temperature < return_air_temperature - 5.0
+  AND outside_air_damper_command < 20.0
+GROUP BY building_id, equipment_id;


### PR DESCRIPTION
## H10 scope

Starts H10 cleanly from merged H9/master (`8cc672e6`). This is the single H10 branch/PR and is not stacked.

### Scale benchmarks
- deterministic synthetic historian generator
- equipment/day, equipment/month, building/hour, monthly aggregation, weather join, representative FDD workloads
- continuous append + rolling AFDD workload source chunks
- repeatable reporting/qualification contract for rows/files/partitions/bytes/time/memory/pruning where measurable
- scalable manual targets for ~1 GB / ~10 GB / ~100 GB / ~1 TB architecture validation without turning ordinary PR CI into a storage benchmark farm

### Release qualification
- changed-head local Docker central + React CSV boot smoke
- canonical historian/DataFusion/FDD benchmark crate tests
- documented optional MinIO/S3-compatible qualification path
- documented Railway candidate qualification path using immutable image SHA evidence
- AFDD scheduler operations UX qualification checklist
- MQTT monitor bounded-buffer/read-only qualification checklist

## Completed H10 assets

- deterministic seeded synthetic telemetry generator (`scripts/historian_scale_generate.py`)
- representative selective/pruning workload suite (`scripts/historian_scale_workloads.sql`)
- deterministic + incremental append self-check (`scripts/historian_scale_check.py`)
- dedicated H10 PR/manual GitHub Actions gate (`.github/workflows/historian-scale-qualification.yml`)
- local central + React container smoke in the H10 workflow
- scale/local/MinIO/Railway qualification runbook (`docs/operations/HISTORIAN_SCALE_QUALIFICATION.md`)

The generator emits portable JSONL workload rows for feeding the production historian ingest/writer path rather than bypassing the H1-H9 canonical storage contract. Large scale runs remain explicit manual qualification targets; the PR gate proves the harness and product contracts cheaply.

## Branch hygiene

Single branch `feat/historian-scale-release-qualification`, based directly on H9 merge `8cc672e6`. No stale H9 branch remains.

## Gate

Do not merge until the exact final H10 head passes required Rust/frontend/security/docs workflows, the H10 qualification workflow, and review threads are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic synthetic historian telemetry generation for scale testing.
  * Added validation checks for generated data, incremental uploads, and workload definitions.
  * Added representative historian workload queries for equipment, buildings, weather, and diagnostics.

* **Documentation**
  * Added H10 historian scale and release qualification guidance, including targets, metrics, and deployment verification.

* **Chores**
  * Added an automated qualification workflow with Python checks, Rust benchmarks, and container smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->