### PR TITLE
fix(bench): gate 10 MQTT peek for 300s publish + BUG_REPORT sign-off

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,7 +1,7 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
 **Date:** 2026-08-26  
-**Platform:** `3.3.4` / `fa14c05` master + `1540225` train (`feat/nightly-b3-mqtt-policy` PR pending)  
+**Platform:** `3.3.4` / `sha-71e1336` (`71e1336` merge #784 on master)  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR=/workspace/.cache/datafusion-spill`)  
 **Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (dual-MQTT gate 10)
 
@@ -11,20 +11,26 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 | Host | Role | Image ref | nightly↔sha | OCI revision | `/health` version |
 |------|------|-----------|-------------|--------------|-------------------|
-| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-*` | from gate `00` `digests.txt` | `image_revs.txt` | `/api/health` |
-| bosspi | fieldbus edge only | same `sha-*` fieldbus | n/a | must == bench fieldbus | `:8081/health` |
+| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-71e1336` | **PASS** (gate `00`) | `71e1336d95c9` | `3.3.4+71e1336d95c9` |
+| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-71e1336` | n/a | **PASS** `71e1336d95c9` == bench | fieldbus healthy (qemu amd64) |
 
-Artifacts: `reports/nightly-ot-*/digests.txt`, `image_revs.txt`, `pi_image_rev.txt` (gate 10).
+Artifacts: `reports/nightly-ot-bench_20260826T202049Z/digests.txt`, `image_revs.txt`, `pi_image_rev.txt` (gate 10).
 
-## Confirmed PASS (master `fa14c05` after #783)
+Digest equality (gate `00`): central / fieldbus / mqtt / mcp `nightly` == `sha-71e1336` (see `digests.txt`).
+
+## Confirmed PASS (`sha-71e1336` after #784)
 
 | Gate | Result |
 |------|--------|
-| Stack health `/api/health` | **PASS** on prior `sha-8e7899e` — re-pull after merge |
+| `00` GHCR pull + nightly↔sha | **GATE PASSED** |
+| `01` stack health | **GATE PASSED** |
+| `02` BACnet OT (5007 + BIP + poll) | **GATE PASSED** — 15 pass |
+| `03` MQTTS + Feather persistence | **GATE PASSED** |
+| `04` Modbus OT | **GATE PASSED** |
+| `05` Haystack live (`HAYSTACK_EXPECT_LIVE=1`) | **GATE PASSED** |
+| `07` cloud-sim (bosspi edge) | **22 pass / 1 fail** — see open #526 below |
+| `10` dual-MQTT sign-off | **GATE PASSED** |
 | Synthetic-59 target pairs | **PASS** — 59/59 (prior tip) |
-| Modbus `04` vs Pi Modbus TCP sim | **GATE PASSED** |
-| Haystack `05` live (`HAYSTACK_EXPECT_LIVE=1`) | **GATE PASSED** — B1/B2 closed; gate script stdin fix in #783 |
-| Fieldbus `/health` | **PASS** — sidecars green |
 
 ## Haystack via fieldbus (B1 / B2) — CLOSED
 
@@ -34,20 +40,20 @@ Artifacts: `reports/nightly-ot-*/digests.txt`, `image_revs.txt`, `pi_image_rev.t
 | Live curVal through fieldbus | **OK** — gate `extract_cur_val` fixed (#783) |
 | Allowlist (`/haystack/eval`) | **OK** — HTTP 404 |
 
-## B3 — MS/TP routing (device 5007) — CLOSED (bench 2026-08-26)
+## B3 — MS/TP routing (device 5007) — CLOSED
 
 **Prior failure:** empty shipped `field_devices.toml` on bench (no 5007 seed) + I-Am overwrite edge case.
 
-**Fix train (`#784`):** vendored `DeviceTable::upsert` preserves routing; Who-Is merges `field_devices.toml`; seed logging.
+**Fix train (#784):** vendored `DeviceTable::upsert` preserves routing; Who-Is merges `field_devices.toml`; seed logging.
 
-**Re-verify ( `sha-8e7899e` + bench overlay):** `02_bacnet_ot.sh` **GATE PASSED** — 15 pass / 0 fail (`source_network=2000`, read AI:1173, poll 3 points).
+**Re-verify (`sha-71e1336` + bench overlay):** `02_bacnet_ot.sh` **GATE PASSED** — 15 pass / 0 fail (`source_network=2000`, read AI:1173, poll 3 points).
 
 Bench requires: `cp scripts/nightly-ot-bench/field_devices.bench.example.toml config/fieldbus/field_devices.toml` + fieldbus recreate.
 
-## MQTT / cell optimization — NEW IN PR TRAIN
+## MQTT / cell optimization — SHIPPED (#784)
 
-| Item | Before | After (`1540225`) |
-|------|--------|-------------------|
+| Item | Before | After (`sha-71e1336`) |
+|------|--------|----------------------|
 | Default poll | 60 s | **300 s** (floor **60 s** unless `OPENFDD_FIELDBUS_DEV_FAST_POLL=1`) |
 | MQTT publish | tied to poll, 5 s floor | `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS` (default 300, min 60) |
 | Payload | full snapshot every cycle | `OPENFDD_MQTT_DELTA=1`, `OPENFDD_MQTT_CELL_MODE=1` (slim tags, no display_name) |
@@ -55,19 +61,31 @@ Bench requires: `cp scripts/nightly-ot-bench/field_devices.bench.example.toml co
 
 Docs: [`BACNET_OT_POLICY.md`](BACNET_OT_POLICY.md), [`deploy/mqtt/README.md`](../../deploy/mqtt/README.md).
 
-**Gate 03 / ingest:** **GATE PASSED** on `sha-8e7899e` after B3 bench overlay + poll (ingest counter growth; artifacts under `reports/nightly-ot-bench_*`). Re-run on `#784` GHCR after merge.
+**Gate 03 / ingest:** **GATE PASSED** on `sha-71e1336` (ingest counter growth).
 
-## Dual-site MQTT (lab + bldg2) — gate 10
+**Gate 10 note:** with 300 s publish interval, dual-MQTT peek uses combined wildcard subscribe (`MQTT_SUB_WAIT_SECS≥330`).
+
+## Dual-site MQTT (lab + bldg2) — gate 10 — PASS
 
 | Check | lab / fieldbus-1 @ bensbench | bldg2 / pi-1 @ bosspi |
 |-------|-------------------------------|------------------------|
-| GHCR fieldbus rev matches bench | n/a | **required PASS** |
-| MQTTS telemetry | topic + numeric values | topic + numeric values |
+| GHCR fieldbus rev matches bench | n/a | **PASS** `71e1336d95c9` |
+| MQTTS telemetry | **PASS** numeric values | **PASS** numeric values |
 | Central `/api/edges` | listed + telemetry | listed + telemetry |
 | Weather city | Madison (Open-Meteo) | Chicago (Open-Meteo) |
 | Stack left running | yes | yes |
 
-Run: `RUN_CLOUD_SIM=1 DUAL_MQTT_WAIT_SECS=600 WEATHER_SOAK_SECS=600 ./scripts/nightly-ot-bench/run_all.sh`
+Run: `RUN_CLOUD_SIM=1 DUAL_MQTT_WAIT_SECS=600 MQTT_SUB_WAIT_SECS=330 ./scripts/nightly-ot-bench/run_all.sh`
+
+**bosspi bootstrap:** minimal repo at `CLOUD_SIM_PI_REPO` needs `docker/compose.edge.yml`, `config/fieldbus/{gateway.toml,objects.csv}`, git init for gate `07` gateway patch.
+
+## Open findings
+
+| ID | Finding | Status |
+|----|---------|--------|
+| #526 | Hosted device 600000 absent from broadcast Who-Is (Pi edge); unicast I-Am to ephemeral source still skipped | **OPEN** — Workbench discovery on Pi-hosted instance |
+| arm64 | No arm64 GHCR fieldbus; bosspi runs amd64 under qemu | **OPEN** — documented |
+| #526 client | Fieldbus Who-Is bind ephemeral misses broadcast I-Am | **OPEN** — client-side |
 
 ## Agent / docs hygiene
 
@@ -76,6 +94,6 @@ Run: `RUN_CLOUD_SIM=1 DUAL_MQTT_WAIT_SECS=600 WEATHER_SOAK_SECS=600 ./scripts/ni
 
 ## Hygiene
 
-- #783 merged → master `fa14c05` (Haystack gate + BUG_REPORT refresh).
-- #780 on `8e7899e`: edge kits, agent auth, nginx resolver executable.
+- #783 merged → `fa14c05` (Haystack gate + BUG_REPORT refresh).
+- #784 merged → `71e1336` (B3 routing, OT policy, MQTT cell mode, gate 10, companion MCP docs).
 - Do not local `docker build` stack on bensbench — GHCR `sha-*` only.

--- a/scripts/nightly-ot-bench/10_dual_mqtt_signoff.sh
+++ b/scripts/nightly-ot-bench/10_dual_mqtt_signoff.sh
@@ -114,16 +114,19 @@ if [[ ! -f "$CERT" ]]; then
   KEY="$ROOT/deploy/mqtt/kits/${SITE1}__${EDGE1}/central.key.pem"
 fi
 if [[ -f "$CA" && -f "$CERT" && -f "$KEY" ]]; then
-  for spec in "${SITE1}|${EDGE1}|mqtt_lab.txt" "${SITE2}|+|mqtt_bldg2.txt"; do
-    IFS='|' read -r site edge out <<<"$spec"
+  sub_wait="${MQTT_SUB_WAIT_SECS:-330}"
+  combined="$ART/mqtt_dual_combined.txt"
+  timeout $((sub_wait + 15)) docker run --rm --net=host -v "$ROOT/deploy/mqtt:/mqtt:ro" eclipse-mosquitto:2 \
+    mosquitto_sub -h 127.0.0.1 -p 8883 \
+    --cafile /mqtt/ca/ca.pem \
+    --cert "/mqtt/kits/${SITE1}__central/central.cert.pem" \
+    --key "/mqtt/kits/${SITE1}__central/central.key.pem" \
+    -t "openfdd/v1/sites/+/edges/+/telemetry/#" -v -C 2 -W "$sub_wait" \
+    >"$combined" 2>&1 || true
+  for spec in "${SITE1}|mqtt_lab.txt" "${SITE2}|mqtt_bldg2.txt"; do
+    IFS='|' read -r site out <<<"$spec"
     out="$ART/$out"
-    timeout 45 docker run --rm --net=host -v "$ROOT/deploy/mqtt:/mqtt:ro" eclipse-mosquitto:2 \
-      mosquitto_sub -h 127.0.0.1 -p 8883 \
-      --cafile /mqtt/ca/ca.pem \
-      --cert "/mqtt/kits/${SITE1}__central/central.cert.pem" \
-      --key "/mqtt/kits/${SITE1}__central/central.key.pem" \
-      -t "openfdd/v1/sites/${site}/edges/${edge}/telemetry/#" -v -C 1 -W 40 \
-      >"$out" 2>&1 || true
+    grep "sites/${site}/" "$combined" >"$out" 2>/dev/null || : >"$out"
     if grep -qE '"value"[[:space:]]*:[[:space:]]*-?[0-9]' "$out" 2>/dev/null; then
       ok "MQTTS telemetry site=$site (numeric values)"
     else

--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -941,8 +941,11 @@ pub fn load_rest_devices(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Mutex;
 
     use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn repo_config_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../config/fieldbus")
@@ -1017,6 +1020,18 @@ mod tests {
 
     #[test]
     fn env_alias_precedence_and_poll_settings() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for key in [
+            "OPENFDD_FIELDBUS_DEV_FAST_POLL",
+            "OPENFDD_FIELDBUS_POLL_INTERVAL_SECS",
+            "RUSTY_GATEWAY_POLL_INTERVAL_SECS",
+            "OPENFDD_FIELDBUS_POLL_ENABLED",
+            "RUSTY_GATEWAY_POLL_ENABLED",
+            "OPENFDD_FIELDBUS_HTTP_PORT",
+            "RUSTY_GATEWAY_HTTP_PORT",
+        ] {
+            std::env::remove_var(key);
+        }
         std::env::set_var("RUSTY_GATEWAY_HTTP_PORT", "8080");
         std::env::set_var("OPENFDD_FIELDBUS_HTTP_PORT", "9091");
         assert_eq!(load_settings().http_port, 9091);
@@ -1033,6 +1048,9 @@ mod tests {
         assert!((load_settings().poll.interval_secs - 60.0).abs() < f64::EPSILON);
         std::env::remove_var("OPENFDD_FIELDBUS_POLL_ENABLED");
         std::env::remove_var("OPENFDD_FIELDBUS_POLL_INTERVAL_SECS");
+        std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
+        std::env::remove_var("RUSTY_GATEWAY_HTTP_PORT");
+        std::env::remove_var("OPENFDD_FIELDBUS_HTTP_PORT");
     }
 
     #[test]

--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -772,7 +772,7 @@ fn dev_fast_poll_enabled() -> bool {
 }
 
 /// Production floor: never poll faster than 60s unless dev/test escape hatch is set.
-fn finalize_poll_interval(s: &mut Settings) {
+pub(crate) fn finalize_poll_interval(s: &mut Settings) {
     const PROD_MIN_POLL_SECS: f64 = 60.0;
     if dev_fast_poll_enabled() {
         return;
@@ -1040,17 +1040,65 @@ mod tests {
 
         std::env::set_var("OPENFDD_FIELDBUS_POLL_ENABLED", "false");
         assert!(!load_settings().poll.enabled);
+        std::env::remove_var("OPENFDD_FIELDBUS_POLL_ENABLED");
+        std::env::remove_var("RUSTY_GATEWAY_HTTP_PORT");
+        std::env::remove_var("OPENFDD_FIELDBUS_HTTP_PORT");
+    }
+
+    #[test]
+    fn poll_interval_prod_floor_is_60_without_dev_fast_poll() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
+        let mut s = Settings::default();
+        s.poll.interval_secs = 12.5;
+        finalize_poll_interval(&mut s);
+        assert!((s.poll.interval_secs - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn poll_interval_dev_fast_poll_skips_prod_floor() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
+        std::env::set_var("OPENFDD_FIELDBUS_DEV_FAST_POLL", "1");
+        let mut s = Settings::default();
+        s.poll.interval_secs = 12.5;
+        finalize_poll_interval(&mut s);
+        assert!((s.poll.interval_secs - 12.5).abs() < f64::EPSILON);
+        std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
+    }
+
+    #[test]
+    fn poll_interval_env_override_through_load_settings() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("ofdd-cfg-test-{stamp}"));
+        std::fs::create_dir_all(&tmp).expect("temp config dir");
+        std::fs::write(
+            tmp.join("gateway.toml"),
+            "[bacnet_server]\ndevice_instance = 599999\n",
+        )
+        .expect("write gateway.toml");
+        std::env::set_var("OPENFDD_FIELDBUS_CONFIG_DIR", &tmp);
+        for key in [
+            "OPENFDD_FIELDBUS_DEV_FAST_POLL",
+            "OPENFDD_FIELDBUS_POLL_INTERVAL_SECS",
+            "RUSTY_GATEWAY_POLL_INTERVAL_SECS",
+        ] {
+            std::env::remove_var(key);
+        }
         std::env::set_var("OPENFDD_FIELDBUS_POLL_INTERVAL_SECS", "12.5");
         std::env::set_var("OPENFDD_FIELDBUS_DEV_FAST_POLL", "1");
         assert!((load_settings().poll.interval_secs - 12.5).abs() < f64::EPSILON);
         std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
         std::env::set_var("OPENFDD_FIELDBUS_POLL_INTERVAL_SECS", "12.5");
         assert!((load_settings().poll.interval_secs - 60.0).abs() < f64::EPSILON);
-        std::env::remove_var("OPENFDD_FIELDBUS_POLL_ENABLED");
+        std::env::remove_var("OPENFDD_FIELDBUS_CONFIG_DIR");
         std::env::remove_var("OPENFDD_FIELDBUS_POLL_INTERVAL_SECS");
         std::env::remove_var("OPENFDD_FIELDBUS_DEV_FAST_POLL");
-        std::env::remove_var("RUSTY_GATEWAY_HTTP_PORT");
-        std::env::remove_var("OPENFDD_FIELDBUS_HTTP_PORT");
+        let _ = std::fs::remove_dir_all(tmp);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Gate 10 dual-MQTT peek uses combined wildcard subscribe with `MQTT_SUB_WAIT_SECS` default 330s to match decoupled 300s MQTT publish from #784.
- BUG_REPORT updated with `sha-71e1336` GHCR sign-off, dual-site PASS, and open #526 finding.

## Test plan
- [x] Gate 10 **GATE PASSED** on bench with lab + bldg2 edges streaming
- [x] Gate 00–05 passed on `sha-71e1336`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Modbus/Haystack operations report for platform build 3.3.4 with current validation results, image references, and open findings.
  * Marked MQTT and cellular optimization work as shipped and documented successful dual-site MQTT verification.

* **Bug Fixes**
  * Improved dual-site MQTT telemetry verification by collecting and separating messages consistently across sites.
  * Added a configurable telemetry wait period for more reliable sign-off checks.
  * Enforced a 60-second minimum production poll interval while preserving faster intervals for development.

* **Tests**
  * Improved test reliability by preventing environment settings from interfering across test runs.
  * Added coverage for poll interval limits and configuration overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->