### PR TITLE
docs(ops): close 3.3.8 patch cycle (sha-9667888)

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,9 +1,10 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** _(fill after tip soak)_  
-**Platform:** `3.3.8` / `sha-_______` _(pin after GHCR publish)_  
+**Date:** 2026-08-29  
+**Platform:** `3.3.8` / `sha-9667888` (`3.3.8+96678888d875`)  
 **Host:** low-RAM GHCR-only bench (`OPENFDD_QUERY_MEMORY_MB=256`, `OPENFDD_DATAFUSION_SPILL_DIR`)  
-**Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (`linux/arm64`)
+**Remote edge:** bosspi (`CLOUD_SIM_PI_SSH` in bench env) — fieldbus only (`linux/arm64`)  
+**Artifacts:** `reports/patch338_20260829T152852Z/`
 
 Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `bench.env.local`.
 
@@ -14,8 +15,8 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 | Host | Role | Image ref | nightly↔sha | OCI revision | `/health` version |
 |------|------|-----------|-------------|--------------|-------------------|
-| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-_______` | | | |
-| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-_______` **linux/arm64** | | | |
+| bensbench | central / fieldbus / mqtt / web | `ghcr.io/bbartling/openfdd-*:sha-9667888` | match (digest equal) | `96678888d875…` | `3.3.8+96678888d875` |
+| bosspi | fieldbus edge only | `openfdd-fieldbus:sha-9667888` **linux/arm64** | tip rev match | `96678888d875…` | fieldbus healthy |
 
 Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without digest check.
 
@@ -23,38 +24,46 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 
 | Gate / check | Result |
 |------|--------|
-| _(blank — fill after dual MQTT / synthetic / pcap / UI smoke)_ | |
+| `00_pull_ghcr_up` react-ot | **PASS** — pin `sha-9667888` |
+| `01_health_gates` | **PASS** |
+| `combined_ot_synth_validate` | **PASS** (OT Who-Is/RP/poll + MQTT ingest + Modbus + Haystack + synth matrix) |
+| `07_cloud_sim` (Pi) | **PASS** — Pi `mqtt_publish_interval=60`, multi-site edges lab+bldg2 |
+| `10_dual_mqtt_signoff` `DUAL_MQTT_WAIT_SECS=600` | **PASS** |
+| `11_bacnet_pcap_fp_scan` | **PASS** — clean FP scan |
+| BUILDING_100 UI smoke | **PASS** — Actions during analytics; economizer/runtime/mech-cool/bas-vs-web-oat; FDD series FC1 (5000 overlay hits); SPA `/` `/actions` `/plot` |
 
 ## Dual-site MQTT (lab + bldg2)
 
 | Check | lab / fieldbus-1 | bldg2 / pi-1 |
 |-------|------------------|--------------|
-| Fieldbus platform | | |
-| Fieldbus tip | | |
-| Ingest / telemetry span | | |
+| Fieldbus platform | linux/amd64 (bench) | linux/arm64 (Pi) |
+| Fieldbus tip | `sha-9667888` rev `96678888d875` | `sha-9667888` rev `96678888d875` |
+| Ingest / telemetry span | 10 numeric lines, span≈540s | 10 numeric lines, span≈540s |
+| Edges after dual wait | `has_telemetry=true` | `has_telemetry=true` |
+| Ingest after dual | `ingest_ok` 39→59 (no dup/reject) | (same central) |
 
 ## BUILDING_100 UI (FDD Plots / Actions)
 
 | Check | Result |
 |------|--------|
-| Overview → Actions while analytics running | _(pending)_ |
-| FDD Plots AHU_1 / FC1 | _(pending)_ |
-| RCx economizer regression | _(pending)_ |
+| Overview → Actions while analytics running | **PASS** (HTTP 200, no 401) |
+| FDD Plots AHU_1 / FC1 | **PASS** (`/api/fdd/series?rule_id=FC1`, 5000 overlay hits) |
+| RCx economizer / runtime / mech-cool / bas-vs-web-oat | **PASS** |
 
 ## BACnet pcap
 
 | Check | Result |
 |------|--------|
 | Capture tool | privileged docker `tcpdump` + rusty-bacnet decode |
-| Decode / FP scan vs bad_rusty_bacnet_app | _(pending)_ |
+| Decode / FP scan vs bad_rusty_bacnet_app | **PASS** — `whois=0`, `ephemeral_whois=0`, `read_property=32`, findings=[] |
 
-## This cycle (3.3.8) — in flight
+## This cycle (3.3.8) — CLOSED
 
-| ID | Finding | Notes |
-|----|---------|--------|
-| coderabbit-storage | Package-ingest / analytics ignore `OPENFDD_STORAGE_URL` | Prefer storage URL over legacy `OPENFDD_PARQUET_ROOT` |
-| bench-field-devices | Tip checkout resets OT `field_devices.toml` | Auto-restore from `.local` / bench example before OT gates |
-| railway-web-resolver | Railway web crash: `invalid port in resolver "fd12::10"` | Bracket IPv6 / prefer IPv4 in `OPENFDD_NGINX_RESOLVER=auto` |
+| ID | Finding | Resolution |
+|----|---------|------------|
+| coderabbit-storage | Package-ingest / analytics ignored `OPENFDD_STORAGE_URL` | **CLOSED** — `fdd_store::local_file_root_from_env()` prefers `OPENFDD_STORAGE_URL` (#797) |
+| bench-field-devices | Tip checkout resets OT `field_devices.toml` | **CLOSED** — `ensure_bench_field_devices()` in nightly lib + combined preflight (#797) |
+| railway-web-resolver | Railway web crash: bare IPv6 resolver `fd12::10` | **CLOSED in tip image** — nginx entrypoint brackets IPv6 / prefers IPv4 (#797). **Operator:** re-pin Railway central/mqtt/web to `sha-9667888`, set `OPENFDD_NGINX_RESOLVER=auto` (clear interim `[fd12::10]`), verify public SPA + `/api/health` |
 
 ## Open findings (deferred — future cycles)
 
@@ -72,4 +81,5 @@ Prefer `OPENFDD_IMAGE_TAG=sha-<7>` — do not trust sticky `:nightly` without di
 - Anti-hardcoding: no private OT IPs in this report.
 - No stale PRs / feature branches after each tiny rev bump.
 - This report is **open-fdd only** (not vibe_code_apps_13).
+- Railway hub re-pin to tip is operator/CLI follow-up (no `RAILWAY_TOKEN` on bensbench this cycle).
 - Next product fix after 3.3.8 closeout → bump `3.3.8` → `3.3.9`, wait GHCR, re-pin both hosts to the same `sha-*`.

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,15 @@
 # Session log
 
+## 2026-08-29 — Patch cycle 3.3.8 CLOSED
+
+- Tip `sha-9667888` / `3.3.8+96678888d875` on bensbench + bosspi **linux/arm64**.
+- Product: `OPENFDD_STORAGE_URL` for package-ingest/analytics roots; bench `field_devices` auto-restore; Railway web nginx IPv6 resolver bracket (#797).
+- Combined OT/synth **PASS**; cloud-sim **PASS**; dual MQTT 600s **PASS** (lab=bldg2=10 numeric, span≈540s); pcap FP scan **PASS**.
+- UI smoke **PASS**: Actions during analytics; RCx economizer/runtime/mech-cool/bas-vs-web-oat; FDD series FC1 (5000 overlay hits); SPA routes.
+- GH tidy: 0 open PRs, no stale `feat|fix` remotes; Publish GHCR **success**. Stack left running on `sha-9667888`.
+- Railway: tip image ships resolver fix — operator re-pin hub to `sha-9667888` + `OPENFDD_NGINX_RESOLVER=auto` (CLI token not on host this cycle).
+- Artifacts: `reports/patch338_20260829T152852Z/`.
+
 ## 2026-08-29 — Patch cycle start (3.3.8)
 
 - BUG_REPORT blanked for patch cycle starting **3.3.8**.


### PR DESCRIPTION
## Summary
- Fill `BUG_REPORT_OT_MODBUS_HAYSTACK.md` for tip `sha-9667888` / `3.3.8` soak (combined, dual MQTT, pcap, BUILDING_100 UI).
- SESSION_LOG **CLOSED** for 3.3.8; note Railway hub re-pin is operator follow-up.

## Test plan
- [x] Bench+Pi already soaked on `sha-9667888` (artifacts `reports/patch338_20260829T152852Z/`)
- [ ] Docs Pages CI green after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Completed the 3.3.8 operational bug report with platform details, artifact references, validation results, and measured test outcomes.
  - Closed and documented three tracked findings, including their resolutions.
  - Added deployment hygiene guidance for a required Railway follow-up.
  - Added a session log entry covering the 3.3.8 patch cycle, test results, deployment instructions, and artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->