### PR TITLE
docs(ops): local FDD parquet root + scoped MCP smoke

### DIFF
--- a/docs/operations/backup-update-restore.md
+++ b/docs/operations/backup-update-restore.md
@@ -35,6 +35,22 @@ tar -xzf ~/openfdd-backups/latest/workspace-full.tgz -C ~/open-fdd
 ./scripts/openfdd_health_check.sh
 ```
 
+### Local FDD + MCP smoke (low-RAM)
+
+Central resolves historian parquet via `OPENFDD_STORAGE_URL` (preferred) or legacy `OPENFDD_PARQUET_ROOT`. For `/api/fdd/run` and MCP `openfdd_fdd_*` tools to return rows, the root must match where CSV/package ingest wrote parquet (typically `workspace/openfdd` locally or `/workspace/openfdd` on Railway).
+
+```bash
+cd ~/open-fdd
+
+# Health + MCP initialize only (no parquet import required):
+OPENFDD_SMOKE_HEALTH_ONLY=1 OPENFDD_SMOKE_TIMEOUT_SECS=60 ./scripts/release/smoke_mcp_central.sh
+
+# Full FDD parity (empty registry OK on fresh central; import package first for non-zero rows):
+OPENFDD_PARQUET_ROOT="$PWD/workspace/openfdd" ./scripts/release/smoke_mcp_central.sh
+```
+
+Scoped FDD on Railway/local: use `rule_ids` in `/api/fdd/run` POST body; avoid full-building rule floods within the default 120s smoke window.
+
 ## Railway hub (mandatory before central re-pin)
 
 **Primary durability:** change the **image tag only**. Keep the same Railway volume mounted at `/workspace`. Never `volume delete`, never attach a **new empty** volume for an upgrade.

--- a/scripts/release/smoke_mcp_central.sh
+++ b/scripts/release/smoke_mcp_central.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Boot central in Docker and smoke MCP stdio against /api/health.
+# Local FDD paths: set OPENFDD_PARQUET_ROOT (or OPENFDD_STORAGE_URL=file://…) to match
+# imported package parquet before expecting openfdd_fdd_* tools to return rows.
+# Low-RAM: OPENFDD_SMOKE_HEALTH_ONLY=1 skips FDD parity; OPENFDD_SMOKE_TIMEOUT_SECS=60 shortens health wait (default 120).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -10,6 +13,7 @@ CENTRAL_NAME="openfdd-central-smoke-$$"
 CENTRAL_IMAGE="${OPENFDD_CENTRAL_SMOKE_IMAGE:-openfdd-central:ci}"
 MCP_IMAGE="${OPENFDD_MCP_SMOKE_IMAGE:-openfdd-mcp:ci}"
 TIMEOUT_SECS="${OPENFDD_SMOKE_TIMEOUT_SECS:-120}"
+HEALTH_ONLY="${OPENFDD_SMOKE_HEALTH_ONLY:-0}"
 
 cleanup() {
   docker rm -f "$CENTRAL_NAME" >/dev/null 2>&1 || true
@@ -43,6 +47,12 @@ until curl -fsS "http://127.0.0.1:18080/api/health" \
   sleep 2
 done
 echo "OK central health"
+
+if [[ "$HEALTH_ONLY" == "1" ]]; then
+  echo "SKIP FDD parity (OPENFDD_SMOKE_HEALTH_ONLY=1)"
+  echo "PASS: MCP central smoke (health only)"
+  exit 0
+fi
 
 MCP_OUT="$(printf '%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \


### PR DESCRIPTION
## Summary
- Document `OPENFDD_PARQUET_ROOT` and low-RAM MCP smoke flags in `backup-update-restore.md`.
- Add `OPENFDD_SMOKE_HEALTH_ONLY=1` to `smoke_mcp_central.sh` to skip FDD parity on constrained hosts.

Patch D from outstanding bug patches plan.

## Test plan
- [ ] `OPENFDD_SMOKE_HEALTH_ONLY=1 OPENFDD_SMOKE_TIMEOUT_SECS=60 ./scripts/release/smoke_mcp_central.sh` exits PASS (when Docker available)
- [ ] Docs render on GitHub Pages workflow


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring local historian storage during backup, update, and restore operations.
  * Documented low-memory smoke test options, including health-only checks and scoped FDD runs.
* **Chores**
  * Updated smoke testing to support a health-only mode that skips full FDD parity checks when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->