### PR TITLE
fix(ci): Wave K gate 10 harness quoting + jq false

### DIFF
--- a/scripts/nightly-ot-bench/21_wave_k_app_test_megas.sh
+++ b/scripts/nightly-ot-bench/21_wave_k_app_test_megas.sh
@@ -45,15 +45,16 @@ fi
 # 2) MQTT quad — recent loopback has zone_t + oa_t + zone_rh; hosted-weather web_oa_t
 body="$(cpost /api/analytics/inspect '{"building_id":"bldg2","equipment_ids":["bldg2-zone-loopback"],"max_points":200}')"
 echo "$body" >"$ART/wave_k_inspect_loopback.json"
+# Single-quoted python -c: use "…" for JSON keys (\" breaks under bash $'…' / eval).
 eval "$(echo "$body" | python3 -c '
 import json,sys
 a=(json.load(sys.stdin).get("analytics") or {})
 pts=a.get("points") or []
 def n(k): return sum(1 for p in pts if p.get(k) is not None)
-print(f"zt={n(\"zone_t\")}")
-print(f"oa={n(\"oa_t\")}")
-print(f"rh={n(\"zone_rh\")}")
-print(f"n={len(pts)}")
+print("zt=%d" % n("zone_t"))
+print("oa=%d" % n("oa_t"))
+print("rh=%d" % n("zone_rh"))
+print("n=%d" % len(pts))
 ')"
 if [[ "${zt:-0}" -gt 0 && "${oa:-0}" -gt 0 ]]; then
   record mqtt_zone_and_oa 1 "zone_t=$zt oa_t=$oa n=$n"
@@ -95,7 +96,8 @@ fi
 
 body="$(cget "/api/csv/import/package/mapping?building_id=BUILDING_100&equipment_id=bldg2-zone-loopback")"
 echo "$body" >"$ART/wave_k_mapping_cross_site.json"
-ok_cross="$(echo "$body" | jq -r '.ok // true')"
+# jq `false // true` yields true — do not use // for boolean .ok
+ok_cross="$(echo "$body" | jq -r '.ok')"
 err_cross="$(echo "$body" | jq -r '.error // empty')"
 if [[ "$ok_cross" == "false" && -n "$err_cross" ]]; then
   record mapping_cross_site 1 "fail_closed"


### PR DESCRIPTION
## Summary
- Fix `21_wave_k_app_test_megas.sh` Python `eval` quoting so MQTT quad counts export under `set -u`.
- Fix cross-site mapping assert: jq `false // true` → use `.ok` directly.
- K6 tip `sha-9c3e8b1` product checks pass locally after fix (sensor-faults, zone_t+oa_t+rh, web_oa_t, mapping roles, fail-closed). Prior full stress failed only on this harness bug.

## Test plan
- [x] Local rerun gate 10 on Railway tip → PASS
- [ ] PR CI green
- [ ] After merge: re-run ONE full `run_railway_hub_stress.sh` for `fully_qualified=true` (started from local fixed harness)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nightly inspection output consistency.
  - Corrected validation handling so explicit failure statuses are preserved instead of being treated as successful.
  - Kept fail-closed behavior intact when validation checks do not pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->