### PR TITLE
fix(fieldbus): Niagara Haystack HTTP Basic (reqwest+zinc)

### DIFF
--- a/config/fieldbus/gateway.toml
+++ b/config/fieldbus/gateway.toml
@@ -35,7 +35,10 @@ default_timeout_secs = 5.0
 base_url = "http://127.0.0.1:8081"
 username = "admin"
 # Local demo credentials only — override via env in real deployments (never use defaults OT-side).
+# Niagara nHaystack: HAYSTACK_AUTH_MODE=basic HAYSTACK_TLS_VERIFY=false HAYSTACK_BASE_URL=https://…/haystack
 password = "changeme"
+auth_mode = "scram"
+tls_verify = true
 
 # Generic REST/JSON driver (#540). Device catalog lives in rest_devices.toml.
 # Writes fail closed: allow_write here AND the per-binding enabled flag must

--- a/docker/compose.react.fieldbus.local.example.yml
+++ b/docker/compose.react.fieldbus.local.example.yml
@@ -1,5 +1,7 @@
 # Copy to compose.react.fieldbus.local.yml (gitignored) for OT LAN bind + API key.
 # Do not commit real addresses or production keys.
+# Niagara nHaystack (optional): set OPENFDD_HAYSTACK_USER/PASS in repo .env, then:
+#   HAYSTACK_BASE_URL / HAYSTACK_AUTH_MODE=basic / HAYSTACK_TLS_VERIFY=false
 services:
   fieldbus:
     environment:
@@ -7,3 +9,8 @@ services:
       OPENFDD_FIELDBUS_API_KEY: "bench-demo-key-1234567890"
       OPENFDD_FIELDBUS_OPENAPI: "1"
       OPENFDD_FIELDBUS_SWAGGER_BENCH: "1"
+      # HAYSTACK_BASE_URL: "https://<niagara-host>/haystack"
+      # HAYSTACK_USER: "${OPENFDD_HAYSTACK_USER}"
+      # HAYSTACK_PASS: "${OPENFDD_HAYSTACK_PASS}"
+      # HAYSTACK_AUTH_MODE: "basic"
+      # HAYSTACK_TLS_VERIFY: "false"

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,46 +1,61 @@
 # BUG REPORT — OT Modbus / Haystack (low-RAM GHCR loop)
 
-**Date:** 2026-08-25  
-**Platform:** `3.3.3` / tip pre-merge of OT gates PR  
+**Date:** 2026-08-25 (updated 2026-08-26 probe)  
+**Platform:** `3.3.3` / `c7dfd92`  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`)
 
-Private OT LAN addresses live only in gitignored `scripts/nightly-ot-bench/bench.env.local` (see `bench.env.example`).
+Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `bench.env.local` / `rusty-haystack/.../.env`.
 
-## Confirmed PASS (this loop)
+## Confirmed PASS
 
 | Gate | Result |
 |------|--------|
-| Modbus `04` vs Pi Modbus TCP sim (gist temp server) | **GATE PASSED** (10 pass / 0 fail) — IR/HR, heartbeat advance, negatives |
-| Combined BACnet/MQTT/suspend/synth (earlier post-maint) | **COMBINED_EXIT=0** |
-| Stack left up | fieldbus poll running, MQTT up, OT NIC bind from local compose override |
+| Modbus `04` vs Pi Modbus TCP sim | **GATE PASSED** |
+| BACnet / MQTT / suspend / synth | **PASS** |
+| **Direct Niagara nHaystack** (2026-08-26) | **PASS** — see B2 closed below |
 
-## Open / blocked (next patch cycles)
+## Haystack probe (niagara_sample / BENCH_VALIDATION) — 2026-08-26
 
-### B1 — Fieldbus Haystack Basic auth not usable on pin v0.8.1
+From bench host via OT path, following [`rusty-haystack/demo/niagara_sample/BENCH_VALIDATION.md`](https://github.com/jscott3201/rusty-haystack/tree/main/demo/niagara_sample):
 
-- Niagara nHaystack requires **HTTP Basic** + insecure TLS ([niagara_sample](https://github.com/jscott3201/rusty-haystack/tree/main/demo/niagara_sample)).
-- Fieldbus `services/fieldbus/src/services/haystack.rs` returns *"Basic auth is not supported with the pinned rusty-haystack client"* for `auth_mode=basic`.
-- Latest **tagged** rusty-haystack release is still **v0.8.1** (no Basic/`connect_with_config`).
-- `main` tip **0.9.0** has Basic but requires **rustc 1.97** + `rand 0.10` — not a safe low-RAM local bump; needs GHCR CI after toolchain alignment or a maintainer **0.9 tag**.
+| Check | Result |
+|-------|--------|
+| TCP `:443` | OPEN |
+| `GET /haystack/about` HTTP Basic + insecure TLS | **OK** — Niagara 4.15.3.28, nHaystack 3.3.0.0, `v4Fifteen` |
+| `read?filter=point and dis=="SomeRandomPoint"` | **OK** — `@C.haystack_tests.SomeRandomPoint`, curVal changing (~50.64 → ~50.36) |
+| `read?filter=point and cur` | Multiple live/stale points (BACnet bindings + SomeRandomPoint) |
 
-**Workaround in gates:** `05_haystack.sh` can probe Niagara **directly** with `HAYSTACK_USER`/`HAYSTACK_PASS` when `HAYSTACK_EXPECT_LIVE=1` (not via fieldbus).
+**Conclusion:** Niagara + creds + firewall are fine. Failure is **only** Open-FDD fieldbus client pin (no Basic on rusty-haystack **v0.8.1**).
 
-### B2 — Live SomeRandomPoint not fully closed this pass
+## Open / blocked
 
-- Niagara HTTPS reachable; Workbench shows Random → `SomeRandomPoint`.
-- No `HAYSTACK_USER` / `HAYSTACK_PASS` present in bench `.env` on this host → live change assert not executed.
-- **Action:** add creds to local `.env` (gitignored), set `HAYSTACK_EXPECT_LIVE=1` in `bench.env.local`, re-run `05_haystack.sh`.
+### B1 — Fieldbus Haystack Basic auth not usable on pin v0.8.1 (OPEN)
 
-### B3 — rusty-bacnet latest release vs MS/TP seed
+- Fieldbus returns 502 / auth failure for `/haystack/*` (tries SCRAM-style path).
+- Latest **tagged** rusty-haystack is still **v0.8.1**. Tip **0.9.0** has `AuthMode::Basic` + `connect_with_config` / `ClientConfig::niagara_lab()` but needs newer rustc / `rand` — bump via **GHCR**, not local cargo on this host.
+- **Preferred architecture:** split Haystack into its own GHCR service (`openfdd-haystack`) so BACnet/Modbus fieldbus is not blocked by haystack dep churn. Same MQTT telemetry schema (`protocol: haystack`).
 
-- Latest release **v0.10.1** still lacks `add_routed_device` on the published API (only `add_device`).
-- Open-FDD keeps **0.9 + vendor patch** for MS/TP routed seed.
-- `dev` tip has `add_routed_device(RoutedDeviceConfig)` (unreleased). Next loop: pin/adapt after release **or** temporary `dev` SHA + GHCR MS/TP `02` re-smoke.
+### B2 — Live SomeRandomPoint — CLOSED at Niagara layer
 
-### B4 — rusty-modbus
+- Direct HTTPS Basic read works; value changes.
+- Remaining: wire same read through Open-FDD after B1 fix; set `HAYSTACK_EXPECT_LIVE=1` in gitignored `bench.env.local` for gate.
 
-- **Already on v0.1.1** release commit — no bump needed.
+### B3 — rusty-bacnet `add_routed_device` — OPEN (MS/TP)
 
-## Hygiene note
+- Release **v0.10.1** lacks it; vendor 0.9 patch remains; `dev` tip has new API.
 
-Keep looping: script/gates PR → merge → (code/dep patches only) watch GHCR → pull → sequential OT re-smoke. No local fieldbus image builds on this host.
+### B4 — rusty-modbus — CLOSED (on v0.1.1)
+
+## Point discovery (product)
+
+Straightforward path after B1:
+
+1. `POST /haystack/read` with filter `point and cur` (or operator filter).
+2. Present grid → operator picks rows → save bindings (id / dis / kind) into site config.
+3. Poll selected ids on interval → MQTT telemetry like BACnet points.
+
+Do **not** invent a second discovery protocol; use Haystack `read`/`nav` allowlist already on fieldbus.
+
+## Hygiene
+
+Keep looping: probe Niagara with demo scripts → patch fieldbus/haystack service via GHCR → OT gates → UI.

--- a/services/fieldbus/Cargo.toml
+++ b/services/fieldbus/Cargo.toml
@@ -45,8 +45,8 @@ bacnet-server = "0.9"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 
-# rusty-haystack v0.8.1 — latest tagged release. main tip 0.9.0 pulls rand 0.10.1 vs
-# tungstenite's ^0.10.2 and fails to resolve in this workspace; revisit when upstream tags a fix.
+# rusty-haystack v0.8.1 — latest tagged release. Niagara Basic uses fieldbus reqwest+zinc
+# (haystack.rs); tip 0.9.0 needs rustc 1.97 + rand 0.10 conflict — revisit when tagged.
 haystack_client = { package = "rusty-haystack-client", git = "https://github.com/jscott3201/rusty-haystack", rev = "d85e72271e789d3dcf4a90f79adb7d1556faae80", version = "0.8.1" }
 haystack_core = { package = "rusty-haystack-core", git = "https://github.com/jscott3201/rusty-haystack", rev = "d85e72271e789d3dcf4a90f79adb7d1556faae80", version = "0.8.1" }
 

--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -718,19 +718,19 @@ pub fn load_settings() -> Settings {
             s.poll.interval_secs = secs;
         }
     }
-    if let Some(v) = env_first(&["HAYSTACK_BASE_URL"]) {
+    if let Some(v) = env_first(&["HAYSTACK_BASE_URL", "OPENFDD_HAYSTACK_BASE_URL"]) {
         s.haystack.base_url = v;
     }
-    if let Some(v) = env_first(&["HAYSTACK_USER"]) {
+    if let Some(v) = env_first(&["HAYSTACK_USER", "OPENFDD_HAYSTACK_USER"]) {
         s.haystack.username = v;
     }
-    if let Some(v) = env_first(&["HAYSTACK_PASS"]) {
+    if let Some(v) = env_first(&["HAYSTACK_PASS", "OPENFDD_HAYSTACK_PASS"]) {
         s.haystack.password = v;
     }
-    if let Some(v) = env_first(&["HAYSTACK_AUTH_MODE"]) {
+    if let Some(v) = env_first(&["HAYSTACK_AUTH_MODE", "OPENFDD_HAYSTACK_AUTH_MODE"]) {
         s.haystack.auth_mode = parse_haystack_auth_mode(&v);
     }
-    if let Some(v) = env_first(&["HAYSTACK_TLS_VERIFY"]) {
+    if let Some(v) = env_first(&["HAYSTACK_TLS_VERIFY", "OPENFDD_HAYSTACK_TLS_VERIFY"]) {
         s.haystack.tls_verify = env_bool(Some(&v), s.haystack.tls_verify);
     }
     if let Some(v) = env_first(&["MODBUS_DEFAULT_HOST"]) {

--- a/services/fieldbus/src/services/haystack.rs
+++ b/services/fieldbus/src/services/haystack.rs
@@ -1,10 +1,15 @@
-//! Read-only Haystack client wrapper (mirrors `app/haystack_client.py`).
+//! Read-only Haystack client wrapper.
+//!
+//! - **SCRAM**: rusty-haystack `HaystackClient::connect` (SkySpark / rusty-haystack server).
+//! - **Basic**: reqwest + Zinc decode via haystack_core (Niagara nHaystack). Stays on
+//!   rusty-haystack v0.8.1 so we do not pull tip 0.9 (rustc 1.97 / rand conflict).
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use haystack_client::transport::http::HttpTransport;
 use haystack_client::HaystackClient;
+use haystack_core::codecs::zinc;
 use haystack_core::data::HGrid;
 use haystack_core::kinds::Kind;
 use serde_json::{json, Value};
@@ -27,9 +32,85 @@ impl std::fmt::Display for HaystackNotAllowedError {
 
 impl std::error::Error for HaystackNotAllowedError {}
 
+enum ClientInner {
+    Scram(HaystackClient<HttpTransport>),
+    Basic(BasicHaystackHttp),
+}
+
+/// Niagara-friendly HTTP Basic + Zinc client (no SCRAM handshake).
+struct BasicHaystackHttp {
+    http: reqwest::Client,
+    base_url: String,
+    username: String,
+    password: String,
+}
+
+impl BasicHaystackHttp {
+    fn new(settings: &HaystackSettings) -> Result<Self, String> {
+        let http = reqwest::Client::builder()
+            .danger_accept_invalid_certs(!settings.tls_verify)
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| e.to_string())?;
+        Ok(Self {
+            http,
+            base_url: settings.base_url.trim_end_matches('/').to_string(),
+            username: settings.username.clone(),
+            password: settings.password.clone(),
+        })
+    }
+
+    async fn get_zinc(&self, path: &str, query: &[(&str, String)]) -> Result<HGrid, String> {
+        let url = format!("{}{}", self.base_url, path);
+        let mut req = self
+            .http
+            .get(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .header("Accept", "text/zinc");
+        if !query.is_empty() {
+            req = req.query(query);
+        }
+        let resp = req.send().await.map_err(|e| e.to_string())?;
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| e.to_string())?;
+        if !status.is_success() {
+            return Err(format!(
+                "haystack HTTP {status}: {}",
+                body.chars().take(240).collect::<String>()
+            ));
+        }
+        zinc::decode_grid(&body).map_err(|e| e.to_string())
+    }
+
+    async fn about(&self) -> Result<HGrid, String> {
+        self.get_zinc("/about", &[]).await
+    }
+
+    async fn read(&self, filter: &str) -> Result<HGrid, String> {
+        self.get_zinc("/read", &[("filter", filter.to_string())])
+            .await
+    }
+
+    async fn nav(&self, nav_id: Option<&str>) -> Result<HGrid, String> {
+        let q: Vec<(&str, String)> = match nav_id {
+            Some(id) if !id.is_empty() => vec![("navId", id.to_string())],
+            _ => vec![],
+        };
+        self.get_zinc("/nav", &q).await
+    }
+
+    async fn his_read(&self, id: &str, range: &str) -> Result<HGrid, String> {
+        self.get_zinc(
+            "/hisRead",
+            &[("id", id.to_string()), ("range", range.to_string())],
+        )
+        .await
+    }
+}
+
 pub struct HaystackService {
     settings: HaystackSettings,
-    client: Arc<Mutex<Option<HaystackClient<HttpTransport>>>>,
+    client: Arc<Mutex<Option<ClientInner>>>,
 }
 
 impl HaystackService {
@@ -41,7 +122,8 @@ impl HaystackService {
     }
 
     pub async fn close(&self) {
-        if let Some(client) = self.client.lock().await.take() {
+        let mut guard = self.client.lock().await;
+        if let Some(ClientInner::Scram(client)) = guard.take() {
             let _ = client.close().await;
         }
     }
@@ -59,22 +141,21 @@ impl HaystackService {
     async fn ensure_client(&self) -> Result<(), String> {
         let mut guard = self.client.lock().await;
         if guard.is_none() {
-            let client = match self.settings.auth_mode {
+            let inner = match self.settings.auth_mode {
                 HaystackAuthMode::Basic => {
-                    return Err(
-                        "Haystack Basic auth is not supported with the pinned rusty-haystack client (use SCRAM)"
-                            .into(),
-                    );
+                    ClientInner::Basic(BasicHaystackHttp::new(&self.settings)?)
                 }
-                HaystackAuthMode::Scram => HaystackClient::connect(
-                    &self.settings.base_url,
-                    &self.settings.username,
-                    &self.settings.password,
-                )
-                .await
-                .map_err(|e| e.to_string())?,
+                HaystackAuthMode::Scram => ClientInner::Scram(
+                    HaystackClient::connect(
+                        &self.settings.base_url,
+                        &self.settings.username,
+                        &self.settings.password,
+                    )
+                    .await
+                    .map_err(|e| e.to_string())?,
+                ),
             };
-            *guard = Some(client);
+            *guard = Some(inner);
         }
         Ok(())
     }
@@ -83,36 +164,30 @@ impl HaystackService {
         self.check_op("about").map_err(|e| e.to_string())?;
         self.ensure_client().await?;
         let guard = self.client.lock().await;
-        guard
-            .as_ref()
-            .unwrap()
-            .about()
-            .await
-            .map_err(|e| e.to_string())
+        match guard.as_ref().unwrap() {
+            ClientInner::Scram(c) => c.about().await.map_err(|e| e.to_string()),
+            ClientInner::Basic(c) => c.about().await,
+        }
     }
 
     pub async fn read(&self, filter: &str) -> Result<HGrid, String> {
         self.check_op("read").map_err(|e| e.to_string())?;
         self.ensure_client().await?;
         let guard = self.client.lock().await;
-        guard
-            .as_ref()
-            .unwrap()
-            .read(filter, None)
-            .await
-            .map_err(|e| e.to_string())
+        match guard.as_ref().unwrap() {
+            ClientInner::Scram(c) => c.read(filter, None).await.map_err(|e| e.to_string()),
+            ClientInner::Basic(c) => c.read(filter).await,
+        }
     }
 
     pub async fn nav(&self, nav_id: Option<&str>) -> Result<HGrid, String> {
         self.check_op("nav").map_err(|e| e.to_string())?;
         self.ensure_client().await?;
         let guard = self.client.lock().await;
-        guard
-            .as_ref()
-            .unwrap()
-            .nav(nav_id)
-            .await
-            .map_err(|e| e.to_string())
+        match guard.as_ref().unwrap() {
+            ClientInner::Scram(c) => c.nav(nav_id).await.map_err(|e| e.to_string()),
+            ClientInner::Basic(c) => c.nav(nav_id).await,
+        }
     }
 
     pub async fn his_read(
@@ -129,11 +204,20 @@ impl HaystackService {
             _ => "today".into(),
         };
         let guard = self.client.lock().await;
-        let client = guard.as_ref().unwrap();
         let mut out = HashMap::new();
-        for id in ids {
-            let grid = client.his_read(id, &rng).await.map_err(|e| e.to_string())?;
-            out.insert(id.clone(), grid);
+        match guard.as_ref().unwrap() {
+            ClientInner::Scram(client) => {
+                for id in ids {
+                    let grid = client.his_read(id, &rng).await.map_err(|e| e.to_string())?;
+                    out.insert(id.clone(), grid);
+                }
+            }
+            ClientInner::Basic(client) => {
+                for id in ids {
+                    let grid = client.his_read(id, &rng).await?;
+                    out.insert(id.clone(), grid);
+                }
+            }
         }
         Ok(out)
     }


### PR DESCRIPTION
## Summary
- Niagara nHaystack needs HTTP Basic + insecure TLS; fieldbus was hard-failing Basic on rusty-haystack **v0.8.1**.
- Implement Basic path with **reqwest + haystack_core Zinc decode** (no tip 0.9 bump / rustc 1.97).
- Env aliases: `HAYSTACK_*` and `OPENFDD_HAYSTACK_*`.
- Bench: direct Niagara `SomeRandomPoint` already proven; this unlocks the same via fieldbus after GHCR.

## Test plan
- [ ] CI green (fieldbus)
- [ ] GHCR fieldbus pull + local compose Haystack env
- [ ] `GET /haystack/about` and read SomeRandomPoint via fieldbus API key
- [ ] BACnet/Modbus/MQTT still healthy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to Niagara nHaystack services using HTTP Basic authentication.
  * Added configuration aliases for Haystack environment variables while preserving existing settings.
  * Added documented options for authentication mode and TLS certificate verification.

* **Documentation**
  * Updated local deployment examples with optional Niagara nHaystack settings.
  * Expanded troubleshooting guidance, discovery steps, compatibility notes, and current integration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->