### PR TITLE
docs(ops): close 3.3.5 dual-MQTT/pcap cycle; harden gate 11

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,9 +1,10 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** _(fill after tip soak)_  
-**Platform:** `3.3.5` / `sha-_______` _(pin after GHCR publish)_  
+**Date:** 2026-08-27  
+**Platform:** `3.3.5+fa83c7245942` / `sha-fa83c72`  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR`)  
-**Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (`linux/arm64`)
+**Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (`linux/arm64`)  
+**Artifacts:** `reports/patch335_validate_233516/`
 
 Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `bench.env.local`.
 
@@ -11,8 +12,8 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 | Host | Role | Image ref | nightly↔sha | OCI revision | `/health` version |
 |------|------|-----------|-------------|--------------|-------------------|
-| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-_______` | | | |
-| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-_______` **linux/arm64** | | | |
+| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-fa83c72` | tip publish success for `#791` | `fa83c7245942` | central `3.3.5+fa83c7245942` |
+| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-fa83c72` **linux/arm64** | same tip | `fa83c7245942` | fieldbus `/health` ok |
 
 Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without digest check.
 
@@ -20,22 +21,30 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 
 | Gate / check | Result |
 |------|--------|
-| _(blank — fill after dual MQTT / synthetic / pcap)_ | |
+| Combined OT + synth (`combined_ot_synth_validate.sh`) | **PASS** (`combined_rc=0`) — BACnet 02, MQTT persist 03, Modbus 04, Haystack 05, synth CSV |
+| Dual MQTT 600s (`10_dual_mqtt_signoff.sh`) | **PASS** (`dual_rc=0`, 16 passed / 1 skipped digests.txt) |
+| BACnet pcap FP scan (`11_bacnet_pcap_fp_scan.sh`) | **PASS** (`pcap_rc=0`) — 33 ReadProperty, 0 Who-Is storm / ephemeral-broadcast findings |
+| Dual edges + ingest growth | **PASS** — `fieldbus-1` (lab) + `pi-1` (bldg2) `has_telemetry:true`; ingest_ok 27→47 during soak |
+| Weather | **PASS** — Madison (bench) / Chicago (Pi) |
 
 ## Dual-site MQTT (lab + bldg2)
 
 | Check | lab / fieldbus-1 | bldg2 / pi-1 |
 |-------|------------------|--------------|
-| Fieldbus platform | | |
-| Fieldbus tip | | |
-| Ingest / telemetry span | | |
+| Fieldbus platform | linux/amd64 (bench) | **linux/arm64** (native) |
+| Fieldbus tip | `sha-fa83c72` / `fa83c7245942` | `sha-fa83c72` / `fa83c7245942` |
+| MQTTS numeric lines (600s peek) | 10 | 10 |
+| Accumulation parity | ratio≥0.5 **PASS** (counts matched; see OPEN on timestamp span) | same |
+
+Ops notes for soak (gitignored local only): `OPENFDD_SITE_ID=+` via `compose.cloudsim.local.yml`; bench OT `field_devices` from `field_devices.bench.example.toml`; optional `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60` on both edges for denser 10‑minute accumulation.
 
 ## BACnet pcap
 
 | Check | Result |
 |------|--------|
-| Capture tool | `bacnet capture` (rusty-bacnet CLI, `pcap` feature) |
-| Decode / FP scan vs bad_rusty_bacnet_app | _(pending)_ |
+| Capture tool | privileged docker `tcpdump` → pcap; decode via rusty-bacnet `bacnet capture --read … --decode` (host lacks passwordless sudo/`CAP_NET_RAW`) |
+| Capture size | `ot_bench.pcap` ~10.6 KiB / 90s |
+| Decode / FP scan vs bad_rusty_bacnet_app | **PASS** — `whois=0`, `read_property=33`, `ephemeral_whois=0`, findings `[]` |
 
 ## Open findings (future patch cycles)
 
@@ -43,7 +52,10 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 |----|---------|--------|
 | H10 | Large historian quals | **OPEN** |
 | dependabot-thrift | Sticky Dependabot thrift updates fail on master | **OPEN** (non-product) |
-| _(add from soak)_ | | |
+| mqtt-span-parse | Dual MQTT parity `span_s=0` / `n_ts=0` (payload timestamps not parsed; count parity still green) | **OPEN** (gate hardening) |
+| pcap-host-caps | Host `bacnet capture` / `tcpdump` need sudo or CAP_NET_RAW; gate uses privileged docker tcpdump | **OPEN** (ops; documented) |
+| coderabbit-storage | Deferred package-ingest full `OPENFDD_STORAGE_URL` layout items if still open | **OPEN** |
+| lint-sweep | Scoped `#[allow]`/`#[expect]` leftovers outside first hygiene pass | **OPEN** |
 
 ## Hygiene
 
@@ -51,3 +63,4 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 - Do not local `docker build` stack on bensbench — GHCR `sha-*` only.
 - Anti-hardcoding: no private OT IPs in this report.
 - No stale PRs / feature branches after each tiny rev bump.
+- Next product fix → bump `3.3.5` → `3.3.6`, wait GHCR, re-pin both hosts to the same `sha-*`.

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,12 @@
 # Session log
 
+## 2026-08-27 — Patch cycle 3.3.5 CLOSED (dual MQTT + pcap)
+
+- Tip `sha-fa83c72` / `3.3.5+fa83c7245942` on bensbench + bosspi **linux/arm64**.
+- Combined OT/synth **PASS**; dual MQTT 600s **PASS** (lab+bldg2 telemetry, ingest growth); pcap FP scan **PASS** (ReadProperty-heavy, no Who-Is storm).
+- BUG_REPORT filled; gate `11` uses privileged docker tcpdump + `bacnet capture --read --decode` when host lacks CAP_NET_RAW.
+- Artifacts: `reports/patch335_validate_233516/`.
+
 ## 2026-08-27 — Patch cycle start (3.3.5)
 
 - BUG_REPORT blanked for patch cycle starting **3.3.5**.

--- a/scripts/nightly-ot-bench/11_bacnet_pcap_fp_scan.sh
+++ b/scripts/nightly-ot-bench/11_bacnet_pcap_fp_scan.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-# Capture BACnet/IP with rusty-bacnet `bacnet capture` and scan for known anti-patterns
-# from bad_rusty_bacnet_app (FP-1 Who-Is storms, ephemeral broadcast, etc.).
+# Capture BACnet/IP and scan for known anti-patterns from bad_rusty_bacnet_app
+# (FP-1 Who-Is storms, ephemeral broadcast, etc.).
+#
+# Live capture uses privileged docker tcpdump (host often lacks CAP_NET_RAW/sudo),
+# then rusty-bacnet `bacnet capture --read … --decode` for FP heuristics.
 #
 # Env:
-#   OT_NIC              — capture device (default from bench.env / enp3s0)
+#   OT_NIC              — capture device (default enp3s0)
 #   BACNET_CLI          — path to bacnet binary (default: bacnet on PATH)
 #   PCAP_SECONDS        — live capture duration (default: 120)
 #   PCAP_OUT            — output pcap path (default under ARTIFACT_DIR)
+#   PCAP_DOCKER_IMAGE   — image with tcpdump (default: nicolaka/netshoot)
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$DIR/lib.sh"
 load_bench_env
+auth_setup
 cd "$ROOT"
 
 ART="${ARTIFACT_DIR:-$(artifact_dir)}"
@@ -22,34 +27,97 @@ SECS="${PCAP_SECONDS:-120}"
 OUT="${PCAP_OUT:-$ART/ot_bench.pcap}"
 DECODE_LOG="$ART/bacnet_capture_decode.txt"
 FP_LOG="$ART/bacnet_fp_scan.txt"
+ERR="$ART/bacnet_capture_err.txt"
+IMG="${PCAP_DOCKER_IMAGE:-nicolaka/netshoot}"
 
 hdr "BACnet pcap capture + FP scan (rusty-bacnet CLI)"
 
-if ! command -v "$CLI" >/dev/null 2>&1 && [[ ! -x "$CLI" ]]; then
+resolve_cli() {
+  if [[ -x "$CLI" ]]; then
+    echo "$CLI"
+    return 0
+  fi
+  if command -v "$CLI" >/dev/null 2>&1; then
+    command -v "$CLI"
+    return 0
+  fi
+  return 1
+}
+
+if ! CLI_PATH="$(resolve_cli)"; then
   skip "bacnet CLI not found (set BACNET_CLI). Install: https://github.com/jscott3201/rusty-bacnet/releases"
   summary
   exit 0
 fi
 
-echo "${DIM}device=$NIC duration=${SECS}s out=$OUT${RST}"
-# Live capture requires privileges on most hosts.
-if timeout "$SECS" sudo -n "$CLI" capture --device "$NIC" --save "$OUT" --quiet 2>"$ART/bacnet_capture_err.txt"; then
-  ok "pcap saved $OUT ($(wc -c <"$OUT") bytes)"
-elif timeout "$SECS" "$CLI" capture --device "$NIC" --save "$OUT" --quiet 2>"$ART/bacnet_capture_err.txt"; then
-  ok "pcap saved $OUT (no sudo)"
-else
-  bad "bacnet capture failed (need sudo/capabilities?). See bacnet_capture_err.txt"
+echo "${DIM}device=$NIC duration=${SECS}s out=$OUT cli=$CLI_PATH${RST}"
+: >"$ERR"
+rm -f "$OUT"
+
+# Light OT traffic during capture — prefer ReadProperty / poll, not Who-Is spam
+# (Who-Is every 2s would falsely trip FP-1 heuristics).
+traffic_loop() {
+  local end=$((SECONDS + SECS - 1))
+  while (( SECONDS < end )); do
+    fb -X POST "$FIELDBUS_BASE/bacnet/poll/once" -d '{}' >/dev/null 2>&1 || true
+    fb -X POST "$FIELDBUS_BASE/bacnet/read" \
+      -d '{"device_instance":5007,"object_type":"analog-input","object_instance":1173}' \
+      >/dev/null 2>&1 || true
+    sleep 5
+  done
+}
+
+capture_ok=0
+
+# 1) passwordless sudo + bacnet --save
+if timeout "$SECS" sudo -n "$CLI_PATH" capture --device "$NIC" --save "$OUT" --quiet 2>>"$ERR"; then
+  if [[ -s "$OUT" ]]; then
+    capture_ok=1
+    ok "pcap saved via sudo -n bacnet capture"
+  fi
+fi
+
+# 2) privileged docker tcpdump (reliable on this bench without host sudo)
+if [[ "$capture_ok" -eq 0 ]]; then
+  echo "${DIM}trying privileged docker tcpdump…${RST}"
+  OUT_DIR="$(cd "$(dirname "$OUT")" && pwd)"
+  OUT_BASE="$(basename "$OUT")"
+  traffic_loop &
+  TPID=$!
+  # shellcheck disable=SC2064
+  trap "kill $TPID 2>/dev/null || true" EXIT
+  if docker run --rm --privileged --network host \
+    -v "$OUT_DIR:/out" \
+    "$IMG" \
+    sh -c "timeout '$SECS' tcpdump -i '$NIC' -nn -c 5000 'udp port 47808' -w '/out/$OUT_BASE' 2>/out/tcpdump_capture_err.txt; echo tcpdump_rc=\$?" \
+    >>"$ERR" 2>&1; then
+    :
+  fi
+  # tcpdump err already under ART when OUT_DIR == ART
+  if [[ -f "$OUT_DIR/tcpdump_capture_err.txt" && "$OUT_DIR" != "$ART" ]]; then
+    mv -f "$OUT_DIR/tcpdump_capture_err.txt" "$ART/" || true
+  fi
+  kill "$TPID" 2>/dev/null || true
+  wait "$TPID" 2>/dev/null || true
+  trap - EXIT
+  if [[ -s "$OUT" ]]; then
+    capture_ok=1
+    ok "pcap saved via privileged docker tcpdump ($(wc -c <"$OUT") bytes)"
+  fi
+fi
+
+if [[ "$capture_ok" -eq 0 || ! -s "$OUT" ]]; then
+  bad "bacnet/tcpdump capture failed or empty (need sudo/--privileged). See $ERR"
   summary
   exit 1
 fi
 
-"$CLI" capture --read "$OUT" --decode >"$DECODE_LOG" 2>&1 || true
+"$CLI_PATH" capture --read "$OUT" --decode >"$DECODE_LOG" 2>&1 || true
 ok "decode log → $DECODE_LOG ($(wc -l <"$DECODE_LOG") lines)"
 
 # Heuristic FP scan (align with bad_rusty_bacnet_app README FPs).
 python3 - "$DECODE_LOG" "$FP_LOG" <<'PY'
-import re, sys
-from collections import Counter
+import re, sys, json
 log_path, out_path = sys.argv[1], sys.argv[2]
 text = open(log_path, encoding="utf-8", errors="replace").read().splitlines()
 whois = [ln for ln in text if re.search(r"\bWHO_IS\b", ln, re.I)]
@@ -61,7 +129,6 @@ for ln in whois:
     m = re.search(r"->\s+(\d+\.\d+\.\d+\.\d+):(\d+)", ln)
     if m and m.group(2) != "47808":
         ephemeral.append(ln)
-# Burst: many Who-Is relative to ReadProperty (FP-1 / FP-6 style storms)
 ratio = (len(whois) / max(len(rp), 1))
 findings = []
 if len(ephemeral) >= 3:
@@ -79,7 +146,6 @@ report = {
     "findings": findings,
     "ok": len(findings) == 0,
 }
-import json
 open(out_path, "w", encoding="utf-8").write(json.dumps(report, indent=2) + "\n")
 print(json.dumps(report))
 sys.exit(0 if report["ok"] else 2)


### PR DESCRIPTION
## Summary
- Fill `BUG_REPORT` + agent `SESSION_LOG` for patch cycle **3.3.5** / `sha-fa83c72` (combined OT/synth, dual MQTT 600s, pcap FP scan all green on bensbench + bosspi arm64).
- Harden nightly gate `11_bacnet_pcap_fp_scan.sh`: privileged docker `tcpdump` → pcap, then rusty-bacnet `bacnet capture --read --decode` + FP heuristics (host has no passwordless sudo/CAP_NET_RAW).

## Test plan
- [x] `combined_ot_synth_validate.sh` PASS (`reports/patch335_validate_233516`)
- [x] `DUAL_MQTT_WAIT_SECS=600 ./scripts/nightly-ot-bench/10_dual_mqtt_signoff.sh` PASS
- [x] `PCAP_SECONDS=90 ./scripts/nightly-ot-bench/11_bacnet_pcap_fp_scan.sh` PASS (FP findings empty)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved BACnet packet-capture validation, including more reliable capture, decoding, and false-positive scanning.
  - Added fallback handling to support environments where standard capture access is unavailable.

- **Documentation**
  - Updated patch validation records with MQTT, BACnet, weather, health, and dual-site verification results.
  - Documented capture procedures, generated artifacts, operational findings, and follow-up hygiene actions.
  - Added a completed patch-cycle session entry covering validation outcomes and operational notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->