### PR TITLE
fix(ci): BACnet→MQTT integration mqtt healthcheck and startup ordering

### DIFF
--- a/docker/compose.bacnet-mqtt-ci.yml
+++ b/docker/compose.bacnet-mqtt-ci.yml
@@ -15,6 +15,12 @@ services:
       - ${OPENFDD_BACNET_MQTT_CERT_DIR:?set OPENFDD_BACNET_MQTT_CERT_DIR}/broker:/mosquitto/certs:ro
       - ${OPENFDD_BACNET_MQTT_CERT_DIR}/acl:/mosquitto/config/acl:ro
       - mqtt-data:/mosquitto/data
+    healthcheck:
+      test: ["CMD-SHELL", "pidof mosquitto >/dev/null"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
     networks:
       ci_net:
         ipv4_address: 172.30.0.30
@@ -43,7 +49,8 @@ services:
     ports:
       - "127.0.0.1:18080:8080"
     depends_on:
-      - mqtt
+      mqtt:
+        condition: service_healthy
     networks:
       ci_net:
         ipv4_address: 172.30.0.40
@@ -71,8 +78,10 @@ services:
     ports:
       - "127.0.0.1:18081:8081"
     depends_on:
-      - bacnet-sim
-      - mqtt
+      bacnet-sim:
+        condition: service_started
+      mqtt:
+        condition: service_healthy
     networks:
       ci_net:
         ipv4_address: 172.30.0.20

--- a/scripts/integration/bacnet_mqtt_container_smoke.sh
+++ b/scripts/integration/bacnet_mqtt_container_smoke.sh
@@ -74,6 +74,7 @@ issue_cert edge 'edge:ci:fieldbus-1' clientAuth
 cp "$TMP/ca.pem" "$TMP/mqtt/broker/ca.pem"
 cp "$TMP/server.cert.pem" "$TMP/mqtt/broker/server.cert.pem"
 cp "$TMP/server.key.pem" "$TMP/mqtt/broker/server.key.pem"
+cp "$TMP/mqtt/acl" "$TMP/mqtt/broker/acl"
 
 cp "$TMP/ca.pem" "$TMP/mqtt/central/ca.pem"
 cp "$TMP/central.cert.pem" "$TMP/mqtt/central/central.cert.pem"
@@ -116,6 +117,34 @@ wait_http() {
 wait_http http://127.0.0.1:18081/health "fieldbus health"
 wait_http http://127.0.0.1:18080/api/health "central health"
 
+TOKEN="$(curl -fsS -X POST http://127.0.0.1:18080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"bacnet-mqtt-ci-admin"}' \
+  | jq -r '.token // .access_token // empty')"
+if [[ -z "$TOKEN" ]]; then
+  echo "FAIL: central login did not return a token" >&2
+  "${COMPOSE[@]}" logs --tail=200 central >&2 || true
+  exit 1
+fi
+
+echo "== Wait for central MQTT client connected =="
+mqtt_deadline=$((SECONDS + 120))
+while true; do
+  MONITOR="$(curl -fsS http://127.0.0.1:18080/api/mqtt/monitor \
+    -H "Authorization: Bearer $TOKEN")"
+  if echo "$MONITOR" | jq -e '.connected == true' >/dev/null 2>&1; then
+    echo "OK central MQTT connected"
+    break
+  fi
+  if (( SECONDS >= mqtt_deadline )); then
+    echo "FAIL: central MQTT client never connected" >&2
+    echo "$MONITOR" | jq . >&2 || true
+    "${COMPOSE[@]}" logs --tail=200 central mqtt >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
+
 # Exercise the real Open-FDD BACnet client against the BACpypes3 server.
 echo "== BACnet read =="
 READ_JSON='{"device_instance":3456,"object_type":"analog-value","object_instance":1,"property_id":"present-value"}'
@@ -144,16 +173,6 @@ echo "$POLL_STATUS" | jq -e '
   ))
 ' >/dev/null
 echo "OK fieldbus poll state contains BACpypes3 point"
-
-TOKEN="$(curl -fsS -X POST http://127.0.0.1:18080/api/auth/login \
-  -H 'Content-Type: application/json' \
-  -d '{"username":"admin","password":"bacnet-mqtt-ci-admin"}' \
-  | jq -r '.token // .access_token // empty')"
-if [[ -z "$TOKEN" ]]; then
-  echo "FAIL: central login did not return a token" >&2
-  "${COMPOSE[@]}" logs --tail=200 central >&2 || true
-  exit 1
-fi
 
 # Wait until central observes, parses, and accepts the fieldbus BACnet telemetry envelope.
 deadline=$((SECONDS + 90))


### PR DESCRIPTION
## Summary
- Add mqtt healthcheck and `depends_on: condition: service_healthy` for central/fieldbus
- Copy generated ACL into broker cert mount for Mosquitto startup
- Wait for `/api/mqtt/monitor` connected before BACnet ingest assertions

Fixes optional workflow failure 33472444691.

## Test plan
- [x] `OPENFDD_IMAGE_TAG=sha-3c9f753 ./scripts/integration/bacnet_mqtt_container_smoke.sh` PASS on bensbench

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT service readiness checks before dependent services start.
  * Ensured fieldbus startup waits for the BACnet simulator.
  * Improved integration validation by applying MQTT access rules and verifying authenticated MQTT connectivity.
  * Removed duplicate authentication steps from the smoke test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->