### PR TITLE
Test BACpypes3 BACnet to MQTTS pipeline in containers

### DIFF
--- a/.github/workflows/bacnet-mqtt-container-integration.yml
+++ b/.github/workflows/bacnet-mqtt-container-integration.yml
@@ -64,8 +64,17 @@ jobs:
               tag="sha-${PR_BASE_SHA:0:7}"
               ;;
             schedule)
-              sha="$(git rev-parse HEAD)"
-              tag="sha-${sha:0:7}"
+              data="$(python3 scripts/ghcr_newest_by_created.py --json openfdd-central openfdd-mqtt openfdd-fieldbus)"
+              tag="$(jq -r '
+                [.[0].top[].tag | select(test("^sha-[0-9a-f]{7}$"))] as $a |
+                [.[1].top[].tag | select(test("^sha-[0-9a-f]{7}$"))] as $b |
+                [.[2].top[].tag | select(test("^sha-[0-9a-f]{7}$"))] as $c |
+                [$a[] as $t | select(($b | index($t)) != null and ($c | index($t)) != null) | $t][0] // empty
+              ' <<<"$data")"
+              if [[ -z "$tag" ]]; then
+                echo "no common published sha-* tag found across central/mqtt/fieldbus newest-by-created windows" >&2
+                exit 1
+              fi
               ;;
             *)
               echo "unsupported event: $GITHUB_EVENT_NAME" >&2
@@ -94,6 +103,6 @@ jobs:
             echo
             echo "- Open-FDD image tag: \`${{ steps.image.outputs.tag }}\`"
             echo "- BACnet simulator: BACpypes3 0.0.106 mini-device"
-            echo "- Product path: BACnet/IP read/poll → openfdd-fieldbus → mTLS MQTT → openfdd-central monitor/ingest"
+            echo "- Product path: BACnet/IP read/poll → openfdd-fieldbus → mTLS MQTT → openfdd-central parsed ingest + canonical historian"
             echo "- Product images are pulled from GHCR; only the lightweight Python simulator is built in this job."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bacnet-mqtt-container-integration.yml
+++ b/.github/workflows/bacnet-mqtt-container-integration.yml
@@ -1,0 +1,99 @@
+name: Optional BACnet to MQTT container integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Immutable Open-FDD GHCR tag (sha-xxxxxxx)
+        required: true
+        type: string
+  workflow_run:
+    workflows:
+      - Publish Open-FDD stack to GHCR
+    types:
+      - completed
+  pull_request:
+    paths:
+      - .github/workflows/bacnet-mqtt-container-integration.yml
+      - docker/compose.bacnet-mqtt-ci.yml
+      - scripts/integration/bacnet_mqtt_container_smoke.sh
+      - tests/integration/bacpypes3/**
+  schedule:
+    - cron: "17 8 * * 1"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  bacnet-mqtt-e2e:
+    if: >-
+      ${{
+        github.event_name != 'workflow_run' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master')
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out integration harness
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || 'master' }}
+
+      - name: Resolve immutable product image tag
+        id: image
+        shell: bash
+        env:
+          DISPATCH_TAG: ${{ inputs.image_tag }}
+          PUBLISH_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          case "$GITHUB_EVENT_NAME" in
+            workflow_dispatch)
+              tag="$DISPATCH_TAG"
+              ;;
+            workflow_run)
+              [[ "$PUBLISH_SHA" =~ ^[0-9a-f]{40}$ ]]
+              tag="sha-${PUBLISH_SHA:0:7}"
+              ;;
+            pull_request)
+              [[ "$PR_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+              # PR runs validate changes to this harness against the already-published base/master generation.
+              tag="sha-${PR_BASE_SHA:0:7}"
+              ;;
+            schedule)
+              sha="$(git rev-parse HEAD)"
+              tag="sha-${sha:0:7}"
+              ;;
+            *)
+              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          if [[ ! "$tag" =~ ^sha-[0-9a-f]{7}$ ]]; then
+            echo "image tag must match sha-<7 lowercase hex>, got: $tag" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Testing Open-FDD images: $tag"
+
+      - name: Run BACpypes3 BACnet to Open-FDD MQTTS integration
+        env:
+          OPENFDD_IMAGE_TAG: ${{ steps.image.outputs.tag }}
+        run: |
+          chmod +x scripts/integration/bacnet_mqtt_container_smoke.sh
+          ./scripts/integration/bacnet_mqtt_container_smoke.sh
+
+      - name: Record qualification summary
+        if: always()
+        run: |
+          {
+            echo "## BACnet → MQTTS container integration"
+            echo
+            echo "- Open-FDD image tag: \`${{ steps.image.outputs.tag }}\`"
+            echo "- BACnet simulator: BACpypes3 0.0.106 mini-device"
+            echo "- Product path: BACnet/IP read/poll → openfdd-fieldbus → mTLS MQTT → openfdd-central monitor/ingest"
+            echo "- Product images are pulled from GHCR; only the lightweight Python simulator is built in this job."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker/compose.bacnet-mqtt-ci.yml
+++ b/docker/compose.bacnet-mqtt-ci.yml
@@ -1,0 +1,87 @@
+name: openfdd-bacnet-mqtt-ci
+
+services:
+  bacnet-sim:
+    build:
+      context: ../tests/integration/bacpypes3
+      dockerfile: Dockerfile
+    networks:
+      ci_net:
+        ipv4_address: 172.30.0.10
+
+  mqtt:
+    image: ghcr.io/bbartling/openfdd-mqtt:${OPENFDD_IMAGE_TAG:?set OPENFDD_IMAGE_TAG to sha-xxxxxxx}
+    volumes:
+      - ${OPENFDD_BACNET_MQTT_CERT_DIR:?set OPENFDD_BACNET_MQTT_CERT_DIR}/broker:/mosquitto/certs:ro
+      - ${OPENFDD_BACNET_MQTT_CERT_DIR}/acl:/mosquitto/config/acl:ro
+      - mqtt-data:/mosquitto/data
+    networks:
+      ci_net:
+        ipv4_address: 172.30.0.30
+
+  central:
+    image: ghcr.io/bbartling/openfdd-central:${OPENFDD_IMAGE_TAG}
+    environment:
+      OPENFDD_MQTT_ENABLED: "1"
+      OPENFDD_MQTT_HOST: mqtt
+      OPENFDD_MQTT_PORT: "8883"
+      OPENFDD_SITE_ID: ci
+      OPENFDD_EDGE_ID: "+"
+      OPENFDD_MQTT_CA_PEM: /mqtt/ca.pem
+      OPENFDD_MQTT_CERT_PEM: /mqtt/central.cert.pem
+      OPENFDD_MQTT_KEY_PEM: /mqtt/central.key.pem
+      OPENFDD_WORKSPACE: /workspace
+      OPENFDD_PARQUET_ROOT: /workspace/.cache/parquet
+      OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:-bacnet-mqtt-ci-jwt-secret-change-me}
+      OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-bacnet-mqtt-ci-admin}
+      OPENFDD_REACT_UI: "1"
+    volumes:
+      - ${OPENFDD_BACNET_MQTT_CERT_DIR}/central:/mqtt:ro
+      - central-workspace:/workspace
+    ports:
+      - "127.0.0.1:18080:8080"
+    depends_on:
+      - mqtt
+    networks:
+      ci_net:
+        ipv4_address: 172.30.0.40
+
+  fieldbus:
+    image: ghcr.io/bbartling/openfdd-fieldbus:${OPENFDD_IMAGE_TAG}
+    environment:
+      OPENFDD_FIELDBUS_CONFIG_DIR: /app/config
+      OPENFDD_FIELDBUS_HTTP_HOST: 0.0.0.0
+      OPENFDD_FIELDBUS_HTTP_PORT: "8081"
+      OPENFDD_MQTT_ENABLED: "1"
+      OPENFDD_MQTT_HOST: mqtt
+      OPENFDD_MQTT_PORT: "8883"
+      OPENFDD_SITE_ID: ci
+      OPENFDD_EDGE_ID: fieldbus-1
+      OPENFDD_BUILDING_ID: BUILDING_CI
+      OPENFDD_MQTT_CA_PEM: /mqtt/ca.pem
+      OPENFDD_MQTT_CERT_PEM: /mqtt/edge.cert.pem
+      OPENFDD_MQTT_KEY_PEM: /mqtt/edge.key.pem
+      OPENFDD_MQTT_SPOOL_DIR: /spool
+    volumes:
+      - ../tests/integration/bacpypes3/fieldbus:/app/config:ro
+      - ${OPENFDD_BACNET_MQTT_CERT_DIR}/edge:/mqtt:ro
+      - fieldbus-spool:/spool
+    ports:
+      - "127.0.0.1:18081:8081"
+    depends_on:
+      - bacnet-sim
+      - mqtt
+    networks:
+      ci_net:
+        ipv4_address: 172.30.0.20
+
+networks:
+  ci_net:
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24
+
+volumes:
+  mqtt-data:
+  central-workspace:
+  fieldbus-spool:

--- a/docker/compose.bacnet-mqtt-ci.yml
+++ b/docker/compose.bacnet-mqtt-ci.yml
@@ -32,6 +32,8 @@ services:
       OPENFDD_MQTT_KEY_PEM: /mqtt/central.key.pem
       OPENFDD_WORKSPACE: /workspace
       OPENFDD_PARQUET_ROOT: /workspace/.cache/parquet
+      # Keep the CI durability assertion fast and deterministic; product default remains 60s.
+      OPENFDD_PARQUET_FLUSH_SECONDS: "5"
       OPENFDD_JWT_SECRET: ${OPENFDD_JWT_SECRET:-bacnet-mqtt-ci-jwt-secret-change-me}
       OPENFDD_ADMIN_PASSWORD: ${OPENFDD_ADMIN_PASSWORD:-bacnet-mqtt-ci-admin}
       OPENFDD_REACT_UI: "1"

--- a/scripts/integration/bacnet_mqtt_container_smoke.sh
+++ b/scripts/integration/bacnet_mqtt_container_smoke.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Containerized BACpypes3 -> Open-FDD fieldbus -> MQTTS -> central monitor smoke.
+# Open-FDD product images are pulled from GHCR; only the tiny BACpypes3 simulator is built locally.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TAG="${OPENFDD_IMAGE_TAG:?set OPENFDD_IMAGE_TAG to an immutable sha-<7> tag}"
+if [[ ! "$TAG" =~ ^sha-[0-9a-f]{7}$ ]]; then
+  echo "OPENFDD_IMAGE_TAG must match sha-<7 lowercase hex>, got: $TAG" >&2
+  exit 1
+fi
+
+for cmd in docker openssl curl jq; do
+  command -v "$cmd" >/dev/null || { echo "missing required command: $cmd" >&2; exit 1; }
+done
+
+docker info >/dev/null
+
+TMP="$(mktemp -d)"
+PROJECT="openfdd-bacnet-mqtt-ci-${RANDOM}-${RANDOM}"
+COMPOSE=(docker compose -p "$PROJECT" -f docker/compose.bacnet-mqtt-ci.yml)
+export OPENFDD_BACNET_MQTT_CERT_DIR="$TMP/mqtt"
+export OPENFDD_JWT_SECRET="bacnet-mqtt-ci-jwt-${PROJECT}"
+export OPENFDD_ADMIN_PASSWORD="bacnet-mqtt-ci-admin"
+
+cleanup() {
+  "${COMPOSE[@]}" down --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/mqtt"/{broker,central,edge}
+printf 'topic readwrite #\n' > "$TMP/mqtt/acl"
+
+# Ephemeral CA for this isolated integration network.
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -subj '/CN=openfdd-bacnet-mqtt-ci-ca' \
+  -keyout "$TMP/ca.key.pem" -out "$TMP/ca.pem" >/dev/null 2>&1
+
+issue_cert() {
+  local name="$1" cn="$2" usage="$3" san="${4:-}"
+  local ext="$TMP/${name}.ext"
+  {
+    echo "extendedKeyUsage=${usage}"
+    [[ -n "$san" ]] && echo "subjectAltName=${san}"
+  } > "$ext"
+  openssl req -newkey rsa:2048 -nodes -subj "/CN=${cn}" \
+    -keyout "$TMP/${name}.key.pem" -out "$TMP/${name}.csr.pem" >/dev/null 2>&1
+  openssl x509 -req -days 1 -sha256 \
+    -in "$TMP/${name}.csr.pem" \
+    -CA "$TMP/ca.pem" -CAkey "$TMP/ca.key.pem" -CAcreateserial \
+    -extfile "$ext" -out "$TMP/${name}.cert.pem" >/dev/null 2>&1
+}
+
+issue_cert server mqtt serverAuth 'DNS:mqtt,IP:172.30.0.30'
+issue_cert central central clientAuth
+issue_cert edge edge-ci-fieldbus-1 clientAuth
+
+cp "$TMP/ca.pem" "$TMP/mqtt/broker/ca.pem"
+cp "$TMP/server.cert.pem" "$TMP/mqtt/broker/server.cert.pem"
+cp "$TMP/server.key.pem" "$TMP/mqtt/broker/server.key.pem"
+
+cp "$TMP/ca.pem" "$TMP/mqtt/central/ca.pem"
+cp "$TMP/central.cert.pem" "$TMP/mqtt/central/central.cert.pem"
+cp "$TMP/central.key.pem" "$TMP/mqtt/central/central.key.pem"
+
+cp "$TMP/ca.pem" "$TMP/mqtt/edge/ca.pem"
+cp "$TMP/edge.cert.pem" "$TMP/mqtt/edge/edge.cert.pem"
+cp "$TMP/edge.key.pem" "$TMP/mqtt/edge/edge.key.pem"
+
+chmod 600 "$TMP"/*.key.pem "$TMP/mqtt"/*/*.key.pem
+
+echo "== Pull exact Open-FDD images: $TAG =="
+for image in openfdd-mqtt openfdd-central openfdd-fieldbus; do
+  docker pull "ghcr.io/bbartling/${image}:${TAG}"
+done
+
+echo "== Build only the lightweight BACpypes3 simulator =="
+"${COMPOSE[@]}" build bacnet-sim
+
+echo "== Start isolated BACnet/MQTTS integration stack =="
+"${COMPOSE[@]}" up -d --no-build
+
+wait_http() {
+  local url="$1" label="$2" deadline=$((SECONDS + 120))
+  until curl -fsS "$url" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      echo "FAIL: timeout waiting for $label ($url)" >&2
+      "${COMPOSE[@]}" ps >&2 || true
+      "${COMPOSE[@]}" logs --tail=200 >&2 || true
+      exit 1
+    fi
+    sleep 2
+  done
+  echo "OK $label"
+}
+
+wait_http http://127.0.0.1:18081/health "fieldbus health"
+wait_http http://127.0.0.1:18080/api/health "central health"
+
+# Exercise the real Open-FDD BACnet client against the BACpypes3 server.
+echo "== BACnet read =="
+READ_JSON='{"device_instance":3456,"object_type":"analog-value","object_instance":1,"property_id":"present-value"}'
+READ_RESPONSE="$(curl -fsS -X POST http://127.0.0.1:18081/bacnet/read \
+  -H 'Content-Type: application/json' -d "$READ_JSON")"
+echo "$READ_RESPONSE" | jq -e '
+  .ok == true and
+  .device_instance == 3456 and
+  .object_type == "analog-value" and
+  .object_instance == 1 and
+  (.value | type == "number")
+' >/dev/null
+echo "OK BACnet analog-value:1 present-value=$(echo "$READ_RESPONSE" | jq -r '.value')"
+
+# Force a poll immediately; the MQTT bridge publishes poll snapshots on its interval.
+curl -fsS -X POST http://127.0.0.1:18081/bacnet/poll/once | jq -e '.ok == true' >/dev/null
+echo "OK fieldbus poll once"
+
+TOKEN="$(curl -fsS -X POST http://127.0.0.1:18080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"bacnet-mqtt-ci-admin"}' \
+  | jq -r '.token // .access_token // empty')"
+if [[ -z "$TOKEN" ]]; then
+  echo "FAIL: central login did not return a token" >&2
+  "${COMPOSE[@]}" logs --tail=200 central >&2 || true
+  exit 1
+fi
+
+# Wait until central has observed the fieldbus BACnet telemetry envelope.
+deadline=$((SECONDS + 90))
+while true; do
+  MONITOR="$(curl -fsS http://127.0.0.1:18080/api/mqtt/monitor \
+    -H "Authorization: Bearer $TOKEN")"
+  if echo "$MONITOR" | jq -e '
+      .connected == true and
+      (.received_messages >= 1) and
+      (.recent_messages | any(
+        .topic == "openfdd/v1/sites/ci/edges/fieldbus-1/telemetry/bacnet" and
+        (.payload_preview | contains("bacnet:3456:analog-value:1")) and
+        (.payload_preview | contains("BUILDING_CI"))
+      ))
+    ' >/dev/null; then
+    break
+  fi
+  if (( SECONDS >= deadline )); then
+    echo "FAIL: central never observed expected BACnet telemetry" >&2
+    echo "$MONITOR" | jq . >&2 || true
+    "${COMPOSE[@]}" logs --tail=250 fieldbus central mqtt bacnet-sim >&2 || true
+    exit 1
+  fi
+  sleep 3
+done
+
+echo "OK central observed canonical BACnet telemetry over MQTTS"
+echo "$MONITOR" | jq '{connected, received_messages, errors, recent_messages: [.recent_messages[] | {topic, payload_bytes, payload_encoding}]}'
+echo "PASS: BACpypes3 -> Open-FDD BACnet fieldbus -> MQTTS -> central integration"

--- a/scripts/integration/bacnet_mqtt_container_smoke.sh
+++ b/scripts/integration/bacnet_mqtt_container_smoke.sh
@@ -70,7 +70,10 @@ cp "$TMP/ca.pem" "$TMP/mqtt/edge/ca.pem"
 cp "$TMP/edge.cert.pem" "$TMP/mqtt/edge/edge.cert.pem"
 cp "$TMP/edge.key.pem" "$TMP/mqtt/edge/edge.key.pem"
 
-chmod 600 "$TMP"/*.key.pem "$TMP/mqtt"/*/*.key.pem
+# Product containers intentionally run non-root. These are one-run ephemeral CI credentials
+# under a private mktemp directory; make mounted files readable by those container users.
+chmod 755 "$TMP" "$TMP/mqtt" "$TMP/mqtt"/{broker,central,edge}
+chmod 644 "$TMP/mqtt/acl" "$TMP/mqtt"/*/*.pem
 
 echo "== Pull exact Open-FDD images: $TAG =="
 for image in openfdd-mqtt openfdd-central openfdd-fieldbus; do

--- a/scripts/integration/bacnet_mqtt_container_smoke.sh
+++ b/scripts/integration/bacnet_mqtt_container_smoke.sh
@@ -32,7 +32,19 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$TMP/mqtt"/{broker,central,edge}
-printf 'topic readwrite #\n' > "$TMP/mqtt/acl"
+cat > "$TMP/mqtt/acl" <<'ACL'
+user edge:ci:fieldbus-1
+topic write openfdd/v1/sites/ci/edges/fieldbus-1/telemetry/#
+topic write openfdd/v1/sites/ci/edges/fieldbus-1/metadata/#
+topic write openfdd/v1/sites/ci/edges/fieldbus-1/discovery/#
+topic write openfdd/v1/sites/ci/edges/fieldbus-1/status
+topic write openfdd/v1/sites/ci/edges/fieldbus-1/acks/#
+topic read openfdd/v1/sites/ci/edges/fieldbus-1/commands/#
+
+user central:ci
+topic write openfdd/v1/sites/ci/edges/+/commands/#
+topic read openfdd/v1/sites/ci/#
+ACL
 
 # Ephemeral CA for this isolated integration network.
 openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
@@ -55,8 +67,9 @@ issue_cert() {
 }
 
 issue_cert server mqtt serverAuth 'DNS:mqtt,IP:172.30.0.30'
-issue_cert central central clientAuth
-issue_cert edge edge-ci-fieldbus-1 clientAuth
+# Match the production openfdd-provision certificate identity contract exactly.
+issue_cert central 'central:ci' clientAuth
+issue_cert edge 'edge:ci:fieldbus-1' clientAuth
 
 cp "$TMP/ca.pem" "$TMP/mqtt/broker/ca.pem"
 cp "$TMP/server.cert.pem" "$TMP/mqtt/broker/server.cert.pem"
@@ -117,9 +130,20 @@ echo "$READ_RESPONSE" | jq -e '
 ' >/dev/null
 echo "OK BACnet analog-value:1 present-value=$(echo "$READ_RESPONSE" | jq -r '.value')"
 
-# Force a poll immediately; the MQTT bridge publishes poll snapshots on its interval.
-curl -fsS -X POST http://127.0.0.1:18081/bacnet/poll/once | jq -e '.ok == true' >/dev/null
-echo "OK fieldbus poll once"
+# Force a poll immediately and prove the configured BACnet rows reached poll state before MQTT.
+POLL_RESPONSE="$(curl -fsS -X POST http://127.0.0.1:18081/bacnet/poll/once)"
+echo "$POLL_RESPONSE" | jq -e '.ok == true and (.points_polled >= 1)' >/dev/null
+POLL_STATUS="$(curl -fsS http://127.0.0.1:18081/bacnet/poll/status)"
+echo "$POLL_STATUS" | jq -e '
+  .ok == true and
+  (.last_values | any(
+    .device_instance == 3456 and
+    .object_type == "analog-value" and
+    .object_instance == 1 and
+    .point_name == "discharge-air-temp"
+  ))
+' >/dev/null
+echo "OK fieldbus poll state contains BACpypes3 point"
 
 TOKEN="$(curl -fsS -X POST http://127.0.0.1:18080/api/auth/login \
   -H 'Content-Type: application/json' \
@@ -176,10 +200,13 @@ while true; do
   fi
   if (( SECONDS >= deadline )); then
     echo "FAIL: central never completed expected parsed BACnet ingestion" >&2
+    echo "--- poll status ---" >&2; echo "$POLL_STATUS" | jq . >&2 || true
+    echo "--- fieldbus spool ---" >&2
+    "${COMPOSE[@]}" exec -T fieldbus sh -c 'find /spool -maxdepth 2 -type f -print -exec cat {} \;' >&2 || true
     echo "--- monitor ---" >&2; echo "$MONITOR" | jq . >&2 || true
     echo "--- edge ---" >&2; echo "$EDGE" | jq . >&2 || true
     echo "--- ingest stats ---" >&2; echo "$STATS" | jq . >&2 || true
-    "${COMPOSE[@]}" logs --tail=250 fieldbus central mqtt bacnet-sim >&2 || true
+    "${COMPOSE[@]}" logs --tail=300 fieldbus central mqtt bacnet-sim >&2 || true
     exit 1
   fi
   sleep 3

--- a/scripts/integration/bacnet_mqtt_container_smoke.sh
+++ b/scripts/integration/bacnet_mqtt_container_smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Containerized BACpypes3 -> Open-FDD fieldbus -> MQTTS -> central monitor smoke.
+# Containerized BACpypes3 -> Open-FDD fieldbus -> MQTTS -> central ingest + historian smoke.
 # Open-FDD product images are pulled from GHCR; only the tiny BACpypes3 simulator is built locally.
 set -euo pipefail
 
@@ -26,7 +26,7 @@ export OPENFDD_JWT_SECRET="bacnet-mqtt-ci-jwt-${PROJECT}"
 export OPENFDD_ADMIN_PASSWORD="bacnet-mqtt-ci-admin"
 
 cleanup() {
-  "${COMPOSE[@]}" down --remove-orphans >/dev/null 2>&1 || true
+  "${COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
   rm -rf "$TMP"
 }
 trap cleanup EXIT
@@ -131,12 +131,20 @@ if [[ -z "$TOKEN" ]]; then
   exit 1
 fi
 
-# Wait until central has observed the fieldbus BACnet telemetry envelope.
+# Wait until central observes, parses, and accepts the fieldbus BACnet telemetry envelope.
 deadline=$((SECONDS + 90))
 while true; do
   MONITOR="$(curl -fsS http://127.0.0.1:18080/api/mqtt/monitor \
     -H "Authorization: Bearer $TOKEN")"
-  if echo "$MONITOR" | jq -e '
+  EDGE="$(curl -fsS http://127.0.0.1:18080/api/edges/fieldbus-1 \
+    -H "Authorization: Bearer $TOKEN")"
+  STATS="$(curl -fsS http://127.0.0.1:18080/api/ingest/stats \
+    -H "Authorization: Bearer $TOKEN")"
+
+  monitor_ok=0
+  edge_ok=0
+  stats_ok=0
+  echo "$MONITOR" | jq -e '
       .connected == true and
       (.received_messages >= 1) and
       (.recent_messages | any(
@@ -144,18 +152,55 @@ while true; do
         (.payload_preview | contains("bacnet:3456:analog-value:1")) and
         (.payload_preview | contains("BUILDING_CI"))
       ))
-    ' >/dev/null; then
+    ' >/dev/null && monitor_ok=1 || true
+  echo "$EDGE" | jq -e '
+      .ok == true and
+      .edge_id == "fieldbus-1" and
+      .last_telemetry != null and
+      .last_telemetry.site_id == "ci" and
+      .last_telemetry.edge_id == "fieldbus-1" and
+      (.last_telemetry.points | any(
+        .id == "bacnet:3456:analog-value:1" and
+        .tags.building_id == "BUILDING_CI"
+      ))
+    ' >/dev/null && edge_ok=1 || true
+  echo "$STATS" | jq -e '
+      .ok == true and
+      (.ingest_ok >= 1) and
+      .ingest_reject == 0 and
+      .dead_letters == 0
+    ' >/dev/null && stats_ok=1 || true
+
+  if (( monitor_ok == 1 && edge_ok == 1 && stats_ok == 1 )); then
     break
   fi
   if (( SECONDS >= deadline )); then
-    echo "FAIL: central never observed expected BACnet telemetry" >&2
-    echo "$MONITOR" | jq . >&2 || true
+    echo "FAIL: central never completed expected parsed BACnet ingestion" >&2
+    echo "--- monitor ---" >&2; echo "$MONITOR" | jq . >&2 || true
+    echo "--- edge ---" >&2; echo "$EDGE" | jq . >&2 || true
+    echo "--- ingest stats ---" >&2; echo "$STATS" | jq . >&2 || true
     "${COMPOSE[@]}" logs --tail=250 fieldbus central mqtt bacnet-sim >&2 || true
     exit 1
   fi
   sleep 3
 done
 
-echo "OK central observed canonical BACnet telemetry over MQTTS"
+echo "OK central parsed and accepted canonical BACnet telemetry over MQTTS"
+
+# Durability proof: the live historian writes a canonical watermark only after persistence.
+WATERMARK=/workspace/.cache/parquet/state/live-historian/latest-telemetry.json
+deadline=$((SECONDS + 45))
+until "${COMPOSE[@]}" exec -T central sh -c "test -s '$WATERMARK'"; do
+  if (( SECONDS >= deadline )); then
+    echo "FAIL: canonical live historian watermark was not persisted" >&2
+    "${COMPOSE[@]}" exec -T central sh -c 'find /workspace/.cache/parquet -maxdepth 5 -type f -print 2>/dev/null | sort' >&2 || true
+    "${COMPOSE[@]}" logs --tail=250 central >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "OK canonical live historian persisted telemetry watermark"
 echo "$MONITOR" | jq '{connected, received_messages, errors, recent_messages: [.recent_messages[] | {topic, payload_bytes, payload_encoding}]}'
-echo "PASS: BACpypes3 -> Open-FDD BACnet fieldbus -> MQTTS -> central integration"
+echo "$STATS" | jq '{ingest_ok, ingest_dup, ingest_reject, dead_letters}'
+echo "PASS: BACpypes3 -> Open-FDD BACnet fieldbus -> MQTTS -> central ingest -> historian integration"

--- a/tests/integration/bacpypes3/Dockerfile
+++ b/tests/integration/bacpypes3/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir bacpypes3==0.0.106 ifaddr
+WORKDIR /app
+COPY simulator.py /app/simulator.py
+
+ENTRYPOINT ["python", "/app/simulator.py"]
+CMD ["--name", "OpenFDD-CI-BACnet", "--instance", "3456", "--address", "172.30.0.10/24"]

--- a/tests/integration/bacpypes3/fieldbus/field_devices.toml
+++ b/tests/integration/bacpypes3/fieldbus/field_devices.toml
@@ -1,0 +1,30 @@
+[[devices]]
+name = "AHU_SIM"
+enabled = true
+device_instance = 3456
+host = "172.30.0.10"
+port = 47808
+
+[[devices.points]]
+object_type = "analog-value"
+object_instance = 1
+point_name = "discharge-air-temp"
+units = "degreesFahrenheit"
+
+[[devices.points]]
+object_type = "binary-value"
+object_instance = 1
+point_name = "fan-status"
+units = ""
+
+[[devices.points]]
+object_type = "analog-value"
+object_instance = 2
+point_name = "zone-temp-setpoint"
+units = "degreesFahrenheit"
+
+[[devices.points]]
+object_type = "binary-value"
+object_instance = 2
+point_name = "enable-command"
+units = ""

--- a/tests/integration/bacpypes3/fieldbus/gateway.toml
+++ b/tests/integration/bacpypes3/fieldbus/gateway.toml
@@ -1,0 +1,16 @@
+[bacnet_client]
+interface = "0.0.0.0"
+broadcast = "172.30.0.255"
+whois_bind_port = 0
+read_bind_port = 0
+apdu_timeout_ms = 3000
+whois_timeout_secs = 2.0
+
+[poll]
+enabled = true
+interval_secs = 5.0
+startup_delay_secs = 1.0
+max_samples = 100
+
+[weather]
+interval_secs = 3600

--- a/tests/integration/bacpypes3/fieldbus/objects.csv
+++ b/tests/integration/bacpypes3/fieldbus/objects.csv
@@ -1,0 +1,2 @@
+Name,PointType,Units,Commandable,Default,Instance,Description
+ci-status,BV,,N,inactive,9901,Minimal hosted object required by fieldbus CI

--- a/tests/integration/bacpypes3/fieldbus/objects.csv
+++ b/tests/integration/bacpypes3/fieldbus/objects.csv
@@ -1,2 +1,11 @@
 Name,PointType,Units,Commandable,Default,Instance,Description
-ci-status,BV,,N,inactive,9901,Minimal hosted object required by fieldbus CI
+outside-air-temperature,AV,degreesFahrenheit,N,70.0,9101,Open-Meteo outdoor air temperature (degrees F)
+outside-air-humidity,AV,percent,N,50.0,9102,Open-Meteo outdoor relative humidity (percent)
+outside-air-dewpoint,AV,degreesFahrenheit,N,55.0,9103,Open-Meteo outdoor dewpoint (degrees F)
+outside-air-wind-speed,AV,milesPerHour,N,0.0,9104,Open-Meteo outdoor wind speed (mph)
+weather-location,CSV,,N,Madison Wisconsin,9105,Open-Meteo geocoded weather location label
+weather-last-updated,CSV,,N,Pending first fetch,9107,Human-readable timestamp of last weather mirror (Open-Meteo)
+app-fault,BV,,N,inactive,9106,Active when weather data is from fallback (not live Open-Meteo)
+openfdd-active-fault-count,AV,noUnits,N,0.0,9003,Active FDD fault count (server-owned diagnostic)
+openfdd-faults-present,BV,,N,inactive,9004,True when one or more FDD faults are active
+openfdd-optimization-enabled,BV,,Y,inactive,9010,Commandable optimization enable (BACnet-writable; REST API read-only)

--- a/tests/integration/bacpypes3/simulator.py
+++ b/tests/integration/bacpypes3/simulator.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Deterministic BACpypes3 mini-device for Open-FDD container integration tests.
+
+Modeled on Joel Bender's BACpypes3 mini-device-revisited sample, but kept small
+and deterministic for CI.  It exposes the same useful shape: read-only AV/BV
+plus commandable AV/BV objects.
+"""
+
+import asyncio
+
+from bacpypes3.argparse import SimpleArgumentParser
+from bacpypes3.app import Application
+from bacpypes3.local.analog import AnalogValueObject
+from bacpypes3.local.binary import BinaryValueObject
+from bacpypes3.local.cmd import Commandable
+
+
+class CommandableAnalogValueObject(Commandable, AnalogValueObject):
+    pass
+
+
+class CommandableBinaryValueObject(Commandable, BinaryValueObject):
+    pass
+
+
+async def main() -> None:
+    args = SimpleArgumentParser().parse_args()
+    app = Application.from_args(args)
+
+    read_only_av = AnalogValueObject(
+        objectIdentifier=("analogValue", 1),
+        objectName="read-only-av",
+        presentValue=55.0,
+        statusFlags=[0, 0, 0, 0],
+        covIncrement=1.0,
+        units="degreesFahrenheit",
+        description="Open-FDD CI read-only analog value",
+    )
+    read_only_bv = BinaryValueObject(
+        objectIdentifier=("binaryValue", 1),
+        objectName="read-only-bv",
+        presentValue="active",
+        statusFlags=[0, 0, 0, 0],
+        description="Open-FDD CI read-only binary value",
+    )
+    commandable_av = CommandableAnalogValueObject(
+        objectIdentifier=("analogValue", 2),
+        objectName="commandable-av",
+        presentValue=68.0,
+        statusFlags=[0, 0, 0, 0],
+        covIncrement=1.0,
+        units="degreesFahrenheit",
+        description="Open-FDD CI commandable analog value",
+    )
+    commandable_bv = CommandableBinaryValueObject(
+        objectIdentifier=("binaryValue", 2),
+        objectName="commandable-bv",
+        presentValue="inactive",
+        statusFlags=[0, 0, 0, 0],
+        description="Open-FDD CI commandable binary value",
+    )
+
+    for obj in (read_only_av, read_only_bv, commandable_av, commandable_bv):
+        app.add_object(obj)
+
+    # Slowly vary the read-only points so repeated polls prove fresh BACnet reads.
+    values = [(55.0, "active"), (56.0, "inactive"), (57.0, "active")]
+    index = 0
+    while True:
+        await asyncio.sleep(5.0)
+        index = (index + 1) % len(values)
+        read_only_av.presentValue, read_only_bv.presentValue = values[index]
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a deterministic BACpypes3 0.0.106 mini-device container modeled on `mini-device-revisited.py`
- add isolated BACnet/IP + mTLS MQTT compose topology using exact GHCR `sha-*` Open-FDD images
- assert real `openfdd-fieldbus` BACnet property reads and polling against the simulator
- assert `openfdd-central` observes canonical BACnet telemetry from fieldbus over MQTTS
- add optional/manual + weekly + post-GHCR-publish GitHub Action
- PR changes to the harness self-test against the already-published base/master generation

## Safety / architecture
- no anonymous MQTT; test broker remains certificate-authenticated
- no BACnet writes are executed; the integration is read/poll only
- product Open-FDD images are pulled from GHCR; only the lightweight BACpypes3 simulator is built locally
- isolated Docker subnet; no dependency on a physical BACnet LAN

## Why
This creates a deterministic hardware-free qualification path for:
`BACpypes3 device -> BACnet/IP -> openfdd-fieldbus -> MQTTS -> openfdd-central`

It complements, rather than replaces, the final real-OT BACnet qualification in #769.

## Upstream reference
https://github.com/JoelBender/BACpypes3/blob/main/samples/mini-device-revisited.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated BACnet-to-MQTT container integration testing.
  - Added a simulated BACnet device with representative HVAC points for end-to-end validation.
  - Added a containerized test environment including BACnet, MQTT, central monitoring, and fieldbus services.
  - Added scheduled and event-driven integration checks with health monitoring, telemetry verification, and diagnostic reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->