### PR TITLE
docs(ops): Wave L plan mirror closeout

### DIFF
--- a/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
@@ -1,6 +1,6 @@
 ---
 name: Wave L multi-client shared hosting
-overview: "CLOSED / PINNED — Wave L 3.5.6. Ops tip sha-e80237c. Stress 20260912T033836Z fully_qualified=true. Mode OFF. Deferred: Stage C / #782 / sql-anomaly."
+overview: "CLOSED / PINNED — Wave L 3.5.6. Ops tip sha-e80237c. Stress 20260912T033836Z fully_qualified=true. Mode OFF. SQL PARKED; Stage C/#782 out-of-Wave-L."
 todos:
   - id: l0-wait-k-pin
     content: L0 — Wave K 3.4.0 PINNED (sha-9c3e8b1 / stress 20260910T021557Z) — UNBLOCKED


### PR DESCRIPTION
## Summary
- Repo Wave L plan mirror overview: Stage C / #782 cancelled as out-of-Wave-L; SQL PARKED.
- Ops pin unchanged (`sha-e80237c` / 3.5.6 PINNED).

## Test plan
- [x] Docs-only
- [ ] Checks green → merge → 0 PRs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plan overview to clarify that SQL-related work and Stage C/#782 are parked outside Wave L.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->