### PR TITLE
Release closeout: safe GHCR candidates and PyPI/SQL parity

### DIFF
--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -2,8 +2,8 @@
 # Product UI is openfdd-web (React SPA).
 # Tag contract:
 # - every publish: immutable sha-<7>
-# - master: moving nightly + immutable run tag
-# - v* release tag: semver + immutable run tag
+# - master: moving nightly + rerun-unique immutable run tag
+# - v* release tag: stable semver + rerun-unique immutable run tag
 # - manual non-master build: candidate-<7> + immutable sha only
 name: Publish Open-FDD stack to GHCR
 
@@ -129,7 +129,7 @@ jobs:
 
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
             nightly=true
-            suffixes+=("${version}-n${GITHUB_RUN_NUMBER}")
+            suffixes+=("${version}-n${GITHUB_RUN_NUMBER}-a${GITHUB_RUN_ATTEMPT}")
           elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             release=true
             ref_version="${GITHUB_REF_NAME#v}"
@@ -137,7 +137,7 @@ jobs:
               echo "release tag v${ref_version} does not match Cargo.toml version ${version}" >&2
               exit 1
             fi
-            suffixes+=("${version}" "${version}-n${GITHUB_RUN_NUMBER}")
+            suffixes+=("${version}" "${version}-n${GITHUB_RUN_NUMBER}-a${GITHUB_RUN_ATTEMPT}")
           else
             candidate=true
             suffixes+=("candidate-${short_sha}")

--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -1,6 +1,10 @@
 # Publish Open-FDD stack images to GHCR (central, web, fieldbus, mqtt).
 # Product UI is openfdd-web (React SPA).
-# Nightly on master; semver + sha tags on every push to master or version tags.
+# Tag contract:
+# - every publish: immutable sha-<7>
+# - master: moving nightly + immutable run tag
+# - v* release tag: semver + immutable run tag
+# - manual non-master build: candidate-<7> + immutable sha only
 name: Publish Open-FDD stack to GHCR
 
 on:
@@ -115,16 +119,60 @@ jobs:
         id: vars
         shell: bash
         run: |
+          set -euo pipefail
           short_sha="${GITHUB_SHA::7}"
           version="$(grep -E '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
-          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "run_tag=${version}-n${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          suffixes=("sha-${short_sha}")
+          nightly=false
+          release=false
+          candidate=false
+
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
-            echo "nightly=true" >> "$GITHUB_OUTPUT"
+            nightly=true
+            suffixes+=("${version}-n${GITHUB_RUN_NUMBER}")
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            release=true
+            ref_version="${GITHUB_REF_NAME#v}"
+            if [[ "${ref_version}" != "${version}" ]]; then
+              echo "release tag v${ref_version} does not match Cargo.toml version ${version}" >&2
+              exit 1
+            fi
+            suffixes+=("${version}" "${version}-n${GITHUB_RUN_NUMBER}")
           else
-            echo "nightly=false" >> "$GITHUB_OUTPUT"
+            candidate=true
+            suffixes+=("candidate-${short_sha}")
           fi
+
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "nightly=${nightly}" >> "$GITHUB_OUTPUT"
+          echo "release=${release}" >> "$GITHUB_OUTPUT"
+          echo "candidate=${candidate}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "tag_suffixes<<EOF"
+            printf '%s\n' "${suffixes[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          write_tags() {
+            local key="$1"
+            local image="$2"
+            {
+              echo "${key}<<EOF"
+              for suffix in "${suffixes[@]}"; do
+                echo "${image}:${suffix}"
+              done
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          write_tags central_tags "$CENTRAL_IMAGE"
+          write_tags web_tags "$WEB_IMAGE"
+          write_tags fieldbus_tags "$FIELDBUS_IMAGE"
+          write_tags mqtt_tags "$MQTT_IMAGE"
+
+          echo "GHCR tag suffixes: ${suffixes[*]}"
 
       - name: Build and push openfdd-central
         uses: docker/build-push-action@v6
@@ -135,10 +183,7 @@ jobs:
           file: services/central/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.CENTRAL_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
-            ${{ env.CENTRAL_IMAGE }}:${{ steps.vars.outputs.version }}
-            ${{ env.CENTRAL_IMAGE }}:${{ steps.vars.outputs.run_tag }}
+          tags: ${{ steps.vars.outputs.central_tags }}
           build-args: |
             OPENFDD_GIT_SHA=${{ github.sha }}
           labels: |
@@ -161,10 +206,7 @@ jobs:
           file: frontend/web/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.WEB_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
-            ${{ env.WEB_IMAGE }}:${{ steps.vars.outputs.version }}
-            ${{ env.WEB_IMAGE }}:${{ steps.vars.outputs.run_tag }}
+          tags: ${{ steps.vars.outputs.web_tags }}
           build-args: |
             OPENFDD_GIT_SHA=${{ github.sha }}
             OPENFDD_WEB_VERSION=${{ steps.vars.outputs.version }}
@@ -190,10 +232,7 @@ jobs:
           file: services/fieldbus/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.FIELDBUS_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
-            ${{ env.FIELDBUS_IMAGE }}:${{ steps.vars.outputs.version }}
-            ${{ env.FIELDBUS_IMAGE }}:${{ steps.vars.outputs.run_tag }}
+          tags: ${{ steps.vars.outputs.fieldbus_tags }}
           labels: |
             org.opencontainers.image.title=Open-FDD Fieldbus
             org.opencontainers.image.source=https://github.com/bbartling/open-fdd
@@ -214,10 +253,7 @@ jobs:
           file: services/mqtt/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.MQTT_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}
-            ${{ env.MQTT_IMAGE }}:${{ steps.vars.outputs.version }}
-            ${{ env.MQTT_IMAGE }}:${{ steps.vars.outputs.run_tag }}
+          tags: ${{ steps.vars.outputs.mqtt_tags }}
           labels: |
             org.opencontainers.image.title=Open-FDD MQTT Broker
             org.opencontainers.image.source=https://github.com/bbartling/open-fdd
@@ -231,6 +267,8 @@ jobs:
         run: docker buildx imagetools create -t "${{ env.MQTT_IMAGE }}:nightly" "${{ env.MQTT_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
 
       - name: Published tags
+        env:
+          TAG_SUFFIXES: ${{ steps.vars.outputs.tag_suffixes }}
         run: |
           set -euo pipefail
           for img in central web fieldbus mqtt; do
@@ -240,9 +278,10 @@ jobs:
               fieldbus) ref="${{ env.FIELDBUS_IMAGE }}" ;;
               mqtt) ref="${{ env.MQTT_IMAGE }}" ;;
             esac
-            docker buildx imagetools inspect "${ref}:sha-${{ steps.vars.outputs.short_sha }}"
-            docker buildx imagetools inspect "${ref}:${{ steps.vars.outputs.version }}"
-            docker buildx imagetools inspect "${ref}:${{ steps.vars.outputs.run_tag }}"
+            while IFS= read -r suffix; do
+              [[ -n "$suffix" ]] || continue
+              docker buildx imagetools inspect "${ref}:${suffix}"
+            done <<< "$TAG_SUFFIXES"
             if [[ "${{ steps.vars.outputs.nightly }}" == "true" ]]; then
               docker buildx imagetools inspect "${ref}:nightly"
             fi

--- a/.github/workflows/pypi-sql-parity.yml
+++ b/.github/workflows/pypi-sql-parity.yml
@@ -1,4 +1,4 @@
-name: Optional PyPI pandas ↔ SQL cross-check
+name: Optional published pandas + current SQL oracle checks
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pypi-sql-cross-check
+  group: published-pandas-current-sql-oracle-checks
   cancel-in-progress: true
 
 jobs:
@@ -73,7 +73,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   contract-note:
-    name: cross-check contract
+    name: independent-check contract
     needs:
       - published-pandas-oracle
       - current-sql-datafusion
@@ -82,9 +82,9 @@ jobs:
       - name: Record interpretation
         run: |
           {
-            echo "## Cross-check interpretation"
+            echo "## Independent oracle-check interpretation"
             echo
-            echo "Both independently maintained oracle paths passed."
-            echo "This workflow intentionally does not claim full 59/59 direct DataFusion↔pandas result equality."
-            echo "A direct engine-to-engine comparison requires both sides to emit the same canonical result set and is reserved for the synthetic/live qualification path."
+            echo "Both independently maintained oracle paths passed their own committed contracts."
+            echo "This workflow does not compare pandas and DataFusion result artifacts and therefore does not claim direct engine-to-engine equality."
+            echo "Direct equality remains part of the synthetic/live qualification path, where both engines can emit the same canonical result set."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pypi-sql-parity.yml
+++ b/.github/workflows/pypi-sql-parity.yml
@@ -1,4 +1,4 @@
-name: Optional PyPI pandas ↔ SQL parity
+name: Optional PyPI pandas ↔ SQL cross-check
 
 on:
   workflow_dispatch:
@@ -9,12 +9,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: pypi-sql-parity
+  group: pypi-sql-cross-check
   cancel-in-progress: true
 
 jobs:
   published-pandas-oracle:
-    name: latest PyPI pandas oracle
+    name: latest PyPI pandas oracle seeds
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -39,6 +39,7 @@ jobs:
             echo
             echo "- PyPI package: \`open-fdd ${version}\`"
             echo "- Source: isolated virtualenv site-packages"
+            echo "- Contract: committed oracle seed expectations"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run committed oracle seeds against PyPI package
@@ -46,7 +47,7 @@ jobs:
           .venv-pypi/bin/python scripts/sql_pandas_oracle_check.py --require-external-oracle
 
   current-sql-datafusion:
-    name: current SQL/DataFusion oracle parity
+    name: current SQL/DataFusion oracle suite
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -58,7 +59,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run FDD SQL/DataFusion parity suite
+      - name: Run FDD SQL/DataFusion oracle suite
         run: cargo test -p fdd_rules
 
       - name: Record checkout revision
@@ -68,4 +69,22 @@ jobs:
             echo
             echo "- Git revision: \`${GITHUB_SHA}\`"
             echo "- Test: \`cargo test -p fdd_rules\`"
+            echo "- Contract: SQL mask/duration oracle tests"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  contract-note:
+    name: cross-check contract
+    needs:
+      - published-pandas-oracle
+      - current-sql-datafusion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record interpretation
+        run: |
+          {
+            echo "## Cross-check interpretation"
+            echo
+            echo "Both independently maintained oracle paths passed."
+            echo "This workflow intentionally does not claim full 59/59 direct DataFusion↔pandas result equality."
+            echo "A direct engine-to-engine comparison requires both sides to emit the same canonical result set and is reserved for the synthetic/live qualification path."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pypi-sql-parity.yml
+++ b/.github/workflows/pypi-sql-parity.yml
@@ -1,0 +1,71 @@
+name: Optional PyPI pandas ↔ SQL parity
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 8 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-sql-parity
+  cancel-in-progress: true
+
+jobs:
+  published-pandas-oracle:
+    name: latest PyPI pandas oracle
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Create isolated PyPI environment
+        run: |
+          python -m venv .venv-pypi
+          .venv-pypi/bin/python -m pip install --upgrade pip
+          .venv-pypi/bin/python -m pip install "open-fdd[oracle]" pyyaml
+
+      - name: Record published oracle version
+        run: |
+          version="$(.venv-pypi/bin/python -c 'import importlib.metadata as m; print(m.version("open-fdd"))')"
+          echo "Installed PyPI open-fdd: ${version}"
+          {
+            echo "## Published pandas oracle"
+            echo
+            echo "- PyPI package: \`open-fdd ${version}\`"
+            echo "- Source: isolated virtualenv site-packages"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run committed oracle seeds against PyPI package
+        run: |
+          .venv-pypi/bin/python scripts/sql_pandas_oracle_check.py --require-external-oracle
+
+  current-sql-datafusion:
+    name: current SQL/DataFusion oracle parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run FDD SQL/DataFusion parity suite
+        run: cargo test -p fdd_rules
+
+      - name: Record checkout revision
+        run: |
+          {
+            echo "## Current SQL/DataFusion side"
+            echo
+            echo "- Git revision: \`${GITHUB_SHA}\`"
+            echo "- Test: \`cargo test -p fdd_rules\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/sql_pandas_oracle_check.py
+++ b/scripts/sql_pandas_oracle_check.py
@@ -11,6 +11,7 @@ the oracle package or required seed fixtures are missing.
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import json
 import sys
 from pathlib import Path
@@ -34,8 +35,34 @@ def load_inventory():
     return yaml.safe_load(INVENTORY.read_text(encoding="utf-8"))
 
 
-def import_oracle():
+def _remove_checkout_import_paths() -> None:
+    """Prevent the checkout from shadowing an externally installed oracle."""
+    for raw in list(sys.path):
+        try:
+            resolved = Path(raw or ".").resolve()
+        except OSError:
+            continue
+        if resolved in {ROOT, ROOT / "scripts"}:
+            sys.path.remove(raw)
+
+
+def _assert_external_module(module_path: Path) -> None:
     try:
+        module_path.relative_to(ROOT)
+    except ValueError:
+        pass
+    else:
+        fail(f"external oracle resolved inside checkout: {module_path}")
+
+    if not any(part in {"site-packages", "dist-packages"} for part in module_path.parts):
+        fail(f"external oracle is not installed from site/dist-packages: {module_path}")
+
+
+def import_oracle(require_external: bool = False):
+    if require_external:
+        _remove_checkout_import_paths()
+    try:
+        import open_fdd.rules as rules_module  # type: ignore
         from open_fdd.rules import RULES_BY_ID, run_rule  # type: ignore
         from open_fdd.rules.cookbook_catalog import RULES  # type: ignore
     except ImportError as e:
@@ -43,6 +70,21 @@ def import_oracle():
             "open_fdd.rules oracle not importable — CI must pip install "
             f"open-fdd[oracle] (or editable .[oracle]). Import error: {e}"
         )
+
+    module_file = getattr(rules_module, "__file__", None)
+    if not module_file:
+        fail("open_fdd.rules has no importable module file")
+    module_path = Path(module_file).resolve()
+    try:
+        package_version = importlib.metadata.version("open-fdd")
+    except importlib.metadata.PackageNotFoundError:
+        package_version = "unknown"
+
+    if require_external:
+        _assert_external_module(module_path)
+
+    print(f"oracle package version={package_version} module={module_path}")
+
     if len(RULES) < 62:
         fail(f"canonical RULES shrunk: {len(RULES)} < 59")
     if "SV-SLEW" not in RULES_BY_ID:
@@ -165,11 +207,16 @@ def main() -> int:
         default=True,
         help="fail if open_fdd.rules cannot be imported (default)",
     )
+    ap.add_argument(
+        "--require-external-oracle",
+        action="store_true",
+        help="require open_fdd.rules to come from an installed site/dist-packages path outside this checkout",
+    )
     args = ap.parse_args()
-    _ = args
+    _ = args.require_package
 
     inv = load_inventory()
-    _, run_rule = import_oracle()
+    _, run_rule = import_oracle(require_external=args.require_external_oracle)
     n = run_seeds(run_rule, inv)
     print(f"OK: sql_pandas_oracle_check ({n} seed fixtures)")
     return 0


### PR DESCRIPTION
Closes the first two items in #769 before Railway qualification.

## What this does
- hardens GHCR tag publication so manual non-master builds publish only immutable `sha-<7>` plus `candidate-<7>`
- keeps `nightly` on master
- reserves plain semver tags for matching `v*` release refs
- keeps an immutable run tag on master/release publishes
- adds an optional/manual + weekly latest-PyPI pandas oracle vs current SQL/DataFusion parity workflow
- makes `scripts/sql_pandas_oracle_check.py --require-external-oracle` strip checkout import paths and fail unless `open_fdd.rules` resolves from installed site/dist-packages outside the repository
- records the installed PyPI `open-fdd` version in the Actions summary

## Why before Railway
The Railway test should pin exact GHCR artifacts without any candidate build being able to mutate an official semver alias. The pandas/SQL job also gives us a cheap independent signal that the published Python oracle seeds still agree with the current SQL/DataFusion implementation.

## Gate
Do not merge until exact-head required CI is green. The PyPI/SQL workflow is intentionally optional/informational and is not a required PR check because current SQL can legitimately be ahead of the latest PyPI release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent container image tags for nightly, release, immutable revision, and manual candidate builds.
  - Added scheduled and on-demand checks comparing the published Python package with the current SQL implementation.
  - Added validation to ensure parity checks use the externally published package when required.

- **Quality Improvements**
  - Improved verification of published image tags, including rerun-specific variants.
  - Added release-version validation to help prevent mismatched image publications.
  - Added clearer reporting of package versions, revisions, and parity-check results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->