### PR TITLE
fix(wave-k): sensor-faults, MQTT quad, data-model + stress gate 10

### DIFF
--- a/config/fieldbus/field_devices.toml
+++ b/config/fieldbus/field_devices.toml
@@ -1,10 +1,11 @@
-# Railway / low-RAM stress catalog — hosted AV 9101 loopback (no Pi / OT LAN).
+# Railway / low-RAM stress catalog — hosted weather AVs loopback (no Pi / OT LAN).
 # Used by scripts/nightly-ot-bench when RAILWAY_ONLY=1.
 #
-# Dual-publish Open-Meteo AV 9101 (Wave I):
-# - bldg2-zone-loopback: zone_t (Zone Other stress) + oa_t (BAS / synthesized)
-# - hosted-weather: web_oa_t (first-class web OAT for bas-vs-web)
+# Quad-publish Open-Meteo AVs (Wave K):
+# - bldg2-zone-loopback: zone_t (9101) + oa_t (9101) + zone_rh (9102)
+# - hosted-weather: web_oa_t (9101)
 # Device name for loopback must NOT contain "weather" (id heuristics).
+# Fieldbus MQTT delta ids must include point_name so dual AV roles both publish.
 
 [[devices]]
 name = "bldg2-zone-loopback"
@@ -15,6 +16,7 @@ port = 47808
 points = [
   { object_type = "analog-value", object_instance = 9101, point_name = "zone-air-temp", units = "°F" },
   { object_type = "analog-value", object_instance = 9101, point_name = "outside-air-temperature", units = "°F" },
+  { object_type = "analog-value", object_instance = 9102, point_name = "zone-air-humidity", units = "%" },
 ]
 
 [[devices]]

--- a/crates/fdd_core/src/columns.rs
+++ b/crates/fdd_core/src/columns.rs
@@ -101,6 +101,7 @@ pub fn haystack_point_to_role(point: &str) -> String {
         "chiller-status" => "chiller_status".into(),
         "loop-enabled" => "loop_enabled".into(),
         "zone-air-temp" => "zone_t".into(),
+        "zone-air-humidity" | "zone-humidity" => "zone_rh".into(),
         "zone-airflow" | "airflow" => "zone_flow".into(),
         "vav-total-airflow" => "vav_total_flow".into(),
         "min-flow-sp" => "min_flow_sp".into(),
@@ -210,6 +211,7 @@ pub fn normalize_role(role: &str) -> String {
         "hws_t" | "hw_supply" | "hwst" | "hws_t_f" | "hw_supply_t" => "hw_supply_t".into(),
         "hwr_t" | "hw_return" | "hwrt" | "hwr_t_f" | "hw_return_t" => "hw_return_t".into(),
         "oa_humidity" | "oa_h" | "relative_humidity_pct" | "oa_rh_pct" => "oa_h".into(),
+        "zone_rh" | "zone_humidity" | "zone_relative_humidity" | "space_rh" => "zone_rh".into(),
         "cooling_setpoint" | "effective_setpoint" | "clg_stpt" => "sat_sp".into(),
         "occ_mode" | "occupancy" | "occupied" | "schedule" => "occ_mode".into(),
         "return_fan" => "return_fan".into(),
@@ -236,6 +238,7 @@ pub const COOKBOOK_ROLES: &[&str] = &[
     "htg_valve_pct",
     "reheat_valve_pct",
     "zone_t",
+    "zone_rh",
     "zone_flow",
     "vav_total_flow",
     "min_flow_sp",
@@ -278,6 +281,7 @@ pub fn is_known_cookbook_role(role: &str) -> bool {
             | "htg_valve_pct"
             | "reheat_valve_pct"
             | "zone_t"
+            | "zone_rh"
             | "zone_flow"
             | "min_flow_sp"
             | "chw_supply_t"

--- a/crates/fdd_store/src/lib.rs
+++ b/crates/fdd_store/src/lib.rs
@@ -43,4 +43,7 @@ pub use migration_exec::{
 pub use parquet_parts::{
     CompletePartPublisher, ParquetPart, ParquetPartWriter, DEFAULT_ROW_GROUP_ROWS,
 };
-pub use stats::{local_historian_stats, local_historian_stats_from_config, HistorianStats};
+pub use stats::{
+    local_historian_stats, local_historian_stats_from_config, peek_equipment_history_columns,
+    HistorianStats,
+};

--- a/crates/fdd_store/src/stats.rs
+++ b/crates/fdd_store/src/stats.rs
@@ -124,6 +124,69 @@ pub fn local_historian_stats_from_config(config: &HistorianConfig) -> Result<His
     local_historian_stats(&LocalStorage::new(root), config.target_file_mb)
 }
 
+/// Footer-only peek of Parquet column names for one equipment partition tree.
+/// Used by Data Model MQTT/historian mapping when no columns.csv exists.
+pub fn peek_equipment_history_columns(
+    storage_root: &Path,
+    building_id: &str,
+    equipment_id: &str,
+) -> Vec<String> {
+    let Ok(building) = crate::historian::safe_partition_value(building_id, "building_id") else {
+        return Vec::new();
+    };
+    let Ok(equipment) = crate::historian::safe_partition_value(equipment_id, "equipment_id") else {
+        return Vec::new();
+    };
+    let prefix = Path::new("history")
+        .join(format!("building_id={building}"))
+        .join(format!("equipment_id={equipment}"));
+    let abs = storage_root.join(&prefix);
+    if !abs.is_dir() {
+        return Vec::new();
+    }
+    let mut names = BTreeSet::new();
+    let mut stack = vec![abs];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("parquet") {
+                continue;
+            }
+            let Ok(file) = fs::File::open(&path) else {
+                continue;
+            };
+            let Ok(builder) = ParquetRecordBatchReaderBuilder::try_new(file) else {
+                continue;
+            };
+            for field in builder.schema().fields() {
+                let name = field.name();
+                if name == "timestamp_utc"
+                    || name == "building_id"
+                    || name == "equipment_id"
+                    || name == "month"
+                    || name == "year"
+                {
+                    continue;
+                }
+                names.insert(name.to_string());
+            }
+            // One readable part is enough for the Data Model role list.
+            break;
+        }
+        if !names.is_empty() {
+            break;
+        }
+    }
+    names.into_iter().collect()
+}
+
 #[derive(Debug, Clone, Copy)]
 struct CanonicalHistoryIdentity<'a> {
     building: &'a str,

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -10,8 +10,8 @@
 **Program (prior CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / 3.3.40  
 **Stress (Wave J closeout):** `reports/nightly-ot-bench_20260909T010712Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + MCP + Wave I MEGAs)  
 **Deferred (not Wave J):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (optional Wave K K4)  
-**Program (ACTIVE):** Wave K — **3.4.0 filesystem-historian pin** · Cursor [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md) · repo [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md)  
-**Next mega (AFTER 3.4.0 pin):** Wave L — **shared DB 3.5.x** · Cursor [`wave_l_shared_db_mega_master`](../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md) · repo [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md)  
+**Program (ACTIVE):** Wave K — **3.4.0 filesystem-historian pin** · Cursor [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md) · repo [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md) · MEGAs + stress gates + Phase-0 multi-client ADR  
+**Next mega (AFTER 3.4.0 pin):** Wave L — **multi-client shared hosting 3.5.x** (tenant-partitioned Parquet + control plane; **not** Postgres time-series) · Cursor [`wave_l_shared_db_mega_master`](../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md) · repo [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md)  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -19,6 +19,9 @@
 
 | ID | Status | Symptom | Evidence | Next |
 |----|--------|---------|----------|------|
+| **sensor-faults-matrix** | **OPEN** (Wave K) | Lakeside Overview Sensor faults empty (`matched_equipment_count=0`) while HP sensors exist; only FC1 FDD rows, no SV-* | Probe 2026-09-09: `sensor-faults` matched=0; `hp-health` matched=67; FDD results SV=0 | K1 — historian equipment discovery + matrix rows; stress gate |
+| **mqtt-bacnet-quad-points** | **OPEN** (Wave K) | Dual-publish AV 9101 collapses to one role (delta id omits `point_name`); zone_t stopped ~Sep 8; humidity missing; need zone_t+oa_t+humidity+web_oa_t | Inspect: Sep5–7 `zone_t` only; Sep9 `oa_t` only; never both on same row | K1 — fieldbus delta id + catalog 9102; Railway CLI re-pin fieldbus; stress gate |
+| **data-model-all-sites** | **OPEN** (Wave K) | MQTT mapping warns roles empty (no columns.csv); wrong-site equipment → not found; Data Model ≠ Haystack browse | `mapping?building_id=bldg2` columns=[]; cross-site eq fails closed poorly in UI | K1 — historian Parquet roles + Mapping UX; stress gate |
 | **lakeside-read-csv-missing** | **CLOSED** (3.3.40 / Wave I) | Was: LAKESIDE_ES FDD `read_csv not found` | #872 `register_csv`; stress gate09 no `read_csv` | — |
 | **overview-tables-unfiltered** | **CLOSED** (3.3.40 / Wave I) | Was: MQTT Overview looked table-filtered vs CSV | #872 Overview chrome pad + Weather section always render | — |
 | **data-model-json-export** | **CLOSED** (3.3.40 / Wave I) | Was: Export JSON dead for MQTT | #872 historian mapping + Export; mapping `bldg2` equipment=2 | — |
@@ -114,15 +117,15 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** Wave K master [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md) — pin **3.4.0** filesystem historian + shared-DB ADR; then Wave L **3.5** shared DB ASAP.  
-**Last closed:** Wave J (RETIRED [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md)) · tip `sha-c1b1aa5` / **3.3.41** · stress `20260909T010712Z` · closeout docs **#882**. Anomaly **PARKED**. #782 optional K4. Multivendor Stage C **after** Wave L.
+**Active:** Wave K master [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md) — pin **3.4.0** Parquet historian + MEGAs + Phase-0 multi-client ADR; then Wave L **3.5** multi-client shared hosting.  
+**Last closed:** Wave J (RETIRED [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md)) · tip `sha-c1b1aa5` / **3.3.41** · stress `20260909T010712Z` · closeout docs **#882**. Anomaly **PARKED**. #782 optional K4. Stage C **after** Wave L baseline.
 
-**This round stress rule:** mid-wave = smoke only. Full `run_railway_hub_stress.sh` at **Wave K K5** (3.4.0 pin) and again at Wave L shippable pins (**no `SKIP_ZAP`**).
+**This round stress rule:** mid-wave = smoke only (Railway CLI tip re-pin + soak). Full `run_railway_hub_stress.sh` at **Wave K K6** (3.4.0 pin) and again at Wave L shippable pins (**no `SKIP_ZAP`**).
 
 | Rev / wave | In-repo / Cursor plan | Concern | Status |
 |------------|----------------------|---------|--------|
-| **Wave K master** | [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md) | **3.4.0 pin** + historian freeze + shared-DB ADR | **OPEN** |
-| **Wave L master** | [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md) | **3.5.x shared DB** mega | **QUEUED** (after K) |
+| **Wave K master** | [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md) | **3.4.0 pin** + MEGAs + historian freeze + Phase-0 ADR | **OPEN** |
+| **Wave L master** | [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md) | **3.5.x multi-client shared hosting** (tenant Parquet + control plane) | **QUEUED** (after K) |
 | **Wave J master** | [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) | DF-boundary + #875 | **RETIRED / CLOSED** |
 | **Wave I master** | [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs | **RETIRED / CLOSED** |
 | **Wave H** | Cursor post_waveg residual H | Demo charts / UI freshness | **CLOSED** |

--- a/docs/operations/patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md
@@ -1,95 +1,139 @@
 ---
 name: Wave K 3.4.0 filesystem pin
-overview: "Wave K — pin Open-FDD 3.4.0 as the last qualified filesystem-historian baseline (Feather/Parquet on volume), wrap BUG_REPORT residuals for handoff, land shared-DB ADR + inventory only. ONE full stress. Then Wave L 3.5 shared-DB mega ASAP. Low-RAM one agent."
+overview: "Wave K — pin 3.4.0 as last qualified single-tenant Parquet/DataFusion historian baseline. Fix MEGAs + stress gates. Phase-0 ADR for Wave L multi-client shared hosting (tenant-partitioned Parquet + control-plane store — NOT Postgres time-series). Low-RAM: tip Publish → Railway CLI backup/re-pin → soak → smoke between builds; ONE full stress at closeout. Log all pins/stress in BUG_REPORT."
 todos:
   - id: k0-hygiene
-    content: K0 — GH hygiene START (0 PRs/branches; tip Actions green; ops pin sha-c1b1aa5 or tip)
+    content: K0 — GH hygiene (merge #883 or supersede; 0 PRs/stale branches; tip Actions green; ops pin sha-c1b1aa5 until product tip)
     status: pending
-  - id: k1-version-340
-    content: K1 — VERSION bump 3.3.41 → 3.4.0 + Cargo pins (baseline pin rev)
+  - id: k0b-bug-report-open
+    content: K0b — BUG_REPORT Active→Wave K; OPEN rows sensor-faults / mqtt-quad / data-model; Next→Wave L multi-client hosting
+    status: pending
+  - id: k1-megas-product
+    content: K1 — MEGAs (sensor-faults matrix, MQTT zone_t+oa_t+humidity+web_oa_t, Data Model) + stress gate script
+    status: pending
+  - id: k1-build-loop
+    content: K1 loop — merge → GHCR tip → Railway CLI backup → hub+fieldbus re-pin → soak → smoke → BUG_REPORT
     status: pending
   - id: k2-historian-freeze-docs
-    content: K2 — Freeze historian contract docs (paths, backup/restore, Railway volume, no silent format change)
+    content: K2 — Freeze historian contract (Parquet paths, backup/restore, volume rules; no silent format change)
     status: pending
-  - id: k3-shared-db-adr-inventory
-    content: K3 — ADR + machine-readable inventory for shared DB (engine options, dual-write, tenancy hooks) — design only
+  - id: k3-multitenant-adr-phase0
+    content: K3 — Wave L Phase-0 ADR + authz matrix + threat model + inventory (design only; feeds Wave L)
     status: pending
   - id: k4-residual-782
-    content: K4 — #782 MQTT SSE — ship small OR explicit PARK with owner (do not block 3.4.0 pin)
+    content: K4 — #782 SSE ship or PARK (never block 3.4.0)
     status: pending
-  - id: k5-stress-340
-    content: K5 — tip Publish → Railway backup+re-pin → ONE run_railway_hub_stress.sh → fully_qualified
+  - id: k5-version-340
+    content: K5 — VERSION 3.3.41 → 3.4.0 + Cargo pins
     status: pending
-  - id: k6-bug-report-closed
-    content: K6 — BUG_REPORT Wave K CLOSED / 3.4.0 pin line; handoff to Wave L
+  - id: k6-stress-340
+    content: K6 — Railway CLI backup+re-pin → ONE full run_railway_hub_stress.sh (no SKIP_ZAP) → fully_qualified
+    status: pending
+  - id: k7-bug-report-closed
+    content: K7 — BUG_REPORT 3.4.0 PINNED; unlock Wave L product coding
     status: pending
   - id: deferred-wave-l
-    content: Wave L 3.5 shared-DB mega — AFTER 3.4.0 pin (see wave_l_shared_db_mega_master)
+    content: Wave L multi-client shared hosting — AFTER 3.4.0 pin (see wave_l_shared_db_mega_master)
     status: pending
 isProject: false
 ---
 
 # Wave K — 3.4.0 filesystem-historian pin (master)
 
-**Active program** after Wave J **CLOSED** (`sha-c1b1aa5` / 3.3.41 · stress `20260909T010712Z` · `fully_qualified=true`).
+**Active** after Wave J **CLOSED** (`sha-c1b1aa5` / 3.3.41 · stress `20260909T010712Z`).
 
-**Retired:** [`wave_j_df_boundary_master.plan.md`](wave_j_df_boundary_master.plan.md) — historical only.
+**Why 3.4.0:** Last fully qualified **single-tenant Parquet + DataFusion** product line before Wave L **multi-client shared hosting**. Freeze the historian contract so Wave L partitions storage — it does **not** replace Parquet with Postgres time-series.
 
-**Why 3.4.0 (not another 3.3.x):** Operator wants a **pinned baseline** before the shared-database mega. 3.4.0 = last fully qualified **volume-local Feather/Parquet** product line. 3.5.x = shared DB cutover.
+## Architecture handoff (locks Wave L)
 
-**Law:** Low-RAM one agent. No local stack `docker build`. 0 open PRs / stale branches / failed tip Actions at child start/end. Mid-wave = smoke only. **ONE** full `run_railway_hub_stress.sh` at **K5**.
+Inspired by the Sep 2026 multi-client hosting assignment. **Wave K freezes; Wave L implements.**
 
-## Non-goals (this wave)
+| Lock | Meaning |
+|------|---------|
+| Historian | **Parquet + DataFusion stay.** No Postgres (or other RDBMS) as time-series store. |
+| “Shared database / shared hosting” | **One shared Railway stack** serving many engineering-firm tenants via **tenant-partitioned storage + control plane** — not a `customer_id` UI filter. |
+| Control plane | Optional small **transactional** store (tenants/users/memberships/buildings) — **metadata only**; justify in K3 ADR. |
+| Mode | Multi-tenant **OFF by default** until qualified; single-tenant/local preserved. |
+| Live ops | Agent uses **Railway CLI** for lab backup/re-pin/smoke/stress on this hub under this wave’s authorization. No DNS purchase, no OT writes, no live customer migration without explicit operator go. |
 
-- Implementing Postgres/shared DB runtime (→ Wave L)
-- Multivendor identity/MFA/tenant isolation Stage C (after shared DB exists)
-- Reopening PARKED `sql-anomaly-screening` or ABANDONED hybrid ML
-- Mass Dependabot merges (hygiene close only)
+## Law — low-RAM + Railway CLI (non-negotiable)
+
+| Rule | Do |
+|------|----|
+| Agents | **One** agent. No competing agents / heavy local stack `docker build`. |
+| Images | Wait **GHCR tip Publish** (central/web/mqtt/fieldbus). |
+| Railway | Agent drives **`railway` CLI**: vars, backups, service image pins, health probes. Re-pin hub **and** fieldbus when tip moves. |
+| Between builds | tip Publish → tip gate → backup → re-pin → soak → **smoke** → BUG_REPORT |
+| Full stress | **ONE** `run_railway_hub_stress.sh` at **K6** (no `SKIP_ZAP`). Mid-wave = smoke only. |
+| Logging | Every pin/smoke/stress → [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md). |
+
+```text
+merge PR → GHCR tip Publish → ./scripts/check_ghcr_tip_stack.sh sha-<7>
+  → Railway CLI backup → ~/openfdd-backups/railway/<UTC>/
+  → re-pin hub + bensbench fieldbus → soak → mid-wave smoke → BUG_REPORT
+```
+
+## Required MEGAs (fix + stress before 3.4.0 CLOSED)
+
+| ID | Fix intent | Stress gate |
+|----|------------|-------------|
+| **sensor-faults-matrix** | Historian equipment discovery; matrix rows pending until SV run | Lakeside `sensor-faults` `matched_equipment_count > 0` |
+| **mqtt-bacnet-quad-points** | Delta-filter id includes `point_name`; AV 9101/9102 + web OAT | Recent non-null `zone_t`,`oa_t`, humidity, `web_oa_t` |
+| **data-model-all-sites** | Historian Parquet roles; fail closed on cross-site eq; honest copy | `bldg2` mapping roles non-empty; wrong-site eq errors |
+
+Add/require gate in `run_railway_hub_stress.sh` (keep Wave I gate 09). **#782** = optional K4 only.
+
+## Non-goals
+
+- Wave L product runtime (except K3 design ADR)
+- Postgres historian / Feather↔DB time-series dual-write
+- Enabling public multi-tenant hosting or live customer migration
+- Multivendor MFA Stage C product (scaffolded in ADR only)
+- PARKED anomaly / ABANDONED hybrid / mass Dependabot
 
 ## Order
 
 ```mermaid
 flowchart TD
   K0[K0 hygiene]
-  K1[K1 VERSION 3.4.0]
-  K2[K2 historian freeze docs]
-  K3[K3 shared-DB ADR + inventory]
+  K0b[K0b BUG_REPORT]
+  K1[K1 MEGAs + gates]
+  loop[Railway refresh loop]
+  K2[K2 historian freeze]
+  K3[K3 Phase0 ADR for L]
   K4[K4 optional 782]
-  K5[K5 ONE stress]
-  K6[K6 BUG_REPORT pin]
-  L[Wave L 3.5 shared DB]
-  K0 --> K1
-  K1 --> K2
-  K2 --> K3
-  K3 --> K4
-  K4 --> K5
+  K5[K5 VERSION 3.4.0]
+  K6[K6 full stress]
+  K7[K7 pin CLOSED]
+  L[Wave L coding]
+  K0 --> K0b --> K1 --> loop --> K2 --> K3
+  K3 --> K4 --> K5 --> loop --> K6 --> K7 --> L
   K3 --> K5
-  K5 --> K6
-  K6 --> L
 ```
 
-| Step | Concern | VERSION? | Images? |
-|------|---------|----------|---------|
-| **K0** | 0 PRs; tip GHCR green | no | tip Publish if docs tip incomplete |
-| **K1** | Bump **3.4.0** | yes | after merge |
-| **K2** | Document freeze: `/workspace` Feather+Parquet, backup script, restore rules | docs ok in same or follow PR | no if docs-only |
-| **K3** | ADR + YAML inventory (engine, schema sketch, dual-write plan, rollback) | no | no |
-| **K4** | [#782](https://github.com/bbartling/open-fdd/issues/782) SSE — ship **or** PARK | if product | if product |
-| **K5** | Backup → re-pin → fieldbus → full stress | — | tip sha |
-| **K6** | BUG_REPORT **3.4.0 PINNED** + Wave L OPEN | docs | — |
+| Step | Concern | Containers | Stress | BUG_REPORT |
+|------|---------|------------|--------|------------|
+| **K0** | Hygiene / tip green | Publish if needed | tip gate | Active=Wave K |
+| **K0b** | Open MEGA rows | no | no | rows OPEN |
+| **K1** | MEGA product + gate | **yes** each product merge | smoke | evidence |
+| **K2** | Historian freeze docs | no if docs-only | no | note |
+| **K3** | Multi-client Phase-0 ADR | no | no | ADR path |
+| **K4** | #782 | if product | smoke | CLOSED/PARK |
+| **K5** | **3.4.0** | **yes** | smoke | VERSION line |
+| **K6** | Full stress | on tip | **full** | stress path |
+| **K7** | Handoff L | — | — | **PINNED 3.4.0** |
 
-## Acceptance (Wave K CLOSED / 3.4.0 pin)
+## Acceptance
 
-- Health `3.4.0+<sha>` on Railway; GHCR tip complete; Python-absence PASS
-- Stress `fully_qualified=true` citing **this** tip only
-- Historian freeze docs + shared-DB ADR merged (design, not runtime)
-- BUG_REPORT header: **PINNED 3.4.0** · Next = Wave L shared DB
-- #782 either CLOSED or PARKED with explicit owner — never “done by docs alone”
+- Health `3.4.0+<sha>`; hub+fieldbus same tip; Python-absence PASS
+- `fully_qualified=true` + Wave K MEGA gates PASS
+- Historian freeze docs + Phase-0 multi-client ADR merged (design)
+- BUG_REPORT **3.4.0 PINNED**; Next = Wave L multi-client hosting
 
 ## Child plans
 
 | Order | Plan |
 |-------|------|
-| K0–K6 | this master |
-| L | [`wave_l_shared_db_mega_master.plan.md`](wave_l_shared_db_mega_master.plan.md) |
-| Optional | [`mqtt_monitor_sse_782.plan.md`](mqtt_monitor_sse_782.plan.md) as K4 |
+| K0–K7 | this master |
+| L | [`wave_l_shared_db_mega_master.plan.md`](openfdd_wave_l_shared_db_mega_program.plan.md) |
+| Optional | [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) |

--- a/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
@@ -1,90 +1,133 @@
 ---
-name: Wave L 3.5 shared-DB mega
-overview: "Wave L — shared database mega (3.5.0+). Cut over historian/jobs from volume-local Feather/Parquet-only to a shared DB with dual-write/migrate, DataFusion still for FDD SQL, React unchanged. Starts only after Wave K 3.4.0 pin CLOSED. Low-RAM one agent; phased PRs; ONE stress per shippable sub-rev."
+name: Wave L multi-client shared hosting
+overview: "Wave L (3.5.x) — multi-client shared hosting on Railway: tenant-partitioned Parquet/DataFusion + transactional control plane (metadata only). NOT Postgres time-series. Feature flag OFF until qualified. Phase 0 ADR during Wave K; product coding after 3.4.0 pin. Agent tests via Railway CLI + disposable qualification. Low-RAM refresh/smoke between builds; full stress + isolation/ZAP tiers per shippable pin."
 todos:
-  - id: l0-hygiene
-    content: L0 — Hygiene START after 3.4.0 pin green
+  - id: l0-wait-k-pin
+    content: L0 — Wait Wave K 3.4.0 PINNED; hygiene START; BUG_REPORT Active→Wave L (Phase0 ADR may land in K3)
     status: pending
-  - id: l1-engine-choice
-    content: L1 — Lock engine (default Postgres) + schema v1 from Wave K ADR; spike connectivity in central
+  - id: l1-control-plane
+    content: L1 — Tenant control plane (tenants/users/memberships/buildings/edges); TenantContext; flag OFF; Railway CLI smoke
     status: pending
-  - id: l2-dual-write
-    content: L2 — Dual-write ingest + package import to Feather AND shared DB; feature flag
+  - id: l2-parquet-isolation
+    content: L2 — Tenant-partitioned Parquet roots + DataFusion providers (no cross-tenant register+WHERE); cache/job scope
     status: pending
-  - id: l3-read-path
-    content: L3 — Historian/query + FDD register path can read shared DB (or Parquet export from DB) with provenance
+  - id: l3-mqtts-isolation
+    content: L3 — MQTTS topic namespace + ACL + provenance from identity not payload; broker client tests
     status: pending
-  - id: l4-jobs-meta
-    content: L4 — Jobs/findings metadata in shared DB (optional same rev or 3.5.1)
+  - id: l4-ui-domains
+    content: L4 — Tenant-aware UI/session; single app domain first; host mapping design only until operator DNS auth
     status: pending
-  - id: l5-migrate-tool
-    content: L5 — Offline migrate workspace historian → shared DB + verify row counts
+  - id: l5-budgets
+    content: L5 — Per-tenant/query budgets + noisy-neighbor lab measurements (report BLOCKED sizes honestly)
     status: pending
-  - id: l6-cutover
-    content: L6 — Flag default ON for shared DB; Feather remains backup/export
+  - id: l6-qual-hardening
+    content: L6 — Strengthen ZAP/AF + A↔B isolation harness + supply-chain digest scans; fix AF fallback PASS bugs
     status: pending
-  - id: l7-stress
-    content: L7 — tip pin + ONE full stress; BUG_REPORT Wave L CLOSED / 3.5.x
+  - id: l7-migrate-handoff
+    content: L7 — Idempotent dry-run migrate → named legacy tenant; export/restore isolation; operator approval checklist
     status: pending
-  - id: deferred-multivendor
-    content: Multivendor Stage C (identity/MFA/tenant) — AFTER shared DB baseline
+  - id: l8-stress-pin
+    content: L8 — Railway CLI tip pin + full stress; fully_qualified; BUG_REPORT 3.5.x; mode still OFF unless operator enables lab
+    status: pending
+  - id: deferred-stage-c
+    content: External IdP / MFA / dedicated-deploy SKUs — after shared-hosting baseline qualified
     status: pending
 isProject: false
 ---
 
-# Wave L — Shared database mega (3.5.x)
+# Wave L — Multi-client shared hosting (3.5.x)
 
-**Depends on:** Wave K **3.4.0 PINNED** ([`wave_k_340_filesystem_pin_master.plan.md`](wave_k_340_filesystem_pin_master.plan.md)).
+**Depends on:** Wave K **3.4.0 PINNED** ([`wave_k_340_filesystem_pin_master.plan.md`](openfdd_wave_k_340_filesystem_pin_program.plan.md)).  
+**Phase-0 ADR** may land as Wave K **K3** (design only). **Product coding** starts only after K7.
 
-**Problem:** Today the product historian is **volume-local** Feather under `/workspace` (+ Parquet trees for FDD). That blocks multi-instance hub, shared analytics across replicas, and clean multivendor tenancy. Operator wants **shared DB** ASAP after a frozen 3.4.0 pin.
+**Renamed intent:** Former “shared DB mega” = **shared Railway hub hosting many engineering firms**, not moving the historian into Postgres.
 
-## Product contract (unchanged)
+## Goal (from Sep 2026 multi-client assignment — verify on checkout)
 
-- Central Rust + DataFusion SQL FDD + React SPA + Mosquitto + fieldbus  
-- **No** product Python/pandas  
-- Shared DB is **storage**, not a second FDD engine  
+- Tenant = engineering firm; building belongs to exactly one tenant; optional per-building auth for building owners.
+- MIT / free software — no licensing server or paid point gates. Quotas = capacity protection.
+- Preserve **Rust central, React, Parquet historian, DataFusion SQL**. **No** product Python. **No** Postgres time-series. **No** Feather↔RDBMS dual-write for telemetry.
+- Shared infrastructure + **tenant-partitioned storage**. A `customer_id` column + UI filter alone is **unacceptable**.
+- Feature branch; **multi-tenant mode OFF by default** until qualified. Preserve single-tenant/local.
+- Agent creates/tests with **Railway CLI** + existing stress/qualification scripts. No OT writes. No live customer migration / public enable / DNS purchase without explicit operator authorization.
 
-## Target architecture (sketch — lock in L1)
+## Law — low-RAM + Railway CLI
+
+Same as Wave K between-build loop. Additionally:
+
+| Tier | When | What |
+|------|------|------|
+| 1 Per PR | every product PR | unit/integration authz; AppSec; no live OT |
+| 2 Candidate digest | every tip Publish set | disposable/synthetic stack; A↔B matrix; ZAP tiers; MQTT ACL tests; restore; bounded perf |
+| 3 Field refresh | operator-authorized Railway hub | smoke/freshness/benign permission checks only — **no** active DoS/OT writes on live data |
+
+**Full stress** at each deployable 3.5.x pin the operator treats as ship; **L8** cutover/qualification pin **must** `fully_qualified=true` (no `SKIP_ZAP`). Wave K MEGA gates stay green.
+
+Log every pin/smoke/stress/migrate dry-run in [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md).
+
+## Target architecture (lock in K3/L0 ADR)
 
 ```text
-fieldbus/MQTT/CSV → central ingest
-       ├─ (3.4) Feather partitions on volume
-       └─ (3.5) dual-write → shared DB (Postgres default)
-                    ↓
-            DataFusion (Scan / foreign table / Parquet export)
-                    ↓
-            /api/fdd/run · /api/analytics/* · SPA
+                    ┌─ transactional control plane (tenants/users/roles/buildings/edges)
+Railway shared hub ─┤
+                    └─ Parquet historian under server-derived tenant roots
+                              ↓
+                     DataFusion SessionContext with tenant-scoped providers only
+                              ↓
+                     /api/* + MCP + jobs (TenantContext fail-closed)
+                              ↓
+                     MQTTS ACL: tenants/{tid}/buildings/{bid}/edges/{eid}/…
 ```
 
-| Decision | Default (override in L1 ADR amend) |
-|----------|--------------------------------------|
-| Engine | **Postgres 16** (Railway plugin or external) |
-| Grain | site/building/equipment/point + timestamp UTC |
-| Tenancy prep | `tenant_id` / `site_id` columns now; Stage C auth later |
-| Rollback | Feature flag → Feather-only; 3.4.0 images remain pin |
-| FDD | Keep `sql_rules/` DataFusion; do not rewrite rules in SQL dialect of PG |
+| Decision | Default |
+|----------|---------|
+| Time-series | **Parquet** (partitioned by tenant) + DataFusion |
+| Control plane | Small transactional store if session_config/files insufficient — **metadata only** |
+| Isolation | Provider/catalog scoping — **not** `WHERE tenant_id` over a shared mega-table |
+| MQTT | Identity→topic mapping; reject payload spoofing |
+| Rollback | Flag OFF → single-tenant; **3.4.0** images remain pin |
+| Dedicated option | Documented for stricter customers |
 
-## Phasing (VERSION)
+## Phases → VERSION (one concern per PR)
 
-| Rev | Concern |
-|-----|---------|
-| **3.5.0** | Engine wiring + dual-write + read flag OFF by default |
-| **3.5.1** | Read path ON for historian/query canary building |
-| **3.5.2** | Migrate tool + cutover default ON + stress |
+| Phase | Rev (sketch) | Deliverable | Railway / stress |
+|-------|--------------|-------------|------------------|
+| **0** | docs (in K3) | ADR, authz matrix, threat model, inventory, ZAP gap list | none |
+| **1** | 3.5.0 | Control plane + TenantContext; mode OFF | tip refresh + smoke |
+| **2** | 3.5.1 | Tenant Parquet roots + DF providers | smoke; A↔B storage tests |
+| **3** | 3.5.2 | MQTTS namespace + ACL + provenance | MQTT client isolation tests |
+| **4** | 3.5.3 | UI membership/tenant chrome; domain design | smoke |
+| **5** | 3.5.4 | Budgets + noisy-neighbor lab notes | lab measurements |
+| **6** | 3.5.5 | ZAP/AF fixes + isolation harness + digest scans | Tier-2 candidate suite |
+| **7–8** | 3.5.x pin | Legacy-tenant migrate dry-run + **L8** full stress | Railway CLI full stress |
 
-One concern per PR. Mid-wave smoke. Full stress at each shippable pin the operator treats as deployable.
+Exact VERSION numbers may compress if operator prefers fewer pins — **never** skip Tier-2 isolation before claiming multi-tenant ready.
 
-## Out of scope
+## Phase 0 checklist (K3 / L0 — before product edits)
 
+Reinspect checkout (assignment paths were GitHub-era). Read AGENTS.md trees, SECURITY.md, RAILWAY_* docs, STRESS_CLOSEOUT, qualification README, openapi, appsec/wave-c workflows. `rg` inventory: routes, JWT, SessionContext/TableProvider, storage URLs, import/export, jobs, MQTT, MCP, workers. Deliver ADR + matrix + threat model + dedicated-vs-shared tradeoff + test plan + rollback limits. One agent; no competing builds.
+
+## Security qualification (must harden in L6)
+
+- Fix ZAP/AF **fallback PASS** (AF failure must not become PASS via empty baseline). Separate unauth baseline / auth passive / auth active. Medium exceptions scoped+owned+expiring.
+- Seed Tenant A/B with **identical labels, different values**; every resource path positive+negative; prove no cross-tenant mutation.
+- Harness self-tests that break scoping and **fail** the gate.
+- Scan **actual** image digests; SBOM; no `continue-on-error` on High/Critical.
+- `qualification_manifest.json` + SUMMARY.md; `fully_qualified=false` on FAIL/ERROR/SKIPPED/BLOCKED.
+
+## Out of scope (this wave)
+
+- Replacing Parquet historian with Postgres  
+- Feather↔DB telemetry dual-write  
+- Licensing/billing servers  
+- Public multi-tenant enablement / live customer migrate / DNS purchase without operator auth  
 - Browser→Mosquitto WebSockets  
-- Full multivendor MFA/tenant isolation (Stage C)  
-- Deleting Feather backup path in 3.5.0  
-- Pandas cookbook deletion  
+- OT command expansion  
 
 ## Acceptance (Wave L CLOSED)
 
-- Shared DB is source of truth for live historian on tip (or documented dual with read preference)  
-- Migration from a 3.4.0 backup verified  
-- Stress `fully_qualified=true` on tip; gate 09 still green  
-- BUG_REPORT pin line **3.5.x**; Wave K 3.4.0 retained as rollback pin  
-- Multivendor Stage C unblocked as **next** program (not this wave)
+- Two synthetic firms cannot read/write/export/subscribe each other’s resources on **any** supported path (evidence in Tier-2 suite)
+- Single-tenant mode still default and qualified on 3.4.0 rollback pin
+- Multi-tenant mode remains **OFF** in production until operator approval checklist signed
+- Stress `fully_qualified=true` on tip; Wave K MEGAs green; isolation+ZAP truthful
+- BUG_REPORT **3.5.x** pin line; migrate dry-run counts recorded; Stage C deferred next

--- a/edge/src/csv_ingest/package.rs
+++ b/edge/src/csv_ingest/package.rs
@@ -1510,24 +1510,57 @@ fn mapping_from_historian_equipment(building_id: &str, equipment_id: Option<&str
                 .get("equipment_type")
                 .cloned()
                 .unwrap_or(json!("GENERAL"));
+            let pq = crate::fdd::registry_api::parquet_root();
+            let cols = fdd_store::peek_equipment_history_columns(&pq, building_id, &eq_id);
+            let mut roles = serde_json::Map::new();
+            let column_rows: Vec<Value> = cols
+                .iter()
+                .map(|col| {
+                    // MQTT/historian wide Parquet already uses cookbook role names as columns.
+                    roles.insert(col.clone(), json!(col));
+                    json!({
+                        "column": col,
+                        "role": col,
+                        "status": "mapped",
+                    })
+                })
+                .collect();
+            let warnings = if column_rows.is_empty() {
+                vec![
+                    "MQTT/historian data model — no Parquet columns discovered yet; roles empty until telemetry arrives"
+                        .to_string(),
+                ]
+            } else {
+                vec![
+                    "MQTT/historian data model — roles inferred from Parquet columns (not CSV columns.csv / not live Haystack browse)"
+                        .to_string(),
+                ]
+            };
             json!({
                 "equipment_id": eq_id,
                 "equipment_type": eq_type,
                 "parent_ahu": Value::Null,
                 "ok": true,
-                "columns": [],
-                "roles": {},
+                "columns": column_rows,
+                "roles": Value::Object(roles),
                 "unmapped_columns": [],
                 "ambiguous_roles": {},
                 "blockers": [],
-                "warnings": [
-                    "MQTT/historian data model — no columns.csv; roles empty until mapped"
-                ],
+                "warnings": warnings,
                 "sampling": Value::Null,
             })
         })
         .collect();
     let n = equipment.len();
+    let warning_count: usize = equipment
+        .iter()
+        .map(|e| {
+            e.get("warnings")
+                .and_then(Value::as_array)
+                .map(|a| a.len())
+                .unwrap_or(0)
+        })
+        .sum();
     json!({
         "ok": true,
         "building_id": building_id,
@@ -1538,7 +1571,7 @@ fn mapping_from_historian_equipment(building_id: &str, equipment_id: Option<&str
         "warnings": ["historian-backed mapping (no csv_buildings package tree)"],
         "validation": {
             "blocker_count": 0,
-            "warning_count": n,
+            "warning_count": warning_count,
             "equipment_count": n,
         },
     })

--- a/frontend/web/src/components/PlantHealthSections.tsx
+++ b/frontend/web/src/components/PlantHealthSections.tsx
@@ -285,7 +285,7 @@ export function PlantHealthSections({
           { key: "spike", ruleId: "SV-SPIKE" },
           { key: "stale", ruleId: "SV-STALE" },
         ]}
-        emptyMessage="No sensor faults in window"
+        emptyMessage="No equipment with sensor history in this site yet"
         renderEmptyTable
         pendingFlags={pendingFlags}
       />

--- a/frontend/web/src/pages/MappingPage.tsx
+++ b/frontend/web/src/pages/MappingPage.tsx
@@ -57,7 +57,7 @@ export function MappingPage() {
     const list = inventory?.equipment ?? [];
     if (!list.length) return null;
     if (equipmentId) {
-      return list.find((e) => e.equipment_id === equipmentId) ?? list[0];
+      return list.find((e) => e.equipment_id === equipmentId) ?? null;
     }
     return list[0];
   }, [inventory, equipmentId]);
@@ -79,19 +79,33 @@ export function MappingPage() {
     setLoading(true);
     setError(null);
     try {
-      const [inv, sess] = await Promise.all([
-        getPackageMapping(buildingId, equipmentId || undefined),
+      // Load site inventory first; only request a specific equipment once it
+      // belongs to this building (avoids cross-site sticky ?eq= errors).
+      const [invAll, sess] = await Promise.all([
+        getPackageMapping(buildingId),
         getSessionConfig(),
       ]);
+      const ids = invAll.equipment_ids ?? [];
+      let inv = invAll;
+      let eqId = equipmentId;
+      if (eqId && !ids.includes(eqId)) {
+        setQuery({ equipment: "" }, true);
+        eqId = "";
+        setError(
+          `Equipment "${equipmentId}" is not in site ${buildingId} — cleared selection.`,
+        );
+      } else if (eqId) {
+        inv = await getPackageMapping(buildingId, eqId);
+      }
       setInventory(inv);
       setSessionConfig(sess.config ?? null);
       const eq =
-        (equipmentId
-          ? inv.equipment?.find((e) => e.equipment_id === equipmentId)
+        (eqId
+          ? inv.equipment?.find((e) => e.equipment_id === eqId)
           : inv.equipment?.[0]) ?? null;
       setDraftRoles({ ...(eq?.roles ?? {}) });
       setDirty(false);
-      if (eq && !equipmentId) {
+      if (eq && !eqId) {
         setQuery({ equipment: eq.equipment_id }, true);
       }
     } catch (err) {
@@ -225,9 +239,11 @@ export function MappingPage() {
       <div className="page-placeholder" data-testid="mapping-page">
         <h2>Role mapping</h2>
         <p>
-          Map CSV columns to cookbook roles for the selected building and equipment.
-          Blank roles stay blank — no guessed fills. Use the Active site / equipment
-          selectors (or URL <code>?site=</code> / <code>?eq=</code>).
+          Map CSV / historian columns to cookbook roles for the selected building
+          and equipment. This tab is <strong>column ↔ role</strong> mapping (package{" "}
+          <code>columns.csv</code> or MQTT Parquet columns) — not live Haystack point
+          browse. Blank roles stay blank — no guessed fills. Use Active site /
+          equipment selectors (or URL <code>?site=</code> / <code>?eq=</code>).
         </p>
 
         <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem" }}>

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -43,7 +43,7 @@ retest. Do not confuse those with this engineering OS.
 
 ## AI agent quick rules (read first)
 
-0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave J CLOSED** (`sha-c1b1aa5` / 3.3.41). **Wave K OPEN** — pin **3.4.0** filesystem historian then Wave L **3.5** shared DB. Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
+0. **Low-RAM bensbench / machine port (always):** One agent only (no duplicate Task/subagents on the same train). Never local `docker build` of central/web/mqtt/fieldbus. Pull GHCR `sha-*` only; prune old images before pull. After ZAP/stress, `docker rm -f` leftover zap/MCP disposable containers — keep only needed fieldbus. Never run Vibe13 `cargo`/Ansible TX in parallel with Open-FDD ZAP/docker. Push often. Portable brain: [`docs/operations/recovery/AI_CONTEXT_HANDOFF.md`](../docs/operations/recovery/AI_CONTEXT_HANDOFF.md). **Wave J CLOSED** (`sha-c1b1aa5` / 3.3.41). **Wave K OPEN** — pin **3.4.0** Parquet historian + MEGAs + Phase-0 multi-client ADR; then Wave L **3.5 multi-client shared hosting** (tenant-partitioned Parquet + control plane — **not** Postgres time-series). Handbook: [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) · [`PATCH_CYCLE.md`](../docs/operations/PATCH_CYCLE.md).
 1. Product FDD + Overview analytics = **DataFusion SQL** on GHCR. Never silent pandas fallback in central.
 2. Pandas oracle stays forever on **PyPI** + cookbooks + vibe19 — never delete the pandas cookbook because production uses SQL.
 3. Never delete the SQL cookbook because pandas remains the oracle.
@@ -104,7 +104,7 @@ retest. Do not confuse those with this engineering OS.
 57. **MQTT dual OAT:** Live fieldbus Open-Meteo must publish into historian as concurrent BAS `oa_t` + web `web_oa_t` (catalog dual-publish on railway loopback). Empty `bas-vs-web-oat` on bldg2 while `/weather` is live is a **P0 MEGA**, not DEFERRED demo fluff.
 58. **Wave I stress:** Mid-wave = smoke only. **ONE** `run_railway_hub_stress.sh` at master I7 after enhanced gates (I6). No duplicate full stresses between children unless a mega cannot be proven without a new tip pin.
 
-**Current ops pin (2026-09-09):** VERSION **3.3.41** · product tip **`sha-c1b1aa5`** · health **`3.3.41+c1b1aa52806b`** · Wave J **CLOSED**. **Wave K OPEN** — 3.4.0 filesystem pin → Wave L 3.5 shared DB. #782 optional K4. Low-RAM always (rule 0).
+**Current ops pin (2026-09-09):** VERSION **3.3.41** · product tip **`sha-c1b1aa5`** · health **`3.3.41+c1b1aa52806b`** · Wave J **CLOSED**. **Wave K OPEN** — 3.4.0 pin → Wave L 3.5 multi-client shared hosting. #782 optional K4. Low-RAM always (rule 0).
 
 ---
 

--- a/scripts/nightly-ot-bench/21_wave_k_app_test_megas.sh
+++ b/scripts/nightly-ot-bench/21_wave_k_app_test_megas.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Gate 21 — Wave K app-test MEGAs (sensor-faults + MQTT quad + data-model).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$DIR/lib.sh"
+load_bench_env
+cd "$ROOT"
+
+ART="${ARTIFACT_DIR:-$(artifact_dir)}"
+mkdir -p "$ART"
+LOG="$ART/wave_k_app_test_megas.log"
+: >"$LOG"
+
+central_auth_setup
+cpost() {
+  local path="$1" body="$2"
+  curl -sS --max-time 120 "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" \
+    -H 'Content-Type: application/json' -d "$body" \
+    "$CENTRAL_BASE$path"
+}
+cget() {
+  curl -sS --max-time 60 "${CENTRAL_AUTH_HDR[@]+"${CENTRAL_AUTH_HDR[@]}"}" \
+    "$CENTRAL_BASE$1"
+}
+
+FAIL=0
+record() {
+  local id="$1" ok="$2" detail="$3"
+  echo "$id ok=$ok $detail" | tee -a "$LOG"
+  [[ "$ok" == "1" ]] || FAIL=1
+}
+
+# 1) Lakeside sensor-faults matrix discovers historian equipment
+body="$(cpost /api/analytics/sensor-faults '{"building_id":"LAKESIDE_ES"}')"
+echo "$body" >"$ART/wave_k_sensor_faults_lakeside.json"
+matched="$(echo "$body" | jq -r '.analytics.coverage.matched_equipment_count // .coverage.matched_equipment_count // 0')"
+rows="$(echo "$body" | jq -r '(.analytics.rows // .rows // []) | length')"
+if [[ "${matched:-0}" -gt 0 && "${rows:-0}" -gt 0 ]]; then
+  record sensor_faults_lakeside 1 "matched=$matched rows=$rows"
+else
+  record sensor_faults_lakeside 0 "matched=$matched rows=$rows"
+fi
+
+# 2) MQTT quad — recent loopback has zone_t + oa_t + zone_rh; hosted-weather web_oa_t
+body="$(cpost /api/analytics/inspect '{"building_id":"bldg2","equipment_ids":["bldg2-zone-loopback"],"max_points":200}')"
+echo "$body" >"$ART/wave_k_inspect_loopback.json"
+eval "$(echo "$body" | python3 -c '
+import json,sys
+a=(json.load(sys.stdin).get("analytics") or {})
+pts=a.get("points") or []
+def n(k): return sum(1 for p in pts if p.get(k) is not None)
+print(f"zt={n(\"zone_t\")}")
+print(f"oa={n(\"oa_t\")}")
+print(f"rh={n(\"zone_rh\")}")
+print(f"n={len(pts)}")
+')"
+if [[ "${zt:-0}" -gt 0 && "${oa:-0}" -gt 0 ]]; then
+  record mqtt_zone_and_oa 1 "zone_t=$zt oa_t=$oa n=$n"
+else
+  record mqtt_zone_and_oa 0 "zone_t=$zt oa_t=$oa n=$n"
+fi
+if [[ "${rh:-0}" -gt 0 ]]; then
+  record mqtt_zone_rh 1 "zone_rh=$rh"
+else
+  record mqtt_zone_rh 0 "zone_rh=$rh (need fieldbus tip + AV9102 soak)"
+fi
+
+body="$(cpost /api/analytics/inspect '{"building_id":"bldg2","equipment_ids":["hosted-weather"],"max_points":50}')"
+echo "$body" >"$ART/wave_k_inspect_hosted_weather.json"
+web="$(echo "$body" | python3 -c 'import json,sys; a=(json.load(sys.stdin).get("analytics") or {}); pts=a.get("points") or []; print(sum(1 for p in pts if p.get("web_oa_t") is not None))')"
+if [[ "${web:-0}" -gt 0 ]]; then
+  record mqtt_web_oa_t 1 "web_oa_t=$web"
+else
+  record mqtt_web_oa_t 0 "web_oa_t=$web"
+fi
+
+# 3) Data model — bldg2 historian roles non-empty; wrong-site eq fails closed
+body="$(cget "/api/csv/import/package/mapping?building_id=bldg2")"
+echo "$body" >"$ART/wave_k_mapping_bldg2.json"
+cols="$(echo "$body" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+eqs=d.get("equipment") or []
+n=0
+for e in eqs:
+  n=max(n, len(e.get("columns") or []), len(e.get("roles") or {}))
+print(n)
+')"
+if [[ "${cols:-0}" -gt 0 ]]; then
+  record mapping_bldg2_roles 1 "max_columns=$cols"
+else
+  record mapping_bldg2_roles 0 "max_columns=$cols"
+fi
+
+body="$(cget "/api/csv/import/package/mapping?building_id=BUILDING_100&equipment_id=bldg2-zone-loopback")"
+echo "$body" >"$ART/wave_k_mapping_cross_site.json"
+ok_cross="$(echo "$body" | jq -r '.ok // true')"
+err_cross="$(echo "$body" | jq -r '.error // empty')"
+if [[ "$ok_cross" == "false" && -n "$err_cross" ]]; then
+  record mapping_cross_site 1 "fail_closed"
+else
+  record mapping_cross_site 0 "ok=$ok_cross error=${err_cross:-none}"
+fi
+
+jq -n --argjson fail "$FAIL" '{gate:"21_wave_k_app_test_megas", fail:$fail}' \
+  >"$ART/wave_k_app_test_megas.json"
+
+if [[ "$FAIL" -eq 0 ]]; then
+  ok "Wave K app-test MEGAs PASS"
+  exit 0
+fi
+bad "Wave K app-test MEGAs FAIL — see $LOG"
+exit 1

--- a/scripts/nightly-ot-bench/field_devices.railway.example.toml
+++ b/scripts/nightly-ot-bench/field_devices.railway.example.toml
@@ -1,10 +1,11 @@
-# Railway / low-RAM stress catalog — hosted AV 9101 loopback (no Pi / OT LAN).
+# Railway / low-RAM stress catalog — hosted weather AVs loopback (no Pi / OT LAN).
 # Used by scripts/nightly-ot-bench when RAILWAY_ONLY=1.
 #
-# Dual-publish Open-Meteo AV 9101 (Wave I):
-# - bldg2-zone-loopback: zone_t (Zone Other stress) + oa_t (BAS / synthesized)
-# - hosted-weather: web_oa_t (first-class web OAT for bas-vs-web)
+# Quad-publish Open-Meteo AVs (Wave K):
+# - bldg2-zone-loopback: zone_t (9101) + oa_t (9101) + zone_rh (9102)
+# - hosted-weather: web_oa_t (9101)
 # Device name for loopback must NOT contain "weather" (id heuristics).
+# Fieldbus MQTT delta ids must include point_name so dual AV roles both publish.
 
 [[devices]]
 name = "bldg2-zone-loopback"
@@ -15,6 +16,7 @@ port = 47808
 points = [
   { object_type = "analog-value", object_instance = 9101, point_name = "zone-air-temp", units = "°F" },
   { object_type = "analog-value", object_instance = 9101, point_name = "outside-air-temperature", units = "°F" },
+  { object_type = "analog-value", object_instance = 9102, point_name = "zone-air-humidity", units = "%" },
 ]
 
 [[devices]]

--- a/scripts/nightly-ot-bench/run_railway_hub_stress.sh
+++ b/scripts/nightly-ot-bench/run_railway_hub_stress.sh
@@ -66,7 +66,8 @@ python3 "$MANIFEST_PY" create \
   --required 06_zap_baseline \
   --required 07_auth_role_matrix \
   --required 08_mcp_accuracy \
-  --required 09_wave_i_app_test_megas
+  --required 09_wave_i_app_test_megas \
+  --required 10_wave_k_app_test_megas
 
 record_gate() {
   local gate="$1" status="$2" title="$3" reason="${4:-}"
@@ -212,6 +213,10 @@ fi
 # --- 09 Wave I app-test MEGAs (basic app + dual OAT + plot span) ---
 run_gate "09_wave_i_app_test_megas" "09 Wave I app-test MEGAs" \
   "$DIR/20_wave_i_app_test_megas.sh"
+
+# --- 10 Wave K app-test MEGAs (sensor-faults + MQTT quad + data-model) ---
+run_gate "10_wave_k_app_test_megas" "10 Wave K app-test MEGAs" \
+  "$DIR/21_wave_k_app_test_megas.sh"
 
 # Finalize — SUMMARY generated from recorded gates only
 set +e

--- a/services/central/src/analytics/historian.rs
+++ b/services/central/src/analytics/historian.rs
@@ -25,6 +25,7 @@ const NUMERIC_ROLE_COLS: &[&str] = &[
     "mat",
     "sat",
     "zone_t",
+    "zone_rh",
     "zone_flow",
     "fan_cmd",
     "fan_status",

--- a/services/central/src/analytics/plant_health.rs
+++ b/services/central/src/analytics/plant_health.rs
@@ -444,8 +444,8 @@ const SENSOR_SPEC: MatrixSpec = MatrixSpec {
     query_version: QV_SENSOR_FAULTS,
     schema: SCHEMA_SENSOR_FAULTS,
     flags: SENSOR_FLAGS,
-    notes: "Sensor validation faults only; clean results intentionally return rows: [].",
-    faults_only: true,
+    notes: "Sensor validation matrix across historian equipment; flags unknown until SV rules run.",
+    faults_only: false,
 };
 const PID_SPEC: MatrixSpec = MatrixSpec {
     scope: EquipmentScope::AnyFdd,
@@ -694,6 +694,27 @@ fn spec_rule_ids(spec: &MatrixSpec) -> BTreeSet<&'static str> {
     ids
 }
 
+async fn historian_equipment_ids(bid: &str) -> Result<Vec<String>> {
+    let ctx = SessionContext::new();
+    if !try_register_history_scoped(&ctx, Some(bid)).await? {
+        return Ok(Vec::new());
+    }
+    let result = run_sql(
+        &ctx,
+        "SELECT equipment_id FROM history GROUP BY equipment_id ORDER BY equipment_id",
+    )
+    .await?;
+    Ok(result
+        .rows
+        .into_iter()
+        .filter_map(|row| {
+            row.get("equipment_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .collect())
+}
+
 async fn equipment_ids_for_spec(
     bid: &str,
     spec: &MatrixSpec,
@@ -701,6 +722,12 @@ async fn equipment_ids_for_spec(
 ) -> Result<Vec<String>> {
     match spec.scope {
         EquipmentScope::AnyFdd => {
+            // Prefer historian equipment so Overview matrices render before SV/FDD
+            // results exist (flags stay Unknown / pending until Run all rules).
+            let hist = historian_equipment_ids(bid).await?;
+            if !hist.is_empty() {
+                return Ok(hist);
+            }
             let rule_ids = spec_rule_ids(spec);
             let mut ids: Vec<String> = index
                 .iter()
@@ -711,26 +738,7 @@ async fn equipment_ids_for_spec(
             ids.dedup();
             Ok(ids)
         }
-        EquipmentScope::Family(_) => {
-            let ctx = SessionContext::new();
-            if !try_register_history_scoped(&ctx, Some(bid)).await? {
-                return Ok(Vec::new());
-            }
-            let result = run_sql(
-                &ctx,
-                "SELECT equipment_id FROM history GROUP BY equipment_id ORDER BY equipment_id",
-            )
-            .await?;
-            Ok(result
-                .rows
-                .into_iter()
-                .filter_map(|row| {
-                    row.get("equipment_id")
-                        .and_then(Value::as_str)
-                        .map(str::to_string)
-                })
-                .collect())
-        }
+        EquipmentScope::Family(_) => historian_equipment_ids(bid).await,
     }
 }
 

--- a/services/fieldbus/src/mqtt_bridge.rs
+++ b/services/fieldbus/src/mqtt_bridge.rs
@@ -656,9 +656,8 @@ pub async fn spawn_if_configured(
                     let object_instance = v.get("object_instance")?.as_u64()? as u32;
                     // Include point_name so dual-publish of the same BACnet object
                     // (e.g. AV 9101 → zone_t + oa_t) is not collapsed by delta filter.
-                    let id = format!(
-                        "bacnet:{device}:{object_type}:{object_instance}:{point_name}"
-                    );
+                    let id =
+                        format!("bacnet:{device}:{object_type}:{object_instance}:{point_name}");
                     let value = telemetry_point_value(&v);
                     let quality = if v.get("error").map(|e| e.is_null()).unwrap_or(true) {
                         Quality::Good

--- a/services/fieldbus/src/mqtt_bridge.rs
+++ b/services/fieldbus/src/mqtt_bridge.rs
@@ -654,7 +654,11 @@ pub async fn spawn_if_configured(
                     }
                     let object_type = v.get("object_type")?.as_str()?.replace('_', "-");
                     let object_instance = v.get("object_instance")?.as_u64()? as u32;
-                    let id = format!("bacnet:{device}:{object_type}:{object_instance}");
+                    // Include point_name so dual-publish of the same BACnet object
+                    // (e.g. AV 9101 → zone_t + oa_t) is not collapsed by delta filter.
+                    let id = format!(
+                        "bacnet:{device}:{object_type}:{object_instance}:{point_name}"
+                    );
                     let value = telemetry_point_value(&v);
                     let quality = if v.get("error").map(|e| e.is_null()).unwrap_or(true) {
                         Quality::Good
@@ -788,6 +792,28 @@ mod tests {
         assert_eq!(dev, 100);
         assert_eq!(ot, "analog-value");
         assert_eq!(inst, 5);
+    }
+
+    #[test]
+    fn delta_filter_keeps_dual_roles_on_same_bacnet_object() {
+        let mut last = HashMap::new();
+        let mk = |id: &str, val: f64| TelemetryPoint {
+            id: id.to_string(),
+            display_name: None,
+            kind: Some(ValueKind::Number),
+            value: serde_json::json!(val),
+            unit: None,
+            quality: Quality::Good,
+            tags: serde_json::Map::new(),
+        };
+        let zone = "bacnet:599999:analog-value:9101:zone-air-temp";
+        let oa = "bacnet:599999:analog-value:9101:outside-air-temperature";
+        let out = apply_delta_filter(vec![mk(zone, 72.0), mk(oa, 72.0)], &mut last);
+        assert_eq!(out.len(), 2, "same AV value must publish both roles");
+        let again = apply_delta_filter(vec![mk(zone, 72.0), mk(oa, 72.0)], &mut last);
+        assert!(again.is_empty(), "unchanged values still delta-suppressed");
+        let bumped = apply_delta_filter(vec![mk(zone, 73.0), mk(oa, 73.0)], &mut last);
+        assert_eq!(bumped.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Sensor faults:** Overview matrix discovers historian equipment (not only SV FDD rows); shows pending flags until rules run.
- **MQTT quad:** Fieldbus delta-filter ids include `point_name` so AV 9101 dual-publish keeps both `zone_t` and `oa_t`; catalog adds AV 9102 `zone_rh`; hosted-weather `web_oa_t` unchanged.
- **Data Model:** MQTT mapping peeks Parquet columns as roles; clears sticky cross-site `?eq=`; honest copy (not Haystack browse).
- **Stress:** new required gate `10_wave_k_app_test_megas` (`21_wave_k_app_test_megas.sh`).
- **Program:** Wave L reoriented to **multi-client shared hosting** (tenant-partitioned Parquet + control plane) — **not** Postgres time-series. BUG_REPORT OPEN rows for the three MEGAs.

## Test plan
- [ ] CI green (Rust Stack + React + AppSec)
- [ ] After tip Publish: Railway CLI backup → re-pin hub **and** fieldbus → soak
- [ ] Mid-wave smoke: Lakeside `sensor-faults` matched>0; Inspect loopback `zone_t`+`oa_t`(+`zone_rh`); mapping `bldg2` columns>0; cross-site eq fails closed
- [ ] Full stress only at Wave K 3.4.0 closeout (includes gate 10)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for zone relative humidity in equipment mappings, analytics, and historian data.
  - Mapping pages now identify available historian columns and provide clearer source descriptions.
  - Added validation for selected equipment and clearer handling of unavailable selections.
  - Added support for discovering equipment history fields from hosted historian data.

- **Bug Fixes**
  - MQTT telemetry now preserves separate readings when multiple roles share the same device object.
  - Sensor health views now include equipment without fault results, clearly identifying unavailable evidence.
  - Updated empty-state messaging to better describe sites without sensor history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->