### PR TITLE
docs(ops): close 3.3.6 patch cycle — dual MQTT + BUILDING_100 UI

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,7 +1,7 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** _(fill after tip soak)_  
-**Platform:** `3.3.6` / `sha-_______` _(pin after GHCR publish)_  
+**Date:** 2026-08-28  
+**Platform:** `3.3.6` / `sha-aac593c`  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR`)  
 **Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (`linux/arm64`)
 
@@ -11,39 +11,52 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 | Host | Role | Image ref | nightly↔sha | OCI revision | `/health` version |
 |------|------|-----------|-------------|--------------|-------------------|
-| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-_______` | | | |
-| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-_______` **linux/arm64** | | | |
+| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-aac593c` | explicit pin (not sticky nightly) | `aac593c19833` | `3.3.6+aac593c19833` |
+| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-aac593c` **linux/arm64** | matches bench pin | `aac593c19833` | fieldbus `/health` ok |
 
-Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without digest check.
+Prefer `OPENFDD_IMAGE_TAG=sha-aac593c` — do not trust sticky `:nightly` without digest check.
+
+GHCR publish: workflow run **33186905614** success for merge `aac593c` (#793).
 
 ## Confirmed PASS
 
 | Gate / check | Result |
 |------|--------|
-| _(blank — fill after dual MQTT / synthetic / pcap / UI smoke)_ | |
+| `combined_ot_synth_validate.sh` | **PASS** — BACnet OT, MQTT persist, Modbus, Haystack, suspend/resume, synthetic CSV bulk |
+| `07_cloud_sim.sh` | **PASS** — multi-site central `OPENFDD_SITE_ID=+`, Pi arm64 edge 600000, Who-Is 599999+600000 |
+| `10_dual_mqtt_signoff.sh` (600s, retry after Pi `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60`) | **PASS** — rev match, lab+bldg2 telemetry, count+span parity, ingest growth |
+| `11_bacnet_pcap_fp_scan.sh` | **PASS** — docker tcpdump + rusty-bacnet decode; 30 ReadProperty, no FP storm |
+| UI smoke BUILDING_100 | **PASS** — JWT login; analytics POSTs + immediate `/api/actions` HTTP 200 (no 401); FC1 `/api/fdd/series` ok (5000 rows, roles mapped); RCx economizer 4000 points |
+| Stack left running | **PASS** — react-ot + Pi edge on `sha-aac593c` |
+| Closeout live MQTT peek (~90s) | **PASS** — lab + bldg2 numeric telemetry both present (`reports/patch336_live_205929/`) |
+| Container health closeout | **PASS** — central/fieldbus healthy; both edges `has_telemetry=true`; 0 open PRs / no `feat/*`\|`fix/*` remotes |
+
+Artifacts: `reports/patch336_20260828_201214/` (+ live peek `reports/patch336_live_205929/`).
 
 ## Dual-site MQTT (lab + bldg2)
 
 | Check | lab / fieldbus-1 | bldg2 / pi-1 |
 |-------|------------------|--------------|
-| Fieldbus platform | | |
-| Fieldbus tip | | |
-| Ingest / telemetry span | | |
+| Fieldbus platform | bench amd64 | **linux/arm64** |
+| Fieldbus tip | `sha-aac593c` / `aac593c19833` | same OCI rev |
+| Ingest / telemetry span | 10 msgs / 540s span | 10 msgs / 540s span (after Pi 60s publish interval) |
+
+Note: first dual-MQTT attempt failed count parity (lab 10 vs bldg2 2) because Pi edge lacked `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60`; fixed in `compose.edge.local.yml` on bosspi before retry.
 
 ## BUILDING_100 UI (FDD Plots / Actions)
 
 | Check | Result |
 |------|--------|
-| Overview → Actions while analytics running | _(pending)_ |
-| FDD Plots AHU_1 / FC1 | _(pending)_ |
-| RCx economizer regression | _(pending)_ |
+| Overview → Actions while analytics running | **PASS** — `/api/actions` 200 during parallel analytics POSTs |
+| FDD Plots AHU_1 / FC1 | **PASS** — `GET /api/fdd/series?equipment_id=AHU_1&rule_id=FC1&building_id=BUILDING_100` ok, 5000 rows, no unmapped roles |
+| RCx economizer regression | **PASS** — `/api/analytics/economizer` rows=2, points=4000 |
 
 ## BACnet pcap
 
 | Check | Result |
 |------|--------|
 | Capture tool | privileged docker `tcpdump` + rusty-bacnet decode |
-| Decode / FP scan vs bad_rusty_bacnet_app | _(pending)_ |
+| Decode / FP scan vs bad_rusty_bacnet_app | **PASS** — 30 ReadProperty, 0 Who-Is storm / ephemeral broadcast findings |
 
 ## Open findings (future patch cycles)
 
@@ -54,6 +67,7 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 | issue-763-ml | Engineering bundle phases 2–8 (ML features, splits, UI rename) | **OPEN** |
 | coderabbit-storage | Deferred package-ingest full `OPENFDD_STORAGE_URL` layout | **OPEN** |
 | lint-sweep | Remaining allow/expect outside scoped pass | **OPEN** |
+| gate10-pi-mqtt-interval | `07_cloud_sim` should set `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60` on Pi edge by default (bench local override already has it) | **OPEN** (ops doc only this cycle) |
 
 ## Hygiene
 

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,14 @@
 # Session log
 
+## 2026-08-28 — Patch cycle 3.3.6 CLOSED
+
+- Tip `sha-aac593c` / `3.3.6+aac593c19833` on bensbench + bosspi **linux/arm64**.
+- Combined OT/synth **PASS**; cloud-sim **PASS**; dual MQTT 600s **PASS** (after Pi `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60`); pcap FP scan **PASS**.
+- UI smoke **PASS**: Actions during analytics (no 401); BUILDING_100 FC1 series 5000 rows; RCx economizer regression green.
+- Closeout re-check: live MQTT peek lab+bldg2 numeric **PASS**; containers healthy; GH tidy (0 open PRs, no stale remotes).
+- BUG_REPORT filled; stack left running on `sha-aac593c`.
+- Artifacts: `reports/patch336_20260828_201214/` + `reports/patch336_live_205929/`.
+
 ## 2026-08-28 — Patch cycle start (3.3.6)
 
 - BUG_REPORT blanked for patch cycle starting **3.3.6**.


### PR DESCRIPTION
## Summary
- Fill `BUG_REPORT_OT_MODBUS_HAYSTACK.md` with tip `sha-aac593c` / `3.3.6` soak evidence (combined OT+synth, cloud-sim, dual MQTT 600s, pcap FP, BUILDING_100 UI smoke).
- SESSION_LOG closeout note; live dual MQTT re-check documented.
- Stacks intentionally left running on matched bench + bosspi arm64 pins.

## Test plan
- [x] Prior gates already green under `reports/patch336_20260828_201214/`
- [x] Live MQTT peek lab+bldg2 numeric telemetry
- [x] Containers healthy; 0 open PRs / no stale remotes at closeout
- [ ] Docs-only review — no product code change


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized the platform 3.3.6 bug report with validation results covering MQTT, user interface, BACnet, and deployment checks.
  * Added a session log documenting completion of the 3.3.6 patch cycle and successful verification across supported environments.
  * Recorded a Raspberry Pi MQTT publish-interval finding for consideration in a future maintenance update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->