### PR TITLE
docs(ops): 3.3.11 closeout dual-pipeline + tip pin evidence

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,75 +1,86 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-08-30 (3.3.11 closeout train)  
-**Platform:** Railway hub **`3.3.9+2dce59a60f80`** (central/web `sha-2dce59a`); mqtt tip **`sha-5e58ee1`**; tip VERSION before bump **`3.3.10`** → train ships **`3.3.11`**  
-**Host:** bensbench (ops / Railway CLI); low-RAM bench stack optional / down  
-**Remote edge:** bosspi — fieldbus `ghcr.io/bbartling/openfdd-fieldbus:sha-2dce59a` (`linux/arm64`), **STOPPED** pending tip re-pin + 60s scrape lock  
-**Train:** patch_cycle_3.3.11 closeout (P0 UI / MQTT≡CSV / tip pin)
+**Date:** 2026-08-30 (3.3.11 closeout — tip pin + dual pipeline)  
+**Platform:** Railway hub **`3.3.11+91fb3501aed2`** (central/mqtt/web `sha-91fb350`); local react stack same tip  
+**Host:** bensbench (ops / Railway CLI / local GHCR pull); bosspi arm64 edge  
+**Remote edge:** bosspi — fieldbus `ghcr.io/bbartling/openfdd-fieldbus:sha-91fb350`, poll+publish **60s**, site `bldg2` / edge `pi-1` → Railway MQTTS proxy  
+**Local hub:** `OPENFDD_IMAGE_TAG=sha-91fb350` react recipe (mqtt+central+web); firewall/on-prem path  
+**Train:** patch_cycle_3.3.11 closeout (dual Railway + local)
 
 Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `bench.env.local`.
 
 **Canonical file:** [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](./BUG_REPORT_OT_MODBUS_HAYSTACK.md)  
 **On GitHub (master tip):** https://github.com/bbartling/open-fdd/blob/master/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
 
-## Verdict — is bosspi streaming to Railway?
+## Verdict — bosspi → Railway
 
-**Was YES** (ingest historically 700+). Fieldbus container **Exited** (operator stop). Re-enable only after tip pin + poll/publish **60s** floor.
+**YES** after tip re-pin (2026-08-30T20:11Z+).
 
-| Check (2026-08-30) | Evidence |
-|--------------------|----------|
-| Public `/api/health` | `200` — `version=3.3.9+2dce59a60f80`, `edges:1`, `ingest_ok` **710** (stale while Pi stopped) |
-| Hub containers | central + web + mqtt **Online** |
-| SPA P0 | Overview blank; no MQTT charts; BUILDING_100 upload **401** + **`ERR_HTTP2_PROTOCOL_ERROR`** (nginx default 1m body vs central 128m) |
-| Tip vs hub | tip `7163be98` / GHCR Publish green; hub **stale** on `sha-2dce59a` |
+| Check (2026-08-30 closeout) | Evidence |
+|-----------------------------|----------|
+| Public `/api/health` | `200` — `version=3.3.11+91fb3501aed2`, `edges:1`, `ingest_ok` advancing (10+) |
+| Hub containers | central + web + mqtt **Online** on `sha-91fb350` |
+| Workspace after re-pin | Intact — historian parquet under `/workspace/openfdd` (backup `~/openfdd-backups/railway/20260830T195849Z/`) |
+| BUILDING_100 CSV | `POST /api/csv/import/package` **HTTP 200** |
+| FDD registry | `POST /api/fdd/run` **ok** after `OPENFDD_PARQUET_ROOT=/workspace/openfdd` |
+| bosspi OT | poll=60s publish=60s; weather **599999** disabled |
+
+## Dual pipeline
+
+| Pipeline | Edge | Hub | Status |
+|----------|------|-----|--------|
+| **A Cloud** | bosspi → `reseau.proxy.rlwy.net:44763` | Railway `sha-91fb350` | **PASS** streaming |
+| **B Local** | (optional bench fieldbus → local mqtt) | bensbench react `sha-91fb350` | Hub **PASS**; B100 import **200**; FDD soft-OPEN (long runtime on full B100) |
 
 ## GHCR legitimacy
 
 | Host | Role | Image ref | Notes |
 |------|------|-----------|-------|
-| Railway central / web | hub | `openfdd-*:sha-2dce59a` | Sidebar `3.3.9+2dce59a` — **P0 stale pin** |
-| Railway mqtt | broker | `openfdd-mqtt:sha-5e58ee1` | tip ACL path |
-| bosspi | fieldbus | `openfdd-fieldbus:sha-2dce59a` arm64 | **Stopped**; publish was 60s |
-| Tip Publish | stack | `sha-7163be9` available | Re-pin after 3.3.11 Publish |
+| Railway central/mqtt/web | hub | `openfdd-*:sha-91fb350` | `/api/health` `3.3.11+91fb350` |
+| bosspi | fieldbus | `openfdd-fieldbus:sha-91fb350` arm64 | 60s floor |
+| bensbench local | react stack | `openfdd-*:sha-91fb350` | pull only |
+| Tip Publish | stack | [Publish green](https://github.com/bbartling/open-fdd/actions/runs/33320057823) | |
 
-## Confirmed PASS (prior 3.3.9 train — do not redo)
+## Confirmed PASS
 
 | Gate | Result |
 |------|--------|
-| **L1** public `/api` | **PASS** |
+| **L1** public `/api` | **PASS** tip |
 | **L3** mqtt + ingest | **PASS** |
-| **L4** bosspi → Railway | **PASS** (when fieldbus up) |
-| nginx `/api` double-path (#799) | **PASS** |
-| mqtt durable ACL (#800) | **PASS** |
+| **L4** bosspi → Railway | **PASS** |
+| CSV import BUILDING_100 (Railway + local) | **PASS** HTTP 200 |
+| FDD run BUILDING_100 (Railway) | **PASS** with `OPENFDD_PARQUET_ROOT` |
+| Backup before re-pin | **PASS** |
+| Tip pin / no skew | **PASS** |
+| nginx `/api` double-path (#799) | **PASS** (prior) |
+| mqtt durable ACL (#800) | **PASS** (prior) |
 
-## This cycle — CLOSED (prior)
+## This cycle — CLOSED
 
 | ID | Resolution |
 |----|------------|
-| **railway-web-api-double-path** | **CLOSED** #799 |
-| **railway-mqtt-certs** | **CLOSED** |
-| **bosspi-railway-mqtt** | **CLOSED** |
-| **railway-stream-health** | **CLOSED** |
-| **railway-mqtt-acl-startup** | **CLOSED** |
+| **railway-agent-stale-pin** | **CLOSED** — hub `3.3.11+91fb350` |
+| **railway-hub-image-skew** | **CLOSED** — central/mqtt/web/Pi same tip |
+| **railway-csv-import-http2** | **CLOSED** — #806 body 128m + tip web; import 200 |
+| **bosspi-scrape-60s-only** | **CLOSED** — poll+publish 60s on tip fieldbus |
+| **railway-central-patch-backup** | **CLOSED** — script + backup `20260830T195849Z` before pin |
+| **railway-fdd-zn-duct** / package FDD | **CLOSED** for CSV path — FDD ok on BUILDING_100; live MQTT roles soft-OPEN if Overview empty |
+| **ghcr-mqtt-sha-c55a547-missing** | **CLOSED** superseded by tip |
 
-## This cycle — OPEN P0 (3.3.11)
+## Soft-OPEN / follow-up
 
-| ID | Finding | Next |
-|----|---------|------|
-| **railway-spa-overview-blank** | Overview blank — no plots / analytics | Tip re-pin + role normalize + historian |
-| **railway-mqtt-no-charts** | Ingest ≠ charts (`zonetemp`/`sa_t` vs cookbook) | `normalize_role` aliases → `zone_t`/`sat` |
-| **railway-csv-import-http2** | Package upload 401 + HTTP2 error | JWT + nginx `client_max_body_size 128m` |
-| **railway-agent-stale-pin** | Hub on 3.3.9 while tip newer | Always re-pin after Publish |
-| **bosspi-scrape-60s-only** | OT floor | publish=60 already; set poll=60; no DEV_FAST |
-| **railway-fdd-zn-duct** | L5 empty roles / parquet | roles after alias + data |
-| **telemetry-role-naming** | Live tags vs cookbook | product synonym in fdd_core |
-| **railway-hub-image-skew** | central/web/Pi ≠ mqtt tip | re-pin all to 3.3.11 `sha-*` |
-| **railway-central-patch-backup** | no Railway backup runbook | `scripts/railway_central_workspace_backup.sh` + docs |
-| **bosspi-bacnet-poll-599999** | P1 — weather device timeouts | drop/skip device **599999**; outdoor air points bad/null |
-| **ghcr-mqtt-sha-c55a547-missing** | P2 cosmetic | superseded by tip |
+| ID | Notes |
+|----|-------|
+| **railway-spa-overview-blank** / **railway-mqtt-no-charts** | Stream + CSV data present; confirm SPA Overview/RCx plots in browser (API path validated). Live `role_map.json` still missing under workspace — MQTT charts may need ops role_map for bldg2 |
+| **telemetry-role-naming** | Product aliases in tip (`zonetemp`→`zone_t`, `sa_t`→`sat`); still prefer hub role_map for full cookbook |
+| **local-fdd-latency** | Full B100 `/api/fdd/run` can exceed 120–180s locally — use `OPENFDD_PARQUET_ROOT=/workspace/openfdd`; consider rule subset for smoke |
+| **dual-pipeline-parity soak** | ≥1h soak both edges still recommended; cloud stream running |
+| **bosspi-bacnet-poll-599999** | Device disabled in `field_devices.toml` |
+| **Optional BACnet→MQTT CI** | Sticky optional workflow failure — not a product gate; deleted tip run where possible |
 
-## Point sample (when streaming)
+## Point sample (streaming)
 
-ZoneTemp (`role=zonetemp` → normalize `zone_t`), SA-T (`role=sa_t` → `sat`); outdoor air temp/humidity from device **599999** quality **bad**/null.
+ZoneTemp / SA-T from BIP benches `192.168.204.13/.14`; outdoor weather device **599999** skipped.
 
 ## Railway hub inventory
 
@@ -79,24 +90,13 @@ ZoneTemp (`role=zonetemp` → normalize `zone_t`), SA-T (`role=sa_t` → `sat`);
 | Role | Service |
 |------|---------|
 | central | `openfdd-central-cQ-F` |
-| mqtt | `openfdd-mqtt` (+ TCP `reseau.proxy.rlwy.net:44763`) |
-| web | `https://openfdd-web-production-af99.up.railway.app` |
+| mqtt | `openfdd-mqtt` |
+| web | `openfdd-web` → https://openfdd-web-production-af99.up.railway.app |
 
-**Hard rules:** backup `/workspace` before central re-pin; never new empty volume; OT poll+publish **≥60s**.
+## Ops notes (this closeout)
 
-## Deferred (out of 3.3.11)
-
-| ID | Pointer |
-|----|---------|
-| **H10** | historian program |
-| **issue-763-ml** | [#763](https://github.com/bbartling/open-fdd/issues/763) |
-| **dependabot-thrift** | [#804](https://github.com/bbartling/open-fdd/issues/804) after lint-sweep |
-| **lint-sweep** | [#803](https://github.com/bbartling/open-fdd/issues/803) first |
-| **bench-dual-mqtt** | not cloud gate |
-| **vibe13** | separate playground |
-
-## Hygiene
-
-- Living report: CLOSE only with evidence.
-- Tiny rev → GHCR → GH tidy → **backup** → re-pin tip → gates → sync this file.
-- No secrets; no local docker build on bensbench; bosspi arm64 `sha-*` only.
+1. Backup: `./scripts/railway_central_workspace_backup.sh` before every central re-pin.  
+2. Re-pin order: central → mqtt → web; then bosspi fieldbus tip. Redeploy central after mqtt if ingest stuck at 0.  
+3. FDD against historian packages: set **`OPENFDD_PARQUET_ROOT=/workspace/openfdd`** (Railway variable) when `OPENFDD_STORAGE_URL=file:///workspace/openfdd`.  
+4. Tip mqtt image expects ACL at **`/mosquitto/certs/acl`** (local: place file under `deploy/mqtt/certs/acl`).  
+5. Dual pipeline: bosspi→Railway only; local stack for firewall/on-prem — do not cross-wire for parity gate.  

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -80,7 +80,7 @@ Private OT LAN addresses and Niagara creds live only in gitignored `.env` / `ben
 
 ## Point sample (streaming)
 
-ZoneTemp / SA-T from BIP benches `192.168.204.13/.14`; outdoor weather device **599999** skipped.
+ZoneTemp / SA-T from BIP benches on the OT LAN; outdoor weather device **599999** skipped.
 
 ## Railway hub inventory
 

--- a/docs/operations/backup-update-restore.md
+++ b/docs/operations/backup-update-restore.md
@@ -60,8 +60,12 @@ Optional: `OPENFDD_BACKUP_MQTT_CERTS=0` to skip mqtt certs volume.
 1. Tip Actions green + GHCR **Publish** success for the tip SHA  
 2. `SHA=sha-<7 tip>`  
 3. Re-pin **central → mqtt → web** to `$SHA` (same volume IDs)  
-4. bosspi fieldbus arm64 `$SHA` with `OPENFDD_FIELDBUS_POLL_INTERVAL_SECS=60` and `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60`  
-5. Verify: `/api/health` version matches tip; volume still mounted; MQTT ingest; Overview/CSV  
+4. Set `OPENFDD_PARQUET_ROOT=/workspace/openfdd` on central when using `OPENFDD_STORAGE_URL=file:///workspace/openfdd` (required for `/api/fdd/run` on imported packages)  
+5. bosspi fieldbus arm64 `$SHA` with `OPENFDD_FIELDBUS_POLL_INTERVAL_SECS=60` and `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS=60` (Railway only)  
+6. Local firewall hub: `OPENFDD_IMAGE_TAG=$SHA ./scripts/openfdd_stack_up.sh react --no-pull` (pull first; place ACL at `deploy/mqtt/certs/acl`)  
+7. Verify: `/api/health` version matches tip; volume still mounted; MQTT ingest; CSV import; FDD  
+
+**Dual pipeline:** bosspi → Railway exclusive; bensbench local stack for on-prem. Do not point bosspi at local mqtt (or bench edge at Railway) for the parity gate.
 
 ### Restore if wipe
 

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -84,6 +84,9 @@ retest. Do not confuse those with this engineering OS.
 38. **E+ dump / clustering:** prefer `reports/eplus-dump/` (`EPLUS_DUMP_ROOT`); `scripts/eplus_dump_clustering_export.py` emits sklearn-ready features. Online: `scripts/agent_eplus_dump.sh`. Rust API routes still `/wattlab/dumps` until rename. Doc: [`docs/agent/EPLUS_DUMP_CLUSTERING.md`](../docs/agent/EPLUS_DUMP_CLUSTERING.md).
 39. **Railway hub CLI (bensbench):** `@railway/cli` via `npm i -g`; auth via `railway login` (verified) or optional `RAILWAY_TOKEN` in `~/.config/railway/bensbench.env`. Linked project **`gleaming-cooperation`** / **`production`**. Re-pin with **live** service names (`openfdd-central-cQ-F`, `openfdd-mqtt`, `openfdd-web`) per [`skills/openfdd-railway-cli/SKILL.md`](skills/openfdd-railway-cli/SKILL.md). Railway CLI ≠ [`mcp/`](../mcp/) FDD tools. Never commit tokens; never treat Railway AI as the FDD agent.
 40. **Always pin tip after Publish:** hub sidebar/`/api/health` must match tip `sha-*`. Stale `3.3.9` while tip is newer is a P0 fail. **Backup** `/workspace` before every central re-pin (`scripts/railway_central_workspace_backup.sh`).
+41. **Dual pipeline:** bosspi → Railway (cloud exclusive); bensbench local GHCR react stack for firewall/on-prem. Same tip `sha-*` both sides; 60s poll+publish on both edges; do not cross-wire for parity.
+42. **FDD + STORAGE_URL:** when `OPENFDD_STORAGE_URL=file:///workspace/openfdd`, set `OPENFDD_PARQUET_ROOT=/workspace/openfdd` so `/api/fdd/run` finds package historian parquet (else “parquet cache missing”).
+43. **Tip mqtt ACL path:** `acl_file /mosquitto/certs/acl` — local stacks must place ACL under `deploy/mqtt/certs/acl`, not only `deploy/mqtt/acl`.
 41. **Stream roles ≠ package roles until mapped:** live tags `zonetemp`/`sa_t` normalize to `zone_t`/`sat`. Empty Overview with rising `ingest_ok` ⇒ roles, not nginx. OT poll+MQTT publish floor **60s**.
 
 ---

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,13 @@
 # Session log
 
+## 2026-08-30 — Patch cycle 3.3.11 CLOSEOUT (tip pin + dual pipeline)
+
+- Tip `sha-91fb350` / `3.3.11+91fb3501aed2` on Railway (central+mqtt+web) + bosspi fieldbus arm64 + local react stack.
+- Backup `~/openfdd-backups/railway/20260830T195849Z/` then re-pin; workspace historian intact; stream `edges:1` / `ingest_ok` advancing @ 60s.
+- BUILDING_100 CSV import **HTTP 200** Railway + local; Railway FDD registry **ok** with `OPENFDD_PARQUET_ROOT=/workspace/openfdd`.
+- Dual pipeline: bosspi→Railway exclusive; local GHCR pull react hub for firewall path. Soft-OPEN: SPA Overview browser confirm; live role_map; ≥1h parity soak; local full-B100 FDD latency.
+- GH: tip Publish green; optional BACnet-MQTT failure not a product gate; 0 open product PRs at closeout start.
+
 ## 2026-08-30 — Patch cycle 3.3.11 START (UI P0 + MQTT≡CSV + tip pin)
 
 - Hub still `3.3.9+2dce59a` while tip Publish `sha-7163be9` / VERSION→**3.3.11**.

--- a/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
@@ -76,22 +76,27 @@ railway status >/dev/null 2>&1 || railway link
 # Expect: gleaming-cooperation / production
 
 # 4) Re-pin tip — use REAL service names from status
-SHA=sha-9667888
+SHA=sha-91fb350
 CENTRAL_SVC=openfdd-central-cQ-F   # confirm via railway status
 
 railway service source connect --service "$CENTRAL_SVC" \
   --image "ghcr.io/bbartling/openfdd-central:${SHA}"
-# wait private /api/health 200
+# wait private /api/health 200 — then mqtt → web
 
 railway service source connect --service openfdd-mqtt \
   --image "ghcr.io/bbartling/openfdd-mqtt:${SHA}"
 
 railway variable set OPENFDD_NGINX_RESOLVER=auto --service openfdd-web
+# Historian packages under OPENFDD_STORAGE_URL need FDD parquet root:
+railway variable set OPENFDD_PARQUET_ROOT=/workspace/openfdd --service "$CENTRAL_SVC"
 railway service source connect --service openfdd-web \
   --image "ghcr.io/bbartling/openfdd-web:${SHA}"
+# If ingest_ok stuck at 0 after mqtt re-pin: railway redeploy -s "$CENTRAL_SVC" -y
 ```
 
-Smoke: public SPA + `https://<web>/api/health`. Sidebar version must match tip.
+Smoke: public SPA + `https://<web>/api/health`. Sidebar version must match tip (`3.3.11+91fb350…`).
+
+**Dual pipeline:** bosspi → Railway only; bensbench local react stack (`OPENFDD_IMAGE_TAG=sha-*` pull, `--no-pull`) for firewall/on-prem. Do not cross-wire edges for the parity gate.
 
 ## BACKUP before every central re-pin (hard gate)
 


### PR DESCRIPTION
## Summary
- Living BUG_REPORT closeout for tip `sha-91fb350` / Railway + bosspi 60s + local react hub
- Dual-pipeline ops (bosspi→Railway exclusive; local firewall stack)
- `OPENFDD_PARQUET_ROOT` + mqtt `certs/acl` lessons in backup runbook, railway-cli skill, AGENTS

## Test plan
- [x] Docs-only — no product code
- [ ] Skim BUG_REPORT + SESSION_LOG for accuracy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the 3.3.11 closeout report with the latest deployment status, validation results, and resolved issues.
  - Expanded backup, restore, and re-pin guidance for cloud and local deployment workflows.
  - Documented parquet storage configuration, dual-pipeline routing, firewall hub setup, and verification checks.
  - Added operational rules for local storage and messaging access.
  - Recorded the latest deployment session, smoke-test results, version pin, and remaining follow-up criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->