### PR TITLE
docs: agent stress closeout + local/Railway bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ OpenClaw, Claude Desktop, or any MCP host — connect via **JWT REST** and optio
 | **mqtt** | Mosquitto MQTTS broker |
 | **mcp** | Optional read-first stdio tools → central (`OPENFDD_API_BASE`) |
 
-**Docs:** [Build recipes](docs/operations/build-recipes.md) · [External agents](docs/examples/external-agents.md) · [MCP README](mcp/README.md) · [ECM engineering (PyPI)](docs/ecm/README.md) · [Package authoring](docs/agent/PACKAGE_AUTHORING.md) · [Security](SECURITY.md)
+**Docs:** [Build recipes](docs/operations/build-recipes.md) · [Local deploy (HTTP / firewall)](docs/operations/LOCAL_DEPLOYMENT.md) · [Railway CLI hub](docs/operations/RAILWAY_DEPLOYMENT.md) · [Stress closeout](docs/operations/STRESS_CLOSEOUT.md) · [External agents](docs/examples/external-agents.md) · [MCP README](mcp/README.md) · [ECM engineering (PyPI)](docs/ecm/README.md) · [Package authoring](docs/agent/PACKAGE_AUTHORING.md) · [Security](SECURITY.md)
 
 **Software-engineering agent OS:** [`openfdd_agent_spec/`](openfdd_agent_spec/) — architecture locks, skills, Milestone A.
 

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,7 +1,7 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-09-02 (3.3.20 engineering export + utilities — **CLOSED**)  
-**Platform:** Railway hub @ `sha-15baccf` / `3.3.19+15baccf84`  
+**Date:** 2026-09-02 (3.3.20 engineering export shipped — **stress closeout remaining**)  
+**Platform:** Railway hub @ `sha-15baccf` / `3.3.19+15baccf84` (hub re-pin + full stress still pending evidence)  
 **Host:** bensbench (GHCR pull / local react); bosspi arm64 edge  
 **Remote edge:** bosspi — fieldbus, poll+publish **60s**, site `bldg2` / edge `pi-1` → Railway MQTTS  
 **Train:** `15baccf8` (#827 3.3.20); hotfix gate 19 shell (#828)
@@ -10,7 +10,7 @@ Private OT LAN addresses, vendor lake credentials, and tunnel endpoints live onl
 
 **Canonical file:** [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](./BUG_REPORT_OT_MODBUS_HAYSTACK.md)
 
-## Verdict — 3.3.20 engineering export + utilities (2026-09-02) — CLOSED
+## Verdict — 3.3.20 engineering export + utilities (2026-09-02) — PRODUCT SHIPPED / STRESS PENDING
 
 | Check | Evidence |
 |-------|----------|
@@ -22,11 +22,13 @@ Private OT LAN addresses, vendor lake credentials, and tunnel endpoints live onl
 | Utilities in package | `utilities_v1` in `package.rs`; fuel ZIP upload removed from Export UI |
 | Utility FDD rules | `UTIL-MONTHLY`, `UTIL-INTERVAL` in registry |
 | Gate 19 shell | jq + `PASS` counter shadow fix in #828 |
+| Railway hub re-pin + backup | **PENDING** — see [`STRESS_CLOSEOUT.md`](./STRESS_CLOSEOUT.md) |
+| Full stress (`run_all` / synth59 / gate17 / B100 / ZAP) | **PENDING** — do not cite 3.3.19 `sha-b565d78` artifacts as tip proof |
 | **bldg2 Overview UI** | **DEFERRED** (carried from 3.3.19) |
 | BUILDING_50 / AFDD flood | **DEFERRED** |
 | Legacy fuel ZIP | `services/central/src/fuel/import.rs` read-only for `liberty_practice_bensbench` |
 
-**Issues closed:** [#763](https://github.com/bbartling/open-fdd/issues/763) (engineering bundle), [#805](https://github.com/bbartling/open-fdd/issues/805) (utilities in package) — #827 + gate evidence.
+**Issues closed (foundation):** [#763](https://github.com/bbartling/open-fdd/issues/763), [#805](https://github.com/bbartling/open-fdd/issues/805) — #827. ML/vibe20 depth deferred.
 
 ## Verdict — 3.3.19 remaining bugs + stress (2026-09-02) — CLOSED
 

--- a/docs/operations/LOCAL_DEPLOYMENT.md
+++ b/docs/operations/LOCAL_DEPLOYMENT.md
@@ -1,0 +1,77 @@
+---
+title: Local deployment (firewall hub)
+parent: Operations
+nav_order: 5
+---
+
+# Local deployment — firewall / on-prem hub
+
+Open-FDD is **local-first**. The typical bench path is a GHCR-pulled Compose stack on a LAN host (e.g. bensbench) behind a firewall — **not** a public internet appliance.
+
+## Threat model (current)
+
+| Fact | Implication for agents |
+|------|------------------------|
+| Dashboard + API are **plain HTTP** on the LAN | Expect `http://127.0.0.1:3000` (UI) and `http://127.0.0.1:8080` (API). **No product TLS termination on local Compose yet.** |
+| Intended exposure | Host firewall / VPN / OT LAN only. Do **not** advertise local `:3000`/`:8080` to the public internet. |
+| Railway vs local | Railway public **web** may terminate TLS at the edge; local stack does **not** mirror that. Private Railway mesh to central is also plain HTTP on `*.railway.internal`. |
+| Auth still required | Admin / agent JWT on central even over HTTP — never skip auth “because it’s local.” |
+
+If a customer needs HTTPS on-prem, that is an **ops add-on** (reverse proxy / Caddy with certs in front of Compose) — not the default `react-ot` recipe today. Do not claim local TLS is shipped.
+
+## Recipes
+
+| Recipe | Compose | Use |
+|--------|---------|-----|
+| `react` | web + central (+ optional) | CSV / package lab UI |
+| **`react-ot`** | + fieldbus + mqtt | OT soak / nightly stress (default bench) |
+
+Docs: [build-recipes.md](build-recipes.md) · agent: [`CONTAINER_AGENT.md`](../../openfdd_agent_spec/CONTAINER_AGENT.md) · skill [`openfdd-stack-ghcr`](../../openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md).
+
+## Bootstrap (GHCR pull — preferred)
+
+```bash
+cd ~/open-fdd
+# After GHCR Publish for tip:
+SHA=sha-<7chars>   # e.g. sha-15baccf
+export OPENFDD_IMAGE_TAG="$SHA"
+
+# Low-RAM: skip aggressive docker prune if operator already cleaned
+./scripts/openfdd_maint_update_resume.sh react-ot "$SHA" --skip-maintenance
+
+curl -sf http://127.0.0.1:8080/api/health | jq '{ok,version,service}'
+# UI: http://127.0.0.1:3000   (or host LAN IP :3000 behind firewall)
+# Fieldbus health (react-ot): http://127.0.0.1:8081
+```
+
+**Never** `docker build` stack images on low-RAM hosts — wait for Actions, pull `sha-*`.
+
+MQTT ACL for local: place under `deploy/mqtt/certs/acl` (tip mqtt images read `acl_file /mosquitto/certs/acl`).
+
+## Dual pipeline
+
+- **Local** = Pipeline B (firewall dashboard + optional local OT).
+- **Railway** = Pipeline A (bosspi → cloud MQTTS). Bootstrap: [`RAILWAY_DEPLOYMENT.md`](RAILWAY_DEPLOYMENT.md).
+
+Same tip `sha-*` both sides. Do not cross-wire for parity.
+
+## MCP against local central
+
+```bash
+export OPENFDD_API_BASE=http://127.0.0.1:8080
+# Mint agent JWT — see mcp/INSTRUCTIONS.md
+export OPENFDD_MCP_TOKEN=…
+```
+
+Use `http://` (not `https://`) for local Compose. See [`mcp/README.md`](../../mcp/README.md).
+
+## Stress on local
+
+After re-pin, run the stress matrix in [`STRESS_CLOSEOUT.md`](STRESS_CLOSEOUT.md) (`run_all`, synth59, gate 17, …). STRESS 7 (ZAP) targets **Railway public URL**, not the local HTTP dashboard.
+
+## Anti-patterns
+
+- Pasting a public URL for a local-only HTTP stack.
+- Claiming “local has TLS” without an explicit fronting proxy.
+- Building central/web images locally on bensbench.
+- Pointing bosspi at local mqtt during Railway parity stress.

--- a/docs/operations/LOCAL_DEPLOYMENT.md
+++ b/docs/operations/LOCAL_DEPLOYMENT.md
@@ -12,7 +12,7 @@ Open-FDD is **local-first**. The typical bench path is a GHCR-pulled Compose sta
 
 | Fact | Implication for agents |
 |------|------------------------|
-| Dashboard + API are **plain HTTP** on the LAN | Expect `http://127.0.0.1:3000` (UI) and `http://127.0.0.1:8080` (API). **No product TLS termination on local Compose yet.** |
+| Dashboard + API are **plain HTTP** on the LAN | Expect `http://127.0.0.1:3000` (UI) and `http://127.0.0.1:8080` (API). **No product TLS termination on local Compose yet.** Login passwords and Bearer JWTs travel in the clear — **trusted/isolated LAN or VPN only**. For shared/untrusted networks, terminate TLS on an ops reverse proxy in front of Compose. |
 | Intended exposure | Host firewall / VPN / OT LAN only. Do **not** advertise local `:3000`/`:8080` to the public internet. |
 | Railway vs local | Railway public **web** may terminate TLS at the edge; local stack does **not** mirror that. Private Railway mesh to central is also plain HTTP on `*.railway.internal`. |
 | Auth still required | Admin / agent JWT on central even over HTTP — never skip auth “because it’s local.” |

--- a/docs/operations/RAILWAY_DEPLOYMENT.md
+++ b/docs/operations/RAILWAY_DEPLOYMENT.md
@@ -8,6 +8,15 @@ nav_order: 4
 
 > **Experimental cloud path.** Open-FDD is local-first and currently intended for LAN/VPN/OT networks. The Railway recipes below are for labs, demos, and controlled evaluation. They are **not** a claim that Open-FDD is production-hardened for direct public-internet exposure.
 
+**Related agent handbooks**
+
+| Doc | Role |
+| --- | --- |
+| [LOCAL_DEPLOYMENT.md](LOCAL_DEPLOYMENT.md) | Firewall / on-prem Compose hub — **plain HTTP**, no product TLS yet |
+| [STRESS_CLOSEOUT.md](STRESS_CLOSEOUT.md) | Rigorous stress LAST after tip re-pin (run_all → … → light ZAP) |
+| [backup-update-restore.md](backup-update-restore.md) | Backup before every central re-pin |
+| Skill [`openfdd-railway-cli`](../../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md) | CLI auth / re-pin on bensbench |
+
 Open-FDD publishes a Rust/React container stack to GHCR. Railway can run the cloud-friendly subset directly from those prebuilt images without rebuilding the application.
 
 **Operator checklist:** [RAILWAY_DEPLOYMENT_CHECKLIST.md](RAILWAY_DEPLOYMENT_CHECKLIST.md).

--- a/docs/operations/STRESS_CLOSEOUT.md
+++ b/docs/operations/STRESS_CLOSEOUT.md
@@ -23,7 +23,7 @@ Same tip `sha-<7>` both sides. Do **not** point bosspi at local mqtt (or bench e
 
 1. Tip Actions green + GHCR **Publish Open-FDD stack** success for tip (or accept product `sha-*` if hotfix is harness-only).
 2. **Railway:** backup → re-pin central → mqtt → web — [`RAILWAY_DEPLOYMENT.md`](RAILWAY_DEPLOYMENT.md) · skill [`openfdd-railway-cli`](../../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md).
-3. **Local:** `./scripts/openfdd_maint_update_resume.sh react-ot sha-<7> --skip-maintenance` — [`LOCAL_DEPLOYMENT.md`](LOCAL_DEPLOYMENT.md) (HTTP only behind firewall; **no TLS yet**).
+3. **Local:** `./scripts/openfdd_maint_update_resume.sh react-ot sha-<7> --skip-maintenance` — [`LOCAL_DEPLOYMENT.md`](LOCAL_DEPLOYMENT.md). **Plain HTTP** (`:3000`/`:8080`) sends passwords and Bearer JWTs in the clear — **trusted/isolated LAN or VPN only**. For shared or untrusted networks, put a TLS-terminating reverse proxy in front (not shipped in default `react-ot`).
 4. **bosspi:** fieldbus arm64 same `sha-*`; 60s poll+publish; Pipeline A `/api/edges` check.
 5. Smoke 01 / 06 / 10 / 18 + Pipeline A, **then** stress.
 
@@ -35,10 +35,10 @@ Low-RAM: never local `docker build` for stack images; `WEATHER_SOAK_SECS=120`; `
 |---|------|--------------------|------|
 | Prep | Smoke + Pipeline A | gates `01`/`06`/`10`/`18`; `/api/edges` | health OK; telemetry present |
 | 1 | `run_all` | `unset SKIP_PULL`; `WEATHER_SOAK_SECS=120`; `./scripts/nightly-ot-bench/run_all.sh` | gates **00–16** PASS → `reports/nightly-ot-bench_<TS>/` |
-| 2 | Synthetic-59 soak | `synthetic_59_target_pair_soak.py --side ofdd` | **59/59** → `reports/wattlab-parity/artifacts/synthetic_59/` |
-| 3 | Gate 17 | `RUN_SYNTH59_HEALTH_MATRIX=1 ./scripts/nightly-ot-bench/17_*.sh` | health matrix + overview analytics PASS |
+| 2 | Synthetic-59 soak | `python3 scripts/synthetic_59_target_pair_soak.py --side ofdd` (from repo root) | **59/59** → `reports/wattlab-parity/artifacts/synthetic_59/` |
+| 3 | Gate 17 | `RUN_SYNTH59_HEALTH_MATRIX=1 ./scripts/nightly-ot-bench/17_synthetic_health_matrix_fault_hours.sh` | health matrix + overview analytics PASS |
 | 4 | B100 parity | `./scripts/gates/railway_b100_parity_spot.sh` | local ≡ Railway within tolerance → `reports/railway-b100-parity_<TS>/` |
-| 5 | Creekside | `creekside_package_import_spot.sh` (+ full zip if available) | nested import PASS; utilities preferred |
+| 5 | Creekside | `./scripts/gates/creekside_package_import_spot.sh` (+ full zip if available) | nested import PASS; utilities preferred |
 | 6 | Gate 19 bundle | `./scripts/nightly-ot-bench/19_engineering_bundle_validate.sh` | validator **READY** |
 | 7 | OWASP ZAP (light) | Docker `zap-baseline.py` vs **Railway public HTTPS URL only** | No unexplained High/Critical; HTML/JSON under `reports/zap-railway_<TS>/` |
 

--- a/docs/operations/STRESS_CLOSEOUT.md
+++ b/docs/operations/STRESS_CLOSEOUT.md
@@ -1,0 +1,81 @@
+---
+title: Stress closeout (nightly OT + Railway)
+parent: Operations
+nav_order: 6
+---
+
+# Stress closeout — agent handbook
+
+Canonical **rigorous stress LAST** protocol after a product tip lands on GHCR. Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](BUG_REPORT_OT_MODBUS_HAYSTACK.md). Plan example: `.cursor/plans/3.3.20_engineering_ml_bundle_utilities.plan.md`.
+
+**Do not claim a train CLOSED** with only merge + one spot gate. Cite tip-pin artifacts (not an older `sha-*` stress run).
+
+## Dual pipeline (never cross-wire for parity)
+
+| Pipeline | Where | Purpose |
+|----------|--------|---------|
+| **A Cloud** | bosspi fieldbus → Railway mqtt → Railway central/web | Live OT MQTTS hub |
+| **B Local** | bensbench `react-ot` GHCR pull | Firewall / on-prem dashboard + OT soak |
+
+Same tip `sha-<7>` both sides. Do **not** point bosspi at local mqtt (or bench edge at Railway) during the parity gate.
+
+## Bootstrap before stress
+
+1. Tip Actions green + GHCR **Publish Open-FDD stack** success for tip (or accept product `sha-*` if hotfix is harness-only).
+2. **Railway:** backup → re-pin central → mqtt → web — [`RAILWAY_DEPLOYMENT.md`](RAILWAY_DEPLOYMENT.md) · skill [`openfdd-railway-cli`](../../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md).
+3. **Local:** `./scripts/openfdd_maint_update_resume.sh react-ot sha-<7> --skip-maintenance` — [`LOCAL_DEPLOYMENT.md`](LOCAL_DEPLOYMENT.md) (HTTP only behind firewall; **no TLS yet**).
+4. **bosspi:** fieldbus arm64 same `sha-*`; 60s poll+publish; Pipeline A `/api/edges` check.
+5. Smoke 01 / 06 / 10 / 18 + Pipeline A, **then** stress.
+
+Low-RAM: never local `docker build` for stack images; `WEATHER_SOAK_SECS=120`; `unset SKIP_PULL` on full `run_all`.
+
+## Stress matrix (fill BUG_REPORT)
+
+| # | Name | Command / artifact | Pass |
+|---|------|--------------------|------|
+| Prep | Smoke + Pipeline A | gates `01`/`06`/`10`/`18`; `/api/edges` | health OK; telemetry present |
+| 1 | `run_all` | `unset SKIP_PULL`; `WEATHER_SOAK_SECS=120`; `./scripts/nightly-ot-bench/run_all.sh` | gates **00–16** PASS → `reports/nightly-ot-bench_<TS>/` |
+| 2 | Synthetic-59 soak | `synthetic_59_target_pair_soak.py --side ofdd` | **59/59** → `reports/wattlab-parity/artifacts/synthetic_59/` |
+| 3 | Gate 17 | `RUN_SYNTH59_HEALTH_MATRIX=1 ./scripts/nightly-ot-bench/17_*.sh` | health matrix + overview analytics PASS |
+| 4 | B100 parity | `./scripts/gates/railway_b100_parity_spot.sh` | local ≡ Railway within tolerance → `reports/railway-b100-parity_<TS>/` |
+| 5 | Creekside | `creekside_package_import_spot.sh` (+ full zip if available) | nested import PASS; utilities preferred |
+| 6 | Gate 19 bundle | `./scripts/nightly-ot-bench/19_engineering_bundle_validate.sh` | validator **READY** |
+| 7 | OWASP ZAP (light) | Docker `zap-baseline.py` vs **Railway public HTTPS URL only** | No unexplained High/Critical; HTML/JSON under `reports/zap-railway_<TS>/` |
+
+### STRESS 7 notes (fluffy, not bug bounty)
+
+- Target: public web origin only (SPA + `/api/health` / login). Operator-owned URL.
+- Out of scope: authenticated deep crawl, MQTT/OT, DoS, permanent CI ZAP gate.
+- Triage Low/Informational cookie noise in BUG_REPORT; fail-stop only on clear public High/Critical.
+- Example:
+
+```bash
+ART="reports/zap-railway_$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$ART"
+docker run --rm -v "$PWD/$ART:/zap/wrk:rw" -t ghcr.io/zaproxy/zaproxy:stable \
+  zap-baseline.py -t "$RAILWAY_PUBLIC_URL" -r zap_baseline.html -J zap_baseline.json -I
+```
+
+## Related product gates (3.3.20+)
+
+| Gate | Purpose |
+|------|---------|
+| `scripts/gates/creekside_package_import_spot.sh` | Nested `openfdd_package_v1` + utilities wrapper |
+| `scripts/nightly-ot-bench/19_engineering_bundle_validate.sh` | `openfdd_engineering_bundle_v1` structural validate |
+| `scripts/openfdd_bundle_validate.py` | Offline bundle schema / READY |
+
+Export UI: `/export` (alias `/wattlab`). Bundle API: `POST /api/jobs/{id}/exports`.
+
+## After stress
+
+1. Flesh BUG_REPORT verdict with **this tip’s** artifact paths (not prior train).
+2. `SESSION_LOG` entry with paths.
+3. GH hygiene END: 0 open PRs, only `master`, tip Actions green.
+
+## Anti-patterns
+
+- Claiming CLOSED after merge without `run_all` / synth59 / B100 on tip pin.
+- Citing `sha-b565d78` stress as proof for a newer tip.
+- Scanning non-owned hosts with ZAP.
+- Cross-wiring Pipeline A and B for “parity.”
+- Local `docker build` of central/web on low-RAM benches.

--- a/docs/operations/STRESS_CLOSEOUT.md
+++ b/docs/operations/STRESS_CLOSEOUT.md
@@ -23,7 +23,7 @@ Same tip `sha-<7>` both sides. Do **not** point bosspi at local mqtt (or bench e
 
 1. Tip Actions green + GHCR **Publish Open-FDD stack** success for tip (or accept product `sha-*` if hotfix is harness-only).
 2. **Railway:** backup → re-pin central → mqtt → web — [`RAILWAY_DEPLOYMENT.md`](RAILWAY_DEPLOYMENT.md) · skill [`openfdd-railway-cli`](../../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md).
-3. **Local:** `./scripts/openfdd_maint_update_resume.sh react-ot sha-<7> --skip-maintenance` — [`LOCAL_DEPLOYMENT.md`](LOCAL_DEPLOYMENT.md). **Plain HTTP** (`:3000`/`:8080`) sends passwords and Bearer JWTs in the clear — **trusted/isolated LAN or VPN only**. For shared or untrusted networks, put a TLS-terminating reverse proxy in front (not shipped in default `react-ot`).
+3. **Local:** `SHA=sha-<7chars>; ./scripts/openfdd_maint_update_resume.sh react-ot "$SHA" --skip-maintenance` — [`LOCAL_DEPLOYMENT.md`](LOCAL_DEPLOYMENT.md). After tip publish, GHCR web on that SHA is correct when the tree matches tip. Overlay a local Overview bundle **only** if `frontend/web` is dirty/unmerged. **Plain HTTP** (`:3000`/`:8080`) sends passwords and Bearer JWTs in the clear — **trusted/isolated LAN or VPN only**. For shared or untrusted networks, put a TLS-terminating reverse proxy in front (not shipped in default `react-ot`).
 4. **bosspi:** fieldbus arm64 same `sha-*`; 60s poll+publish; Pipeline A `/api/edges` check.
 5. Smoke 01 / 06 / 10 / 18 + Pipeline A, **then** stress.
 

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -48,11 +48,13 @@ Railway: keep MCP on private networking; see [RAILWAY_DEPLOYMENT.md](../docs/ope
 
 | Tool | Purpose |
 |------|---------|
-| **`railway` CLI** (`@railway/cli`) | Deploy/re-pin hub images, vars, logs on Railway (`gleaming-cooperation`). Skill: [`openfdd-railway-cli`](../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md). |
+| **`railway` CLI** (`@railway/cli`) | Deploy/re-pin hub images, vars, logs on Railway (`gleaming-cooperation`). Skill: [`openfdd-railway-cli`](../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md). Docs: [`RAILWAY_DEPLOYMENT.md`](../docs/operations/RAILWAY_DEPLOYMENT.md). |
+| **Local Compose (`react-ot`)** | Firewall / on-prem hub — **plain HTTP** UI `:3000` / API `:8080`; **no product TLS yet**. Docs: [`LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md). |
+| **Stress closeout** | After tip re-pin: `run_all` → synth59 → gate17 → B100 → Creekside → gate19 → optional light ZAP on Railway public URL. Docs: [`STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd_agent_spec/skills/openfdd-stress-closeout/SKILL.md). |
 | **Railway’s optional MCP** (`railway setup agent`) | Railway platform deploys/docs — **not** HVAC FDD. |
 | **`openfdd-mcp` (this package)** | FDD / sites / historian tools against central via `OPENFDD_MCP_TOKEN`. |
 
-Do not point Cursor at Railway MCP and expect Open-FDD AFDD tools. For cloud lab: keep central private; mint agent JWT; set `OPENFDD_API_BASE` to a reachable central URL (private mesh or VPN), not the public web SPA alone for write tools.
+Do not point Cursor at Railway MCP and expect Open-FDD AFDD tools. For cloud lab: keep central private; mint agent JWT; set `OPENFDD_API_BASE` to a reachable central URL (private mesh or VPN), not the public web SPA alone for write tools. For local: `OPENFDD_API_BASE=http://127.0.0.1:8080` (HTTP).
 
 ## Model + FDD wiresheet
 

--- a/mcp/INSTRUCTIONS.md
+++ b/mcp/INSTRUCTIONS.md
@@ -50,7 +50,7 @@ Railway: keep MCP on private networking; see [RAILWAY_DEPLOYMENT.md](../docs/ope
 |------|---------|
 | **`railway` CLI** (`@railway/cli`) | Deploy/re-pin hub images, vars, logs on Railway (`gleaming-cooperation`). Skill: [`openfdd-railway-cli`](../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md). Docs: [`RAILWAY_DEPLOYMENT.md`](../docs/operations/RAILWAY_DEPLOYMENT.md). |
 | **Local Compose (`react-ot`)** | Firewall / on-prem hub — **plain HTTP** UI `:3000` / API `:8080`; **no product TLS yet**. Docs: [`LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md). |
-| **Stress closeout** | After tip re-pin: `run_all` → synth59 → gate17 → B100 → Creekside → gate19 → optional light ZAP on Railway public URL. Docs: [`STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd_agent_spec/skills/openfdd-stress-closeout/SKILL.md). |
+| **Stress closeout** | After tip re-pin: smoke 01/06/10/18 + Pipeline A, then `run_all` → synth59 → gate17 → B100 → Creekside → gate19 → optional light ZAP on Railway public URL. Docs: [`STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd_agent_spec/skills/openfdd-stress-closeout/SKILL.md). |
 | **Railway’s optional MCP** (`railway setup agent`) | Railway platform deploys/docs — **not** HVAC FDD. |
 | **`openfdd-mcp` (this package)** | FDD / sites / historian tools against central via `OPENFDD_MCP_TOKEN`. |
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,7 +14,7 @@ MCP is opt-in — bring up a stack recipe first, then pull MCP on the **same tag
 
 | Path | Doc / skill |
 |------|-------------|
-| Local firewall hub (HTTP `:3000`/`:8080`, **no TLS**) | [`docs/operations/LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md) · `openfdd_maint_update_resume.sh react-ot sha-*` |
+| Local firewall hub (HTTP `:3000`/`:8080`, **no TLS**) | [`docs/operations/LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md) · `SHA=sha-<7chars>; ./scripts/openfdd_maint_update_resume.sh react-ot \"$SHA\" --skip-maintenance` |
 | Railway cloud hub | [`docs/operations/RAILWAY_DEPLOYMENT.md`](../docs/operations/RAILWAY_DEPLOYMENT.md) · skill [`openfdd-railway-cli`](../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md) |
 | Stress LAST after re-pin | [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd_agent_spec/skills/openfdd-stress-closeout/SKILL.md) |
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -10,6 +10,14 @@ Open-FDD does **not** include a built-in AI chatbot. External agents (Codex CLI,
 
 MCP is opt-in — bring up a stack recipe first, then pull MCP on the **same tag**.
 
+**Deploy bootstrap (agents):**
+
+| Path | Doc / skill |
+|------|-------------|
+| Local firewall hub (HTTP `:3000`/`:8080`, **no TLS**) | [`docs/operations/LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md) · `openfdd_maint_update_resume.sh react-ot sha-*` |
+| Railway cloud hub | [`docs/operations/RAILWAY_DEPLOYMENT.md`](../docs/operations/RAILWAY_DEPLOYMENT.md) · skill [`openfdd-railway-cli`](../openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md) |
+| Stress LAST after re-pin | [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd_agent_spec/skills/openfdd-stress-closeout/SKILL.md) |
+
 ```bash
 cd ~/open-fdd
 export OPENFDD_IMAGE_TAG=nightly   # or a pinned semver / sha-*
@@ -18,6 +26,7 @@ export OPENFDD_IMAGE_TAG=nightly   # or a pinned semver / sha-*
 ./scripts/openfdd_stack_pull.sh mcp
 
 # JWT for central REST — prefer dedicated agent identity (operator role)
+# Local: http://127.0.0.1:8080 (plain HTTP — no TLS on Compose yet)
 # On Railway: OPENFDD_AGENT_PASSWORD + username "agent", or admin POST /api/auth/agent-token
 # Hub deploy/re-pin is the Railway CLI (not this MCP) — see docs/operations/RAILWAY_DEPLOYMENT.md
 #   and openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md (project gleaming-cooperation).

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -92,8 +92,10 @@ retest. Do not confuse those with this engineering OS.
 46. **Rule display names (one contract):** `rule_id` is the machine key; `sql_rules/registry.yaml` `description` is the **short human name** for all product UI. Cookbook headings extend that name (GL36 refs, etc.) — see [`docs/RULE_DISPLAY_NAMES.md`](docs/RULE_DISPLAY_NAMES.md). React must use shared formatters (`ruleLabels.ts` — planned) in sidebar `RuleTuningPanel`, FDD Plots picker, plot titles, health-matrix tooltips, and CSV exports. Do **not** truncate sidebar labels while showing full names in the center panel. Merge API rules into `cookbookRuleCatalog` at boot; avoid duplicate static description maps. Cookbook/registry drift is a parity bug — fix in the same PR family as rule changes.
 47. **Package utilities (#805):** `openfdd_package_v1` may include `utilities/manifest.json` (`utilities_v1`) with `electric/monthly_bills.csv`, optional interval/submeter CSVs, or wrapper-level `utility_bills_monthly.csv` (Creekside). Ingest code: [`edge/src/csv_ingest/package.rs`](../edge/src/csv_ingest/package.rs). Legacy fuel campus ZIP: [`services/central/src/fuel/import.rs`](../services/central/src/fuel/import.rs) (read-only).
 48. **Utility meter FDD:** `UTIL-MONTHLY` / `UTIL-INTERVAL` in `sql_rules/registry.yaml` compare BAS vs utility bills/intervals; `SV-*` rules accept `kwh` / `electric_kw` roles on `meter` equipment. Modeling skill: [`skills/data-modeling/SKILL.md`](skills/data-modeling/SKILL.md).
+49. **Local deploy = HTTP behind firewall** — Compose UI `:3000` / API `:8080` are **plain HTTP**; product local stack does **not** terminate TLS yet. Do not expose to the public internet; do not claim local HTTPS unless an ops reverse proxy is documented. Handbook: [`docs/operations/LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md).
+50. **Stress LAST (rigorous closeout):** after tip GHCR + Railway/local re-pin — smoke → `run_all` 00–16 → synth59 → gate 17 → B100 Railway vs local → Creekside → gate 19 bundle → optional light OWASP ZAP on **Railway public URL only**. Cite tip-pin artifacts only (never older-pin stress as proof). Handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](skills/openfdd-stress-closeout/SKILL.md).
 
-**Current ops pin (2026-09-02):** `sha-42b3f49` / `3.3.18` baseline → **3.3.19** engineering export train — verdict in BUG_REPORT.
+**Current ops pin (2026-09-03):** tip `233e6cf6` / product **`sha-15baccf`** / **3.3.19** — engineering export shipped; stress closeout remaining per STRESS_CLOSEOUT + plan 3.3.20. Verdict in BUG_REPORT (flesh after stress).
 
 ---
 
@@ -114,13 +116,14 @@ Nested instructions may specialize but never contradict a higher authority.
 3. [`../docs/agent/PACKAGE_AUTHORING.md`](../docs/agent/PACKAGE_AUTHORING.md)
 4. [`../docs/modeling/`](../docs/modeling/) when packaging / HP / readiness context matters
 5. [`ARCHITECTURE.md`](ARCHITECTURE.md) + [`ownership.yaml`](ownership.yaml)
-6. [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md)
-7. [`tools/open-fdd-vibe21-production/prompts/MASTER_PRODUCTION_LOOP.md`](../tools/open-fdd-vibe21-production/prompts/MASTER_PRODUCTION_LOOP.md)
-8. [`MILESTONE_A.md`](MILESTONE_A.md) if executing Milestone A
-9. [`PR_PROTOCOL.md`](PR_PROTOCOL.md) before opening a PR
-10. [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md) during ops patch cycles
-11. Matching skill
-12. Cookbooks under `docs/rules/cookbook/` + [`docs/RULE_DISPLAY_NAMES.md`](docs/RULE_DISPLAY_NAMES.md) when touching rule labels in UI
+6. Deploy bootstrap: [`docs/operations/LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md) (firewall HTTP hub) + [`docs/operations/RAILWAY_DEPLOYMENT.md`](../docs/operations/RAILWAY_DEPLOYMENT.md) (Railway CLI) + [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) (stress LAST)
+7. [`BUILD_CHECKPOINTS.md`](BUILD_CHECKPOINTS.md)
+8. [`tools/open-fdd-vibe21-production/prompts/MASTER_PRODUCTION_LOOP.md`](../tools/open-fdd-vibe21-production/prompts/MASTER_PRODUCTION_LOOP.md)
+9. [`MILESTONE_A.md`](MILESTONE_A.md) if executing Milestone A
+10. [`PR_PROTOCOL.md`](PR_PROTOCOL.md) before opening a PR
+11. [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md) during ops patch cycles
+12. Matching skill
+13. Cookbooks under `docs/rules/cookbook/` + [`docs/RULE_DISPLAY_NAMES.md`](docs/RULE_DISPLAY_NAMES.md) when touching rule labels in UI
 
 ---
 
@@ -134,8 +137,9 @@ Nested instructions may specialize but never contradict a higher authority.
 | [`openfdd-sql-fdd`](skills/openfdd-sql-fdd/SKILL.md) | DataFusion SQL rules |
 | [`openfdd-pypi-oracle`](skills/openfdd-pypi-oracle/SKILL.md) | PyPI pandas oracle packaging |
 | [`openfdd-cookbook-parity`](skills/openfdd-cookbook-parity/SKILL.md) | Dual cookbook honesty |
-| [`openfdd-stack-ghcr`](skills/openfdd-stack-ghcr/SKILL.md) | GHCR pull / recreate |
+| [`openfdd-stack-ghcr`](skills/openfdd-stack-ghcr/SKILL.md) | GHCR pull / recreate / local firewall hub |
 | [`openfdd-railway-cli`](skills/openfdd-railway-cli/SKILL.md) | Railway CLI auth / tip re-pin |
+| [`openfdd-stress-closeout`](skills/openfdd-stress-closeout/SKILL.md) | Stress LAST / run_all / ZAP / BUG_REPORT evidence |
 | [`openfdd-ecm-engineering`](skills/openfdd-ecm-engineering/SKILL.md) | ECM math library |
 | [`openfdd-milestone-a-pr`](skills/openfdd-milestone-a-pr/SKILL.md) | Milestone A PR loop |
 | [`data-modeling`](skills/data-modeling/SKILL.md) | Package layout, utilities/, equipType, export bundle |

--- a/openfdd_agent_spec/BUILD_CHECKPOINTS.md
+++ b/openfdd_agent_spec/BUILD_CHECKPOINTS.md
@@ -229,3 +229,14 @@ Product voice = React + DataFusion only. Track deletion / GHCR / agent_spec hone
 - [x] P1-M7-02 — H5 generic S3/object-store + DataFusion tuning + central scoped runtime/Railway/loopback-MinIO merged via #762 (`9239574a`); canonical S3 bucket remains private and container disk is scratch/spill
 - [~] P1-M7-03 — H6 migration/operator tooling active via #764: trusted Parquet/JSONL/Arrow discovery + bounded restart-safe conversion, preservation receipts/reports, footer-only canonical stats, operator CLI, fail-closed S3 compatibility scope
 - [ ] P1-M7-04 — H7 live-ingest micro-batch cutover: trustworthy equipment/role identity, H2 accumulator wiring, elapsed/shutdown flush, persisted latest timestamp, retire durability-critical JSONL/IPC rewrite
+
+---
+
+# Ops train 3.3.20 (2026-09-03)
+
+Product ship vs stress closeout — living detail: [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md) · [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md).
+
+- [x] Engineering export + utilities foundation — #827 `15baccf8` / pin `sha-15baccf` / VERSION **3.3.19**; #828 gate-19 shell
+- [x] Agent handbooks — `LOCAL_DEPLOYMENT.md`, `STRESS_CLOSEOUT.md`, skill `openfdd-stress-closeout` (#829)
+- [ ] 3.3.20 rigorous stress LAST — Railway backup + hub re-pin evidence, `run_all` 00–16, synth59, gate 17, B100, Creekside full, gate 19 re-run, optional ZAP
+- [ ] capabilities.yaml — **not** an ops-stress ledger; leave product-capability rows unchanged for this train

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -35,7 +35,12 @@ Product UI: **React** (`compose.react.yml` → host `:3000`). Central image is
 
 OT LAN benches need fieldbus — recipe **`react-ot`**
 (`compose.react.yml` + `compose.react.fieldbus.yml`). Full stress suite:
-[`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md).
+[`scripts/nightly-ot-bench/`](../scripts/nightly-ot-bench/README.md) · agent handbook
+[`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md).
+
+**Local UI/API are plain HTTP** (`:3000` / `:8080`) behind a firewall — product
+Compose does **not** terminate TLS yet. See
+[`docs/operations/LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md).
 
 **Pi 3 edges (~905 MiB):** run **fieldbus-only** (no central/web soak). Prefer
 native `linux/arm64` `openfdd-fieldbus` from GHCR multi-arch (Plan 3 CLOSED on

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,12 @@
 # Session log
 
+## 2026-09-03 — Agent ops docs: stress + local/Railway bootstrap
+
+- Added [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) (STRESS 1–7 incl. light OWASP ZAP) + skill `openfdd-stress-closeout`.
+- Added [`docs/operations/LOCAL_DEPLOYMENT.md`](../docs/operations/LOCAL_DEPLOYMENT.md) — firewall hub, **HTTP only / no product TLS yet**.
+- Wired AGENTS.md rules 49–50, railway-cli / stack-ghcr skills, `mcp/README.md` + `INSTRUCTIONS.md`, `RAILWAY_DEPLOYMENT.md` related-docs table.
+- Plan stress remaining: `.cursor/plans/3.3.20_engineering_ml_bundle_utilities.plan.md` (do not start stress in this docs pass).
+
 ## 2026-09-02 (evening) — 3.3.20 engineering export + utilities closeout
 
 - **Merge:** #827 → `15baccf8`; VERSION **3.3.19**; Export & ML UI, `openfdd_engineering_bundle_v1`, `utilities_v1`, Creekside nested import, `UTIL-MONTHLY`/`UTIL-INTERVAL`.
@@ -8,6 +15,7 @@
 - **Hotfix:** #828 — gate 19 jq `NOT_READY` quote + `PASS` counter shadow fix.
 - **Issues closed:** #763, #805.
 - **GH hygiene END:** 0 open PRs after #828 merge; only `master`.
+- **Note:** full stress matrix (`run_all` / synth59 / B100 / ZAP) still pending per STRESS_CLOSEOUT — BUG_REPORT 3.3.20 verdict still thin until then.
 - Plan: `.cursor/plans/3.3.20_engineering_ml_bundle_utilities.plan.md`
 
 ## 2026-09-02 (afternoon) — 3.3.20 engineering export + utilities (in flight)

--- a/openfdd_agent_spec/docs/WORKFLOWS.md
+++ b/openfdd_agent_spec/docs/WORKFLOWS.md
@@ -14,12 +14,14 @@ Actual workflow files under `.github/workflows/` (open-fdd). Re-list with
 | `docs-pdf.yml` | Docs PDF |
 | `publish-open-fdd.yml` | Publish `open-fdd` to PyPI |
 | `ghcr-openfdd-stack.yml` | Publish stack images; retarget `:nightly` on master |
-
-Low-RAM hosts: **never** local `docker build` of stack images. Wait for this workflow, prune, pull `sha-*`, `openfdd_stack_up.sh --no-pull`.
 | `rust-ghcr-mcp.yml` | Publish `openfdd-mcp` (`:nightly`) |
 | `ghcr-prune.yml` | GHCR retention |
 | `rust-release.yml` | Rust release |
 | `security.yml` / `appsec.yml` | Security / AppSec |
+
+Low-RAM hosts: **never** local `docker build` of stack images. Wait for GHCR publish, prune, pull `sha-*`, `openfdd_stack_up.sh --no-pull`.
+
+**Ops closeout:** after tip publish + re-pin, stress LAST — [`docs/operations/STRESS_CLOSEOUT.md`](../../docs/operations/STRESS_CLOSEOUT.md). Local hub HTTP only — [`docs/operations/LOCAL_DEPLOYMENT.md`](../../docs/operations/LOCAL_DEPLOYMENT.md).
 
 ## Playground (reference)
 

--- a/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
@@ -14,15 +14,16 @@ Checklist: [`RAILWAY_DEPLOYMENT_CHECKLIST.md`](../../../docs/operations/RAILWAY_
 
 **Not Open-FDD MCP.** Railway CLI / Railway’s optional MCP manage cloud deploys. HVAC FDD tools stay in [`mcp/`](../../../mcp/) (`openfdd-mcp` + agent JWT to private central).
 
-## Verified host state (bensbench, 2026-09-01)
+## Verified host state (bensbench, 2026-09-03)
 
 | Item | Value |
 | --- | --- |
 | Package | `@railway/cli` via `npm i -g @railway/cli` |
 | Auth | **`railway login`** (browser) — verified; optional `RAILWAY_TOKEN` in `~/.config/railway/bensbench.env` |
 | Link | `~/open-fdd` → project **`gleaming-cooperation`**, env **`production`** |
-| **Current hub pin** | **`sha-3c9f753`** / `3.3.15+3c9f75311ae1` (re-pin after each Phase 7 fix publish) |
-| Last backup | `~/openfdd-backups/railway/20260901T144551Z/` |
+| **Product hub pin (shipped)** | **`sha-15baccf`** / `3.3.19+15baccf84e24` (#827); tip commit `233e6cf6` (#828 harness) |
+| Stress closeout | After re-pin — [`STRESS_CLOSEOUT.md`](../../../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd-stress-closeout/SKILL.md) |
+| Local firewall hub | HTTP only — [`LOCAL_DEPLOYMENT.md`](../../../docs/operations/LOCAL_DEPLOYMENT.md) |
 
 ### Live services (names matter for CLI)
 
@@ -36,16 +37,17 @@ Always `railway status` / `railway service list` before re-pin — do **not** as
 
 Post-auth snapshot (pre tip re-pin): mqtt Online on `sha-3395551`; web **Crashed** with `invalid port in resolver "fd12::10"` (needs tip `openfdd-web:sha-9667888` + `OPENFDD_NGINX_RESOLVER=auto`).
 
-## Patch train (bosspi → Railway + Phase 7 local gates)
+## Patch train (bosspi → Railway + stress LAST)
 
 Do **not** treat bensbench dual-MQTT as the cloud gate. After each tiny rev / ops fix:
 
-1. Tip Actions green + GHCR Publish (`sha-*` == nightly digest)
+1. Tip Actions green + GHCR Publish (`sha-*` == nightly digest when retargeted)
 2. GH tidy (0 open PRs; delete feature branch)
-3. Re-pin central → mqtt → web; bosspi fieldbus arm64 to same `sha-*`
+3. **Backup** then re-pin central → mqtt → web; bosspi fieldbus arm64 to same `sha-*`
 4. Gates: L1 `/api/health` → L3 mqtt Online + ingest → L4 Pi `has_telemetry` → stream healthy → L5 FDD
-5. **Local bench:** re-stress only the gate(s) fixed (`scripts/nightly-ot-bench/<gate>.sh`); full `run_all` when Phase 7 queue is empty
-6. Sync [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../../../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md) — log FAIL before fix; move to **patched** when green; Railway F1 under separate table
+5. **Local bench:** `openfdd_maint_update_resume.sh react-ot sha-* --skip-maintenance` (HTTP `:3000`/`:8080`, **no TLS**)
+6. **Stress LAST:** full matrix in [`STRESS_CLOSEOUT.md`](../../../docs/operations/STRESS_CLOSEOUT.md) (`run_all` → synth59 → gate17 → B100 → Creekside → gate19 → optional ZAP)
+7. Sync [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../../../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md) — tip-pin artifact paths only
 
 MQTT certs: `railway volume add` on `openfdd-mqtt` at `/mosquitto/certs`, upload `ca.pem` + server cert/key. Pi reachability: `railway tcp-proxy create --port 8883 --service openfdd-mqtt` (human-approved) or VPN. Never commit PEMs/tokens.
 
@@ -96,7 +98,7 @@ railway service source connect --service openfdd-web \
 
 Smoke: public SPA + `https://<web>/api/health`. Sidebar version must match tip (`3.3.11+91fb350…`).
 
-**Dual pipeline:** bosspi → Railway only; bensbench local react stack (`OPENFDD_IMAGE_TAG=sha-*` pull, `--no-pull`) for firewall/on-prem. Do not cross-wire edges for the parity gate.
+**Dual pipeline:** bosspi → Railway only; bensbench local react stack (`OPENFDD_IMAGE_TAG=sha-*` pull) for firewall/on-prem. Local UI/API are **plain HTTP** (`:3000`/`:8080`) — **no product TLS yet**; keep behind firewall. Do not cross-wire edges for the parity gate. See [`LOCAL_DEPLOYMENT.md`](../../../docs/operations/LOCAL_DEPLOYMENT.md).
 
 ## BACKUP before every central re-pin (hard gate)
 

--- a/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
@@ -78,7 +78,7 @@ railway status >/dev/null 2>&1 || railway link
 # Expect: gleaming-cooperation / production
 
 # 4) Re-pin tip — use REAL service names from status
-SHA=sha-15baccf   # product pin 3.3.19; or sha-233e6cf if tip publish available
+SHA=sha-15baccf   # product pin 3.3.19 (#827). Health must match THIS tag.
 CENTRAL_SVC=openfdd-central-cQ-F   # confirm via railway status
 
 railway service source connect --service "$CENTRAL_SVC" \
@@ -96,9 +96,9 @@ railway service source connect --service openfdd-web \
 # If ingest_ok stuck at 0 after mqtt re-pin: railway redeploy -s "$CENTRAL_SVC" -y
 ```
 
-Smoke: public SPA + `https://<web>/api/health`. Sidebar version must match tip (`3.3.19+15baccf…`).
+Smoke: public SPA + `https://<web>/api/health`. Sidebar / `/api/health` version must match the **pinned** SHA (`3.3.19+15baccf…` for `sha-15baccf`).
 
-**Dual pipeline:** bosspi → Railway only; bensbench local react stack (`OPENFDD_IMAGE_TAG=sha-*` pull) for firewall/on-prem. Local UI/API are **plain HTTP** (`:3000`/`:8080`) — **no product TLS yet**; keep behind firewall. Do not cross-wire edges for the parity gate. See [`LOCAL_DEPLOYMENT.md`](../../../docs/operations/LOCAL_DEPLOYMENT.md).
+**Dual pipeline:** bosspi → Railway only; bensbench local `react-ot` for firewall/on-prem. After tip GHCR publish, pull **the same** `sha-*` for central/mqtt/fieldbus **and** web when the checkout matches that tip. Use a local Overview overlay / bind-mount **only** if `frontend/web` is dirty or unmerged (GHCR web would be stale). Local UI/API are **plain HTTP** (`:3000`/`:8080`) — **no product TLS yet**; keep behind firewall. Do not cross-wire edges for the parity gate. See [`LOCAL_DEPLOYMENT.md`](../../../docs/operations/LOCAL_DEPLOYMENT.md).
 
 ## BACKUP before every central re-pin (hard gate)
 

--- a/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
@@ -78,7 +78,7 @@ railway status >/dev/null 2>&1 || railway link
 # Expect: gleaming-cooperation / production
 
 # 4) Re-pin tip — use REAL service names from status
-SHA=sha-91fb350
+SHA=sha-15baccf   # product pin 3.3.19; or sha-233e6cf if tip publish available
 CENTRAL_SVC=openfdd-central-cQ-F   # confirm via railway status
 
 railway service source connect --service "$CENTRAL_SVC" \
@@ -96,7 +96,7 @@ railway service source connect --service openfdd-web \
 # If ingest_ok stuck at 0 after mqtt re-pin: railway redeploy -s "$CENTRAL_SVC" -y
 ```
 
-Smoke: public SPA + `https://<web>/api/health`. Sidebar version must match tip (`3.3.11+91fb350…`).
+Smoke: public SPA + `https://<web>/api/health`. Sidebar version must match tip (`3.3.19+15baccf…`).
 
 **Dual pipeline:** bosspi → Railway only; bensbench local react stack (`OPENFDD_IMAGE_TAG=sha-*` pull) for firewall/on-prem. Local UI/API are **plain HTTP** (`:3000`/`:8080`) — **no product TLS yet**; keep behind firewall. Do not cross-wire edges for the parity gate. See [`LOCAL_DEPLOYMENT.md`](../../../docs/operations/LOCAL_DEPLOYMENT.md).
 

--- a/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-stack-ghcr/SKILL.md
@@ -50,9 +50,11 @@ operator JWT); do not put `OPENFDD_ADMIN_PASSWORD` into Cursor MCP config.
 Admins may `POST /api/auth/agent-token` for short-lived operator JWTs.
 Edge kits: operator/admin `POST /api/mqtt/edge-kits` or Operations MQTT UI
 (ZIP never includes CA private key).
-Local Compose keeps the default `central:8080`. Do not claim a Railway-ready
-nightly until stack + MCP GHCR publish jobs are green and the target `sha-*`
-digest resolves.
+Local Compose keeps the default `central:8080`. **Local dashboard is HTTP only** (UI `:3000`, API `:8080`) behind a firewall — product Compose does **not** terminate TLS yet. Handbook: [`docs/operations/LOCAL_DEPLOYMENT.md`](../../docs/operations/LOCAL_DEPLOYMENT.md).
+
+Do not claim a Railway-ready nightly until stack + MCP GHCR publish jobs are green and the target `sha-*` digest resolves.
+
+**Stress LAST** after re-pin: [`docs/operations/STRESS_CLOSEOUT.md`](../../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd-stress-closeout/SKILL.md).
 
 Hourly CSV append is API `POST /api/csv/import/package/append` on central (GHA image), not a local compile.
 

--- a/openfdd_agent_spec/skills/openfdd-stress-closeout/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-stress-closeout/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: openfdd-stress-closeout
+description: >-
+  Use when closing a nightly/product train with rigorous stress LAST, dual
+  pipeline (Railway + local), BUG_REPORT evidence, Creekside/gate 19/bundle,
+  or light OWASP ZAP on Railway. Triggers on: run_all, stress closeout,
+  synthetic-59, gate 17, B100 parity, gate 19, zap-baseline, STRESS 1–7,
+  WEATHER_SOAK_SECS, SKIP_PULL.
+---
+
+# Stress closeout (Open-FDD)
+
+Full handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../../../docs/operations/STRESS_CLOSEOUT.md)  
+Local hub (HTTP / no TLS): [`docs/operations/LOCAL_DEPLOYMENT.md`](../../../docs/operations/LOCAL_DEPLOYMENT.md)  
+Railway CLI re-pin: [`openfdd-railway-cli`](../openfdd-railway-cli/SKILL.md)  
+Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../../../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md)
+
+## Order (non-negotiable)
+
+1. Tip GHCR publish green → Railway backup + re-pin (central→mqtt→web) → local `react-ot` re-pin → bosspi if in scope  
+2. Smoke 01/06/10/18 + Pipeline A  
+3. STRESS 1–6 on tip pin (`run_all` → synth59 → gate17 → B100 → Creekside → gate19)  
+4. STRESS 7 light ZAP on **Railway public HTTPS** only (optional fluffy AppSec)  
+5. BUG_REPORT + SESSION_LOG with **this tip’s** artifact paths → GH hygiene END  
+
+## Quick commands
+
+```bash
+SHA=sha-<7>
+export OPENFDD_IMAGE_TAG="$SHA" WEATHER_SOAK_SECS=120
+unset SKIP_PULL
+
+./scripts/railway_central_workspace_backup.sh   # before hub re-pin
+# railway service source connect …  (see railway-cli skill)
+
+./scripts/openfdd_maint_update_resume.sh react-ot "$SHA" --skip-maintenance
+./scripts/nightly-ot-bench/run_all.sh
+# … then STRESS 2–7 per STRESS_CLOSEOUT.md
+```
+
+## Agent rules
+
+- Stress is **LAST** — never before tip re-pin.
+- Do not cite older-pin stress as proof for a newer tip.
+- Local dashboard = **HTTP behind firewall**; no product TLS yet.
+- ZAP = Railway public origin only; not bug-bounty depth; archive under `reports/zap-railway_<TS>/`.
+- MCP/FDD tools ≠ Railway CLI (deploy) ≠ Railway platform MCP.


### PR DESCRIPTION
## Summary
- Add `docs/operations/STRESS_CLOSEOUT.md` (rigorous stress LAST matrix, STRESS 7 light OWASP ZAP)
- Add `docs/operations/LOCAL_DEPLOYMENT.md` (firewall hub, plain HTTP `:3000`/`:8080`, **no product TLS yet**)
- New skill `openfdd-stress-closeout`; refresh railway-cli / stack-ghcr / AGENTS / MCP / CONTAINER_AGENT

## Test plan
- [ ] CodeRabbit review
- [ ] Spot-check links from `openfdd_agent_spec/AGENTS.md` bootstrap reading order
- [ ] Confirm no secrets / protected cookbook paths without bypass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for local, firewall-protected Compose deployments, including HTTP endpoints, authentication, MQTT access, and optional HTTPS proxying.
  * Added a rigorous post-deployment stress-validation workflow for local and Railway environments, including required checks and optional security scanning.
  * Expanded deployment references, workflow guidance, agent handbooks, and operational skills with updated links, sequencing, and release-pinning instructions.
  * Clarified that local Compose services use HTTP without built-in TLS termination and documented the associated network security requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->