### PR TITLE
docs: post-3.3.33 closeout stress LAST + Wave G hybrid train

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -7,7 +7,7 @@
 **Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Telemetry = hosted AV `9101` loopback as `bldg2-zone-loopback` / role **`zone_t`** / `equipment_type=zone_other`.  
 **Backup:** `~/openfdd-backups/railway/20260906T030735Z/` (prior: `20260905T195204Z`)  
 **Program (CLOSED):** [`patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) (Cursor: `nightly_3.3.27+_master_4cc5bbd5.plan.md`)  
-**Active program:** [`patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) (Cursor: `post_3.3.33_soft_open_master_a1b2c3d4.plan.md`)  
+**Active program:** [`patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) (Cursor: `post_3.3.33_soft_open_master_a1b2c3d4.plan.md`) — Waves D→E→F then **ONE full Railway stress LAST** → BUG_REPORT round  
 **Pis freed (not in stress):** bosspi · BensFakeAhu · Zone1VAV.
 
 ## OPEN / tracked bugs (post-3.3.33)
@@ -40,14 +40,17 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) — Waves D/E/F.  
+**Active:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) — Waves D/E/F + **closeout full stress**.  
 **Last closed:** [`3.3.33_mqtt_overview_csv_parity.plan.md`](patch_trains/3.3.33_mqtt_overview_csv_parity.plan.md) — MQTTS Overview = CSV Overview (**CLOSED**).
+
+**This round stress rule:** mid-wave = Railway **smoke** / isolated only. **ONE full** `run_railway_hub_stress.sh` at **program closeout** (after F) → cite `fully_qualified` + Overview MQTT gate in BUG_REPORT. Do not re-run full matrix after every child.
 
 | Rev / wave | In-repo plan | Concern | Status |
 |------------|--------------|---------|--------|
-| **Wave D / 3.3.34** | [`3.3.34_mqtt_ingest_reconnect.plan.md`](patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md) | Central MQTT ingest resilience after mqtt re-pin | **OPEN** |
-| **Wave E / 3.3.35** | [`3.3.35_overview_ui_fdd_scope.plan.md`](patch_trains/3.3.35_overview_ui_fdd_scope.plan.md) | `railway-ui-fdd-stale` + Overview browser sign-off | **OPEN** |
-| **Wave F / 3.3.36** | [`3.3.36_lab_gate_residual.plan.md`](patch_trains/3.3.36_lab_gate_residual.plan.md) | Honest Lab residual / optional viewer matrix | **OPEN** |
+| **Wave D / 3.3.34** | [`3.3.34_mqtt_ingest_reconnect.plan.md`](patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md) | Central MQTT ingest resilience after mqtt re-pin | **OPEN** — smoke mid-wave |
+| **Wave E / 3.3.35** | [`3.3.35_overview_ui_fdd_scope.plan.md`](patch_trains/3.3.35_overview_ui_fdd_scope.plan.md) | `railway-ui-fdd-stale` + Overview browser sign-off | **OPEN** — smoke mid-wave |
+| **Wave F / 3.3.36** | [`3.3.36_lab_gate_residual.plan.md`](patch_trains/3.3.36_lab_gate_residual.plan.md) | Honest Lab residual / optional viewer matrix | **OPEN** — isolated + smoke |
+| **Closeout** | parent master | Full Railway matrix on final tip | **OPEN** — **required LAST** before program CLOSED verdict |
 | **3.3.33** | [`3.3.33_mqtt_overview_csv_parity.plan.md`](patch_trains/3.3.33_mqtt_overview_csv_parity.plan.md) | FDD inventory/run/series + buildings list use historian `building_id=` | **CLOSED** — #856 · tip `sha-25826cf` · stress PASS · Overview probe PASS · docs #857 |
 | **Wave A** | closeout + [`3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md`](patch_trains/3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip pin + one full stress | **CLOSED** |
 | **Wave B** | [`3.3.28`](patch_trains/3.3.28_lab_tuners_econ_ahu_residual.plan.md) + [`3.3.29`](patch_trains/3.3.29_viewer_login_and_ui_scope.plan.md) | Lab + viewer + #851 historian scope | **CLOSED** — #852 · tip `sha-10d1ec5` · stress PASS · #851 CLOSED · docs #853 |

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -437,6 +437,7 @@ Triage as of **post-3.3.33** (2026-09-06). Prior PASS rows are **not** rewritten
 | **mqtt-overview-spa-parity** | **CLOSED** (3.3.33) | FDD inventory/run/series historian parity — Overview MQTT=CSV |
 | **isolated-authenticated-zap-af** | **CLOSED** (Wave C harness) | Disposable AF+OpenAPI PASS; field closeout stays public baseline |
 | **qualification-viewer-login** | **CLOSED** (3.3.28) | `OPENFDD_VIEWER_PASSWORD` on Railway; optional matrix password path remains soft → Wave F |
+| **hybrid-ml-physics-ahu-vav** | **OPEN** → Wave G (after OT closeout) | Experimental semantic hybrid; AHU+VAV first slice; OT full stress ≠ scientific validation |
 
 ## Series wrap draft — Lab tuners 3.3.21→3.3.26
 

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -7,7 +7,7 @@
 **Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Telemetry = hosted AV `9101` loopback as `bldg2-zone-loopback` / role **`zone_t`** / `equipment_type=zone_other`.  
 **Backup:** `~/openfdd-backups/railway/20260906T030735Z/` (prior: `20260905T195204Z`)  
 **Program (CLOSED):** [`patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](patch_trains/openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) (Cursor: `nightly_3.3.27+_master_4cc5bbd5.plan.md`)  
-**Active program:** [`patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) (Cursor: `post_3.3.33_soft_open_master_a1b2c3d4.plan.md`) — Waves D→E→F then **ONE full Railway stress LAST** → BUG_REPORT round  
+**Active program:** [`patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) (Cursor: `post_3.3.33_soft_open_master_a1b2c3d4.plan.md`) — Waves D→E→F → **full stress LAST** → optional **Wave G** hybrid AHU/VAV  
 **Pis freed (not in stress):** bosspi · BensFakeAhu · Zone1VAV.
 
 ## OPEN / tracked bugs (post-3.3.33)
@@ -17,6 +17,7 @@
 | **mqtt-ingest-stall** | **OPEN** → 3.3.34 | After mqtt/central re-pin, `edges:1` + `has_telemetry:true` but **`ingest_ok` flat** until `railway redeploy -s openfdd-central-cQ-F` | 2026-09-06 live: stuck at `ingest_ok=6` ~40m; post-redeploy `1→3` in ~70s | Wave D — auto-reconnect / resilient ingest; do not trust sticky edges alone |
 | **railway-ui-fdd-stale** | **DEFERRED** → 3.3.35 | Building filter / scoped FDD UX across sites | BUG_REPORT prior | Wave E |
 | **bldg2-overview-signoff** | **DEFERRED** → operator | SPA Overview tables/charts human confirm for `?site=bldg2` | API gate PASS on 3.3.33 | Wave E evidence |
+| **hybrid-ml-physics-ahu-vav** | **OPEN** → Wave G | Semantic hybrid ML/Physics Overview column + EnergyPlus calibration export (AHU/VAV first slice) | Mission prompt 2026-09-06; experimental | **After** soft-OPEN closeout — [`openfdd_hybrid_diagnostics_ahu_vav_program.plan.md`](patch_trains/openfdd_hybrid_diagnostics_ahu_vav_program.plan.md) |
 | **mqtt-overview-spa-parity** | **CLOSED** (3.3.33) | Was: equipment=0 for MQTT `bldg2` → empty Overview | #856 · probe + stress | — |
 | **mqtt-fieldbus-tip-pin-sync** | **CLOSED** (3.3.33) | Was hybrid mqtt/fieldbus tip | All services `sha-25826cf` | — |
 | **qualification-viewer-login** | **CLOSED** (3.3.28) | `OPENFDD_VIEWER_PASSWORD` → `username=viewer` JWT | Railway var set | Optional auth_matrix path → Wave F soft |
@@ -43,14 +44,15 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 **Active:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md) — Waves D/E/F + **closeout full stress**.  
 **Last closed:** [`3.3.33_mqtt_overview_csv_parity.plan.md`](patch_trains/3.3.33_mqtt_overview_csv_parity.plan.md) — MQTTS Overview = CSV Overview (**CLOSED**).
 
-**This round stress rule:** mid-wave = Railway **smoke** / isolated only. **ONE full** `run_railway_hub_stress.sh` at **program closeout** (after F) → cite `fully_qualified` + Overview MQTT gate in BUG_REPORT. Do not re-run full matrix after every child.
+**This round stress rule:** mid-wave = Railway **smoke** / isolated only. **ONE full** `run_railway_hub_stress.sh` at **soft-OPEN closeout** (after F) → BUG_REPORT D–F. **Wave G** (hybrid ML/Physics) starts only after that closeout; G uses synthetic/unit gates — OT full stress does **not** scientifically validate ML.
 
 | Rev / wave | In-repo plan | Concern | Status |
 |------------|--------------|---------|--------|
 | **Wave D / 3.3.34** | [`3.3.34_mqtt_ingest_reconnect.plan.md`](patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md) | Central MQTT ingest resilience after mqtt re-pin | **OPEN** — smoke mid-wave |
 | **Wave E / 3.3.35** | [`3.3.35_overview_ui_fdd_scope.plan.md`](patch_trains/3.3.35_overview_ui_fdd_scope.plan.md) | `railway-ui-fdd-stale` + Overview browser sign-off | **OPEN** — smoke mid-wave |
 | **Wave F / 3.3.36** | [`3.3.36_lab_gate_residual.plan.md`](patch_trains/3.3.36_lab_gate_residual.plan.md) | Honest Lab residual / optional viewer matrix | **OPEN** — isolated + smoke |
-| **Closeout** | parent master | Full Railway matrix on final tip | **OPEN** — **required LAST** before program CLOSED verdict |
+| **Closeout** | parent master | Full Railway matrix on final tip | **OPEN** — **required LAST** before D–F CLOSED |
+| **Wave G / 3.3.37+** | [`openfdd_hybrid_diagnostics_ahu_vav_program.plan.md`](patch_trains/openfdd_hybrid_diagnostics_ahu_vav_program.plan.md) | Experimental semantic hybrid ML/Physics AHU+VAV slice | **OPEN** — **after** closeout; synthetic gates primary |
 | **3.3.33** | [`3.3.33_mqtt_overview_csv_parity.plan.md`](patch_trains/3.3.33_mqtt_overview_csv_parity.plan.md) | FDD inventory/run/series + buildings list use historian `building_id=` | **CLOSED** — #856 · tip `sha-25826cf` · stress PASS · Overview probe PASS · docs #857 |
 | **Wave A** | closeout + [`3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md`](patch_trains/3.3.27_mqtt_fieldbus_tip_pin_sync.plan.md) | Tip pin + one full stress | **CLOSED** |
 | **Wave B** | [`3.3.28`](patch_trains/3.3.28_lab_tuners_econ_ahu_residual.plan.md) + [`3.3.29`](patch_trains/3.3.29_viewer_login_and_ui_scope.plan.md) | Lab + viewer + #851 historian scope | **CLOSED** — #852 · tip `sha-10d1ec5` · stress PASS · #851 CLOSED · docs #853 |

--- a/docs/operations/patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md
+++ b/docs/operations/patch_trains/3.3.34_mqtt_ingest_reconnect.plan.md
@@ -1,6 +1,6 @@
 ---
 name: 3.3.34 mqtt ingest reconnect
-overview: "Tiny VERSION 3.3.33→3.3.34. Central MQTT ingest must auto-recover after mqtt/central re-pin so ingest_ok advances without sticky-edge false confidence. Full Railway stress LAST. Low-RAM."
+overview: "Tiny VERSION 3.3.33→3.3.34. Central MQTT ingest auto-recover after re-pin. Mid-wave smoke; full Railway stress at program closeout. Low-RAM."
 todos:
   - id: p0-hygiene
     content: GH hygiene START — 0 open PRs; tip Actions green
@@ -17,11 +17,11 @@ todos:
   - id: p4-repin
     content: Railway backup + re-pin central→mqtt→web; x86 fieldbus same sha-*; prove ingest_ok advances ≥2 intervals
     status: pending
-  - id: p5-stress
-    content: ONE full run_railway_hub_stress.sh → fully_qualified + Overview MQTT gate
+  - id: p5-smoke
+    content: Railway smoke + ingest_ok advance ≥2 intervals; Overview equipment bldg2 non-empty
     status: pending
   - id: p6-bug-report
-    content: BUG_REPORT Wave D / 3.3.34 CLOSED
+    content: BUG_REPORT Wave D note (program full stress stays at closeout)
     status: pending
 isProject: false
 ---
@@ -39,14 +39,15 @@ After mqtt (or central) redeploy, hub can show `edges:1` / `has_telemetry:true` 
 - Force mqtt peer bounce (or controlled disconnect) → central ingest reconnects in logs
 - `ingest_ok` increases across ≥2× publish interval (60s default) without manual redeploy
 - Edge `pi-1`/`bldg2` remains `has_telemetry:true`
-- Full `run_railway_hub_stress.sh` → `fully_qualified=true`
 - Overview equipment `bldg2` still non-empty (regression)
+- Mid-wave: **Railway smoke** only — **full matrix waits for program closeout**
 
 ## Stress tier
 
-**Full Railway** (image-shipping wave).
+**Railway smoke** mid-wave. Parent owns **ONE full** `run_railway_hub_stress.sh` at program end.
 
 ## Out of scope
 
 - Overview SPA chrome (`railway-ui-fdd-stale`) → 3.3.35
 - Lab operational-gate trio → 3.3.36 / DEFER
+- Program-end full stress (parent closeout todo)

--- a/docs/operations/patch_trains/README.md
+++ b/docs/operations/patch_trains/README.md
@@ -2,9 +2,9 @@
 
 These Markdown files are **copies** of Cursor plans under `~/.cursor/plans/` so a dead laptop does not lose the program. **GitHub is source of truth** — edit here first, then mirror to `~/.cursor/plans/`.
 
-## Active — post-3.3.33 soft-OPEN (optimized waves D/E/F)
+## Active — post-3.3.33 soft-OPEN (optimized waves D/E/F + closeout full stress)
 
-Full Railway stress **only** on image-shipping Wave D (ingest). Waves E/F prefer smoke / isolated. See master.
+Mid-wave = smoke / isolated. **ONE full** Railway stress **LAST** at program closeout → BUG_REPORT. See master.
 
 | Wave | File | Rev / concern |
 |------|------|---------------|

--- a/docs/operations/patch_trains/README.md
+++ b/docs/operations/patch_trains/README.md
@@ -2,16 +2,17 @@
 
 These Markdown files are **copies** of Cursor plans under `~/.cursor/plans/` so a dead laptop does not lose the program. **GitHub is source of truth** — edit here first, then mirror to `~/.cursor/plans/`.
 
-## Active — post-3.3.33 soft-OPEN (optimized waves D/E/F + closeout full stress)
+## Active — post-3.3.33 soft-OPEN (D/E/F + closeout) then Wave G hybrid
 
-Mid-wave = smoke / isolated. **ONE full** Railway stress **LAST** at program closeout → BUG_REPORT. See master.
+Mid-wave = smoke / isolated. **ONE full** Railway stress **LAST** at soft-OPEN closeout → BUG_REPORT D–F. **Wave G** = experimental hybrid AHU/VAV (3.3.37+) **after** that closeout.
 
 | Wave | File | Rev / concern |
 |------|------|---------------|
-| — | [openfdd_post_3.3.33_soft_open_program.plan.md](openfdd_post_3.3.33_soft_open_program.plan.md) | **Master** (waves D/E/F) |
+| — | [openfdd_post_3.3.33_soft_open_program.plan.md](openfdd_post_3.3.33_soft_open_program.plan.md) | **Master** (waves D/E/F + closeout + G pointer) |
 | D | [3.3.34_mqtt_ingest_reconnect.plan.md](3.3.34_mqtt_ingest_reconnect.plan.md) | MQTT ingest reconnect |
 | E | [3.3.35_overview_ui_fdd_scope.plan.md](3.3.35_overview_ui_fdd_scope.plan.md) | Overview UI / FDD scope |
 | F | [3.3.36_lab_gate_residual.plan.md](3.3.36_lab_gate_residual.plan.md) | Lab residual (honest only) |
+| G | [openfdd_hybrid_diagnostics_ahu_vav_program.plan.md](openfdd_hybrid_diagnostics_ahu_vav_program.plan.md) | Hybrid ML/Physics AHU+VAV (after closeout) |
 
 ## Predecessor — nightly bug train 3.3.27+ (CLOSED through 3.3.33)
 

--- a/docs/operations/patch_trains/openfdd_hybrid_diagnostics_ahu_vav_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_hybrid_diagnostics_ahu_vav_program.plan.md
@@ -1,0 +1,94 @@
+---
+name: Hybrid diagnostics AHU VAV program
+overview: "Experimental Wave G after soft-OPEN closeout. Semantic hybrid ML/Physics first vertical slice for AHU+VAV only — real train/score, Overview column, EnergyPlus calibration export. Not mature/production-qualified without measured gates. Incremental 3.3.37→3.3.42."
+todos:
+  - id: g0-inventory
+    content: "G0 — Reconcile tip vs proposal (40ac066 era); inventory actual vs promised; short plan; update stale guidance; no product code yet"
+    status: pending
+  - id: g37-semantic
+    content: "3.3.37 — Detector/feature manifests + applicability (AHU/VAV supported; other families explicit N/A reasons)"
+    status: pending
+  - id: g38-features
+    content: "3.3.38 — Shared DataFusion/Arrow feature pipeline; typed dataset; no zero-fill missing physics"
+    status: pending
+  - id: g39-ml
+    content: "3.3.39 — Seeded KMeans regimes + within-regime deviation; background jobs; persisted artifacts"
+    status: pending
+  - id: g40-physics
+    content: "3.3.40 — AHU mixing + VAV sensible residuals with honest observability gates"
+    status: pending
+  - id: g41-overview
+    content: "3.3.41 — Overview ML/Physics column + evidence drilldown; no train-on-page-load; no Plotly on Overview"
+    status: pending
+  - id: g42-export
+    content: "3.3.42 — EnergyPlus calibration export purpose (primary) + research reproducibility bundle; completeness tests"
+    status: pending
+  - id: g-gates
+    content: "G-gates — Synthetic-59 + required unit/contract tests; optional labeled AHU/VAV set or document blocker + disable research claims"
+    status: pending
+isProject: false
+---
+
+# Wave G — Semantic hybrid diagnostics (AHU + VAV first slice)
+
+**Parent:** [`openfdd_post_3.3.33_soft_open_program.plan.md`](openfdd_post_3.3.33_soft_open_program.plan.md) (Cursor: `post_3.3.33_soft_open_master_a1b2c3d4.plan.md`)
+
+**Status:** experimental extension of an actively changing AFDD platform. Useful mechanical diagnostics with reproducible artifacts — **not** scientifically validated / production-qualified without evidence.
+
+**Start only after** soft-OPEN D→E→F + **full Railway closeout** PASS (or explicit operator waiver). Do **not** merge/publish/deploy Wave G unless separately authorized.
+
+## Runtime boundary (locked)
+
+- Rust central + React web + canonical Parquet historian + DataFusion SQL
+- No Python in central/web request paths; no chatbot; no control writes
+- Prefer small native Rust numerical deps compatible with lockfile (DataFusion **55** / Arrow **59** declared — verify `Cargo.lock` before coding)
+- Python may stay offline research oracle only (`tools/wattlab_export/`, scripts) — do **not** promote `scripts/eplus_dump_clustering_export.py` zero-fill KMeans into product
+- No ONNX / GPU / graph DB / distributed query without measured need
+
+## Actual vs promised (recheck on tip before G0 closes)
+
+| Area | Current product truth (recheck) | Wave G target |
+|------|----------------------------------|---------------|
+| Overview | Rules/analytics matrices; no ML/Physics column | Typed **ML / Physics** states + evidence drilldown |
+| Engineering bundle | `openfdd_engineering_bundle_v1`; historically weak feature catalog / placeholders | **EnergyPlus calibration** purpose as primary download; research bundle separate |
+| Offline clustering | `eplus_dump_clustering_export.py` descriptive + example KMeans | Not product ML |
+| Rules | `crates/fdd_sql` / registry — stay intact | Hybrid compares on eligible periods; rules ≠ ground truth |
+| Families | Many equipment types in Overview | **AHU+VAV slice first**; others show applicability/readiness only |
+
+Proposal inspected commit `40ac0664` (2026-09-05). **Recheck** `engineering_bundle.rs`, `OverviewPopulated.tsx`, analytics routes, capability ledger against tip before editing.
+
+## Child revs (one concern each)
+
+| Rev | Concern | Prove |
+|-----|---------|-------|
+| **3.3.37** | Semantic applicability + versioned manifests | AHU/VAV applicable with reasons; heat-pump/etc. explicit unavailable; FDD-ON crosswalk only where verified |
+| **3.3.38** | Shared feature pipeline | Same pipeline train+score; typed Parquet features; missing ≠ zero; unit boundary versioned |
+| **3.3.39** | Regimes + deviation | Real fit/score; persisted artifacts; chronological splits + purge; novelty/OOD states |
+| **3.3.40** | Physics residuals | Mixing + VAV sensible with gates; poorly conditioned → unavailable; no unique stuck-valve from one residual |
+| **3.3.41** | Overview integration | Column states (not_run/training/normal/anomaly/N/A/…); job id run/train; cached reads; charts off Overview |
+| **3.3.42** | Exports | EnergyPlus calibration bundle contents from **actual** available evidence; research bundle for ML audit; readiness from validated files |
+
+## Stress / acceptance (Wave G)
+
+| Tier | Role |
+|------|------|
+| Unit / contract / synthetic-59 | **Required** each child |
+| Independent labeled public AHU/VAV set | Required for research claims; else document blocker and **disable** those claims |
+| Railway smoke | Only after image-shipping tips; hybrid endpoints + Overview state |
+| Soft-OPEN full Railway | Qualifies **OT hub**, not hybrid science |
+
+Required test themes (from mission): unit conversions, missing roles, opaque ids, incomplete topology, duplicates/DST/gaps, train/test leakage, poorly conditioned mixing, no-training-data, unsupported family, save/load score parity, stale invalidation, cancel/restart, cross-building isolation, Overview freshness, export energy conservation, healthy→false-positive transitions.
+
+## Out of scope until first slice gates pass
+
+- Additional equipment families beyond AHU/VAV (beyond N/A chrome)
+- Claiming Guideline 14 / full FDD-ON conformance / production ML readiness
+- OT Modbus/MQTT soft-OPEN work (Waves D–F)
+- Control writes, Python sidecar, chat UI
+
+## Research grounding (synthesis, not prescription)
+
+- Reproducibility of ML-based HVAC FDD (arxiv 2508.00880)
+- ORNL fault behavior vs impact (read full OSTI PDF before detailed claims)
+- FDD-ON (arxiv 2607.29657) — structure motivation only
+- DataFusion docs — verify against pinned crate versions

--- a/docs/operations/patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md
@@ -1,15 +1,18 @@
 ---
 name: Post-3.3.33 soft-OPEN master
-overview: "Optimized 3.3.34→3.3.36 program for leftovers after MQTT Overview=CSV CLOSED. Full Railway stress only on image-shipping waves; smoke/operator checks for UX; isolated where that is the real proof. No redundant full matrix between children."
+overview: "Optimized 3.3.34→3.3.36 leftovers after MQTT Overview=CSV CLOSED. Mid-wave = smoke/isolated. ONE full Railway stress LAST at program closeout → BUG_REPORT round. No redundant full matrices between children."
 todos:
   - id: wave-d-ingest
-    content: "Wave D — 3.3.34 MQTT ingest resilience after mqtt/central re-pin (ingest_ok advancing; edges has_telemetry); ONE full Railway stress if images ship"
+    content: "Wave D — 3.3.34 MQTT ingest resilience (ingest_ok advancing after re-pin); Railway smoke + reconnect proof (no full matrix mid-wave)"
     status: pending
   - id: wave-e-ui
-    content: "Wave E — 3.3.35 railway-ui-fdd-stale + bldg2 Overview browser sign-off (tables visible by default); Railway smoke + Overview probe (full only if SPA images change)"
+    content: "Wave E — 3.3.35 railway-ui-fdd-stale + bldg2 Overview browser sign-off; Railway smoke + Overview probe"
     status: pending
   - id: wave-f-lab
-    content: "Wave F — 3.3.36 Lab residual (vibe19 operational-gate DEFER if still dishonest) + optional auth_matrix viewer path; isolated/unit proof; Railway smoke unless tip moved"
+    content: "Wave F — 3.3.36 Lab residual (DEFER dishonest operational-gate) + optional auth_matrix viewer; isolated/unit + smoke"
+    status: pending
+  - id: closeout-full-stress
+    content: "Program closeout — ONE full run_railway_hub_stress.sh on final tip → fully_qualified + Overview MQTT gate → BUG_REPORT Waves D–F verdict"
     status: pending
 isProject: false
 ---
@@ -18,11 +21,13 @@ isProject: false
 
 **Not a VERSION bump itself.** Child plans are the concern backlog. Parent program [`openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) is **CLOSED** through 3.3.33.
 
-**Honesty rule:** every concern still gets evidence. Drop only **duplicate full Railway matrices** when hub/field images and MQTT topology did not change.
+**Honesty rule:** every concern still gets evidence. Drop only **duplicate full Railway matrices** between children.
+
+**Preferred stress shape:** mid-wave **smoke / isolated**; **ONE full** `run_railway_hub_stress.sh` **LAST** (program closeout) before the BUG_REPORT round update. If a child ships hub/field images, re-pin + smoke mid-wave — do **not** run the full matrix until closeout unless topology broke and you need an early abort.
 
 **Gate:** Fix live ingest stall (Wave D) before UI polish (Wave E). Do not merge docs mid-Publish.
 
-**Mirrors:** write children under [``]() then copy to `~/.cursor/plans/`. Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
+**Mirrors:** this `patch_trains/` dir + `~/.cursor/plans/post_3.3.33_soft_open_master_a1b2c3d4.plan.md`. Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
 
 **Baseline tip (start):** `25826cf6` · **`sha-25826cf`** · health **`3.3.33+25826cf67999`** · field `bldg2` / `pi-1` · hosted AV `9101` → `bldg2-zone-loopback` / `zone_t`.
 
@@ -30,37 +35,39 @@ isProject: false
 
 ```mermaid
 flowchart LR
-  waveD[WaveD_mqtt_ingest_resilience_full_stress]
-  waveE[WaveE_overview_ui_scope_smoke]
-  waveF[WaveF_lab_residual_isolated_smoke]
-  waveD --> waveE --> waveF
+  waveD[WaveD_ingest_smoke]
+  waveE[WaveE_ui_smoke]
+  waveF[WaveF_lab_isolated_smoke]
+  closeout[Closeout_ONE_full_Railway_stress]
+  waveD --> waveE --> waveF --> closeout
 ```
 
 | Wave | Children | Ship how | Stress (required) |
 |------|----------|----------|-------------------|
-| **D — ingest** | [`3.3.34`](3.3.34_mqtt_ingest_reconnect.plan.md) | Product/ops fix so central MQTT ingest **reconnects** after mqtt re-pin; VERSION bump if GHCR ships | **One full** `run_railway_hub_stress.sh` after tip lands + prove `ingest_ok` advances over ≥2 publish intervals |
-| **E — UI** | [`3.3.35`](3.3.35_overview_ui_fdd_scope.plan.md) | Close `railway-ui-fdd-stale` + operator Overview tables-visible default for MQTT=`CSV` | **Railway smoke** + Overview probe (`equipment`, Zone Other, picker). **Full** only if web/central images changed |
-| **F — Lab residual** | [`3.3.36`](3.3.36_lab_gate_residual.plan.md) | Honest Lab leftovers only; keep Path B refusal for fake SQL-bound gates | **Isolated/unit** primary; end with **Railway smoke**. Full only if tip images moved |
+| **D — ingest** | [`3.3.34`](3.3.34_mqtt_ingest_reconnect.plan.md) | Product fix so central MQTT ingest **reconnects** after mqtt re-pin; VERSION if GHCR ships | **Railway smoke** + prove `ingest_ok` advances ≥2 publish intervals after deliberate mqtt/central bounce |
+| **E — UI** | [`3.3.35`](3.3.35_overview_ui_fdd_scope.plan.md) | Close `railway-ui-fdd-stale` + Overview tables-visible for MQTT=`CSV` | **Railway smoke** + Overview probe + browser sign-off artifact |
+| **F — Lab residual** | [`3.3.36`](3.3.36_lab_gate_residual.plan.md) | Honest Lab leftovers only; Path B refuse fake gates | **Isolated/unit** + **Railway smoke** |
+| **Closeout** | — (same final tip) | No new product unless tip moved | **ONE full** `run_railway_hub_stress.sh` → `fully_qualified` → **BUG_REPORT program verdict** |
 
 ### Child index (one concern each)
 
 | Rev | Plan | One concern |
 |-----|------|-------------|
 | 3.3.34 | `3.3.34_mqtt_ingest_reconnect.plan.md` | Central MQTT ingest stays live after mqtt/central redeploy (`ingest_ok` rising; not sticky `has_telemetry` alone) |
-| 3.3.35 | `3.3.35_overview_ui_fdd_scope.plan.md` | Building-scoped FDD chrome + Overview tables visible by default for live MQTT sites (close `railway-ui-fdd-stale` / browser sign-off) |
-| 3.3.36 | `3.3.36_lab_gate_residual.plan.md` | Lab residual that has honest bindings; **DEFER** vibe19 operational-gate trio if still no SQL/session truth |
+| 3.3.35 | `3.3.35_overview_ui_fdd_scope.plan.md` | Building-scoped FDD chrome + Overview tables visible by default (close `railway-ui-fdd-stale` / browser sign-off) |
+| 3.3.36 | `3.3.36_lab_gate_residual.plan.md` | Lab residual with honest bindings; **DEFER** vibe19 operational-gate if still no SQL/session truth |
 
 ## Soft-OPEN → wave map (from BUG_REPORT)
 
 | ID | Disposition entering this program | Wave |
 |----|-----------------------------------|------|
-| **mqtt-ingest-stall** (new) | **OPEN** — hub `edges:1` + fieldbus healthy but `ingest_ok` flat after re-pin | **D** |
-| **mqtt-fieldbus-tip-pin-sync** | **CLOSED** on 3.3.33 tip (`sha-25826cf` all services) — remove hybrid deferral | — |
+| **mqtt-ingest-stall** | **OPEN** — `edges:1` + healthy fieldbus but `ingest_ok` flat after re-pin | **D** |
+| **mqtt-fieldbus-tip-pin-sync** | **CLOSED** on 3.3.33 tip | — |
 | **railway-ui-fdd-stale** | **DEFERRED** → UX | **E** |
-| **bldg2-overview-signoff** | **DEFERRED** → operator browser | **E** (evidence, may close without product PR) |
-| **vibe19-operational-gate-lab** | **DEFERRED** → future (no honest SQL) | **F** or stay DEFERRED |
+| **bldg2-overview-signoff** | **DEFERRED** → operator browser | **E** |
+| **vibe19-operational-gate-lab** | **DEFERRED** (no honest SQL) | **F** or stay DEFERRED |
 | **qualification-viewer-login** optional matrix path | soft | **F** optional |
-| **weather-legitimacy-chicago** | tier-C optional | out of wave (operator soak) |
+| **weather-legitimacy-chicago** | tier-C optional | out of wave |
 | **railway-f1-stress** B50/AFDD | operator-skip | out of wave |
 | **local-parquet-root-split** | lab-only | out of wave |
 
@@ -68,9 +75,9 @@ flowchart LR
 
 | Tier | When | What |
 |------|------|------|
-| **Full Railway** | Wave D tip; any rev that changes hub/field images or MQTT topology | Full `run_railway_hub_stress.sh` → `fully_qualified` + Overview MQTT=`CSV` gate |
-| **Railway smoke** | Wave E/F end; docs-only mid-wave | Hub health + fieldbus `:8081` + edges `has_telemetry` + **`ingest_ok` advancing** + Overview equipment/Zone Other + public ZAP if cheap |
-| **Isolated / unit** | Wave F Lab honesty; Wave D reconnect unit if feasible | Prove reconnect without claiming live PASS from docs alone |
+| **Full Railway** | **Program closeout only** (preferred); early abort only if tip/topology looks broken | Full `run_railway_hub_stress.sh` → `fully_qualified` + Overview MQTT=`CSV` gate → BUG_REPORT |
+| **Railway smoke** | End of Waves D / E / F | Hub health + fieldbus `:8081` + edges + **`ingest_ok` advancing** + Overview equipment/Zone Other + public ZAP if cheap |
+| **Isolated / unit** | Wave F Lab; Wave D reconnect unit if feasible | Prove reconnect / Lab honesty without claiming live PASS from docs alone |
 
 ### Full / smoke MUST still validate MQTTS → Overview
 
@@ -78,44 +85,35 @@ flowchart LR
 |-------|----------|
 | Field | x86 fieldbus → MQTTS; hosted-weather AV **9101** |
 | Edge | `pi-1` / `bldg2` `has_telemetry:true` |
-| Ingest | `ingest_ok` **increases** across ≥2× `OPENFDD_MQTT_PUBLISH_INTERVAL_SECS` (do not trust sticky edges alone) |
+| Ingest | `ingest_ok` **increases** across ≥2× publish interval |
 | Role | **`zone_t`** / `bldg2-zone-loopback` |
-| Overview | Equipment non-empty; Zone Other **tables visible** (not hidden empty); AFDD `fdd/run` scoped to `bldg2` |
+| Overview | Equipment non-empty; Zone Other **tables visible**; AFDD `fdd/run` on `bldg2` |
 | Evidence | BUG_REPORT verdict + report dir — or **DEFERRED** with operator-browser reason |
 
-## Dropped as silly (keep evidence elsewhere)
+## Dropped as silly
 
-- Full backup + re-pin + full matrix after every UI-only or docs child when tip images unchanged
+- Full matrix after every child when tip images unchanged
 - Claiming ingest healthy from `edges:1` alone while `ingest_ok` is flat
-- Merging docs while Publish is still building fieldbus
-- Shipping fake Lab sliders for operational-gate trio without SQL/session binding
+- Merging docs mid-Publish (cancels fieldbus)
+- Fake Lab operational-gate sliders without SQL/session binding
 
 ## Wave loops
 
-**Wave D (image-shipping / ingest):**
+**Waves D / E / F (mid-wave):**
 
 ```text
-hygiene → VERSION + reconnect fix → PR merge → wait GHCR tip (mqtt+fieldbus too)
-  → one backup → re-pin central→mqtt→web → fieldbus sha-<7>
-  → prove ingest_ok advances → ONE full run_railway_hub_stress.sh
-  → BUG_REPORT wave verdict → hygiene
+hygiene → one-concern PR (VERSION only if images ship)
+  → if images: backup → re-pin central→mqtt→web → fieldbus sha-<7>
+  → Railway smoke (D also: ingest_ok advance proof) → wave note in BUG_REPORT → hygiene
 ```
 
-**Wave E (UI / smoke-first):**
+**Program closeout (LAST — required for this round):**
 
 ```text
-hygiene → SPA/FDD scope fix (bump VERSION only if web/central ship)
-  → if images changed: backup/re-pin + smoke or full per tier table
-  → Overview probe + operator browser sign-off artifact
-  → BUG_REPORT → hygiene
-```
-
-**Wave F (Lab residual / isolated):**
-
-```text
-hygiene → honest Lab PR(s) or explicit DEFER in BUG_REPORT
-  → unit/isolated proof → Railway smoke unless tip moved
-  → BUG_REPORT → hygiene
+final tip pinned + fieldbus up
+  → ONE full run_railway_hub_stress.sh
+  → cite fully_qualified + Overview MQTT gate
+  → BUG_REPORT Waves D–F / program CLOSED verdict → hygiene
 ```
 
 Locked: Railway hub + bensbench x86 fieldbus; low-RAM; no Pi / no live OT DoS. Ops: [`PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md).

--- a/docs/operations/patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_post_3.3.33_soft_open_program.plan.md
@@ -1,6 +1,6 @@
 ---
 name: Post-3.3.33 soft-OPEN master
-overview: "Optimized 3.3.34→3.3.36 leftovers after MQTT Overview=CSV CLOSED. Mid-wave = smoke/isolated. ONE full Railway stress LAST at program closeout → BUG_REPORT round. No redundant full matrices between children."
+overview: "Soft-OPEN D→E→F then ONE full Railway stress LAST. After OT closeout, optional Wave G starts the experimental semantic hybrid ML/Physics AHU+VAV slice — separate from OT qualification; never claim scientific validation from Railway stress alone."
 todos:
   - id: wave-d-ingest
     content: "Wave D — 3.3.34 MQTT ingest resilience (ingest_ok advancing after re-pin); Railway smoke + reconnect proof (no full matrix mid-wave)"
@@ -12,7 +12,10 @@ todos:
     content: "Wave F — 3.3.36 Lab residual (DEFER dishonest operational-gate) + optional auth_matrix viewer; isolated/unit + smoke"
     status: pending
   - id: closeout-full-stress
-    content: "Program closeout — ONE full run_railway_hub_stress.sh on final tip → fully_qualified + Overview MQTT gate → BUG_REPORT Waves D–F verdict"
+    content: "Soft-OPEN closeout — ONE full run_railway_hub_stress.sh on final tip → fully_qualified + Overview MQTT gate → BUG_REPORT D–F CLOSED"
+    status: pending
+  - id: wave-g-hybrid
+    content: "Wave G (AFTER closeout) — experimental semantic hybrid diagnostics AHU+VAV first vertical slice; child revs 3.3.37+; synthetic gates primary; no merge/deploy without separate auth"
     status: pending
 isProject: false
 ---
@@ -21,15 +24,21 @@ isProject: false
 
 **Not a VERSION bump itself.** Child plans are the concern backlog. Parent program [`openfdd_nightly_bug_train_3.3.27_plus_program.plan.md`](openfdd_nightly_bug_train_3.3.27_plus_program.plan.md) is **CLOSED** through 3.3.33.
 
-**Honesty rule:** every concern still gets evidence. Drop only **duplicate full Railway matrices** between children.
+**Honesty rule:** every concern still gets evidence. Drop only **duplicate full Railway matrices** between OT children.
 
-**Preferred stress shape:** mid-wave **smoke / isolated**; **ONE full** `run_railway_hub_stress.sh` **LAST** (program closeout) before the BUG_REPORT round update. If a child ships hub/field images, re-pin + smoke mid-wave — do **not** run the full matrix until closeout unless topology broke and you need an early abort.
+**Preferred OT stress shape:** mid-wave **smoke / isolated**; **ONE full** `run_railway_hub_stress.sh` **LAST** (soft-OPEN closeout) before the BUG_REPORT D–F verdict.
 
 **Gate:** Fix live ingest stall (Wave D) before UI polish (Wave E). Do not merge docs mid-Publish.
 
 **Mirrors:** this `patch_trains/` dir + `~/.cursor/plans/post_3.3.33_soft_open_master_a1b2c3d4.plan.md`. Living evidence: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
 
 **Baseline tip (start):** `25826cf6` · **`sha-25826cf`** · health **`3.3.33+25826cf67999`** · field `bldg2` / `pi-1` · hosted AV `9101` → `bldg2-zone-loopback` / `zone_t`.
+
+## Would Wave G (hybrid ML/Physics) be nuts?
+
+**Nuts if:** jammed into D/E/F, one mega-PR, OT full stress treated as scientific validation, green Overview cells for unsupported families, Python in central request paths, promoting `eplus_dump_clustering_export.py` zero-fill KMeans into product, merge/deploy without separate authorization.
+
+**Not nuts if:** **after** soft-OPEN closeout; **separate experimental product train**; incremental reviewable children; AHU+VAV first slice only; explicit not-applicable/insufficient states; synthetic-59 + unit gates primary; Railway smoke only after images ship and **never** marketed as Guideline-14 / production-qualified ML.
 
 ## Waves (do this)
 
@@ -39,34 +48,50 @@ flowchart LR
   waveE[WaveE_ui_smoke]
   waveF[WaveF_lab_isolated_smoke]
   closeout[Closeout_ONE_full_Railway_stress]
-  waveD --> waveE --> waveF --> closeout
+  waveG[WaveG_hybrid_AHU_VAV_experimental]
+  waveD --> waveE --> waveF --> closeout --> waveG
 ```
 
 | Wave | Children | Ship how | Stress (required) |
 |------|----------|----------|-------------------|
-| **D — ingest** | [`3.3.34`](3.3.34_mqtt_ingest_reconnect.plan.md) | Product fix so central MQTT ingest **reconnects** after mqtt re-pin; VERSION if GHCR ships | **Railway smoke** + prove `ingest_ok` advances ≥2 publish intervals after deliberate mqtt/central bounce |
-| **E — UI** | [`3.3.35`](3.3.35_overview_ui_fdd_scope.plan.md) | Close `railway-ui-fdd-stale` + Overview tables-visible for MQTT=`CSV` | **Railway smoke** + Overview probe + browser sign-off artifact |
-| **F — Lab residual** | [`3.3.36`](3.3.36_lab_gate_residual.plan.md) | Honest Lab leftovers only; Path B refuse fake gates | **Isolated/unit** + **Railway smoke** |
-| **Closeout** | — (same final tip) | No new product unless tip moved | **ONE full** `run_railway_hub_stress.sh` → `fully_qualified` → **BUG_REPORT program verdict** |
+| **D — ingest** | [`3.3.34`](3.3.34_mqtt_ingest_reconnect.plan.md) | MQTT ingest reconnect; VERSION if GHCR ships | **Railway smoke** + `ingest_ok` advance ≥2 intervals |
+| **E — UI** | [`3.3.35`](3.3.35_overview_ui_fdd_scope.plan.md) | `railway-ui-fdd-stale` + Overview tables-visible | **Railway smoke** + Overview probe + browser sign-off |
+| **F — Lab residual** | [`3.3.36`](3.3.36_lab_gate_residual.plan.md) | Honest Lab only; Path B refuse fake gates | **Isolated/unit** + **Railway smoke** |
+| **Closeout** | — (same final tip) | No new product unless tip moved | **ONE full** Railway → `fully_qualified` → **BUG_REPORT D–F CLOSED** |
+| **G — hybrid diagnostics** | [`openfdd_hybrid_diagnostics_ahu_vav_program.plan.md`](openfdd_hybrid_diagnostics_ahu_vav_program.plan.md) · revs **3.3.37+** | Experimental semantic ML/Physics column + EnergyPlus calibration export; **AHU+VAV first vertical slice** | **Synthetic/unit/contract primary**; Railway smoke after image tips; **do not** claim scientific validation from OT full stress |
 
-### Child index (one concern each)
+### Soft-OPEN child index
 
 | Rev | Plan | One concern |
 |-----|------|-------------|
-| 3.3.34 | `3.3.34_mqtt_ingest_reconnect.plan.md` | Central MQTT ingest stays live after mqtt/central redeploy (`ingest_ok` rising; not sticky `has_telemetry` alone) |
-| 3.3.35 | `3.3.35_overview_ui_fdd_scope.plan.md` | Building-scoped FDD chrome + Overview tables visible by default (close `railway-ui-fdd-stale` / browser sign-off) |
-| 3.3.36 | `3.3.36_lab_gate_residual.plan.md` | Lab residual with honest bindings; **DEFER** vibe19 operational-gate if still no SQL/session truth |
+| 3.3.34 | `3.3.34_mqtt_ingest_reconnect.plan.md` | Central MQTT ingest stays live after mqtt/central redeploy |
+| 3.3.35 | `3.3.35_overview_ui_fdd_scope.plan.md` | Building-scoped FDD chrome + Overview tables visible by default |
+| 3.3.36 | `3.3.36_lab_gate_residual.plan.md` | Honest Lab residual; **DEFER** vibe19 operational-gate if no SQL truth |
+
+### Wave G child index (after closeout — experimental)
+
+| Rev | Plan (under patch_trains) | One concern |
+|-----|---------------------------|-------------|
+| 3.3.37 | `3.3.37_hybrid_semantic_applicability.plan.md` | Versioned detector/feature manifests + applicability states (AHU/VAV supported; others explicit N/A) |
+| 3.3.38 | `3.3.38_hybrid_feature_pipeline.plan.md` | Shared DataFusion/Arrow feature dataset; no zero-fill of missing physics |
+| 3.3.39 | `3.3.39_hybrid_regimes_deviation.plan.md` | Seeded KMeans regimes + within-regime deviation jobs/artifacts (real train/score) |
+| 3.3.40 | `3.3.40_hybrid_physics_ahu_vav.plan.md` | AHU mixing + VAV sensible residuals with observability gates |
+| 3.3.41 | `3.3.41_hybrid_overview_ml_physics.plan.md` | Overview **ML / Physics** column + evidence drilldown (no Plotly on Overview) |
+| 3.3.42 | `3.3.42_hybrid_eplus_research_export.plan.md` | EnergyPlus calibration purpose (primary) + research reproducibility bundle |
+
+Full mission text / gates: child program plan. Proposal originally inspected `40ac0664` (2026-09-05); **recheck tip before implementing**.
 
 ## Soft-OPEN → wave map (from BUG_REPORT)
 
 | ID | Disposition entering this program | Wave |
 |----|-----------------------------------|------|
-| **mqtt-ingest-stall** | **OPEN** — `edges:1` + healthy fieldbus but `ingest_ok` flat after re-pin | **D** |
+| **mqtt-ingest-stall** | **OPEN** | **D** |
 | **mqtt-fieldbus-tip-pin-sync** | **CLOSED** on 3.3.33 tip | — |
 | **railway-ui-fdd-stale** | **DEFERRED** → UX | **E** |
 | **bldg2-overview-signoff** | **DEFERRED** → operator browser | **E** |
 | **vibe19-operational-gate-lab** | **DEFERRED** (no honest SQL) | **F** or stay DEFERRED |
 | **qualification-viewer-login** optional matrix path | soft | **F** optional |
+| **hybrid-ml-physics-ahu-vav** | **OPEN** → experimental product | **G** (after OT closeout) |
 | **weather-legitimacy-chicago** | tier-C optional | out of wave |
 | **railway-f1-stress** B50/AFDD | operator-skip | out of wave |
 | **local-parquet-root-split** | lab-only | out of wave |
@@ -75,11 +100,12 @@ flowchart LR
 
 | Tier | When | What |
 |------|------|------|
-| **Full Railway** | **Program closeout only** (preferred); early abort only if tip/topology looks broken | Full `run_railway_hub_stress.sh` → `fully_qualified` + Overview MQTT=`CSV` gate → BUG_REPORT |
-| **Railway smoke** | End of Waves D / E / F | Hub health + fieldbus `:8081` + edges + **`ingest_ok` advancing** + Overview equipment/Zone Other + public ZAP if cheap |
-| **Isolated / unit** | Wave F Lab; Wave D reconnect unit if feasible | Prove reconnect / Lab honesty without claiming live PASS from docs alone |
+| **Full Railway** | Soft-OPEN **closeout only** (preferred) | Full `run_railway_hub_stress.sh` → `fully_qualified` + Overview MQTT=`CSV` → BUG_REPORT D–F |
+| **Railway smoke** | End of D / E / F; after Wave G image tips | Hub + fieldbus + edges + **`ingest_ok` advancing** + Overview; G adds hybrid endpoint smoke only |
+| **Isolated / unit / synthetic** | F Lab; **all of Wave G** | Reconnect units; hybrid feature/train/score/export/Overview state tests; synthetic-59 regression |
+| **Wave G honesty** | Always | OT full stress **≠** ML scientific acceptance; disable research claims until labeled/held-out gates pass |
 
-### Full / smoke MUST still validate MQTTS → Overview
+### Full / smoke MUST still validate MQTTS → Overview (OT waves)
 
 | Check | Expected |
 |-------|----------|
@@ -92,28 +118,41 @@ flowchart LR
 
 ## Dropped as silly
 
-- Full matrix after every child when tip images unchanged
+- Full matrix after every OT child when tip images unchanged
 - Claiming ingest healthy from `edges:1` alone while `ingest_ok` is flat
 - Merging docs mid-Publish (cancels fieldbus)
 - Fake Lab operational-gate sliders without SQL/session binding
+- Wave G mockups backed by constants; green N/A families; Python in central/web paths; ONNX/GPU/graph DB without measured need
+- Calling Wave G “production-qualified” or Guideline 14 without matched sim + measurements
 
 ## Wave loops
 
-**Waves D / E / F (mid-wave):**
+**Waves D / E / F (OT mid-wave):**
 
 ```text
 hygiene → one-concern PR (VERSION only if images ship)
   → if images: backup → re-pin central→mqtt→web → fieldbus sha-<7>
-  → Railway smoke (D also: ingest_ok advance proof) → wave note in BUG_REPORT → hygiene
+  → Railway smoke → wave note in BUG_REPORT → hygiene
 ```
 
-**Program closeout (LAST — required for this round):**
+**Soft-OPEN closeout (required before Wave G):**
 
 ```text
 final tip pinned + fieldbus up
   → ONE full run_railway_hub_stress.sh
   → cite fully_qualified + Overview MQTT gate
-  → BUG_REPORT Waves D–F / program CLOSED verdict → hygiene
+  → BUG_REPORT Waves D–F CLOSED → hygiene
 ```
 
-Locked: Railway hub + bensbench x86 fieldbus; low-RAM; no Pi / no live OT DoS. Ops: [`PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md).
+**Wave G (experimental — after closeout):**
+
+```text
+inventory vs tip → short plan in BUG_REPORT/capability ledger
+  → one child rev at a time (37→42), Rust+React gates green
+  → synthetic/unit proof each child; smoke only if images ship
+  → no Railway deploy / merge-to-prod unless separately authorized
+  → handoff: limitations + disabled research claims if external labeled set missing
+```
+
+Locked OT path: Railway hub + bensbench x86 fieldbus; low-RAM; no Pi / no live OT DoS. Ops: [`PATCH_CYCLE.md`](../PATCH_CYCLE.md) · [`STRESS_CLOSEOUT.md`](../STRESS_CLOSEOUT.md).  
+Wave G runtime boundary: Rust central, React web, Parquet historian, DataFusion features — see [`AGENTS.md`](../../AGENTS.md) / [`openfdd_agent_spec/AGENTS.md`](../../openfdd_agent_spec/AGENTS.md).


### PR DESCRIPTION
## Summary
- Soft-OPEN: mid-wave smoke; **ONE full Railway stress LAST** after D→E→F
- Add **Wave G** (after OT closeout): experimental semantic hybrid ML/Physics AHU+VAV program (3.3.37+)
- Track `hybrid-ml-physics-ahu-vav` in BUG_REPORT; OT full stress does not scientifically validate ML

## Test plan
- [ ] Wave table order D→E→F→Closeout→G
- [ ] Hybrid program plan lists 37–42 children + honesty locks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental Wave G plan for hybrid ML/physics diagnostics across AHU and VAV equipment.
  * Added tracking and planning for semantic applicability, shared features, operating regimes, physics residuals, dashboard integration, and calibration exports.

* **Documentation**
  * Updated post-3.3.33 plans to sequence Waves D–F, closeout stress validation, and optional Wave G activities.
  * Clarified mid-wave smoke checks, closeout requirements, acceptance criteria, and follow-up tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->