### PR TITLE
fix: gate 19 jq NOT_READY default

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,30 +1,32 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-09-02 (3.3.20 engineering export + utilities — **IN FLIGHT**)  
-**Platform:** Railway hub @ `sha-42b3f49` / `3.3.18+42b3f498` (pre-3.3.19 repin)  
+**Date:** 2026-09-02 (3.3.20 engineering export + utilities — **CLOSED**)  
+**Platform:** Railway hub @ `sha-15baccf` / `3.3.19+15baccf84`  
 **Host:** bensbench (GHCR pull / local react); bosspi arm64 edge  
 **Remote edge:** bosspi — fieldbus, poll+publish **60s**, site `bldg2` / edge `pi-1` → Railway MQTTS  
-**Train:** `42b3f498` (#826 B100 parity); VERSION bump **3.3.19** on `fix/3.3.20-engineering-ml-export`
+**Train:** `15baccf8` (#827 3.3.20); hotfix gate 19 shell (#828)
 
 Private OT LAN addresses, vendor lake credentials, and tunnel endpoints live only in session env / gitignored files — **never Discord→git**.
 
 **Canonical file:** [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](./BUG_REPORT_OT_MODBUS_HAYSTACK.md)
 
-## Verdict — 3.3.20 engineering export + utilities (2026-09-02)
+## Verdict — 3.3.20 engineering export + utilities (2026-09-02) — CLOSED
 
 | Check | Evidence |
 |-------|----------|
-| Nested Creekside import | Code + `tests/fixtures/creekside_nested/` + `scripts/gates/creekside_package_import_spot.sh` — live gate after GHCR repin |
-| Utilities in package | `utilities_v1` materialize in `package.rs`; fuel ZIP upload removed from Export UI |
-| Engineering bundle | `openfdd_engineering_bundle_v1` Rust export; `POST /api/jobs/{id}/exports`; `/wattlab/dumps` alias |
-| Utility FDD rules | `UTIL-MONTHLY`, `UTIL-INTERVAL` + meter roles on `SV-RANGE` |
-| Gate 19 | `scripts/nightly-ot-bench/19_engineering_bundle_validate.sh` |
-| GHCR + stress | **PENDING** — merge PR → publish → re-pin → `run_all` + gate 19 + Creekside gate |
+| Merge | #827 → `15baccf8`; VERSION **3.3.19** |
+| GHCR publish | `sha-15baccf` central/fieldbus/mqtt pulled; health `3.3.19+15baccf84e24` |
+| Local re-pin | `openfdd_maint_update_resume.sh react-ot sha-15baccf --skip-maintenance` |
+| Nested Creekside import | **PASS** — `reports/creekside-package-import_20260902T230020Z/` |
+| Engineering bundle | **PASS** — gate 19 artifact `READY` @ `reports/nightly-ot-bench_20260902T230020Z/bundle_validate.json` |
+| Utilities in package | `utilities_v1` in `package.rs`; fuel ZIP upload removed from Export UI |
+| Utility FDD rules | `UTIL-MONTHLY`, `UTIL-INTERVAL` in registry |
+| Gate 19 shell | jq + `PASS` counter shadow fix in #828 |
 | **bldg2 Overview UI** | **DEFERRED** (carried from 3.3.19) |
 | BUILDING_50 / AFDD flood | **DEFERRED** |
 | Legacy fuel ZIP | `services/central/src/fuel/import.rs` read-only for `liberty_practice_bensbench` |
 
-**Issues closed:** [#763](https://github.com/bbartling/open-fdd/issues/763) (engineering bundle), [#805](https://github.com/bbartling/open-fdd/issues/805) (utilities in package) — evidence on merge PR.
+**Issues closed:** [#763](https://github.com/bbartling/open-fdd/issues/763) (engineering bundle), [#805](https://github.com/bbartling/open-fdd/issues/805) (utilities in package) — #827 + gate evidence.
 
 ## Verdict — 3.3.19 remaining bugs + stress (2026-09-02) — CLOSED
 

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,15 @@
 # Session log
 
+## 2026-09-02 (evening) — 3.3.20 engineering export + utilities closeout
+
+- **Merge:** #827 → `15baccf8`; VERSION **3.3.19**; Export & ML UI, `openfdd_engineering_bundle_v1`, `utilities_v1`, Creekside nested import, `UTIL-MONTHLY`/`UTIL-INTERVAL`.
+- **GHCR + re-pin:** `sha-15baccf`; local react `openfdd_maint_update_resume.sh react-ot sha-15baccf --skip-maintenance`; health `3.3.19+15baccf84e24`.
+- **Gates:** Creekside import **PASS** (`reports/creekside-package-import_20260902T230020Z/`); gate 19 bundle validator **READY** (`reports/nightly-ot-bench_20260902T230020Z/`).
+- **Hotfix:** #828 — gate 19 jq `NOT_READY` quote + `PASS` counter shadow fix.
+- **Issues closed:** #763, #805.
+- **GH hygiene END:** 0 open PRs after #828 merge; only `master`.
+- Plan: `.cursor/plans/3.3.20_engineering_ml_bundle_utilities.plan.md`
+
 ## 2026-09-02 (afternoon) — 3.3.20 engineering export + utilities (in flight)
 
 - **Branch:** `fix/3.3.20-engineering-ml-export` — nested Creekside import, `utilities_v1`, Rust `openfdd_engineering_bundle_v1`, Export & ML UI, `UTIL-MONTHLY`/`UTIL-INTERVAL`, gate 19 + Creekside spot.

--- a/scripts/nightly-ot-bench/19_engineering_bundle_validate.sh
+++ b/scripts/nightly-ot-bench/19_engineering_bundle_validate.sh
@@ -14,16 +14,16 @@ hdr "Engineering bundle validate (gate 19)"
 
 BASE="${BASE:-http://127.0.0.1:8080}"
 BUILDING_ID="${BUILDING_ID:-BUILDING_100}"
-PASS="${OPENFDD_ADMIN_PASSWORD:-}"
+ADMIN_PASS="${OPENFDD_ADMIN_PASSWORD:-}"
 
 login() {
   curl -fsS --max-time 30 -X POST "$BASE/api/auth/login" \
     -H 'Content-Type: application/json' \
-    -d "$(jq -nc --arg u admin --arg p "$PASS" '{username:$u,password:$p}')" \
+    -d "$(jq -nc --arg u admin --arg p "$ADMIN_PASS" '{username:$u,password:$p}')" \
     | jq -r '.token // .access_token // empty'
 }
 
-if [[ -z "$PASS" ]]; then
+if [[ -z "$ADMIN_PASS" ]]; then
   bad "OPENFDD_ADMIN_PASSWORD required"
 fi
 

--- a/scripts/nightly-ot-bench/19_engineering_bundle_validate.sh
+++ b/scripts/nightly-ot-bench/19_engineering_bundle_validate.sh
@@ -57,7 +57,7 @@ curl -fsS --max-time 300 \
 
 VALIDATE_JSON="$ART/bundle_validate.json"
 python3 "$ROOT/scripts/openfdd_bundle_validate.py" validate "$ZIP_PATH" >"$VALIDATE_JSON"
-STATUS="$(jq -r '.status // NOT_READY' "$VALIDATE_JSON")"
+STATUS="$(jq -r '.status // "NOT_READY"' "$VALIDATE_JSON")"
 if [[ "$STATUS" == "NOT_READY" ]]; then
   jq . "$VALIDATE_JSON" >&2
   bad "bundle validator NOT_READY"


### PR DESCRIPTION
Quote NOT_READY in gate 19 jq fallback. Export validator already READY on sha-15baccf.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved engineering bundle validation to use the correct administrator credential configuration.
  - Standardized reporting when validation results are not yet available.

- **Documentation**
  - Updated the Modbus Haystack operations report to reflect the completed 3.3.20 release validation and closed issues.
  - Added a session-log entry covering the engineering export, utilities closeout, validation gates, and related release activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->