### PR TITLE
fix(ot): Haystack live gate curVal parse + BUG_REPORT 3.3.4

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,7 +1,7 @@
 # BUG REPORT — OT Modbus / Haystack (low-RAM GHCR loop)
 
-**Date:** 2026-08-25 (updated 2026-08-26 probe)  
-**Platform:** `3.3.3` / `c7dfd92`  
+**Date:** 2026-08-26  
+**Platform:** `3.3.4` / `8e7899e` (`sha-8e7899e` GHCR; includes tip `b1811da` + #778 Haystack Basic + #780 edge kits / agent auth / nginx resolver fix)  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`)
 
 Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `bench.env.local` / `rusty-haystack/.../.env`.
@@ -10,52 +10,53 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 | Gate | Result |
 |------|--------|
-| Modbus `04` vs Pi Modbus TCP sim | **GATE PASSED** |
-| BACnet / MQTT / suspend / synth | **PASS** |
-| **Direct Niagara nHaystack** (2026-08-26) | **PASS** — see B2 closed below |
+| Stack health `/api/health` | **PASS** — `3.3.4+8e7899e62c3d` |
+| Synthetic-59 target pairs | **PASS** — 59/59 |
+| Synthetic-59 overview analytics | **PASS** — 0 fails |
+| Synthetic-59 health-matrix fault hours | **PASS** — 0 fails |
+| Modbus `04` vs Pi Modbus TCP sim | **GATE PASSED** (10 pass / 0 fail) |
+| Haystack `05` live (`HAYSTACK_EXPECT_LIVE=1`) | **GATE PASSED** — see B1/B2 closed |
+| Fieldbus `/health` | **PASS** — poll_running, bacnet/modbus/haystack sidecars green on stack strip |
 
-## Haystack probe (niagara_sample / BENCH_VALIDATION) — 2026-08-26
+## Haystack via fieldbus (B1 / B2) — CLOSED
 
-From bench host via OT path, following [`rusty-haystack/demo/niagara_sample/BENCH_VALIDATION.md`](https://github.com/jscott3201/rusty-haystack/tree/main/demo/niagara_sample):
+Proven on tip fieldbus (not only direct Niagara):
 
 | Check | Result |
 |-------|--------|
-| TCP `:443` | OPEN |
-| `GET /haystack/about` HTTP Basic + insecure TLS | **OK** — Niagara 4.15.3.28, nHaystack 3.3.0.0, `v4Fifteen` |
-| `read?filter=point and dis=="SomeRandomPoint"` | **OK** — `@C.haystack_tests.SomeRandomPoint`, curVal changing (~50.64 → ~50.36) |
-| `read?filter=point and cur` | Multiple live/stale points (BACnet bindings + SomeRandomPoint) |
+| `GET /haystack/about` via fieldbus | **OK** — Niagara 4 / nHaystack 3.3.0.0 grid |
+| `POST /haystack/read` `point and dis=="SomeRandomPoint"` | **OK** — `@C.haystack_tests.SomeRandomPoint` |
+| Live curVal change through fieldbus | **OK** — e.g. `50.1747 → 50.2187` (gate parse fixed; see Hygiene) |
+| Allowlist (`/haystack/eval`) | **OK** — HTTP 404 |
 
-**Conclusion:** Niagara + creds + firewall are fine. Failure is **only** Open-FDD fieldbus client pin (no Basic on rusty-haystack **v0.8.1**).
+**Conclusion:** #778 Basic auth on rusty-haystack **v0.8.1** is sufficient for this Niagara lab. Preferred long-term split to `openfdd-haystack` remains an architecture note, not a blocker for Basic.
 
-## Open / blocked
+## Open / residual
 
-### B1 — Fieldbus Haystack Basic auth not usable on pin v0.8.1 (OPEN)
+### B3 — rusty-bacnet `add_routed_device` / MS/TP routing — OPEN
 
-- Fieldbus returns 502 / auth failure for `/haystack/*` (tries SCRAM-style path).
-- Latest **tagged** rusty-haystack is still **v0.8.1**. Tip **0.9.0** has `AuthMode::Basic` + `connect_with_config` / `ClientConfig::niagara_lab()` but needs newer rustc / `rand` — bump via **GHCR**, not local cargo on this host.
-- **Preferred architecture:** split Haystack into its own GHCR service (`openfdd-haystack`) so BACnet/Modbus fieldbus is not blocked by haystack dep churn. Same MQTT telemetry schema (`protocol: haystack`).
+BACnet `02` on this tip: **GATE FAILED** (hosted server 599999 objects PASS; device **5007** routed MS/TP + BIP companions FAIL — “device not in device table” / UNKNOWN_OBJECT class failures). Still needs bacnet crate bump / seed of routed devices; not closed by 3.3.4.
 
-### B2 — Live SomeRandomPoint — CLOSED at Niagara layer
+### MQTT ingest growth (`03`) — FAIL this run (honest)
 
-- Direct HTTPS Basic read works; value changes.
-- Remaining: wire same read through Open-FDD after B1 fix; set `HAYSTACK_EXPECT_LIVE=1` in gitignored `bench.env.local` for gate.
+- Central MQTTS client **connected** (`mqtt:8883`).
+- After forced fieldbus `poll/once`, **ingest_ok stayed 0**; MQTTS subscribe peek captured no telemetry; feather file count unchanged in the wait window.
+- Likely coupled to BACnet poll producing no live points (B3) rather than broker down. Re-check after bacnet routing is fixed or with a dedicated Modbus→MQTT publish path.
 
-### B3 — rusty-bacnet `add_routed_device` — OPEN (MS/TP)
+### Agent password on bench
 
-- Release **v0.10.1** lacks it; vendor 0.9 patch remains; `dev` tip has new API.
-
-### B4 — rusty-modbus — CLOSED (on v0.1.1)
+`GET /api/auth/status` → `agent_login_configured: false` until `OPENFDD_AGENT_PASSWORD` is set in compose `.env` (Railway docs require it; optional on LAN admin-only benches).
 
 ## Point discovery (product)
 
-Straightforward path after B1:
+Unchanged happy path after B1:
 
 1. `POST /haystack/read` with filter `point and cur` (or operator filter).
-2. Present grid → operator picks rows → save bindings (id / dis / kind) into site config.
-3. Poll selected ids on interval → MQTT telemetry like BACnet points.
-
-Do **not** invent a second discovery protocol; use Haystack `read`/`nav` allowlist already on fieldbus.
+2. Present grid → operator picks rows → save bindings.
+3. Poll selected ids → MQTT telemetry like BACnet points.
 
 ## Hygiene
 
-Keep looping: probe Niagara with demo scripts → patch fieldbus/haystack service via GHCR → OT gates → UI.
+- GHCR publish for `b1811da` was cancelled/timed out earlier; tip images for this report are **`sha-8e7899e`** after #780 (nginx `15-openfdd-resolver.envsh` executable + 90m GHCR test timeout).
+- Haystack gate `extract_cur_val` previously fed JSON via stdin into a `<<'PY'` heredoc (stdin stolen → empty v1/v2). Fixed to pass payload via env; gate now correctly PASSes live change.
+- Do not invent a second discovery protocol; use Haystack `read`/`nav` allowlist on fieldbus.

--- a/scripts/nightly-ot-bench/05_haystack.sh
+++ b/scripts/nightly-ot-bench/05_haystack.sh
@@ -5,9 +5,9 @@
 # Live (HAYSTACK_EXPECT_LIVE=1): require successful about/read and a changing SomeRandomPoint.
 #
 # Niagara nHaystack needs HTTP Basic + insecure TLS (see rusty-haystack demo/niagara_sample).
-# Fieldbus on rusty-haystack v0.8.1 cannot Basic-auth yet — when live is requested and
-# fieldbus returns the Basic-not-supported error, fall back to direct HTTPS probe using
-# HAYSTACK_USER / HAYSTACK_PASS (same as demo) so the bench still validates the point.
+# Fieldbus tip (≥3.3.4 / #778) speaks Basic via reqwest+zinc on rusty-haystack v0.8.1.
+# When live is requested and fieldbus still fails, fall back to direct HTTPS probe using
+# HAYSTACK_USER / HAYSTACK_PASS so the bench still validates the point.
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
@@ -82,10 +82,11 @@ else
 fi
 
 extract_cur_val() {
-  # Prefer JSON curVal / number fields; Zinc fallback n:NNN
-  python3 - <<'PY'
-import json, re, sys
-raw = sys.stdin.read()
+  # Prefer JSON curVal / number fields; Zinc fallback n:NNN.
+  # Data must come via argv/env — a <<'PY' heredoc would steal stdin.
+  RAW="${1:-}" python3 - <<'PY'
+import json, os, re
+raw = os.environ.get("RAW", "")
 try:
     d = json.loads(raw)
 except Exception:
@@ -117,11 +118,11 @@ live_somerandom_via_fieldbus() {
   body="$(jq -nc --arg f "$HS_FILTER" '{filter:$f}')"
   r1="$(fb -X POST "$FIELDBUS_BASE/haystack/read" -d "$body" 2>/dev/null || true)"
   echo "$r1" >"$ART/haystack_somerandom_1.json"
-  v1="$(extract_cur_val <<<"$r1")"
+  v1="$(extract_cur_val "$r1")"
   sleep 3
   r2="$(fb -X POST "$FIELDBUS_BASE/haystack/read" -d "$body" 2>/dev/null || true)"
   echo "$r2" >"$ART/haystack_somerandom_2.json"
-  v2="$(extract_cur_val <<<"$r2")"
+  v2="$(extract_cur_val "$r2")"
   echo "${DIM}  fieldbus SomeRandomPoint v1=$v1 v2=$v2${RST}"
   if [[ -n "$v1" && -n "$v2" && "$v1" != "$v2" ]]; then
     ok "SomeRandomPoint changed via fieldbus ($v1 → $v2)"
@@ -138,13 +139,17 @@ live_somerandom_direct() {
   echo "$a1" >"$ART/haystack_direct_about.zinc"
   [[ -n "$a1" ]] || return 1
   ok "direct Niagara /about (Basic + insecure TLS)"
-  local enc
+  local enc z1 z2
   enc="$(F="$HS_FILTER" python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["F"]))')"
-  v1="$(curl -fsSk --max-time 20 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
-    "$u/read?filter=$enc" 2>/dev/null | tee "$ART/haystack_direct_read_1.zinc" | extract_cur_val)"
+  z1="$(curl -fsSk --max-time 20 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+    "$u/read?filter=$enc" 2>/dev/null || true)"
+  echo "$z1" >"$ART/haystack_direct_read_1.zinc"
+  v1="$(extract_cur_val "$z1")"
   sleep 3
-  v2="$(curl -fsSk --max-time 20 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
-    "$u/read?filter=$enc" 2>/dev/null | tee "$ART/haystack_direct_read_2.zinc" | extract_cur_val)"
+  z2="$(curl -fsSk --max-time 20 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+    "$u/read?filter=$enc" 2>/dev/null || true)"
+  echo "$z2" >"$ART/haystack_direct_read_2.zinc"
+  v2="$(extract_cur_val "$z2")"
   echo "${DIM}  direct SomeRandomPoint v1=$v1 v2=$v2${RST}"
   if [[ -n "$v1" && -n "$v2" && "$v1" != "$v2" ]]; then
     ok "SomeRandomPoint changed via direct Niagara HTTPS ($v1 → $v2)"
@@ -158,7 +163,7 @@ if [[ "$EXPECT_LIVE" == "1" ]]; then
   if live_somerandom_via_fieldbus; then
     :
   else
-    skip "fieldbus live read did not show changing SomeRandomPoint (Basic auth gap on rusty-haystack 0.8.1?)"
+    skip "fieldbus live read did not show changing SomeRandomPoint (retry / check Niagara Random)"
     rc=0
     live_somerandom_direct || rc=$?
     if [[ "$rc" -eq 2 ]]; then


### PR DESCRIPTION
## Summary
- Fix `05_haystack.sh` `extract_cur_val` so live SomeRandomPoint changes are detected (heredoc was stealing stdin).
- Rewrite `BUG_REPORT_OT_MODBUS_HAYSTACK.md` for **3.3.4 / `8e7899e`**: B1/B2 CLOSED via fieldbus; B3 + MQTT ingest residual OPEN.

## Test plan
- [ ] `HAYSTACK_EXPECT_LIVE=1 ./scripts/nightly-ot-bench/05_haystack.sh` → GATE PASSED
- [ ] docs-guard / stack script syntax green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Haystack fieldbus validation, including Basic authentication, live value updates, and evaluation allowlist handling.
  - Updated Haystack benchmark checks to reliably process JSON and Zinc responses.
  - Removed outdated failure messaging related to Basic authentication support.

- **Documentation**
  - Updated operational testing records for platform version 3.3.4.
  - Recorded passing stack, Modbus, Haystack, and fieldbus validation gates.
  - Documented remaining limitations involving routed BACnet devices, MS/TP, MQTT ingestion, and optional agent passwords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->