### PR TITLE
docs: bench recovery + patch train mirrors (3.3.21–3.3.26)

### DIFF
--- a/docs/operations/BENCH_RECOVERY.md
+++ b/docs/operations/BENCH_RECOVERY.md
@@ -1,0 +1,182 @@
+---
+title: Bench recovery (machine death)
+parent: Operations
+nav_order: 2
+---
+
+# Bench recovery — recreate Open-FDD field edge if this host dies
+
+**Purpose:** If **bensbench** (or any field laptop) is lost, a new x86 Linux box can resume the Railway hub + fieldbus topology and continue the **3.3.21→3.3.26** patch trains using **only** GitHub + GHCR + Railway + documented secrets (never secrets in git).
+
+Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](BUG_REPORT_OT_MODBUS_HAYSTACK.md).  
+Patch trains (mirrored Cursor plans): [`patch_trains/`](patch_trains/).  
+AI handoff: [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
+Stress handbook: [`STRESS_CLOSEOUT.md`](STRESS_CLOSEOUT.md).  
+Rev loop: [`PATCH_CYCLE.md`](PATCH_CYCLE.md).
+
+## What survives without this disk
+
+| Asset | Where | Notes |
+|-------|--------|------|
+| Product source + scripts | `github.com/bbartling/open-fdd` `master` | Clone fresh |
+| Stack images | `ghcr.io/bbartling/openfdd-{central,web,mqtt,fieldbus}:sha-<7>` | Pull only — never local docker build on low-RAM |
+| Hub data | Railway volume `/workspace` | Restore from `~/openfdd-backups/railway/<UTC>/` **if you copied backups off-box**; else hub Parquet may still be on Railway |
+| MQTT edge kit | **Not in git** | Re-issue via `POST /api/mqtt/edge-kits` **only if** Railway mqtt volume has CA **key**; today often **reuse `pi-1` kit** (CA key absent) — see BUG_REPORT |
+| Railway CLI token | Operator secret | `railway login` / `RAILWAY_TOKEN` |
+| GH token | Operator secret | `gh auth login` |
+| Creekside fixture zip | Operator file | Path historically `/home/ben/OpenFdd_Creekside.zip` — **copy off-box**; not in git |
+| Cursor plans | **Also in-repo** under `docs/operations/patch_trains/` | Do not rely on `~/.cursor/plans` alone |
+| Tuner baseline JSON | `docs/operations/recovery/*_tuners_snapshot*.json` | Vibe19 vs Lab counts |
+
+## Target topology (do not invent a new one)
+
+```text
+[new x86 host]
+  openfdd-fieldbus (GHCR sha-<7>, host net)
+       │ MQTTS
+       ▼
+Railway: openfdd-mqtt :8883 (TCP proxy reseau.proxy.rlwy.net:44763)
+       │
+       ▼
+Railway: openfdd-central-cQ-F  (volume /workspace)
+       │
+       ▼
+Railway: openfdd-web  https://openfdd-web-production-af99.up.railway.app
+```
+
+- **No** Raspberry Pi on Open-FDD closeout.
+- **No** local `react-ot` hub as AFDD head-end for patch cycles.
+- Project: Railway `gleaming-cooperation` / env `production`.
+
+## Day-0 on a new machine (checklist)
+
+### 1) OS + tools
+
+```bash
+# docker, gh, railway CLI, python3, git, curl, jq
+gh auth login
+railway login   # or export RAILWAY_TOKEN
+docker login ghcr.io   # if private pulls required
+```
+
+### 2) Clone + link Railway
+
+```bash
+git clone https://github.com/bbartling/open-fdd.git
+cd open-fdd
+git checkout master && git pull
+railway link   # gleaming-cooperation / production / openfdd-central-cQ-F
+```
+
+Optional: copy [`~/.config/railway/bensbench.env.example`](../../.config/railway/bensbench.env.example) pattern — **never commit** filled `bensbench.env`.
+
+### 3) Discover tip pin
+
+```bash
+git log -1 --oneline
+cat VERSION
+gh run list --branch master --workflow "Publish Open-FDD stack to GHCR" --limit 3
+# SHA=sha-<first7 of tip commit that Publish succeeded for>
+```
+
+Health must read `3.3.N+<fullsha-prefix>` after re-pin.
+
+### 4) Hub backup (before any re-pin)
+
+```bash
+./scripts/railway_central_workspace_backup.sh
+# → ~/openfdd-backups/railway/<UTC>/central-workspace.tgz (+ mqtt-certs.tgz)
+# COPY THAT DIRECTORY OFF-BOX (USB / other host / encrypted cloud)
+```
+
+### 5) Re-pin hub (central → mqtt → web)
+
+See [`RAILWAY_DEPLOYMENT.md`](RAILWAY_DEPLOYMENT.md):
+
+```bash
+SHA=sha-<7>
+CENTRAL_SVC=openfdd-central-cQ-F
+railway service source connect --service "$CENTRAL_SVC" \
+  --image "ghcr.io/bbartling/openfdd-central:${SHA}"
+railway service source connect --service openfdd-mqtt \
+  --image "ghcr.io/bbartling/openfdd-mqtt:${SHA}"
+railway variable set OPENFDD_NGINX_RESOLVER=auto --service openfdd-web
+railway service source connect --service openfdd-web \
+  --image "ghcr.io/bbartling/openfdd-web:${SHA}"
+curl -sS "$OPENFDD_API_BASE/api/health"   # expect 3.3.N+…
+```
+
+Public web: `https://openfdd-web-production-af99.up.railway.app`
+
+### 6) Fieldbus only on this host
+
+```bash
+# Edge kit: deploy/mqtt/kits/bldg2__pi-1/  (restore from backup OR mint if CA allows)
+./scripts/openfdd_fieldbus_railway_up.sh "$SHA"
+curl -sf http://127.0.0.1:8081/health
+# Railway: /api/edges → has_telemetry true for pi-1 / bldg2
+```
+
+Defaults in script: `OPENFDD_MQTT_HOST=reseau.proxy.rlwy.net`, port `44763`, site `bldg2`, edge `pi-1`.
+
+Field devices: hosted weather loopback AV (see `config/fieldbus/` + compose edge railway) — no JCI/Pi required for stress.
+
+### 7) Stress LAST (must cite this tip)
+
+```bash
+export OPENFDD_API_BASE=https://openfdd-web-production-af99.up.railway.app
+# ensure RAILWAY_ADMIN_PASSWORD available for gates that need it
+./scripts/nightly-ot-bench/run_railway_hub_stress.sh
+```
+
+Matrix: [`STRESS_CLOSEOUT.md`](STRESS_CLOSEOUT.md) STRESS 0–6 (synth59, gate17, B100 `RAILWAY_ONLY=1`, Creekside, gate19, light ZAP).
+
+**Creekside zip:** place operator copy then run spot scripts under `scripts/gates/creekside_package_import_spot.sh`.
+
+### 8) Resume patch trains
+
+1. Read [`patch_trains/openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](patch_trains/openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md)
+2. Open **one** child plan at a time
+3. Log every Verdict in BUG_REPORT (silent skip forbidden)
+4. Optional: copy plans into `~/.cursor/plans/` for Cursor UI TODOs
+
+### 9) GH hygiene every rev
+
+```bash
+gh pr list --state open          # must be 0 at END
+git ls-remote --heads origin     # only master (+ current PR head while open)
+gh run list --branch master --limit 15
+```
+
+## Off-box backup pack (operator — do this before the disk dies)
+
+Copy periodically to USB / second host (secrets encrypted):
+
+```text
+~/openfdd-backups/railway/<latest>/          # central-workspace.tgz + mqtt-certs.tgz
+~/open-fdd/deploy/mqtt/kits/bldg2__pi-1/     # edge kit PEMs (sensitive)
+~/OpenFdd_Creekside.zip                      # fixture
+~/.config/railway/bensbench.env              # if used (sensitive)
+open-fdd/.env                                # if used (sensitive) — never git
+```
+
+Git alone is **not** enough for kits/certs/zips.
+
+## Scripts map (all in-repo)
+
+| Script | Role |
+|--------|------|
+| `scripts/railway_central_workspace_backup.sh` | Hub volume tar |
+| `scripts/openfdd_fieldbus_railway_up.sh` | x86 field → Railway MQTTS |
+| `scripts/nightly-ot-bench/run_railway_hub_stress.sh` | CSV + ZAP closeout |
+| `scripts/gates/railway_b100_parity_spot.sh` | B100 Railway parity |
+| `scripts/gates/creekside_package_import_spot.sh` | Creekside import |
+| `scripts/openfdd_docker_maintenance.sh` | Low-RAM non-aggressive cleanup |
+
+## Anti-patterns
+
+- Local `docker build` of central/web on a small bench
+- Standing up `react-ot` as production AFDD head-end for closeout
+- Putting Pis back on stress path
+- Committing kits, tokens, OT LAN IPs, or filled `.env`
+- Claiming a rev CLOSED with stress artifacts from an older `sha-*`

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -8,14 +8,31 @@
 
 ## Next patch cycle (copy into `.cursor/plans/patch_cycle_3.3.N_<slug>.plan.md`)
 
-Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes in the **3.3.21** column as you go. Do **not** bump VERSION for a pure evidence/docs PR.
+Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. Do **not** bump VERSION for a pure evidence/docs PR.
+
+### Upcoming trains (Cursor plans — 2026-09-04)
+
+**Source of truth in-repo (survives laptop death):** [`patch_trains/`](patch_trains/) · machine recreate [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · AI handoff [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
+Optional local Cursor copies: `~/.cursor/plans/` (keep in sync with `patch_trains/`).  
+Topology: Railway hub + bensbench **x86 fieldbus** + light ZAP. **Skip** only with a **DEFERRED** row here.
+
+| Rev | In-repo plan | Concern | Status |
+|-----|--------------|---------|--------|
+| 3.3.21 closeout | [`patch_trains/3.3.21_closeout_railway_stress.plan.md`](patch_trains/3.3.21_closeout_railway_stress.plan.md) | Re-pin + stress + Verdict (product already merged) | PENDING |
+| 3.3.22 | [`patch_trains/3.3.22_one_dump_ia.plan.md`](patch_trains/3.3.22_one_dump_ia.plan.md) | One **Dump** page; ingest left-rail only; kill Export&ML multi-page | PENDING |
+| 3.3.23 | [`patch_trains/3.3.23_faults_lab_declutter.plan.md`](patch_trains/3.3.23_faults_lab_declutter.plan.md) | Faults/Lab declutter (category-first; less settings-on-faults) | PENDING |
+| 3.3.24 | [`patch_trains/3.3.24_tuners_gl36_wave.plan.md`](patch_trains/3.3.24_tuners_gl36_wave.plan.md) | Lab/registry GL36 FC thresholds (SQL-honest) | PENDING |
+| 3.3.25 | [`patch_trains/3.3.25_tuners_sv_econ_ahu_wave.plan.md`](patch_trains/3.3.25_tuners_sv_econ_ahu_wave.plan.md) | Lab/registry SV/ECON/AHU/plant gaps | PENDING |
+| 3.3.26 | [`patch_trains/3.3.26_tuners_gates_residual.plan.md`](patch_trains/3.3.26_tuners_gates_residual.plan.md) | Optional gate trio + soft-OPEN triage + series wrap | PENDING |
+
+**Tuner reference:** Vibe19 UI ~414 vs Lab ~184 — JSON snapshots in [`recovery/`](recovery/). Goal = phased SQL-honest Lab expansion — **not** a hard 414.
 
 | TODO | 3.3.20 | 3.3.21 |
 |------|--------|--------|
 | Hygiene START (0 PRs, only master, tip Actions green) | [x] | |
-| VERSION + Cargo `3.3.(N-1)` → `3.3.N` | [x] 3.3.19→3.3.20 | |
-| One-concern fix | [x] x86→Railway hub | |
-| PR squash-merge + delete branch | [x] #831 | |
+| VERSION + Cargo `3.3.(N-1)` → `3.3.N` | [x] 3.3.19→3.3.20 | [ ] product merged; closeout ops |
+| One-concern fix | [x] x86→Railway hub | [x] Overview/MQTT/Metering (#833) |
+| PR squash-merge + delete branch | [x] #831 | [x] #833 |
 | GHCR Publish `sha-<7>` | [x] `sha-aef6fc1` | |
 | Railway backup + re-pin central→mqtt→web | [x] `20260904T035328Z` | |
 | `openfdd_fieldbus_railway_up.sh sha-<7>` | [x] | |

--- a/docs/operations/PATCH_CYCLE.md
+++ b/docs/operations/PATCH_CYCLE.md
@@ -12,7 +12,9 @@ Copy this file’s **Cursor plan YAML** into `.cursor/plans/patch_cycle_3.3.N_<s
 **Field:** bensbench **x86** `openfdd-fieldbus` only → Railway MQTTS.  
 **Pis:** not in Open-FDD stress (freed for vibe13 / other benches).
 
-Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](BUG_REPORT_OT_MODBUS_HAYSTACK.md). Stress handbook: [`STRESS_CLOSEOUT.md`](STRESS_CLOSEOUT.md).
+Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](BUG_REPORT_OT_MODBUS_HAYSTACK.md). Stress handbook: [`STRESS_CLOSEOUT.md`](STRESS_CLOSEOUT.md).  
+**Machine death / new bench:** [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md). **AI handoff:** [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
+**Active series (3.3.21–3.3.26):** [`patch_trains/`](patch_trains/) (mirrored Cursor plans — keep GitHub as source of truth).
 
 ## Rev bump rule
 

--- a/docs/operations/STRESS_CLOSEOUT.md
+++ b/docs/operations/STRESS_CLOSEOUT.md
@@ -62,7 +62,8 @@ docker run --rm -v "$PWD/$ART:/zap/wrk:rw" -t ghcr.io/zaproxy/zaproxy:stable \
 | `scripts/nightly-ot-bench/19_engineering_bundle_validate.sh` | `openfdd_engineering_bundle_v1` structural validate |
 | `scripts/openfdd_bundle_validate.py` | Offline bundle schema / READY |
 
-Export UI: `/export` (alias `/wattlab`). Bundle API: `POST /api/jobs/{id}/exports`.
+Export / Dump UI: `/export` (nav label **Dump** after 3.3.22; alias `/wattlab`). Bundle API: `POST /api/jobs/{id}/exports`.  
+Machine recreate: [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md). Patch trains: [`patch_trains/`](patch_trains/).
 
 ## After stress
 

--- a/docs/operations/patch_trains/3.3.21_closeout_railway_stress.plan.md
+++ b/docs/operations/patch_trains/3.3.21_closeout_railway_stress.plan.md
@@ -1,0 +1,101 @@
+---
+name: 3.3.21 closeout Railway stress
+overview: "Finish 3.3.21 train already merged to master — GH hygiene, wait/confirm GHCR sha for tip, Railway backup+re-pin, x86 fieldbus, Railway CSV+ZAP stress LAST, BUG_REPORT Verdict 3.3.21. No new product scope unless tip publish is blocked."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START — 0 open PRs (merge/close paypal leftovers); only master; tip Actions green; kill failed tip noise with cause
+    status: pending
+  - id: p1-tip-ghcr
+    content: Confirm master tip VERSION 3.3.21; wait Publish Open-FDD stack green; record sha-<7> (prefer tip including docs-only paypal.me if already merged)
+    status: pending
+  - id: p2-backup-repin
+    content: railway_central_workspace_backup.sh; re-pin central→mqtt→web to sha-<7>; prove health 3.3.21+…
+    status: pending
+  - id: p3-fieldbus
+    content: openfdd_fieldbus_railway_up.sh sha-<7>; /api/edges has_telemetry; no local react-ot hub
+    status: pending
+  - id: p4-site-cleanup
+    content: "SKIPpable: Railway sites list vs MQTT+CSV truth (bosspi leftovers); DEFER if blocked"
+    status: pending
+  - id: p5-stress
+    content: run_railway_hub_stress.sh LAST (synth59, gate17, B100 RAILWAY_ONLY, Creekside, gate19, light ZAP)
+    status: pending
+  - id: p6-bug-report
+    content: BUG_REPORT Verdict 3.3.21 + SESSION_LOG paths; evidence PR no VERSION bump if needed
+    status: pending
+  - id: p7-hygiene-end
+    content: GH hygiene END — 0 PRs; only master; tip green
+    status: pending
+isProject: false
+---
+
+# 3.3.21 closeout — Railway re-pin + stress (no new product)
+
+**Parent program:** [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](./openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md)
+
+Product honesty for 3.3.21 (Overview/MQTT Zone Other/Metering) already squash-merged. This plan **only** closes the ops loop so the hub matches tip and BUG_REPORT gets a real Verdict table.
+
+Do **not** start 3.3.22 until this plan’s `p6-bug-report` is done (CLOSED or partial with DEFERRED rows).
+
+## Preconditions
+
+- Repo: `/home/ben/open-fdd`
+- Hub still may show `3.3.20+aef6fc1…` until re-pin — that is expected
+- Low-RAM: no local `docker build`; non-aggressive `openfdd_docker_maintenance.sh` only if disk tight
+- Merge any open docs-only PRs (e.g. paypal.me) **before** or **after** stress; if merged after product tip publish, prefer re-pin to tip that still contains 3.3.21 product bits — docs-only tip may republish GHCR; re-pin only if you want tip SHA identity match ([`PATCH_CYCLE.md`](../open-fdd/docs/operations/PATCH_CYCLE.md) docs tip note)
+
+## Hygiene START
+
+```bash
+cd ~/open-fdd
+gh pr list --state open          # empty or only this train’s docs PR
+git fetch --prune
+git ls-remote --heads origin     # only master (+ optional docs head)
+gh run list --branch master --limit 20
+```
+
+Cancel/rerun failed tip runs only with written cause in SESSION_LOG.
+
+## GHCR
+
+1. `git log -1 --oneline origin/master` → expect VERSION file `3.3.21`
+2. Wait workflow **Publish Open-FDD stack to GHCR** success on tip (or nearest tip with product)
+3. Record `SHA=sha-<7>` (first 7 of full commit) and Publish run URL
+
+## Railway + field
+
+```bash
+./scripts/railway_central_workspace_backup.sh
+# re-pin central → mqtt → web to $SHA (RAILWAY_DEPLOYMENT.md)
+./scripts/openfdd_fieldbus_railway_up.sh "$SHA"
+# prove: public /api/health version 3.3.21+… ; edges has_telemetry
+```
+
+**SKIP / DEFER `p4-site-cleanup`** if operator time-boxed — log `DEFERRED: railway-site-cleanup → 3.3.26`.
+
+## Stress LAST
+
+```bash
+export OPENFDD_API_BASE=https://openfdd-web-production-af99.up.railway.app
+./scripts/nightly-ot-bench/run_railway_hub_stress.sh
+```
+
+Fill STRESS 0–6 per [`STRESS_CLOSEOUT.md`](../open-fdd/docs/operations/STRESS_CLOSEOUT.md). Cite **this** tip’s report dirs only.
+
+## BUG_REPORT
+
+Add **Verdict — 3.3.21** table (mirror 3.3.20 CLOSED shape) including:
+
+- Shipped: Overview readiness, Lab A–Z, series window honesty, Zone Other, Metering package utilities, Creekside HP smoke (as actually merged)
+- Ops: backup path, `sha-<7>`, fieldbus, stress paths, ZAP summary
+- DEFERRED: anything skipped (site cleanup, deep ZAP, B50, etc.)
+
+## Hygiene END
+
+0 open PRs; only `master`; tip Actions green; remote feature branches deleted.
+
+## Anti-patterns
+
+- Claiming 3.3.21 CLOSED with hub still on `sha-aef6fc1` / `3.3.20`
+- Starting 3.3.22 product work mid-stress
+- Local react-ot / Pi fieldbus for closeout

--- a/docs/operations/patch_trains/3.3.22_one_dump_ia.plan.md
+++ b/docs/operations/patch_trains/3.3.22_one_dump_ia.plan.md
@@ -1,0 +1,98 @@
+---
+name: 3.3.22 one Dump IA
+overview: "Low-RAM 3.3.21→3.3.22: single Dump page (one engineering dump); remove Export&ML multi-page Uploads/Fuel/Twin/ECM chrome; CSV/package ingest only via left-rail Upload — not main tab bodies. Railway re-pin + CSV+ZAP stress LAST. GH tidy START+END."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START — 0 open PRs; only master; tip Actions green
+    status: pending
+  - id: p1-version
+    content: Bump VERSION + Cargo 3.3.21 → 3.3.22
+    status: pending
+  - id: p2a-nav-rename
+    content: MAIN_SECTIONS + SIDEBAR_NAV — Export & ML → Dump; routes /export keep alias; tests AppShell
+    status: pending
+  - id: p2b-one-dump-ui
+    content: WattLabPage/ExportPage — one dump workflow only; remove EXPORT_PAGES radio (Uploads/Fuel/Twin/ECMs)
+    status: pending
+  - id: p2c-ingest-left-rail
+    content: No CSV/package upload widgets in Dump/Metering main bodies; ingest via /upload + sidebar Building data only
+    status: pending
+  - id: p2d-fuel-metering
+    content: Fuel analytics stay on Metering (package utilities); deep-link from Dump if needed — no second fuel ZIP path
+    status: pending
+  - id: p2e-twin-ecm
+    content: Twin/ECM remain /twin and engineering paths — not Dump sub-tabs; copy + nav honesty
+    status: pending
+  - id: p2f-docs-agents
+    content: AGENTS/ops docs — Dump not Export&ML; update STRESS_CLOSEOUT Export UI line
+    status: pending
+  - id: p3-pr
+    content: One PR; squash-merge --delete-branch; wait GHCR sha-<7>
+    status: pending
+  - id: p4-repin
+    content: Railway backup + re-pin; x86 fieldbus same sha
+    status: pending
+  - id: p5-stress
+    content: run_railway_hub_stress.sh + Dump smoke (one profile download) + Metering package utilities smoke
+    status: pending
+  - id: p6-bug-report
+    content: BUG_REPORT Verdict 3.3.22 — IA shipped + DEFERRED; SESSION_LOG
+    status: pending
+  - id: p7-hygiene-end
+    content: GH hygiene END
+    status: pending
+isProject: false
+---
+
+# 3.3.22 — One Dump + information architecture honesty
+
+**Parent:** [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](./openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md)  
+**Requires:** 3.3.21 closeout CLOSED (or hub already on 3.3.21+ with stress logged).
+
+## Pain (operator)
+
+Main tab **Export & ML** currently hosts a radio of **Uploads / Fuel dashboard / Twin / ECMs** plus export machinery — feels like a second app. CSV ingest also appears lumped with fuel/HVAC in confusing chrome. Goal: **one dump**, **ingest only in left rail**.
+
+## Product scope (one concern: IA)
+
+### Ship
+
+1. **Rename** primary nav label `Export & ML` → **Dump** in [`frontend/web/src/nav/sections.ts`](../open-fdd/frontend/web/src/nav/sections.ts) (`MAIN_SECTIONS` + `SIDEBAR_NAV`). Keep path `/export` (+ `/wattlab` redirect) for bookmarks.
+2. **Single Dump page** in [`frontend/web/src/pages/WattLabPage.tsx`](../open-fdd/frontend/web/src/pages/WattLabPage.tsx):
+   - Remove `EXPORT_PAGES` radio (`Uploads`, `Fuel dashboard`, `Twin / calibrate`, `ECMs`).
+   - One column: Active site caption → job pick (or create) → profile (`summary`/`diagnostic`/`forensic`) → **Run dump / download** → short JSON/status.
+   - Optional: one-line links “Package ingest → Upload”, “Fuel analytics → Metering”, “Twin → Twin” — **not** embedded multi-apps.
+3. **Ingest rule:** No CSV / package / fuel ZIP upload controls on Dump or Metering **main** bodies. Upload lives at `/upload` and sidebar Building data / Sites flows already used for packages.
+4. **Metering** remains the place for package `utilities_v1` / Creekside monthly+interval charts ([`MeteringPage.tsx`](../open-fdd/frontend/web/src/pages/MeteringPage.tsx)) — already fuel-ZIP-free from 3.3.21; verify no regress.
+5. **Twin** stays [`/twin`](../open-fdd/frontend/web/src/pages/TwinPage.tsx); ECM flows stay Actions / engineering — not Dump tabs.
+6. Tests: [`AppShell.test.tsx`](../open-fdd/frontend/web/src/components/AppShell.test.tsx) expects “Dump”; Export page tests updated for single workflow.
+7. Docs: AGENTS + [`STRESS_CLOSEOUT.md`](../open-fdd/docs/operations/STRESS_CLOSEOUT.md) “Export UI” → Dump.
+
+### Explicit non-goals (SKIP → DEFERRED)
+
+- Redesigning WattLab ML clustering / time-window (#763 depth)
+- New export profiles beyond existing three
+- Moving Metering charts into Dump
+- Sidebar IA mega-refactor beyond label honesty
+
+## Loop
+
+Hygiene → VERSION **3.3.22** → PR → GHCR → Railway backup/re-pin → fieldbus → **stress LAST** → BUG_REPORT → hygiene END.
+
+### Stress extras for this rev
+
+- After hub stress matrix: operator or scripted smoke — Dump produces one downloadable bundle for `BUILDING_100` or Creekside site without visiting Uploads/Fuel sub-tabs (they must not exist).
+- Metering still shows package utilities for LAKESIDE_ES / active site with utilities.
+
+## BUG_REPORT Verdict 3.3.22 must log
+
+- Nav label Dump; removed Export multi-page radio
+- Ingest-only-left-rail confirmation
+- Stress + ZAP artifact paths for `sha-<7>`
+- Any SKIP as DEFERRED with next rev id
+
+## Anti-patterns
+
+- Leaving “Export & ML” string in main radio
+- Re-introducing fuel campus ZIP upload
+- Embedding Twin/ECM full UIs inside Dump “for convenience”

--- a/docs/operations/patch_trains/3.3.23_faults_lab_declutter.plan.md
+++ b/docs/operations/patch_trains/3.3.23_faults_lab_declutter.plan.md
@@ -1,0 +1,90 @@
+---
+name: 3.3.23 Faults Lab declutter
+overview: "Low-RAM 3.3.22→3.3.23: stop Faults/Lab from feeling like a wall of settings — category-first rule pickers, quieter status chrome, clearer Run vs Tune copy. No fake tuner expansion this rev. Railway stress + ZAP LAST. GH tidy."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START
+    status: pending
+  - id: p1-version
+    content: Bump VERSION + Cargo 3.3.22 → 3.3.23
+    status: pending
+  - id: p2a-lab-category-first
+    content: RuleTuningPanel — default category filter; avoid dumping entire 60+ rule list as primary chrome
+    status: pending
+  - id: p2b-faults-page-chrome
+    content: Findings/Faults / Reports filters — Status All/FAULT/PASS not mixed with tuner settings; honest empty states
+    status: pending
+  - id: p2c-copy
+    content: "Toolbar copy: Tune thresholds in Lab sidebar; Run all rules = health flags; Update analytics ≠ FDD"
+    status: pending
+  - id: p2d-tests
+    content: RuleTuningPanel + Findings/Reports tests for category-first + copy
+    status: pending
+  - id: p3-pr
+    content: One PR; merge --delete-branch; GHCR sha-<7>
+    status: pending
+  - id: p4-repin
+    content: Railway backup + re-pin; x86 fieldbus
+    status: pending
+  - id: p5-stress
+    content: run_railway_hub_stress.sh + Lab UX smoke (pick family → tune → run one rule)
+    status: pending
+  - id: p6-bug-report
+    content: BUG_REPORT Verdict 3.3.23
+    status: pending
+  - id: p7-hygiene-end
+    content: GH hygiene END
+    status: pending
+isProject: false
+---
+
+# 3.3.23 — Faults / Lab declutter (UX only)
+
+**Parent:** [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](./openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md)  
+**Requires:** 3.3.22 Dump IA CLOSED.
+
+## Pain (operator)
+
+Faults / rule UI presents a **giant flat rule roster** plus status filters in a way that feels like “why are all these settings on faults?” Tuning belongs in the **Lab sidebar**; Faults/Results should emphasize **outcomes**, not a second settings sheet.
+
+## Product scope (one concern: declutter)
+
+### Ship
+
+1. [`RuleTuningPanel.tsx`](../open-fdd/frontend/web/src/components/RuleTuningPanel.tsx)
+   - Default **Category** to a concrete family (e.g. `VAV` or `GL36`/`FC`) rather than `(all)` when that reduces first-paint overload — or keep `(all)` but **collapse** expanders and show count caption “N rules in category — expand to tune”.
+   - Keep natural A–Z from 3.3.21 (`visibleRulesForLab`).
+   - Caption: **Sliders store thresholds only; click Update rule / Run all rules to evaluate.**
+2. Findings / Faults / Reports surfaces ([`findings`](../open-fdd/frontend/web/src/pages/), [`ReportsPage.tsx`](../open-fdd/frontend/web/src/pages/ReportsPage.tsx))
+   - Status filter (`All` / `FAULT` / `PASS` / `SKIPPED` / `Not run`) stays on **results**, not adjacent to Lab param editors.
+   - Do not duplicate full registry parameter forms on the Faults page body.
+3. Overview / Lab cross-links: one sentence pointing tuners → left rail Lab.
+4. Tests for default category behavior + no regression on run/update.
+
+### Explicit non-goals (SKIP → later tuner revs)
+
+- Adding missing registry parameters (that is **3.3.24–26**)
+- Changing SQL fault math
+- Removing rules from the registry
+- Redesigning Overview health matrices
+
+## Loop
+
+Hygiene → VERSION **3.3.23** → PR → GHCR → Railway → fieldbus → stress LAST → BUG_REPORT → hygiene END.
+
+### Stress extras
+
+- After matrix: Lab — select category VAV → open VAV-1 → move `confirm_min` → Update rule → Results show refreshed row (Railway session).
+
+## BUG_REPORT Verdict 3.3.23
+
+- What chrome was removed/quieted
+- Default category behavior
+- Confirm **no** new Lab param keys this rev (tuner gap still tracked for 3.3.24+)
+- Stress paths
+
+## Anti-patterns
+
+- Hiding Lab entirely (operators still need tune)
+- Shipping fake “settings” pages on Faults
+- Mixing Dump/Upload work into this PR

--- a/docs/operations/patch_trains/3.3.24_tuners_gl36_wave.plan.md
+++ b/docs/operations/patch_trains/3.3.24_tuners_gl36_wave.plan.md
@@ -1,0 +1,97 @@
+---
+name: 3.3.24 tuners GL36 wave
+overview: "Low-RAM 3.3.23→3.3.24: SQL-honest Lab/registry threshold expansion for GL36 FC rules (FC1–FC15 / FC13-SAT-HIGH) — close largest Vibe19→Lab gaps. No fake sliders. Railway stress + ZAP LAST. GH tidy."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START
+    status: pending
+  - id: p1-version
+    content: Bump VERSION + Cargo 3.3.23 → 3.3.24
+    status: pending
+  - id: p2a-inventory
+    content: Diff Vibe19 catalog keys vs registry parameters for FC1–FC15; list SQL placeholders already in .sql files
+    status: pending
+  - id: p2b-registry
+    content: Extend sql_rules/registry.yaml parameters for FC rules where SQL substitutes today (eps_*, mix_tol, econ_*, mode_delay, fan_on_min, …)
+    status: pending
+  - id: p2c-sql-wire
+    content: Ensure FC SQL files use placeholders for every new registry key; no dead Lab sliders
+    status: pending
+  - id: p2d-api-lab
+    content: Confirm GET /api/fdd/rules/{id}/params exposes new keys; Lab sliders render; confirm_min mapping intact
+    status: pending
+  - id: p2e-tests
+    content: Registry/parity tests + React Lab smoke for FC1/FC8/FC12 param counts
+    status: pending
+  - id: p3-pr
+    content: One PR; merge; GHCR sha-<7>
+    status: pending
+  - id: p4-repin
+    content: Railway backup + re-pin; x86 fieldbus
+    status: pending
+  - id: p5-stress
+    content: run_railway_hub_stress.sh + B100 FC1 after param tweak smoke (confirm hours still sane)
+    status: pending
+  - id: p6-bug-report
+    content: BUG_REPORT Verdict 3.3.24 — before/after Lab tuner counts for FC family; DEFERRED keys
+    status: pending
+  - id: p7-hygiene-end
+    content: GH hygiene END
+    status: pending
+isProject: false
+---
+
+# 3.3.24 — Lab tuners wave 1 (GL36 FC)
+
+**Parent:** [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](./openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md)  
+**Requires:** 3.3.23 declutter CLOSED.
+
+## Why
+
+Canvas / inventory: Vibe19 UI ~**414** sliders vs Open-FDD Lab ~**184**. Largest Δ on **FC2/FC3/FC8–FC15** (often Lab only `confirm_min` while Vibe19 has full pandas cookbook thresholds).
+
+**Success metric (this rev):** Every FC rule that has substitutable SQL knobs exposes them in Lab; **no** slider without a SQL placeholder. Do **not** require Lab sum = 414.
+
+## Inventory method (do first)
+
+1. Source Vibe19 keys: `vibe_code_apps_19` cookbook / `configs/rule_defaults.yaml` for `FC1`…`FC15`.
+2. Source Open-FDD: [`sql_rules/registry.yaml`](../open-fdd/sql_rules/registry.yaml) `parameters` + matching `sql_rules/*.sql`.
+3. Build table in PR description / BUG_REPORT: rule → keys added → keys DEFERRED (pandas-only / no SQL).
+
+Priority order inside rev: **FC8, FC9, FC10, FC11, FC12, FC14, FC15, FC2, FC3, FC5, FC6, FC1, FC7, FC4, FC13-SAT-HIGH** (worst Lab starvation first). SKIP remainder to DEFERRED→3.3.25 if PR grows unreviewable — split is OK if hygiene stays one open PR.
+
+## Product scope
+
+### Ship
+
+1. Registry `parameters` blocks with `frontend_control: slider`, units, min/max/step, `sql_placeholder`.
+2. SQL files bind placeholders (same pattern as existing `CONFIRM_SECONDS`, `SAT_ERR`, …).
+3. [`registry_api.rs`](../open-fdd/edge/src/fdd/registry_api.rs) `param_to_json` already maps `confirm_seconds`→`confirm_min` — do not break.
+4. Lab UI picks up params via existing `getFddRuleParams` — no second tuning framework.
+5. Tests: inventory parity helpers; React asserts FC12 (or worst former-gap rule) `parameter_count` / params keys ≥ threshold agreed in PR.
+
+### Explicit non-goals
+
+- Operational gate trio (`require_operational_gate`, …) → **3.3.26**
+- SV/ECON/AHU family → **3.3.25**
+- Changing fault pass/fail semantics beyond threshold parameterization
+- Porting pandas-only math that has no SQL twin (log DEFERRED)
+
+## Loop
+
+Hygiene → VERSION **3.3.24** → PR → GHCR → Railway → fieldbus → stress LAST → BUG_REPORT → hygiene END.
+
+### Stress extras
+
+- B100: run FC1 with default params — hours remain in known band (document pre/post).
+- Lab: FC12 expander shows >1 slider; Update rule succeeds.
+
+## BUG_REPORT Verdict 3.3.24
+
+Must include **tuner delta table** (FC rules: Lab count before tip vs after tip) and DEFERRED key list.
+
+## Anti-patterns
+
+- Lab slider with no SQL effect (fake UX)
+- One mega-PR that also does Dump/IA
+- Claiming “parity with 414” without SQL honesty

--- a/docs/operations/patch_trains/3.3.25_tuners_sv_econ_ahu_wave.plan.md
+++ b/docs/operations/patch_trains/3.3.25_tuners_sv_econ_ahu_wave.plan.md
@@ -1,0 +1,86 @@
+---
+name: 3.3.25 tuners SV ECON AHU wave
+overview: "Low-RAM 3.3.24→3.3.25: SQL-honest Lab/registry param expansion for SV-*, ECON-*, AHU-*, selected VAV/plant gaps vs Vibe19. Railway stress + ZAP LAST. GH tidy."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START
+    status: pending
+  - id: p1-version
+    content: Bump VERSION + Cargo 3.3.24 → 3.3.25
+    status: pending
+  - id: p2a-inventory
+    content: Diff Vibe19 vs registry for SV-RANGE/SPIKE/FLATLINE/STALE/RATE, ECON-1..7, AHU-*, VAV-*, CHW/CW/TRIM leftovers from 3.3.24 DEFERRED
+    status: pending
+  - id: p2b-sv
+    content: "SV family — per-type scales (temp/humidity/pressure) only if SQL supports; else DEFER"
+    status: pending
+  - id: p2c-econ-ahu
+    content: ECON + AHU-SATDEV/DUCTHI/SIMUL + MECH-OAT / RESET missing keys wired to SQL
+    status: pending
+  - id: p2d-vav-plant
+    content: Fill VAV/CHW/CW/TRIM keys that SQL already can take; skip pandas-only
+    status: pending
+  - id: p2e-tests
+    content: Registry + Lab tests for newly expanded rules
+    status: pending
+  - id: p3-pr
+    content: One PR; merge; GHCR sha-<7>
+    status: pending
+  - id: p4-repin
+    content: Railway backup + re-pin; x86 fieldbus
+    status: pending
+  - id: p5-stress
+    content: run_railway_hub_stress.sh + SV-RANGE/ECON Lab smoke on B100 or Creekside
+    status: pending
+  - id: p6-bug-report
+    content: BUG_REPORT Verdict 3.3.25 — family tuner counts before/after
+    status: pending
+  - id: p7-hygiene-end
+    content: GH hygiene END
+    status: pending
+isProject: false
+---
+
+# 3.3.25 — Lab tuners wave 2 (SV / ECON / AHU / plant)
+
+**Parent:** [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](./openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md)  
+**Requires:** 3.3.24 GL36 wave CLOSED (or its DEFERRED FC keys explicitly re-homed here).
+
+## Why
+
+After GL36, remaining Lab starvation is concentrated in **sensor sweeps**, **economizer**, **AHU helpers**, and some **VAV/plant** keys that Vibe19 exposes (e.g. SV per-type scales, ECON damper/DB bands).
+
+## Product scope
+
+### Ship (SQL-honest only)
+
+1. Inventory from Vibe19 `rule_defaults` / catalog vs [`registry.yaml`](../open-fdd/sql_rules/registry.yaml).
+2. Prefer keys already partially present (e.g. SV-RANGE `range_scale_temperature` only → add humidity/pressure **iff** SQL reads them).
+3. ECON-1…7 / MECH-OAT-1 / AHU-* / RESET-1 — add missing bands that SQL can substitute.
+4. Carry forward any **3.3.24 DEFERRED** FC keys that became SQL-ready.
+5. Lab + tests; document still-pandas-only keys as DEFERRED→future or wontfix.
+
+### Explicit non-goals
+
+- Operational gate Lab knobs → **3.3.26**
+- New fault rules
+- Dump/Faults IA (already 3.3.22–23)
+- Hard target Lab sum ≥ 414
+
+## Loop
+
+Hygiene → VERSION **3.3.25** → PR → GHCR → Railway → fieldbus → stress LAST → BUG_REPORT → hygiene END.
+
+### Stress extras
+
+- Lab: SV-SPIKE / ECON-3 expanders show expanded keys; Update rule on active site.
+- Creekside or B100: no regress on fault hours for untouched rules.
+
+## BUG_REPORT Verdict 3.3.25
+
+Family-level tuner count table (SV, ECON, AHU, VAV, plant) before/after tip; DEFERRED list.
+
+## Anti-patterns
+
+- Adding `spike_scale_humidity` Lab slider when SQL ignores it
+- Re-opening ML dump IA work in this PR

--- a/docs/operations/patch_trains/3.3.26_tuners_gates_residual.plan.md
+++ b/docs/operations/patch_trains/3.3.26_tuners_gates_residual.plan.md
@@ -1,0 +1,90 @@
+---
+name: 3.3.26 tuners gates residual
+overview: "Low-RAM 3.3.25→3.3.26: optional Lab operational-gate knobs (SQL/session-honest) + triage soft-OPEN / DEFERRED leftovers from series; Railway stress + ZAP LAST; series wrap BUG_REPORT. GH tidy. Skip gate knobs entirely if SQL cannot honor them — log DEFERRED."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START
+    status: pending
+  - id: p1-version
+    content: Bump VERSION + Cargo 3.3.25 → 3.3.26
+    status: pending
+  - id: p2a-gate-design
+    content: Decide SQL/session model for require_operational_gate / startup_delay_min / minimum_active_coverage_pct — skip ship if no honest binding
+    status: pending
+  - id: p2b-gate-ship-or-defer
+    content: Either wire gate trio into registry+Lab for gated rules OR DEFER with BUG_REPORT rationale (Vibe19-only)
+    status: pending
+  - id: p2c-soft-open
+    content: Triage BUG_REPORT soft-OPEN (bldg2 signoff, B50, deep ZAP, site cleanup) — close or re-DEFER with owner
+    status: pending
+  - id: p2d-series-summary
+    content: BUG_REPORT series wrap — Lab tuner sum trend 3.3.21→3.3.26 vs Vibe19 414 reference
+    status: pending
+  - id: p3-pr
+    content: One PR (product and/or docs); merge; GHCR if product shipped
+    status: pending
+  - id: p4-repin
+    content: Railway backup + re-pin if images shipped; else skip with note
+    status: pending
+  - id: p5-stress
+    content: run_railway_hub_stress.sh if product shipped; else light health+ZAP only — log which
+    status: pending
+  - id: p6-bug-report
+    content: BUG_REPORT Verdict 3.3.26 + series CLOSED/CONTINUE note
+    status: pending
+  - id: p7-hygiene-end
+    content: GH hygiene END — program todos on parent plan marked done
+    status: pending
+isProject: false
+---
+
+# 3.3.26 — Gate tuners (optional) + series residual
+
+**Parent:** [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](./openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md)  
+**Requires:** 3.3.25 CLOSED.
+
+## Why
+
+Vibe19 adds **+3** UI knobs on most gated rules (`require_operational_gate`, `startup_delay_min`, `minimum_active_coverage_pct`) via [`operational_gate.py`](../py-bacnet-stacks-playground/vibe_code_apps_19/app/rules/operational_gate.py). Open-FDD Lab has **none**. Only ship if central/SQL/session can honor them; otherwise **DEFER** honestly — fake gate sliders are worse than fewer tuners.
+
+Also use this rev to **clean the BUG_REPORT soft-OPEN table** accumulated across the series.
+
+## Product scope
+
+### Path A — ship gates (preferred if feasible)
+
+1. Define session/SQL binding (e.g. run options / rule params consumed by registry engine).
+2. Expose three Lab sliders (or checkbox + two sliders) on rules that are gated in Vibe19.
+3. Tests: gate off expands evaluation window; startup delay changes active coverage behavior in a documented fixture.
+
+### Path B — DEFER gates (allowed)
+
+1. No Lab gate knobs.
+2. BUG_REPORT: `DEFERRED: vibe19-operational-gate-lab → future` with reason (no SQL binding yet).
+3. Still bump VERSION only if other product ships; **docs-only residual triage may skip VERSION** per PATCH_CYCLE — if docs-only, mark `p1-version` cancelled and skip GHCR re-pin stress full matrix (still hygiene + BUG_REPORT).
+
+### Soft-OPEN triage (always)
+
+Walk [`BUG_REPORT` soft-OPEN](../open-fdd/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md): for each row → CLOSED (with evidence) / DEFERRED (next id) / WONTFIX.
+
+## Loop
+
+Hygiene → (VERSION if product) → PR → (GHCR/re-pin/stress if product) → BUG_REPORT series wrap → hygiene END → mark parent program todos complete.
+
+## BUG_REPORT Verdict 3.3.26 + series wrap
+
+Must include:
+
+| Metric | 3.3.21 hub | 3.3.26 tip |
+|--------|------------|-----------|
+| Lab tuner sum (approx) | ~184 | measured |
+| Vibe19 UI reference | ~414 | ~414 |
+| Gate knobs | no | shipped / DEFERRED |
+| Dump IA | pre | shipped 3.3.22 |
+| Faults declutter | pre | shipped 3.3.23 |
+
+## Anti-patterns
+
+- Shipping gate sliders that ignore the engine
+- Leaving parent program todos pending after CLOSED
+- Opening 3.3.27 mid-flight without new program index

--- a/docs/operations/patch_trains/README.md
+++ b/docs/operations/patch_trains/README.md
@@ -1,0 +1,17 @@
+# Patch trains (Cursor plan mirrors)
+
+These Markdown files are **copies** of Cursor plans under `~/.cursor/plans/` so a dead laptop does not lose the 3.3.21→3.3.26 program.
+
+| File | Rev |
+|------|-----|
+| [openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md](openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md) | Program index |
+| [3.3.21_closeout_railway_stress.plan.md](3.3.21_closeout_railway_stress.plan.md) | Closeout ops |
+| [3.3.22_one_dump_ia.plan.md](3.3.22_one_dump_ia.plan.md) | One Dump IA |
+| [3.3.23_faults_lab_declutter.plan.md](3.3.23_faults_lab_declutter.plan.md) | Faults/Lab UX |
+| [3.3.24_tuners_gl36_wave.plan.md](3.3.24_tuners_gl36_wave.plan.md) | Tuners GL36 |
+| [3.3.25_tuners_sv_econ_ahu_wave.plan.md](3.3.25_tuners_sv_econ_ahu_wave.plan.md) | Tuners SV/ECON/AHU |
+| [3.3.26_tuners_gates_residual.plan.md](3.3.26_tuners_gates_residual.plan.md) | Gates + wrap |
+
+**Ops companions:** [../BENCH_RECOVERY.md](../BENCH_RECOVERY.md) · [../recovery/AI_CONTEXT_HANDOFF.md](../recovery/AI_CONTEXT_HANDOFF.md) · [../BUG_REPORT_OT_MODBUS_HAYSTACK.md](../BUG_REPORT_OT_MODBUS_HAYSTACK.md)
+
+When editing plans in Cursor, **copy changes back here** (or edit here first) so GitHub stays source of truth.

--- a/docs/operations/patch_trains/openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md
@@ -1,0 +1,94 @@
+---
+name: Open-FDD patch series 3.3.21→3.3.26
+overview: "Program index (not a shipping rev). Sequential low-RAM patch cycles: finish 3.3.21 closeout → One Dump IA → Faults Lab declutter → three phased Lab tuner waves. Each child plan owns hygiene, GHCR, Railway re-pin, x86 fieldbus, CSV+ZAP stress, BUG_REPORT logging. Skip allowed only with DEFERRED row in BUG_REPORT."
+todos:
+  - id: close-321
+    content: "Execute 3.3.21_closeout plan — re-pin/stress/BUG_REPORT only (product already merged)"
+    status: pending
+  - id: ship-322
+    content: "Execute 3.3.22_one_dump_ia — single Dump page; ingest only in left rail"
+    status: pending
+  - id: ship-323
+    content: "Execute 3.3.23_faults_lab_declutter — category-first Lab; less Faults chrome"
+    status: pending
+  - id: ship-324
+    content: "Execute 3.3.24_tuners_gl36 — registry+Lab GL36 FC threshold parity wave"
+    status: pending
+  - id: ship-325
+    content: "Execute 3.3.25_tuners_sv_econ_ahu — SV/ECON/AHU/VAV missing Lab params"
+    status: pending
+  - id: ship-326
+    content: "Execute 3.3.26_tuners_gates_residual — optional gate trio + soft-OPEN triage"
+    status: pending
+isProject: false
+---
+
+# Open-FDD patch series — 3.3.21 closeout through 3.3.26
+
+**Not a shipping VERSION bump.** This file is the program index. Open **one child plan at a time**. Do not start the next child until the previous child’s BUG_REPORT verdict exists (CLOSED or DEFERRED with reason).
+
+## Decisions locked (operator left design to agent)
+
+| Topic | Choice |
+|-------|--------|
+| Order | Closeout → **One Dump / IA** → **Faults Lab declutter** → **Tuner waves** |
+| Tuners | **Phased**, SQL-honest: Wave1 GL36 FC gaps → Wave2 SV/ECON/AHU → Wave3 optional gate trio. **Not** a hard “414 = success” — success = every Lab slider substitutes real SQL / session params; Vibe19-only leftovers logged DEFERRED |
+| Topology | Railway hub (central→mqtt→web) + bensbench **x86 fieldbus** only + light ZAP. **No** Pi. **No** local `react-ot` as AFDD head-end. **No** local `docker build` |
+| Hygiene | Every child: START+END — **0** open PRs, **only** `master`, tip Actions green, delete merged remote branches, no unexplained failed tip runs |
+| Skip | Allowed mid-rev for out-of-scope or blocked items — must add **DEFERRED** row in BUG_REPORT with why + next rev id |
+
+## Child plans (open these)
+
+| Rev | Plan file | One concern |
+|-----|-----------|-------------|
+| 3.3.21 closeout | [`3.3.21_closeout_railway_stress.plan.md`](3.3.21_closeout_railway_stress.plan.md) | Finish re-pin + stress + BUG_REPORT (product already on master) |
+| 3.3.22 | [`3.3.22_one_dump_ia.plan.md`](3.3.22_one_dump_ia.plan.md) | One Dump; kill Export&ML multi-page confusion; ingest left-rail only |
+| 3.3.23 | [`3.3.23_faults_lab_declutter.plan.md`](3.3.23_faults_lab_declutter.plan.md) | Faults/Lab UX — category-first, less “settings on faults” overload |
+| 3.3.24 | [`3.3.24_tuners_gl36_wave.plan.md`](3.3.24_tuners_gl36_wave.plan.md) | Lab/registry GL36 FC threshold expansion |
+| 3.3.25 | [`3.3.25_tuners_sv_econ_ahu_wave.plan.md`](3.3.25_tuners_sv_econ_ahu_wave.plan.md) | Lab/registry SV / ECON / AHU / VAV missing keys |
+| 3.3.26 | [`3.3.26_tuners_gates_residual.plan.md`](3.3.26_tuners_gates_residual.plan.md) | Optional operational-gate Lab knobs + soft-OPEN triage |
+
+Evidence inventory (tuners): canvas `vibe19-openfdd-rule-tuners` — Vibe19 ~414 UI vs Open-FDD Lab ~184.
+
+## Shared loop (every shipping child)
+
+```text
+hygiene START → (VERSION bump if shipping) → one product concern → one PR
+  → squash-merge --delete-branch → wait GHCR Publish sha-<7>
+  → Railway backup → re-pin central→mqtt→web → x86 fieldbus up
+  → run_railway_hub_stress.sh (CSV + ZAP) LAST
+  → BUG_REPORT Verdict 3.3.N + SESSION_LOG paths → hygiene END
+```
+
+Canonical ops: [`open-fdd/docs/operations/PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md) · living log [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
+
+## BUG_REPORT logging contract (every child)
+
+Append **Verdict — 3.3.N** table with at least:
+
+- Product PR + tip SHA + VERSION
+- GHCR `sha-<7>` + Publish URL
+- Railway backup dir
+- Hub re-pin order proof + health `3.3.N+…`
+- Fieldbus `sha-<7>` + `/api/edges` telemetry
+- Stress artifact dirs (synth59, gate17, B100, Creekside, gate19, ZAP)
+- **Shipped** bullets for this rev’s product concern
+- **DEFERRED / SKIPPED** rows (id, reason, next rev) — never silent skip
+- Soft-OPEN updates if touched
+
+Evidence-only follow-up PR (docs/BUG_REPORT/SESSION_LOG) may land **without** VERSION bump.
+
+## Explicit non-goals (program-wide)
+
+- Raspberry Pi back on Open-FDD closeout
+- Local docker build of central/web/fieldbus
+- Reopening ML/vibe20 depth (#763/#805 closed foundation)
+- Authenticated deep ZAP / bug bounty
+- Force-push / `--no-verify` / secrets in git or Discord→git
+- Parallel open feature PRs across children (one train at a time)
+
+## How to run
+
+1. Finish [`3.3.21_closeout_railway_stress.plan.md`](3.3.21_closeout_railway_stress.plan.md) first if hub still on `3.3.20` / `sha-aef6fc1`.
+2. Then open 3.3.22 … 3.3.26 in order.
+3. After each CLOSED verdict, mark the matching todo on **this** program file completed.

--- a/docs/operations/recovery/AI_CONTEXT_HANDOFF.md
+++ b/docs/operations/recovery/AI_CONTEXT_HANDOFF.md
@@ -1,0 +1,68 @@
+---
+title: AI context handoff (patch series)
+parent: Operations
+nav_order: 2
+---
+
+# AI / agent context handoff — Open-FDD patch series 3.3.21→3.3.26
+
+**Read this first** on a new machine or new Cursor chat when continuing the train. Prefer **in-repo** sources over chat memory.
+
+## Canonical files
+
+| Priority | Path |
+|----------|------|
+| 1 | [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md) — living verdicts + Upcoming trains |
+| 2 | [`patch_trains/openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](../patch_trains/openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md) |
+| 3 | Active child under [`patch_trains/`](../patch_trains/) |
+| 4 | [`BENCH_RECOVERY.md`](../BENCH_RECOVERY.md) — recreate field host |
+| 5 | [`PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md) |
+| 6 | [`RAILWAY_DEPLOYMENT.md`](../RAILWAY_DEPLOYMENT.md) |
+| 7 | Tuner baselines: [`recovery/lab_tuners_snapshot_pre_3.3.24.json`](lab_tuners_snapshot_pre_3.3.24.json) (~184) · [`recovery/vibe19_ui_tuners_snapshot.json`](vibe19_ui_tuners_snapshot.json) (~414) |
+
+Optional local Cursor UI copies: `~/.cursor/plans/*.plan.md` (same content mirrored here).
+
+## Locked decisions
+
+- **Order:** 3.3.21 closeout → Dump IA (3.3.22) → Faults declutter (3.3.23) → tuner waves (3.3.24 GL36 → 3.3.25 SV/ECON/AHU → 3.3.26 gates/residual)
+- **Tuners:** SQL-honest Lab expansion; **not** hard “match 414”
+- **Topology:** Railway hub + bensbench **x86 fieldbus** + light ZAP; **no Pi**; **no** local react-ot closeout; **no** local docker build
+- **Hygiene:** 0 open PRs / only `master` / tip Actions green at END of every rev
+- **Skip:** only with **DEFERRED** row in BUG_REPORT
+
+## Current product pain (why the trains exist)
+
+1. **Export & ML** tab = confusing multi-page (Uploads / Fuel / Twin / ECM) — want **one Dump**; CSV ingest **left rail only**
+2. **Faults** feels like a wall of settings — Lab should own tuners; Faults own outcomes
+3. **Lab tuners ~184** vs **Vibe19 UI ~414** — largest gaps GL36 FC2/3/8–15
+
+## Runtime facts (verify on tip — do not assume)
+
+- Public web: `https://openfdd-web-production-af99.up.railway.app`
+- MQTTS proxy: `reseau.proxy.rlwy.net:44763`
+- Railway project: `gleaming-cooperation` / `production`
+- Central service id name: `openfdd-central-cQ-F`
+- Field site/edge often `bldg2` / `pi-1` (kit reuse — CA key may be missing on Railway)
+- Hub may lag tip until closeout re-pin (historically `3.3.20+aef6fc1…` while master already had 3.3.21 product)
+
+## Agent loop (every shipping rev)
+
+```text
+hygiene START → VERSION bump (if shipping) → one concern → one PR
+  → squash-merge --delete-branch → wait GHCR Publish sha-<7>
+  → railway backup → re-pin central→mqtt→web → openfdd_fieldbus_railway_up.sh
+  → run_railway_hub_stress.sh LAST → BUG_REPORT Verdict → hygiene END
+```
+
+Low-RAM: `scripts/openfdd_docker_maintenance.sh` non-aggressive only; never `docker build` central/web on bench.
+
+## Do not
+
+- Force-push / `--no-verify` / commit secrets or OT LAN IPs
+- Reopen #763 / #805 ML depth
+- Parallel feature PRs across trains
+- Claim CLOSED using older `sha-*` stress dirs
+
+## SESSION_LOG
+
+Append paths under [`openfdd_agent_spec/SESSION_LOG.md`](../../openfdd_agent_spec/SESSION_LOG.md) when closing a Verdict.

--- a/docs/operations/recovery/README.md
+++ b/docs/operations/recovery/README.md
@@ -1,0 +1,15 @@
+# Recovery snapshots
+
+| File | Meaning |
+|------|---------|
+| [lab_tuners_snapshot_pre_3.3.24.json](lab_tuners_snapshot_pre_3.3.24.json) | Open-FDD Lab tuners (~184 sum) before GL36/SV waves |
+| [vibe19_ui_tuners_snapshot.json](vibe19_ui_tuners_snapshot.json) | Vibe19 Streamlit UI sliders (~414 sum) for parity planning |
+| [AI_CONTEXT_HANDOFF.md](AI_CONTEXT_HANDOFF.md) | Agent/chat reboot context |
+
+Regenerate Lab snapshot after a tuner rev:
+
+```bash
+python3 -c "..."  # or re-run inventory from sql_rules/registry.yaml
+```
+
+See parent [../BENCH_RECOVERY.md](../BENCH_RECOVERY.md).

--- a/docs/operations/recovery/bensbench.env.example
+++ b/docs/operations/recovery/bensbench.env.example
@@ -1,0 +1,6 @@
+# Copy to bensbench.env and fill. Never commit bensbench.env.
+# RAILWAY_TOKEN=...
+# Also useful on a new bench (session only):
+# export OPENFDD_API_BASE=https://openfdd-web-production-af99.up.railway.app
+# export RAILWAY_ADMIN_PASSWORD=...
+# export OPENFDD_IMAGE_TAG=sha-<7>

--- a/docs/operations/recovery/lab_tuners_snapshot_pre_3.3.24.json
+++ b/docs/operations/recovery/lab_tuners_snapshot_pre_3.3.24.json
@@ -1,0 +1,674 @@
+{
+  "generated": "2026-09-04",
+  "note": "Open-FDD Lab-facing tuners (confirm_seconds\u2192confirm_min). Pre tuner-wave baseline ~184 sum.",
+  "rule_count": 68,
+  "lab_tuner_sum": 184,
+  "rules": [
+    {
+      "rule_id": "FAN-RUNTIME-HOURS",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "zone_t_lo",
+        "zone_t_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-2",
+      "lab_n": 2,
+      "lab_keys": [
+        "setback_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "AVG-ZONE-TEMP",
+      "lab_n": 3,
+      "lab_keys": [
+        "zone_t_lo",
+        "zone_t_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "ZONE-COMFORT-PCT",
+      "lab_n": 3,
+      "lab_keys": [
+        "zone_t_lo",
+        "zone_t_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FAULT-ELAPSED-HOURS",
+      "lab_n": 3,
+      "lab_keys": [
+        "zone_t_lo",
+        "zone_t_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "OAT-METEO",
+      "lab_n": 2,
+      "lab_keys": [
+        "oat_err",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC13-SAT-HIGH",
+      "lab_n": 5,
+      "lab_keys": [
+        "sat_err",
+        "clg_valve_min",
+        "oa_damper_econ_low",
+        "oa_damper_econ_high",
+        "confirm_min"
+      ],
+      "aliases": [
+        "FC13"
+      ]
+    },
+    {
+      "rule_id": "ECON-2",
+      "lab_n": 3,
+      "lab_keys": [
+        "econ2_oat_hi",
+        "econ2_damper",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC1",
+      "lab_n": 3,
+      "lab_keys": [
+        "eps_dsp",
+        "eps_vfd_spd",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC2",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC3",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC7",
+      "lab_n": 3,
+      "lab_keys": [
+        "sat_err",
+        "htg_full_min",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC8",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC9",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC10",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC11",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC12",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "ECON-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "econ1_oat_min",
+        "econ1_damper_max",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "ECON-4",
+      "lab_n": 2,
+      "lab_keys": [
+        "oa_min_pct",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "SV-RANGE",
+      "lab_n": 2,
+      "lab_keys": [
+        "range_scale_temperature",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "SV-FLATLINE",
+      "lab_n": 3,
+      "lab_keys": [
+        "flatline_tol",
+        "flatline_hours",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "SV-SPIKE",
+      "lab_n": 2,
+      "lab_keys": [
+        "spike_scale",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "SV-STALE",
+      "lab_n": 3,
+      "lab_keys": [
+        "stale_hours",
+        "stale_tol",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "SV-RATE",
+      "lab_n": 3,
+      "lab_keys": [
+        "persistence_min",
+        "steady_fault_per_hour",
+        "confirm_min"
+      ],
+      "aliases": [
+        "SV-SLEW"
+      ]
+    },
+    {
+      "rule_id": "PID-HUNT-1",
+      "lab_n": 8,
+      "lab_keys": [
+        "window_hours",
+        "change_deadband_pct",
+        "minimum_span_pct",
+        "total_variation_fault_pct",
+        "minimum_equivalent_cycles",
+        "minimum_reversals",
+        "minimum_coverage_pct",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC4",
+      "lab_n": 2,
+      "lab_keys": [
+        "delta_os_max",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC5",
+      "lab_n": 3,
+      "lab_keys": [
+        "mix_tol",
+        "htg_on_min",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC6",
+      "lab_n": 4,
+      "lab_keys": [
+        "airflow_err",
+        "delta_t_min",
+        "min_cfm_design",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC14",
+      "lab_n": 2,
+      "lab_keys": [
+        "mix_tol",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "FC15",
+      "lab_n": 2,
+      "lab_keys": [
+        "mix_tol",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "AHU-SATDEV",
+      "lab_n": 2,
+      "lab_keys": [
+        "sat_dev_err",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "AHU-DUCTHI",
+      "lab_n": 3,
+      "lab_keys": [
+        "duct_high_margin",
+        "pressure_on_min",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "AHU-SIMUL",
+      "lab_n": 2,
+      "lab_keys": [
+        "valve_open_pct",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "ECON-3",
+      "lab_n": 5,
+      "lab_keys": [
+        "econ3_db_min",
+        "econ3_db_max",
+        "econ3_dp_max",
+        "econ3_damper_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "ECON-5",
+      "lab_n": 2,
+      "lab_keys": [
+        "preheat_over_f",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "ECON-6",
+      "lab_n": 3,
+      "lab_keys": [
+        "econ6_oat_max_f",
+        "econ6_damper_max",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "ECON-7",
+      "lab_n": 5,
+      "lab_keys": [
+        "econ7_db_min",
+        "econ7_db_max",
+        "econ7_dp_max",
+        "econ7_damper_min",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "MECH-OAT-1",
+      "lab_n": 2,
+      "lab_keys": [
+        "mech_oat_max_f",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CMD-1",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "OA-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "min_oa_frac",
+        "oat_rat_guard",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "DMP-1",
+      "lab_n": 2,
+      "lab_keys": [
+        "leak_delta",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VLV-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "sat_err",
+        "mat_leak_delta",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-3",
+      "lab_n": 4,
+      "lab_keys": [
+        "reheat_oat",
+        "reheat_pct",
+        "flow_on_min",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-4",
+      "lab_n": 4,
+      "lab_keys": [
+        "full_open_pct",
+        "flow_on_min",
+        "sustain_hours",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-5",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-6",
+      "lab_n": 3,
+      "lab_keys": [
+        "free_cool_oat",
+        "reheat_pct",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-REHEAT",
+      "lab_n": 4,
+      "lab_keys": [
+        "reheat_cmd",
+        "min_rise",
+        "flow_on_min",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-AHU-LEAVE",
+      "lab_n": 3,
+      "lab_keys": [
+        "delta_f",
+        "flow_on_min",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "VAV-7",
+      "lab_n": 6,
+      "lab_keys": [
+        "high_min_flow_sp",
+        "flow_on_min",
+        "fixed_flow_hours",
+        "fixed_flow_max_std",
+        "fixed_flow_min_mean",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "RESET-1",
+      "lab_n": 5,
+      "lab_keys": [
+        "reset_err_f",
+        "reset_sat_at_65",
+        "reset_slope",
+        "reset_oat_ref",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CHW-NOLOAD-1",
+      "lab_n": 1,
+      "lab_keys": [
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CHW-1",
+      "lab_n": 2,
+      "lab_keys": [
+        "min_dt",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CHW-2",
+      "lab_n": 3,
+      "lab_keys": [
+        "dp_margin",
+        "pump_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CHW-3",
+      "lab_n": 2,
+      "lab_keys": [
+        "sp_band",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CHW-4",
+      "lab_n": 3,
+      "lab_keys": [
+        "flow_hi",
+        "pump_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CW-OPT-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "cw_approach",
+        "cw_slack",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CW-APR-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "approach_max_f",
+        "tower_fan_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "CW-FAN-1",
+      "lab_n": 4,
+      "lab_keys": [
+        "cw_approach",
+        "excess_beyond_approach_f",
+        "tower_fan_hi",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "HP-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "min_sat",
+        "zone_cold",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "WX-1",
+      "lab_n": 2,
+      "lab_keys": [
+        "spike_limit",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "TRIM-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "duct_hi",
+        "request_lo",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "TRIM-3",
+      "lab_n": 3,
+      "lab_keys": [
+        "hwst_hi",
+        "request_lo",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "TRIM-4",
+      "lab_n": 3,
+      "lab_keys": [
+        "chw_lo",
+        "request_lo",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "SCHED-1",
+      "lab_n": 3,
+      "lab_keys": [
+        "comfort_low_f",
+        "comfort_high_f",
+        "confirm_min"
+      ],
+      "aliases": [
+        "excess_runtime"
+      ]
+    },
+    {
+      "rule_id": "SCHED-247",
+      "lab_n": 2,
+      "lab_keys": [
+        "always_on_pct",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "UTIL-MONTHLY",
+      "lab_n": 2,
+      "lab_keys": [
+        "util_pct_err",
+        "confirm_min"
+      ],
+      "aliases": []
+    },
+    {
+      "rule_id": "UTIL-INTERVAL",
+      "lab_n": 2,
+      "lab_keys": [
+        "util_interval_mae",
+        "confirm_min"
+      ],
+      "aliases": []
+    }
+  ]
+}

--- a/docs/operations/recovery/vibe19_ui_tuners_snapshot.json
+++ b/docs/operations/recovery/vibe19_ui_tuners_snapshot.json
@@ -1,0 +1,918 @@
+{
+  "generated": "2026-09-04",
+  "source": "vibe_code_apps_19 Streamlit sidebar model",
+  "rule_count": 62,
+  "ui_tuner_sum": 414,
+  "rules": [
+    {
+      "rule_id": "SV-RANGE",
+      "ui_n": 7,
+      "ui_keys": [
+        "confirm_min",
+        "range_scale_humidity",
+        "range_scale_pressure",
+        "range_scale_temperature",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 4,
+      "gate": "equipment_energized"
+    },
+    {
+      "rule_id": "SV-FLATLINE",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "flatline_hours",
+        "flatline_tol",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "conditional"
+    },
+    {
+      "rule_id": "SV-SPIKE",
+      "ui_n": 8,
+      "ui_keys": [
+        "confirm_min",
+        "spike_scale",
+        "spike_scale_humidity",
+        "spike_scale_pressure",
+        "spike_scale_temperature",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 5,
+      "gate": "equipment_energized"
+    },
+    {
+      "rule_id": "SV-STALE",
+      "ui_n": 2,
+      "ui_keys": [
+        "confirm_min",
+        "stale_hours"
+      ],
+      "catalog_n": 2,
+      "gate": "always"
+    },
+    {
+      "rule_id": "SV-RATE",
+      "ui_n": 4,
+      "ui_keys": [
+        "confirm_min",
+        "design_flow",
+        "max_gap_hours",
+        "sensor_span"
+      ],
+      "catalog_n": 6,
+      "gate": "always"
+    },
+    {
+      "rule_id": "PID-HUNT-1",
+      "ui_n": 10,
+      "ui_keys": [
+        "change_deadband_pct",
+        "confirm_min",
+        "minimum_coverage_pct",
+        "minimum_equivalent_cycles",
+        "minimum_reversals",
+        "minimum_span_pct",
+        "total_variation_fault_pct",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 7,
+      "gate": "control_loop"
+    },
+    {
+      "rule_id": "FC1",
+      "ui_n": 9,
+      "ui_keys": [
+        "confirm_min",
+        "duct_static_err",
+        "eps_dsp",
+        "eps_vfd_spd",
+        "fan_hi",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 6,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC2",
+      "ui_n": 10,
+      "ui_keys": [
+        "confirm_min",
+        "eps_mat",
+        "eps_oat",
+        "eps_rat",
+        "fan_on_min",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 7,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC3",
+      "ui_n": 10,
+      "ui_keys": [
+        "confirm_min",
+        "eps_mat",
+        "eps_oat",
+        "eps_rat",
+        "fan_on_min",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 7,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC4",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "delta_os_max",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "control_loop"
+    },
+    {
+      "rule_id": "FC5",
+      "ui_n": 11,
+      "ui_keys": [
+        "confirm_min",
+        "delta_supply_fan",
+        "eps_mat",
+        "eps_sat",
+        "fan_on_min",
+        "htg_on_min",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 8,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC6",
+      "ui_n": 11,
+      "ui_keys": [
+        "airflow_err",
+        "confirm_min",
+        "delta_t_min",
+        "eps_airflow",
+        "fan_on_min",
+        "min_cfm_design",
+        "mode_delay_min",
+        "oat_rat_delta_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 8,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC7",
+      "ui_n": 9,
+      "ui_keys": [
+        "confirm_min",
+        "eps_sat",
+        "fan_on_min",
+        "htg_full_min",
+        "mode_delay_min",
+        "sat_err",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 6,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC8",
+      "ui_n": 12,
+      "ui_keys": [
+        "clg_inactive_max",
+        "confirm_min",
+        "delta_supply_fan",
+        "econ_min_pos",
+        "eps_mat",
+        "eps_sat",
+        "mix_tol",
+        "mode_delay_min",
+        "supply_tol",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 9,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC9",
+      "ui_n": 11,
+      "ui_keys": [
+        "clg_inactive_max",
+        "confirm_min",
+        "delta_supply_fan",
+        "econ_min_pos",
+        "eps_oat",
+        "eps_sat",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 8,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC10",
+      "ui_n": 10,
+      "ui_keys": [
+        "clg_on_min",
+        "confirm_min",
+        "econ_full_open",
+        "eps_mat",
+        "eps_oat",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 7,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC11",
+      "ui_n": 11,
+      "ui_keys": [
+        "clg_on_min",
+        "confirm_min",
+        "delta_supply_fan",
+        "econ_full_open",
+        "eps_oat",
+        "eps_sat",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 8,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC12",
+      "ui_n": 13,
+      "ui_keys": [
+        "clg_on_min",
+        "confirm_min",
+        "delta_supply_fan",
+        "econ_full_open",
+        "econ_min_pos",
+        "eps_mat",
+        "eps_sat",
+        "mix_tol",
+        "mode_delay_min",
+        "supply_tol",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 10,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC13",
+      "ui_n": 10,
+      "ui_keys": [
+        "clg_full_min",
+        "confirm_min",
+        "econ_full_open",
+        "econ_min_pos",
+        "eps_sat",
+        "mode_delay_min",
+        "sat_err",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 7,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC14",
+      "ui_n": 12,
+      "ui_keys": [
+        "clg_inactive_max",
+        "confirm_min",
+        "delta_supply_fan",
+        "econ_min_pos",
+        "eps_ccet",
+        "eps_cclt",
+        "htg_on_min",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 9,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "FC15",
+      "ui_n": 13,
+      "ui_keys": [
+        "clg_inactive_max",
+        "clg_on_min",
+        "confirm_min",
+        "delta_supply_fan",
+        "econ_full_open",
+        "econ_min_pos",
+        "eps_hcet",
+        "eps_hclt",
+        "mix_tol",
+        "mode_delay_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 10,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "AHU-SATDEV",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "sat_dev_err",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "AHU-DUCTHI",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "duct_high_margin",
+        "pressure_on_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "conditional"
+    },
+    {
+      "rule_id": "AHU-SIMUL",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "valve_open_pct",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "OAT-METEO",
+      "ui_n": 2,
+      "ui_keys": [
+        "confirm_min",
+        "oat_err"
+      ],
+      "catalog_n": 2,
+      "gate": "always"
+    },
+    {
+      "rule_id": "ECON-1",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "econ1_oat_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "ECON-2",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "econ2_damper",
+        "econ2_oat_hi",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "ECON-3",
+      "ui_n": 8,
+      "ui_keys": [
+        "confirm_min",
+        "econ3_damper_hi",
+        "econ3_db_max",
+        "econ3_db_min",
+        "econ3_dp_max",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 5,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "ECON-4",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "oa_min_pct",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "ECON-5",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "preheat_over_f",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "ECON-6",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "econ6_damper_max",
+        "econ6_oat_max_f",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "ECON-7",
+      "ui_n": 8,
+      "ui_keys": [
+        "confirm_min",
+        "econ7_damper_min",
+        "econ7_db_max",
+        "econ7_db_min",
+        "econ7_dp_max",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 5,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "MECH-OAT-1",
+      "ui_n": 2,
+      "ui_keys": [
+        "confirm_min",
+        "mech_oat_max_f"
+      ],
+      "catalog_n": 2,
+      "gate": "always"
+    },
+    {
+      "rule_id": "CHW-NOLOAD-1",
+      "ui_n": 4,
+      "ui_keys": [
+        "comfort_high_f",
+        "comfort_low_f",
+        "confirm_min",
+        "sat_band_f"
+      ],
+      "catalog_n": 4,
+      "gate": "always"
+    },
+    {
+      "rule_id": "VAV-1",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "zone_hi",
+        "zone_lo",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "conditional"
+    },
+    {
+      "rule_id": "VAV-2",
+      "ui_n": 2,
+      "ui_keys": [
+        "setback_hi",
+        "confirm_min"
+      ],
+      "catalog_n": 2,
+      "gate": "always"
+    },
+    {
+      "rule_id": "VAV-3",
+      "ui_n": 7,
+      "ui_keys": [
+        "confirm_min",
+        "flow_on_min",
+        "reheat_oat",
+        "reheat_pct",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 4,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "VAV-4",
+      "ui_n": 7,
+      "ui_keys": [
+        "confirm_min",
+        "flow_on_min",
+        "full_open_pct",
+        "sustain_hours",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 4,
+      "gate": "control_loop"
+    },
+    {
+      "rule_id": "VAV-5",
+      "ui_n": 4,
+      "ui_keys": [
+        "confirm_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 1,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "VAV-6",
+      "ui_n": 6,
+      "ui_keys": [
+        "free_cool_oat",
+        "reheat_pct",
+        "confirm_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "VAV-REHEAT",
+      "ui_n": 7,
+      "ui_keys": [
+        "confirm_min",
+        "flow_on_min",
+        "min_rise",
+        "reheat_cmd",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 4,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "VAV-AHU-LEAVE",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "delta_f",
+        "flow_on_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "VAV-7",
+      "ui_n": 8,
+      "ui_keys": [
+        "confirm_min",
+        "fixed_flow_max_std",
+        "fixed_flow_min_mean",
+        "flow_on_min",
+        "high_min_flow_sp",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 5,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "CHW-1",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "min_dt",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "CHW-2",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "dp_margin",
+        "pump_hi",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "CHW-3",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "sp_band",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "CHW-4",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "flow_hi",
+        "pump_hi",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "HP-1",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "min_sat",
+        "zone_cold",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "compressor"
+    },
+    {
+      "rule_id": "WX-1",
+      "ui_n": 2,
+      "ui_keys": [
+        "confirm_min",
+        "spike_limit"
+      ],
+      "catalog_n": 2,
+      "gate": "always"
+    },
+    {
+      "rule_id": "CW-OPT-1",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "cw_approach",
+        "cw_slack",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "CW-APR-1",
+      "ui_n": 6,
+      "ui_keys": [
+        "approach_max_f",
+        "confirm_min",
+        "tower_fan_hi",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "CW-FAN-1",
+      "ui_n": 7,
+      "ui_keys": [
+        "confirm_min",
+        "cw_approach",
+        "excess_beyond_approach_f",
+        "tower_fan_hi",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 4,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "TRIM-1",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "duct_hi",
+        "request_lo",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "TRIM-3",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "hwst_hi",
+        "request_lo",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "TRIM-4",
+      "ui_n": 6,
+      "ui_keys": [
+        "chw_lo",
+        "confirm_min",
+        "request_lo",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "hydronic_flow"
+    },
+    {
+      "rule_id": "SCHED-1",
+      "ui_n": 3,
+      "ui_keys": [
+        "comfort_high_f",
+        "comfort_low_f",
+        "confirm_min"
+      ],
+      "catalog_n": 3,
+      "gate": "always"
+    },
+    {
+      "rule_id": "SCHED-247",
+      "ui_n": 3,
+      "ui_keys": [
+        "always_on_pct",
+        "confirm_min",
+        "pressure_on_min"
+      ],
+      "catalog_n": 3,
+      "gate": "always"
+    },
+    {
+      "rule_id": "RESET-1",
+      "ui_n": 8,
+      "ui_keys": [
+        "reset_err_f",
+        "reset_sat_at_65",
+        "reset_slope",
+        "reset_oat_ref",
+        "confirm_min",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 5,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "CMD-1",
+      "ui_n": 1,
+      "ui_keys": [
+        "confirm_min"
+      ],
+      "catalog_n": 1,
+      "gate": "always"
+    },
+    {
+      "rule_id": "OA-1",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "min_oa_frac",
+        "oat_rat_guard",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "fan_running"
+    },
+    {
+      "rule_id": "DMP-1",
+      "ui_n": 5,
+      "ui_keys": [
+        "confirm_min",
+        "leak_delta",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 2,
+      "gate": "conditional"
+    },
+    {
+      "rule_id": "VLV-1",
+      "ui_n": 6,
+      "ui_keys": [
+        "confirm_min",
+        "mat_leak_delta",
+        "sat_err",
+        "require_operational_gate",
+        "startup_delay_min",
+        "minimum_active_coverage_pct"
+      ],
+      "catalog_n": 3,
+      "gate": "conditional"
+    }
+  ]
+}

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,14 @@
 # Session log
 
+## 2026-09-04 — Bench recovery pack + patch trains mirrored in-repo
+
+- Added `docs/operations/BENCH_RECOVERY.md`, `docs/operations/recovery/AI_CONTEXT_HANDOFF.md`
+- Mirrored Cursor plans → `docs/operations/patch_trains/` (3.3.21 closeout … 3.3.26)
+- Tuner snapshots: Lab ~184 (`lab_tuners_snapshot_pre_3.3.24.json`), Vibe19 UI ~414 (`vibe19_ui_tuners_snapshot.json`)
+- BUG_REPORT / PATCH_CYCLE / STRESS_CLOSEOUT link to in-repo trains + recovery
+- Operator still must off-box copy: Railway backups, mqtt edge kit, Creekside zip, tokens
+
+
 ## 2026-09-04 — 3.3.20 x86 field → Railway hub CLOSED
 
 - **Merge:** #831 → `aef6fc1f`; VERSION **3.3.20**; pin **`sha-aef6fc1`**; health **`3.3.20+aef6fc1f5b29`**.


### PR DESCRIPTION
## Summary
- Add [`docs/operations/BENCH_RECOVERY.md`](docs/operations/BENCH_RECOVERY.md) — recreate x86 field edge + Railway hub if this host dies
- Add [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](docs/operations/recovery/AI_CONTEXT_HANDOFF.md) — agent reboot context
- Mirror Cursor plans into [`docs/operations/patch_trains/`](docs/operations/patch_trains/) (program + 3.3.21 closeout … 3.3.26)
- Snapshot Lab (~184) and Vibe19 UI (~414) tuner inventories as JSON
- Wire BUG_REPORT / PATCH_CYCLE / STRESS_CLOSEOUT / SESSION_LOG

No VERSION bump (docs/ops only).

## Test plan
- [ ] Links resolve on GitHub
- [ ] Confirm no secrets in `bensbench.env.example` or kits
- [ ] Operator still off-box copies Railway backups + edge kit + Creekside zip


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added bench-recovery and AI handoff guides covering recovery steps, operational references, and environment setup.
  - Added patch-train plans and an index for releases 3.3.21–3.3.26, including UI, tuner, stress, and release-checklist details.
  - Updated bug-report, patch-cycle, and stress-closeout documentation with current train and recovery references.
  - Added recovery snapshots documenting Lab and UI tuner configurations.
  - Added a recovery documentation index and session log entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->