### PR TITLE
docs(ops): close 3.3.7 patch cycle — dual MQTT + BUG_REPORT

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,7 +1,7 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** _(fill after tip soak)_  
-**Platform:** `3.3.7` / `sha-_______` _(pin after GHCR publish)_  
+**Date:** 2026-08-29  
+**Platform:** `3.3.7` / `sha-3395551` (`3.3.7+33955515540e`)  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR`)  
 **Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (`linux/arm64`)
 
@@ -11,8 +11,8 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 | Host | Role | Image ref | nightly↔sha | OCI revision | `/health` version |
 |------|------|-----------|-------------|--------------|-------------------|
-| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-_______` | | | |
-| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-_______` **linux/arm64** | | | |
+| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-3395551` | fieldbus digest match | `33955515540e` | central `3.3.7+33955515540e` |
+| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-3395551` **linux/arm64** | same tip | `33955515540e` | fieldbus ok; `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60` |
 
 Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without digest check.
 
@@ -20,30 +20,34 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 
 | Gate / check | Result |
 |------|--------|
-| _(blank — fill after dual MQTT / synthetic / pcap / UI smoke)_ | |
+| Combined OT + synth-59 health-matrix | **PASS** (BACnet 15/15 after bench `field_devices` restore; MQTT ingest live; synth 0 fails) |
+| Cloud-sim `07` (Pi tip + env instance 600000) | **PASS** (23 pass / 0 fail; override logs `mqtt_publish_interval=60`) |
+| Dual MQTT 600s | **PASS** (lab+bldg2 numeric 10/10, span≈540s, ratio≥0.5; ingest 25→45) |
+| BACnet pcap FP scan | **PASS** (ReadProperty-heavy, no Who-Is storm) |
+| BUILDING_100 UI smoke | **PASS** (Actions no 401; analytics; RCx economizer; FC1 series ok/0 pts WARN) |
 
 ## Dual-site MQTT (lab + bldg2)
 
 | Check | lab / fieldbus-1 | bldg2 / pi-1 |
 |-------|------------------|--------------|
-| Fieldbus platform | | |
-| Fieldbus tip | | |
-| Ingest / telemetry span | | |
+| Fieldbus platform | linux/amd64 (bench) | linux/arm64 |
+| Fieldbus tip | `sha-3395551` / `33955515540e` | `sha-3395551` / `33955515540e` |
+| Ingest / telemetry span | MQTTS 10 numeric / ~540s | MQTTS 10 numeric / ~540s (parity **without** hand-edit — baked in `07_cloud_sim`) |
 
 ## BUILDING_100 UI (FDD Plots / Actions)
 
 | Check | Result |
 |------|--------|
-| Overview → Actions while analytics running | _(pending)_ |
-| FDD Plots AHU_1 / FC1 | _(pending)_ |
-| RCx economizer regression | _(pending)_ |
+| Overview → Actions while analytics running | **PASS** (200, no 401) |
+| FDD Plots AHU_1 / FC1 | **PASS** API (`ok`); series points=0 WARN (same as prior tip when empty window) |
+| RCx economizer regression | **PASS** (200, rows=2, points=4000) |
 
 ## BACnet pcap
 
 | Check | Result |
 |------|--------|
 | Capture tool | privileged docker `tcpdump` + rusty-bacnet decode |
-| Decode / FP scan vs bad_rusty_bacnet_app | _(pending)_ |
+| Decode / FP scan vs bad_rusty_bacnet_app | **PASS** (`read_property=32`, `whois=0`, findings=[]) |
 
 ## Open findings (future patch cycles)
 
@@ -54,6 +58,7 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 | issue-763-ml | Engineering bundle phases 2–8 (ML features, splits, UI rename) | **OPEN** |
 | coderabbit-storage | Deferred package-ingest full `OPENFDD_STORAGE_URL` layout | **OPEN** |
 | lint-sweep | Remaining allow/expect outside scoped pass | **OPEN** |
+| bench-field-devices | Tip checkout resets committed example `field_devices.toml`; restore from local overlay before OT poll gates | **OPEN** (ops hygiene) |
 
 ## Hygiene
 
@@ -61,4 +66,6 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 - Do not local `docker build` stack on bensbench — GHCR `sha-*` only.
 - Anti-hardcoding: no private OT IPs in this report.
 - No stale PRs / feature branches after each tiny rev bump.
+- Product fix this cycle: gate10-pi-mqtt-interval closed via `07_cloud_sim` Pi override bake (#795).
 - Next product fix → bump `3.3.7` → `3.3.8`, wait GHCR, re-pin both hosts to the same `sha-*`.
+- Artifacts: `reports/patch337_20260829_020507/`. Stacks left running on `sha-3395551`.

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,14 @@
 # Session log
 
+## 2026-08-29 — Patch cycle 3.3.7 CLOSED
+
+- Tip `sha-3395551` / `3.3.7+33955515540e` on bensbench + bosspi **linux/arm64**.
+- Product: bake `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60` into `07_cloud_sim` Pi override (#795) — closes gate10-pi-mqtt-interval.
+- Combined OT/synth **PASS**; cloud-sim **PASS** (`mqtt_publish_interval=60`); dual MQTT 600s **PASS** (lab=bldg2=10 numeric, span≈540s, no hand-edit); pcap FP scan **PASS**.
+- UI smoke **PASS**: Actions during analytics (no 401); RCx economizer green; FC1 series API ok.
+- GH tidy: 0 open PRs, no stale `feat|fix` remotes. Stack left running on `sha-3395551`.
+- Artifacts: `reports/patch337_20260829_020507/`.
+
 ## 2026-08-28 — Patch cycle start (3.3.7)
 
 - BUG_REPORT blanked for patch cycle starting **3.3.7**.


### PR DESCRIPTION
## Summary
- Fill `BUG_REPORT_OT_MODBUS_HAYSTACK.md` for tip `sha-3395551` / `3.3.7+33955515540e`.
- SESSION_LOG: 3.3.7 CLOSED (combined, cloud-sim with baked MQTT 60s, dual MQTT parity, pcap, UI smoke).

## Test plan
- [x] Dual MQTT 600s PASS lab=bldg2 without Pi hand-edit
- [x] Stacks left running; no product code in this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the operations bug report with verified results for release 3.3.7 across image validation, MQTT, UI, BACnet, and health checks.
  * Added patch-cycle closeout details, test metrics, artifact locations, and environment status to the session log.
  * Documented the 60-second MQTT publishing configuration and closure of the related validation finding.
* **Verification**
  * Recorded successful dual-site MQTT, cloud simulation, UI smoke, packet-capture, and combined OT/synthetic tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->