### PR TITLE
docs: Wave I CLOSED on sha-d1312b0 after fully_qualified stress

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -9,8 +9,8 @@
 **Program (CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · agent_spec rules **55–58**  
 **Program (prior CLOSED):** Wave H — Cursor [`post_waveg_openfdd_residual_wave_h`](../../../.cursor/plans/post_waveg_openfdd_residual_wave_h.plan.md)  
 **Stress (Wave I closeout):** `reports/nightly-ot-bench_20260908T182149Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + Wave I MEGAs)  
-**Deferred after Wave I:** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (**sequential** vs Wave J — not same train)  
-**Next program (OPEN):** Wave J — Rust/DataFusion boundary repair + qualification (`df-boundary-repair`) — Stage A truth/docs/guards before multivendor rebase  
+**Deferred sequential (Wave J J7):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md)  
+**Program (ACTIVE):** Wave J — Cursor [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) (DF-boundary + [#875](https://github.com/bbartling/open-fdd/issues/875) cookbook parity)  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -25,8 +25,9 @@
 | **weather-local-vs-web-bldg2** | **CLOSED** (3.3.40 / Wave I) | Was: bldg2 bas-vs-web empty | #872 dual OAT catalog; gate09 `bas_vs_web` points>0 | — |
 | **mqtt-bldg2-plot-surface** | **CLOSED** (3.3.40 / Wave I) | Was: MQTT plots empty/wrong roles | Inspect `zone_t` non_null=696; dual OAT live | — |
 | **wave-i-stress-gates** | **CLOSED** (3.3.40 / Wave I) | Was: stress green while basics broken | Gate `09_wave_i_app_test_megas` required; #873 AHU_1 fix | — |
-| **mqtt-monitor-sse-782** | **DEFERRED** (post–Wave I) | Ops MQTT Test Client is 1s poll; no browser→Mosquitto WS | [#782](https://github.com/bbartling/open-fdd/issues/782); Central `GET /api/mqtt/monitor` already works | Cursor [`mqtt_monitor_sse_782`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) — **not** simultaneous with DF mega |
-| **df-boundary-repair** | **OPEN (MEGA)** next program | Stale pandas/UI docs + incomplete Python-absence / DF provenance qualification | 2026-09-08 source review: Dockerfiles Python-free; `datafusion-first.md` / `analytics-boundary.md` contradict ARCHITECTURE; soak accepts engine-label shortcuts | **Wave J** Stage A→B then multivendor rebase — **separate** from #782 |
+| **mqtt-monitor-sse-782** | **DEFERRED** (Wave J **J7**) | Ops MQTT Test Client is 1s poll; no browser→Mosquitto WS | [#782](https://github.com/bbartling/open-fdd/issues/782); Central `GET /api/mqtt/monitor` already works | [`mqtt_monitor_sse_782`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) — sequential after J1/J6; **not** parallel w/ DF coding |
+| **df-boundary-repair** | **OPEN (MEGA)** Wave J | Stale pandas/UI docs + incomplete Python-absence / DF provenance qualification | 2026-09-08 source review; Dockerfiles Python-free; contradictory architecture docs | Master [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) |
+| **cookbook-parity-875** | **OPEN** Wave J **J2** | SQL↔pandas drift: FC3 tol/fan priority; VAV-2 fractional occupancy | [#875](https://github.com/bbartling/open-fdd/issues/875) Trenyx @ c20ab48 | [`wave_j_cookbook_parity_875`](../../../.cursor/plans/wave_j_cookbook_parity_875.plan.md) |
 | **mqtt-ingest-stall** | **CLOSED** (3.3.34) | Was: flat `ingest_ok` after mqtt bounce until central redeploy | #860 · tip `sha-9aebf42` · smoke `reports/waveD_railway_smoke_20260906T173032Z/` | — |
 | **railway-ui-fdd-stale** | **CLOSED** (Wave E) | Was: building filter / scoped FDD UX across sites | Tip `sha-9aebf42`: Overview clears on site change; PlantHealthSections empty shells; equipment=8 / zone-other rows=7 | No VERSION — UX already on tip |
 | **bldg2-overview-signoff** | **CLOSED** (Wave H) | Was: SPA charts weak; buyer mash Run/Update | #868/#869 · Inspect/RCx points>0; Overview auto-load | — |
@@ -100,18 +101,22 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** **Wave J** Rust/DataFusion boundary repair + qualification (Stage A truth/docs/guards first) — see `df-boundary-repair` row.  
-**Optional small:** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md). **Do not** run #782 product coding in parallel with Wave J product/CI (low-RAM one-agent). Interleave only after Stage A docs/guards land, or after Wave J Stage B.  
-**Last closed:** Wave I [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / **#872** · gate fix **#873** · stress `20260908T182149Z`. Anomaly **PARKED**.
+**Active:** Wave J master [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) — J0 land #874 → J1 Stage A docs → J2 [#875](https://github.com/bbartling/open-fdd/issues/875) → J3/J5 CI+image gates → J4 Stage B gaps → J6 soak → optional J7 [#782](https://github.com/bbartling/open-fdd/issues/782) → **J8 ONE full stress**. Low-RAM one agent; #782 never parallel with J1–J6 coding.  
+**Last closed:** Wave I (RETIRED plan [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md)) · tip `sha-d1312b0` / **#872** · gate fix **#873** · stress `20260908T182149Z`. Anomaly **PARKED**. Multivendor Stage C **deferred after Wave J**.
 
-**This round stress rule:** Wave I I7 complete — do **not** multi-stress “just in case.” Wave J adds digest/Python-absence/numerical gates before promotion.
+**This round stress rule:** mid-wave = smoke only. **ONE full** `run_railway_hub_stress.sh` at **Wave J J8** (keep gate 09; add DF gates when ready; **no `SKIP_ZAP`**).
 
 | Rev / wave | In-repo / Cursor plan | Concern | Status |
 |------------|----------------------|---------|--------|
-| **Wave J / DF boundary** | (create) `df_boundary_repair_qualify` · brief 2026-09-08 | Rust/DF product contract, docs, CI/image gates, numerical soak | **OPEN** Stage A next |
-| **#782 SSE** | [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) | Browser MQTT monitor via Central SSE | **DEFERRED** — sequential, not parallel w/ Wave J coding |
-| **Wave I master** | Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs + basic functionality | **CLOSED** |
-| **Wave I / I1–I6** | child plans + #872 / #873 | Lakeside / Overview / export / span / dual OAT / gates | **CLOSED** |
+| **Wave J master** | [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) | DF-boundary + #875 + optional #782 | **OPEN** |
+| **Wave J / J0** | [`wave_j0_land_wave_i_closeout_docs`](../../../.cursor/plans/wave_j0_land_wave_i_closeout_docs.plan.md) | Land #874 | **OPEN** |
+| **Wave J / J1** | [`wave_j_a_truth_docs_guards`](../../../.cursor/plans/wave_j_a_truth_docs_guards.plan.md) | Stage A truth/docs | **OPEN** |
+| **Wave J / J2** | [`wave_j_cookbook_parity_875`](../../../.cursor/plans/wave_j_cookbook_parity_875.plan.md) | #875 FC3 + VAV-2 parity | **OPEN** |
+| **Wave J / J3+J5** | [`wave_j_ci_image_gates`](../../../.cursor/plans/wave_j_ci_image_gates.plan.md) | Policy CI + image Python-absence | **OPEN** |
+| **Wave J / J4** | [`wave_j_b_close_python_gaps`](../../../.cursor/plans/wave_j_b_close_python_gaps.plan.md) | Stage B close gaps | **OPEN** |
+| **Wave J / J6** | [`wave_j_numerical_soak_harden`](../../../.cursor/plans/wave_j_numerical_soak_harden.plan.md) | Soak provenance | **OPEN** |
+| **Wave J / J7** | [`mqtt_monitor_sse_782`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) | #782 Central SSE | **DEFERRED** sequential |
+| **Wave I master** | [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs | **RETIRED / CLOSED** |
 | **Wave H** | Cursor post_waveg residual H | Demo charts / UI freshness | **CLOSED** |
 | **Wave G / 3.3.37–3.3.40** | [`openfdd_lab_tuner_parity_program.plan.md`](patch_trains/openfdd_lab_tuner_parity_program.plan.md) | Lab tuner Vibe19 parity | **CLOSED** — #864 · tip `sha-a40787b` |
 

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,14 +1,15 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-09-08 (Wave H **CLOSED**; **Wave I OPEN** — app-test MEGAs / basic functionality)  
+**Date:** 2026-09-08 (Wave I **CLOSED** — app-test MEGAs / basic functionality)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
-**Tip / pin (3.3.39):** `2e136b48` · VERSION **3.3.39** · health **`3.3.39+2e136b482786`** · GHCR **central/web/mqtt/fieldbus `sha-2e136b4`**  
-**Last CLOSED tip:** `2e136b48` · **`sha-2e136b4`** · **`3.3.39+2e136b482786`** · product **#869** (+ **#868** RCx) · docs **#870** VERSION sync  
-**Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Telemetry = hosted AV `9101` loopback as `bldg2-zone-loopback` / role **`zone_t`** / `equipment_type=zone_other` (+ `hosted-weather`).  
-**Backup:** `~/openfdd-backups/railway/20260908T0157*` (prior: `20260907T231243Z`)  
-**Program (CLOSED):** Wave H — Cursor [`post_waveg_openfdd_residual_wave_h`](../../../.cursor/plans/post_waveg_openfdd_residual_wave_h.plan.md)  
-**Program (ACTIVE):** Wave I app-test MEGAs — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · agent_spec rules **55–58** · **ONE full stress at I7 only**  
-**Stress (last closed):** `reports/nightly-ot-bench_20260908T021007Z/` · **`fully_qualified=true`**  
+**Tip / pin (3.3.40):** `d1312b0c` · VERSION **3.3.40** · health **`3.3.40+d1312b0ccb07`** · GHCR **central/web/mqtt/fieldbus `sha-d1312b0`**  
+**Last CLOSED tip:** `d1312b0c` · **`sha-d1312b0`** · **`3.3.40+d1312b0ccb07`** · product **#872** · stress gate fix **#873**  
+**Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Dual-publish AV `9101`: `bldg2-zone-loopback` **`zone_t`+`oa_t`**, `hosted-weather` **`web_oa_t`**.  
+**Backup:** `~/openfdd-backups/railway/20260908T171523Z/` (prior: `20260908T0157*`)  
+**Program (CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · agent_spec rules **55–58**  
+**Program (prior CLOSED):** Wave H — Cursor [`post_waveg_openfdd_residual_wave_h`](../../../.cursor/plans/post_waveg_openfdd_residual_wave_h.plan.md)  
+**Stress (Wave I closeout):** `reports/nightly-ot-bench_20260908T182149Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + Wave I MEGAs)  
+**Deferred after Wave I:** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md)  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -16,13 +17,13 @@
 
 | ID | Status | Symptom | Evidence | Next |
 |----|--------|---------|----------|------|
-| **lakeside-read-csv-missing** | **OPEN (MEGA)** basic app | LAKESIDE_ES FDD/select → `table function 'read_csv' not found`; Inspect no parquet | 2026-09-08 FC1 `ok:false`; equip list still ~71 | Wave I **I1** [`wave_i_lakeside_read_csv`](../../../.cursor/plans/wave_i_lakeside_read_csv.plan.md) |
-| **overview-tables-unfiltered** | **OPEN (MEGA)** basic app | Overview on MQTT `bldg2` looks table-filtered vs CSV; bottom devices table must never be source-filtered | Operator app-test 2026-09-08 | Wave I **I2** [`wave_i_overview_tables_unfiltered`](../../../.cursor/plans/wave_i_overview_tables_unfiltered.plan.md) |
-| **data-model-json-export** | **OPEN (MEGA)** basic app | Data Model needs working Export JSON for **any** building (MQTT + CSV) | Mapping download often dead when inventory fails on MQTT | Wave I **I3** [`wave_i_data_model_json_export`](../../../.cursor/plans/wave_i_data_model_json_export.plan.md) |
-| **plot-default-full-span-b100** | **OPEN (MEGA)** | B100 plots default ~July only — not full historian span | Operator app-test; newest-`max_points`/`LIMIT` | Wave I **I4** [`wave_i_plot_full_span_b100`](../../../.cursor/plans/wave_i_plot_full_span_b100.plan.md) |
-| **weather-local-vs-web-bldg2** | **OPEN (MEGA)** | bldg2 bas-vs-web empty — catalog zone_t only; OAT null; hosted-weather stale | `bas-vs-web-oat` pts=0; Open-Meteo live on `/weather` but not MQTT roles | Wave I **I5** [`mqtt_dual_oat_wave`](../../../.cursor/plans/mqtt_dual_oat_wave_a209637a.plan.md) |
-| **mqtt-bldg2-plot-surface** | **OPEN (MEGA)** | MQTTS ingest OK but buyer plots look empty/wrong (OAT/plant first) | Inspect `zone_t`~4k live; plant RCx empty expected if honest | Wave I **I5** + Overview I2 |
-| **wave-i-stress-gates** | **OPEN** | Stress can green while basic app broken | Need gates for Lakeside/Overview/export/span/dual-OAT | Wave I **I6** [`wave_i_stress_gates_enhance`](../../../.cursor/plans/wave_i_stress_gates_enhance.plan.md) |
+| **lakeside-read-csv-missing** | **CLOSED** (3.3.40 / Wave I) | Was: LAKESIDE_ES FDD `read_csv not found` | #872 `register_csv`; stress gate09 no `read_csv` | — |
+| **overview-tables-unfiltered** | **CLOSED** (3.3.40 / Wave I) | Was: MQTT Overview looked table-filtered vs CSV | #872 Overview chrome pad + Weather section always render | — |
+| **data-model-json-export** | **CLOSED** (3.3.40 / Wave I) | Was: Export JSON dead for MQTT | #872 historian mapping + Export; mapping `bldg2` equipment=2 | — |
+| **plot-default-full-span-b100** | **CLOSED** (3.3.40 / Wave I) | Was: B100 plots July-only | #872 span-preserving Inspect; gate09 AHU_1 `plot_days=123.4` (#873) | — |
+| **weather-local-vs-web-bldg2** | **CLOSED** (3.3.40 / Wave I) | Was: bldg2 bas-vs-web empty | #872 dual OAT catalog; gate09 `bas_vs_web` points>0 | — |
+| **mqtt-bldg2-plot-surface** | **CLOSED** (3.3.40 / Wave I) | Was: MQTT plots empty/wrong roles | Inspect `zone_t` non_null=696; dual OAT live | — |
+| **wave-i-stress-gates** | **CLOSED** (3.3.40 / Wave I) | Was: stress green while basics broken | Gate `09_wave_i_app_test_megas` required; #873 AHU_1 fix | — |
 | **mqtt-ingest-stall** | **CLOSED** (3.3.34) | Was: flat `ingest_ok` after mqtt bounce until central redeploy | #860 · tip `sha-9aebf42` · smoke `reports/waveD_railway_smoke_20260906T173032Z/` | — |
 | **railway-ui-fdd-stale** | **CLOSED** (Wave E) | Was: building filter / scoped FDD UX across sites | Tip `sha-9aebf42`: Overview clears on site change; PlantHealthSections empty shells; equipment=8 / zone-other rows=7 | No VERSION — UX already on tip |
 | **bldg2-overview-signoff** | **CLOSED** (Wave H) | Was: SPA charts weak; buyer mash Run/Update | #868/#869 · Inspect/RCx points>0; Overview auto-load | — |
@@ -52,7 +53,19 @@
 | Inspect / RCx | loopback Inspect points>0 · `zone_comfort_rank` includes loopback |
 | Demo sites | Lakeside / B100 / B50 Inspect data visible |
 | Stress | `reports/nightly-ot-bench_20260908T021007Z/` **`fully_qualified=true`** |
-| H5 bldg2 OAT overlay | **OPEN MEGA** Wave I — was DEFERRED; see `weather-local-vs-web-bldg2` |
+| H5 bldg2 OAT overlay | **CLOSED** Wave I — `weather-local-vs-web-bldg2` |
+
+### Wave I closeout (2026-09-08T18:25Z)
+
+| Check | Result |
+|-------|--------|
+| Hub | `3.3.40+d1312b0ccb07` · central/mqtt/web **Online** · `sha-d1312b0` |
+| Tip gate | GHCR tip completeness **PASS** on `d1312b0c` |
+| Backup / pin | `~/openfdd-backups/railway/20260908T171523Z/` · full-stack + fieldbus `sha-d1312b0` |
+| Ingest | `edges:1` · `ingest_ok` climbing · dual OAT publishing |
+| Gate 09 | Lakeside FC1 / mapping bldg2 / Inspect `zone_t` / bas-vs-web / B100 span **PASS** |
+| Stress | `reports/nightly-ot-bench_20260908T182149Z/` **`fully_qualified=true`** (00–09) |
+| Deferred | #782 MQTT monitor SSE — after Wave I |
 
 ### Wave H kickoff probe (2026-09-07T20:35Z)
 
@@ -84,20 +97,16 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** Wave I app-test MEGAs — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) (I1 Lakeside → I2 Overview tables → I3 Data Model export → I4 B100 span → I5 dual OAT → I6 stress gates → **I7 ONE full stress**). Low-RAM; **0 stale PRs / failed tip Actions** each child. Basic app MEGAs must be SPA+API validated — stress alone is not enough.  
-**Last closed:** Wave H [`post_waveg_openfdd_residual_wave_h`](../../../.cursor/plans/post_waveg_openfdd_residual_wave_h.plan.md) · Wave G Lab tuners. Anomaly **PARKED**. #782 SSE **deferred** after Wave I.
+**Active:** none (Wave I **CLOSED**). Next optional: [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md). Anomaly **PARKED**.  
+**Last closed:** Wave I [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / **#872** · gate fix **#873** · stress `20260908T182149Z`.
 
-**This round stress rule:** mid-wave = Railway **smoke** / unit. **ONE full** `run_railway_hub_stress.sh` at **Wave I I7 closeout** (enhanced I6 gates, **no `SKIP_ZAP`**) → BUG_REPORT. Do **not** multi-stress between children.
+**This round stress rule:** Wave I I7 complete — do **not** multi-stress “just in case.”
 
 | Rev / wave | In-repo / Cursor plan | Concern | Status |
 |------------|----------------------|---------|--------|
-| **Wave I master** | Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs + basic functionality | **OPEN** |
-| **Wave I / I1** | [`wave_i_lakeside_read_csv`](../../../.cursor/plans/wave_i_lakeside_read_csv.plan.md) | Lakeside `read_csv` | **OPEN** |
-| **Wave I / I2** | [`wave_i_overview_tables_unfiltered`](../../../.cursor/plans/wave_i_overview_tables_unfiltered.plan.md) | Overview tables MQTT=CSV | **OPEN** |
-| **Wave I / I3** | [`wave_i_data_model_json_export`](../../../.cursor/plans/wave_i_data_model_json_export.plan.md) | Data Model JSON export | **OPEN** |
-| **Wave I / I4** | [`wave_i_plot_full_span_b100`](../../../.cursor/plans/wave_i_plot_full_span_b100.plan.md) | B100 full date span | **OPEN** |
-| **Wave I / I5** | [`mqtt_dual_oat_wave`](../../../.cursor/plans/mqtt_dual_oat_wave_a209637a.plan.md) | MQTT dual OAT + plot surface | **OPEN** |
-| **Wave I / I6** | [`wave_i_stress_gates_enhance`](../../../.cursor/plans/wave_i_stress_gates_enhance.plan.md) | Stress gates for MEGAs | **OPEN** |
+| **Wave I master** | Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs + basic functionality | **CLOSED** |
+| **Wave I / I1–I6** | child plans + #872 / #873 | Lakeside / Overview / export / span / dual OAT / gates | **CLOSED** |
+| **#782 SSE** | [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) | Browser MQTT monitor via Central SSE | **DEFERRED** (after Wave I) |
 | **Wave H** | Cursor post_waveg residual H | Demo charts / UI freshness | **CLOSED** |
 | **Wave G / 3.3.37–3.3.40** | [`openfdd_lab_tuner_parity_program.plan.md`](patch_trains/openfdd_lab_tuner_parity_program.plan.md) | Lab tuner Vibe19 parity | **CLOSED** — #864 · tip `sha-a40787b` |
 

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -9,7 +9,8 @@
 **Program (CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · agent_spec rules **55–58**  
 **Program (prior CLOSED):** Wave H — Cursor [`post_waveg_openfdd_residual_wave_h`](../../../.cursor/plans/post_waveg_openfdd_residual_wave_h.plan.md)  
 **Stress (Wave I closeout):** `reports/nightly-ot-bench_20260908T182149Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + Wave I MEGAs)  
-**Deferred after Wave I:** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md)  
+**Deferred after Wave I:** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (**sequential** vs Wave J — not same train)  
+**Next program (OPEN):** Wave J — Rust/DataFusion boundary repair + qualification (`df-boundary-repair`) — Stage A truth/docs/guards before multivendor rebase  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -24,6 +25,8 @@
 | **weather-local-vs-web-bldg2** | **CLOSED** (3.3.40 / Wave I) | Was: bldg2 bas-vs-web empty | #872 dual OAT catalog; gate09 `bas_vs_web` points>0 | — |
 | **mqtt-bldg2-plot-surface** | **CLOSED** (3.3.40 / Wave I) | Was: MQTT plots empty/wrong roles | Inspect `zone_t` non_null=696; dual OAT live | — |
 | **wave-i-stress-gates** | **CLOSED** (3.3.40 / Wave I) | Was: stress green while basics broken | Gate `09_wave_i_app_test_megas` required; #873 AHU_1 fix | — |
+| **mqtt-monitor-sse-782** | **DEFERRED** (post–Wave I) | Ops MQTT Test Client is 1s poll; no browser→Mosquitto WS | [#782](https://github.com/bbartling/open-fdd/issues/782); Central `GET /api/mqtt/monitor` already works | Cursor [`mqtt_monitor_sse_782`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) — **not** simultaneous with DF mega |
+| **df-boundary-repair** | **OPEN (MEGA)** next program | Stale pandas/UI docs + incomplete Python-absence / DF provenance qualification | 2026-09-08 source review: Dockerfiles Python-free; `datafusion-first.md` / `analytics-boundary.md` contradict ARCHITECTURE; soak accepts engine-label shortcuts | **Wave J** Stage A→B then multivendor rebase — **separate** from #782 |
 | **mqtt-ingest-stall** | **CLOSED** (3.3.34) | Was: flat `ingest_ok` after mqtt bounce until central redeploy | #860 · tip `sha-9aebf42` · smoke `reports/waveD_railway_smoke_20260906T173032Z/` | — |
 | **railway-ui-fdd-stale** | **CLOSED** (Wave E) | Was: building filter / scoped FDD UX across sites | Tip `sha-9aebf42`: Overview clears on site change; PlantHealthSections empty shells; equipment=8 / zone-other rows=7 | No VERSION — UX already on tip |
 | **bldg2-overview-signoff** | **CLOSED** (Wave H) | Was: SPA charts weak; buyer mash Run/Update | #868/#869 · Inspect/RCx points>0; Overview auto-load | — |
@@ -65,7 +68,7 @@
 | Ingest | `edges:1` · `ingest_ok` climbing · dual OAT publishing |
 | Gate 09 | Lakeside FC1 / mapping bldg2 / Inspect `zone_t` / bas-vs-web / B100 span **PASS** |
 | Stress | `reports/nightly-ot-bench_20260908T182149Z/` **`fully_qualified=true`** (00–09) |
-| Deferred | #782 MQTT monitor SSE — after Wave I |
+| Deferred | #782 MQTT monitor SSE — **do not** combine with DF-boundary mega |
 
 ### Wave H kickoff probe (2026-09-07T20:35Z)
 
@@ -97,16 +100,18 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** none (Wave I **CLOSED**). Next optional: [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md). Anomaly **PARKED**.  
-**Last closed:** Wave I [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / **#872** · gate fix **#873** · stress `20260908T182149Z`.
+**Active:** **Wave J** Rust/DataFusion boundary repair + qualification (Stage A truth/docs/guards first) — see `df-boundary-repair` row.  
+**Optional small:** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md). **Do not** run #782 product coding in parallel with Wave J product/CI (low-RAM one-agent). Interleave only after Stage A docs/guards land, or after Wave J Stage B.  
+**Last closed:** Wave I [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / **#872** · gate fix **#873** · stress `20260908T182149Z`. Anomaly **PARKED**.
 
-**This round stress rule:** Wave I I7 complete — do **not** multi-stress “just in case.”
+**This round stress rule:** Wave I I7 complete — do **not** multi-stress “just in case.” Wave J adds digest/Python-absence/numerical gates before promotion.
 
 | Rev / wave | In-repo / Cursor plan | Concern | Status |
 |------------|----------------------|---------|--------|
+| **Wave J / DF boundary** | (create) `df_boundary_repair_qualify` · brief 2026-09-08 | Rust/DF product contract, docs, CI/image gates, numerical soak | **OPEN** Stage A next |
+| **#782 SSE** | [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) | Browser MQTT monitor via Central SSE | **DEFERRED** — sequential, not parallel w/ Wave J coding |
 | **Wave I master** | Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs + basic functionality | **CLOSED** |
 | **Wave I / I1–I6** | child plans + #872 / #873 | Lakeside / Overview / export / span / dual OAT / gates | **CLOSED** |
-| **#782 SSE** | [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) | Browser MQTT monitor via Central SSE | **DEFERRED** (after Wave I) |
 | **Wave H** | Cursor post_waveg residual H | Demo charts / UI freshness | **CLOSED** |
 | **Wave G / 3.3.37–3.3.40** | [`openfdd_lab_tuner_parity_program.plan.md`](patch_trains/openfdd_lab_tuner_parity_program.plan.md) | Lab tuner Vibe19 parity | **CLOSED** — #864 · tip `sha-a40787b` |
 

--- a/docs/operations/patch_trains/openfdd_wave_j_df_boundary_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_j_df_boundary_program.plan.md
@@ -1,0 +1,19 @@
+# Wave J — DF-boundary program (GitHub mirror)
+
+Cursor master: [`.cursor/plans/wave_j_df_boundary_master.plan.md`](../../../../.cursor/plans/wave_j_df_boundary_master.plan.md)
+
+Living log: [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
+
+## Children
+
+| Step | Cursor plan |
+|------|-------------|
+| J0 | `wave_j0_land_wave_i_closeout_docs.plan.md` |
+| J1 | `wave_j_a_truth_docs_guards.plan.md` |
+| J2 | `wave_j_cookbook_parity_875.plan.md` (#875) |
+| J3+J5 | `wave_j_ci_image_gates.plan.md` |
+| J4 | `wave_j_b_close_python_gaps.plan.md` |
+| J6 | `wave_j_numerical_soak_harden.plan.md` |
+| J7 | `mqtt_monitor_sse_782.plan.md` (#782 sequential) |
+
+Wave I master is **RETIRED** — `wave_i_app_test_mega_master.plan.md`.

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -104,7 +104,7 @@ retest. Do not confuse those with this engineering OS.
 57. **MQTT dual OAT:** Live fieldbus Open-Meteo must publish into historian as concurrent BAS `oa_t` + web `web_oa_t` (catalog dual-publish on railway loopback). Empty `bas-vs-web-oat` on bldg2 while `/weather` is live is a **P0 MEGA**, not DEFERRED demo fluff.
 58. **Wave I stress:** Mid-wave = smoke only. **ONE** `run_railway_hub_stress.sh` at master I7 after enhanced gates (I6). No duplicate full stresses between children unless a mega cannot be proven without a new tip pin.
 
-**Current ops pin (2026-09-08):** VERSION **3.3.40** · tip **`sha-d1312b0`** · health **`3.3.40+d1312b0ccb07`** · Wave I **CLOSED**. **Wave J OPEN** (DF boundary repair/qualify — Stage A next). #782 SSE deferred sequential (not parallel w/ Wave J). Low-RAM always (rule 0).
+**Current ops pin (2026-09-08):** VERSION **3.3.40** · tip **`sha-d1312b0`** · health **`3.3.40+d1312b0ccb07`** · Wave I **CLOSED**. **Wave J OPEN** — master [`wave_j_df_boundary_master`](../../.cursor/plans/wave_j_df_boundary_master.plan.md) (DF-boundary + #875; #782=J7 sequential). #782 SSE deferred sequential (not parallel w/ Wave J). Low-RAM always (rule 0).
 
 ---
 

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -43,7 +43,7 @@ retest. Do not confuse those with this engineering OS.
 
 ## AI agent quick rules (read first)
 
-0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Active Wave I:** Cursor [`.cursor/plans/wave_i_app_test_mega_master.plan.md`](../../.cursor/plans/wave_i_app_test_mega_master.plan.md) — basic app MEGAs first, **ONE full stress at I7**. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
+0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave I CLOSED** on tip **`sha-d1312b0`** / **3.3.40** — next optional [#782](https://github.com/bbartling/open-fdd/issues/782) SSE. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
 1. Product FDD + Overview analytics = **DataFusion SQL** on GHCR. Never silent pandas fallback in central.
 2. Pandas oracle stays forever on **PyPI** + cookbooks + vibe19 — never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
@@ -104,7 +104,7 @@ retest. Do not confuse those with this engineering OS.
 57. **MQTT dual OAT:** Live fieldbus Open-Meteo must publish into historian as concurrent BAS `oa_t` + web `web_oa_t` (catalog dual-publish on railway loopback). Empty `bas-vs-web-oat` on bldg2 while `/weather` is live is a **P0 MEGA**, not DEFERRED demo fluff.
 58. **Wave I stress:** Mid-wave = smoke only. **ONE** `run_railway_hub_stress.sh` at master I7 after enhanced gates (I6). No duplicate full stresses between children unless a mega cannot be proven without a new tip pin.
 
-**Current ops pin (2026-09-08):** VERSION **3.3.39** · tip **`sha-2e136b4`** · Wave H **CLOSED**. **Wave I OPEN** — master [`wave_i_app_test_mega_master`](../../.cursor/plans/wave_i_app_test_mega_master.plan.md). Low-RAM always (rule 0).
+**Current ops pin (2026-09-08):** VERSION **3.3.40** · tip **`sha-d1312b0`** · health **`3.3.40+d1312b0ccb07`** · Wave I **CLOSED**. Next optional: #782 MQTT monitor SSE. Low-RAM always (rule 0).
 
 ---
 

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -43,7 +43,7 @@ retest. Do not confuse those with this engineering OS.
 
 ## AI agent quick rules (read first)
 
-0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave I CLOSED** on tip **`sha-d1312b0`** / **3.3.40** — next optional [#782](https://github.com/bbartling/open-fdd/issues/782) SSE. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
+0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave I CLOSED** on tip **`sha-d1312b0`** / **3.3.40**. **Wave J OPEN** (DF boundary). #782 SSE sequential only — never parallel with Wave J coding. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
 1. Product FDD + Overview analytics = **DataFusion SQL** on GHCR. Never silent pandas fallback in central.
 2. Pandas oracle stays forever on **PyPI** + cookbooks + vibe19 — never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
@@ -104,7 +104,7 @@ retest. Do not confuse those with this engineering OS.
 57. **MQTT dual OAT:** Live fieldbus Open-Meteo must publish into historian as concurrent BAS `oa_t` + web `web_oa_t` (catalog dual-publish on railway loopback). Empty `bas-vs-web-oat` on bldg2 while `/weather` is live is a **P0 MEGA**, not DEFERRED demo fluff.
 58. **Wave I stress:** Mid-wave = smoke only. **ONE** `run_railway_hub_stress.sh` at master I7 after enhanced gates (I6). No duplicate full stresses between children unless a mega cannot be proven without a new tip pin.
 
-**Current ops pin (2026-09-08):** VERSION **3.3.40** · tip **`sha-d1312b0`** · health **`3.3.40+d1312b0ccb07`** · Wave I **CLOSED**. Next optional: #782 MQTT monitor SSE. Low-RAM always (rule 0).
+**Current ops pin (2026-09-08):** VERSION **3.3.40** · tip **`sha-d1312b0`** · health **`3.3.40+d1312b0ccb07`** · Wave I **CLOSED**. **Wave J OPEN** (DF boundary repair/qualify — Stage A next). #782 SSE deferred sequential (not parallel w/ Wave J). Low-RAM always (rule 0).
 
 ---
 

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -113,7 +113,7 @@ required for health, FDD, or Overview analytics.
 ## Ops patch cycle (Railway hub + qualification — 3.3.20+)
 
 Living log: [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md).  
-Active program: Wave I **CLOSED** on `sha-d1312b0` / 3.3.40 (agent rules **55–58** remain law). Next optional: #782 MQTT monitor SSE (`mqtt_monitor_sse_782`).  
+Active program: Wave I **CLOSED** on `sha-d1312b0` / 3.3.40. **Wave J OPEN** — Rust/DataFusion boundary repair + qualification (Stage A first). #782 SSE = sequential optional; not parallel with Wave J product/CI.  
 Stress handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · entry [`scripts/qualification/README.md`](../scripts/qualification/README.md).
 
 | Step | Action |

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -113,7 +113,7 @@ required for health, FDD, or Overview analytics.
 ## Ops patch cycle (Railway hub + qualification — 3.3.20+)
 
 Living log: [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md).  
-Active program: Wave I app-test MEGAs / basic functionality — Cursor `wave_i_app_test_mega_master` (agent rules **55–58**; **ONE full stress at I7**).  
+Active program: Wave I **CLOSED** on `sha-d1312b0` / 3.3.40 (agent rules **55–58** remain law). Next optional: #782 MQTT monitor SSE (`mqtt_monitor_sse_782`).  
 Stress handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · entry [`scripts/qualification/README.md`](../scripts/qualification/README.md).
 
 | Step | Action |

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -113,7 +113,7 @@ required for health, FDD, or Overview analytics.
 ## Ops patch cycle (Railway hub + qualification — 3.3.20+)
 
 Living log: [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md).  
-Active program: Wave I **CLOSED** on `sha-d1312b0` / 3.3.40. **Wave J OPEN** — Rust/DataFusion boundary repair + qualification (Stage A first). #782 SSE = sequential optional; not parallel with Wave J product/CI.  
+Active program: Wave I **CLOSED** on `sha-d1312b0` / 3.3.40. **Wave J OPEN** — Cursor `wave_j_df_boundary_master` (DF-boundary + #875; #782 = J7 sequential only).  
 Stress handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · entry [`scripts/qualification/README.md`](../scripts/qualification/README.md).
 
 | Step | Action |

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -6,7 +6,8 @@
 - Harness **#873** (`935e71de`): B100 gate requires `AHU_1` + plot span ≥60d (scripts-only; no re-pin).
 - Railway pin `3.3.40+d1312b0ccb07` · backup `20260908T171523Z` · fieldbus `sha-d1312b0`.
 - Stress `reports/nightly-ot-bench_20260908T182149Z/` **fully_qualified=true** (gates 00–09).
-- #782 MQTT monitor SSE remains **deferred** (plan `mqtt_monitor_sse_782`).
+- #782 MQTT monitor SSE remains **deferred** (plan `mqtt_monitor_sse_782`) — **not** parallel with Wave J DF-boundary coding.
+- Next **OPEN** program: Wave J `df-boundary-repair` (Rust/DataFusion boundary + qualification) — Stage A docs/guards first.
 
 ## 2026-09-08 — Wave I implementation started (3.3.40)
 

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,11 @@
 # Session log
 
+## 2026-09-08 — Wave J master planned (DF-boundary + #875)
+
+- Cursor master: `wave_j_df_boundary_master` — J0 land #874 → J1 Stage A → J2 #875 FC3/VAV-2 → J3/J5 CI+image → J4 Stage B → J6 soak → optional J7 #782 → J8 ONE stress.
+- Wave I master **RETIRED**. #782 remains sequential J7 only.
+- Multivendor Stage C deferred after Wave J.
+
 ## 2026-09-08 — Wave I CLOSED (3.3.40 / sha-d1312b0)
 
 - Product **#872** (`d1312b0c`): Lakeside `register_csv`, Overview unfiltered chrome, Data Model JSON export, Inspect span-preserve, MQTT dual OAT catalog, stress gate 09.

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,13 @@
 # Session log
 
+## 2026-09-08 — Wave I CLOSED (3.3.40 / sha-d1312b0)
+
+- Product **#872** (`d1312b0c`): Lakeside `register_csv`, Overview unfiltered chrome, Data Model JSON export, Inspect span-preserve, MQTT dual OAT catalog, stress gate 09.
+- Harness **#873** (`935e71de`): B100 gate requires `AHU_1` + plot span ≥60d (scripts-only; no re-pin).
+- Railway pin `3.3.40+d1312b0ccb07` · backup `20260908T171523Z` · fieldbus `sha-d1312b0`.
+- Stress `reports/nightly-ot-bench_20260908T182149Z/` **fully_qualified=true** (gates 00–09).
+- #782 MQTT monitor SSE remains **deferred** (plan `mqtt_monitor_sse_782`).
+
 ## 2026-09-08 — Wave I implementation started (3.3.40)
 
 - Product: utility `register_csv` (no SQL `read_csv`); Overview devices chrome padded; Weather section always shown; Data Model historian mapping + Export JSON; Inspect/bas-vs-web span-preserving downsample; fieldbus dual OAT catalog; stress gate `20_wave_i_app_test_megas` / required `09_wave_i_app_test_megas`.


### PR DESCRIPTION
## Summary
- BUG_REPORT / SESSION_LOG / agent_spec: Wave I **CLOSED** on tip `sha-d1312b0` / VERSION **3.3.40**.
- Stress evidence: `reports/nightly-ot-bench_20260908T182149Z/` `fully_qualified=true` (gates 00–09).
- #782 MQTT monitor SSE remains deferred.

## Test plan
- [x] I7 stress already PASS (no product change in this PR)
- [ ] Docs CI / Pages


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Wave I is complete in version 3.3.40.
  - CSV register support, improved Overview filtering, Data Model JSON export, preserved Inspect spans, and dual OAT catalog publishing are included.
  - Stress validation and Gate 09 checks are complete, including long-range plotting coverage.
- **Documentation**
  - Operational records and release guidance now reflect the completed Wave I rollout.
  - Wave J is now the active program for Rust/DataFusion boundary repair and qualification.
  - MQTT monitor SSE work remains deferred and will be handled sequentially rather than in parallel with Wave J.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->