### PR TITLE
Polish PayPal support links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,3 @@
 # Support open-source BAS development
 custom:
-  - "https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&amount=25&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"
-  - "https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&amount=50&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"
-  - "https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&amount=250&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"
   - "https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ Intended for **LAN / VPN / OT networks**, not public internet hosting.
 
 Do **not** report vulnerabilities through public GitHub issues or discussions. Use [GitHub Private Vulnerability Reporting](https://github.com/bbartling/open-fdd/security/advisories/new). See [SECURITY.md](SECURITY.md) for what to include and how to redact sensitive OT/deployment evidence.
 
+## 💛 Support Open-FDD
+
+If Open-FDD saves you time or helps with BAS/FDD work, you can support continued open-source development through PayPal.
+
+<p align="center">
+  <a href="https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&amount=25&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"><img src="https://img.shields.io/badge/Donate-$25-0070BA?style=for-the-badge&logo=paypal&logoColor=white" alt="Donate $25 via PayPal"></a>
+  <a href="https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&amount=50&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"><img src="https://img.shields.io/badge/Donate-$50-0070BA?style=for-the-badge&logo=paypal&logoColor=white" alt="Donate $50 via PayPal"></a>
+  <a href="https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&amount=250&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"><img src="https://img.shields.io/badge/Donate-$250-0070BA?style=for-the-badge&logo=paypal&logoColor=white" alt="Donate $250 via PayPal"></a>
+  <a href="https://www.paypal.com/donate/?business=VBRBPMBZ6ZKM8&no_recurring=0&item_name=Thank+you+for+supporting+open+source+building+automation+system+software+development&currency_code=USD"><img src="https://img.shields.io/badge/Donate-Custom%20Amount-0070BA?style=for-the-badge&logo=paypal&logoColor=white" alt="Choose a custom PayPal donation amount"></a>
+</p>
+
+The repository Sponsor button uses the same custom PayPal donation page so the popup stays clean with a single external link.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Simplifies the GitHub Sponsor popup to a single PayPal donation link and adds clean README donation buttons for $25, $50, $250, and a custom amount. This keeps the native Sponsor UI minimal while preserving fixed donation choices in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a “Support Open-FDD” section to the README with PayPal donation options for $25, $50, $250, or a custom amount.
  - Clarified that the repository’s Sponsor button links to the custom PayPal donation page.

- **Chores**
  - Updated the funding configuration to use a single PayPal donation link without a preset amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->