### PR TITLE
docs: open Wave K 3.4.0 pin + Wave L 3.5 shared-DB mega

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -9,8 +9,9 @@
 **Program (CLOSED):** Wave J — Cursor [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) · ownership inventory + #875 FC3/VAV-2 + policy/image Python-absence + soak provenance  
 **Program (prior CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / 3.3.40  
 **Stress (Wave J closeout):** `reports/nightly-ot-bench_20260909T010712Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + MCP + Wave I MEGAs)  
-**Deferred (not Wave J):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (commented deferred on issue)  
-**Next:** Multivendor Stage C **deferred** (identity/MFA/tenant) — after Wave J; anomaly **PARKED**  
+**Deferred (not Wave J):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (optional Wave K K4)  
+**Program (ACTIVE):** Wave K — **3.4.0 filesystem-historian pin** · Cursor [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md) · repo [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md)  
+**Next mega (AFTER 3.4.0 pin):** Wave L — **shared DB 3.5.x** · Cursor [`wave_l_shared_db_mega_master`](../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md) · repo [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md)  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -113,15 +114,16 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** none (Wave J **CLOSED**). Next: Multivendor Stage C (deferred) or #782 SSE when scheduled.  
-**Last closed:** Wave J (RETIRED plan [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md)) · tip `sha-c1b1aa5` / **3.3.41** · stress `20260909T010712Z`. Anomaly **PARKED**. #782 **DEFERRED**.
+**Active:** Wave K master [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md) — pin **3.4.0** filesystem historian + shared-DB ADR; then Wave L **3.5** shared DB ASAP.  
+**Last closed:** Wave J (RETIRED [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md)) · tip `sha-c1b1aa5` / **3.3.41** · stress `20260909T010712Z` · closeout docs **#882**. Anomaly **PARKED**. #782 optional K4. Multivendor Stage C **after** Wave L.
 
-**This round stress rule:** mid-wave = smoke only. Full `run_railway_hub_stress.sh` only at program closeout (**no `SKIP_ZAP`**).
+**This round stress rule:** mid-wave = smoke only. Full `run_railway_hub_stress.sh` at **Wave K K5** (3.4.0 pin) and again at Wave L shippable pins (**no `SKIP_ZAP`**).
 
 | Rev / wave | In-repo / Cursor plan | Concern | Status |
 |------------|----------------------|---------|--------|
-| **Wave J master** | [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) | DF-boundary + #875 + optional #782 | **RETIRED / CLOSED** |
-| **Wave J / J0–J8** | children under `.cursor/plans/wave_j_*` | docs → #875 → CI/image → soak → stress | **CLOSED** (J7 #782 deferred) |
+| **Wave K master** | [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md) | **3.4.0 pin** + historian freeze + shared-DB ADR | **OPEN** |
+| **Wave L master** | [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md) | **3.5.x shared DB** mega | **QUEUED** (after K) |
+| **Wave J master** | [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) | DF-boundary + #875 | **RETIRED / CLOSED** |
 | **Wave I master** | [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs | **RETIRED / CLOSED** |
 | **Wave H** | Cursor post_waveg residual H | Demo charts / UI freshness | **CLOSED** |
 | **Wave G / 3.3.37–3.3.40** | [`openfdd_lab_tuner_parity_program.plan.md`](patch_trains/openfdd_lab_tuner_parity_program.plan.md) | Lab tuner Vibe19 parity | **CLOSED** — #864 · tip `sha-a40787b` |

--- a/docs/operations/patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md
@@ -1,0 +1,95 @@
+---
+name: Wave K 3.4.0 filesystem pin
+overview: "Wave K — pin Open-FDD 3.4.0 as the last qualified filesystem-historian baseline (Feather/Parquet on volume), wrap BUG_REPORT residuals for handoff, land shared-DB ADR + inventory only. ONE full stress. Then Wave L 3.5 shared-DB mega ASAP. Low-RAM one agent."
+todos:
+  - id: k0-hygiene
+    content: K0 — GH hygiene START (0 PRs/branches; tip Actions green; ops pin sha-c1b1aa5 or tip)
+    status: pending
+  - id: k1-version-340
+    content: K1 — VERSION bump 3.3.41 → 3.4.0 + Cargo pins (baseline pin rev)
+    status: pending
+  - id: k2-historian-freeze-docs
+    content: K2 — Freeze historian contract docs (paths, backup/restore, Railway volume, no silent format change)
+    status: pending
+  - id: k3-shared-db-adr-inventory
+    content: K3 — ADR + machine-readable inventory for shared DB (engine options, dual-write, tenancy hooks) — design only
+    status: pending
+  - id: k4-residual-782
+    content: K4 — #782 MQTT SSE — ship small OR explicit PARK with owner (do not block 3.4.0 pin)
+    status: pending
+  - id: k5-stress-340
+    content: K5 — tip Publish → Railway backup+re-pin → ONE run_railway_hub_stress.sh → fully_qualified
+    status: pending
+  - id: k6-bug-report-closed
+    content: K6 — BUG_REPORT Wave K CLOSED / 3.4.0 pin line; handoff to Wave L
+    status: pending
+  - id: deferred-wave-l
+    content: Wave L 3.5 shared-DB mega — AFTER 3.4.0 pin (see wave_l_shared_db_mega_master)
+    status: pending
+isProject: false
+---
+
+# Wave K — 3.4.0 filesystem-historian pin (master)
+
+**Active program** after Wave J **CLOSED** (`sha-c1b1aa5` / 3.3.41 · stress `20260909T010712Z` · `fully_qualified=true`).
+
+**Retired:** [`wave_j_df_boundary_master.plan.md`](wave_j_df_boundary_master.plan.md) — historical only.
+
+**Why 3.4.0 (not another 3.3.x):** Operator wants a **pinned baseline** before the shared-database mega. 3.4.0 = last fully qualified **volume-local Feather/Parquet** product line. 3.5.x = shared DB cutover.
+
+**Law:** Low-RAM one agent. No local stack `docker build`. 0 open PRs / stale branches / failed tip Actions at child start/end. Mid-wave = smoke only. **ONE** full `run_railway_hub_stress.sh` at **K5**.
+
+## Non-goals (this wave)
+
+- Implementing Postgres/shared DB runtime (→ Wave L)
+- Multivendor identity/MFA/tenant isolation Stage C (after shared DB exists)
+- Reopening PARKED `sql-anomaly-screening` or ABANDONED hybrid ML
+- Mass Dependabot merges (hygiene close only)
+
+## Order
+
+```mermaid
+flowchart TD
+  K0[K0 hygiene]
+  K1[K1 VERSION 3.4.0]
+  K2[K2 historian freeze docs]
+  K3[K3 shared-DB ADR + inventory]
+  K4[K4 optional 782]
+  K5[K5 ONE stress]
+  K6[K6 BUG_REPORT pin]
+  L[Wave L 3.5 shared DB]
+  K0 --> K1
+  K1 --> K2
+  K2 --> K3
+  K3 --> K4
+  K4 --> K5
+  K3 --> K5
+  K5 --> K6
+  K6 --> L
+```
+
+| Step | Concern | VERSION? | Images? |
+|------|---------|----------|---------|
+| **K0** | 0 PRs; tip GHCR green | no | tip Publish if docs tip incomplete |
+| **K1** | Bump **3.4.0** | yes | after merge |
+| **K2** | Document freeze: `/workspace` Feather+Parquet, backup script, restore rules | docs ok in same or follow PR | no if docs-only |
+| **K3** | ADR + YAML inventory (engine, schema sketch, dual-write plan, rollback) | no | no |
+| **K4** | [#782](https://github.com/bbartling/open-fdd/issues/782) SSE — ship **or** PARK | if product | if product |
+| **K5** | Backup → re-pin → fieldbus → full stress | — | tip sha |
+| **K6** | BUG_REPORT **3.4.0 PINNED** + Wave L OPEN | docs | — |
+
+## Acceptance (Wave K CLOSED / 3.4.0 pin)
+
+- Health `3.4.0+<sha>` on Railway; GHCR tip complete; Python-absence PASS
+- Stress `fully_qualified=true` citing **this** tip only
+- Historian freeze docs + shared-DB ADR merged (design, not runtime)
+- BUG_REPORT header: **PINNED 3.4.0** · Next = Wave L shared DB
+- #782 either CLOSED or PARKED with explicit owner — never “done by docs alone”
+
+## Child plans
+
+| Order | Plan |
+|-------|------|
+| K0–K6 | this master |
+| L | [`wave_l_shared_db_mega_master.plan.md`](wave_l_shared_db_mega_master.plan.md) |
+| Optional | [`mqtt_monitor_sse_782.plan.md`](mqtt_monitor_sse_782.plan.md) as K4 |

--- a/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
@@ -1,0 +1,90 @@
+---
+name: Wave L 3.5 shared-DB mega
+overview: "Wave L — shared database mega (3.5.0+). Cut over historian/jobs from volume-local Feather/Parquet-only to a shared DB with dual-write/migrate, DataFusion still for FDD SQL, React unchanged. Starts only after Wave K 3.4.0 pin CLOSED. Low-RAM one agent; phased PRs; ONE stress per shippable sub-rev."
+todos:
+  - id: l0-hygiene
+    content: L0 — Hygiene START after 3.4.0 pin green
+    status: pending
+  - id: l1-engine-choice
+    content: L1 — Lock engine (default Postgres) + schema v1 from Wave K ADR; spike connectivity in central
+    status: pending
+  - id: l2-dual-write
+    content: L2 — Dual-write ingest + package import to Feather AND shared DB; feature flag
+    status: pending
+  - id: l3-read-path
+    content: L3 — Historian/query + FDD register path can read shared DB (or Parquet export from DB) with provenance
+    status: pending
+  - id: l4-jobs-meta
+    content: L4 — Jobs/findings metadata in shared DB (optional same rev or 3.5.1)
+    status: pending
+  - id: l5-migrate-tool
+    content: L5 — Offline migrate workspace historian → shared DB + verify row counts
+    status: pending
+  - id: l6-cutover
+    content: L6 — Flag default ON for shared DB; Feather remains backup/export
+    status: pending
+  - id: l7-stress
+    content: L7 — tip pin + ONE full stress; BUG_REPORT Wave L CLOSED / 3.5.x
+    status: pending
+  - id: deferred-multivendor
+    content: Multivendor Stage C (identity/MFA/tenant) — AFTER shared DB baseline
+    status: pending
+isProject: false
+---
+
+# Wave L — Shared database mega (3.5.x)
+
+**Depends on:** Wave K **3.4.0 PINNED** ([`wave_k_340_filesystem_pin_master.plan.md`](wave_k_340_filesystem_pin_master.plan.md)).
+
+**Problem:** Today the product historian is **volume-local** Feather under `/workspace` (+ Parquet trees for FDD). That blocks multi-instance hub, shared analytics across replicas, and clean multivendor tenancy. Operator wants **shared DB** ASAP after a frozen 3.4.0 pin.
+
+## Product contract (unchanged)
+
+- Central Rust + DataFusion SQL FDD + React SPA + Mosquitto + fieldbus  
+- **No** product Python/pandas  
+- Shared DB is **storage**, not a second FDD engine  
+
+## Target architecture (sketch — lock in L1)
+
+```text
+fieldbus/MQTT/CSV → central ingest
+       ├─ (3.4) Feather partitions on volume
+       └─ (3.5) dual-write → shared DB (Postgres default)
+                    ↓
+            DataFusion (Scan / foreign table / Parquet export)
+                    ↓
+            /api/fdd/run · /api/analytics/* · SPA
+```
+
+| Decision | Default (override in L1 ADR amend) |
+|----------|--------------------------------------|
+| Engine | **Postgres 16** (Railway plugin or external) |
+| Grain | site/building/equipment/point + timestamp UTC |
+| Tenancy prep | `tenant_id` / `site_id` columns now; Stage C auth later |
+| Rollback | Feature flag → Feather-only; 3.4.0 images remain pin |
+| FDD | Keep `sql_rules/` DataFusion; do not rewrite rules in SQL dialect of PG |
+
+## Phasing (VERSION)
+
+| Rev | Concern |
+|-----|---------|
+| **3.5.0** | Engine wiring + dual-write + read flag OFF by default |
+| **3.5.1** | Read path ON for historian/query canary building |
+| **3.5.2** | Migrate tool + cutover default ON + stress |
+
+One concern per PR. Mid-wave smoke. Full stress at each shippable pin the operator treats as deployable.
+
+## Out of scope
+
+- Browser→Mosquitto WebSockets  
+- Full multivendor MFA/tenant isolation (Stage C)  
+- Deleting Feather backup path in 3.5.0  
+- Pandas cookbook deletion  
+
+## Acceptance (Wave L CLOSED)
+
+- Shared DB is source of truth for live historian on tip (or documented dual with read preference)  
+- Migration from a 3.4.0 backup verified  
+- Stress `fully_qualified=true` on tip; gate 09 still green  
+- BUG_REPORT pin line **3.5.x**; Wave K 3.4.0 retained as rollback pin  
+- Multivendor Stage C unblocked as **next** program (not this wave)

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -43,7 +43,7 @@ retest. Do not confuse those with this engineering OS.
 
 ## AI agent quick rules (read first)
 
-0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave J CLOSED** on tip **`sha-c1b1aa5`** / **3.3.41**. #782 SSE remains deferred — schedule separately. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
+0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave J CLOSED** (`sha-c1b1aa5` / 3.3.41). **Wave K OPEN** — pin **3.4.0** filesystem historian then Wave L **3.5** shared DB. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
 1. Product FDD + Overview analytics = **DataFusion SQL** on GHCR. Never silent pandas fallback in central.
 2. Pandas oracle stays forever on **PyPI** + cookbooks + vibe19 — never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
@@ -104,7 +104,7 @@ retest. Do not confuse those with this engineering OS.
 57. **MQTT dual OAT:** Live fieldbus Open-Meteo must publish into historian as concurrent BAS `oa_t` + web `web_oa_t` (catalog dual-publish on railway loopback). Empty `bas-vs-web-oat` on bldg2 while `/weather` is live is a **P0 MEGA**, not DEFERRED demo fluff.
 58. **Wave I stress:** Mid-wave = smoke only. **ONE** `run_railway_hub_stress.sh` at master I7 after enhanced gates (I6). No duplicate full stresses between children unless a mega cannot be proven without a new tip pin.
 
-**Current ops pin (2026-09-09):** VERSION **3.3.41** · tip **`sha-c1b1aa5`** · health **`3.3.41+c1b1aa52806b`** · Wave J **CLOSED**. #782 SSE deferred. Multivendor Stage C deferred. Low-RAM always (rule 0).
+**Current ops pin (2026-09-09):** VERSION **3.3.41** · product tip **`sha-c1b1aa5`** · health **`3.3.41+c1b1aa52806b`** · Wave J **CLOSED**. **Wave K OPEN** — 3.4.0 filesystem pin → Wave L 3.5 shared DB. #782 optional K4. Low-RAM always (rule 0).
 
 ---
 

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -113,7 +113,7 @@ required for health, FDD, or Overview analytics.
 ## Ops patch cycle (Railway hub + qualification — 3.3.20+)
 
 Living log: [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md).  
-Active program: Wave J **CLOSED** on `sha-c1b1aa5` / 3.3.41. #782 SSE deferred. Multivendor Stage C deferred.
+Active program: Wave K **OPEN** — pin `3.4.0` filesystem historian ([`wave_k_340_filesystem_pin_master`](../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md)); then Wave L **3.5** shared DB. Wave J CLOSED on `sha-c1b1aa5` / 3.3.41.
 Stress handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · entry [`scripts/qualification/README.md`](../scripts/qualification/README.md).
 
 | Step | Action |

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,12 @@
 # Session log
 
+## 2026-09-09 — Wave K / L program opened (3.4.0 pin → 3.5 shared DB)
+
+- Wave J closeout docs **#882** merged; Dependabot #880/#881 closed for hygiene; only `master` branch.
+- Active: Wave K `wave_k_340_filesystem_pin_master` — VERSION **3.4.0** filesystem-historian pin + shared-DB ADR.
+- Queued: Wave L `wave_l_shared_db_mega_master` — shared Postgres (default) dual-write/cutover **3.5.x** ASAP after pin.
+- Ops product pin remains `sha-c1b1aa5` / 3.3.41 until Wave K ships 3.4.0.
+
 ## 2026-09-09 — Wave J CLOSED (3.3.41 / sha-c1b1aa5)
 
 - Stage A docs **#876**; FC3/VAV-2 cookbook parity **#877** (3.3.41); policy+tip Python-absence+soak **#878**; J4 Stage B **waived** (no product Python).


### PR DESCRIPTION
## Summary
- Wave J hygiene complete (#882); next active program is **Wave K** (pin **3.4.0** filesystem historian + shared-DB ADR).
- Queued **Wave L** for **3.5.x shared database** mega ASAP after the 3.4.0 pin.
- Mirrors Cursor plans under `docs/operations/patch_trains/`.

## Test plan
- [ ] Docs-only CI green
- [ ] Confirm no product/VERSION change in this PR
- [ ] After merge: tip Publish (docs SHA); ops product pin stays `sha-c1b1aa5` until Wave K ships 3.4.0


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational plans for the Wave K 3.4.0 filesystem-historian milestone and the subsequent Wave L 3.5 shared-database transition.
  * Updated program status to show Wave J completed, Wave K active, and Wave L queued.
  * Clarified rollout sequencing, acceptance criteria, rollback planning, and stress-validation checkpoints.
  * Reclassified MQTT monitoring as an optional Wave K task.
  * Deferred Multivendor Stage C until after the shared-database transition.
  * Added Wave J closeout and session-history documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->