### PR TITLE
docs: pin Wave H closeout tip to sha-2e136b4

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-09-08 (Wave H **CLOSED** — demo charts / multi-site / UI freshness; Wave G Lab tuners **CLOSED**)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
-**Tip / pin (3.3.39):** `4a100567` · VERSION **3.3.39** · health **`3.3.39+4a100567dc2b`** · GHCR **central/web/mqtt/fieldbus `sha-4a10056`**  
-**Last CLOSED tip:** `4a100567` · **`sha-4a10056`** · **`3.3.39+4a100567dc2b`** · product **#869** (+ **#868** RCx)  
+**Tip / pin (3.3.39):** `2e136b48` · VERSION **3.3.39** · health **`3.3.39+2e136b482786`** · GHCR **central/web/mqtt/fieldbus `sha-2e136b4`**  
+**Last CLOSED tip:** `2e136b48` · **`sha-2e136b4`** · **`3.3.39+2e136b482786`** · product **#869** (+ **#868** RCx) · docs **#870** VERSION sync  
 **Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Telemetry = hosted AV `9101` loopback as `bldg2-zone-loopback` / role **`zone_t`** / `equipment_type=zone_other` (+ `hosted-weather`).  
 **Backup:** `~/openfdd-backups/railway/20260908T0157*` (prior: `20260907T231243Z`)  
 **Program (CLOSED):** Wave H demo charts — Cursor [`post_waveg_openfdd_residual_wave_h`](../../../.cursor/plans/post_waveg_openfdd_residual_wave_h.plan.md) · agent_spec rules 51–54  
@@ -38,9 +38,9 @@
 
 | Check | Result |
 |-------|--------|
-| Hub | `3.3.39+4a100567dc2b` · central/mqtt/web **Online** · `sha-4a10056` |
-| Tip gate | `./scripts/check_ghcr_tip_stack.sh sha-4a10056` **PASS** |
-| Ingest | `edges:1` · `ingest_ok` climbing · fieldbus `sha-4a10056` |
+| Hub | `3.3.39+2e136b482786` · central/mqtt/web **Online** · `sha-2e136b4` |
+| Tip gate | `./scripts/check_ghcr_tip_stack.sh sha-2e136b4` **PASS** |
+| Ingest | `edges:1` · `ingest_ok` climbing · fieldbus `sha-2e136b4` |
 | bldg2 equip | **2** — `bldg2-zone-loopback`, `hosted-weather` |
 | Inspect / RCx | loopback Inspect points>0 · `zone_comfort_rank` includes loopback |
 | Demo sites | Lakeside / B100 / B50 Inspect data visible |

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -100,7 +100,7 @@ retest. Do not confuse those with this engineering OS.
 53. **MQTT = CSV data model:** MQTTS historian paths use the same `history/building_id=<site>/…` shape as packages. Inspect must pick MQTT equipment (not CSV-only). Roles normalize to columns (`zone_t`, etc.). RCx/FDD plots share the CSV codepath.
 54. **Keep this spec current:** any PR that changes demo freshness, site catalog scoping, Inspect/MQTT plots, or Railway closeout workflow updates this file + [`SESSION_LOG.md`](SESSION_LOG.md) in the same train (H0 or the product PR).
 
-**Current ops pin (2026-09-08):** VERSION **3.3.39** · tip **`sha-4a10056`** · Wave H **CLOSED** (stress `nightly-ot-bench_20260908T021007Z` fully_qualified). Residual: **weather-local-vs-web-bldg2** DEFERRED. Low-RAM always (rule 0).
+**Current ops pin (2026-09-08):** VERSION **3.3.39** · tip **`sha-2e136b4`** · Wave H **CLOSED** (stress `nightly-ot-bench_20260908T021007Z` fully_qualified). Residual: **weather-local-vs-web-bldg2** DEFERRED. Low-RAM always (rule 0).
 
 ---
 


### PR DESCRIPTION
## Summary
- After #870 VERSION sync Publish, tip-complete images are **`sha-2e136b4`**.
- Railway hub + fieldbus already re-pinned; BUG_REPORT / agent_spec match live health `3.3.39+2e136b482786`.

## Test plan
- [ ] Docs CI green
- [ ] No product image change required (docs-only)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated operational bug-report references to the latest validated build.
  - Synchronized the AI agent operations guidance with the current pinned image.
  - Refreshed Wave H closeout tracking and documentation version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->