### PR TITLE
fix(fieldbus): Who-Is discovery bind for broadcast I-Am (#526)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ OpenClaw, Claude Desktop, or any MCP host — connect via **JWT REST** and optio
 
 | Layer | Responsibility |
 | --- | --- |
-| **central** | MQTTS ingest, Feather/Parquet historian, DataFusion SQL FDD + `/api/analytics/*`, REST + JWT (Rust image — no Python) |
+| **central** | MQTTS ingest, **Parquet** historian, DataFusion SQL FDD + `/api/analytics/*`, REST + JWT (Rust image — no Python) |
 | **web** | React product UI (`frontend/web`) — sole product UI ([ADR-001](docs/architecture/adr-001-react-rust-modernization.md)) |
 | **fieldbus** | BACnet / Modbus / Haystack OT drivers |
 | **mqtt** | Mosquitto MQTTS broker |
@@ -44,6 +44,18 @@ TOKEN="$(curl -s -X POST http://127.0.0.1:8080/api/auth/login \
 On Railway: set `OPENFDD_JWT_SECRET`, `OPENFDD_ADMIN_PASSWORD`, and `OPENFDD_AGENT_PASSWORD` on central; keep MCP private; see [RAILWAY_DEPLOYMENT.md](docs/operations/RAILWAY_DEPLOYMENT.md) § Secure agent auth. Admins can also `POST /api/auth/agent-token` for short-lived operator JWTs.
 
 Discover routes: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/agent/tools | jq '.tools | length'`
+
+## Rust hygiene (agents)
+
+When changing Rust in this repo:
+
+- **Delete** unused items (`dead_code`) — do not keep “just in case”; Git retains history.
+- **Remove** `#[allow(...)]` / `#![allow(...)]`; fix the cause. Prefer `_` / `_guard`, `?`, or smallest-scope `#[expect(...)]` with a one-line constraint comment.
+- Never silently discard `Result`/`Option`; prefer `?` or explicit match/log. Last resort: `let _ = …;` + why.
+- Prefer `?` / combinators over `.unwrap()` on production paths.
+- Historian: **Parquet** under `OPENFDD_STORAGE_URL` is canonical; do not add Feather dual-write. App updates keep the same volume/S3 bucket.
+
+Full train checklist + sweep: Plans 1–4 under `~/.cursor/plans/` (`whois_client_526_fix` → `bug_report_tip_refresh` → `arm64_ghcr_fieldbus_pi` → `historian_legacy_retire`).
 
 ## Safe scripts
 
@@ -127,6 +139,7 @@ A Railway one-click template should eventually encode **central → mqtt → web
 - Before pulling new images: prune unused/old digests first, then `./scripts/openfdd_stack_pull.sh …` and `./scripts/openfdd_stack_up.sh … --no-pull`.
 - DataFusion: `OPENFDD_QUERY_MEMORY_MB=256` (or 512) + `OPENFDD_DATAFUSION_SPILL_DIR` — see [`docs/operations/AFDD_MODES.md`](docs/operations/AFDD_MODES.md).
 - BACnet OT on cell edges: default **300 s** poll/publish, **60 s** floor, poll ~**30%** health points only — [`docs/operations/BACNET_OT_POLICY.md`](docs/operations/BACNET_OT_POLICY.md). Hard BACnet debug: [`docs/mcp-agents/companion-rusty-bacnet-mcp.md`](docs/mcp-agents/companion-rusty-bacnet-mcp.md).
+- Who-Is / discovery: fieldbus binds the hosted BACnet/IP port (`whois_bind_port = 0` → `bacnet_server.port`, `SO_REUSEADDR`) so broadcast I-Am is receivable (#526); unicast reads stay ephemeral — see [`services/fieldbus/AGENTS.md`](services/fieldbus/AGENTS.md).
 - Details: [`openfdd_agent_spec/CONTAINER_AGENT.md`](openfdd_agent_spec/CONTAINER_AGENT.md).
 
 ## AFDD vs bulk FDD

--- a/config/fieldbus/gateway.toml
+++ b/config/fieldbus/gateway.toml
@@ -10,7 +10,9 @@ broadcast = "255.255.255.255"
 [bacnet_client]
 interface = "0.0.0.0"
 broadcast = "255.255.255.255"
-# Ephemeral client bind — never share UDP :47808 with the hosted server socket.
+# Who-Is / discovery: 0 = auto-bind hosted bacnet_server.port (SO_REUSEADDR) so
+# broadcast I-Am is receivable (#526). Non-zero overrides. Unicast reads stay
+# on read_bind_port (0 = ephemeral) and must not hold :47808 across polls.
 whois_bind_port = 0
 read_bind_port = 0
 apdu_timeout_ms = 6000

--- a/docs/mcp-agents/companion-rusty-bacnet-mcp.md
+++ b/docs/mcp-agents/companion-rusty-bacnet-mcp.md
@@ -17,7 +17,7 @@ Production polling stays on **`openfdd-fieldbus`**. [rusty-bacnet-mcp](https://g
 |-----------|------|
 | FDD, historian, edges, MQTT ingest | `openfdd-mcp` → Central |
 | Routed MS/TP (device 5007), Who-Is, ReadProperty isolation | rusty-bacnet-mcp on OT subnet |
-| Product poll / MQTT publish | `openfdd-fieldbus` only |
+| Product poll / MQTT publish / Who-Is discovery (#526 bind) | `openfdd-fieldbus` only |
 
 ## Install (bench)
 

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -119,6 +119,8 @@ Read tools (preview, plan, preflight, contract, test-sql, fusion, historian quer
 
 Use **commission** API (`OPENFDD_COMMISSION_BASE`, default `http://127.0.0.1:9091`) for OT Who-Is/reads — not bridge host-network.
 
+On **fieldbus**, `POST /bacnet/whois` binds the hosted BACnet/IP port (`whois_bind_port = 0` → server port, `SO_REUSEADDR`) so broadcast I-Am is heard (#526). Unicast ReadProperty stays on ephemeral ports. Prefer fieldbus `:8081` for product discovery; commission/MCP companions for isolated debug.
+
 Production BACnet throttling (agents): **300 s** default poll, **60 s** minimum, ~**30%** HVAC health points on cell sites — [`docs/operations/BACNET_OT_POLICY.md`](../docs/operations/BACNET_OT_POLICY.md). Independent OT debug: [`docs/mcp-agents/companion-rusty-bacnet-mcp.md`](../docs/mcp-agents/companion-rusty-bacnet-mcp.md) (read-only; does not replace fieldbus).
 
 ## Model (Haystack RDF)

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,10 @@
 # Session log
 
+## 2026-08-27 — Who-Is client #526 (discovery bind)
+
+- Fieldbus Who-Is: `whois_bind_port = 0` auto-binds hosted `bacnet_server.port` with `SO_REUSEADDR` so broadcast I-Am (remote Pi 600000 + local 599999) is receivable; unicast reads stay ephemeral.
+- Gate `07` F3 expects both instances in `POST /bacnet/whois`. Docs: root `AGENTS.md`, `services/fieldbus/AGENTS.md`, mcp INSTRUCTIONS.
+
 ## 2026-08-26 — Edge kit download + Railway agent auth (in flight)
 
 - `POST /api/mqtt/edge-kits` + Operations MQTT **Download edge kit** (ZIP: public PEMs + `edge.json`, never CA key).

--- a/services/fieldbus/AGENTS.md
+++ b/services/fieldbus/AGENTS.md
@@ -15,9 +15,13 @@ The gateway hosts a BACnet/IP server on UDP **47808** (configurable via `OPENFDD
 
 ### Server vs client UDP sockets
 
-- **Server** binds `0.0.0.0:47808` (or configured port) — only socket on that port.
-- **Client** uses **ephemeral** UDP ports (`whois_bind_port = 0` in `gateway.toml`).
-- Never bind the BACnet client to the same UDP port as the hosted server (causes Workbench `???` / dropped ReadProperty).
+- **Server** binds `0.0.0.0:47808` (or configured port) for Workbench / BMS discovery.
+- **Who-Is / discovery** (`device == None`): bind the **same** BACnet/IP port with
+  `SO_REUSEADDR` (`whois_bind_port = 0` → `bacnet_server.port`) so broadcast I-Am is
+  receivable (#526). Short-lived under the bus lock only.
+- **Unicast reads / RPM / poll**: ephemeral `read_bind_port = 0` (and routed seed
+  stays ephemeral). Do **not** hold `:47808` across long poll cycles — that steals
+  hosted-server unicast and causes Workbench `???` / dropped ReadProperty.
 
 ## REST vs BACnet write split (critical — no data races)
 

--- a/services/fieldbus/README.md
+++ b/services/fieldbus/README.md
@@ -102,10 +102,10 @@ See [`docs/rust-migration-report.md`](docs/rust-migration-report.md) for the ful
 
 ## Design
 
-The hosted server and the client use **separate sockets**. The server binds
-`0.0.0.0:47808` so it receives broadcast Who-Is from BMS discovery tools, while
-the client sends Who-Is on `:47808` and performs unicast reads on ephemeral
-ports.
+The hosted server binds `0.0.0.0:47808` for BMS/Workbench discovery. Who-Is
+temporarily shares that port via `SO_REUSEADDR` (`whois_bind_port = 0` → server
+port) so broadcast I-Am is receivable (#526). Unicast reads/RPM use ephemeral
+ports and must not hold `:47808` across polls.
 
 Set **`OPENFDD_FIELDBUS_BACNET_PORT`** when the building uses a non-default BACnet UDP port.
 

--- a/services/fieldbus/src/services/bacnet_client.rs
+++ b/services/fieldbus/src/services/bacnet_client.rs
@@ -77,11 +77,23 @@ impl BacnetClientService {
             .find(|d| d.device_instance == device_instance)
     }
 
+    /// UDP bind for a client session.
+    ///
+    /// - **Discovery / Who-Is** (`device == None`): hear broadcast I-Am on the BACnet/IP
+    ///   port. `whois_bind_port = 0` means "use hosted `bacnet_server.port`" (default
+    ///   47808). `bacnet-transport` BIP sets `SO_REUSEADDR`, so this coexists with the
+    ///   hosted server for the short Who-Is window (#526).
+    /// - **Routed MS/TP**: keep ephemeral (or explicit `whois_bind_port`) — do not hold
+    ///   `:47808` across long poll cycles (would steal hosted-server unicast).
+    /// - **IP field devices**: ephemeral `read_bind_port` for unicast ReadProperty.
     fn bind_port(&self, device: Option<&FieldDevice>) -> u16 {
-        if device.is_none() || device.is_some_and(|d| d.is_routed()) {
-            self.settings.bacnet_client.whois_bind_port
-        } else {
-            self.settings.bacnet_client.read_bind_port
+        match device {
+            None => discovery_bind_port(
+                self.settings.bacnet_client.whois_bind_port,
+                self.settings.bacnet_server.port,
+            ),
+            Some(d) if d.is_routed() => self.settings.bacnet_client.whois_bind_port,
+            Some(_) => self.settings.bacnet_client.read_bind_port,
         }
     }
 
@@ -575,8 +587,7 @@ impl BacnetClientService {
             self.seed_configured_field_devices(&client).await?;
             client.who_is(low, high).await.map_err(|e| e.to_string())?;
             tokio::time::sleep(Duration::from_secs_f64(cfg.whois_timeout_secs)).await;
-            // Re-seed so configured bench devices appear even when broadcast I-Am is not
-            // received on the client's ephemeral UDP port (hosted server owns :47808).
+            // Re-seed configured devices (table may already include live I-Am from #526 bind).
             self.seed_configured_field_devices(&client).await?;
             let devices = client.discovered_devices().await;
             // #539: discovered_devices() is a full device-table snapshot (incl.
@@ -589,9 +600,8 @@ impl BacnetClientService {
                 })
                 .map(device_summary)
                 .collect();
-            // #526 follow-up: co-located hosted BACnet server answers Workbench on :47808,
-            // but the client Who-Is socket is ephemeral and often never sees that I-Am.
-            // Surface the local hosted device in Who-Is results so self-discovery matches OT.
+            // Fallback only: live I-Am should cover remote + co-located hosted after
+            // discovery bind on bacnet_server.port (#526). Keep synthesize for edge cases.
             self.merge_local_hosted_device(&mut out, low, high);
             self.merge_configured_routed_devices(&mut out, low, high);
             Ok(out)
@@ -660,7 +670,7 @@ impl BacnetClientService {
             "source_network": null,
             "max_apdu": null,
             "hosted_local": true,
-            "note": "synthesized — client ephemeral Who-Is often misses I-Am on :47808 (#526)",
+            "note": "synthesized fallback — live I-Am missing after discovery bind on server port",
         }));
     }
 
@@ -1302,6 +1312,16 @@ fn select_poll_points(device: &FieldDevice, health_only: bool) -> Vec<FieldPoint
     selected
 }
 
+/// Resolve Who-Is / discovery UDP bind. `whois_bind_port == 0` → hosted server port
+/// so broadcast I-Am on BACnet/IP is receivable (`SO_REUSEADDR` in bacnet-transport).
+fn discovery_bind_port(whois_bind_port: u16, server_port: u16) -> u16 {
+    if whois_bind_port != 0 {
+        whois_bind_port
+    } else {
+        server_port
+    }
+}
+
 fn device_summary(d: &bacnet_client::discovery::DiscoveredDevice) -> Value {
     let mac = d.mac_address.as_slice();
     let addr = if mac.len() == 6 {
@@ -1356,6 +1376,13 @@ mod poll_select_tests {
         let d = dev("ahu", 1, points);
         let selected = select_poll_points(&d, true);
         assert_eq!(selected.len(), 3);
+    }
+
+    #[test]
+    fn discovery_bind_port_auto_uses_server_port() {
+        assert_eq!(discovery_bind_port(0, 47808), 47808);
+        assert_eq!(discovery_bind_port(0, 47809), 47809);
+        assert_eq!(discovery_bind_port(47900, 47808), 47900);
     }
 }
 


### PR DESCRIPTION
## Summary
- Who-Is / discovery binds hosted `bacnet_server.port` when `whois_bind_port = 0` (`SO_REUSEADDR` via bacnet-transport) so broadcast I-Am reaches the client (bench 599999 + Pi 600000).
- Unicast reads/RPM stay on ephemeral ports; routed poll does not hold `:47808`.
- Agent docs: `AGENTS.md`, `services/fieldbus/AGENTS.md`, `mcp/INSTRUCTIONS.md`, `openfdd_agent_spec/SESSION_LOG.md`.

## Test plan
- [x] Unit: `discovery_bind_port_auto_uses_server_port`
- [x] Clippy `-p openfdd-fieldbus`
- [ ] After GHCR: gate `07` F3 PASS for 599999 + 600000
- [ ] Abbreviated dual-MQTT health on tip SHA


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved BACnet device discovery so broadcast responses are reliably received from hosted BACnet/IP services.
  * Preserved short-lived connections for unicast reads and polling, improving compatibility with hosted services.
* **Documentation**
  * Updated configuration guidance and fieldbus documentation to explain discovery, port usage, and polling behavior.
  * Clarified that BACnet discovery is handled by the fieldbus service and documented the recommended discovery endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->