### PR TITLE
Release closeout: smoke exact GHCR candidate images

### DIFF
--- a/.github/workflows/ghcr-candidate-smoke.yml
+++ b/.github/workflows/ghcr-candidate-smoke.yml
@@ -30,17 +30,24 @@ jobs:
       - name: Resolve candidate revision
         id: candidate
         shell: bash
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          PUBLISH_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            tag="${{ inputs.image_tag }}"
-            if [[ "$tag" != sha-* ]]; then
-              echo "image_tag must be an immutable sha-* tag" >&2
+            tag="$INPUT_IMAGE_TAG"
+            if [[ ! "$tag" =~ ^sha-[0-9a-f]{7}$ ]]; then
+              echo "image_tag must match immutable sha-<7 lowercase hex>" >&2
               exit 1
             fi
             ref="master"
           else
-            sha="${{ github.event.workflow_run.head_sha }}"
+            sha="$PUBLISH_HEAD_SHA"
+            if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "publisher head SHA is invalid: $sha" >&2
+              exit 1
+            fi
             tag="sha-${sha::7}"
             ref="$sha"
           fi

--- a/.github/workflows/ghcr-candidate-smoke.yml
+++ b/.github/workflows/ghcr-candidate-smoke.yml
@@ -31,6 +31,7 @@ jobs:
         id: candidate
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
           PUBLISH_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
@@ -41,19 +42,28 @@ jobs:
               echo "image_tag must match immutable sha-<7 lowercase hex>" >&2
               exit 1
             fi
-            ref="master"
-          else
-            sha="$PUBLISH_HEAD_SHA"
-            if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "publisher head SHA is invalid: $sha" >&2
+            short_sha="${tag#sha-}"
+            ref="$(curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${short_sha}" | jq -r '.sha')"
+            if [[ ! "$ref" =~ ^[0-9a-f]{40}$ || "${ref::7}" != "$short_sha" ]]; then
+              echo "failed to resolve ${tag} to an exact repository commit" >&2
               exit 1
             fi
-            tag="sha-${sha::7}"
-            ref="$sha"
+          else
+            ref="$PUBLISH_HEAD_SHA"
+            if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "publisher head SHA is invalid: $ref" >&2
+              exit 1
+            fi
+            tag="sha-${ref::7}"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
           echo "Candidate tag: $tag"
+          echo "Candidate source commit: $ref"
 
       - uses: actions/checkout@v5
         with:
@@ -85,6 +95,7 @@ jobs:
             echo "## GHCR candidate CSV smoke"
             echo
             echo "- Tag: \`${{ steps.candidate.outputs.tag }}\`"
+            echo "- Source commit: \`${{ steps.candidate.outputs.ref }}\`"
             echo "- Central: \`ghcr.io/bbartling/openfdd-central:${{ steps.candidate.outputs.tag }}\`"
             echo "- Web: \`ghcr.io/bbartling/openfdd-web:${{ steps.candidate.outputs.tag }}\`"
             echo "- Mode: pull prebuilt images, compose up with \`--no-build\`"

--- a/.github/workflows/ghcr-candidate-smoke.yml
+++ b/.github/workflows/ghcr-candidate-smoke.yml
@@ -1,0 +1,84 @@
+name: GHCR candidate CSV smoke
+
+on:
+  workflow_run:
+    workflows:
+      - Publish Open-FDD stack to GHCR
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Exact GHCR tag to smoke (for example sha-abcdef0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  smoke:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master')
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Resolve candidate revision
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.image_tag }}"
+            if [[ "$tag" != sha-* ]]; then
+              echo "image_tag must be an immutable sha-* tag" >&2
+              exit 1
+            fi
+            ref="master"
+          else
+            sha="${{ github.event.workflow_run.head_sha }}"
+            tag="sha-${sha::7}"
+            ref="$sha"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Candidate tag: $tag"
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.candidate.outputs.ref }}
+
+      - name: Pull exact published images
+        env:
+          TAG: ${{ steps.candidate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          docker pull "ghcr.io/bbartling/openfdd-central:${TAG}"
+          docker pull "ghcr.io/bbartling/openfdd-web:${TAG}"
+
+      - name: Smoke published central + web
+        env:
+          TAG: ${{ steps.candidate.outputs.tag }}
+          OPENFDD_SMOKE_SKIP_BUILD: "1"
+          OPENFDD_CENTRAL_IMAGE: ghcr.io/bbartling/openfdd-central:${{ steps.candidate.outputs.tag }}
+          OPENFDD_WEB_IMAGE: ghcr.io/bbartling/openfdd-web:${{ steps.candidate.outputs.tag }}
+          OPENFDD_SMOKE_TIMEOUT_SECS: "180"
+        run: |
+          chmod +x scripts/release/smoke_csv_central_boot.sh
+          ./scripts/release/smoke_csv_central_boot.sh
+
+      - name: Record candidate proof
+        if: always()
+        run: |
+          {
+            echo "## GHCR candidate CSV smoke"
+            echo
+            echo "- Tag: \`${{ steps.candidate.outputs.tag }}\`"
+            echo "- Central: \`ghcr.io/bbartling/openfdd-central:${{ steps.candidate.outputs.tag }}\`"
+            echo "- Web: \`ghcr.io/bbartling/openfdd-web:${{ steps.candidate.outputs.tag }}\`"
+            echo "- Mode: pull prebuilt images, compose up with \`--no-build\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/release/smoke_csv_central_boot.sh
+++ b/scripts/release/smoke_csv_central_boot.sh
@@ -10,6 +10,7 @@ COMPOSE=(docker compose -p "$PROJECT" -f docker/compose.csv.yml)
 TIMEOUT_SECS="${OPENFDD_SMOKE_TIMEOUT_SECS:-300}"
 CENTRAL_IMAGE="${OPENFDD_CENTRAL_IMAGE:-openfdd-central:ci}"
 WEB_IMAGE="${OPENFDD_WEB_IMAGE:-openfdd-web:ci}"
+SKIP_BUILD="${OPENFDD_SMOKE_SKIP_BUILD:-0}"
 
 cleanup() {
   "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
@@ -23,13 +24,19 @@ export OPENFDD_WEB_IMAGE="$WEB_IMAGE"
 export OPENFDD_MQTT_ENABLED=0
 export OPENFDD_ALLOW_OPEN_BIND="${OPENFDD_ALLOW_OPEN_BIND:-1}"
 
-docker build -f services/central/Dockerfile -t "$CENTRAL_IMAGE" . >/dev/null
-docker build \
-  --build-arg OPENFDD_GIT_SHA=ci-smoke \
-  --build-arg OPENFDD_WEB_VERSION=0.0.0-ci \
-  -f frontend/web/Dockerfile \
-  -t "$WEB_IMAGE" \
-  frontend/web >/dev/null
+if [[ "$SKIP_BUILD" == "1" ]]; then
+  echo "Using prebuilt images: central=$CENTRAL_IMAGE web=$WEB_IMAGE"
+  docker image inspect "$CENTRAL_IMAGE" >/dev/null
+  docker image inspect "$WEB_IMAGE" >/dev/null
+else
+  docker build -f services/central/Dockerfile -t "$CENTRAL_IMAGE" . >/dev/null
+  docker build \
+    --build-arg OPENFDD_GIT_SHA=ci-smoke \
+    --build-arg OPENFDD_WEB_VERSION=0.0.0-ci \
+    -f frontend/web/Dockerfile \
+    -t "$WEB_IMAGE" \
+    frontend/web >/dev/null
+fi
 
 "${COMPOSE[@]}" up -d --no-build central web
 


### PR DESCRIPTION
Closes the clean-container proof gap in #769.

## What this does
- adds `OPENFDD_SMOKE_SKIP_BUILD=1` to the existing CSV central+React smoke so it can validate already-pulled images instead of rebuilding source
- adds `GHCR candidate CSV smoke`, triggered after a successful master `Publish Open-FDD stack to GHCR` run
- derives the immutable `sha-<7>` tag from the publisher head SHA, pulls central + web from GHCR, and runs compose with `--no-build`
- supports manual reruns only for explicit immutable `sha-*` tags

## Why
The existing CSV boot smoke proves source builds. This closes a different release gate: the actual published GHCR artifacts must pull and boot cleanly before pinning the same images in Railway.

## Gate
Merge only after exact-head required CI is green. After merge, the master GHCR publisher should publish the new merge SHA and this workflow should automatically smoke those exact central/web images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated smoke testing for candidate container images after publishing.
  * Added support for manually triggering candidate image validation with immutable version tags.
  * Candidate tags are verified against their corresponding source revisions before testing.
  * Smoke tests can now run against prebuilt images without rebuilding them.
  * Validation results record the tested image details, source revision, and execution mode for release review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->