### PR TITLE
fix(fieldbus): Who-Is bind 0.0.0.0 for broadcast I-Am (#526)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ A Railway one-click template should eventually encode **central → mqtt → web
 - Before pulling new images: prune unused/old digests first, then `./scripts/openfdd_stack_pull.sh …` and `./scripts/openfdd_stack_up.sh … --no-pull`.
 - DataFusion: `OPENFDD_QUERY_MEMORY_MB=256` (or 512) + `OPENFDD_DATAFUSION_SPILL_DIR` — see [`docs/operations/AFDD_MODES.md`](docs/operations/AFDD_MODES.md).
 - BACnet OT on cell edges: default **300 s** poll/publish, **60 s** floor, poll ~**30%** health points only — [`docs/operations/BACNET_OT_POLICY.md`](docs/operations/BACNET_OT_POLICY.md). Hard BACnet debug: [`docs/mcp-agents/companion-rusty-bacnet-mcp.md`](docs/mcp-agents/companion-rusty-bacnet-mcp.md).
-- Who-Is / discovery: fieldbus binds the hosted BACnet/IP port (`whois_bind_port = 0` → `bacnet_server.port`, `SO_REUSEADDR`) so broadcast I-Am is receivable (#526); unicast reads stay ephemeral — see [`services/fieldbus/AGENTS.md`](services/fieldbus/AGENTS.md).
+- Who-Is / discovery: fieldbus binds **`0.0.0.0`** + hosted BACnet/IP port (`whois_bind_port = 0` → `bacnet_server.port`, `SO_REUSEADDR`) so directed-broadcast I-Am is receivable (#526); do not use the unicast `OPENFDD_FIELDBUS_BIND` address for discovery. Unicast reads stay ephemeral — see [`services/fieldbus/AGENTS.md`](services/fieldbus/AGENTS.md).
 - Details: [`openfdd_agent_spec/CONTAINER_AGENT.md`](openfdd_agent_spec/CONTAINER_AGENT.md).
 
 ## AFDD vs bulk FDD

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -119,7 +119,7 @@ Read tools (preview, plan, preflight, contract, test-sql, fusion, historian quer
 
 Use **commission** API (`OPENFDD_COMMISSION_BASE`, default `http://127.0.0.1:9091`) for OT Who-Is/reads — not bridge host-network.
 
-On **fieldbus**, `POST /bacnet/whois` binds the hosted BACnet/IP port (`whois_bind_port = 0` → server port, `SO_REUSEADDR`) so broadcast I-Am is heard (#526). Unicast ReadProperty stays on ephemeral ports. Prefer fieldbus `:8081` for product discovery; commission/MCP companions for isolated debug.
+On **fieldbus**, `POST /bacnet/whois` binds **`0.0.0.0`** + hosted BACnet/IP port (`whois_bind_port = 0` → server port, `SO_REUSEADDR`) so directed-broadcast I-Am is heard (#526). Unicast ReadProperty stays on ephemeral ports. Prefer fieldbus `:8081` for product discovery; commission/MCP companions for isolated debug.
 
 Production BACnet throttling (agents): **300 s** default poll, **60 s** minimum, ~**30%** HVAC health points on cell sites — [`docs/operations/BACNET_OT_POLICY.md`](../docs/operations/BACNET_OT_POLICY.md). Independent OT debug: [`docs/mcp-agents/companion-rusty-bacnet-mcp.md`](../docs/mcp-agents/companion-rusty-bacnet-mcp.md) (read-only; does not replace fieldbus).
 

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-08-27 — Who-Is client #526 (discovery bind)
 
-- Fieldbus Who-Is: `whois_bind_port = 0` auto-binds hosted `bacnet_server.port` with `SO_REUSEADDR` so broadcast I-Am (remote Pi 600000 + local 599999) is receivable; unicast reads stay ephemeral.
+- Fieldbus Who-Is: `whois_bind_port = 0` auto-binds hosted `bacnet_server.port` on **`0.0.0.0`** with `SO_REUSEADDR` so directed-broadcast I-Am (remote Pi 600000 + LAN devices) is receivable; unicast `OPENFDD_FIELDBUS_BIND` is not used for discovery (misses broadcasts). Unicast reads stay ephemeral.
 - Gate `07` F3 expects both instances in `POST /bacnet/whois`. Docs: root `AGENTS.md`, `services/fieldbus/AGENTS.md`, mcp INSTRUCTIONS.
 
 ## 2026-08-26 — Edge kit download + Railway agent auth (in flight)

--- a/services/fieldbus/AGENTS.md
+++ b/services/fieldbus/AGENTS.md
@@ -16,12 +16,13 @@ The gateway hosts a BACnet/IP server on UDP **47808** (configurable via `OPENFDD
 ### Server vs client UDP sockets
 
 - **Server** binds `0.0.0.0:47808` (or configured port) for Workbench / BMS discovery.
-- **Who-Is / discovery** (`device == None`): bind the **same** BACnet/IP port with
-  `SO_REUSEADDR` (`whois_bind_port = 0` → `bacnet_server.port`) so broadcast I-Am is
-  receivable (#526). Short-lived under the bus lock only.
+- **Who-Is / discovery** (`device == None`): bind **`0.0.0.0`** + hosted BACnet/IP port
+  with `SO_REUSEADDR` (`whois_bind_port = 0` → `bacnet_server.port`) so directed-broadcast
+  I-Am is receivable (#526). Do not bind the unicast `OPENFDD_FIELDBUS_BIND` address for
+  discovery — that misses broadcasts on Linux. Short-lived under the bus lock only.
 - **Unicast reads / RPM / poll**: ephemeral `read_bind_port = 0` (and routed seed
-  stays ephemeral). Do **not** hold `:47808` across long poll cycles — that steals
-  hosted-server unicast and causes Workbench `???` / dropped ReadProperty.
+  stays ephemeral), optionally on the BIND unicast address. Do **not** hold `:47808`
+  across long poll cycles — that steals hosted-server unicast and causes Workbench `???`.
 
 ## REST vs BACnet write split (critical — no data races)
 

--- a/services/fieldbus/README.md
+++ b/services/fieldbus/README.md
@@ -103,9 +103,11 @@ See [`docs/rust-migration-report.md`](docs/rust-migration-report.md) for the ful
 ## Design
 
 The hosted server binds `0.0.0.0:47808` for BMS/Workbench discovery. Who-Is
-temporarily shares that port via `SO_REUSEADDR` (`whois_bind_port = 0` → server
-port) so broadcast I-Am is receivable (#526). Unicast reads/RPM use ephemeral
-ports and must not hold `:47808` across polls.
+temporarily shares that port on **`0.0.0.0`** via `SO_REUSEADDR` (`whois_bind_port = 0`
+→ server port) so directed-broadcast I-Am is receivable (#526). Do not bind the
+unicast `OPENFDD_FIELDBUS_BIND` address for discovery. Unicast reads/RPM use
+ephemeral ports and must not hold `:47808` across polls. `OPENFDD_FIELDBUS_BIND`
+still derives the subnet broadcast used when *sending* Who-Is.
 
 Set **`OPENFDD_FIELDBUS_BACNET_PORT`** when the building uses a non-default BACnet UDP port.
 

--- a/services/fieldbus/src/services/bacnet_client.rs
+++ b/services/fieldbus/src/services/bacnet_client.rs
@@ -102,8 +102,16 @@ impl BacnetClientService {
         device: Option<&FieldDevice>,
     ) -> Result<BACnetClient<bacnet_transport::bip::BipTransport>, String> {
         let cfg = &self.settings.bacnet_client;
+        // Who-Is must bind INADDR_ANY to receive BACnet/IP directed-broadcast I-Am.
+        // A unicast interface from OPENFDD_FIELDBUS_BIND (e.g. 192.168.204.55) misses
+        // those datagrams on Linux even with SO_REUSEADDR on :47808 (#526).
+        let interface = if device.is_none() {
+            Ipv4Addr::UNSPECIFIED
+        } else {
+            cfg.interface
+        };
         BACnetClient::bip_builder()
-            .interface(cfg.interface)
+            .interface(interface)
             .port(self.bind_port(device))
             .broadcast_address(cfg.broadcast)
             .apdu_timeout_ms(u64::from(cfg.apdu_timeout_ms))


### PR DESCRIPTION
## Summary
- Follow-up to #786: discovery Who-Is binds **`0.0.0.0:bacnet_server.port`** so directed-broadcast I-Am is received.
- `OPENFDD_FIELDBUS_BIND` unicast interface is not used for discovery (Linux drops broadcasts on that bind); it still derives the subnet broadcast for *sending* Who-Is.

## Test plan
- [ ] Bench: `POST /bacnet/whois` includes **600000** (Pi) with fieldbus host-net + BIND set
- [ ] Gate `07` F3 PASS for 599999 + 600000 after GHCR tip


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved BACnet device discovery by allowing directed-broadcast responses to be received reliably.
  * Discovery now works across remote and local BACnet/IP devices while preserving unicast reads and polling behavior.

* **Documentation**
  * Updated setup and troubleshooting guidance for discovery bindings, broadcast handling, and unicast communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->