### PR TITLE
docs(ops): BUG_REPORT 3.3.15 closeout verdict

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,14 +1,28 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-08-31 (3.3.14 MQTT Overview parity closeout)  
-**Platform:** Railway hub @ `sha-a1b1c52` / `3.3.14+a1b1c5215e8d`  
+**Date:** 2026-09-01 (3.3.15 closeout — DataFusion 55 + timing gate pre-req done)  
+**Platform:** Railway hub @ `sha-3c9f753` / `3.3.15+3c9f75311ae1`  
 **Host:** bensbench (GHCR pull / local react); bosspi arm64 edge  
 **Remote edge:** bosspi — fieldbus, poll+publish **60s**, site `bldg2` / edge `pi-1` → Railway MQTTS  
-**Train:** outstanding_bug_patches — Patch A 3.3.13 + Patch B 3.3.14 (#809, #810)
+**Train:** outstanding_bug_patches — #803/#804/#812/#813/#814 merged; BACnet CI harness #815
 
 Private OT LAN addresses, vendor lake credentials, and tunnel endpoints live only in session env / gitignored files — **never Discord→git**.
 
 **Canonical file:** [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](./BUG_REPORT_OT_MODBUS_HAYSTACK.md)
+
+## Verdict — 3.3.15 closeout (2026-09-01)
+
+| Check | Evidence |
+|-------|----------|
+| **#814** merged | `3c9f7531` — DataFusion 55 stack upgrade |
+| **#815** merged | `41af8523` — BACnet→MQTT CI mqtt healthcheck + startup ordering |
+| GHCR Publish | `sha-3c9f753` images (3.3.15 product); publish for `41af8523` in progress |
+| Railway re-pin | central + mqtt + web → `sha-3c9f753`; backup `~/openfdd-backups/railway/20260901T144551Z/` |
+| Public `/api/health` | `version: 3.3.15+3c9f75311ae1`, `edges:1`, `ingest_ok` advancing |
+| Local smoke (L1–L2) | `01_health_gates` **13/13 pass**; `10_react_spa` **24 pass** (react-ot) |
+| Optional BACnet CI | PR #815 `bacnet-mqtt-e2e` **PASS**; tip master workflow pending post-publish |
+| **bldg2 Overview** | **DEFERRED** — bosspi fieldbus re-pin + `OPENFDD_EQUIPMENT_TYPE=zone_other` UI sign-off |
+| Full `run_all` stress | **IN PROGRESS** — `WEATHER_SOAK_SECS=120` shortened tier on bensbench |
 
 ## Verdict — 3.3.14 MQTT Overview parity (2026-08-31)
 
@@ -38,13 +52,17 @@ Private OT LAN addresses, vendor lake credentials, and tunnel endpoints live onl
 
 | Pipeline | Status |
 |----------|--------|
-| **A Cloud** bosspi → Railway | **PASS** streaming @ 3.3.14 |
-| **B Local** react `sha-a1b1c52` | **PASS** SPA gate; central healthy; no local fieldbus (by design) |
+| **A Cloud** bosspi → Railway | **PASS** streaming @ 3.3.15 (hub re-pinned) |
+| **B Local** react `sha-3c9f753` | **PASS** SPA + health gates |
 
 ## This cycle — bugs found / patched
 
 | ID | Severity | Resolution |
 |----|----------|------------|
+| **#803 lint hygiene** | P2 | **CLOSED** — #812 merged |
+| **#804 DataFusion 55** | P1 | **CLOSED** — #814 merged (`3c9f753`) |
+| **Patch D parquet root** | P1 | **CLOSED** — #813 merged |
+| **Optional BACnet→MQTT CI** | P2 CI | **FIXED** — #815 mqtt healthcheck + smoke ordering |
 | **mqtt-equipment-types-missing** | P0 bldg2 Overview | **FIXED 3.3.14** — fieldbus `equipment_type` tag + central `equipment_types.json` persist (#810) |
 | **overview-shells-hidden** | P0 MQTT UX | **FIXED 3.3.14** — all health-matrix shells always visible (#810) |
 | **csv-flood-vav-parent-equip** | P0 AFDD stream sim | **FIXED** 3.3.12 — `csv_flood_afdd_routine_sim.py` leaf equipment_id |
@@ -55,13 +73,10 @@ Private OT LAN addresses, vendor lake credentials, and tunnel endpoints live onl
 
 | ID | Notes |
 |----|-------|
-| **bldg2-overview-signoff** | Hub on tip; bosspi needs `OPENFDD_EQUIPMENT_TYPE=zone_other` + fieldbus `sha-a1b1c52` re-pin → confirm Zone Other + sensor faults in UI |
+| **bldg2-overview-signoff** | Hub on `sha-3c9f753`; bosspi needs `OPENFDD_EQUIPMENT_TYPE=zone_other` + fieldbus re-pin → confirm Zone Other + sensor faults in UI |
 | **lake-credential-rotation** | Read-only lake password was shared in chat — rotate; session-env only |
 | **lake→openfdd packaging** | Manual zip builder worked; formalize in private sidecar later |
-| **local-fdd-latency** | Full B100 local FDD still soft-OPEN — Patch D |
-| **#803 lint hygiene** | [issue #803](https://github.com/bbartling/open-fdd/issues/803) — next scoped PR |
-| **#804 thrift / DF upgrade** | [issue #804](https://github.com/bbartling/open-fdd/issues/804) — after #803 |
-| **Optional BACnet→MQTT CI** | Not a product gate; sticky failures deleted |
+| **local-fdd-latency** | **CLOSED** — Patch D (#813) |
 
 ## AFDD flood evidence (post-fix)
 
@@ -85,6 +100,6 @@ artifacts: reports/wattlab-parity/artifacts/csv_flood_sim/BUILDING_50/
 1. Backup before every central re-pin.  
 2. Re-pin order: central → mqtt → web; bosspi fieldbus; redeploy central if ingest stuck at 0.  
 3. `OPENFDD_PARQUET_ROOT=/workspace/openfdd` when `OPENFDD_STORAGE_URL=file:///workspace/openfdd`.  
-4. Bench pin: `OPENFDD_IMAGE_TAG=sha-a1b1c52` in local `.env` (gitignored).  
+4. Bench pin: `OPENFDD_IMAGE_TAG=sha-3c9f753` in local `.env` (gitignored).  
 5. AFDD stream sim: `scripts/csv_flood_afdd_routine_sim.py` + `scripts/fixtures/b50_afdd_routine.json`.  
 6. Private lake bench: read-only Postgres via session tunnel; credentials never in git.


### PR DESCRIPTION
## Summary
- Update canonical BUG_REPORT for 3.3.15 hub re-pin (`sha-3c9f753`)
- Close #803/#804/Patch D/local-fdd-latency soft-OPEN items
- Record #815 BACnet CI fix; bldg2 Overview still deferred (bosspi)

## Test plan
- [x] Railway `/api/health` → `3.3.15+3c9f75311ae1`
- [x] Local `01_health_gates` + `10_react_spa` PASS
- [ ] Full `run_all` stress (in progress on bensbench)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Modbus Haystack bug report for the 3.3.15 closeout.
  * Recorded resolved items, including DataFusion 55 upgrades and the BACnet-to-MQTT CI harness.
  * Documented the closure of local FDD latency follow-up.
  * Noted that bldg2 Overview sign-off remains deferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->