### PR TITLE
docs: Wave J CLOSED on sha-c1b1aa5 after fully_qualified stress

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,16 +1,16 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-09-08 (Wave I **CLOSED** — app-test MEGAs / basic functionality)  
+**Date:** 2026-09-09 (Wave J **CLOSED** — DF-boundary + cookbook parity)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
-**Tip / pin (3.3.40):** `d1312b0c` · VERSION **3.3.40** · health **`3.3.40+d1312b0ccb07`** · GHCR **central/web/mqtt/fieldbus `sha-d1312b0`**  
-**Last CLOSED tip:** `d1312b0c` · **`sha-d1312b0`** · **`3.3.40+d1312b0ccb07`** · product **#872** · stress gate fix **#873**  
+**Tip / pin (3.3.41):** `c1b1aa52` · VERSION **3.3.41** · health **`3.3.41+c1b1aa52806b`** · GHCR **central/web/mqtt/fieldbus `sha-c1b1aa5`**  
+**Last CLOSED tip:** `c1b1aa52` · **`sha-c1b1aa5`** · **`3.3.41+c1b1aa52806b`** · product **#877** · CI/gates **#878** · docs Stage A **#876**  
 **Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Dual-publish AV `9101`: `bldg2-zone-loopback` **`zone_t`+`oa_t`**, `hosted-weather` **`web_oa_t`**.  
-**Backup:** `~/openfdd-backups/railway/20260908T171523Z/` (prior: `20260908T0157*`)  
-**Program (CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · agent_spec rules **55–58**  
-**Program (prior CLOSED):** Wave H — Cursor [`post_waveg_openfdd_residual_wave_h`](../../../.cursor/plans/post_waveg_openfdd_residual_wave_h.plan.md)  
-**Stress (Wave I closeout):** `reports/nightly-ot-bench_20260908T182149Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + Wave I MEGAs)  
-**Deferred sequential (Wave J J7):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md)  
-**Program (ACTIVE):** Wave J — Cursor [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) (DF-boundary + [#875](https://github.com/bbartling/open-fdd/issues/875) cookbook parity)  
+**Backup:** `~/openfdd-backups/railway/20260909T002816Z/` (prior Wave I: `20260908T171523Z/`)  
+**Program (CLOSED):** Wave J — Cursor [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) · ownership inventory + #875 FC3/VAV-2 + policy/image Python-absence + soak provenance  
+**Program (prior CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / 3.3.40  
+**Stress (Wave J closeout):** `reports/nightly-ot-bench_20260909T010712Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + MCP + Wave I MEGAs)  
+**Deferred (not Wave J):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (commented deferred on issue)  
+**Next:** Multivendor Stage C **deferred** (identity/MFA/tenant) — after Wave J; anomaly **PARKED**  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -25,9 +25,9 @@
 | **weather-local-vs-web-bldg2** | **CLOSED** (3.3.40 / Wave I) | Was: bldg2 bas-vs-web empty | #872 dual OAT catalog; gate09 `bas_vs_web` points>0 | — |
 | **mqtt-bldg2-plot-surface** | **CLOSED** (3.3.40 / Wave I) | Was: MQTT plots empty/wrong roles | Inspect `zone_t` non_null=696; dual OAT live | — |
 | **wave-i-stress-gates** | **CLOSED** (3.3.40 / Wave I) | Was: stress green while basics broken | Gate `09_wave_i_app_test_megas` required; #873 AHU_1 fix | — |
-| **mqtt-monitor-sse-782** | **DEFERRED** (Wave J **J7**) | Ops MQTT Test Client is 1s poll; no browser→Mosquitto WS | [#782](https://github.com/bbartling/open-fdd/issues/782); Central `GET /api/mqtt/monitor` already works | [`mqtt_monitor_sse_782`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) — sequential after J1/J6; **not** parallel w/ DF coding |
-| **df-boundary-repair** | **OPEN (MEGA)** Wave J | Stale pandas/UI docs + incomplete Python-absence / DF provenance qualification | 2026-09-08 source review; Dockerfiles Python-free; contradictory architecture docs | Master [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) |
-| **cookbook-parity-875** | **OPEN** Wave J **J2** | SQL↔pandas drift: FC3 tol/fan priority; VAV-2 fractional occupancy | [#875](https://github.com/bbartling/open-fdd/issues/875) Trenyx @ c20ab48 | [`wave_j_cookbook_parity_875`](../../../.cursor/plans/wave_j_cookbook_parity_875.plan.md) |
+| **mqtt-monitor-sse-782** | **DEFERRED** (post–Wave J) | Ops MQTT Test Client is 1s poll; no browser→Mosquitto WS | [#782](https://github.com/bbartling/open-fdd/issues/782); Central `GET /api/mqtt/monitor` already works | [`mqtt_monitor_sse_782`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) — **not** claimed done by Wave J |
+| **df-boundary-repair** | **CLOSED** (Wave J / 3.3.41) | Was: stale pandas/UI docs + incomplete Python-absence / DF provenance | #876 Stage A · #878 policy+image+soak · tip Python-absence PASS | — |
+| **cookbook-parity-875** | **CLOSED** (3.3.41 / #877) | Was: FC3 tol/fan priority; VAV-2 fractional occupancy | #877 · #875 closed · oracle_parity FC3/VAV-2 | — |
 | **mqtt-ingest-stall** | **CLOSED** (3.3.34) | Was: flat `ingest_ok` after mqtt bounce until central redeploy | #860 · tip `sha-9aebf42` · smoke `reports/waveD_railway_smoke_20260906T173032Z/` | — |
 | **railway-ui-fdd-stale** | **CLOSED** (Wave E) | Was: building filter / scoped FDD UX across sites | Tip `sha-9aebf42`: Overview clears on site change; PlantHealthSections empty shells; equipment=8 / zone-other rows=7 | No VERSION — UX already on tip |
 | **bldg2-overview-signoff** | **CLOSED** (Wave H) | Was: SPA charts weak; buyer mash Run/Update | #868/#869 · Inspect/RCx points>0; Overview auto-load | — |
@@ -71,6 +71,18 @@
 | Stress | `reports/nightly-ot-bench_20260908T182149Z/` **`fully_qualified=true`** (00–09) |
 | Deferred | #782 MQTT monitor SSE — **do not** combine with DF-boundary mega |
 
+### Wave J closeout (2026-09-09T01:10Z)
+
+| Check | Result |
+|-------|--------|
+| Hub | `3.3.41+c1b1aa52806b` · central/mqtt/web **Online** · `sha-c1b1aa5` |
+| Tip gate | `./scripts/check_ghcr_tip_stack.sh sha-c1b1aa5` **PASS** · GHCR tip completeness Actions **PASS** |
+| Python-absence | `./scripts/check_ghcr_tip_python_absence.sh sha-c1b1aa5` **PASS** (central/web/mqtt/fieldbus) |
+| Backup / pin | `~/openfdd-backups/railway/20260909T002816Z/` · hub + fieldbus `sha-c1b1aa5` |
+| Landed | #876 Stage A docs · #877 FC3/VAV-2 (3.3.41) · #878 policy+image+soak · J4 waive · #782 deferred |
+| Stress | `reports/nightly-ot-bench_20260909T010712Z/` **`fully_qualified=true`** (00–09) |
+| Note | First stress attempt failed gate 08 when sticky `.env` `OPENFDD_IMAGE_TAG` clobbered MCP pin — fixed in `load_bench_env` |
+
 ### Wave H kickoff probe (2026-09-07T20:35Z)
 
 | Check | Result |
@@ -101,21 +113,15 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** Wave J master [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) — J0 land #874 → J1 Stage A docs → J2 [#875](https://github.com/bbartling/open-fdd/issues/875) → J3/J5 CI+image gates → J4 Stage B gaps → J6 soak → optional J7 [#782](https://github.com/bbartling/open-fdd/issues/782) → **J8 ONE full stress**. Low-RAM one agent; #782 never parallel with J1–J6 coding.  
-**Last closed:** Wave I (RETIRED plan [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md)) · tip `sha-d1312b0` / **#872** · gate fix **#873** · stress `20260908T182149Z`. Anomaly **PARKED**. Multivendor Stage C **deferred after Wave J**.
+**Active:** none (Wave J **CLOSED**). Next: Multivendor Stage C (deferred) or #782 SSE when scheduled.  
+**Last closed:** Wave J (RETIRED plan [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md)) · tip `sha-c1b1aa5` / **3.3.41** · stress `20260909T010712Z`. Anomaly **PARKED**. #782 **DEFERRED**.
 
-**This round stress rule:** mid-wave = smoke only. **ONE full** `run_railway_hub_stress.sh` at **Wave J J8** (keep gate 09; add DF gates when ready; **no `SKIP_ZAP`**).
+**This round stress rule:** mid-wave = smoke only. Full `run_railway_hub_stress.sh` only at program closeout (**no `SKIP_ZAP`**).
 
 | Rev / wave | In-repo / Cursor plan | Concern | Status |
 |------------|----------------------|---------|--------|
-| **Wave J master** | [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) | DF-boundary + #875 + optional #782 | **OPEN** |
-| **Wave J / J0** | [`wave_j0_land_wave_i_closeout_docs`](../../../.cursor/plans/wave_j0_land_wave_i_closeout_docs.plan.md) | Land #874 | **OPEN** |
-| **Wave J / J1** | [`wave_j_a_truth_docs_guards`](../../../.cursor/plans/wave_j_a_truth_docs_guards.plan.md) | Stage A truth/docs | **OPEN** |
-| **Wave J / J2** | [`wave_j_cookbook_parity_875`](../../../.cursor/plans/wave_j_cookbook_parity_875.plan.md) | #875 FC3 + VAV-2 parity | **OPEN** |
-| **Wave J / J3+J5** | [`wave_j_ci_image_gates`](../../../.cursor/plans/wave_j_ci_image_gates.plan.md) | Policy CI + image Python-absence | **OPEN** |
-| **Wave J / J4** | [`wave_j_b_close_python_gaps`](../../../.cursor/plans/wave_j_b_close_python_gaps.plan.md) | Stage B close gaps | **OPEN** |
-| **Wave J / J6** | [`wave_j_numerical_soak_harden`](../../../.cursor/plans/wave_j_numerical_soak_harden.plan.md) | Soak provenance | **OPEN** |
-| **Wave J / J7** | [`mqtt_monitor_sse_782`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) | #782 Central SSE | **DEFERRED** sequential |
+| **Wave J master** | [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) | DF-boundary + #875 + optional #782 | **RETIRED / CLOSED** |
+| **Wave J / J0–J8** | children under `.cursor/plans/wave_j_*` | docs → #875 → CI/image → soak → stress | **CLOSED** (J7 #782 deferred) |
 | **Wave I master** | [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs | **RETIRED / CLOSED** |
 | **Wave H** | Cursor post_waveg residual H | Demo charts / UI freshness | **CLOSED** |
 | **Wave G / 3.3.37–3.3.40** | [`openfdd_lab_tuner_parity_program.plan.md`](patch_trains/openfdd_lab_tuner_parity_program.plan.md) | Lab tuner Vibe19 parity | **CLOSED** — #864 · tip `sha-a40787b` |

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -43,7 +43,7 @@ retest. Do not confuse those with this engineering OS.
 
 ## AI agent quick rules (read first)
 
-0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave I CLOSED** on tip **`sha-d1312b0`** / **3.3.40**. **Wave J OPEN** (DF boundary). #782 SSE sequential only — never parallel with Wave J coding. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
+0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave J CLOSED** on tip **`sha-c1b1aa5`** / **3.3.41**. #782 SSE remains deferred — schedule separately. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
 1. Product FDD + Overview analytics = **DataFusion SQL** on GHCR. Never silent pandas fallback in central.
 2. Pandas oracle stays forever on **PyPI** + cookbooks + vibe19 — never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
@@ -104,7 +104,7 @@ retest. Do not confuse those with this engineering OS.
 57. **MQTT dual OAT:** Live fieldbus Open-Meteo must publish into historian as concurrent BAS `oa_t` + web `web_oa_t` (catalog dual-publish on railway loopback). Empty `bas-vs-web-oat` on bldg2 while `/weather` is live is a **P0 MEGA**, not DEFERRED demo fluff.
 58. **Wave I stress:** Mid-wave = smoke only. **ONE** `run_railway_hub_stress.sh` at master I7 after enhanced gates (I6). No duplicate full stresses between children unless a mega cannot be proven without a new tip pin.
 
-**Current ops pin (2026-09-08):** VERSION **3.3.40** · tip **`sha-d1312b0`** · health **`3.3.40+d1312b0ccb07`** · Wave I **CLOSED**. **Wave J OPEN** — master [`wave_j_df_boundary_master`](../../.cursor/plans/wave_j_df_boundary_master.plan.md) (DF-boundary + #875; #782=J7 sequential). #782 SSE deferred sequential (not parallel w/ Wave J). Low-RAM always (rule 0).
+**Current ops pin (2026-09-09):** VERSION **3.3.41** · tip **`sha-c1b1aa5`** · health **`3.3.41+c1b1aa52806b`** · Wave J **CLOSED**. #782 SSE deferred. Multivendor Stage C deferred. Low-RAM always (rule 0).
 
 ---
 

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -113,7 +113,7 @@ required for health, FDD, or Overview analytics.
 ## Ops patch cycle (Railway hub + qualification — 3.3.20+)
 
 Living log: [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md).  
-Active program: Wave I **CLOSED** on `sha-d1312b0` / 3.3.40. **Wave J OPEN** — Cursor `wave_j_df_boundary_master` (DF-boundary + #875; #782 = J7 sequential only).  
+Active program: Wave J **CLOSED** on `sha-c1b1aa5` / 3.3.41. #782 SSE deferred. Multivendor Stage C deferred.
 Stress handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · entry [`scripts/qualification/README.md`](../scripts/qualification/README.md).
 
 | Step | Action |

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,15 @@
 # Session log
 
+## 2026-09-09 — Wave J CLOSED (3.3.41 / sha-c1b1aa5)
+
+- Stage A docs **#876**; FC3/VAV-2 cookbook parity **#877** (3.3.41); policy+tip Python-absence+soak **#878**; J4 Stage B **waived** (no product Python).
+- #875 closed; #782 **deferred** (issue comment) — not claimed done by Wave J.
+- Railway backup `20260909T002816Z` · hub+fieldbus pin `sha-c1b1aa5` · health `3.3.41+c1b1aa52806b`.
+- Tip Python-absence PASS; GHCR tip completeness Actions PASS.
+- Stress `reports/nightly-ot-bench_20260909T010712Z/` **fully_qualified=true** (gates 00–09).
+- Harness: `load_bench_env` preserves `OPENFDD_IMAGE_TAG` / `OPENFDD_MCP_IMAGE` under `RAILWAY_ONLY=1` (sticky `.env` no longer clobbers tip MCP).
+- Wave J master **RETIRED**. Next: Multivendor Stage C (deferred) or #782 when scheduled.
+
 ## 2026-09-08 — Wave J master planned (DF-boundary + #875)
 
 - Cursor master: `wave_j_df_boundary_master` — J0 land #874 → J1 Stage A → J2 #875 FC3/VAV-2 → J3/J5 CI+image → J4 Stage B → J6 soak → optional J7 #782 → J8 ONE stress.

--- a/scripts/nightly-ot-bench/lib.sh
+++ b/scripts/nightly-ot-bench/lib.sh
@@ -14,6 +14,9 @@ load_bench_env() {
   local saved_api="${OPENFDD_API_BASE:-}"
   local saved_base="${BASE:-}"
   local saved_central="${CENTRAL_BASE:-}"
+  # Railway field stress: sticky local .env must not clobber tip pin / MCP image.
+  local saved_image_tag="${OPENFDD_IMAGE_TAG:-}"
+  local saved_mcp_image="${OPENFDD_MCP_IMAGE:-}"
   if [[ -f "$ROOT/.env" ]]; then
     # shellcheck disable=SC1091
     set -a && source "$ROOT/.env" && set +a
@@ -34,6 +37,7 @@ load_bench_env() {
     [[ -n "$saved_api" ]] && export OPENFDD_API_BASE="$saved_api"
     [[ -n "$saved_base" ]] && export BASE="$saved_base"
     [[ -n "$saved_central" ]] && CENTRAL_BASE="$saved_central"
+    [[ -n "$saved_image_tag" ]] && export OPENFDD_IMAGE_TAG="$saved_image_tag"
   fi
 
   FIELDBUS_BASE="${FIELDBUS_BASE:-http://127.0.0.1:8081}"
@@ -51,6 +55,10 @@ load_bench_env() {
   # shellcheck source=scripts/openfdd_stack_lib.sh
   source "$ROOT/scripts/openfdd_stack_lib.sh"
   openfdd_stack_export_image_env
+  # Restore explicit MCP pin after stack export (which derives from IMAGE_TAG).
+  if [[ "$railway_only" == "1" && -n "$saved_mcp_image" ]]; then
+    export OPENFDD_MCP_IMAGE="$saved_mcp_image"
+  fi
   ensure_bench_field_devices
 }
 


### PR DESCRIPTION
## Summary
- BUG_REPORT / SESSION_LOG / AGENTS / CONTAINER_AGENT: Wave J **CLOSED** on tip `sha-c1b1aa5` / 3.3.41.
- Stress evidence: `reports/nightly-ot-bench_20260909T010712Z/` · `fully_qualified=true` (gates 00–09).
- Harness: `load_bench_env` preserves `OPENFDD_IMAGE_TAG` + `OPENFDD_MCP_IMAGE` under `RAILWAY_ONLY=1` so sticky local `.env` cannot clobber tip MCP (gate 08 false fail).
- #782 remains deferred; Multivendor Stage C still deferred.

## Test plan
- [x] Stress already green on tip (no re-stress for docs)
- [ ] Docs-only CI green
- [ ] After merge: tip Publish may cancel (docs SHA) — ops pin remains `sha-c1b1aa5` until next product rev


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated operations and agent guidance to reflect Wave J closeout for version 3.3.41.
  - Recorded validation results, backups, stress evidence, and completed cookbook-parity and boundary fixes.
  - Documented deferred MQTT monitoring and Multivendor Stage C work.
  - Added a session record summarizing the closeout and verification status.

- **Bug Fixes**
  - Improved benchmark runs so explicitly selected image versions remain in effect when local environment settings are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->