### PR TITLE
docs: Wave L L2 closeout (sha-2dea571 / 3.5.1 LIVE)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Aliases: [`docs/migration/vibe19/ROLE_MAPPING_PARITY.md`](docs/migration/vibe19/
 
 Railway is an **experimental cloud path**, not a replacement for the LAN/VPN/OT deployment contract or a claim of production public-internet hardening.
 
-**Agent ops (bensbench):** use the **Railway CLI** for backup + hub tip re-pin — [`openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md`](openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md) · [`docs/operations/RAILWAY_DEPLOYMENT.md`](docs/operations/RAILWAY_DEPLOYMENT.md). Do **not** confuse Railway CLI / Railway MCP with **`openfdd-mcp`** FDD tools. Current product pin: **`sha-a11b6cb`** / **3.5.0** (Wave L L1, `multi_tenant=false`); rollback **`sha-9c3e8b1`** / **3.4.0**.
+**Agent ops (bensbench):** use the **Railway CLI** for backup + hub tip re-pin — [`openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md`](openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md) · [`docs/operations/RAILWAY_DEPLOYMENT.md`](docs/operations/RAILWAY_DEPLOYMENT.md). Do **not** confuse Railway CLI / Railway MCP with **`openfdd-mcp`** FDD tools. Current product pin: **`sha-2dea571`** / **3.5.1** (Wave L L2, `multi_tenant=false`); rollback **`sha-9c3e8b1`** / **3.4.0**.
 
 - **CSV-only lab:** `openfdd-central` + `openfdd-web`.
 - **Cloud MQTTS hub (preferred when live OT is the goal):** `openfdd-central` + `openfdd-web` + **`openfdd-mqtt`** on Railway private networking; keep **`openfdd-fieldbus` on-prem** publishing MQTTS into the cloud broker. MQTTS is the point of the hub — do not leave mqtt off by default for live sites.

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,23 +1,26 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-09-10 (Wave L **L1 LIVE** · mode OFF · not L8 PINNED)  
+**Date:** 2026-09-10 (Wave L **L2 LIVE** · mode OFF · not L8 PINNED)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
-**Tip / pin (ops):** `a11b6cb1` · VERSION **3.5.0** · health **`3.5.0+a11b6cb181fc`** · GHCR **central/web/mqtt/fieldbus `sha-a11b6cb`** · `multi_tenant=false`  
+**Tip / pin (ops):** `2dea571c` · VERSION **3.5.1** · health **`3.5.1+2dea571cea05`** · GHCR **central/web/mqtt/fieldbus `sha-2dea571`** · `multi_tenant=false` · `historian_prefix=""`  
 **Rollback pin (Wave K):** `9c3e8b1c` · **`sha-9c3e8b1`** · **`3.4.0+9c3e8b1c30c1`** · MEGAs stress `20260910T021557Z` · docs **#890**  
+**Prior Wave L tip (L1):** `a11b6cb1` · **`sha-a11b6cb`** · **`3.5.0+a11b6cb181fc`** · product **#891**  
 **Last CLOSED tip (Wave J):** `c1b1aa52` · **`sha-c1b1aa5`** · **`3.3.41+c1b1aa52806b`** · product **#877** · CI/gates **#878** · docs Stage A **#876**  
 **Field:** bensbench x86 `openfdd-fieldbus` → Railway MQTTS (`bldg2` / client `pi-1` kit). Dual-publish AV `9101`: `bldg2-zone-loopback` **`zone_t`+`oa_t`**, `hosted-weather` **`web_oa_t`**.  
-**Backup:** `~/openfdd-backups/railway/20260910T161828Z/` (pre–L1 tip re-pin; prior K5 `20260910T020319Z/`)  
+**Backup:** `~/openfdd-backups/railway/20260910T230450Z/` (pre–L2 tip re-pin; prior L1 `20260910T161828Z/`; K5 `20260910T020319Z/`)  
 **Program (ACTIVE):** Wave L — **multi-client shared hosting 3.5.x** (tenant-partitioned Parquet + control plane; **not** Postgres time-series) · Cursor [`wave_l_shared_db_mega_master`](../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md) · repo [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md)  
 **Program (CLOSED):** Wave K — **3.4.0 filesystem-historian pin** · tip `sha-9c3e8b1` · stress `reports/nightly-ot-bench_20260910T021557Z/` **`fully_qualified=true`** (gates 00–10) · harness fix **#889** · Cursor [`wave_k_340_filesystem_pin_master`](../../../.cursor/plans/wave_k_340_filesystem_pin_master.plan.md)  
 **Program (prior CLOSED):** Wave J — Cursor [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) · tip `sha-c1b1aa5` / 3.3.41  
 **Program (prior CLOSED):** Wave I — Cursor [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) · tip `sha-d1312b0` / 3.3.40  
 **Stress (Wave K closeout):** `reports/nightly-ot-bench_20260910T021557Z/` · **`fully_qualified=true`** (gates 00–10 incl. ZAP + MCP + Wave I + Wave K MEGAs)  
-**Stress (Wave L):** mid-wave = **smoke + gate 11** only; **ONE enhanced full stress at L8** (00–11+, no `SKIP_ZAP`) → BUG_REPORT **3.5.x PINNED**  
-**L1 smoke:** gate 11 PASS · `/tmp/wave_l_l1_smoke_20260910T165010Z/` · health `3.5.0+a11b6cb181fc` · `multi_tenant=false` · tenants legacy · ingest_ok soak  
+**Stress (Wave L):** mid-wave = **smoke + gates 11–12** only; **ONE enhanced full stress at L8** (00–12+, no `SKIP_ZAP`) → BUG_REPORT **3.5.x PINNED**  
+**L2 smoke:** gates **11+12 PASS** · `/tmp/wave_l_l2_smoke_20260910T230823Z/` · health `3.5.1+2dea571cea05` · `multi_tenant=false` · empty `historian_prefix` · ingest_ok soak  
+**L1 smoke:** gate 11 PASS · `/tmp/wave_l_l1_smoke_20260910T165010Z/` · health `3.5.0+a11b6cb181fc`  
 **Deferred:** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — Cursor [`mqtt_monitor_sse_782.plan.md`](../../../.cursor/plans/mqtt_monitor_sse_782.plan.md) (optional; never blocks Wave L)  
 **K1:** MEGAs **#884 MERGED** (`5aed663c`). Docs K2/K3 → **#885**.  
 **K1b:** Plot-span **#886 MERGED** (`cee2f4ec`) — smoke on `sha-cee2f4e`.  
 **L1:** TenantContext **#891 MERGED** (`a11b6cb1`) — VERSION **3.5.0** · mode OFF  
+**L2:** Tenant Parquet roots **#894 MERGED** (`2dea571c`) — VERSION **3.5.1** · mode OFF · gate 12  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -53,7 +56,7 @@
 | **hybrid-ml-physics-ahu-vav** | **ABANDONED** | Was: physics/RCA / ML / E+ hybrid Wave G | Felt bogus 2026-09-07 | Do not implement |
 | **sql-anomaly-screening** | **PARKED** | SQL self/peer anomaly | Lab parity first 2026-09-07 | After Wave H demo |
 | **wave-l-l1-tenant-context** | **CLOSED** (Wave L L1 / 3.5.0 / `sha-a11b6cb`) | Control plane + `TenantContext` + mode OFF; health/tenants; gate 11 | #891 · tip smoke `/tmp/wave_l_l1_smoke_20260910T165010Z/` · `multi_tenant=false` | L2 Parquet isolation |
-| **wave-l-l2-parquet-roots** | **OPEN** (Wave L / 3.5.1) | Tenant-partitioned Parquet roots + DF path scoping; gate 12; mode OFF = hub root | L2 PR | Merge → tip → smoke + gates 11–12 |
+| **wave-l-l2-parquet-roots** | **CLOSED** (Wave L L2 / 3.5.1 / `sha-2dea571`) | Tenant-partitioned Parquet roots + DF path scoping; gate 12; mode OFF = hub root | #894 · tip smoke `/tmp/wave_l_l2_smoke_20260910T230823Z/` · gates 11+12 PASS · `historian_prefix=""` | L3 MQTTS isolation |
 | **lab-tuner-vibe19-parity** | **CLOSED** (3.3.37) | Vibe19 Lab tuners → production (~217→~444) | #864 · stress `reports/nightly-ot-bench_20260907T183808Z/` · `fully_qualified=true` | — |
 | **ghcr-publish-hub-blocked-by-fieldbus** | **CLOSED** (#865) | Serial Publish put mqtt after multi-arch fieldbus | Merged 2026-09-07; tip-completeness workflow live | — |
 | **mqtt-overview-spa-parity** | **CLOSED** (3.3.33) | Was: equipment=0 for MQTT `bldg2` → empty Overview | #856 · probe + stress | — |
@@ -135,7 +138,7 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 
 | Rev / wave | In-repo / Cursor plan | Concern | Status |
 |------------|----------------------|---------|--------|
-| **Wave L master** | [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md) | **3.5.x multi-client shared hosting** (tenant Parquet + control plane) | **ACTIVE** (L1 LIVE on `sha-a11b6cb`; L2 next) |
+| **Wave L master** | [`openfdd_wave_l_shared_db_mega_program.plan.md`](patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md) | **3.5.x multi-client shared hosting** (tenant Parquet + control plane) | **ACTIVE** (L2 LIVE on `sha-2dea571` / 3.5.1; L3 next) |
 | **Wave K master** | [`openfdd_wave_k_340_filesystem_pin_program.plan.md`](patch_trains/openfdd_wave_k_340_filesystem_pin_program.plan.md) | **3.4.0 pin** + MEGAs + historian freeze + Phase-0 ADR | **CLOSED / PINNED** |
 | **Wave J master** | [`wave_j_df_boundary_master`](../../../.cursor/plans/wave_j_df_boundary_master.plan.md) | DF-boundary + #875 | **RETIRED / CLOSED** |
 | **Wave I master** | [`wave_i_app_test_mega_master`](../../../.cursor/plans/wave_i_app_test_mega_master.plan.md) | App-test MEGAs | **RETIRED / CLOSED** |

--- a/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
@@ -1,6 +1,6 @@
 ---
 name: Wave L multi-client shared hosting
-overview: "ACTIVE — Wave L 3.5.x. L1 LIVE sha-a11b6cb / 3.5.0 mode OFF. Low-RAM GH loop; Actions green + 0 stale PRs/branches. L2 next. L8 = enhanced full stress (00–11+) + BUG_REPORT 3.5.x PINNED."
+overview: "ACTIVE — Wave L 3.5.x. L2 LIVE sha-2dea571 / 3.5.1. L3 next (MQTTS). Low-RAM; Actions green; 0 stale PRs/branches. L8 = enhanced stress + 3.5.x PINNED."
 todos:
   - id: l0-wait-k-pin
     content: L0 — Wave K 3.4.0 PINNED (sha-9c3e8b1 / stress 20260910T021557Z) — UNBLOCKED
@@ -15,8 +15,8 @@ todos:
     content: L1 — #891 MERGED; tip sha-a11b6cb; gate 11 PASS; mode OFF LIVE
     status: completed
   - id: l2-parquet-isolation
-    content: L2 — Tenant Parquet roots + DF providers (no shared-table WHERE)
-    status: pending
+    content: L2 — #894 MERGED; tip sha-2dea571; gates 11+12 PASS; mode OFF LIVE
+    status: completed
   - id: l3-mqtts-isolation
     content: L3 — MQTTS namespace + ACL + identity provenance
     status: pending
@@ -33,7 +33,7 @@ todos:
     content: L7 — Legacy-tenant migrate dry-run + operator checklist
     status: pending
   - id: l8-stress-pin
-    content: L8 — ENHANCED full stress (00–11+ A↔B) + BUG_REPORT 3.5.x PINNED; mode OFF
+    content: L8 — ENHANCED full stress (00–12+ A↔B) + BUG_REPORT 3.5.x PINNED; mode OFF
     status: pending
   - id: deferred-stage-c
     content: IdP/MFA/dedicated SKUs — after shared-hosting baseline
@@ -49,28 +49,19 @@ isProject: false
 
 # Wave L — Multi-client shared hosting (3.5.x)
 
-**Cursor SoT:** [`wave_l_shared_db_mega_master.plan.md`](../../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md)  
-**Depends on:** Wave K **3.4.0 PINNED** (`sha-9c3e8b1`). Phase-0 ADR in K3. Product coding after K pin.
+**Cursor SoT:** [`wave_l_shared_db_mega_master.plan.md`](../../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md)
 
 ## Where we are (2026-09-10) — **ACTIVE**
 
 | Item | State |
 |------|--------|
 | **Program** | **ACTIVE** — Wave L **3.5.x** |
-| **Gate L0** | **DONE** — Wave K **3.4.0 PINNED** |
+| **Gate L0** | **DONE** — Wave K **3.4.0 PINNED** (`sha-9c3e8b1`) |
 | **Phase-0 ADR** | **DONE** (#885) — `docs/architecture/ADR_multi_client_shared_hosting.md` |
-| **BUG_REPORT product OPEN** | **None** (L1 CLOSED; Wave K MEGAs CLOSED) |
-| **Ops pin** | **`sha-a11b6cb`** / `3.5.0+a11b6cb181fc` · `multi_tenant=false` (rollback `sha-9c3e8b1`) |
-| **Step** | **L2** — Tenant Parquet roots + DF providers |
-
-### BUG_REPORT carry-in
-
-| ID | Status | In Wave L? |
-|----|--------|------------|
-| Wave K MEGAs + plot-span | CLOSED | Keep green (gate 10 + L8) |
-| #782 SSE | DEFERRED | **No** |
-| sql-anomaly | PARKED | **No** |
-| Stage C | after L8 | deferred-stage-c |
+| **L1** | **DONE** — #891 · tip **`sha-a11b6cb`** · health **`3.5.0+a11b6cb181fc`** · gate 11 PASS · `multi_tenant=false` |
+| **L2** | **DONE** — #894 · tip **`sha-2dea571`** · health **`3.5.1+2dea571cea05`** · gates **11+12 PASS** · empty `historian_prefix` |
+| **Ops pin** | **`sha-2dea571`** (rollback **`sha-9c3e8b1`** / 3.4.0; prior L1 **`sha-a11b6cb`**) |
+| **Step** | **L3** — MQTTS namespace + ACL + identity provenance |
 
 ### Progress board
 
@@ -78,8 +69,9 @@ isProject: false
 [x] L0 / L0b / L0c  pin + BUG_REPORT carry + hygiene law
 [x] Phase-0 ADR (#885)
 [x] L1  Control plane OFF + TenantContext + gate 11 (#891 / sha-a11b6cb)
-[ ] L2  Tenant Parquet + DF   ← YOU ARE HERE
-[ ] L3–L7 …
+[x] L2  Tenant Parquet + DF + gate 12 (#894 / sha-2dea571)
+[ ] L3  MQTTS namespace + ACL   ← YOU ARE HERE
+[ ] L4–L7 …
 [ ] L8  ENHANCED full stress + BUG_REPORT 3.5.x PINNED
 ```
 
@@ -94,9 +86,9 @@ isProject: false
 | Between tips | tip Publish → tip gate → backup → Railway re-pin hub+fieldbus → soak → **smoke** → **BUG_REPORT** |
 | GH Actions | Every product PR: wait checks **green** before merge. No merge on red. |
 | Branches / PRs | After merge: **0 open PRs**, remote **only `master`**, delete merged local branches. |
-| Full stress | **Not** every tip. Mid-wave = smoke (+ gate **11** when present). **ONE enhanced full stress at L8**. |
-| Tip noise | Cancelled/incomplete Publish on non-tip SHAs is noise — judge **latest tip** checks only. |
-| Logging | Every pin/smoke/stress/migrate → [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md). Mid-wave: tip/smoke + gate 11; **PINNED only at L8**. |
+| Full stress | **Not** every tip. Mid-wave = smoke (+ gates **11–12**). **ONE enhanced full stress at L8**. |
+| Tip noise | Cancelled/incomplete Publish on non-tip SHAs is noise — judge **latest tip** checks only. Early tip-completeness red before Publish completes is noise. |
+| Logging | Every pin/smoke/stress/migrate → [`BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../BUG_REPORT_OT_MODBUS_HAYSTACK.md). Mid-wave: tip/smoke + gates 11–12; **PINNED only at L8**. |
 
 ### Qual tiers
 
@@ -151,8 +143,8 @@ control plane (tenants/users/memberships/buildings)
 | Phase | Rev | Deliverable | Stress |
 |-------|-----|-------------|--------|
 | 0 | docs | ADR (done) | — |
-| **1** | **3.5.0** | Control plane + TenantContext; **OFF** | smoke + gate 11 |
-| 2 | 3.5.1 | Tenant Parquet + DF | A↔B storage |
+| **1** | **3.5.0** | Control plane + TenantContext; **OFF** | **DONE** smoke + gate 11 |
+| **2** | **3.5.1** | Tenant Parquet + DF | **DONE** smoke + gates 11–12 |
 | 3 | 3.5.2 | MQTTS ACL | MQTT clients |
 | 4 | 3.5.3 | UI membership | smoke |
 | 5 | 3.5.4 | Budgets | lab notes |

--- a/openfdd_agent_spec/AGENTS.md
+++ b/openfdd_agent_spec/AGENTS.md
@@ -106,7 +106,7 @@ retest. Do not confuse those with this engineering OS.
 59. **Wave L multi-tenant (mode OFF until Tier-2):** `OPENFDD_MULTI_TENANT` defaults OFF. L1: `TenantContext` + `/api/tenants` + gate 11. L2: tenant Parquet roots via `fdd_store::tenant_storage_root` / `TenantContext::historian_root` (hub root when OFF; `{base}/tenants/{tid}` when ON) + gate 12. Isolation = **path-scoped DF providers**, never shared mega-table + `WHERE tenant_id`. ADR: [`docs/architecture/ADR_multi_client_shared_hosting.md`](../docs/architecture/ADR_multi_client_shared_hosting.md).
 60. **Agent tooling map (use the right tool):** GHCR Publish / tip gate = GitHub Actions + `scripts/check_ghcr_tip_stack.sh`. Hub re-pin / backup / ssh health = **Railway CLI** (rule 39). Local lab stack = `openfdd_stack_*.sh` (HTTP firewall only). FDD/analytics for AI hosts = **`openfdd-mcp`** + agent JWT — not Railway MCP. Stress = `scripts/nightly-ot-bench/`. Typst RCx PDFs = [`skills/openfdd-typst-rcx-report`](skills/openfdd-typst-rcx-report/SKILL.md). Hygiene every merge: **0 open PRs**, remote **only `master`**, tip Actions green (ignore cancelled docs-tip Publish noise).
 
-**Current ops pin (2026-09-10):** VERSION **3.5.0** · tip **`sha-a11b6cb`** · health **`3.5.0+a11b6cb181fc`** · `multi_tenant=false` · Wave L **L1 LIVE**. Rollback: Wave K **`sha-9c3e8b1`** / **3.4.0**. Low-RAM always (rule 0).
+**Current ops pin (2026-09-10):** VERSION **3.5.1** · tip **`sha-2dea571`** · health **`3.5.1+2dea571cea05`** · `multi_tenant=false` · Wave L **L2 LIVE**. Rollback: Wave K **`sha-9c3e8b1`** / **3.4.0**. Low-RAM always (rule 0).
 
 ---
 

--- a/openfdd_agent_spec/CONTAINER_AGENT.md
+++ b/openfdd_agent_spec/CONTAINER_AGENT.md
@@ -113,7 +113,7 @@ required for health, FDD, or Overview analytics.
 ## Ops patch cycle (Railway hub + qualification — 3.3.20+)
 
 Living log: [`docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md`](../docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md).  
-Active program: Wave L **ACTIVE** — multi-client shared hosting **3.5.x** (L1 LIVE on `sha-a11b6cb` / mode OFF; L2 Parquet roots next). Wave K **CLOSED / PINNED** on `sha-9c3e8b1` / 3.4.0. Cursor: [`wave_l_shared_db_mega_master`](../../.cursor/plans/wave_l_shared_db_mega_master.plan.md).
+Active program: Wave L **ACTIVE** — multi-client shared hosting **3.5.x** (L2 LIVE on `sha-2dea571` / 3.5.1 / mode OFF; L3 MQTTS next). Wave K **CLOSED / PINNED** on `sha-9c3e8b1` / 3.4.0. Cursor: [`wave_l_shared_db_mega_master`](../../.cursor/plans/wave_l_shared_db_mega_master.plan.md).
 Stress handbook: [`docs/operations/STRESS_CLOSEOUT.md`](../docs/operations/STRESS_CLOSEOUT.md) · entry [`scripts/qualification/README.md`](../scripts/qualification/README.md).
 
 | Step | Action |

--- a/openfdd_agent_spec/SESSION_LOG.md
+++ b/openfdd_agent_spec/SESSION_LOG.md
@@ -1,5 +1,11 @@
 # Session log
 
+## 2026-09-10 — Wave L L2 LIVE (3.5.1 / sha-2dea571)
+
+- Product #894 tenant Parquet roots + gate 12; tip `sha-2dea571`; health `3.5.1+2dea571cea05`; gates **11+12 PASS**; backup `20260910T230450Z`.
+- Closed junk external #896 (SECURITY_ADVISORY.md only — not #752). Hygiene: 0 open PRs / only `master`.
+- Next: L3 MQTTS namespace + ACL + identity provenance.
+
 ## 2026-09-10 — README + agent-spec tooling / Wave L context
 
 - README revised (Install/run + PyPI blurb; Support section); spelling-only fix (`AI agent assistance:`).

--- a/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
+++ b/openfdd_agent_spec/skills/openfdd-railway-cli/SKILL.md
@@ -21,7 +21,7 @@ Checklist: [`RAILWAY_DEPLOYMENT_CHECKLIST.md`](../../../docs/operations/RAILWAY_
 | Package | `@railway/cli` via `npm i -g @railway/cli` |
 | Auth | **`railway login`** (browser) — verified; optional `RAILWAY_TOKEN` in `~/.config/railway/bensbench.env` |
 | Link | `~/open-fdd` → project **`gleaming-cooperation`**, env **`production`** |
-| **Product hub pin** | **`sha-a11b6cb`** / VERSION **3.5.0** / health **`3.5.0+a11b6cb181fc`** · `multi_tenant=false` (Wave L L1). Rollback **`sha-9c3e8b1`** / **3.4.0**. |
+| **Product hub pin** | **`sha-2dea571`** / VERSION **3.5.1** / health **`3.5.1+2dea571cea05`** · `multi_tenant=false` · empty `historian_prefix` (Wave L L2). Rollback **`sha-9c3e8b1`** / **3.4.0** (Wave K); prior L1 **`sha-a11b6cb`** / **3.5.0**. |
 | Stress closeout | Mid-wave = smoke + gates **11–12**. Full stress at Wave L **L8** / shippable pins — [`STRESS_CLOSEOUT.md`](../../../docs/operations/STRESS_CLOSEOUT.md) · skill [`openfdd-stress-closeout`](../openfdd-stress-closeout/SKILL.md) |
 | Local firewall hub | HTTP only — [`LOCAL_DEPLOYMENT.md`](../../../docs/operations/LOCAL_DEPLOYMENT.md) |
 | Fieldbus | **Not** a Railway service — bensbench x86 via `./scripts/openfdd_fieldbus_railway_up.sh sha-<7>` |
@@ -111,7 +111,7 @@ railway service source connect --service openfdd-web \
 ./scripts/openfdd_fieldbus_railway_up.sh "$SHA"
 ```
 
-Smoke: public SPA + `https://<web>/api/health` (and `/api/tenants` — Wave L: `multi_tenant=false`, empty `historian_prefix` when OFF). Version must match the **pinned** SHA (`3.5.0+a11b6cb…` for `sha-a11b6cb`).
+Smoke: public SPA + `https://<web>/api/health` (and `/api/tenants` — Wave L: `multi_tenant=false`, empty `historian_prefix` when OFF). Version must match the **pinned** SHA (`3.5.1+2dea571…` for `sha-2dea571`).
 
 **Wave L mid-wave:** gates **11** + **12** only (`22_wave_l_tenant_mode.sh`, `23_wave_l_parquet_isolation.sh`). Full `run_railway_hub_stress.sh` at **L8**.
 

--- a/services/central/src/tenant.rs
+++ b/services/central/src/tenant.rs
@@ -193,15 +193,25 @@ pub struct TenantsListResponse {
 mod tests {
     use super::*;
     use crate::auth::{AuthUser, Role};
+    use std::sync::{Mutex, MutexGuard};
+
+    /// Serialize env mutations — `OPENFDD_MULTI_TENANT` is process-global.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     #[test]
     fn multi_tenant_flag_defaults_off() {
+        let _g = lock_env();
         std::env::remove_var("OPENFDD_MULTI_TENANT");
         assert!(!multi_tenant_enabled());
     }
 
     #[test]
     fn multi_tenant_flag_on() {
+        let _g = lock_env();
         std::env::set_var("OPENFDD_MULTI_TENANT", "1");
         assert!(multi_tenant_enabled());
         std::env::remove_var("OPENFDD_MULTI_TENANT");
@@ -209,6 +219,7 @@ mod tests {
 
     #[test]
     fn resolve_off_is_legacy_passthrough() {
+        let _g = lock_env();
         std::env::remove_var("OPENFDD_MULTI_TENANT");
         let user = AuthUser {
             sub: "admin".into(),
@@ -224,6 +235,7 @@ mod tests {
 
     #[test]
     fn resolve_on_without_membership_fails_closed() {
+        let _g = lock_env();
         std::env::set_var("OPENFDD_MULTI_TENANT", "true");
         let user = AuthUser {
             sub: "operator".into(),
@@ -238,6 +250,7 @@ mod tests {
 
     #[test]
     fn resolve_on_scopes_buildings() {
+        let _g = lock_env();
         std::env::set_var("OPENFDD_MULTI_TENANT", "on");
         let user = AuthUser {
             sub: "eng".into(),
@@ -260,6 +273,7 @@ mod tests {
 
     #[test]
     fn historian_root_off_is_hub_base() {
+        let _g = lock_env();
         std::env::remove_var("OPENFDD_MULTI_TENANT");
         let user = AuthUser {
             sub: "admin".into(),
@@ -275,6 +289,7 @@ mod tests {
 
     #[test]
     fn historian_root_on_partitions_by_tenant() {
+        let _g = lock_env();
         std::env::set_var("OPENFDD_MULTI_TENANT", "1");
         let user = AuthUser {
             sub: "eng".into(),


### PR DESCRIPTION
## Summary
- BUG_REPORT: L2 **CLOSED** — tip **`sha-2dea571`** / **3.5.1+2dea571cea05**; backup `20260910T230450Z`; smoke `/tmp/wave_l_l2_smoke_20260910T230823Z/` gates **11+12 PASS**
- Plan mirror + agent-spec / Railway CLI pin → L2 LIVE; next **L3 MQTTS**

## Test plan
- [x] Tip GHCR complete (`check_ghcr_tip_stack.sh sha-2dea571`)
- [x] Railway hub+fieldbus re-pin + ingest_ok
- [x] Gates 11 + 12 PASS
- [ ] Docs-only merge; delete branch; 0 open PRs / only `master`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product documentation to reflect Version 3.5.1 and Wave L L2 as live.
  * Recorded successful smoke testing and gates 11–12 validation.
  * Updated operational plans, status dashboards, and session logs to show L2 completion and L3 MQTTS as the next phase.
  * Refreshed rollback, backup, verification, and deployment health information for the current release.

* **Tests**
  * Improved reliability of multi-tenant environment-dependent tests by serializing shared configuration access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->