### PR TITLE
fix(ci): GHCR hub parallel to fieldbus + tip completeness gate

### DIFF
--- a/.github/workflows/ghcr-openfdd-stack.yml
+++ b/.github/workflows/ghcr-openfdd-stack.yml
@@ -1,5 +1,7 @@
-# Publish Open-FDD stack images to GHCR (central, web, fieldbus, mqtt).
+# Publish Open-FDD stack images to GHCR (central, web, mqtt hub + fieldbus).
 # Product UI is openfdd-web (React SPA).
+# Hub images (central/web/mqtt) publish in parallel with multi-arch fieldbus so a
+# slow/hung fieldbus QEMU build cannot block Railway tip re-pin on mqtt.
 # Tag contract:
 # - every publish: immutable sha-<7>
 # - master: moving nightly + rerun-unique immutable run tag
@@ -98,14 +100,13 @@ jobs:
           chmod +x scripts/release/smoke_csv_central_boot.sh
           ./scripts/release/smoke_csv_central_boot.sh
 
-  publish:
+  # Railway hub tip: central + web + mqtt (amd64). Must not wait on multi-arch fieldbus.
+  publish-hub:
     needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 420
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v5
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -169,15 +170,14 @@ jobs:
 
           write_tags central_tags "$CENTRAL_IMAGE"
           write_tags web_tags "$WEB_IMAGE"
-          write_tags fieldbus_tags "$FIELDBUS_IMAGE"
           write_tags mqtt_tags "$MQTT_IMAGE"
 
-          echo "GHCR tag suffixes: ${suffixes[*]}"
+          echo "GHCR hub tag suffixes: ${suffixes[*]}"
 
       - name: Build and push openfdd-central
         uses: docker/build-push-action@v6
         # RocksDB via oxrocksdb + QEMU arm64 exceeds 2h; ship amd64 nightly first for local MQTTS tests.
-        timeout-minutes: 240
+        timeout-minutes: 90
         with:
           context: .
           file: services/central/Dockerfile
@@ -224,28 +224,6 @@ jobs:
         if: steps.vars.outputs.nightly == 'true'
         run: docker buildx imagetools create -t "${{ env.WEB_IMAGE }}:nightly" "${{ env.WEB_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
 
-      - name: Build and push openfdd-fieldbus
-        uses: docker/build-push-action@v6
-        # Pi / arm64 edges (bosspi): multi-arch. Central/web stay amd64-first (RocksDB/QEMU cost).
-        timeout-minutes: 240
-        with:
-          context: .
-          file: services/fieldbus/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.vars.outputs.fieldbus_tags }}
-          labels: |
-            org.opencontainers.image.title=Open-FDD Fieldbus
-            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.vars.outputs.version }}
-          cache-from: type=gha,scope=openfdd-fieldbus
-          cache-to: type=gha,mode=max,scope=openfdd-fieldbus
-
-      - name: Tag openfdd-fieldbus nightly
-        if: steps.vars.outputs.nightly == 'true'
-        run: docker buildx imagetools create -t "${{ env.FIELDBUS_IMAGE }}:nightly" "${{ env.FIELDBUS_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
-
       - name: Build and push openfdd-mqtt
         uses: docker/build-push-action@v6
         timeout-minutes: 15
@@ -267,16 +245,15 @@ jobs:
         if: steps.vars.outputs.nightly == 'true'
         run: docker buildx imagetools create -t "${{ env.MQTT_IMAGE }}:nightly" "${{ env.MQTT_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
 
-      - name: Published tags
+      - name: Verify hub tags (central/web/mqtt)
         env:
           TAG_SUFFIXES: ${{ steps.vars.outputs.tag_suffixes }}
         run: |
           set -euo pipefail
-          for img in central web fieldbus mqtt; do
+          for img in central web mqtt; do
             case "$img" in
               central) ref="${{ env.CENTRAL_IMAGE }}" ;;
               web) ref="${{ env.WEB_IMAGE }}" ;;
-              fieldbus) ref="${{ env.FIELDBUS_IMAGE }}" ;;
               mqtt) ref="${{ env.MQTT_IMAGE }}" ;;
             esac
             while IFS= read -r suffix; do
@@ -287,3 +264,101 @@ jobs:
               docker buildx imagetools inspect "${ref}:nightly"
             fi
           done
+
+  # Edge fieldbus: multi-arch (amd64 + arm64). Parallel to hub — must not gate mqtt.
+  publish-fieldbus:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          version="$(grep -E '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+          suffixes=("sha-${short_sha}")
+          nightly=false
+
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            nightly=true
+            suffixes+=("${version}-n${GITHUB_RUN_NUMBER}-a${GITHUB_RUN_ATTEMPT}")
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            ref_version="${GITHUB_REF_NAME#v}"
+            if [[ "${ref_version}" != "${version}" ]]; then
+              echo "release tag v${ref_version} does not match Cargo.toml version ${version}" >&2
+              exit 1
+            fi
+            suffixes+=("${version}" "${version}-n${GITHUB_RUN_NUMBER}-a${GITHUB_RUN_ATTEMPT}")
+          else
+            suffixes+=("candidate-${short_sha}")
+          fi
+
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "nightly=${nightly}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "tag_suffixes<<EOF"
+            printf '%s\n' "${suffixes[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "fieldbus_tags<<EOF"
+            for suffix in "${suffixes[@]}"; do
+              echo "${FIELDBUS_IMAGE}:${suffix}"
+            done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "GHCR fieldbus tag suffixes: ${suffixes[*]}"
+
+      - name: Build and push openfdd-fieldbus
+        uses: docker/build-push-action@v6
+        # Pi / arm64 edges (bosspi): multi-arch. Hub images stay amd64-only in publish-hub.
+        timeout-minutes: 240
+        with:
+          context: .
+          file: services/fieldbus/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.vars.outputs.fieldbus_tags }}
+          labels: |
+            org.opencontainers.image.title=Open-FDD Fieldbus
+            org.opencontainers.image.source=https://github.com/bbartling/open-fdd
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.vars.outputs.version }}
+          cache-from: type=gha,scope=openfdd-fieldbus
+          cache-to: type=gha,mode=max,scope=openfdd-fieldbus
+
+      - name: Tag openfdd-fieldbus nightly
+        if: steps.vars.outputs.nightly == 'true'
+        run: docker buildx imagetools create -t "${{ env.FIELDBUS_IMAGE }}:nightly" "${{ env.FIELDBUS_IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}"
+
+      - name: Verify fieldbus tags
+        env:
+          TAG_SUFFIXES: ${{ steps.vars.outputs.tag_suffixes }}
+        run: |
+          set -euo pipefail
+          ref="${{ env.FIELDBUS_IMAGE }}"
+          while IFS= read -r suffix; do
+            [[ -n "$suffix" ]] || continue
+            docker buildx imagetools inspect "${ref}:${suffix}"
+          done <<< "$TAG_SUFFIXES"
+          if [[ "${{ steps.vars.outputs.nightly }}" == "true" ]]; then
+            docker buildx imagetools inspect "${ref}:nightly"
+          fi

--- a/.github/workflows/ghcr-tip-completeness.yml
+++ b/.github/workflows/ghcr-tip-completeness.yml
@@ -1,0 +1,79 @@
+# After Publish Open-FDD stack completes (success or failure), assert tip hub
+# tags exist. Catches the partial-tip failure mode: central/web published but
+# mqtt still missing because fieldbus blocked a serial publish job.
+name: GHCR tip completeness
+
+on:
+  workflow_run:
+    workflows:
+      - Publish Open-FDD stack to GHCR
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Exact tip tag (sha-<7>); empty = origin/master short SHA
+        required: false
+        type: string
+      hub_only:
+        description: Only require central/web/mqtt (skip fieldbus)
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  tip-complete:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Resolve tip tag
+        id: tip
+        env:
+          INPUT_TAG: ${{ inputs.image_tag }}
+          PUBLISH_SHA: ${{ github.event.workflow_run.head_sha }}
+          PUBLISH_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          HUB_ONLY_INPUT: ${{ inputs.hub_only }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_TAG:-}" ]]; then
+            tag="$INPUT_TAG"
+          elif [[ -n "${PUBLISH_SHA:-}" ]]; then
+            tag="sha-${PUBLISH_SHA:0:7}"
+          else
+            git fetch --depth=1 origin master
+            tag="sha-$(git rev-parse --short=7 origin/master)"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Publish conclusion=${PUBLISH_CONCLUSION:-n/a} tip=${tag}"
+
+          hub_only=0
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${HUB_ONLY_INPUT}" == "true" ]]; then
+            hub_only=1
+          fi
+          # After a cancelled/failed Publish, still check hub — partial tags are the bug.
+          if [[ "${PUBLISH_CONCLUSION:-}" == "cancelled" || "${PUBLISH_CONCLUSION:-}" == "failure" ]]; then
+            hub_only=1
+            echo "Publish was ${PUBLISH_CONCLUSION}; enforcing hub-only completeness (central/web/mqtt)."
+          fi
+          echo "hub_only=${hub_only}" >> "$GITHUB_OUTPUT"
+
+      - name: Check GHCR tip stack
+        env:
+          TAG: ${{ steps.tip.outputs.tag }}
+          HUB_ONLY: ${{ steps.tip.outputs.hub_only }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/check_ghcr_tip_stack.sh
+          if [[ "${HUB_ONLY}" == "1" ]]; then
+            ./scripts/check_ghcr_tip_stack.sh "$TAG" --hub-only
+          else
+            ./scripts/check_ghcr_tip_stack.sh "$TAG"
+          fi

--- a/scripts/check_ghcr_tip_stack.sh
+++ b/scripts/check_ghcr_tip_stack.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Fail-closed GHCR tip completeness for Open-FDD stack.
+# Hub (central/web/mqtt) must all exist for the same sha-<7>.
+# Fieldbus is required by default for full tip; use --hub-only for Railway hub
+# re-pin before multi-arch fieldbus finishes.
+#
+# Usage:
+#   ./scripts/check_ghcr_tip_stack.sh sha-a40787b
+#   ./scripts/check_ghcr_tip_stack.sh sha-a40787b --hub-only
+#   ./scripts/check_ghcr_tip_stack.sh   # resolves tip from origin/master
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+HUB_ONLY=0
+TAG=""
+for arg in "$@"; do
+  case "$arg" in
+    --hub-only) HUB_ONLY=1 ;;
+    sha-*) TAG="$arg" ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  if git rev-parse --verify origin/master >/dev/null 2>&1; then
+    TAG="sha-$(git rev-parse --short=7 origin/master)"
+  else
+    TAG="sha-$(git rev-parse --short=7 HEAD)"
+  fi
+fi
+
+if [[ ! "$TAG" =~ ^sha-[0-9a-f]{7}$ ]]; then
+  echo "FAIL: tag must look like sha-<7 hex>, got ${TAG}" >&2
+  exit 2
+fi
+
+REGISTRY="${OPENFDD_GHCR_REGISTRY:-ghcr.io/bbartling}"
+HUB=(openfdd-central openfdd-web openfdd-mqtt)
+EDGE=(openfdd-fieldbus)
+
+present=()
+missing=()
+
+check_one() {
+  local name="$1"
+  local ref="${REGISTRY}/${name}:${TAG}"
+  if docker manifest inspect "$ref" >/dev/null 2>&1; then
+    present+=("$name")
+    echo "OK  ${ref}"
+  else
+    missing+=("$name")
+    echo "MISS ${ref}"
+  fi
+}
+
+echo "=== GHCR tip completeness: ${TAG} (hub_only=${HUB_ONLY}) ==="
+for n in "${HUB[@]}"; do check_one "$n"; done
+if [[ "$HUB_ONLY" -eq 0 ]]; then
+  for n in "${EDGE[@]}"; do check_one "$n"; done
+fi
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+  echo "PASS: tip ${TAG} complete"
+  exit 0
+fi
+
+# Specific diagnosis for the Wave G hang pattern.
+if printf '%s\n' "${present[@]}" | grep -qx openfdd-central \
+  && printf '%s\n' "${missing[@]}" | grep -qx openfdd-mqtt; then
+  echo "FAIL: PARTIAL TIP — central present but mqtt missing for ${TAG}." >&2
+  echo "  Likely: Publish still on multi-arch fieldbus (or hung) before mqtt push." >&2
+  echo "  Do not Railway re-pin until hub (central/web/mqtt) is complete." >&2
+  exit 1
+fi
+
+echo "FAIL: incomplete tip ${TAG}; missing: ${missing[*]}" >&2
+exit 1


### PR DESCRIPTION
## Summary
- **Publish Open-FDD stack:** `publish-hub` (central/web/mqtt) runs **in parallel** with `publish-fieldbus` (amd64+arm64).
- **Failure check:** `scripts/check_ghcr_tip_stack.sh` + workflow **GHCR tip completeness** runs after every Publish and fails on partial tips (e.g. central OK, mqtt missing).

## Why
Wave G tip `sha-a40787b` left mqtt unpublished for hours while serial fieldbus QEMU ran/hung — Railway re-pin blocked.

## Test plan
- [x] `./scripts/check_ghcr_tip_stack.sh sha-a40787b` PASS
- [ ] Merge → next master Publish shows hub finishing without waiting on fieldbus
- [ ] Tip completeness workflow green after Publish


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Container images for hub services and fieldbus components are now published in parallel, helping streamline release availability.
  - Hub images use streamlined builds, while fieldbus images continue supporting both amd64 and arm64 architectures.
  - Added automated checks to confirm that required images are available under the same release tag.
  - Completeness checks can distinguish hub-only releases when fieldbus publishing is unavailable or unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->