### PR TITLE
chore(fieldbus): scoped lint hygiene (#803)

### DIFF
--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -147,7 +147,7 @@ fn parse_rest_auth(raw: &str) -> Result<RestAuth, String> {
 pub struct RestPoint {
     pub point_name: String,
     /// Validated to GET at load time; retained for catalog parity.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "loaded from rest_points.toml for catalog parity; not yet read on poll path")]
     pub method: String,
     pub path: String,
     pub select: String,
@@ -265,7 +265,7 @@ pub struct FieldPoint {
     pub object_type: String,
     pub object_instance: u32,
     pub point_name: String,
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "loaded from field_devices.toml units column; display/export TBD")]
     pub units: String,
 }
 

--- a/services/fieldbus/src/config.rs
+++ b/services/fieldbus/src/config.rs
@@ -147,7 +147,8 @@ fn parse_rest_auth(raw: &str) -> Result<RestAuth, String> {
 pub struct RestPoint {
     pub point_name: String,
     /// Validated to GET at load time; retained for catalog parity.
-    #[expect(dead_code, reason = "loaded from rest_points.toml for catalog parity; not yet read on poll path")]
+    /// Catalog field loaded from rest_points.toml; not yet read on poll path.
+    #[expect(dead_code)]
     pub method: String,
     pub path: String,
     pub select: String,
@@ -265,7 +266,8 @@ pub struct FieldPoint {
     pub object_type: String,
     pub object_instance: u32,
     pub point_name: String,
-    #[expect(dead_code, reason = "loaded from field_devices.toml units column; display/export TBD")]
+    /// Loaded from field_devices.toml units column; display/export TBD.
+    #[expect(dead_code)]
     pub units: String,
 }
 

--- a/services/fieldbus/src/openapi_bench.rs
+++ b/services/fieldbus/src/openapi_bench.rs
@@ -66,7 +66,7 @@ pub fn bacnet_write_bench() -> Value {
     })
 }
 
-#[allow(dead_code)]
+#[expect(dead_code, reason = "OpenAPI bench fixture for BACnet write dry-run; retained for utoipa example expansion")]
 pub fn bacnet_write_dry_run_bench() -> Value {
     json!({
         "device_instance": 5007,

--- a/services/fieldbus/src/openapi_bench.rs
+++ b/services/fieldbus/src/openapi_bench.rs
@@ -66,7 +66,8 @@ pub fn bacnet_write_bench() -> Value {
     })
 }
 
-#[expect(dead_code, reason = "OpenAPI bench fixture for BACnet write dry-run; retained for utoipa example expansion")]
+/// OpenAPI bench fixture for BACnet write dry-run; retained for utoipa example expansion.
+#[expect(dead_code)]
 pub fn bacnet_write_dry_run_bench() -> Value {
     json!({
         "device_instance": 5007,


### PR DESCRIPTION
## Summary
- Replace `#[allow(dead_code)]` with `#[expect(dead_code, reason = "...")]` on fieldbus config catalog fields and openapi bench fixtures.
- Scoped sweep on `openfdd-fieldbus` only (patch-cycle touched crate); no drive-by refactors.

Closes #803 (fieldbus slice).

## Test plan
- [ ] CI `rust-ci` green (`-D warnings`)
- [ ] No behavior change


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code annotations to clarify intentionally unused configuration and benchmark elements.
  * No user-visible functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->