### PR TITLE
fix(ci): BACnet MQTT smoke + Wave K K1b hygiene

### DIFF
--- a/docker/compose.bacnet-mqtt-ci.yml
+++ b/docker/compose.bacnet-mqtt-ci.yml
@@ -71,6 +71,9 @@ services:
       OPENFDD_MQTT_CERT_PEM: /mqtt/edge.cert.pem
       OPENFDD_MQTT_KEY_PEM: /mqtt/edge.key.pem
       OPENFDD_MQTT_SPOOL_DIR: /spool
+      # CI-only: deterministic waits (product Railway / OT floor stays 60s).
+      OPENFDD_FIELDBUS_POLL_INTERVAL_SECS: "5"
+      OPENFDD_MQTT_PUBLISH_INTERVAL_SECS: "5"
     volumes:
       - ../tests/integration/bacpypes3/fieldbus:/app/config:ro
       - ${OPENFDD_BACNET_MQTT_CERT_DIR}/edge:/mqtt:ro

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -2,15 +2,16 @@
 
 **Date:** 2026-09-09 (Wave J **CLOSED** — DF-boundary + cookbook parity)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
-**Tip / pin (3.3.41):** `c1b1aa52` · VERSION **3.3.41** · health **`3.3.41+c1b1aa52806b`** · GHCR **central/web/mqtt/fieldbus `sha-c1b1aa5`**  
-**Last CLOSED tip:** `c1b1aa52` · **`sha-c1b1aa5`** · **`3.3.41+c1b1aa52806b`** · product **#877** · CI/gates **#878** · docs Stage A **#876**  
+**Tip / pin (ops):** `cee2f4ec` · VERSION **3.3.41** (K5 → 3.4.0 next) · health **`3.3.41+cee2f4ec6c65`** · GHCR **central/web/mqtt/fieldbus `sha-cee2f4e`**  
+**Last CLOSED tip (Wave J):** `c1b1aa52` · **`sha-c1b1aa5`** · **`3.3.41+c1b1aa52806b`** · product **#877** · CI/gates **#878** · docs Stage A **#876**  
 **Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Dual-publish AV `9101`: `bldg2-zone-loopback` **`zone_t`+`oa_t`**, `hosted-weather` **`web_oa_t`**.  
-**Backup:** `~/openfdd-backups/railway/20260909T135419Z/` (pre–K1 tip re-pin; prior Wave J: `20260909T002816Z/`)  
+**Backup:** `~/openfdd-backups/railway/20260909T203549Z/` (pre–K1b plot-span tip re-pin; prior `20260909T194731Z/` / Wave J `20260909T002816Z/`)  
 **Program (CLOSED):** Wave J — Cursor [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) · ownership inventory + #875 FC3/VAV-2 + policy/image Python-absence + soak provenance  
 **Program (prior CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / 3.3.40  
 **Stress (Wave J closeout):** `reports/nightly-ot-bench_20260909T010712Z/` · **`fully_qualified=true`** (gates 00–09 incl. ZAP + MCP + Wave I MEGAs)  
 **Deferred (not Wave J):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (optional Wave K K4)  
-**K1:** MEGAs **#884 MERGED** (`5aed663c`) — tip Publish in progress for `sha-5aed663`; Railway still on `sha-c1b1aa5` until re-pin. Docs K2/K3 → **#885**.
+**K1:** MEGAs **#884 MERGED** (`5aed663c`) — hub lived on `sha-5aed663` until K1b. Docs K2/K3 → **#885**.  
+**K1b:** Plot-span **#886 MERGED** (`cee2f4ec`) — GHCR tip **PASS** · Railway hub+fieldbus re-pin **`sha-cee2f4e`** · smoke 2026-09-09T20:42Z (FC1 series = Inspect Mar→Jul; econ points Mar→Jul; OAT scatter max_points 20k)  
 **Program (ACTIVE):** Wave K — **3.4.0 filesystem-historian pin** · Cursor [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md) · repo [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md) · MEGAs + stress gates + Phase-0 multi-client ADR  
 **Next mega (AFTER 3.4.0 pin):** Wave L — **multi-client shared hosting 3.5.x** (tenant-partitioned Parquet + control plane; **not** Postgres time-series) · Cursor [`wave_l_shared_db_mega_master`](../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md) · repo [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md)  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
@@ -20,12 +21,12 @@
 
 | ID | Status | Symptom | Evidence | Next |
 |----|--------|---------|----------|------|
-| **sensor-faults-matrix** | **OPEN** (Wave K) | Lakeside Overview Sensor faults empty (`matched_equipment_count=0`) while HP sensors exist; only FC1 FDD rows, no SV-* | Probe 2026-09-09: `sensor-faults` matched=0; `hp-health` matched=67; FDD results SV=0 | K1 — historian equipment discovery + matrix rows; stress gate |
-| **mqtt-bacnet-quad-points** | **OPEN** (Wave K) | Dual-publish AV 9101 collapses to one role (delta id omits `point_name`); zone_t stopped ~Sep 8; humidity missing; need zone_t+oa_t+humidity+web_oa_t | Inspect: Sep5–7 `zone_t` only; Sep9 `oa_t` only; never both on same row | K1 — fieldbus delta id + catalog 9102; Railway CLI re-pin fieldbus; stress gate |
-| **data-model-all-sites** | **OPEN** (Wave K) | MQTT mapping warns roles empty (no columns.csv); wrong-site equipment → not found; Data Model ≠ Haystack browse | `mapping?building_id=bldg2` columns=[]; cross-site eq fails closed poorly in UI | K1 — historian Parquet roles + Mapping UX; stress gate |
-| **fdd-series-recent-only** | **OPEN** (Wave K) | `GET /api/fdd/series` uses `ORDER BY timestamp DESC LIMIT 5000` → FC1/ECON/SATDEV Plots & lab PDF fault lane only cover ~last 2 weeks, not full Mar→Jul historian | Probe 2026-09-09 BUILDING_100: series span `2026-06-30→07-17`; Inspect span-preserving `2026-03-16→07-17` | Patch `edge/src/fdd/registry_api.rs` span-preserving 8k downsample (working tree); tip Publish → re-pin → smoke; stress: B100 FC1 series first_ts ≈ mapping first_ts |
-| **econ-points-prefix-limit** | **OPEN** (Wave K) | Historian economizer plot points `ORDER BY … LIMIT N` (not span-preserving) → Overview/RCx econ temps truncate early window | Probe: `economizer` points ended ~Apr 23 at max_points=8000 while history runs to Jul 17 | Patch `historian::economizer_from_history` ranked/sampled CTE (working tree); tip → smoke |
-| **rcx-oat-scatter-cap** | **OPEN** (Wave K) | `rcx_oat_scatter_from_history` clamp 12k → HW/CHW/SAT scatters miss late-season OAT | Probe: `hw_reset_scatter` ended ~Apr 26 at 12k pts | Raise clamp to 20k (working tree); tip → smoke |
+| **sensor-faults-matrix** | **OPEN** (Wave K) | Lakeside Overview Sensor faults empty (`matched_equipment_count=0`) while HP sensors exist; only FC1 FDD rows, no SV-* | Probe 2026-09-09: `sensor-faults` matched=0; `hp-health` matched=67; FDD results SV=0 | K1 product in #884 — prove on tip via stress gate 10 |
+| **mqtt-bacnet-quad-points** | **OPEN** (Wave K) | Dual-publish AV 9101 collapses to one role (delta id omits `point_name`); zone_t stopped ~Sep 8; humidity missing; need zone_t+oa_t+humidity+web_oa_t | Inspect: Sep5–7 `zone_t` only; Sep9 `oa_t` only; never both on same row | K1 product in #884 + fieldbus `sha-cee2f4e` — prove via stress gate 10 |
+| **data-model-all-sites** | **OPEN** (Wave K) | MQTT mapping warns roles empty (no columns.csv); wrong-site equipment → not found; Data Model ≠ Haystack browse | `mapping?building_id=bldg2` columns=[]; cross-site eq fails closed poorly in UI | K1 product in #884 — prove via stress gate 10 |
+| **fdd-series-recent-only** | **CLOSED** (K1b / #886 / `sha-cee2f4e`) | Was: `GET /api/fdd/series` recent-only DESC LIMIT | Smoke 2026-09-09: AHU_1 FC1 series n=7109 span `2026-03-16→07-17` matches Inspect | — |
+| **econ-points-prefix-limit** | **CLOSED** (K1b / #886 / `sha-cee2f4e`) | Was: economizer points prefix LIMIT truncated early window | Smoke: `POST /api/analytics/economizer` n=8000 span `2026-03-16→07-17` | — |
+| **rcx-oat-scatter-cap** | **CLOSED** (K1b / #886 / `sha-cee2f4e`) | Was: OAT scatter clamp 12k ended ~Apr | Smoke: `hw_reset_scatter` max_points=20000 → n=20000 (was 12k) | — |
 | **lakeside-read-csv-missing** | **CLOSED** (3.3.40 / Wave I) | Was: LAKESIDE_ES FDD `read_csv not found` | #872 `register_csv`; stress gate09 no `read_csv` | — |
 | **overview-tables-unfiltered** | **CLOSED** (3.3.40 / Wave I) | Was: MQTT Overview looked table-filtered vs CSV | #872 Overview chrome pad + Weather section always render | — |
 | **data-model-json-export** | **CLOSED** (3.3.40 / Wave I) | Was: Export JSON dead for MQTT | #872 historian mapping + Export; mapping `bldg2` equipment=2 | — |

--- a/docs/operations/patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md
@@ -1,25 +1,28 @@
 ---
 name: Wave K 3.4.0 filesystem pin
-overview: "Wave K — pin 3.4.0 as last qualified single-tenant Parquet/DataFusion historian baseline. Fix MEGAs + stress gates. Phase-0 ADR for Wave L multi-client shared hosting (tenant-partitioned Parquet + control-plane store — NOT Postgres time-series). Low-RAM: tip Publish → Railway CLI backup/re-pin → soak → smoke between builds; ONE full stress at closeout. Log all pins/stress in BUG_REPORT."
+overview: "ACTIVE — Wave K pins 3.4.0. K1 MEGA tip live on Railway (sha-5aed663). K1b=#886 plot-span (CI in flight). K2/K3 #885 MERGED. Wave L QUEUED. ONE full stress at K6."
 todos:
   - id: k0-hygiene
-    content: K0 — GH hygiene (merge #883 or supersede; 0 PRs/stale branches; tip Actions green; ops pin sha-c1b1aa5 until product tip)
-    status: pending
+    content: K0 — GH hygiene (#883 merged)
+    status: completed
   - id: k0b-bug-report-open
-    content: K0b — BUG_REPORT Active→Wave K; OPEN rows sensor-faults / mqtt-quad / data-model; Next→Wave L multi-client hosting
-    status: pending
+    content: K0b — BUG_REPORT Active→Wave K; OPEN MEGA rows
+    status: completed
   - id: k1-megas-product
-    content: K1 — MEGAs (sensor-faults matrix, MQTT zone_t+oa_t+humidity+web_oa_t, Data Model) + stress gate script
-    status: pending
+    content: K1 — MEGAs #884 MERGED; tip+Railway sha-5aed663 DONE
+    status: completed
   - id: k1-build-loop
-    content: K1 loop — merge → GHCR tip → Railway CLI backup → hub+fieldbus re-pin → soak → smoke → BUG_REPORT
-    status: pending
+    content: K1 loop — MEGA tip re-pin DONE; plot-span tip pending #886
+    status: completed
+  - id: k1b-plot-span
+    content: K1b — #886 plot-span → green → merge → tip → Railway re-pin
+    status: in_progress
   - id: k2-historian-freeze-docs
-    content: K2 — Freeze historian contract (Parquet paths, backup/restore, volume rules; no silent format change)
-    status: pending
+    content: K2 — Historian freeze docs (#885 MERGED)
+    status: completed
   - id: k3-multitenant-adr-phase0
-    content: K3 — Wave L Phase-0 ADR + authz matrix + threat model + inventory (design only; feeds Wave L)
-    status: pending
+    content: K3 — Wave L Phase-0 ADR (#885 MERGED)
+    status: completed
   - id: k4-residual-782
     content: K4 — #782 SSE ship or PARK (never block 3.4.0)
     status: pending
@@ -27,20 +30,20 @@ todos:
     content: K5 — VERSION 3.3.41 → 3.4.0 + Cargo pins
     status: pending
   - id: k6-stress-340
-    content: K6 — Railway CLI backup+re-pin → ONE full run_railway_hub_stress.sh (no SKIP_ZAP) → fully_qualified
+    content: K6 — ONE full run_railway_hub_stress.sh (gates 00–10) → fully_qualified
     status: pending
   - id: k7-bug-report-closed
     content: K7 — BUG_REPORT 3.4.0 PINNED; unlock Wave L product coding
     status: pending
   - id: deferred-wave-l
-    content: Wave L multi-client shared hosting — AFTER 3.4.0 pin (see wave_l_shared_db_mega_master)
+    content: Wave L multi-client shared hosting — AFTER 3.4.0 pin
     status: pending
 isProject: false
 ---
 
 # Wave K — 3.4.0 filesystem-historian pin (master)
 
-**Active** after Wave J **CLOSED** (`sha-c1b1aa5` / 3.3.41 · stress `20260909T010712Z`).
+**Active.** Ops Railway hub **`sha-5aed663`** / 3.3.41. K2/K3 docs **#885 MERGED**. Next tip: **[#886](https://github.com/bbartling/open-fdd/pull/886)** plot-span. Cursor live board: `~/.cursor/plans/wave_k_340_filesystem_pin_master.plan.md`.
 
 **Why 3.4.0:** Last fully qualified **single-tenant Parquet + DataFusion** product line before Wave L **multi-client shared hosting**. Freeze the historian contract so Wave L partitions storage — it does **not** replace Parquet with Postgres time-series.
 
@@ -99,9 +102,9 @@ Overview / RCx / FDD series (UI Plotly palette, Overview tables, per-AHU **FC1**
 [`openfdd_agent_spec/skills/openfdd-typst-rcx-report/SKILL.md`](../../../openfdd_agent_spec/skills/openfdd-typst-rcx-report/SKILL.md).
 Not `rust-text-pdf`; never blocks K7.
 
-**OPEN plot-span debt (ship in tip):** BUG_REPORT `fdd-series-recent-only`,
-`econ-points-prefix-limit`, `rcx-oat-scatter-cap` — patches on working tree in
-`edge/src/fdd/registry_api.rs` + `services/central/src/analytics/historian.rs`.
+**OPEN plot-span debt (K1b tip):** BUG_REPORT `fdd-series-recent-only`,
+`econ-points-prefix-limit`, `rcx-oat-scatter-cap` — [#886](https://github.com/bbartling/open-fdd/pull/886)
+(`edge/src/fdd/registry_api.rs` + `services/central/src/analytics/historian.rs`).
 
 ## Order
 

--- a/openfdd_agent_spec/skills/openfdd-typst-rcx-report/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-typst-rcx-report/SKILL.md
@@ -1,110 +1,118 @@
 ---
 name: openfdd-typst-rcx-report
 description: >-
-  Build engineer-facing Typst RCx lab PDFs from live DataFusion Overview / RCx /
-  FDD series APIs (VAV AHU systems). Use when the user asks for an RCx lab report,
-  BUILDING_100 screening pack, Typst PDF from Railway analytics, FC1/SATDEV/ECON
-  fault overlays, Overview health tables in PDF/Excel, or agent lab report (not
-  rust-text-pdf). Triggers on: typst rcx, rcx lab report, VAV AHU report,
-  confirmed_fault overlay PDF, building100_rcx_report.
+  Build engineer-facing Typst lab PDFs from live DataFusion Overview / RCx /
+  Inspect APIs. Covers VAV AHU (BUILDING_100), heat-pump + metering (LAKESIDE_ES /
+  Creekside), and MQTTS zone monitoring (bldg2). CRITICAL: preserve Overview-
+  mirrored charts; never strip reports to thin package layouts. Triggers on:
+  typst rcx, rcx lab report, heat pump report, lakeside, creekside, mqtts zone
+  PDF, building100_rcx_report, elec_power metering PDF, box plot, seasonal heat cool.
 ---
 
-# Open-FDD Typst RCx lab report (VAV AHU)
+# Open-FDD Typst lab reports (multi-profile)
 
 **Not** the product PDF path (`rust-text-pdf`). Agent lab screening pack:
-DataFusion → Plotly (UI palette) → Typst → PDF + Overview CSVs for Excel.
+DataFusion → Plotly (UI palette) → Typst → PDF + CSVs for Excel.
 
 Reference kit: `/home/ben/building100_rcx_report/`.
 
-## When to use
+**PyPI staging (not in open-fdd master yet):** package `open-fdd-lab-typst`
+(`openfdd_lab_typst`, CLI `open-fdd-lab-typst`). Future monorepo path
+`open_fdd.lab_typst` — see kit `FUTURE_OPENFDD_MERGE.md`.
 
-- **VAV AHU** RCx / Overview screening PDF from Railway (or any hub)
-- Per-AHU **FC1**, **AHU-SATDEV**, **FC13-SAT-HIGH**, **ECON-*** with
-  **`confirmed_fault` swim lane**
-- Overview health matrices as **tables** (not heatmaps) + Excel CSVs
-- Engineer narrative (system type, data volume/freq, RCx insights) — **no** IT method section
+---
 
-## Hard rules
+## NEVER vibe-code these reports (hard law)
 
-1. **Data model driven** — only plot Overview / RCx / FDD payloads. Empty = missing roles (`openfdd-package-mapping`).
-2. **Colors** — `RAINBOW_PALETTE` (`frontend/web/src/api/plotlyTheme.ts`).
-3. **Line gaps (adaptive)** — null **Y only** (`connectgaps=False`). Gap threshold =
-   `max(3600, 4 × median_Δt)` — **never** fixed 900s after span-preserving downsample
-   (~25 min spacing would blank every point).
-4. **Full historian span** — line plots from `POST /api/analytics/inspect`
-   (`max_points: 8000`, span-preserving). Merge `confirmed_fault` from
-   `GET /api/fdd/series` by timestamp. Until hub tip has span-preserving FDD series,
-   fault lane may be sparse (series still recent-only on ops pin).
-5. **FDD overlays** — `FC1`, `AHU-SATDEV`, `FC13-SAT-HIGH`, faulted `ECON-*`.
-6. **PDF layout** — snapshot + insights → **charts by plot type** (both AHUs under each
-   chart family) → Overview tables **last**. FDD fault-hours bars = **rule × equipment**
-   labels + caption listing drivers.
-7. **Overview tables** — UI columns in PDF + `tables/*.csv` for Excel.
-8. **Product boundary** — do not replace `rust-text-pdf`; no Plotly on SPA Overview.
-9. **Low-RAM** — no local stack `docker build`; fetch live hub JWT.
+These rules exist because agents previously **destroyed** good Overview-mirrored
+PDFs by regenerating thin package layouts. Violating them is a regression.
 
-## Known product bugs (document + patch; lab workarounds above)
+### Sacred deliverables (kit root)
 
-Log in `docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md` and Wave K master:
+| File | Pipeline | Sacred? |
+|------|----------|---------|
+| `BUILDING_100_RCx_Lab_Report.pdf` | **Legacy only** | **YES — never replace with package strip-down** |
+| `LAKESIDE_ES_Creekside_HeatPump_RCx_Lab_Report.pdf` | Package `heat_pump` | Keep runtime/comfort/OAT/meter/geo/HP detail |
+| `LAKESIDE_ES_Creekside_Seasonal_HeatCool_RCx.pdf` | `seasonal_hp` | Separate from HeatPump report — do not overwrite HeatPump PDF |
+| `bldg2_MQTTS_Zone_Lab_Report.pdf` | Package `mqtts_zone` | Keep zone T/RH + weather |
 
-| ID | Defect | Patch location |
-|----|--------|----------------|
-| **fdd-series-recent-only** | `DESC LIMIT 5000` → last ~2 weeks only | `edge/src/fdd/registry_api.rs` span-preserving 8k |
-| **econ-points-prefix-limit** | economizer points prefix LIMIT | `historian::economizer_from_history` ranked sample |
-| **rcx-oat-scatter-cap** | OAT scatter clamp 12k truncates season | `rcx_oat_scatter_from_history` → 20k |
+### BUILDING_100 — Overview mirror forever
 
-Working-tree patches may exist before tip Publish — do **not** claim hub fixed until
-Railway re-pin + smoke. Wave K: ship with / right after K1 tip.
+1. **Always** use legacy kit scripts — never `openfdd_lab_typst.render` / `typst_build` for this site.
+2. CLI already forces legacy when `--building BUILDING_100`.
+3. Sacred Typst entry: kit-root **`main.typ`** (charts-before-tables, plot-type layout).
+   - Includes: zone comfort, weekly runtimes (air/boiler/chiller), **mech cooling OAT bins**,
+     BAS/web OAT, plant scatters, FDD fault hours + caption, econ Δ/MAT/temps (dual-axis damper %),
+     FC1 / SATDEV / FC13 / ECON-1 / ECON-4 overlays with `confirmed_fault`, then Overview tables.
+4. **Additive only:** box plots (`bx_sat_leave`, `bx_duct_static`, `bx_fan_speed`) — same unit per chart.
+5. **Do not** overwrite `main.typ` with package `write_main_typ`.
+6. **Do not** replace Overview PNGs (`02_site_runtime_*`, `03_site_mech_cooling_bins`, `11_econ_temps_*`,
+   `12_fdd_*` …) with crappy multi-role line dumps (`50_AHU_*.png`).
+7. Regen command:
 
-## Pipeline
-
-```text
-fetch_railway.py    → data/*.json (+ inspect_* + fdd_series_*)
-render_plots.py     → figures/*.png + tables/*.csv + fdd_fault_hours_caption.md
-build_typst_body.py → generated_snapshot.typ + generated_tables.typ + generated_fdd_caption.typ
-typst compile main.typ BUILDING_<ID>_RCx_Lab_Report.pdf
+```bash
+cd /home/ben/building100_rcx_report
+# optional: skip fetch if data fresh
+.venv/bin/python render_plots.py
+.venv/bin/python build_typst_body.py
+typst compile main.typ BUILDING_100_RCx_Lab_Report.pdf
+# or: open-fdd-lab-typst --building BUILDING_100 --skip-fetch
 ```
 
-Auth: `POST /api/auth/login` + Railway `OPENFDD_ADMIN_PASSWORD` (central).
+### Additive changes only
 
-### Required fetches (VAV AHU)
+When the user asks for “a few box plots / one scatter / rounding”:
 
-| Surface | Endpoint |
-|---------|----------|
-| Runtime / mech / econ / BAS | `POST /api/analytics/{runtime,mechanical-cooling,economizer,bas-vs-web-oat}` max_points≥8000 |
-| Inspect (full-span lines) | `POST /api/analytics/inspect` per AHU, columns sat/mat/rat/oa_t/damper/fan/duct/sat_sp |
-| Health matrices | `POST /api/analytics/ahu-*-health`, chiller, boiler, pid, sensor, vav, … |
-| RCx scatters / rank | `POST /api/analytics/rcx/preset` with max_points≤20000 |
-| FDD overlays | `GET /api/fdd/series` AHU × `{FC1,AHU-SATDEV,FC13-SAT-HIGH,ECON-*}` |
-| Inventory | equipment, mapping, `GET /api/fdd/results` |
+| Do | Do not |
+|----|--------|
+| Append figures + Typst sections | Rewrite `main.typ` layout |
+| Keep Overview plot styles (`overview_layout`, dual y-axis for mixed units) | Mix °F + % + in.w.c. on one axis |
+| Round display values to **1 decimal** (`fmt_sensor` / `fmt_h`) | Dump raw floats (`668.166666…`) |
+| Season PDF = own file | Overwrite HeatPump PDF with seasonal |
+| Fan-filter leave SAT / duct static when fan ON | Invent occ_mode when only `fan_status` exists |
 
-SPA intercepts some RCx ids (`ahu_motor_weekly`, `mech_cooling_oat_bins`, `bas_vs_web_oat`) —
-use Overview analytics POSTs for those charts.
+### Line plots with mixed units
 
-### Site snapshot + insights
+Temps (°F) and damper/fan (%) **must** use dual y-axis (`yaxis` + `yaxis2`) — see
+`render_plots.py` economizer temps overlay. Never plot damper % on the temperature axis.
 
-HVAC type, equipment counts, history window, ~5-min frequency, historian row volume,
-plant motor hours. RCx advice separates **data** faults from **HVAC** faults.
+---
 
-## Figure checklist (dual VAV AHU)
+## Profiles
 
-- [ ] Zone comfort; weekly runtimes air/boiler/chiller; mech OAT bins; BAS vs web
-- [ ] HW / CHW / SAT scatters
-- [ ] FDD fault hours **rule × equipment** + caption
-- [ ] Economizer Δ / MAT residual / temps (plot-type groups, both AHUs)
-- [ ] FC1 / AHU-SATDEV / FC13-SAT-HIGH / ECON-1 / ECON-4 overlays (both AHUs)
-- [ ] Overview health tables after charts; `tables/*.csv`
+| Profile | Sites | Pipeline |
+|---------|-------|----------|
+| `vav_ahu` / legacy | BUILDING_100 | `fetch_railway.py` → `render_plots.py` → `build_typst_body.py` → `main.typ` |
+| `heat_pump` | LAKESIDE_ES | `openfdd_lab_typst` fetch/render/typst → copy to Creekside HeatPump PDF |
+| `mqtts_zone` | bldg2 | package path → copy to `bldg2_MQTTS_Zone_Lab_Report.pdf` |
+| seasonal | LAKESIDE_ES | `python -m openfdd_lab_typst.seasonal_hp` → **Seasonal** PDF only |
 
-## Anti-patterns
+## Hard rules (data / plots)
 
-- Fixed 15-min gap on downsampled series (blanks the plot)
-- Inserting `None` into **X** timestamps (collapses traces)
-- Heatmap health flags; anonymous rule bars without equipment
-- AHU-first then all chart types (prefer plot-type-first)
-- IT method / JWT / Kaleido section for engineers
-- Claiming hub FDD series is full-span before tip re-pin
+1. **Data model driven** — mapped cookbook roles only for inspect columns.
+2. **Colors** — `RAINBOW_PALETTE` (`frontend/web/src/api/plotlyTheme.ts`).
+3. **Line gaps (adaptive)** — null **Y only**. Gap = `max(3600, 4 × median_Δt)`.
+4. **Full span via Inspect** — `POST /api/analytics/inspect` max_points 8000.
+5. **Metering** — if `elec_power` mapped, chart kW + monthly + (optional) kW vs OAT weekday/weekend.
+6. **FDD overlays** — only when results exist; do not invent faults.
+7. **Round** all sensor/hour table cells and insight prose to nearest tenth.
+8. **Product boundary** — do not replace `rust-text-pdf`.
+
+## Kit layout
+
+```text
+/home/ben/building100_rcx_report/
+  main.typ                 # BUILDING_100 sacred layout
+  render_plots.py          # Overview-parity Plotly
+  build_typst_body.py      # snapshot + insights + tables
+  openfdd_lab_typst/       # package (HP / MQTTS / seasonal)
+  sites/LAKESIDE_ES/       # HP + seasonal working copies
+  sites/bldg2/
+  AGENTS.md                # short agent gate (read first)
+```
 
 ## Related
 
-- `openfdd-react-spa` · `openfdd-package-mapping` · `openfdd-ecm-engineering` · `openfdd-railway-cli`
-- Wave K plan + BUG_REPORT plot-span OPEN rows
+- Kit `AGENTS.md` · `README.md` · `FUTURE_OPENFDD_MERGE.md`
+- Skills: `openfdd-react-spa` · `openfdd-package-mapping` · `openfdd-railway-cli`
+- Wave K plan + BUG_REPORT plot-span rows

--- a/scripts/integration/bacnet_mqtt_container_smoke.sh
+++ b/scripts/integration/bacnet_mqtt_container_smoke.sh
@@ -203,7 +203,7 @@ while true; do
       .last_telemetry.site_id == "ci" and
       .last_telemetry.edge_id == "fieldbus-1" and
       (.last_telemetry.points | any(
-        .id == "bacnet:3456:analog-value:1" and
+        ((.id | tostring) | startswith("bacnet:3456:analog-value:1")) and
         .tags.building_id == "BUILDING_CI"
       ))
     ' >/dev/null && edge_ok=1 || true


### PR DESCRIPTION
## Summary
- Fix optional BACnet→MQTTS CI: accept telemetry point ids that include `point_name` suffix (post–#884 delta id).
- CI fieldbus poll/publish 5s for deterministic waits (OT floor remains 60s).
- BUG_REPORT: K1b `sha-cee2f4e` live; plot-span rows CLOSED.
- Typst RCx skill: BUILDING_100 Overview mirror is sacred (no package strip-down).

## Test plan
- [x] Local tip stack `sha-cee2f4e` PASS; Railway health `3.3.41+cee2f4ec`
- [ ] Optional BACnet workflow green on this PR / after merge Publish
- [x] 0 open PRs after merge; only `master` remote branch


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry validation to recognize BACnet analog-value point identifiers with valid prefixes.

* **Documentation**
  * Updated operational bug tracking and rollout plans with current release status, completed milestones, and resolved issues.
  * Expanded the RCX reporting guidance to cover legacy VAV, heat-pump and metering, and MQTT zone-monitoring profiles.
  * Added guidance for mixed-unit plots, profile selection, required deliverables, and data-quality rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->