### PR TITLE
feat(fieldbus): B3 routing, OT poll policy, MQTT cell mode, dual-MQTT gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ A Railway one-click template should eventually encode **central → mqtt → web
 - **Never** local `docker build` / heavy Rust compile for stack images. Ship via PR → GH Actions → GHCR `nightly` / `sha-*`.
 - Before pulling new images: prune unused/old digests first, then `./scripts/openfdd_stack_pull.sh …` and `./scripts/openfdd_stack_up.sh … --no-pull`.
 - DataFusion: `OPENFDD_QUERY_MEMORY_MB=256` (or 512) + `OPENFDD_DATAFUSION_SPILL_DIR` — see [`docs/operations/AFDD_MODES.md`](docs/operations/AFDD_MODES.md).
+- BACnet OT on cell edges: default **300 s** poll/publish, **60 s** floor, poll ~**30%** health points only — [`docs/operations/BACNET_OT_POLICY.md`](docs/operations/BACNET_OT_POLICY.md). Hard BACnet debug: [`docs/mcp-agents/companion-rusty-bacnet-mcp.md`](docs/mcp-agents/companion-rusty-bacnet-mcp.md).
 - Details: [`openfdd_agent_spec/CONTAINER_AGENT.md`](openfdd_agent_spec/CONTAINER_AGENT.md).
 
 ## AFDD vs bulk FDD

--- a/config/fieldbus/gateway.toml
+++ b/config/fieldbus/gateway.toml
@@ -46,5 +46,10 @@ tls_verify = true
 [rest]
 default_timeout_secs = 10
 default_tls_verify = true
-default_poll_interval_secs = 60
+default_poll_interval_secs = 300
 allow_write = false
+
+# Production BACnet poll cadence (override with OPENFDD_FIELDBUS_DEV_FAST_POLL=1 on benches).
+[poll]
+interval_secs = 300
+# health_roles_only = true   # optional: ~30% HVAC health subset for cell sites

--- a/deploy/mqtt/README.md
+++ b/deploy/mqtt/README.md
@@ -65,3 +65,18 @@ Mount the generated kit at `/mqtt` (read-only) and set:
 - `OPENFDD_MQTT_KEY_PEM=/mqtt/edge.key.pem`
 
 Outbound TCP **8883** (MQTTS) is the only required central connectivity from the edge.
+
+## Cell modem bandwidth
+
+Fieldbus MQTT defaults assume **infrequent, small** publishes on metered links:
+
+| Env | Default (prod) | Effect |
+|-----|----------------|--------|
+| `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS` | 300 (min 60) | Decouple publish cadence from BACnet poll |
+| `OPENFDD_MQTT_CELL_MODE=1` | off | Omit `display_name`; slim tags to `building_id`, `equipment_id`, `role` |
+| `OPENFDD_MQTT_DELTA=1` | on when cell mode | Publish only changed point values |
+| `OPENFDD_POLL_HEALTH_ONLY=1` | off | Poll ~30% HVAC health roles (see [`BACNET_OT_POLICY.md`](../docs/operations/BACNET_OT_POLICY.md)) |
+
+Rough sizing: full snapshot ≈ **150–250 B × N points** per message; delta mode ≈ **80–120 B × changed points**. Prefer delta + health subset on LTE.
+
+Dev benches: `OPENFDD_FIELDBUS_DEV_FAST_POLL=1` allows faster poll/publish for OT gates.

--- a/docs/mcp-agents/companion-rusty-bacnet-mcp.md
+++ b/docs/mcp-agents/companion-rusty-bacnet-mcp.md
@@ -1,0 +1,54 @@
+---
+title: Companion — rusty-bacnet-mcp
+parent: MCP Agents
+nav_order: 6
+---
+
+# Companion: rusty-bacnet-mcp (BACnet debug)
+
+**Use when fieldbus OT gates fail and you need independent BACnet proof on the OT LAN.**  
+`openfdd-mcp` talks to **Central REST** — it does **not** send BACnet ReadProperty on the wire.
+
+Production polling stays on **`openfdd-fieldbus`**. [rusty-bacnet-mcp](https://github.com/jscott3201/rusty-bacnet-mcp) is a **read-only diagnostic** MCP on the rusty-bacnet stack.
+
+## When to use
+
+| Situation | Tool |
+|-----------|------|
+| FDD, historian, edges, MQTT ingest | `openfdd-mcp` → Central |
+| Routed MS/TP (device 5007), Who-Is, ReadProperty isolation | rusty-bacnet-mcp on OT subnet |
+| Product poll / MQTT publish | `openfdd-fieldbus` only |
+
+## Install (bench)
+
+```bash
+cargo install --git https://github.com/jscott3201/rusty-bacnet-mcp bacnet-mcp --features bin
+cp examples/bacnet-mcp.json ./bacnet-mcp.json
+# Edit transports.bip.broadcast for your OT subnet; keep mcp.read_only true
+```
+
+## Cursor snippet (stdio)
+
+```json
+{
+  "mcpServers": {
+    "openfdd": { "...": "see mcp/README.md" },
+    "bacnet": {
+      "command": "/path/to/bacnet-mcp",
+      "args": ["--config", "/path/to/bacnet-mcp.json"]
+    }
+  }
+}
+```
+
+## Typical debug flow (B3 / MS/TP)
+
+1. `discover_devices` / `list_known_devices` — confirm router + instance 5007.
+2. `read_property` on `analog-input:1173` for device 5007.
+3. Compare with `POST /bacnet/read` on fieldbus `:8081`.
+4. If MCP succeeds and fieldbus fails → fieldbus seed/config bug. If both fail → OT LAN / router.
+
+## Safety
+
+- Keep **`read_only: true`** unless a human explicitly approves writes.
+- Follow [`BACNET_OT_POLICY.md`](../operations/BACNET_OT_POLICY.md) — default **300 s** poll, **60 s** floor, ~**30%** health points on cell sites.

--- a/docs/operations/BACNET_OT_POLICY.md
+++ b/docs/operations/BACNET_OT_POLICY.md
@@ -1,0 +1,35 @@
+# BACnet OT polling policy (production + agent context)
+
+Operators and AI agents must treat BACnet as a **shared, fragile OT resource** — especially on cell-modem edges.
+
+## Production defaults (fieldbus)
+
+| Setting | Production | Dev / bench override |
+|---------|------------|----------------------|
+| Poll interval | **300 s** (`gateway.toml` `[poll].interval_secs`) | `OPENFDD_FIELDBUS_DEV_FAST_POLL=1` + lower `OPENFDD_FIELDBUS_POLL_INTERVAL_SECS` |
+| Minimum interval | **60 s** (enforced unless dev flag) | Same flag allows faster poll for OT gates |
+| MQTT publish | **300 s** default (`OPENFDD_MQTT_PUBLISH_INTERVAL_SECS`) | Dev flag allows 5 s floor |
+| Point subset | Optional **health roles only** (~30% cap) | Full catalog when dev flag set |
+
+## Health-point subset
+
+Enable for cell sites:
+
+- Env: `OPENFDD_POLL_HEALTH_ONLY=1`
+- Or `gateway.toml`: `[poll] health_roles_only = true`
+
+Only points whose `point_name` maps via `haystack_point_to_role` to a known cookbook role are polled. If that set exceeds ~30% of the configured catalog, fieldbus logs a warning and caps the list.
+
+## Agent rules
+
+1. **Never** bulk-discover and poll an entire BACnet network on a production/cell site.
+2. Default to **300 s** poll and publish; use faster cadence only on labeled dev benches.
+3. Target **~30%** of points — HVAC health roles (AHU SAT/RAT/OAT, VAV flow/temp, chiller/boiler status, key sensors).
+4. MS/TP routed devices must be seeded via `field_devices.toml` (`mstp_network`, `mstp_mac`) — see B3 notes in [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](BUG_REPORT_OT_MODBUS_HAYSTACK.md).
+5. For hard BACnet commissioning/debug only, use companion [rusty-bacnet-mcp](companion-rusty-bacnet-mcp.md) — **read-only**; do not replace `openfdd-fieldbus`.
+
+## Related
+
+- [`deploy/mqtt/README.md`](../../deploy/mqtt/README.md) — cell payload / bandwidth
+- [`AGENTS.md`](../../AGENTS.md) — stack + low-RAM bench
+- [`config/fieldbus/gateway.toml`](../../config/fieldbus/gateway.toml) — poll defaults

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -34,19 +34,15 @@ Artifacts: `reports/nightly-ot-*/digests.txt`, `image_revs.txt`, `pi_image_rev.t
 | Live curVal through fieldbus | **OK** — gate `extract_cur_val` fixed (#783) |
 | Allowlist (`/haystack/eval`) | **OK** — HTTP 404 |
 
-## B3 — MS/TP routing (device 5007) — FIX IN PR TRAIN
+## B3 — MS/TP routing (device 5007) — CLOSED (bench 2026-08-26)
 
-**Symptom (prior tip):** Who-Is found 5007 but `source_network` null; ReadProperty UNKNOWN_OBJECT.
+**Prior failure:** empty shipped `field_devices.toml` on bench (no 5007 seed) + I-Am overwrite edge case.
 
-**Root cause:** I-Am responses without NPDU routing overwrote `add_routed_device` seeds in the ephemeral client device table.
+**Fix train (`#784`):** vendored `DeviceTable::upsert` preserves routing; Who-Is merges `field_devices.toml`; seed logging.
 
-**Fix (`1540225`):**
+**Re-verify ( `sha-8e7899e` + bench overlay):** `02_bacnet_ot.sh` **GATE PASSED** — 15 pass / 0 fail (`source_network=2000`, read AI:1173, poll 3 points).
 
-- Vendored `DeviceTable::upsert` preserves `source_network` / `source_address` when I-Am lacks routing.
-- Who-Is merges configured routed devices from `field_devices.toml`.
-- Structured log on successful `add_routed_device` seed.
-
-**Re-verify:** `./scripts/nightly-ot-bench/02_bacnet_ot.sh` after GHCR pull of PR tip. Bench must mount [`field_devices.bench.example.toml`](../scripts/nightly-ot-bench/field_devices.bench.example.toml) → `config/fieldbus/field_devices.toml`.
+Bench requires: `cp scripts/nightly-ot-bench/field_devices.bench.example.toml config/fieldbus/field_devices.toml` + fieldbus recreate.
 
 ## MQTT / cell optimization — NEW IN PR TRAIN
 
@@ -59,7 +55,7 @@ Artifacts: `reports/nightly-ot-*/digests.txt`, `image_revs.txt`, `pi_image_rev.t
 
 Docs: [`BACNET_OT_POLICY.md`](BACNET_OT_POLICY.md), [`deploy/mqtt/README.md`](../../deploy/mqtt/README.md).
 
-**Gate 03 / ingest:** Re-run after B3 + new fieldbus image; weather/hosted points may prove MQTT path even when OT BACnet poll is sparse.
+**Gate 03 / ingest:** **GATE PASSED** on `sha-8e7899e` after B3 bench overlay + poll (ingest counter growth; artifacts under `reports/nightly-ot-bench_*`). Re-run on `#784` GHCR after merge.
 
 ## Dual-site MQTT (lab + bldg2) — gate 10
 

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,62 +1,85 @@
-# BUG REPORT — OT Modbus / Haystack (low-RAM GHCR loop)
+# BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
 **Date:** 2026-08-26  
-**Platform:** `3.3.4` / `8e7899e` (`sha-8e7899e` GHCR; includes tip `b1811da` + #778 Haystack Basic + #780 edge kits / agent auth / nginx resolver fix)  
-**Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`)
+**Platform:** `3.3.4` / `fa14c05` master + `1540225` train (`feat/nightly-b3-mqtt-policy` PR pending)  
+**Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR=/workspace/.cache/datafusion-spill`)  
+**Remote edge:** bosspi `192.168.204.12` — fieldbus only (dual-MQTT gate 10)
 
 Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `bench.env.local` / `rusty-haystack/.../.env`.
 
-## Confirmed PASS
+## GHCR legitimacy (required sign-off)
+
+| Host | Role | Image ref | nightly↔sha | OCI revision | `/health` version |
+|------|------|-----------|-------------|--------------|-------------------|
+| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-*` | from gate `00` `digests.txt` | `image_revs.txt` | `/api/health` |
+| bosspi | fieldbus edge only | same `sha-*` fieldbus | n/a | must == bench fieldbus | `:8081/health` |
+
+Artifacts: `reports/nightly-ot-*/digests.txt`, `image_revs.txt`, `pi_image_rev.txt` (gate 10).
+
+## Confirmed PASS (master `fa14c05` after #783)
 
 | Gate | Result |
 |------|--------|
-| Stack health `/api/health` | **PASS** — `3.3.4+8e7899e62c3d` |
-| Synthetic-59 target pairs | **PASS** — 59/59 |
-| Synthetic-59 overview analytics | **PASS** — 0 fails |
-| Synthetic-59 health-matrix fault hours | **PASS** — 0 fails |
-| Modbus `04` vs Pi Modbus TCP sim | **GATE PASSED** (10 pass / 0 fail) |
-| Haystack `05` live (`HAYSTACK_EXPECT_LIVE=1`) | **GATE PASSED** — see B1/B2 closed |
-| Fieldbus `/health` | **PASS** — poll_running, bacnet/modbus/haystack sidecars green on stack strip |
+| Stack health `/api/health` | **PASS** on prior `sha-8e7899e` — re-pull after merge |
+| Synthetic-59 target pairs | **PASS** — 59/59 (prior tip) |
+| Modbus `04` vs Pi Modbus TCP sim | **GATE PASSED** |
+| Haystack `05` live (`HAYSTACK_EXPECT_LIVE=1`) | **GATE PASSED** — B1/B2 closed; gate script stdin fix in #783 |
+| Fieldbus `/health` | **PASS** — sidecars green |
 
 ## Haystack via fieldbus (B1 / B2) — CLOSED
 
-Proven on tip fieldbus (not only direct Niagara):
-
 | Check | Result |
 |-------|--------|
-| `GET /haystack/about` via fieldbus | **OK** — Niagara 4 / nHaystack 3.3.0.0 grid |
-| `POST /haystack/read` `point and dis=="SomeRandomPoint"` | **OK** — `@C.haystack_tests.SomeRandomPoint` |
-| Live curVal change through fieldbus | **OK** — e.g. `50.1747 → 50.2187` (gate parse fixed; see Hygiene) |
+| `GET /haystack/about` via fieldbus | **OK** |
+| Live curVal through fieldbus | **OK** — gate `extract_cur_val` fixed (#783) |
 | Allowlist (`/haystack/eval`) | **OK** — HTTP 404 |
 
-**Conclusion:** #778 Basic auth on rusty-haystack **v0.8.1** is sufficient for this Niagara lab. Preferred long-term split to `openfdd-haystack` remains an architecture note, not a blocker for Basic.
+## B3 — MS/TP routing (device 5007) — FIX IN PR TRAIN
 
-## Open / residual
+**Symptom (prior tip):** Who-Is found 5007 but `source_network` null; ReadProperty UNKNOWN_OBJECT.
 
-### B3 — rusty-bacnet `add_routed_device` / MS/TP routing — OPEN
+**Root cause:** I-Am responses without NPDU routing overwrote `add_routed_device` seeds in the ephemeral client device table.
 
-BACnet `02` on this tip: **GATE FAILED** (hosted server 599999 objects PASS; device **5007** routed MS/TP + BIP companions FAIL — “device not in device table” / UNKNOWN_OBJECT class failures). Still needs bacnet crate bump / seed of routed devices; not closed by 3.3.4.
+**Fix (`1540225`):**
 
-### MQTT ingest growth (`03`) — FAIL this run (honest)
+- Vendored `DeviceTable::upsert` preserves `source_network` / `source_address` when I-Am lacks routing.
+- Who-Is merges configured routed devices from `field_devices.toml`.
+- Structured log on successful `add_routed_device` seed.
 
-- Central MQTTS client **connected** (`mqtt:8883`).
-- After forced fieldbus `poll/once`, **ingest_ok stayed 0**; MQTTS subscribe peek captured no telemetry; feather file count unchanged in the wait window.
-- Likely coupled to BACnet poll producing no live points (B3) rather than broker down. Re-check after bacnet routing is fixed or with a dedicated Modbus→MQTT publish path.
+**Re-verify:** `./scripts/nightly-ot-bench/02_bacnet_ot.sh` after GHCR pull of PR tip. Bench must mount [`field_devices.bench.example.toml`](../scripts/nightly-ot-bench/field_devices.bench.example.toml) → `config/fieldbus/field_devices.toml`.
 
-### Agent password on bench
+## MQTT / cell optimization — NEW IN PR TRAIN
 
-`GET /api/auth/status` → `agent_login_configured: false` until `OPENFDD_AGENT_PASSWORD` is set in compose `.env` (Railway docs require it; optional on LAN admin-only benches).
+| Item | Before | After (`1540225`) |
+|------|--------|-------------------|
+| Default poll | 60 s | **300 s** (floor **60 s** unless `OPENFDD_FIELDBUS_DEV_FAST_POLL=1`) |
+| MQTT publish | tied to poll, 5 s floor | `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS` (default 300, min 60) |
+| Payload | full snapshot every cycle | `OPENFDD_MQTT_DELTA=1`, `OPENFDD_MQTT_CELL_MODE=1` (slim tags, no display_name) |
+| Health subset | all points | `OPENFDD_POLL_HEALTH_ONLY=1` (~30% cap) |
 
-## Point discovery (product)
+Docs: [`BACNET_OT_POLICY.md`](BACNET_OT_POLICY.md), [`deploy/mqtt/README.md`](../../deploy/mqtt/README.md).
 
-Unchanged happy path after B1:
+**Gate 03 / ingest:** Re-run after B3 + new fieldbus image; weather/hosted points may prove MQTT path even when OT BACnet poll is sparse.
 
-1. `POST /haystack/read` with filter `point and cur` (or operator filter).
-2. Present grid → operator picks rows → save bindings.
-3. Poll selected ids → MQTT telemetry like BACnet points.
+## Dual-site MQTT (lab + bldg2) — gate 10
+
+| Check | lab / fieldbus-1 @ bensbench | bldg2 / pi-1 @ bosspi |
+|-------|-------------------------------|------------------------|
+| GHCR fieldbus rev matches bench | n/a | **required PASS** |
+| MQTTS telemetry | topic + numeric values | topic + numeric values |
+| Central `/api/edges` | listed + telemetry | listed + telemetry |
+| Weather city | Madison (Open-Meteo) | Chicago (Open-Meteo) |
+| Stack left running | yes | yes |
+
+Run: `RUN_CLOUD_SIM=1 DUAL_MQTT_WAIT_SECS=600 WEATHER_SOAK_SECS=600 ./scripts/nightly-ot-bench/run_all.sh`
+
+## Agent / docs hygiene
+
+- [`companion-rusty-bacnet-mcp.md`](../mcp-agents/companion-rusty-bacnet-mcp.md) — read-only BACnet debug MCP (not production poll).
+- `OPENFDD_AGENT_PASSWORD` optional on LAN bench; Railway requires it.
 
 ## Hygiene
 
-- GHCR publish for `b1811da` was cancelled/timed out earlier; tip images for this report are **`sha-8e7899e`** after #780 (nginx `15-openfdd-resolver.envsh` executable + 90m GHCR test timeout).
-- Haystack gate `extract_cur_val` previously fed JSON via stdin into a `<<'PY'` heredoc (stdin stolen → empty v1/v2). Fixed to pass payload via env; gate now correctly PASSes live change.
-- Do not invent a second discovery protocol; use Haystack `read`/`nav` allowlist on fieldbus.
+- #783 merged → master `fa14c05` (Haystack gate + BUG_REPORT refresh).
+- #780 on `8e7899e`: edge kits, agent auth, nginx resolver executable.
+- Do not local `docker build` stack on bensbench — GHCR `sha-*` only.

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-26  
 **Platform:** `3.3.4` / `fa14c05` master + `1540225` train (`feat/nightly-b3-mqtt-policy` PR pending)  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR=/workspace/.cache/datafusion-spill`)  
-**Remote edge:** bosspi `192.168.204.12` — fieldbus only (dual-MQTT gate 10)
+**Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (dual-MQTT gate 10)
 
 Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `bench.env.local` / `rusty-haystack/.../.env`.
 

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -119,6 +119,8 @@ Read tools (preview, plan, preflight, contract, test-sql, fusion, historian quer
 
 Use **commission** API (`OPENFDD_COMMISSION_BASE`, default `http://127.0.0.1:9091`) for OT Who-Is/reads — not bridge host-network.
 
+Production BACnet throttling (agents): **300 s** default poll, **60 s** minimum, ~**30%** HVAC health points on cell sites — [`docs/operations/BACNET_OT_POLICY.md`](../docs/operations/BACNET_OT_POLICY.md). Independent OT debug: [`docs/mcp-agents/companion-rusty-bacnet-mcp.md`](../docs/mcp-agents/companion-rusty-bacnet-mcp.md) (read-only; does not replace fieldbus).
+
 ## Model (Haystack RDF)
 
 Use `openfdd_model_sparql_catalog` then `openfdd_model_sparql` with a SELECT query. Assignments: `openfdd_model_assignments_save` with full points/bindings doc.

--- a/scripts/nightly-ot-bench/10_dual_mqtt_signoff.sh
+++ b/scripts/nightly-ot-bench/10_dual_mqtt_signoff.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Dual-MQTT sign-off: bench (lab/fieldbus-1) + bosspi (bldg2/pi-1) → single central.
+# Run after 07_cloud_sim.sh. Validates GHCR image rev match, health, dual telemetry,
+# ingest growth. Leaves both edges running (no teardown).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+auth_setup
+central_auth_setup
+cd "$ROOT"
+
+PI_SSH="${CLOUD_SIM_PI_SSH:-ben@192.168.204.12}"
+SSH_OPTS=(-i "$HOME/.ssh/id_rsa" -o BatchMode=yes -o ConnectTimeout=10)
+SITE1="${OPENFDD_SITE_ID:-lab}"
+EDGE1="${OPENFDD_EDGE_ID:-fieldbus-1}"
+SITE2="${CLOUD_SIM_SITE_ID:-bldg2}"
+EDGE2="${CLOUD_SIM_EDGE_ID:-pi-1}"
+WAIT="${DUAL_MQTT_WAIT_SECS:-120}"
+PIN="${OPENFDD_IMAGE_TAG:-}"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+pi() { ssh "${SSH_OPTS[@]}" "$PI_SSH" "$@"; }
+
+container_rev() {
+  local ctr="$1"
+  docker inspect "$ctr" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null | head -c 12 || true
+}
+
+hdr "0. GHCR legitimacy (bench + bosspi fieldbus)"
+FB_CTR="$(docker ps --format '{{.Names}}' | grep -E 'fieldbus' | head -1 || true)"
+if [[ -z "$FB_CTR" ]]; then
+  bad "no bench fieldbus container running"
+else
+  BENCH_REV="$(container_rev "$FB_CTR")"
+  echo "bench_fieldbus=$FB_CTR rev=${BENCH_REV}" | tee "$ART/pi_image_rev.txt"
+  ok "bench fieldbus container $FB_CTR rev=${BENCH_REV:-?}"
+fi
+
+PI_UP=0
+if pi 'hostname' >/dev/null 2>&1; then
+  ok "ssh to Pi ($PI_SSH)"
+  PI_REV="$(pi "docker inspect openfdd-edge-fieldbus-1 --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}' 2>/dev/null | head -c 12" || true)"
+  echo "pi_fieldbus=openfdd-edge-fieldbus-1 rev=${PI_REV}" | tee -a "$ART/pi_image_rev.txt"
+  if [[ -n "$BENCH_REV" && -n "$PI_REV" && "$BENCH_REV" == "$PI_REV" ]]; then
+    ok "Pi fieldbus OCI revision matches bench ($BENCH_REV)"
+  elif [[ -n "$PI_REV" ]]; then
+    bad "Pi rev '$PI_REV' != bench '$BENCH_REV' — stale or mismatched GHCR pin"
+  else
+    skip "Pi fieldbus not running yet (run 07_cloud_sim first)"
+  fi
+  if pi 'curl -fsS --max-time 8 http://127.0.0.1:8081/health' 2>/dev/null | tee "$ART/pi_fieldbus_health.json" | jq -e '.ok==true' >/dev/null; then
+    PI_UP=1
+    ok "Pi fieldbus /health ok"
+  else
+    bad "Pi fieldbus /health failed"
+  fi
+else
+  bad "cannot ssh to $PI_SSH — dual-MQTT blocked"
+fi
+
+if [[ -f "$ART/digests.txt" ]]; then
+  ok "bench digests artifact present ($ART/digests.txt)"
+else
+  skip "digests.txt missing — run 00_pull_ghcr_up first"
+fi
+
+hdr "1. Bench stack health"
+if H="$(central "$CENTRAL_BASE/api/health" 2>/dev/null)"; then
+  echo "$H" | tee "$ART/central_health_dual.json" | jq -c '{version,status}' 2>/dev/null || true
+  ok "central /api/health"
+else
+  bad "central /api/health unreachable"
+fi
+if fb "$FIELDBUS_BASE/health" 2>/dev/null | tee "$ART/bench_fieldbus_health.json" | jq -e '.ok==true' >/dev/null; then
+  ok "bench fieldbus /health"
+else
+  bad "bench fieldbus /health failed"
+fi
+
+hdr "2. Weather API (Madison bench / Chicago Pi)"
+WB="$(fb "$FIELDBUS_BASE/weather" 2>/dev/null || echo '{}')"
+echo "$WB" >"$ART/weather_api_bench_dual.json"
+if jq -e '.location | test("Madison")' <<<"$WB" >/dev/null 2>&1; then
+  ok "bench weather city Madison"
+else
+  bad "bench weather not Madison: $(jq -r '.location // "?"' <<<"$WB")"
+fi
+if [[ "$PI_UP" == "1" ]]; then
+  WP="$(pi 'curl -fsS --max-time 10 http://127.0.0.1:8081/weather' 2>/dev/null || echo '{}')"
+  echo "$WP" >"$ART/weather_api_pi_dual.json"
+  if jq -e '.location | test("Chicago")' <<<"$WP" >/dev/null 2>&1; then
+    ok "Pi weather city Chicago"
+  else
+    bad "Pi weather not Chicago: $(jq -r '.location // "?"' <<<"$WP")"
+  fi
+fi
+
+hdr "3. Ingest baseline"
+IB="$(central "$CENTRAL_BASE/api/ingest/stats" 2>/dev/null || echo '{}')"
+echo "$IB" | tee "$ART/ingest_dual_before.json" | jq -c . 2>/dev/null || echo "$IB"
+
+hdr "4. Wait ${WAIT}s for dual MQTT publish"
+sleep "$WAIT"
+
+hdr "5. MQTTS telemetry (both sites)"
+CA="$ROOT/deploy/mqtt/ca/ca.pem"
+CERT="$ROOT/deploy/mqtt/kits/${SITE1}__central/central.cert.pem"
+KEY="$ROOT/deploy/mqtt/kits/${SITE1}__central/central.key.pem"
+if [[ ! -f "$CERT" ]]; then
+  CERT="$ROOT/deploy/mqtt/kits/${SITE1}__${EDGE1}/central.cert.pem"
+  KEY="$ROOT/deploy/mqtt/kits/${SITE1}__${EDGE1}/central.key.pem"
+fi
+if [[ -f "$CA" && -f "$CERT" && -f "$KEY" ]]; then
+  for spec in "${SITE1}|${EDGE1}|mqtt_lab.txt" "${SITE2}|+|mqtt_bldg2.txt"; do
+    IFS='|' read -r site edge out <<<"$spec"
+    out="$ART/$out"
+    timeout 45 docker run --rm --net=host -v "$ROOT/deploy/mqtt:/mqtt:ro" eclipse-mosquitto:2 \
+      mosquitto_sub -h 127.0.0.1 -p 8883 \
+      --cafile /mqtt/ca/ca.pem \
+      --cert "/mqtt/kits/${SITE1}__central/central.cert.pem" \
+      --key "/mqtt/kits/${SITE1}__central/central.key.pem" \
+      -t "openfdd/v1/sites/${site}/edges/${edge}/telemetry/#" -v -C 1 -W 40 \
+      >"$out" 2>&1 || true
+    if grep -qE '"value"[[:space:]]*:[[:space:]]*-?[0-9]' "$out" 2>/dev/null; then
+      ok "MQTTS telemetry site=$site (numeric values)"
+    else
+      bad "no numeric telemetry site=$site (see $out)"
+    fi
+  done
+else
+  skip "MQTT central certs missing for subscribe peek"
+fi
+
+hdr "6. Central /api/edges + ingest after wait"
+if E="$(central "$CENTRAL_BASE/api/edges" 2>/dev/null)"; then
+  echo "$E" | tee "$ART/edges_dual.json" | jq -c . 2>/dev/null | head -c 500
+  echo
+  jq_ok "≥2 edges listed" "$E" '(.edges // . // []) | length >= 2'
+  if jq -e --arg e "$EDGE2" 'any(.edges[]?; .edge_id==$e)' <<<"$E" >/dev/null 2>&1; then
+    ok "remote edge $EDGE2 visible"
+  else
+    bad "remote edge $EDGE2 missing from /api/edges"
+  fi
+else
+  bad "GET /api/edges failed"
+fi
+IA="$(central "$CENTRAL_BASE/api/ingest/stats" 2>/dev/null || echo '{}')"
+echo "$IA" | tee "$ART/ingest_dual_after.json" | jq -c . 2>/dev/null || echo "$IA"
+if python3 - "$ART/ingest_dual_before.json" "$ART/ingest_dual_after.json" <<'PY'
+import json, sys
+b=json.load(open(sys.argv[1]))
+a=json.load(open(sys.argv[2]))
+def dig(d):
+  if not isinstance(d, dict):
+    return 0
+  for k in ("ingest_ok","messages_ok","ok","accepted","total","count"):
+    v=d.get(k)
+    if isinstance(v,(int,float)):
+      return float(v)
+  for v in d.values():
+    if isinstance(v, dict):
+      x=dig(v)
+      if x: return x
+  return 0
+sys.exit(0 if dig(a)>dig(b) or dig(a)>0 else 1)
+PY
+then
+  ok "ingest stats grew or non-zero after dual wait"
+else
+  bad "ingest stats did not grow (MQTT path may be idle)"
+fi
+
+hdr "7. Sign-off — stacks left running"
+ok "bench react-ot + Pi edge compose intentionally NOT torn down"
+echo "${DIM}GHCR pin: ${PIN:-unset}  artifacts: $ART${RST}"
+echo "${DIM}Update docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md dual-site + GHCR tables.${RST}"
+
+summary

--- a/scripts/nightly-ot-bench/README.md
+++ b/scripts/nightly-ot-bench/README.md
@@ -72,6 +72,8 @@ Optional:
 BENCH_ALLOW_WRITES=1 ./scripts/nightly-ot-bench/09_rest_ot.sh   # REST write clamp
 RUN_CLOUD_SIM=1 ./scripts/nightly-ot-bench/run_all.sh
 SKIP_PULL=1 ./scripts/nightly-ot-bench/run_all.sh               # reuse running stack
+# Dual-MQTT only (after 07): ./scripts/nightly-ot-bench/10_dual_mqtt_signoff.sh
+DUAL_MQTT_WAIT_SECS=600 RUN_CLOUD_SIM=1 WEATHER_SOAK_SECS=600 ./scripts/nightly-ot-bench/run_all.sh  # ~10m weather + dual ingest
 ABORT_ON_PULL_FAIL=0 ./scripts/nightly-ot-bench/run_all.sh      # forensic cascade after 00 FAIL
 GHCR_WAIT_SECS=900 GHCR_POLL_SECS=30 ./scripts/nightly-ot-bench/00_pull_ghcr_up.sh
 ```
@@ -96,6 +98,9 @@ GHCR_WAIT_SECS=900 GHCR_POLL_SECS=30 ./scripts/nightly-ot-bench/00_pull_ghcr_up.
 5. Central ingest/Feather shows **new** telemetry when MQTT path is live
 6. React SPA routes + honesty/MCP gates pass
 7. Gates **14–15** PASS (capability ledger validator + product-truth honesty)
+8. Optional dual-MQTT (`RUN_CLOUD_SIM=1`): gate **10** — bosspi fieldbus OCI rev matches bench; both sites telemetry + ingest
+
+Low-RAM bench: set `OPENFDD_QUERY_MEMORY_MB=256` in `.env`. Document GHCR legitimacy for **bensbench + bosspi** in [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md).
 
 **FAIL with evidence** if any gate fails — do not weaken asserts. OT LAN
 failures (5007 missing, MQTT silent, weather freeze) remain honest FAILs —

--- a/scripts/nightly-ot-bench/run_all.sh
+++ b/scripts/nightly-ot-bench/run_all.sh
@@ -95,6 +95,7 @@ run_phase 06_csv_fdd_sql.sh "06 CSV import + SQL FDD (FC1)" || OVERALL=1
 # 07 cloud-sim is opt-in: RUN_CLOUD_SIM=1 ./run_all.sh (needs bosspi reachable)
 if [[ "${RUN_CLOUD_SIM:-0}" == "1" ]]; then
   run_phase 07_cloud_sim.sh "07 cloud-sim (remote Pi edge, instance 600000)" || OVERALL=1
+  run_phase 10_dual_mqtt_signoff.sh "10 dual-MQTT sign-off (lab + bldg2)" || OVERALL=1
 else
   echo "- **07 cloud-sim:** SKIPPED (set RUN_CLOUD_SIM=1)" >>"$REPORT"
   skip "cloud-sim skipped (RUN_CLOUD_SIM=1 to enable)"

--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -106,7 +106,7 @@ impl Default for RestSettings {
         Self {
             default_timeout_secs: 10,
             default_tls_verify: true,
-            default_poll_interval_secs: 60,
+            default_poll_interval_secs: 300,
             allow_write: false,
         }
     }
@@ -244,15 +244,18 @@ pub struct PollSettings {
     pub interval_secs: f64,
     pub startup_delay_secs: f64,
     pub max_samples: usize,
+    /// When true, poll only points whose names map to known HVAC health roles (~30% cap).
+    pub health_roles_only: bool,
 }
 
 impl Default for PollSettings {
     fn default() -> Self {
         Self {
             enabled: true,
-            interval_secs: 60.0,
+            interval_secs: 300.0,
             startup_delay_secs: 5.0,
             max_samples: 5000,
+            health_roles_only: false,
         }
     }
 }
@@ -409,6 +412,7 @@ struct PollToml {
     interval_secs: Option<f64>,
     startup_delay_secs: Option<f64>,
     max_samples: Option<usize>,
+    health_roles_only: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -662,6 +666,9 @@ pub fn load_settings() -> Settings {
         if let Some(v) = p.max_samples {
             s.poll.max_samples = v;
         }
+        if let Some(v) = p.health_roles_only {
+            s.poll.health_roles_only = v;
+        }
     }
 
     if let Some(v) = env_first(&["OPENFDD_FIELDBUS_BIND", "RUSTY_GATEWAY_BIND"]) {
@@ -746,7 +753,34 @@ pub fn load_settings() -> Settings {
         "RUSTY_GATEWAY_SWAGGER_SERVERS_URL",
     ]);
 
+    if env_bool(
+        env_first(&["OPENFDD_POLL_HEALTH_ONLY"]).as_deref(),
+        s.poll.health_roles_only,
+    ) {
+        s.poll.health_roles_only = true;
+    }
+
+    finalize_poll_interval(&mut s);
     s
+}
+
+fn dev_fast_poll_enabled() -> bool {
+    env_bool(
+        env_first(&["OPENFDD_FIELDBUS_DEV_FAST_POLL"]).as_deref(),
+        false,
+    )
+}
+
+/// Production floor: never poll faster than 60s unless dev/test escape hatch is set.
+fn finalize_poll_interval(s: &mut Settings) {
+    const PROD_MIN_POLL_SECS: f64 = 60.0;
+    if dev_fast_poll_enabled() {
+        return;
+    }
+    if s.poll.interval_secs < PROD_MIN_POLL_SECS {
+        s.poll.interval_secs = PROD_MIN_POLL_SECS;
+    }
+}
 }
 
 pub fn load_objects_csv(path: Option<&Path>) -> Result<Vec<HostedObjectRow>, String> {
@@ -993,7 +1027,11 @@ mod tests {
         std::env::set_var("OPENFDD_FIELDBUS_POLL_ENABLED", "false");
         assert!(!load_settings().poll.enabled);
         std::env::set_var("OPENFDD_FIELDBUS_POLL_INTERVAL_SECS", "12.5");
+        std::env::set_var("OPENFDD_FIELDBUS_DEV_FAST_POLL", "1");
         assert!((load_settings().poll.interval_secs - 12.5).abs() < f64::EPSILON);
+        std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
+        std::env::set_var("OPENFDD_FIELDBUS_POLL_INTERVAL_SECS", "12.5");
+        assert!((load_settings().poll.interval_secs - 60.0).abs() < f64::EPSILON);
         std::env::remove_var("OPENFDD_FIELDBUS_POLL_ENABLED");
         std::env::remove_var("OPENFDD_FIELDBUS_POLL_INTERVAL_SECS");
     }
@@ -1039,7 +1077,7 @@ mod tests {
         let s = RestSettings::default();
         assert_eq!(s.default_timeout_secs, 10);
         assert!(s.default_tls_verify);
-        assert_eq!(s.default_poll_interval_secs, 60);
+        assert_eq!(s.default_poll_interval_secs, 300);
         assert!(!s.allow_write);
     }
 

--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -781,7 +781,6 @@ fn finalize_poll_interval(s: &mut Settings) {
         s.poll.interval_secs = PROD_MIN_POLL_SECS;
     }
 }
-}
 
 pub fn load_objects_csv(path: Option<&Path>) -> Result<Vec<HostedObjectRow>, String> {
     let csv_path = path

--- a/services/fieldbus/src/mqtt_bridge.rs
+++ b/services/fieldbus/src/mqtt_bridge.rs
@@ -531,9 +531,7 @@ pub async fn spawn_if_configured(
     let delta_mode = mqtt_delta_enabled();
     info!(
         publish_interval_secs = interval,
-        cell_mode,
-        delta_mode,
-        "mqtt bridge publish profile"
+        cell_mode, delta_mode, "mqtt bridge publish profile"
     );
 
     let topics = TopicBuilder::new(site_id.clone(), edge_id.clone());
@@ -607,12 +605,7 @@ pub async fn spawn_if_configured(
                             .as_object()
                             .cloned()
                             .unwrap_or_default();
-                        historian_tags(
-                            base,
-                            building_id.as_deref(),
-                            equipment_id,
-                            point_name,
-                        )
+                        historian_tags(base, building_id.as_deref(), equipment_id, point_name)
                     };
                     Some(TelemetryPoint {
                         id,
@@ -663,8 +656,7 @@ pub async fn spawn_if_configured(
                 }
             }
             if !rest_out.is_empty() {
-                let env =
-                    TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Rest, seq, rest_out);
+                let env = TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Rest, seq, rest_out);
                 let topic = topics.topic(TopicKind::Telemetry, Some(Protocol::Rest));
                 if let Err(err) = spool.enqueue(&topic, env).await {
                     warn!(%err, "rest spool enqueue failed");

--- a/services/fieldbus/src/mqtt_bridge.rs
+++ b/services/fieldbus/src/mqtt_bridge.rs
@@ -1,6 +1,6 @@
 //! Optional MQTTS bridge: spool poll snapshots, publish telemetry, and safely execute commands.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -26,6 +26,87 @@ use crate::services::rest::RestClientService;
 use crate::services::telemetry_control::{parse_telemetry_command, TelemetryControl};
 
 const MAX_SEEN_COMMANDS: usize = 10_000;
+
+fn env_flag(name: &str) -> bool {
+    matches!(
+        std::env::var(name)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn dev_fast_poll_enabled() -> bool {
+    env_flag("OPENFDD_FIELDBUS_DEV_FAST_POLL")
+}
+
+fn mqtt_cell_mode() -> bool {
+    env_flag("OPENFDD_MQTT_CELL_MODE")
+}
+
+fn mqtt_delta_enabled() -> bool {
+    env_flag("OPENFDD_MQTT_DELTA") || mqtt_cell_mode()
+}
+
+fn mqtt_publish_interval_secs(settings: &Settings) -> f64 {
+    const PROD_MIN: f64 = 60.0;
+    let default = settings.poll.interval_secs;
+    let raw = std::env::var("OPENFDD_MQTT_PUBLISH_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(default);
+    if dev_fast_poll_enabled() {
+        raw.max(5.0)
+    } else {
+        raw.max(PROD_MIN)
+    }
+}
+
+fn historian_tags_slim(
+    building_id: Option<&str>,
+    equipment_id: &str,
+    point_name: &str,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut tags = serde_json::Map::new();
+    tags.insert(
+        "equipment_id".into(),
+        serde_json::Value::String(equipment_id.to_string()),
+    );
+    tags.insert(
+        "role".into(),
+        serde_json::Value::String(haystack_point_to_role(point_name)),
+    );
+    if let Some(building_id) = building_id {
+        tags.insert(
+            "building_id".into(),
+            serde_json::Value::String(building_id.to_string()),
+        );
+    }
+    tags
+}
+
+fn telemetry_point_signature(point: &TelemetryPoint) -> String {
+    format!("{}:{:?}", point.value, point.quality)
+}
+
+fn apply_delta_filter(
+    points: Vec<TelemetryPoint>,
+    last: &mut HashMap<String, String>,
+) -> Vec<TelemetryPoint> {
+    points
+        .into_iter()
+        .filter(|p| {
+            let sig = telemetry_point_signature(p);
+            if last.get(&p.id) == Some(&sig) {
+                false
+            } else {
+                last.insert(p.id.clone(), sig);
+                true
+            }
+        })
+        .collect()
+}
 
 pub fn mqtt_enabled() -> bool {
     matches!(
@@ -445,7 +526,15 @@ pub async fn spawn_if_configured(
         std::env::var("OPENFDD_MQTT_SPOOL_DIR")
             .unwrap_or_else(|_| format!("/tmp/openfdd-spool-{edge_id}")),
     );
-    let interval = settings.poll.interval_secs.max(5.0);
+    let interval = mqtt_publish_interval_secs(&settings);
+    let cell_mode = mqtt_cell_mode();
+    let delta_mode = mqtt_delta_enabled();
+    info!(
+        publish_interval_secs = interval,
+        cell_mode,
+        delta_mode,
+        "mqtt bridge publish profile"
+    );
 
     let topics = TopicBuilder::new(site_id.clone(), edge_id.clone());
     let command_ctx = Arc::new(CommandContext {
@@ -466,6 +555,7 @@ pub async fn spawn_if_configured(
         };
 
         let mut mqtt: Option<MqttSession> = None;
+        let mut last_published: HashMap<String, String> = HashMap::new();
 
         let mut seq = 0u64;
         loop {
@@ -504,48 +594,77 @@ pub async fn spawn_if_configured(
                     let object_type = v.get("object_type")?.as_str()?.replace('_', "-");
                     let object_instance = v.get("object_instance")?.as_u64()? as u32;
                     let id = format!("bacnet:{device}:{object_type}:{object_instance}");
-                    // Poll status emits `value`; tolerate legacy `present_value`.
                     let value = telemetry_point_value(&v);
-                    let tags = serde_json::json!({"bacnet": true, "device_instance": device})
-                        .as_object()
-                        .cloned()
-                        .unwrap_or_default();
-                    Some(TelemetryPoint {
-                        id,
-                        display_name: Some(point_name.to_string()),
-                        kind: Some(ValueKind::Number),
-                        value,
-                        unit: v.get("units").and_then(|x| x.as_str()).map(str::to_string),
-                        quality: if v.get("error").map(|e| e.is_null()).unwrap_or(true) {
-                            Quality::Good
-                        } else {
-                            Quality::Bad
-                        },
-                        tags: historian_tags(
-                            tags,
+                    let quality = if v.get("error").map(|e| e.is_null()).unwrap_or(true) {
+                        Quality::Good
+                    } else {
+                        Quality::Bad
+                    };
+                    let tags = if cell_mode {
+                        historian_tags_slim(building_id.as_deref(), equipment_id, point_name)
+                    } else {
+                        let base = serde_json::json!({"bacnet": true, "device_instance": device})
+                            .as_object()
+                            .cloned()
+                            .unwrap_or_default();
+                        historian_tags(
+                            base,
                             building_id.as_deref(),
                             equipment_id,
                             point_name,
-                        ),
+                        )
+                    };
+                    Some(TelemetryPoint {
+                        id,
+                        display_name: if cell_mode {
+                            None
+                        } else {
+                            Some(point_name.to_string())
+                        },
+                        kind: Some(ValueKind::Number),
+                        value,
+                        unit: v.get("units").and_then(|x| x.as_str()).map(str::to_string),
+                        quality,
+                        tags,
                     })
                 })
                 .collect();
             let rest_rows = rest.last_values().await;
             let rest_points = rest_telemetry_points(&rest_rows, building_id.as_deref());
-            if points.is_empty() && rest_points.is_empty() {
+            let mut bacnet_points = if delta_mode {
+                apply_delta_filter(points, &mut last_published)
+            } else {
+                points
+            };
+            let mut rest_out = rest_points;
+            if cell_mode {
+                for p in &mut bacnet_points {
+                    p.display_name = None;
+                }
+                for p in &mut rest_out {
+                    p.display_name = None;
+                }
+            }
+            if bacnet_points.is_empty() && rest_out.is_empty() {
                 continue;
             }
-            if !points.is_empty() {
-                let env = TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Bacnet, seq, points);
+            if !bacnet_points.is_empty() {
+                let env = TelemetryEnvelope::new(
+                    &site_id,
+                    &edge_id,
+                    Protocol::Bacnet,
+                    seq,
+                    bacnet_points,
+                );
                 let topic = topics.topic(TopicKind::Telemetry, Some(Protocol::Bacnet));
                 if let Err(err) = spool.enqueue(&topic, env).await {
                     warn!(%err, "spool enqueue failed");
                     continue;
                 }
             }
-            if !rest_points.is_empty() {
+            if !rest_out.is_empty() {
                 let env =
-                    TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Rest, seq, rest_points);
+                    TelemetryEnvelope::new(&site_id, &edge_id, Protocol::Rest, seq, rest_out);
                 let topic = topics.topic(TopicKind::Telemetry, Some(Protocol::Rest));
                 if let Err(err) = spool.enqueue(&topic, env).await {
                     warn!(%err, "rest spool enqueue failed");
@@ -581,6 +700,15 @@ pub async fn spawn_if_configured(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mqtt_publish_interval_respects_prod_floor() {
+        let mut s = Settings::default();
+        s.poll.interval_secs = 30.0;
+        std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
+        std::env::remove_var("OPENFDD_MQTT_PUBLISH_INTERVAL_SECS");
+        assert!((mqtt_publish_interval_secs(&s) - 60.0).abs() < f64::EPSILON);
+    }
 
     #[test]
     fn parse_bacnet_target_id() {

--- a/services/fieldbus/src/services/bacnet_client.rs
+++ b/services/fieldbus/src/services/bacnet_client.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use fdd_core::columns::{haystack_point_to_role, is_known_cookbook_role};
 use bacnet_client::client::BACnetClient;
 use bacnet_encoding::primitives::{decode_application_value, encode_property_value};
 use bacnet_services::common::PropertyReference;
@@ -13,6 +12,7 @@ use bacnet_transport::bvll::encode_bip_mac;
 use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 use bytes::BytesMut;
+use fdd_core::columns::{haystack_point_to_role, is_known_cookbook_role};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 use tracing::{info, warn};

--- a/services/fieldbus/src/services/bacnet_client.rs
+++ b/services/fieldbus/src/services/bacnet_client.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use fdd_core::columns::{haystack_point_to_role, is_known_cookbook_role};
 use bacnet_client::client::BACnetClient;
 use bacnet_encoding::primitives::{decode_application_value, encode_property_value};
 use bacnet_services::common::PropertyReference;
@@ -14,9 +15,9 @@ use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 use bytes::BytesMut;
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
-use tracing::warn;
+use tracing::{info, warn};
 
-use crate::config::{load_field_devices, FieldDevice, Settings};
+use crate::config::{load_field_devices, FieldDevice, FieldPoint, Settings};
 use crate::services::bacnet_server::{property_value_tag, property_value_to_json};
 
 const RPM_CHUNK_SIZE: usize = 25;
@@ -135,6 +136,13 @@ impl BacnetClientService {
                 )
                 .await
                 .map_err(|e| e.to_string())?;
+            info!(
+                device_instance = d.device_instance,
+                router = %d.host,
+                mstp_network = net,
+                mstp_mac = dest_mac,
+                "seeded routed BACnet device (add_routed_device)"
+            );
             // Best-effort: probe the remote MSTP network via the router.
             if let Err(e) = client
                 .who_is_network(net, Some(d.device_instance), Some(d.device_instance))
@@ -459,8 +467,12 @@ impl BacnetClientService {
             if !d.enabled || d.points.is_empty() {
                 continue;
             }
+            let points = select_poll_points(d, self.settings.poll.health_roles_only);
+            if points.is_empty() {
+                continue;
+            }
             let mut specs = Vec::new();
-            for p in &d.points {
+            for p in &points {
                 let Ok(ot) = parse_object_type(&p.object_type) else {
                     continue;
                 };
@@ -480,7 +492,7 @@ impl BacnetClientService {
 
             match self.poll_device(d, &specs).await {
                 Ok(map) => {
-                    for p in &d.points {
+                    for p in &points {
                         let Ok(ot) = parse_object_type(&p.object_type) else {
                             continue;
                         };
@@ -501,7 +513,7 @@ impl BacnetClientService {
                 }
                 Err(e) => {
                     warn!("poll cycle failed for device {}: {e}", d.device_instance);
-                    for p in &d.points {
+                    for p in &points {
                         out.push(json!({
                             "device_instance": d.device_instance,
                             "device_name": d.name,
@@ -581,10 +593,49 @@ impl BacnetClientService {
             // but the client Who-Is socket is ephemeral and often never sees that I-Am.
             // Surface the local hosted device in Who-Is results so self-discovery matches OT.
             self.merge_local_hosted_device(&mut out, low, high);
+            self.merge_configured_routed_devices(&mut out, low, high);
             Ok(out)
         }
         .await;
         Self::finish_client(client, result).await
+    }
+
+    /// Enrich Who-Is results with configured MS/TP routing metadata.
+    fn merge_configured_routed_devices(
+        &self,
+        out: &mut Vec<Value>,
+        low: Option<u32>,
+        high: Option<u32>,
+    ) {
+        for d in &self.field_devices {
+            if !d.enabled || !d.is_routed() {
+                continue;
+            }
+            let inst = d.device_instance;
+            if low.is_some_and(|lo| inst < lo) || high.is_some_and(|hi| inst > hi) {
+                continue;
+            }
+            let net = d.mstp_network.unwrap_or(0);
+            if let Some(row) = out.iter_mut().find(|v| {
+                v.get("device_instance")
+                    .and_then(|x| x.as_u64())
+                    .is_some_and(|n| n as u32 == inst)
+            }) {
+                if row.get("source_network").and_then(|v| v.as_u64()).is_none() {
+                    row["source_network"] = json!(net);
+                }
+                continue;
+            }
+            out.push(json!({
+                "device_instance": inst,
+                "address": d.address(),
+                "vendor_id": null,
+                "source_network": net,
+                "max_apdu": null,
+                "configured_routed": true,
+                "note": "synthesized from field_devices.toml — I-Am lacked source_network",
+            }));
+        }
     }
 
     /// Append configured hosted BACnet server instance when missing from discovery.
@@ -1222,6 +1273,35 @@ fn serialize_rpm(rpm: &bacnet_services::rpm::ReadPropertyMultipleACK) -> Vec<Val
     out
 }
 
+/// Select BACnet points for a poll cycle; optional health-role subset (~30% cap).
+fn select_poll_points(device: &FieldDevice, health_only: bool) -> Vec<FieldPoint> {
+    if !health_only {
+        return device.points.clone();
+    }
+    let total = device.points.len();
+    let mut selected: Vec<FieldPoint> = device
+        .points
+        .iter()
+        .filter(|p| is_known_cookbook_role(&haystack_point_to_role(&p.point_name)))
+        .cloned()
+        .collect();
+    if total == 0 {
+        return selected;
+    }
+    let max_keep = ((total as f64) * 0.30).ceil() as usize;
+    let max_keep = max_keep.max(1);
+    if selected.len() > max_keep {
+        warn!(
+            device = %device.name,
+            total,
+            kept = max_keep,
+            "health-only poll capped to ~30% of configured catalog"
+        );
+        selected.truncate(max_keep);
+    }
+    selected
+}
+
 fn device_summary(d: &bacnet_client::discovery::DiscoveredDevice) -> Value {
     let mac = d.mac_address.as_slice();
     let addr = if mac.len() == 6 {
@@ -1243,6 +1323,40 @@ fn device_summary(d: &bacnet_client::discovery::DiscoveredDevice) -> Value {
         "source_network": d.source_network,
         "max_apdu": d.max_apdu_length,
     })
+}
+
+#[cfg(test)]
+mod poll_select_tests {
+    use super::*;
+    use crate::config::FieldPoint;
+
+    fn dev(name: &str, inst: u32, points: Vec<FieldPoint>) -> FieldDevice {
+        FieldDevice {
+            name: name.into(),
+            enabled: true,
+            device_instance: inst,
+            host: "127.0.0.1".into(),
+            port: 47808,
+            mstp_network: None,
+            mstp_mac: vec![],
+            points,
+        }
+    }
+
+    #[test]
+    fn health_only_caps_to_thirty_percent() {
+        let points: Vec<_> = (0..10)
+            .map(|i| FieldPoint {
+                object_type: "analog-input".into(),
+                object_instance: i,
+                point_name: "fan-status".into(),
+                units: "bool".into(),
+            })
+            .collect();
+        let d = dev("ahu", 1, points);
+        let selected = select_poll_points(&d, true);
+        assert_eq!(selected.len(), 3);
+    }
 }
 
 #[cfg(test)]

--- a/vendor/bacnet-client/OPENFDD_PATCH.md
+++ b/vendor/bacnet-client/OPENFDD_PATCH.md
@@ -2,5 +2,8 @@
 # `BACnetClient::add_routed_device` — seeds MS/TP devices with source_network +
 # source_address so RPM/ReadProperty route through the BIP router (bench device 5007).
 #
+# Open-FDD also patches `DeviceTable::upsert` to preserve routing metadata when a
+# later I-Am arrives without NPDU source routing (ephemeral client ports).
+#
 # Remove this vendor + `[patch.crates-io]` in the workspace Cargo.toml when
 # https://github.com/jscott3201/rusty-bacnet publishes an equivalent API.

--- a/vendor/bacnet-client/src/discovery.rs
+++ b/vendor/bacnet-client/src/discovery.rs
@@ -56,6 +56,17 @@ impl DeviceTable {
         if !self.devices.contains_key(&key) && self.devices.len() >= MAX_DEVICE_TABLE_ENTRIES {
             return;
         }
+        let mut device = device;
+        // Preserve MS/TP routing seeded via add_routed_device when a later I-Am
+        // arrives without NPDU source routing (common on ephemeral client ports).
+        if let Some(existing) = self.devices.get(&key) {
+            if device.source_network.is_none() {
+                device.source_network = existing.source_network;
+            }
+            if device.source_address.is_none() {
+                device.source_address = existing.source_address.clone();
+            }
+        }
         self.devices.insert(key, device);
     }
 
@@ -124,6 +135,22 @@ mod tests {
         assert_eq!(table.len(), 1);
         let dev = table.get(1234).unwrap();
         assert_eq!(dev.vendor_id, 42);
+    }
+
+    #[test]
+    fn upsert_preserves_routing_when_iam_lacks_npdu_source() {
+        let mut table = DeviceTable::new();
+        let mut routed = make_device(5007);
+        routed.source_network = Some(2000);
+        routed.source_address = Some(MacAddr::from_slice(&[7]));
+        table.upsert(routed);
+        let mut iam = make_device(5007);
+        iam.vendor_id = 77;
+        table.upsert(iam);
+        let dev = table.get(5007).unwrap();
+        assert_eq!(dev.vendor_id, 77);
+        assert_eq!(dev.source_network, Some(2000));
+        assert_eq!(dev.source_address.as_ref().map(|m| m.as_slice()), Some([7u8].as_slice()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve MS/TP routing in vendored bacnet-client device table when I-Am lacks NPDU source (B3).
- Enrich Who-Is with configured routed devices; seed logging for `add_routed_device`.
- Production poll defaults: 300s interval, 60s floor, optional health-role subset (~30% cap).
- MQTT: decoupled publish interval, delta + cell payload modes for metered links.
- Docs: `BACNET_OT_POLICY.md`, `companion-rusty-bacnet-mcp.md`, deploy/mqtt bandwidth section.
- New OT gate `10_dual_mqtt_signoff.sh` (bench + bosspi GHCR rev match, dual ingest).

## Test plan
- [ ] Rust Stack CI green
- [ ] GHCR publish for tip SHA
- [ ] `./scripts/nightly-ot-bench/02_bacnet_ot.sh` with bench `field_devices.toml`
- [ ] `./scripts/nightly-ot-bench/03_mqtt_feather_persist.sh`
- [ ] `RUN_CLOUD_SIM=1` gates 07 + 10 + abbreviated 08


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bandwidth-saving MQTT options, including delta publishing, compact cell-mode messages, and health-only polling.
  * Added support for conservative BACnet polling with configurable health-point subsets.
  * Improved BACnet routed-device discovery and telemetry quality reporting.
* **Bug Fixes**
  * Preserved routed-device information when later device announcements omit routing details.
* **Documentation**
  * Added BACnet operational guidance, diagnostic companion instructions, and metered-link configuration details.
* **Tests**
  * Added dual-site MQTT sign-off and expanded low-memory and polling validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->