### PR TITLE
fix(bench): prefer native arm64 fieldbus on Pi (Plan 3 close)

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,7 +1,7 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
 **Date:** 2026-08-27  
-**Platform:** `3.3.4` / `sha-6c2b89e` (merge #787 Who-Is INADDR_ANY; #786 discovery port bind)  
+**Platform:** `3.3.4` / `sha-fadf167` (multi-arch fieldbus) + Plan 4 merge `sha-21fc909` on master  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR`)  
 **Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only
 
@@ -11,48 +11,45 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 | Host | Role | Image ref | nightly↔sha | OCI revision | `/health` version |
 |------|------|-----------|-------------|--------------|-------------------|
-| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-6c2b89e` | pin tip explicitly if nightly lag | `6c2b89ee1fd1` | `3.3.4+6c2b89ee1fd1` |
-| bosspi | fieldbus edge only | `openfdd-fieldbus:nightly` @ tip rev | n/a | **PASS** `6c2b89ee1fd1` == bench | fieldbus healthy (amd64/qemu until Plan 3) |
+| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-*` tip | pin tip explicitly if nightly lag | tip OCI rev | tip |
+| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-fadf167` **linux/arm64** | n/a | **PASS** `fadf167ee984` native | fieldbus **healthy** (no qemu) |
 
-Prefer `OPENFDD_IMAGE_TAG=sha-6c2b89e` (or later tip) — do not trust sticky `:nightly` without digest check.
+Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without digest check.
 
-## Confirmed PASS (`sha-6c2b89e`)
+## Confirmed PASS
 
 | Gate / check | Result |
 |------|--------|
-| Who-Is F3 (#526 client) | **PASS** — `POST /bacnet/whois` lists **599999** + **600000** |
-| Prior OT train (`sha-71e1336`) | Gates `00`–`05`, `10` dual-MQTT **PASS** (retained); gate `03` now Parquet persist |
-| Synthetic-59 | **PASS** — 59/59 (prior tip) |
+| Who-Is F3 (#526 client) | **PASS** — `POST /bacnet/whois` lists **599999** + **600000** (`sha-6c2b89e`+) |
+| bosspi native arm64 | **PASS** — `Arch=arm64`, health OK, ~905 MiB fieldbus-only (`sha-fadf167`) |
+| Prior OT train | Gates `00`–`05`, `10` dual-MQTT **PASS** (retained); gate `03` = Parquet persist |
+| Plan 4 Feather retire | **MERGED** `#789` (`sha-21fc909`) — Parquet / `OPENFDD_STORAGE_URL` only |
 
 ## #526 Who-Is client — CLOSED
 
 **Root cause:** discovery socket used ephemeral port and/or unicast `OPENFDD_FIELDBUS_BIND` address → missed directed-broadcast I-Am on Linux.
 
-**Fix:** `#786` bind discovery to `bacnet_server.port` with `SO_REUSEADDR`; `#787` bind Who-Is on **`0.0.0.0`** (not BIND unicast). Unicast reads stay ephemeral.
-
-**Evidence (`sha-6c2b89e`):** devices include `600000` @ Pi BIP and `599999` (live or hosted_local fallback).
-
-Unicast I-Am to ephemeral requester may still skip (server broadcasts I-Am) — Workbench on `:47808` is fine.
+**Fix:** `#786` bind discovery to `bacnet_server.port` with `SO_REUSEADDR`; `#787` bind Who-Is on **`0.0.0.0`** (not BIND unicast).
 
 ## Haystack / B3 / MQTT cell — CLOSED (prior)
 
-See history on `sha-71e1336` (#783/#784): Haystack curVal, MS/TP 5007, 300 s poll / cell MQTT.
+See history on `sha-71e1336` (#783/#784).
 
 ## Dual-site MQTT (lab + bldg2)
 
 | Check | lab / fieldbus-1 | bldg2 / pi-1 |
 |-------|------------------|--------------|
-| Fieldbus rev tip | `6c2b89e` | `6c2b89e` |
+| Fieldbus platform | amd64 bench | **linux/arm64** native |
+| Fieldbus tip | pin `sha-*` | `sha-fadf167` (or later multi-arch tip) |
 | Who-Is sees peer hosted | 600000 from bench | n/a |
-| MQTTS / `/api/edges` | recreate may need 300 s publish soak | restart edge after central recreate |
 
 ## Historian ledger (H)
 
 | Item | Status |
 |------|--------|
 | H1–H9 Parquet path | **done** — canonical under `OPENFDD_STORAGE_URL` |
-| Feather / dual-write / H6 migrate product | **CLOSED** — deleted writers / LEGACY_INGEST_MIRROR / product migrate CLI; gate `03` = Parquet |
-| Durable restore | same volume / `s3://` across GHCR image updates — **not** wipe `/workspace` |
+| Feather / dual-write / H6 migrate product | **CLOSED** — `#789` |
+| Durable restore | same volume / `s3://` across GHCR image updates |
 | H10 TB quals | **OPEN** |
 | Railway AI vs FDD AI | Railway may bootstrap GHCR; HVAC/FDD AI = local + **agent JWT** to private central |
 
@@ -60,12 +57,12 @@ See history on `sha-71e1336` (#783/#784): Haystack curVal, MS/TP 5007, 300 s pol
 
 | ID | Finding | Status |
 |----|---------|--------|
-| arm64 | Multi-arch fieldbus workflow (#788); bosspi native verify after GHCR publish | **IN PROGRESS** — Plan 3 |
+| arm64 | Multi-arch fieldbus + bosspi native verify | **CLOSED** — Plan 3 |
 | H10 | Large historian quals | **OPEN** |
 | nightly lag | `:nightly` may lag `sha-*` after multi-image publish | pin `sha-*` on benches |
 
 ## Hygiene
 
-- #786 / #787 Who-Is; #788 BUG_REPORT + arm64 fieldbus publish; Plan 4 Feather retire.
+- #786 / #787 Who-Is; #788 BUG_REPORT + arm64 publish; #789 Feather retire; Plan 3 gate `07` prefers `linux/arm64`.
 - Do not local `docker build` stack on bensbench — GHCR `sha-*` only.
 - Anti-hardcoding: no private OT IPs in this report.

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -38,8 +38,8 @@ OT LAN benches need fieldbus — recipe **`react-ot`**
 [`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md).
 
 **Pi 3 edges (~905 MiB):** run **fieldbus-only** (no central/web soak). Prefer
-native `linux/arm64` `openfdd-fieldbus` from GHCR multi-arch; qemu-amd64 is a
-fallback only until the arm64 manifest is present.
+native `linux/arm64` `openfdd-fieldbus` from GHCR multi-arch (Plan 3 CLOSED on
+bosspi `sha-fadf167`); qemu-amd64 is fallback only when arm64 pull is unavailable.
 
 Post-merge soak: **wait for** `Publish Open-FDD stack to GHCR` (+ MCP) **success**
 on the tip SHA before pulling `sha-<7>`. Tip git SHA can exist minutes before

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,11 @@
 # Session log
 
+## 2026-08-27 — Plan 3 arm64 fieldbus CLOSED (bosspi native)
+
+- bosspi: `openfdd-fieldbus:sha-fadf167` **linux/arm64** healthy (no qemu); OCI rev `fadf167ee984`.
+- Gate `07` prefers native arm64 pull; amd64/qemu is fallback only.
+- BUG_REPORT arm64 row **CLOSED**.
+
 ## 2026-08-27 — Plan 4 Feather retirement
 
 - Deleted `feather_store` writers, central `OPENFDD_LEGACY_INGEST_MIRROR` dual-write, and product CLI `historian-migrate` / `historian-dry-run` / `historian-stats`.

--- a/scripts/nightly-ot-bench/07_cloud_sim.sh
+++ b/scripts/nightly-ot-bench/07_cloud_sim.sh
@@ -9,7 +9,7 @@
 #   B. broker server cert must carry the LAN IP SAN (remote edges verify TLS by IP)
 #   C. provision second-site edge kit + merge broker ACL
 #   D. central multi-site subscribe (OPENFDD_SITE_ID="+" via local compose override)
-#   E. remote edge bring-up on the Pi (amd64 image under qemu/binfmt — arm64 gap is a finding)
+#   E. remote edge bring-up on the Pi (prefer native linux/arm64 fieldbus; qemu amd64 fallback)
 #   F. assertions: two edges on /api/edges, bldg2 telemetry with numeric values,
 #      Who-Is sees 599999 and 600000 as distinct hosted devices
 set -euo pipefail
@@ -163,20 +163,44 @@ fi
 # --- E. remote edge on the Pi ---------------------------------------------------
 hdr "E. remote edge bring-up on Pi (site=$SITE2 edge=$EDGE2 device=$DEV2)"
 
-# qemu/binfmt for amd64 images on aarch64 (stack images are amd64-only: known gap)
-AMD64_PROBE='timeout 60 docker run --rm --entrypoint /bin/sh --platform linux/amd64 ghcr.io/bbartling/openfdd-fieldbus:nightly -c "echo qemu-ok"'
-if pi "$AMD64_PROBE" 2>/dev/null | grep -q qemu-ok; then
-  ok "Pi can execute amd64 fieldbus image (binfmt present)"
+PI_FIELDBUS_IMAGE="${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:${OPENFDD_IMAGE_TAG:-nightly}}"
+echo "${DIM}Pi fieldbus image pin: $PI_FIELDBUS_IMAGE${RST}"
+
+# Prefer native linux/arm64 when GHCR publishes a multi-arch fieldbus tip (#788+).
+# Fall back to amd64 under qemu/binfmt only if arm64 pull is unavailable.
+PI_PLATFORM=linux/arm64
+if pi "docker pull --platform linux/arm64 $PI_FIELDBUS_IMAGE >/dev/null 2>&1"; then
+  ok "Pi pulled native linux/arm64 tip ($PI_FIELDBUS_IMAGE)"
 else
-  echo "${DIM}installing qemu binfmt handlers on Pi${RST}"
-  pi 'docker run --privileged --rm tonistiigi/binfmt --install amd64' >/dev/null 2>&1 || true
+  echo "${DIM}arm64 pull unavailable — falling back to amd64 under qemu/binfmt${RST}"
+  PI_PLATFORM=linux/amd64
+  AMD64_PROBE="timeout 60 docker run --rm --entrypoint /bin/sh --platform linux/amd64 $PI_FIELDBUS_IMAGE -c \"echo qemu-ok\""
   if pi "$AMD64_PROBE" 2>/dev/null | grep -q qemu-ok; then
-    ok "qemu binfmt installed — amd64 image runs under emulation (finding: no arm64 nightlies)"
+    ok "Pi can execute amd64 fieldbus image (binfmt present)"
   else
-    bad "Pi cannot run amd64 fieldbus image even with binfmt — arm64 image gap blocks real deployments"
-    skip "falling back is manual: run a second edge compose project on the bench instead"
+    echo "${DIM}installing qemu binfmt handlers on Pi${RST}"
+    pi 'docker run --privileged --rm tonistiigi/binfmt --install amd64' >/dev/null 2>&1 || true
+    if pi "$AMD64_PROBE" 2>/dev/null | grep -q qemu-ok; then
+      ok "qemu binfmt installed — amd64 fieldbus under emulation (arm64 tip missing)"
+    else
+      bad "Pi cannot run fieldbus arm64 or amd64/qemu — blocks real deployments"
+      skip "falling back is manual: run a second edge compose project on the bench instead"
+      summary; exit 1
+    fi
+  fi
+  if ! pi "docker pull --platform linux/amd64 $PI_FIELDBUS_IMAGE >/dev/null 2>&1"; then
+    bad "explicit amd64 pull failed on Pi for $PI_FIELDBUS_IMAGE — refusing stale soak"
     summary; exit 1
   fi
+fi
+
+PI_REV="$(pi "docker inspect $PI_FIELDBUS_IMAGE --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}'" 2>/dev/null | head -c 12 || true)"
+BENCH_REV="$(docker inspect "$PI_FIELDBUS_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null | head -c 12 || true)"
+if [[ -n "$PI_REV" && "$PI_REV" == "$BENCH_REV" ]]; then
+  ok "Pi tip rev $PI_REV matches bench ($PI_PLATFORM)"
+else
+  bad "Pi tip rev '$PI_REV' != bench '$BENCH_REV' — stale image would fake results"
+  summary; exit 1
 fi
 
 # Ship the kit (public CA + edge cert/key only)
@@ -205,14 +229,12 @@ fi
 
 # compose.edge.yml does not pass OPENFDD_BACNET_DEVICE_INSTANCE through, so a local
 # (gitignored-style) override supplies it — this is the #532 env path under test.
-pi "cat > $PI_REPO/docker/compose.edge.local.yml <<'EOF'
+# Pin platform explicitly so compose does not reuse a stale local amd64 layer.
+pi "cat > $PI_REPO/docker/compose.edge.local.yml <<EOF
 # Cloud-sim bench override — hosted BACnet instance via env (#532). Do not commit.
 services:
   fieldbus:
-    # Explicit platform: 'pull always' fails on arm64 (no manifest, #530) and compose
-    # silently reuses the STALE local amd64 image — that shipped yesterday's build and
-    # caused the 2026-07-18 duplicate-instance-599999 incident in Workbench.
-    platform: linux/amd64
+    platform: ${PI_PLATFORM}
     environment:
       OPENFDD_BACNET_DEVICE_INSTANCE: \"${DEV2}\"
     # Bench mitigation for the per-operation UDP socket leak (BACnetClient::stop());
@@ -222,24 +244,7 @@ services:
         soft: 65536
         hard: 65536
 EOF
-echo wrote-override"
-
-# Pull the pinned tip image explicitly (amd64 under qemu) and FAIL LOUDLY on digest drift.
-PI_FIELDBUS_IMAGE="${OPENFDD_FIELDBUS_IMAGE:-ghcr.io/bbartling/openfdd-fieldbus:${OPENFDD_IMAGE_TAG:-nightly}}"
-echo "${DIM}Pi fieldbus image pin: $PI_FIELDBUS_IMAGE${RST}"
-if pi "docker pull --platform linux/amd64 $PI_FIELDBUS_IMAGE >/dev/null 2>&1"; then
-  PI_REV="$(pi "docker inspect $PI_FIELDBUS_IMAGE --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}'" 2>/dev/null | head -c 12 || true)"
-  BENCH_REV="$(docker inspect "$PI_FIELDBUS_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null | head -c 12 || true)"
-  if [[ -n "$PI_REV" && "$PI_REV" == "$BENCH_REV" ]]; then
-    ok "Pi pulled amd64 tip rev $PI_REV (matches bench)"
-  else
-    bad "Pi tip rev '$PI_REV' != bench '$BENCH_REV' — stale image would fake results"
-    summary; exit 1
-  fi
-else
-  bad "explicit amd64 pull failed on Pi for $PI_FIELDBUS_IMAGE — refusing stale soak"
-  summary; exit 1
-fi
+echo wrote-override platform=${PI_PLATFORM}"
 
 # field_devices: Pi polls the BIP bench sims as its "building devices" PLUS the bench
 # hosted server 599999 — the cross-device weather read for gate 08 (600000's edge
@@ -301,7 +306,7 @@ elif [[ -n "$PI_REV" ]]; then
   bad "Pi fieldbus rev drift: pi=${PI_REV:0:12} tip=${BENCH_FB_REV:0:12}"
 fi
 
-echo "${DIM}waiting up to 90s for Pi fieldbus health (qemu is slow)${RST}"
+echo "${DIM}waiting up to 90s for Pi fieldbus health ($PI_PLATFORM)${RST}"
 PI_HEALTH=""
 for _ in $(seq 1 18); do
   PI_HEALTH="$(pi 'curl -fsS --max-time 5 http://127.0.0.1:8081/health' 2>/dev/null || true)"
@@ -309,10 +314,17 @@ for _ in $(seq 1 18); do
   sleep 5
 done
 if [[ -n "$PI_HEALTH" ]] && jq -e '.ok==true' <<<"$PI_HEALTH" >/dev/null 2>&1; then
-  ok "Pi fieldbus healthy under emulation"
+  PI_ARCH="$(pi "docker image inspect \$(docker inspect openfdd-edge-fieldbus-1 --format '{{.Image}}') --format '{{.Architecture}}'" 2>/dev/null || true)"
+  if [[ "$PI_PLATFORM" == "linux/arm64" && "$PI_ARCH" == "arm64" ]]; then
+    ok "Pi fieldbus healthy on native arm64"
+  elif [[ "$PI_PLATFORM" == "linux/amd64" ]]; then
+    ok "Pi fieldbus healthy under amd64/qemu fallback"
+  else
+    ok "Pi fieldbus healthy (platform=$PI_PLATFORM arch=$PI_ARCH)"
+  fi
   echo "${DIM}  $(jq -c '{service,version}' <<<"$PI_HEALTH" 2>/dev/null)${RST}"
 else
-  bad "Pi fieldbus not healthy after 90s (qemu/arm64 gap — capture logs)"
+  bad "Pi fieldbus not healthy after 90s (platform=$PI_PLATFORM — capture logs)"
   pi "docker logs openfdd-edge-fieldbus-1 --tail 40" >"$ART/pi_fieldbus.log" 2>&1 || true
   tail -15 "$ART/pi_fieldbus.log" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary
- Gate `07` prefers GHCR `linux/arm64` fieldbus on bosspi; amd64/qemu only if arm64 pull fails.
- BUG_REPORT: arm64 row **CLOSED**; bosspi verified native healthy on `sha-fadf167`.
- Agent docs: SESSION_LOG (+ CONTAINER_AGENT if needed).

## Evidence
- bosspi: `Arch=arm64`, health OK, OCI `fadf167ee984`, fieldbus-only ~905 MiB.

## Test plan
- [x] Manual bosspi native pull + recreate
- [ ] CI on this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native ARM64 fieldbus image support for Pi deployments.
  * Cloud simulation now automatically falls back to AMD64 with emulation when ARM64 images are unavailable.
  * Added configurable image references, matching validation, and clearer platform health reporting.

* **Documentation**
  * Updated deployment guidance, bug reports, and session logs to reflect completed ARM64 support and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->