### PR TITLE
fix: synth-59 health-matrix soak for nightly

### DIFF
--- a/scripts/synthetic_59_health_matrix_fault_hours_soak.py
+++ b/scripts/synthetic_59_health_matrix_fault_hours_soak.py
@@ -5,9 +5,9 @@ Run after ``synthetic_59_target_pair_soak.py --side ofdd`` so the fixture and
 FDD registry results are populated.
 
 The soak exercises every Overview health endpoint introduced for the split
-matrices, validates arbitrary ``n/m`` scoring, requires every matrix flag to
-carry its ``{flag}_fault_h`` field, and compares known synthetic FAULT rows to
-``expected_faults.csv``.
+matrices, validates ``n/m`` scoring (and ``?/m`` when any flag is Unknown),
+requires every matrix flag to carry its ``{flag}_fault_h`` field, and compares
+known synthetic FAULT rows to ``expected_faults.csv``.
 """
 from __future__ import annotations
 
@@ -198,10 +198,19 @@ def expected_faults(rows: list[dict]) -> dict[tuple[str, str], float]:
     return out
 
 
+def expected_score_label(row: dict, flags: list[str]) -> str:
+    """Match plant_health score_label: ?/n when any flag is Unknown (null)."""
+    total = len(flags)
+    values = [tri(row.get(flag)) for flag in flags]
+    if any(v is None for v in values):
+        return f"?/{total}"
+    hit = sum(v is True for v in values)
+    return f"{hit}/{total}"
+
+
 def assert_score_contract(path: str, row: dict, flags: list[str], checks: list[dict]) -> None:
     label = str(row.get("score_label") or "")
-    true_count = sum(tri(row.get(flag)) is True for flag in flags)
-    expected_label = f"{true_count}/{len(flags)}"
+    expected_label = expected_score_label(row, flags)
     check(
         f"{path}_score_{row.get('equipment_id')}",
         label == expected_label,

--- a/scripts/synthetic_59_stage.py
+++ b/scripts/synthetic_59_stage.py
@@ -173,6 +173,70 @@ def build_role_map_normalized(pkg_dir: Path) -> Path:
     return dest
 
 
+CW_TOWER_RULES = frozenset({"CW-OPT-1", "CW-APR-1", "CW-FAN-1"})
+
+
+def stamp_cooling_tower_equip_types(pkg_dir: Path, fixture_root: Path) -> int:
+    """CW cases must use coolingTower so Overview tower matrix membership works."""
+    changed = 0
+    for cm_path in pkg_dir.rglob("column_map.json"):
+        if "test_contract" in cm_path.parts:
+            continue
+        data = json.loads(cm_path.read_text(encoding="utf-8"))
+        rule = str(data.get("test_target_rule_id") or "")
+        if rule not in CW_TOWER_RULES:
+            continue
+        if data.get("equipType") == "coolingTower" and data.get("equipment_type") == "COOLING_TOWER":
+            continue
+        data["equipType"] = "coolingTower"
+        data["equipment_type"] = "COOLING_TOWER"
+        cm_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        changed += 1
+
+    legend = fixture_root / "equipment_legend.csv"
+    if legend.is_file():
+        rows = list(csv.DictReader(legend.open(encoding="utf-8")))
+        fields = list(rows[0].keys()) if rows else []
+        legend_changed = False
+        for row in rows:
+            if str(row.get("target_rule_id") or "") in CW_TOWER_RULES:
+                if row.get("equipment_type") != "COOLING_TOWER" or row.get("runner_kind") != "cooling_tower":
+                    row["equipment_type"] = "COOLING_TOWER"
+                    row["runner_kind"] = "cooling_tower"
+                    legend_changed = True
+        if legend_changed and fields:
+            with legend.open("w", newline="", encoding="utf-8") as f:
+                w = csv.DictWriter(f, fieldnames=fields)
+                w.writeheader()
+                w.writerows(rows)
+            changed += 1
+
+    for exp in (
+        fixture_root / "expected_faults.csv",
+        pkg_dir / "test_contract" / "expected_faults.csv",
+    ):
+        if not exp.is_file():
+            continue
+        rows = list(csv.DictReader(exp.open(encoding="utf-8")))
+        if not rows:
+            continue
+        fields = list(rows[0].keys())
+        exp_changed = False
+        for row in rows:
+            if str(row.get("rule_id") or "") in CW_TOWER_RULES:
+                if row.get("equipment_type") != "COOLING_TOWER" or row.get("runner_kind") != "cooling_tower":
+                    row["equipment_type"] = "COOLING_TOWER"
+                    row["runner_kind"] = "cooling_tower"
+                    exp_changed = True
+        if exp_changed:
+            with exp.open("w", newline="", encoding="utf-8") as f:
+                w = csv.DictWriter(f, fieldnames=fields)
+                w.writeheader()
+                w.writerows(rows)
+            changed += 1
+    return changed
+
+
 def add_sched1_string_companion(pkg_dir: Path, fixture_root: Path) -> None:
     src_eq = pkg_dir / "AHU_CASE_SCHED_1"
     dst_eq = pkg_dir / "AHU_CASE_SCHED_1_STRING"
@@ -367,6 +431,8 @@ def main() -> int:
     print(f"role_map {rm} mappings={json.loads(rm.read_text())['count']}")
     add_sched1_string_companion(pkg_dir, fixture_root)
     print("added AHU_CASE_SCHED_1_STRING + expected_faults_extra.csv")
+    n_tower = stamp_cooling_tower_equip_types(pkg_dir, fixture_root)
+    print(f"stamped coolingTower equipType on {n_tower} CW fixture artifact(s)")
 
     pkg_zip = rezip_package(pkg_dir, fixture_root)
     print(f"rezipped {pkg_zip} ({pkg_zip.stat().st_size} bytes)")

--- a/tools/wattlab_export/app/column_map_json.py
+++ b/tools/wattlab_export/app/column_map_json.py
@@ -557,7 +557,7 @@ Rules later consume these exact point names. Return ONLY valid JSON matching thi
   "notes": "<short note>",
   "equip": {
     "<equip id>": {
-      "equipType": "ahu|vav|chwPlant|boiler|heatPump|weather|meter|unknown",
+      "equipType": "ahu|vav|chwPlant|coolingTower|boiler|heatPump|weather|meter|unknown",
       "device": "<same as equip id unless a clearer device name exists>",
       "points": {
         "<haystack-point-name>": "<exact_csv_column_name>"


### PR DESCRIPTION
## Summary
- Align health-matrix soak score expectations with product `?/n` when any flag is Unknown.
- Stage CW synthetic cases with `equipType: coolingTower` so `/api/analytics/cooling-tower-health` can see them.
- Document `coolingTower` in column-map authoring prompt.

## Test plan
- [x] `OPENFDD_ALLOW_STALE_GHCR_WEB=1 ./scripts/openfdd_stack_up.sh react-ot`
- [x] `python3 scripts/synthetic_59_target_pair_soak.py --side ofdd` → 59/59
- [x] `python3 scripts/synthetic_59_overview_analytics_soak.py` → PASS
- [x] `python3 scripts/synthetic_59_health_matrix_fault_hours_soak.py` → PASS 0 fails
- [ ] CI green → merge → GHCR nightly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for cooling-tower equipment in staged and exported data.
  * Cooling-tower records now receive consistent equipment classifications, legend entries, and expected-fault information.
  * Expanded equipment type options to include cooling towers.
  * Updated health-matrix validation to correctly display unknown scores when any underlying flag is unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->