### PR TITLE
docs: nightly 3.3.27+ master linked TODOs

### DIFF
--- a/docs/operations/patch_trains/README.md
+++ b/docs/operations/patch_trains/README.md
@@ -4,15 +4,17 @@ These Markdown files are **copies** of Cursor plans under `~/.cursor/plans/` so 
 
 ## Active — nightly bug train 3.3.27+
 
-| File | Rev |
-|------|-----|
-| [openfdd_nightly_bug_train_3.3.27_plus_program.plan.md](openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) | Program index |
-| [3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md](3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip pin sync |
-| [3.3.28_lab_tuners_econ_ahu_residual.plan.md](3.3.28_lab_tuners_econ_ahu_residual.plan.md) | Lab ECON/AHU residual |
-| [3.3.29_viewer_login_and_ui_scope.plan.md](3.3.29_viewer_login_and_ui_scope.plan.md) | Viewer + UI scope |
-| [3.3.30_isolated_zap_af_auth.plan.md](3.3.30_isolated_zap_af_auth.plan.md) | Isolated ZAP AF |
-| [3.3.31_mqtts_transport_isolation.plan.md](3.3.31_mqtts_transport_isolation.plan.md) | MQTTS isolation |
-| [3.3.32_durability_restore_perf.plan.md](3.3.32_durability_restore_perf.plan.md) | Restore + perf |
+Execute **in order** (one child at a time). Master TODOs: `ship-327` … `ship-332`.
+
+| Order | File | Rev / concern |
+|------:|------|---------------|
+| — | [openfdd_nightly_bug_train_3.3.27_plus_program.plan.md](openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) | **Master** program index |
+| 1 | [3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md](3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip mqtt/fieldbus pin |
+| 2 | [3.3.28_lab_tuners_econ_ahu_residual.plan.md](3.3.28_lab_tuners_econ_ahu_residual.plan.md) | Lab ECON/AHU residual |
+| 3 | [3.3.29_viewer_login_and_ui_scope.plan.md](3.3.29_viewer_login_and_ui_scope.plan.md) | Viewer + UI scope |
+| 4 | [3.3.30_isolated_zap_af_auth.plan.md](3.3.30_isolated_zap_af_auth.plan.md) | Isolated ZAP AF |
+| 5 | [3.3.31_mqtts_transport_isolation.plan.md](3.3.31_mqtts_transport_isolation.plan.md) | MQTTS isolation |
+| 6 | [3.3.32_durability_restore_perf.plan.md](3.3.32_durability_restore_perf.plan.md) | Restore + perf |
 
 ## Predecessor — 3.3.21→3.3.26 (CLOSED after 3.3.26 verdict)
 

--- a/docs/operations/patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md
@@ -1,62 +1,68 @@
 ---
 name: Open-FDD nightly bug train 3.3.27+
-overview: "Program index after 3.3.26 CLOSED. Sequential low-RAM nightlies: mqtt/fieldbus tip sync → Lab ECON/AHU residual → viewer/UI scope → isolated ZAP AF → MQTTS isolation → durability/restore/perf. Each child owns hygiene, GHCR, Railway re-pin, x86 fieldbus, qualification stress LAST, BUG_REPORT. Skip only with DEFERRED."
+overview: "Master Cursor program index for Open-FDD nightlies 3.3.27→3.3.32: one TODO per child plan in order, each linking the child `.plan.md`. Start only after 3.3.26 closeout is CLOSED."
 todos:
   - id: ship-327
-    content: Execute 3.3.27 mqtt/fieldbus tip pin sync
-    status: pending
+    content: Execute [3.3.27 tip pin sync](3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) — mqtt/fieldbus tip pin or DEFERRED
+    status: in_progress
   - id: ship-328
-    content: Execute 3.3.28 Lab tuners ECON/AHU/VAV residual
+    content: Execute [3.3.28 Lab residual](3.3.28_lab_tuners_econ_ahu_residual.plan.md) — ECON/AHU/VAV Lab leftovers
     status: pending
   - id: ship-329
-    content: Execute 3.3.29 viewer login + UI building scope
+    content: Execute [3.3.29 viewer/UI](3.3.29_viewer_login_and_ui_scope.plan.md) — viewer login + building scope
     status: pending
   - id: ship-330
-    content: Execute 3.3.30 isolated authenticated ZAP AF
+    content: Execute [3.3.30 isolated ZAP](3.3.30_isolated_zap_af_auth.plan.md) — authenticated ZAP AF + OpenAPI
     status: pending
   - id: ship-331
-    content: Execute 3.3.31 MQTTS transport isolation (disposable)
+    content: Execute [3.3.31 MQTTS](3.3.31_mqtts_transport_isolation.plan.md) — disposable MQTTS ACL/QoS/freshness
     status: pending
   - id: ship-332
-    content: Execute 3.3.32 durability restore + bounded perf
+    content: Execute [3.3.32 restore/perf](3.3.32_durability_restore_perf.plan.md) — Gate 18 restore + perf budgets
     status: pending
 isProject: false
 ---
 
-# Open-FDD nightly bug train — 3.3.27+
+# Open-FDD nightly bug train master (3.3.27+)
 
-**Not a shipping VERSION bump.** Program index after series 3.3.21→3.3.26. Open **one child at a time**. Do not start the next until the previous BUG_REPORT verdict is CLOSED or DEFERRED with reason.
+**Not a VERSION bump itself.** Sequential program: open **one child plan at a time**; mark the matching TODO done only when that child’s BUG_REPORT verdict is CLOSED or DEFERRED with reason.
 
-Predecessor: [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](./openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md) (CLOSED when 3.3.26 verdict lands).
+**Gate:** Finish current closeout first — Verdict 3.3.26 / tip pin (`readme_and_nightly_trains` Cursor plan). Do not start 3.3.27 until then.
 
-## Decisions locked
+**Mirrors:** GitHub is source of truth here; Cursor copies under `~/.cursor/plans/`. Index: [`README.md`](README.md) · handoff: [`../recovery/AI_CONTEXT_HANDOFF.md`](../recovery/AI_CONTEXT_HANDOFF.md).
 
-| Topic | Choice |
-|-------|--------|
-| Topology | Railway hub (central→mqtt→web) + bensbench **x86 fieldbus** + qualification stress LAST |
-| Stress | `run_railway_hub_stress.sh` → cite `qualification_manifest.json` `fully_qualified` |
-| Hygiene | 0 open PRs, only `master`, tip Actions green at END |
-| Skip | **DEFERRED** row in BUG_REPORT only |
-| Non-goals | Pi closeout; local react-ot head-end; local docker build; live OT DoS/activeScan; ML depth reopen |
+## Children in order (TODOs)
 
-## Children
+| Order | Rev | TODO | Child plan | One concern |
+|-------|-----|------|------------|-------------|
+| 1 | 3.3.27 | `ship-327` | [`3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md`](3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip mqtt/fieldbus pin (or honest BLOCKED) |
+| 2 | 3.3.28 | `ship-328` | [`3.3.28_lab_tuners_econ_ahu_residual.plan.md`](3.3.28_lab_tuners_econ_ahu_residual.plan.md) | Lab ECON/AHU/VAV residual |
+| 3 | 3.3.29 | `ship-329` | [`3.3.29_viewer_login_and_ui_scope.plan.md`](3.3.29_viewer_login_and_ui_scope.plan.md) | Viewer login + building UI scope |
+| 4 | 3.3.30 | `ship-330` | [`3.3.30_isolated_zap_af_auth.plan.md`](3.3.30_isolated_zap_af_auth.plan.md) | Isolated authenticated ZAP AF |
+| 5 | 3.3.31 | `ship-331` | [`3.3.31_mqtts_transport_isolation.plan.md`](3.3.31_mqtts_transport_isolation.plan.md) | Disposable MQTTS isolation |
+| 6 | 3.3.32 | `ship-332` | [`3.3.32_durability_restore_perf.plan.md`](3.3.32_durability_restore_perf.plan.md) | Restore + bounded perf |
 
-| Rev | Plan | One concern |
-|-----|------|-------------|
-| 3.3.27 | [`3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md`](./3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip mqtt/fieldbus pin (or honest BLOCKED) |
-| 3.3.28 | [`3.3.28_lab_tuners_econ_ahu_residual.plan.md`](./3.3.28_lab_tuners_econ_ahu_residual.plan.md) | SQL-honest ECON/AHU/VAV/plant Lab leftovers |
-| 3.3.29 | [`3.3.29_viewer_login_and_ui_scope.plan.md`](./3.3.29_viewer_login_and_ui_scope.plan.md) | Viewer password identity + building-scoped FDD UX |
-| 3.3.30 | [`3.3.30_isolated_zap_af_auth.plan.md`](./3.3.30_isolated_zap_af_auth.plan.md) | Isolated authenticated ZAP AF + OpenAPI |
-| 3.3.31 | [`3.3.31_mqtts_transport_isolation.plan.md`](./3.3.31_mqtts_transport_isolation.plan.md) | Disposable MQTTS ACL/QoS/freshness |
-| 3.3.32 | [`3.3.32_durability_restore_perf.plan.md`](./3.3.32_durability_restore_perf.plan.md) | Gate 18 restore-to-empty + perf budgets |
+```mermaid
+flowchart LR
+  c326[Verdict_3_3_26]
+  c327[3_3_27_tip_pin]
+  c328[3_3_28_Lab]
+  c329[3_3_29_viewer]
+  c330[3_3_30_ZAP]
+  c331[3_3_31_MQTTS]
+  c332[3_3_32_restore]
+  c326 --> c327 --> c328 --> c329 --> c330 --> c331 --> c332
+```
 
-## Shared loop
+## Shared loop (every child)
 
 ```text
 hygiene START → VERSION bump → one concern → one PR
   → squash-merge → wait GHCR sha-<7>
-  → Railway backup → re-pin → x86 fieldbus up
+  → Railway backup → re-pin → x86 fieldbus
   → run_railway_hub_stress.sh LAST → BUG_REPORT → hygiene END
 ```
 
-Canonical ops: [`PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md) · [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md) · [`scripts/qualification/README.md`](../../../scripts/qualification/README.md).
+Locked: Railway hub + bensbench x86 fieldbus; low-RAM (no local docker build); no Pi / no live OT DoS. Ops: [`../PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`../STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md) · [`../BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
+
+Predecessor: [`openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md`](openfdd_patch_series_3.3.21_to_3.3.26_program.plan.md) (CLOSED when 3.3.26 verdict lands).

--- a/docs/operations/recovery/AI_CONTEXT_HANDOFF.md
+++ b/docs/operations/recovery/AI_CONTEXT_HANDOFF.md
@@ -21,7 +21,7 @@ nav_order: 2
 | # | Path | Why |
 |---|------|-----|
 | 1 | [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md) | Living verdicts + Upcoming trains |
-| 2 | [`patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](../patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) | **Active** program index (3.3.27+) |
+| 2 | [`patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](../patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) | **Active** master — TODOs `ship-327`…`ship-332` link each child in order |
 | 3 | Active child under [`patch_trains/`](../patch_trains/) | One concern per nightly |
 | 4 | [`scripts/qualification/README.md`](../../../scripts/qualification/README.md) | Stress entry; cite `fully_qualified` |
 | 5 | [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md) · [`PATCH_CYCLE.md`](../PATCH_CYCLE.md) | Handbook + rev template |


### PR DESCRIPTION
## Summary
- Sync master program plan so each TODO links its child (3.3.27–3.3.32) in order.
- Update patch_trains README order table and AI_CONTEXT_HANDOFF pointers.

## Test plan
- [ ] Links resolve under docs/operations/patch_trains/
- [ ] Master frontmatter TODOs match Cursor program


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated nightly bug train documentation with an ordered execution plan for revisions 3.3.27–3.3.32.
  * Added linked child plans, execution statuses, sequential start and closeout guidance, and a dependency overview.
  * Clarified the active master plan and updated related recovery guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->