### PR TITLE
docs: post-3.3.33 soft-OPEN Waves D/E/F + MQTT health

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,35 +1,54 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-09-06 (Wave A/B/C **CLOSED**; **3.3.33** MQTT Overview=CSV **CLOSED**)  
+**Date:** 2026-09-06 (Wave A/B/C **CLOSED**; **3.3.33** MQTT Overview=CSV **CLOSED**; MQTTS live **healthy after central redeploy**)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in stress)  
 **Tip / pin (3.3.33):** `25826cf6` · VERSION **3.3.33** · health **`3.3.33+25826cf67999`** · GHCR **central/web/mqtt/fieldbus `sha-25826cf`**  
-**Last CLOSED tip:** `25826cf6` · **`sha-25826cf`** · **`3.3.33+25826cf67999`**  
+**Last CLOSED tip:** `25826cf6` · **`sha-25826cf`** · **`3.3.33+25826cf67999`** · docs merge **`d444b800`** (#857)  
 **Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Telemetry = hosted AV `9101` loopback as `bldg2-zone-loopback` / role **`zone_t`** / `equipment_type=zone_other`.  
-**Backup:** `~/openfdd-backups/railway/20260905T195204Z/`  
-**Program:** optimized waves — [`patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) (Cursor: `nightly_3.3.27+_master_4cc5bbd5.plan.md`)  
+**Backup:** `~/openfdd-backups/railway/20260906T030735Z/` (prior: `20260905T195204Z`)  
+**Program (CLOSED):** [`patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) (Cursor: `nightly_3.3.27+_master_4cc5bbd5.plan.md`)  
+**Active program:** [`patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) (Cursor: `post_3.3.33_soft_open_master_a1b2c3d4.plan.md`)  
 **Pis freed (not in stress):** bosspi · BensFakeAhu · Zone1VAV.
 
 ## OPEN / tracked bugs (post-3.3.33)
 
 | ID | Status | Symptom | Evidence | Next |
 |----|--------|---------|----------|------|
-| **railway-ui-fdd-stale** | **DEFERRED** → UX | Building filter / scoped FDD UX across sites | BUG_REPORT prior | Soft-OPEN; picker union helps |
+| **mqtt-ingest-stall** | **OPEN** → 3.3.34 | After mqtt/central re-pin, `edges:1` + `has_telemetry:true` but **`ingest_ok` flat** until `railway redeploy -s openfdd-central-cQ-F` | 2026-09-06 live: stuck at `ingest_ok=6` ~40m; post-redeploy `1→3` in ~70s | Wave D — auto-reconnect / resilient ingest; do not trust sticky edges alone |
+| **railway-ui-fdd-stale** | **DEFERRED** → 3.3.35 | Building filter / scoped FDD UX across sites | BUG_REPORT prior | Wave E |
+| **bldg2-overview-signoff** | **DEFERRED** → operator | SPA Overview tables/charts human confirm for `?site=bldg2` | API gate PASS on 3.3.33 | Wave E evidence |
 | **mqtt-overview-spa-parity** | **CLOSED** (3.3.33) | Was: equipment=0 for MQTT `bldg2` → empty Overview | #856 · probe + stress | — |
-| **qualification-viewer-login** | **CLOSED** (3.3.28) | `OPENFDD_VIEWER_PASSWORD` → `username=viewer` JWT | Railway var set | Optional auth_matrix password path |
+| **mqtt-fieldbus-tip-pin-sync** | **CLOSED** (3.3.33) | Was hybrid mqtt/fieldbus tip | All services `sha-25826cf` | — |
+| **qualification-viewer-login** | **CLOSED** (3.3.28) | `OPENFDD_VIEWER_PASSWORD` → `username=viewer` JWT | Railway var set | Optional auth_matrix path → Wave F soft |
 | **wave-c-railway-smoke** | **CLOSED** | Wave C smoke | `reports/waveC_railway_smoke_final/` · #854 | — |
+
+### MQTTS pipeline health check (2026-09-06T03:57Z)
+
+| Check | Result |
+|-------|--------|
+| Hub | `3.3.33+25826cf67999` · `edges:1` |
+| Fieldbus | `openfdd-fieldbus:sha-25826cf` healthy · `poll_running` · publish 60s |
+| Edge | `pi-1` / `bldg2` `has_telemetry:true` |
+| Ingest | **Recovered** after central redeploy — `ingest_ok` **1→3** over ~70s (was stalled at 6) |
+| Overview API | `GET /api/fdd/equipment?building_id=bldg2` **count=8** incl. loopback; sensor-stats has `zone-air-temp` |
+| Residual product risk | Central MQTT ingest can stall after mqtt peer bounce without auto-recovery → **mqtt-ingest-stall** |
 
 ## Next patch cycle (copy into `.cursor/plans/patch_cycle_3.3.N_<slug>.plan.md`)
 
 Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. Do **not** bump VERSION for a pure evidence/docs PR.
 
-### Upcoming trains (Cursor plans — optimized waves 2026-09-05)
+### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Last closed:** [`patch_cycle_3.3.33_mqtt_overview_csv_parity.plan.md`](../../.cursor/plans/patch_cycle_3.3.33_mqtt_overview_csv_parity.plan.md) — MQTTS Overview = CSV Overview (**CLOSED**).
+**Active:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) — Waves D/E/F.  
+**Last closed:** [`3.3.33_mqtt_overview_csv_parity.plan.md`](patch_trains/3.3.33_mqtt_overview_csv_parity.plan.md) — MQTTS Overview = CSV Overview (**CLOSED**).
 
 | Rev / wave | In-repo plan | Concern | Status |
 |------------|--------------|---------|--------|
-| **3.3.33** | [`3.3.33_mqtt_overview_csv_parity.plan.md`](patch_trains/3.3.33_mqtt_overview_csv_parity.plan.md) | FDD inventory/run/series + buildings list use historian `building_id=` | **CLOSED** — #856 · tip `sha-25826cf` · stress PASS · Overview probe PASS |
+| **Wave D / 3.3.34** | [`3.3.34_mqtt_ingest_reconnect.plan.md`](patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md) | Central MQTT ingest resilience after mqtt re-pin | **OPEN** |
+| **Wave E / 3.3.35** | [`3.3.35_overview_ui_fdd_scope.plan.md`](patch_trains/3.3.35_overview_ui_fdd_scope.plan.md) | `railway-ui-fdd-stale` + Overview browser sign-off | **OPEN** |
+| **Wave F / 3.3.36** | [`3.3.36_lab_gate_residual.plan.md`](patch_trains/3.3.36_lab_gate_residual.plan.md) | Honest Lab residual / optional viewer matrix | **OPEN** |
+| **3.3.33** | [`3.3.33_mqtt_overview_csv_parity.plan.md`](patch_trains/3.3.33_mqtt_overview_csv_parity.plan.md) | FDD inventory/run/series + buildings list use historian `building_id=` | **CLOSED** — #856 · tip `sha-25826cf` · stress PASS · Overview probe PASS · docs #857 |
 | **Wave A** | closeout + [`3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md`](patch_trains/3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip pin + one full stress | **CLOSED** |
 | **Wave B** | [`3.3.28`](patch_trains/3.3.28_lab_tuners_econ_ahu_residual.plan.md) + [`3.3.29`](patch_trains/3.3.29_viewer_login_and_ui_scope.plan.md) | Lab + viewer + #851 historian scope | **CLOSED** — #852 · tip `sha-10d1ec5` · stress PASS · #851 CLOSED · docs #853 |
 | **Wave C** | [`3.3.30`](patch_trains/3.3.30_isolated_zap_af_auth.plan.md)–[`3.3.32`](patch_trains/3.3.32_durability_restore_perf.plan.md) | Isolated ZAP/MQTTS/restore + smoke | **CLOSED** — #854 · CI isolated PASS · Railway smoke PASS · tip stays `sha-10d1ec5` |
@@ -69,7 +88,7 @@ Private OT LAN addresses, vendor lake credentials, and tunnel endpoints live onl
 | Zone Other tables | **PASS** — rows=7; loopback present (tables not hidden) |
 | AFDD | **PASS** — `POST /api/fdd/run` `{building_id:bldg2, rule_ids:[VAV-1,SV-RANGE]}` ok; succeeded=2 |
 | STRESS | **PASS** `fully_qualified=true` — `reports/nightly-ot-bench_20260906T031744Z/` (gates 00–08) |
-| Soft-OPEN | `railway-ui-fdd-stale` remains UX deferral |
+| Soft-OPEN | `railway-ui-fdd-stale` + browser sign-off → Wave E; **mqtt-ingest-stall** opened post-closeout |
 
 
 ## Verdict — Wave C isolated harness (2026-09-05) — CLOSED
@@ -396,22 +415,23 @@ Script: `scripts/nightly-ot-bench/18_volume_restore_smoke.sh`
 
 ## Soft-OPEN / follow-up
 
-Triage as of **3.3.26** (series residual). Prior PASS rows are **not** rewritten as enhanced-suite evidence.
+Triage as of **post-3.3.33** (2026-09-06). Prior PASS rows are **not** rewritten as enhanced-suite evidence.
 
 | ID | Disposition | Notes |
 |----|-------------|-------|
-| **bldg2-overview-signoff** | **DEFERRED** → operator browser | SPA Zone Other shells still need human confirm; not blocked on harness |
+| **mqtt-ingest-stall** | **OPEN** → Wave D / 3.3.34 | Sticky `has_telemetry` while `ingest_ok` flat after mqtt peer bounce; ops recovery = central redeploy |
+| **bldg2-overview-signoff** | **DEFERRED** → Wave E | SPA Zone Other shells still need human confirm; API gate already PASS |
 | **railway-f1-stress** | **CLOSED** (B100) / **DEFERRED** (B50/AFDD) | B100 PASS retained; B50 package + AFDD flood still operator-skip |
 | **weather-legitimacy-chicago** | **DEFERRED** → tier-C | Full soak optional; short soak already green historically |
-| **railway-ui-fdd-stale** | **DEFERRED** → UX | Use building filter; not a stress-harness gate |
+| **railway-ui-fdd-stale** | **DEFERRED** → Wave E / 3.3.35 | Building-scoped FDD chrome; not a stress-harness gate alone |
 | **local-parquet-root-split** | **DEFERRED** → lab | Local path split; Railway uses `/workspace/openfdd` |
 | **lake-credential-rotation** | **CLOSED** | Ops hygiene done; session-env only |
 | **deploy-mqtt-acl-mount** | **CLOSED** | Documented ops note; file-not-dir |
-| **vibe19-operational-gate-lab** | **DEFERRED** → future | No SQL/session binding for `require_operational_gate` / `startup_delay_min` / `minimum_active_coverage_pct` — Path B (fake Lab sliders refused) |
-| **mqtt-fieldbus-tip-pin-sync** | **DEFERRED** → next pin train | Hybrid central/web tip vs older mqtt/fieldbus `sha-*` remains allowed with explicit hybrid note |
+| **vibe19-operational-gate-lab** | **DEFERRED** → Wave F or stay | No SQL/session binding for `require_operational_gate` / `startup_delay_min` / `minimum_active_coverage_pct` — Path B refused |
+| **mqtt-fieldbus-tip-pin-sync** | **CLOSED** (3.3.33) | Tip pin same-sha central/web/mqtt/fieldbus `sha-25826cf` |
 | **mqtt-overview-spa-parity** | **CLOSED** (3.3.33) | FDD inventory/run/series historian parity — Overview MQTT=CSV |
 | **isolated-authenticated-zap-af** | **CLOSED** (Wave C harness) | Disposable AF+OpenAPI PASS; field closeout stays public baseline |
-| **qualification-viewer-login** | **CLOSED** (3.3.28) | `OPENFDD_VIEWER_PASSWORD` on Railway; optional matrix password path remains soft |
+| **qualification-viewer-login** | **CLOSED** (3.3.28) | `OPENFDD_VIEWER_PASSWORD` on Railway; optional matrix password path remains soft → Wave F |
 
 ## Series wrap draft — Lab tuners 3.3.21→3.3.26
 

--- a/docs/operations/patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md
+++ b/docs/operations/patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md
@@ -1,0 +1,52 @@
+---
+name: 3.3.34 mqtt ingest reconnect
+overview: "Tiny VERSION 3.3.33→3.3.34. Central MQTT ingest must auto-recover after mqtt/central re-pin so ingest_ok advances without sticky-edge false confidence. Full Railway stress LAST. Low-RAM."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START — 0 open PRs; tip Actions green
+    status: pending
+  - id: p1-version
+    content: Bump VERSION + Cargo 3.3.33 → 3.3.34
+    status: pending
+  - id: p2-fix
+    content: Central MQTT ingest reconnect / resilient subscribe after peer bounce (close mqtt-ingest-stall)
+    status: pending
+  - id: p3-pr
+    content: One PR; squash-merge; wait GHCR tip (mqtt+fieldbus)
+    status: pending
+  - id: p4-repin
+    content: Railway backup + re-pin central→mqtt→web; x86 fieldbus same sha-*; prove ingest_ok advances ≥2 intervals
+    status: pending
+  - id: p5-stress
+    content: ONE full run_railway_hub_stress.sh → fully_qualified + Overview MQTT gate
+    status: pending
+  - id: p6-bug-report
+    content: BUG_REPORT Wave D / 3.3.34 CLOSED
+    status: pending
+isProject: false
+---
+
+# 3.3.34 — MQTT ingest reconnect (Wave D)
+
+**Parent:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](openfdd_post_3.3.33_soft_open_program.plan.md)
+
+## Concern (one)
+
+After mqtt (or central) redeploy, hub can show `edges:1` / `has_telemetry:true` while **`ingest_ok` stays flat**. Ops recovery today is `railway redeploy -s openfdd-central-cQ-F`. Product should reconnect ingest without a manual second redeploy.
+
+## Prove
+
+- Force mqtt peer bounce (or controlled disconnect) → central ingest reconnects in logs
+- `ingest_ok` increases across ≥2× publish interval (60s default) without manual redeploy
+- Edge `pi-1`/`bldg2` remains `has_telemetry:true`
+- Full `run_railway_hub_stress.sh` → `fully_qualified=true`
+- Overview equipment `bldg2` still non-empty (regression)
+
+## Stress tier
+
+**Full Railway** (image-shipping wave).
+
+## Out of scope
+
+- Overview SPA chrome (`railway-ui-fdd-stale`) → 3.3.35
+- Lab operational-gate trio → 3.3.36 / DEFER

--- a/docs/operations/patch_trains/3.3.35_overview_ui_fdd_scope.plan.md
+++ b/docs/operations/patch_trains/3.3.35_overview_ui_fdd_scope.plan.md
@@ -1,0 +1,48 @@
+---
+name: 3.3.35 overview ui fdd scope
+overview: "Tiny VERSION only if web/central ship. Close railway-ui-fdd-stale + bldg2 Overview browser sign-off; tables visible by default for MQTT=CSV. Prefer Railway smoke; full stress only if images change. Low-RAM."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START
+    status: pending
+  - id: p1-fix
+    content: Building-scoped FDD chrome + Overview tables visible by default for live MQTT sites
+    status: pending
+  - id: p2-pr
+    content: PR merge; bump VERSION only if GHCR images ship
+    status: pending
+  - id: p3-smoke
+    content: Railway smoke + Overview probe; full matrix only if tip images moved
+    status: pending
+  - id: p4-signoff
+    content: Operator browser artifact for ?site=bldg2 Overview (or DEFER with reason)
+    status: pending
+  - id: p5-bug-report
+    content: BUG_REPORT Wave E / 3.3.35 CLOSED
+    status: pending
+isProject: false
+---
+
+# 3.3.35 — Overview UI / FDD scope (Wave E)
+
+**Parent:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](openfdd_post_3.3.33_soft_open_program.plan.md)
+
+## Concern (one)
+
+Close **`railway-ui-fdd-stale`**: building-scoped FDD UX so MQTT live sites look the same as CSV in Overview chrome (tables **not** hidden by default). Capture **`bldg2-overview-signoff`** browser evidence.
+
+## Prove
+
+- Overview `?site=bldg2` shows equipment / Zone Other tables without empty-hero collapse
+- Building picker keeps MQTT ∪ CSV union (3.3.33 regression)
+- AFDD scoped run still works for `bldg2`
+- Smoke (or full if images changed) green
+
+## Stress tier
+
+**Railway smoke** by default. **Full** only if web/central/mqtt/fieldbus tip images changed.
+
+## Out of scope
+
+- Ingest reconnect → 3.3.34 (do Wave D first)
+- Fake Lab operational-gate sliders

--- a/docs/operations/patch_trains/3.3.36_lab_gate_residual.plan.md
+++ b/docs/operations/patch_trains/3.3.36_lab_gate_residual.plan.md
@@ -1,0 +1,45 @@
+---
+name: 3.3.36 lab gate residual
+overview: "Honest Lab residual only after Waves D/E. Keep Path B refusal for vibe19 operational-gate trio without SQL/session binding. Isolated/unit primary; Railway smoke unless tip moved. Low-RAM."
+todos:
+  - id: p0-hygiene
+    content: GH hygiene START
+    status: pending
+  - id: p1-triage
+    content: List Lab leftovers with honest bindings vs explicit DEFER vibe19 operational-gate trio
+    status: pending
+  - id: p2-fix
+    content: Ship only honest Lab / optional auth_matrix viewer password path
+    status: pending
+  - id: p3-proof
+    content: Unit/isolated proof; Railway smoke unless images changed
+    status: pending
+  - id: p4-bug-report
+    content: BUG_REPORT Wave F / 3.3.36 CLOSED or DEFER with reason
+    status: pending
+isProject: false
+---
+
+# 3.3.36 — Lab residual (Wave F)
+
+**Parent:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](openfdd_post_3.3.33_soft_open_program.plan.md)
+
+## Concern (one)
+
+Close remaining **honest** Lab tuner gaps. **`vibe19-operational-gate-lab`** stays **DEFERRED** unless SQL/session binding exists — do not ship fake sliders.
+
+## Prove
+
+- Each shipped Lab control binds to real rule/session fields
+- Optional: auth_matrix viewer password path soft close
+- Isolated/unit green; Railway smoke at end
+
+## Stress tier
+
+**Isolated/unit** primary · **Railway smoke** at wave end · **Full** only if tip images moved.
+
+## Out of scope
+
+- MQTT ingest / Overview SPA (Waves D/E)
+- B50 package / AFDD flood (operator-skip)
+- Weather Chicago full soak (tier-C)

--- a/docs/operations/patch_trains/README.md
+++ b/docs/operations/patch_trains/README.md
@@ -2,19 +2,31 @@
 
 These Markdown files are **copies** of Cursor plans under `~/.cursor/plans/` so a dead laptop does not lose the program. **GitHub is source of truth** — edit here first, then mirror to `~/.cursor/plans/`.
 
-## Active — nightly bug train 3.3.27+ (optimized waves)
+## Active — post-3.3.33 soft-OPEN (optimized waves D/E/F)
+
+Full Railway stress **only** on image-shipping Wave D (ingest). Waves E/F prefer smoke / isolated. See master.
+
+| Wave | File | Rev / concern |
+|------|------|---------------|
+| — | [openfdd_post_3.3.33_soft_open_program.plan.md](openfdd_post_3.3.33_soft_open_program.plan.md) | **Master** (waves D/E/F) |
+| D | [3.3.34_mqtt_ingest_reconnect.plan.md](3.3.34_mqtt_ingest_reconnect.plan.md) | MQTT ingest reconnect |
+| E | [3.3.35_overview_ui_fdd_scope.plan.md](3.3.35_overview_ui_fdd_scope.plan.md) | Overview UI / FDD scope |
+| F | [3.3.36_lab_gate_residual.plan.md](3.3.36_lab_gate_residual.plan.md) | Lab residual (honest only) |
+
+## Predecessor — nightly bug train 3.3.27+ (CLOSED through 3.3.33)
 
 Full Railway stress **only** on image-shipping waves (A tip pin, B product tip). Wave C = isolated suites + Railway smoke. See master.
 
 | Wave | File | Rev / concern |
 |------|------|---------------|
-| — | [openfdd_nightly_bug_train_3.3.27_plus_program.plan.md](openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) | **Master** (waves A/B/C) |
+| — | [openfdd_nightly_bug_train_3.3.27_plus_program.plan.md](openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) | **Master** (waves A/B/C) + 3.3.33 |
 | A | [3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md](3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip mqtt/fieldbus pin |
 | B | [3.3.28_lab_tuners_econ_ahu_residual.plan.md](3.3.28_lab_tuners_econ_ahu_residual.plan.md) | Lab ECON/AHU residual |
 | B | [3.3.29_viewer_login_and_ui_scope.plan.md](3.3.29_viewer_login_and_ui_scope.plan.md) | Viewer + UI scope |
 | C | [3.3.30_isolated_zap_af_auth.plan.md](3.3.30_isolated_zap_af_auth.plan.md) | Isolated ZAP AF |
 | C | [3.3.31_mqtts_transport_isolation.plan.md](3.3.31_mqtts_transport_isolation.plan.md) | MQTTS isolation |
 | C | [3.3.32_durability_restore_perf.plan.md](3.3.32_durability_restore_perf.plan.md) | Restore + perf |
+| — | [3.3.33_mqtt_overview_csv_parity.plan.md](3.3.33_mqtt_overview_csv_parity.plan.md) | MQTT Overview = CSV |
 
 ## Predecessor — 3.3.21→3.3.26 (CLOSED after 3.3.26 verdict)
 

--- a/docs/operations/patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md
@@ -1,0 +1,121 @@
+---
+name: Post-3.3.33 soft-OPEN master
+overview: "Optimized 3.3.34→3.3.36 program for leftovers after MQTT Overview=CSV CLOSED. Full Railway stress only on image-shipping waves; smoke/operator checks for UX; isolated where that is the real proof. No redundant full matrix between children."
+todos:
+  - id: wave-d-ingest
+    content: "Wave D — 3.3.34 MQTT ingest resilience after mqtt/central re-pin (ingest_ok advancing; edges has_telemetry); ONE full Railway stress if images ship"
+    status: pending
+  - id: wave-e-ui
+    content: "Wave E — 3.3.35 railway-ui-fdd-stale + bldg2 Overview browser sign-off (tables visible by default); Railway smoke + Overview probe (full only if SPA images change)"
+    status: pending
+  - id: wave-f-lab
+    content: "Wave F — 3.3.36 Lab residual (vibe19 operational-gate DEFER if still dishonest) + optional auth_matrix viewer path; isolated/unit proof; Railway smoke unless tip moved"
+    status: pending
+isProject: false
+---
+
+# Open-FDD post-3.3.33 soft-OPEN master — optimized
+
+**Not a VERSION bump itself.** Child plans are the concern backlog. Parent program [`openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) is **CLOSED** through 3.3.33.
+
+**Honesty rule:** every concern still gets evidence. Drop only **duplicate full Railway matrices** when hub/field images and MQTT topology did not change.
+
+**Gate:** Fix live ingest stall (Wave D) before UI polish (Wave E). Do not merge docs mid-Publish.
+
+**Mirrors:** write children under [``]() then copy to `~/.cursor/plans/`. Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
+
+**Baseline tip (start):** `25826cf6` · **`sha-25826cf`** · health **`3.3.33+25826cf67999`** · field `bldg2` / `pi-1` · hosted AV `9101` → `bldg2-zone-loopback` / `zone_t`.
+
+## Waves (do this)
+
+```mermaid
+flowchart LR
+  waveD[WaveD_mqtt_ingest_resilience_full_stress]
+  waveE[WaveE_overview_ui_scope_smoke]
+  waveF[WaveF_lab_residual_isolated_smoke]
+  waveD --> waveE --> waveF
+```
+
+| Wave | Children | Ship how | Stress (required) |
+|------|----------|----------|-------------------|
+| **D — ingest** | [`3.3.34`](3.3.34_mqtt_ingest_reconnect.plan.md) | Product/ops fix so central MQTT ingest **reconnects** after mqtt re-pin; VERSION bump if GHCR ships | **One full** `run_railway_hub_stress.sh` after tip lands + prove `ingest_ok` advances over ≥2 publish intervals |
+| **E — UI** | [`3.3.35`](3.3.35_overview_ui_fdd_scope.plan.md) | Close `railway-ui-fdd-stale` + operator Overview tables-visible default for MQTT=`CSV` | **Railway smoke** + Overview probe (`equipment`, Zone Other, picker). **Full** only if web/central images changed |
+| **F — Lab residual** | [`3.3.36`](3.3.36_lab_gate_residual.plan.md) | Honest Lab leftovers only; keep Path B refusal for fake SQL-bound gates | **Isolated/unit** primary; end with **Railway smoke**. Full only if tip images moved |
+
+### Child index (one concern each)
+
+| Rev | Plan | One concern |
+|-----|------|-------------|
+| 3.3.34 | `3.3.34_mqtt_ingest_reconnect.plan.md` | Central MQTT ingest stays live after mqtt/central redeploy (`ingest_ok` rising; not sticky `has_telemetry` alone) |
+| 3.3.35 | `3.3.35_overview_ui_fdd_scope.plan.md` | Building-scoped FDD chrome + Overview tables visible by default for live MQTT sites (close `railway-ui-fdd-stale` / browser sign-off) |
+| 3.3.36 | `3.3.36_lab_gate_residual.plan.md` | Lab residual that has honest bindings; **DEFER** vibe19 operational-gate trio if still no SQL/session truth |
+
+## Soft-OPEN → wave map (from BUG_REPORT)
+
+| ID | Disposition entering this program | Wave |
+|----|-----------------------------------|------|
+| **mqtt-ingest-stall** (new) | **OPEN** — hub `edges:1` + fieldbus healthy but `ingest_ok` flat after re-pin | **D** |
+| **mqtt-fieldbus-tip-pin-sync** | **CLOSED** on 3.3.33 tip (`sha-25826cf` all services) — remove hybrid deferral | — |
+| **railway-ui-fdd-stale** | **DEFERRED** → UX | **E** |
+| **bldg2-overview-signoff** | **DEFERRED** → operator browser | **E** (evidence, may close without product PR) |
+| **vibe19-operational-gate-lab** | **DEFERRED** → future (no honest SQL) | **F** or stay DEFERRED |
+| **qualification-viewer-login** optional matrix path | soft | **F** optional |
+| **weather-legitimacy-chicago** | tier-C optional | out of wave (operator soak) |
+| **railway-f1-stress** B50/AFDD | operator-skip | out of wave |
+| **local-parquet-root-split** | lab-only | out of wave |
+
+## Stress tiers (not cheat — right tier)
+
+| Tier | When | What |
+|------|------|------|
+| **Full Railway** | Wave D tip; any rev that changes hub/field images or MQTT topology | Full `run_railway_hub_stress.sh` → `fully_qualified` + Overview MQTT=`CSV` gate |
+| **Railway smoke** | Wave E/F end; docs-only mid-wave | Hub health + fieldbus `:8081` + edges `has_telemetry` + **`ingest_ok` advancing** + Overview equipment/Zone Other + public ZAP if cheap |
+| **Isolated / unit** | Wave F Lab honesty; Wave D reconnect unit if feasible | Prove reconnect without claiming live PASS from docs alone |
+
+### Full / smoke MUST still validate MQTTS → Overview
+
+| Check | Expected |
+|-------|----------|
+| Field | x86 fieldbus → MQTTS; hosted-weather AV **9101** |
+| Edge | `pi-1` / `bldg2` `has_telemetry:true` |
+| Ingest | `ingest_ok` **increases** across ≥2× `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS` (do not trust sticky edges alone) |
+| Role | **`zone_t`** / `bldg2-zone-loopback` |
+| Overview | Equipment non-empty; Zone Other **tables visible** (not hidden empty); AFDD `fdd/run` scoped to `bldg2` |
+| Evidence | BUG_REPORT verdict + report dir — or **DEFERRED** with operator-browser reason |
+
+## Dropped as silly (keep evidence elsewhere)
+
+- Full backup + re-pin + full matrix after every UI-only or docs child when tip images unchanged
+- Claiming ingest healthy from `edges:1` alone while `ingest_ok` is flat
+- Merging docs while Publish is still building fieldbus
+- Shipping fake Lab sliders for operational-gate trio without SQL/session binding
+
+## Wave loops
+
+**Wave D (image-shipping / ingest):**
+
+```text
+hygiene → VERSION + reconnect fix → PR merge → wait GHCR tip (mqtt+fieldbus too)
+  → one backup → re-pin central→mqtt→web → fieldbus sha-<7>
+  → prove ingest_ok advances → ONE full run_railway_hub_stress.sh
+  → BUG_REPORT wave verdict → hygiene
+```
+
+**Wave E (UI / smoke-first):**
+
+```text
+hygiene → SPA/FDD scope fix (bump VERSION only if web/central ship)
+  → if images changed: backup/re-pin + smoke or full per tier table
+  → Overview probe + operator browser sign-off artifact
+  → BUG_REPORT → hygiene
+```
+
+**Wave F (Lab residual / isolated):**
+
+```text
+hygiene → honest Lab PR(s) or explicit DEFER in BUG_REPORT
+  → unit/isolated proof → Railway smoke unless tip moved
+  → BUG_REPORT → hygiene
+```
+
+Locked: Railway hub + bensbench x86 fieldbus; low-RAM; no Pi / no live OT DoS. Ops: [`PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md).


### PR DESCRIPTION
## Summary
- Refresh BUG_REPORT for tip `sha-25826cf` / docs #857, backup `20260906T030735Z`
- Open **mqtt-ingest-stall** (sticky edges vs flat `ingest_ok`; recovered via central redeploy; `ingest_ok` 1→3)
- Close **mqtt-fieldbus-tip-pin-sync** on 3.3.33 tip
- Add optimized master + children 3.3.34 / 3.3.35 / 3.3.36 (full stress only on Wave D)

## Test plan
- [x] Hub health `3.3.33+25826cf67999`
- [x] Fieldbus healthy; edges `pi-1`/`bldg2` `has_telemetry`
- [x] `ingest_ok` advancing after central redeploy
- [ ] Review wave map vs soft-OPEN table


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational bug tracking with current MQTT ingest status, recovery details, deployment state, and wave dispositions.
  * Added patch-train plans for MQTT ingest resilience, Overview UI/FDD updates, and remaining Lab work.
  * Added a post-3.3.33 soft-open program covering optimized validation waves and testing criteria.
  * Updated the patch-train index and closed the previous nightly train through version 3.3.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->