### PR TITLE
ci: Wave J policy fail fixtures + tip Python-absence + soak provenance

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -67,4 +67,5 @@ jobs:
           python3 -m pip install --user PyYAML
           python3 scripts/validate_capabilities_ledger.py
           python3 scripts/phase2_computation_policy_check.py
+          python3 scripts/phase2_computation_policy_check.py --self-test
           python3 scripts/phase2_shadow_compare.py

--- a/docs/architecture/compute_capability_matrix.md
+++ b/docs/architecture/compute_capability_matrix.md
@@ -11,3 +11,7 @@ Machine-readable companion: evidence for J4/J6. Not a pass/fail gate by itself.
 | PyPI cookbook | `open_fdd.rules` | pandas | External oracle only |
 
 **J4 triage (tip sample):** no product Python in central/web images found in Stage A inventory → prefer waive with evidence unless J5 image smoke finds otherwise.
+
+## J4 Stage B waive (2026-09-08)
+
+Tip inventory (`compute_boundary_ownership.yaml`) found **no** product Python runtime in central/web/mqtt/fieldbus sources or compose. Production analytics callers use `/api/analytics/*` (Rust). **Waive Stage B migration** — no product rewrite. Revisit only if J5 tip-image smoke finds a Python footprint.

--- a/scripts/check_ghcr_tip_python_absence.sh
+++ b/scripts/check_ghcr_tip_python_absence.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Digest-bound tip image Python-absence smoke (Wave J J5).
+# Pulls (or uses local) sha-<7> stack images and fails if a Python interpreter
+# or obvious pandas/pip footprint is present in the *runtime* filesystem.
+#
+# Usage:
+#   ./scripts/check_ghcr_tip_python_absence.sh
+#   ./scripts/check_ghcr_tip_python_absence.sh sha-a40787b
+#   ./scripts/check_ghcr_tip_python_absence.sh sha-a40787b --hub-only
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+HUB_ONLY=0
+TAG=""
+for arg in "$@"; do
+  case "$arg" in
+    --hub-only) HUB_ONLY=1 ;;
+    sha-*) TAG="$arg" ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  if git rev-parse --verify origin/master >/dev/null 2>&1; then
+    TAG="sha-$(git rev-parse --short=7 origin/master)"
+  else
+    TAG="sha-$(git rev-parse --short=7 HEAD)"
+  fi
+fi
+
+SERVICES=(openfdd-central openfdd-web openfdd-mqtt)
+if [[ "$HUB_ONLY" -eq 0 ]]; then
+  SERVICES+=(openfdd-fieldbus)
+fi
+
+REPORT_DIR="${OPENFDD_TIP_PYTHON_REPORT_DIR:-$ROOT/reports/ghcr-tip-python-absence}"
+mkdir -p "$REPORT_DIR"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+REPORT="$REPORT_DIR/${TAG}_${STAMP}.txt"
+
+echo "=== GHCR tip Python-absence: $TAG (hub_only=$HUB_ONLY) ===" | tee "$REPORT"
+
+fail=0
+missing=()
+for svc in "${SERVICES[@]}"; do
+  ref="ghcr.io/bbartling/${svc}:${TAG}"
+  if ! docker image inspect "$ref" >/dev/null 2>&1; then
+    if ! docker pull "$ref" >/dev/null 2>&1; then
+      echo "MISS $ref" | tee -a "$REPORT"
+      missing+=("$svc")
+      fail=1
+      continue
+    fi
+  fi
+  digest="$(docker image inspect "$ref" --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}local{{end}}' 2>/dev/null || echo local)"
+  # Runtime smoke: interpreter on PATH, common python paths, pip, pandas .so names.
+  if docker run --rm --entrypoint sh "$ref" -c '
+    set -e
+    if command -v python >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1 || command -v pip >/dev/null 2>&1 || command -v pip3 >/dev/null 2>&1; then
+      echo "interpreter_or_pip_on_path"
+      exit 11
+    fi
+    for p in /usr/bin/python /usr/bin/python3 /usr/local/bin/python /usr/local/bin/python3 \
+             /opt/conda/bin/python /home/python; do
+      if [ -e "$p" ]; then
+        echo "path_exists:$p"
+        exit 12
+      fi
+    done
+    if ls /usr/lib/python* >/dev/null 2>&1 || ls /usr/local/lib/python* >/dev/null 2>&1; then
+      echo "python_lib_tree"
+      exit 13
+    fi
+    exit 0
+  ' >>"$REPORT" 2>&1; then
+    echo "OK  $ref ($digest)" | tee -a "$REPORT"
+  else
+    echo "FAIL $ref ($digest) — Python footprint detected" | tee -a "$REPORT"
+    fail=1
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "FAIL: incomplete tip $TAG; missing: ${missing[*]}" | tee -a "$REPORT"
+  exit 1
+fi
+if [[ "$fail" -ne 0 ]]; then
+  echo "FAIL: Python footprint on tip $TAG (report $REPORT)" | tee -a "$REPORT"
+  exit 1
+fi
+echo "PASS: tip $TAG has no runtime Python footprint (report $REPORT)" | tee -a "$REPORT"

--- a/scripts/phase2_computation_policy_check.py
+++ b/scripts/phase2_computation_policy_check.py
@@ -1,25 +1,37 @@
 #!/usr/bin/env python3
-"""P2-M1 computation / no-Python product policy gates.
+"""Wave J computation / no-Python product policy gates.
 
-Fails if the React no-Python product path still ships a legacy UI service,
-enables pandas FDD/oracle flags on that compose file, or if central production
-sources spawn/import python/pandas runtimes.
+Fails if product compose files enable retired pandas/oracle flags, or if product
+service sources spawn/import Python/pandas runtimes.
+
+Use ``--self-test`` to assert intentional fail fixtures fail the gate (CI).
+External PyPI / oracle / tools trees are not scanned as product runtime.
 """
 
 from __future__ import annotations
 
+import argparse
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-COMPOSE_REACT = ROOT / "docker" / "compose.react.yml"
-CLOSURE = ROOT / "docs" / "migration" / "react-rust" / "COMPUTATION_CLOSURE.md"
-CENTRAL_SRC = ROOT / "services" / "central" / "src"
+ROOT = Path(os.environ.get("PHASE2_POLICY_ROOT", Path(__file__).resolve().parents[1]))
 
 FORBIDDEN_ENV = (
     "OPENFDD_ALLOW_PANDAS_FDD",
     "OPENFDD_ANALYTICS_ORACLE",
+)
+
+PRODUCT_COMPOSE_REL = (
+    "docker/compose.react.yml",
+    "docker/compose.react.fieldbus.yml",
+    "docker/compose.central.yml",
+    "docker/compose.standalone.yml",
+    "docker/compose.caddy.react.yml",
+    "docker/compose.wattlab.react.yml",
+    "docker/compose.web.local-overview.yml",
 )
 
 FORBIDDEN_COMPOSE_MARKERS = (
@@ -30,12 +42,23 @@ FORBIDDEN_COMPOSE_MARKERS = (
     re.compile(r"import\s+streamlit", re.I),
 )
 
-FORBIDDEN_CENTRAL = (
-    re.compile(r"\bpandas\b", re.I),
-    re.compile(r"""Command::new\(\s*["'](?:python3?|pip3?|streamlit)["']""", re.I),
-    re.compile(r"""["'](?:python3?|pip3?)\s+-[cm]""", re.I),
-    re.compile(r"std::process::Command", re.I),
+PRODUCT_SRC_RELS = (
+    "services/central/src",
+    "services/fieldbus/src",
+    "crates/openfdd_mqtt/src",
+    "edge/src",
 )
+
+# Strict markers never exempt on "not pandas" prose. Broad Command token may.
+FORBIDDEN_PRODUCT_RS = (
+    # Denylist / policy strings may mention pandas; require no policy prose for hit.
+    (re.compile(r"\bpandas\b", re.I), "policy_prose_ok"),
+    (re.compile(r"""Command::new\(\s*["'](?:python3?|pip3?|streamlit)["']""", re.I), "strict"),
+    (re.compile(r"""["'](?:python3?|pip3?)\s+-[cm]""", re.I), "strict"),
+    (re.compile(r"std::process::Command", re.I), "policy_prose_ok"),
+)
+
+CLOSURE_REL = "docs/migration/react-rust/COMPUTATION_CLOSURE.md"
 
 
 def _strip_yaml_comments(text: str) -> str:
@@ -51,68 +74,149 @@ def _strip_yaml_comments(text: str) -> str:
     return "\n".join(lines)
 
 
-def check_compose_react(errors: list[str]) -> None:
-    if not COMPOSE_REACT.is_file():
-        errors.append(f"missing {COMPOSE_REACT.relative_to(ROOT)}")
-        return
-    raw = COMPOSE_REACT.read_text(encoding="utf-8")
-    text = _strip_yaml_comments(raw)
-    if re.search(r"(?m)^  ui:\s*$", text):
-        errors.append("compose.react.yml must not define a legacy `ui` service")
-    for pat in FORBIDDEN_COMPOSE_MARKERS:
-        if pat.search(text):
-            errors.append(
-                f"compose.react.yml must not reference forbidden UI marker {pat.pattern!r}"
-            )
-    for env in FORBIDDEN_ENV:
-        if env in text:
-            errors.append(f"compose.react.yml must not set {env}")
+def check_product_compose(errors: list[str], root: Path = ROOT) -> None:
+    for rel in PRODUCT_COMPOSE_REL:
+        path = root / rel
+        if not path.is_file():
+            continue
+        text = _strip_yaml_comments(path.read_text(encoding="utf-8"))
+        for env in FORBIDDEN_ENV:
+            if env in text:
+                errors.append(f"{rel} must not set {env}")
+        if path.name == "compose.react.yml":
+            if re.search(r"(?m)^  ui:\s*$", text):
+                errors.append("compose.react.yml must not define a legacy `ui` service")
+            for pat in FORBIDDEN_COMPOSE_MARKERS:
+                if pat.search(text):
+                    errors.append(
+                        f"{rel} must not reference forbidden UI marker {pat.pattern!r}"
+                    )
 
 
-def check_closure_ledger(errors: list[str]) -> None:
-    if not CLOSURE.is_file():
-        errors.append(f"missing {CLOSURE.relative_to(ROOT)}")
+def check_closure_ledger(errors: list[str], root: Path = ROOT) -> None:
+    path = root / CLOSURE_REL
+    if not path.is_file():
+        errors.append(f"missing {CLOSURE_REL}")
         return
-    text = CLOSURE.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8")
     for needle in ("CLOSED", "ORACLE", "PROVISIONAL", "sql_screening"):
         if needle not in text:
             errors.append(f"COMPUTATION_CLOSURE.md missing required marker {needle!r}")
 
 
-def check_central_src(errors: list[str]) -> None:
-    if not CENTRAL_SRC.is_dir():
-        errors.append("missing services/central/src")
-        return
-    for path in CENTRAL_SRC.rglob("*.rs"):
-        rel = str(path.relative_to(ROOT)).replace("\\", "/")
-        try:
-            text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError as exc:
-            errors.append(f"unreadable {rel}: {exc}")
+def _policy_prose(line: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(forbid|forbidden|ban|banned|never|not|reject|must not|policy|deny)\b",
+            line,
+            re.I,
+        )
+    )
+
+
+def check_product_rust(errors: list[str], root: Path = ROOT) -> None:
+    for rel_root in PRODUCT_SRC_RELS:
+        src_root = root / rel_root
+        if not src_root.is_dir():
+            # Optional in synthetic self-test trees.
             continue
-        for pat in FORBIDDEN_CENTRAL:
-            for i, line in enumerate(text.splitlines(), 1):
-                stripped = line.strip()
-                if stripped.startswith("//"):
-                    continue
-                if not pat.search(line):
-                    continue
-                if re.search(
-                    r"\b(forbid|forbidden|ban|banned|never|not|reject|must not|policy|deny)\b",
-                    line,
-                    re.I,
-                ):
-                    continue
-                errors.append(
-                    f"{rel}:{i} matches forbidden runtime marker {pat.pattern!r}: {stripped}"
-                )
+        for path in src_root.rglob("*.rs"):
+            rel = str(path.relative_to(root)).replace("\\", "/")
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                errors.append(f"unreadable {rel}: {exc}")
+                continue
+            for pat, mode in FORBIDDEN_PRODUCT_RS:
+                for i, line in enumerate(text.splitlines(), 1):
+                    stripped = line.strip()
+                    if stripped.startswith("//"):
+                        continue
+                    if not pat.search(line):
+                        continue
+                    if mode == "policy_prose_ok" and _policy_prose(line):
+                        continue
+                    errors.append(
+                        f"{rel}:{i} matches forbidden runtime marker {pat.pattern!r}: {stripped}"
+                    )
 
 
-def main() -> int:
+def collect_errors(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
-    check_compose_react(errors)
-    check_closure_ledger(errors)
-    check_central_src(errors)
+    check_product_compose(errors, root)
+    check_closure_ledger(errors, root)
+    check_product_rust(errors, root)
+    return errors
+
+
+def self_test() -> int:
+    """Intentional fail fixtures — each must produce at least one error."""
+    failures: list[str] = []
+
+    # 1) Retired pandas FDD env in product compose.
+    with tempfile.TemporaryDirectory(prefix="phase2-compose-") as tmp:
+        root = Path(tmp)
+        compose = root / "docker" / "compose.react.yml"
+        compose.parent.mkdir(parents=True)
+        compose.write_text(
+            "services:\n  web:\n    environment:\n      OPENFDD_ALLOW_PANDAS_FDD: \"1\"\n",
+            encoding="utf-8",
+        )
+        (root / CLOSURE_REL).parent.mkdir(parents=True)
+        (root / CLOSURE_REL).write_text(
+            "CLOSED ORACLE PROVISIONAL sql_screening\n", encoding="utf-8"
+        )
+        errs = collect_errors(root)
+        if not any("OPENFDD_ALLOW_PANDAS_FDD" in e for e in errs):
+            failures.append("compose pandas env fixture did not fail")
+
+    # 2) Strict python spawn — "not pandas" prose must NOT exempt.
+    with tempfile.TemporaryDirectory(prefix="phase2-py-") as tmp:
+        root = Path(tmp)
+        rs = root / "services" / "central" / "src" / "bad.rs"
+        rs.parent.mkdir(parents=True)
+        rs.write_text(
+            '// not pandas — still forbidden\nlet _ = Command::new("python3");\n',
+            encoding="utf-8",
+        )
+        (root / CLOSURE_REL).parent.mkdir(parents=True)
+        (root / CLOSURE_REL).write_text(
+            "CLOSED ORACLE PROVISIONAL sql_screening\n", encoding="utf-8"
+        )
+        errs = collect_errors(root)
+        if not any("python3" in e for e in errs):
+            failures.append("python Command::new fixture did not fail (strict)")
+
+    # 3) Missing closure markers.
+    with tempfile.TemporaryDirectory(prefix="phase2-closure-") as tmp:
+        root = Path(tmp)
+        (root / CLOSURE_REL).parent.mkdir(parents=True)
+        (root / CLOSURE_REL).write_text("incomplete ledger\n", encoding="utf-8")
+        errs = collect_errors(root)
+        if not any("missing required marker" in e for e in errs):
+            failures.append("incomplete closure fixture did not fail")
+
+    if failures:
+        print("phase2_computation_policy_check --self-test FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("phase2_computation_policy_check --self-test OK")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run intentional fail fixtures (must fail the gate).",
+    )
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return self_test()
+
+    errors = collect_errors(ROOT)
     if errors:
         print("phase2_computation_policy_check FAILED:", file=sys.stderr)
         for err in errors:

--- a/scripts/synthetic_59_overview_analytics_soak.py
+++ b/scripts/synthetic_59_overview_analytics_soak.py
@@ -125,9 +125,13 @@ def assert_runtime(base: str, token: str, building: str, checks: list[dict]) -> 
     engine = str(env.get("engine") or "")
     qv = str(env.get("query_version") or "")
     rows = list(env.get("rows") or env.get("equipment") or [])
+    # Wave J: engine label alone is insufficient — require non-empty query_version
+    # and an honest DF / central-analytics engine (no label-only shortcut).
+    engine_l = engine.lower()
+    honest = ("datafusion" in engine_l) or ("central-analytics" in engine_l)
     check(
         "runtime_envelope",
-        bool(env) and ("datafusion" in engine.lower() or qv.startswith("runtime")),
+        bool(env) and honest and bool(qv),
         f"engine={engine!r} query_version={qv!r} n_rows={len(rows)}",
         checks,
     )
@@ -202,9 +206,12 @@ def assert_mech_cooling(
     engine = str(env.get("engine") or "")
     rows = list(env.get("rows") or env.get("equipment") or [])
     oat_bins = [r for r in rows if str(r.get("kind") or "") == "oat_bin"]
+    # Wave J: OAT-bin presence alone is not provenance — require honest engine.
+    engine_l = engine.lower()
+    honest = ("datafusion" in engine_l) or ("central-analytics" in engine_l)
     check(
         "mech_envelope",
-        bool(env) and ("datafusion" in engine.lower() or len(oat_bins) > 0),
+        bool(env) and honest and len(oat_bins) >= 1,
         f"engine={engine!r} n_oat_bins={len(oat_bins)}",
         checks,
     )


### PR DESCRIPTION
## Summary
- **J3:** Tighten `phase2_computation_policy_check` across product compose files + product Rust trees; strict python spawn (no \"not pandas\" exemption); `--self-test` intentional fail fixtures wired in `security.yml`.
- **J5:** Add `scripts/check_ghcr_tip_python_absence.sh` (digest-bound tip image runtime Python smoke).
- **J6:** Overview analytics soak requires honest DF / central-analytics provenance (no engine-label or OAT-bin-only shortcuts).

Harness/CI only — no VERSION bump.

## Test plan
- [x] `python3 scripts/phase2_computation_policy_check.py`
- [x] `python3 scripts/phase2_computation_policy_check.py --self-test`
- [ ] CI green
- [ ] After tip Publish: `./scripts/check_ghcr_tip_python_absence.sh sha-<tip>`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened analytics soak checks to reject results that do not identify an approved analytics engine or expected supporting data.

* **Chores**
  * Expanded product security policy validation across additional product configurations and Rust services.
  * Added automated self-testing for security policy checks.
  * Added smoke testing to detect unexpected Python runtimes in published container images.

* **Documentation**
  * Updated the capability matrix to record the current Stage B migration waiver and its conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->