### PR TITLE
docs(arch): Wave J Stage A DF-boundary truth inventory

### DIFF
--- a/docs/architecture/PANDAS_USAGE_INVENTORY.md
+++ b/docs/architecture/PANDAS_USAGE_INVENTORY.md
@@ -1,96 +1,19 @@
+# SUPERSEDED — 2026-07-28 pandas UI inventory
+
+**Status:** historical tombstone (Wave J Stage A, 2026-09-08).
+
+This inventory classified `frontend/web/app/*.py` files as React product runtime.
+On tip those paths **do not exist**. The product UI is TypeScript under
+`frontend/web/src/`; FDD/analytics run in central (Rust/DataFusion).
+
+**Current contract:** [compute_boundary_ownership.md](compute_boundary_ownership.md) ·
+[compute_boundary_ownership.yaml](compute_boundary_ownership.yaml) ·
+[datafusion-first.md](datafusion-first.md).
+
+Do **not** recreate deleted Python SPA paths to “satisfy” this table.
+Do **not** treat rows below as live call-graph evidence.
+
 ---
-title: Pandas usage inventory (frontend/web)
-parent: Architecture
-nav_order: 13
----
 
-# Pandas usage inventory (`frontend/web`)
-
-**Audit date:** 2026-07-28 · Milestone A closeout / Milestone B input.
-
-Production FDD execution is **DataFusion SQL** via central (`POST /api/fdd/run`).
-This inventory classifies pandas / `open_fdd.rules` / `analytics` usage in the
-product React SPA so agents do not confuse lab/oracle paths with production.
-
-## Classification legend
-
-| Class | Meaning |
-|-------|---------|
-| `ORACLE_ONLY` | Pandas cookbook / oracle / custom rules — allowed |
-| `DISPLAY_BOUNDARY` | Charts, tables, React display — allowed |
-| `PACKAGE_IO` | CSV/package/WattLab load/save — allowed |
-| `REPORT_RENDERING` | DOCX/xlsx/report builders — allowed |
-| `MIGRATE_TO_DATAFUSION` | Should move toward central DataFusion-first APIs over time |
-| `PROHIBITED_PRODUCTION_FDD` | Must not replace SQL FDD (none identified in UI as production path) |
-
-## Inventory
-
-| File | Purpose | Runtime path | Class | Status | Target |
-|------|---------|--------------|-------|--------|--------|
-|frontend/web/app/agent_api.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/agent_prerun.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/analytics.py|oracle/analytics helpers (lab path); production callers → central `/api/analytics/*`|frontend/web React|MIGRATE_TO_DATAFUSION|temporary_ok|central-analytics-v1 APIs now; DataFusion SQL follow-up per family|
-|frontend/web/app/analytics_baseline.py|oracle/analytics helpers (lab path); production callers → central `/api/analytics/*`|frontend/web React|MIGRATE_TO_DATAFUSION|temporary_ok|central-analytics-v1 APIs now; DataFusion SQL follow-up per family|
-|frontend/web/app/cache.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/app/charts.py|React plots / UI tables|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|approved|keep display; FDD exec via central SQL|
-|frontend/web/app/column_map_json.py|CSV/package/WattLab I/O|frontend/web React (not central FDD)|PACKAGE_IO|approved|keep|
-|frontend/web/app/data_contract.py|CSV/package/WattLab I/O|frontend/web React (not central FDD)|PACKAGE_IO|approved|keep|
-|frontend/web/app/data_loader.py|CSV/package/WattLab I/O|frontend/web React (not central FDD)|PACKAGE_IO|approved|keep|
-|frontend/web/app/data_model_tree.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/app/daytypes.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/app/docx_report.py|report rendering|frontend/web React (not central FDD)|REPORT_RENDERING|approved|open_fdd.reporting where shared|
-|frontend/web/app/load_satisfaction.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/metering.py|oracle/analytics helpers (lab path); production → `/api/analytics/metering`|frontend/web React|MIGRATE_TO_DATAFUSION|temporary_ok|central metering stub live; DF SQL follow-up|
-|frontend/web/app/model_seed.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/app/occupancy.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/open_meteo.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/app/package_io.py|CSV/package/WattLab I/O|frontend/web React (not central FDD)|PACKAGE_IO|approved|keep|
-|frontend/web/app/rcx_plots.py|React plots; production series → `/api/analytics/rcx/*`|frontend/web React|MIGRATE_TO_DATAFUSION|temporary_ok|display stays; compute via central analytics|
-|frontend/web/app/reports.py|report rendering|frontend/web React (not central FDD)|REPORT_RENDERING|approved|open_fdd.reporting where shared|
-|frontend/web/app/role_map.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/role_map_gap.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/rule_card.py|React plots / UI tables|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|approved|keep display; FDD exec via central SQL|
-|frontend/web/app/rule_plot_meta.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/app/rules/__init__.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/base.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/common.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/cookbook_catalog.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/custom_boilerplate.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/custom_registry.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/custom_rules.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/economizer_weather.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/operational_gate.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/pid_hunting.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/runner.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/sensor_rate.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/rules/sensor_rate_profiles.py|pandas oracle / custom rule surface|frontend/web React (not central FDD)|ORACLE_ONLY|approved|keep (oracle)|
-|frontend/web/app/runtime_intervals.py|oracle/analytics helpers; production → `/api/analytics/runtime`|frontend/web React|MIGRATE_TO_DATAFUSION|temporary_ok|central runtime Δt compute live; keep oracle for vibe19 parity|
-|frontend/web/app/source_profile.py|CSV/package/WattLab I/O|frontend/web React (not central FDD)|PACKAGE_IO|approved|keep|
-|frontend/web/app/sql_sources.py|SQL/DataFusion bridge helpers using pandas frames|frontend/web React (not central FDD)|MIGRATE_TO_DATAFUSION|temporary_ok|central DataFusion-first APIs|
-|frontend/web/app/topology_enrich.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/tuning_report.py|report rendering|frontend/web React (not central FDD)|REPORT_RENDERING|approved|open_fdd.reporting where shared|
-|frontend/web/app/ui_rcx_tab.py|React plots; production analytics → `/api/analytics/*`|frontend/web React|MIGRATE_TO_DATAFUSION|temporary_ok|cut over to central envelopes; keep display/Plotly in UI|
-|frontend/web/app/unit_system.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/app/wattlab_dump.py|CSV/package/WattLab I/O|frontend/web React (not central FDD)|PACKAGE_IO|approved|keep|
-|frontend/web/app/weather_psychrometrics.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/app/weather_resolver.py|oracle/analytics helpers (lab path)|frontend/web React (not central FDD)|ORACLE_ONLY|temporary_ok|DataFusion analytics where production; keep oracle for vibe19 parity|
-|frontend/web/scripts/_gen_building100_openfdd_json.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/scripts/csv_parity_check.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/scripts/gen_building_openfdd_maps.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/scripts/gen_openfdd_building_maps.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/scripts/profile_wattlab_export.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web/shared/validate_hvac_data.py|UI/lab pandas usage|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|temporary_ok|review in Milestone B Jobs cutover|
-|frontend/web App.tsx|React plots / UI tables|frontend/web React (not central FDD)|DISPLAY_BOUNDARY|approved|keep display; FDD exec via central SQL|
-
-## Prohibited production FDD
-
-No `frontend/web` module was classified as `PROHIBITED_PRODUCTION_FDD`. The UI
-must continue to call central for production rule execution. Local pandas rule
-runners are **oracle / lab** paths only.
-
-## Related
-
-- [Analytics boundary](analytics-boundary.md)
-- [Milestone C analytics matrix](../migration/MILESTONE_C_ANALYTICS_MATRIX.md)
-- [Milestone A closeout](../migration/MILESTONE_A_CLOSEOUT.md)
-- [openfdd_agent_spec ARCHITECTURE](../../openfdd_agent_spec/ARCHITECTURE.md)
+(Original table body intentionally omitted from the active doc surface — see git
+history at commit predating Wave J Stage A if you need the 2026-07-28 listing.)

--- a/docs/architecture/analytics-boundary.md
+++ b/docs/architecture/analytics-boundary.md
@@ -6,27 +6,40 @@ nav_order: 12
 
 # Analytics boundary
 
-**Status:** target contract (PR2+). Do not scatter ad-hoc SQL through React.
+**Status:** **active product contract** (Wave J Stage A, 2026-09-08).
 
 ## Boundary
 
 ```text
-React asks → typed service call → DataFusion SQL / views → Arrow → thin UI frame
+React SPA → typed /api/analytics/* → central Rust → DataFusion SQL and/or
+central-analytics-v1 inline Rust → Arrow/JSON → UI render only
 ```
 
-## Domains (planned)
+Do not scatter ad-hoc SQL through React. Do not reintroduce `frontend/web/app/*.py`
+(removed; historical inventory only).
+
+## Domains
 
 runtime · sensor_health · weather · economizer · comfort · airside · hydronic ·
 mechanical_cooling · metering · schedules · equipment · rcx · wattlab_exports
 
-Each domain: typed inputs, params, SQL, Arrow schema, null/unit rules, tests.
+Each domain: typed inputs, params, SQL or documented Rust path, null/unit rules, tests.
+
+## Engine labels (honest)
+
+| Label | Meaning |
+|-------|---------|
+| `datafusion` | Historian / package Parquet via DataFusion SQL |
+| `central-analytics-v1` | Deterministic Rust compute on registered samples (not “secret pandas”) |
+
+An engine label alone is not qualification — dispatch path + plan/fixture evidence required (Wave J J5/J6).
 
 ## Today
 
-- FDD: `crates/fdd_sql` + `fdd_rules` (production)
-- Analytics APIs: `services/central/src/analytics/` + `POST /api/analytics/{runtime,sensor-health,schedule,mechanical-cooling,economizer,rcx/ahu,rcx/vav,metering}`
-  - Engine: `central-analytics-v1` (pure Rust; DataFusion SQL wiring next — see [MILESTONE_C_ANALYTICS_MATRIX](../migration/MILESTONE_C_ANALYTICS_MATRIX.md))
-  - Runtime + economizer: live compute from inline samples/series; other families schema stubs
-- RCx / Overview UI: still largely pandas via `frontend/web/app/analytics.py` + `rcx_plots.py` — migrate per matrix
+- FDD: `sql_rules/` + `crates/fdd_rules` (production)
+- Analytics: `services/central/src/analytics/` + `POST /api/analytics/*`
+- SPA: `frontend/web/src/` (Overview tables, RCx/Inspect Plotly) — **no** local pandas FDD
 
 No arbitrary operator SQL editor. Integrator SQL lab (if any) is separate and gated.
+
+SoT: [`openfdd_agent_spec/ARCHITECTURE.md`](../../openfdd_agent_spec/ARCHITECTURE.md) · [compute_boundary_ownership.yaml](compute_boundary_ownership.yaml).

--- a/docs/architecture/compute_boundary_ownership.md
+++ b/docs/architecture/compute_boundary_ownership.md
@@ -1,0 +1,30 @@
+---
+title: Compute boundary ownership inventory
+parent: Architecture
+nav_order: 13
+---
+
+# Compute boundary ownership inventory
+
+**Audit:** 2026-09-08 · tip `e3c7660b` · Wave J Stage A  
+**Machine-readable:** [compute_boundary_ownership.yaml](compute_boundary_ownership.yaml)
+
+## Supersedes
+
+[`PANDAS_USAGE_INVENTORY.md`](PANDAS_USAGE_INVENTORY.md) (2026-07-28) listed dozens of
+`frontend/web/app/*.py` paths as React runtime. **Those paths do not exist on tip**
+and must **not** be recreated. That file is retained only as a historical tombstone.
+
+## Policy summary
+
+| Category | Policy |
+|----------|--------|
+| Product Rust / SQL / Parquet | Required runtime |
+| Product React SPA | Required presentation |
+| PyPI pandas oracle / cookbook | External only |
+| Offline WattLab / ECM tools | External only |
+| Test / soak harnesses (may use Python drivers) | Allowed non-product |
+| Deleted `frontend/web/app/` | Do not recreate |
+
+Product must run with **no** Python interpreter in central/web/mqtt/fieldbus images
+and no `OPENFDD_ALLOW_PANDAS_FDD` (Wave J J5 image gates).

--- a/docs/architecture/compute_boundary_ownership.yaml
+++ b/docs/architecture/compute_boundary_ownership.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+audit:
+  date: "2026-09-08"
+  commit: "e3c7660b"
+  program: wave_j_stage_a
+categories:
+  - id: product_runtime_rust
+    policy: required
+    paths:
+      - services/central/
+      - services/fieldbus/
+      - services/mqtt/
+      - crates/
+      - sql_rules/
+      - edge/
+  - id: product_ui_react
+    policy: required
+    paths:
+      - frontend/web/src/
+      - frontend/web/Dockerfile
+  - id: pypi_oracle_pandas
+    policy: external_only
+    paths:
+      - open_fdd/rules/
+      - open_fdd/analytics/
+      - docs/rules/cookbook/pandas-cookbook.md
+  - id: offline_tools
+    policy: external_only
+    paths:
+      - tools/wattlab_export/
+      - tools/open-fdd-vibe21-production/
+  - id: test_harness
+    policy: allowed_non_product
+    paths:
+      - scripts/
+      - crates/fdd_rules/
+      - frontend/web/e2e/
+  - id: historical_removed
+    policy: do_not_recreate
+    paths:
+      - frontend/web/app/
+entries:
+  - path: services/central/
+    class: product_runtime_rust
+    evidence: "Dockerfile Rust-only; no OPENFDD_ALLOW_PANDAS_FDD in product code (2026-09-08 sample)"
+  - path: frontend/web/src/
+    class: product_ui_react
+    evidence: "Vite/React SPA; no frontend/web/app/ on tip"
+  - path: frontend/web/app/
+    class: historical_removed
+    evidence: "path missing on tip e3c7660b; prior inventory retired"
+  - path: open_fdd/rules/
+    class: pypi_oracle_pandas
+    evidence: "PyPI oracle / cookbook; not loaded by openfdd-central image"

--- a/docs/architecture/compute_capability_matrix.md
+++ b/docs/architecture/compute_capability_matrix.md
@@ -1,0 +1,13 @@
+# Capability matrix stub — Wave J Stage A (2026-09-08)
+
+Machine-readable companion: evidence for J4/J6. Not a pass/fail gate by itself.
+
+| Surface | Entry | Engine | Provenance note |
+|---------|-------|--------|-----------------|
+| FDD Run Rules | `POST /api/fdd/run` | `datafusion` | `sql_rules/` + `crates/fdd_rules` |
+| Overview / RCx analytics | `POST /api/analytics/*` | `datafusion` and/or `central-analytics-v1` | `services/central/src/analytics/` — label alone ≠ soak pass |
+| Export / packages | central export APIs | Rust I/O | No Python in product path |
+| React SPA | `frontend/web/src/` | n/a (render) | No local FDD recompute |
+| PyPI cookbook | `open_fdd.rules` | pandas | External oracle only |
+
+**J4 triage (tip sample):** no product Python in central/web images found in Stage A inventory → prefer waive with evidence unless J5 image smoke finds otherwise.

--- a/docs/architecture/datafusion-first.md
+++ b/docs/architecture/datafusion-first.md
@@ -6,37 +6,41 @@ nav_order: 10
 
 # DataFusion-first policy
 
-**Status:** target contract (audit 2026-07-25). Implementation deepens in migration PR2+.
+**Status:** **active product contract** (Wave J Stage A, 2026-09-08). Supersedes the 2026-07-25 “target / PR2+” wording below where they conflict.
 
-For tabular building telemetry computation:
+For tabular building telemetry computation in the **product**:
 
-> If the operation can reasonably be expressed as DataFusion SQL, it belongs in DataFusion SQL.
+> If the operation can reasonably be expressed as DataFusion SQL, it belongs in DataFusion SQL in central.
 
-Pandas may remain as:
+## Product (required)
+
+| Layer | Owns |
+|-------|------|
+| Central + `sql_rules/` + DataFusion | FDD, Overview/RCx analytics, exports of computed values |
+| React SPA (`frontend/web`) | Rendering, interaction, presentation-only formatting — **no** engineering recomputation |
+| Mosquitto + fieldbus | Transport / edge ingest |
+
+**Forbidden in product** (any request path, job, export, sidecar, or opt-in flag):
+
+- Python / pandas / Pyodide / WASM Python / subprocess bridges for FDD or analytics
+- Silent pandas FDD fallback when DataFusion fails
+- `OPENFDD_ALLOW_PANDAS_FDD` (retired — must not reappear in product)
+- Millions of raw rows into the browser for client-side downsample before fault math
+- A second React app for WattLab/EnergyPlus (keep Export handoff in the united UI)
+
+## External tooling (allowed outside the product)
 
 | Class | When |
 |-------|------|
-| UI boundary | Tiny final frame for React SPA/Plotly **after** DF aggregation |
-| Test oracle | Independent reference vs SQL (online Pandas cookbook + vibe19 playground) |
-| Non-SQL | ZIP/IO, IDF, DOCX, config parse, Plotly figure build |
-| In-tree catalog | `frontend/web/app/rules/` — **do not delete**; emergency FDD only with `OPENFDD_ALLOW_PANDAS_FDD=1` |
+| PyPI oracle | Independent `open_fdd.rules` / cookbook parity vs SQL |
+| Offline helpers | WattLab/ECM tools consuming authenticated exports like any client |
+| Test harnesses | Python drivers against a Python-free SUT |
 
-## Forbidden
-
-- Silent pandas FDD fallback when DataFusion fails
-- Millions of raw rows into React for Python downsample
-- Downsampling before fault math
-- Vibe-coding away the pandas cookbook because SQL exists
-- A second React app for WattLab/EnergyPlus (keep Export handoff in the united UI)
+Do **not** delete the pandas cookbook because production uses SQL. Do **not** recreate deleted `frontend/web/app/*.py` paths.
 
 ## Production FDD today
 
 Canonical path: `sql_rules/` + `crates/fdd_rules` + `POST /api/fdd/run`.  
-Pandas cookbook only with explicit `OPENFDD_ALLOW_PANDAS_FDD=1`.
+UI: **one** React SPA (`frontend/web` → `openfdd-web`).
 
-UI: **one** React app (`frontend/web`) for vibe19 + WattLab export as the
-**default** product surface. Phase 1 authorizes a React SPA behind a flag
-([ADR-001](adr-001-react-rust-modernization.md)); React remains fallback
-until Phase 2. Deterministic FDD stays DataFusion SQL either way.
-
-See [VIBE19_VIBE20_OPENFDD_AUDIT.md](../migration/VIBE19_VIBE20_OPENFDD_AUDIT.md) · [Rule Cookbook](../rules/cookbook/) · [React/Rust modernization](../migration/react-rust/).
+See SoT: [`openfdd_agent_spec/ARCHITECTURE.md`](../../openfdd_agent_spec/ARCHITECTURE.md) · [ownership inventory](compute_boundary_ownership.yaml) · [Rule Cookbook](../rules/cookbook/).

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -16,8 +16,9 @@ Open-FDD is a **container stack** (central / React SPA / fieldbus / mqtt / mcp) 
 | [Services](services.html) | Stack images and compose roles |
 | [Data flow](data-flow.html) | Drivers → model → historian → FDD → UI |
 | [Storage & DataFusion](storage-and-datafusion.html) | Feather historian and SQL rules |
-| [DataFusion-first](datafusion-first.html) | Pandas policy and production SQL rule |
+| [DataFusion-first](datafusion-first.html) | Product DF SQL contract (no product pandas FDD) |
 | [Job workspaces](job-workspaces.html) | Persistent analysis Jobs under `workspace/jobs/` |
 | [Analytics boundary](analytics-boundary.html) | Typed DF analytics vs React |
+| [Compute boundary ownership](compute_boundary_ownership.html) | Product vs PyPI/oracle vs historical paths |
 
 Modernization ledgers: [React / Rust migration](../migration/react-rust/).

--- a/docs/architecture/job-workspaces.md
+++ b/docs/architecture/job-workspaces.md
@@ -52,10 +52,10 @@ Telemetry stays in Feather / parquet (site historian). Jobs hold **pointers**, c
 
 | Piece | Path |
 |-------|------|
-| Store (thin client; central SoT when up) | [`frontend/web/app/job_store.py`](../../frontend/web/app/job_store.py) |
+| SPA API client | [`frontend/web/src/api/jobsApi.ts`](../../frontend/web/src/api/jobsApi.ts) |
 | Central API | [`services/central/src/jobs.rs`](../../services/central/src/jobs.rs) |
-| React entry | [`frontend/web/app/ui_jobs.py`](../../frontend/web/app/ui_jobs.py) |
-| Tests | `frontend/web/app/test_job_store.py` |
+| React entry | [`frontend/web/src/pages/JobsPage.tsx`](../../frontend/web/src/pages/JobsPage.tsx) |
+| Historical note | Deleted `frontend/web/app/job_store.py` / `ui_jobs.py` — do not recreate ([ownership](compute_boundary_ownership.md)) |
 
 ## `job.json` (schema_version 1)
 
@@ -102,8 +102,8 @@ Duplicate copies mapping/config/dataset_refs — **not** runs, findings, or repo
 ## WattLab (job-native SoT)
 
 **Production source of truth** is job-native handoffs under `wattlab/handoffs/*.json`
-(central `POST /api/jobs/{id}/wattlab/handoffs`, React helper
-[`ui_wattlab_job.py`](../../frontend/web/app/ui_wattlab_job.py)). Zip dumps from Export
+(central `POST /api/jobs/{id}/wattlab/handoffs`, React
+[`WattLabPage.tsx`](../../frontend/web/src/pages/WattLabPage.tsx)). Zip dumps from Export
 remain **additive** for offline / vibe20 / backup — they do not replace the job
 manifest. External EnergyPlus run metadata (when queued) lands under
 `wattlab/runs/*.json`; central tracks status/artifacts only.
@@ -115,4 +115,5 @@ Metadata writes use temp file + fsync + rename.
 ## Related
 
 - [Milestone A closeout](../migration/MILESTONE_A_CLOSEOUT.md)
-- Pandas inventory (UI lab vs production SQL): [PANDAS_USAGE_INVENTORY.md](PANDAS_USAGE_INVENTORY.md)
+- Compute boundary ownership: [compute_boundary_ownership.md](compute_boundary_ownership.md)
+- Historical pandas inventory tombstone: [PANDAS_USAGE_INVENTORY.md](PANDAS_USAGE_INVENTORY.md)


### PR DESCRIPTION
## Summary
- Rewrite DataFusion-first / analytics-boundary to match product contract (Rust + DF + React; no product pandas FDD).
- Supersede pandas UI inventory with ownership YAML/MD + capability matrix stub for J4/J6.
- Fix Jobs / WattLab architecture links away from deleted `frontend/web/app/*.py`.

## Test plan
- [ ] Docs-only — no VERSION / no GHCR product rebuild required
- [ ] Spot-check architecture index links after Pages build
- [ ] Confirm no product code changes in diff


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated architecture documentation to reflect the current React SPA, central API, and Rust/DataFusion analytics and computation flows.
  - Added compute-boundary ownership and capability references covering product runtimes, external tooling, and test harnesses.
  - Clarified that retired Python application paths and local pandas-based product processing are historical and must not be recreated.
  - Updated job workspace documentation to reflect the central `/api/jobs` source of truth and current React pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->