### PR TITLE
docs(ops): Wave L TODO mirror + BUG_REPORT closeout

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -3,7 +3,7 @@
 **Date:** 2026-09-12 (Wave L **3.5.6 PINNED** · mode OFF · L8 closeout · plan TODOs closed except SQL PARKED)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
 **Tip / pin (ops):** `e80237c0` · VERSION **3.5.6** · health **`3.5.6+e80237c0e758`** · GHCR **central/web/mqtt/fieldbus `sha-e80237c`** · `multi_tenant=false` · `historian_prefix=""` · `active_tenant_id=legacy` · `tenant_budgets=false`  
-**Docs tip (post-pin; ops held):** `d01957d9` · **`sha-d01957d`** · BUG_REPORT/#910 · plan-mirror/#911 · TODOs sync (this PR) — **do not re-pin Railway** for docs-only tips  
+**Docs tip (post-pin; ops held):** `d01957d9` · **`sha-d01957d`** · BUG_REPORT/#910 · plan-mirror/#911 · TODOs sync **#912** — **do not re-pin Railway** for docs-only tips  
 **Rollback pin (Wave K):** `9c3e8b1c` · **`sha-9c3e8b1`** · **`3.4.0+9c3e8b1c30c1`** · MEGAs stress `20260910T021557Z` · docs **#890**  
 **Prior Wave L tip (L5 ops):** `c5b3ccc9` · **`sha-c5b3ccc`** · **`3.5.5+c5b3ccc947c8`** · docs **#906**  
 **Prior Wave L tip (L5 product):** `ecd97a47` · **`sha-ecd97a4`** · **`3.5.5+ecd97a473405`** · product **#904** · docs **#905**  

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -1,8 +1,9 @@
 # BUG REPORT — OT Modbus / Haystack / BACnet / MQTT (low-RAM GHCR loop)
 
-**Date:** 2026-09-12 (Wave L **3.5.6 PINNED** · mode OFF · L8 closeout)  
+**Date:** 2026-09-12 (Wave L **3.5.6 PINNED** · mode OFF · L8 closeout · plan TODOs closed except SQL PARKED)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
 **Tip / pin (ops):** `e80237c0` · VERSION **3.5.6** · health **`3.5.6+e80237c0e758`** · GHCR **central/web/mqtt/fieldbus `sha-e80237c`** · `multi_tenant=false` · `historian_prefix=""` · `active_tenant_id=legacy` · `tenant_budgets=false`  
+**Docs tip (post-pin; ops held):** `d01957d9` · **`sha-d01957d`** · BUG_REPORT/#910 · plan-mirror/#911 · TODOs sync (this PR) — **do not re-pin Railway** for docs-only tips  
 **Rollback pin (Wave K):** `9c3e8b1c` · **`sha-9c3e8b1`** · **`3.4.0+9c3e8b1c30c1`** · MEGAs stress `20260910T021557Z` · docs **#890**  
 **Prior Wave L tip (L5 ops):** `c5b3ccc9` · **`sha-c5b3ccc`** · **`3.5.5+c5b3ccc947c8`** · docs **#906**  
 **Prior Wave L tip (L5 product):** `ecd97a47` · **`sha-ecd97a4`** · **`3.5.5+ecd97a473405`** · product **#904** · docs **#905**  
@@ -25,7 +26,8 @@
 **L3 smoke:** gates **11+12+13 PASS** · `/tmp/wave_l_l3_smoke_20260911T032648Z/` · health `3.5.2+be65366316bb` · `multi_tenant=false` · ingest_ok soak · fieldbus `sha-be65366`  
 **L2 smoke:** gates **11+12 PASS** · `/tmp/wave_l_l2_smoke_20260910T230823Z/` (product `sha-2dea571`) · re-pin smoke `/tmp/wave_l_l2b_smoke_20260911T005453Z/` · health `3.5.1+af08ac7b9889` · `multi_tenant=false` · empty `historian_prefix` · ingest_ok soak  
 **L1 smoke:** gate 11 PASS · `/tmp/wave_l_l1_smoke_20260910T165010Z/` · health `3.5.0+a11b6cb181fc`  
-**Deferred (not Wave L):** [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE · sql-anomaly PARKED · Stage C IdP/MFA/dedicated SKUs  
+**Deferred (not Wave L):** Stage C IdP/MFA/dedicated SKUs · [#782](https://github.com/bbartling/open-fdd/issues/782) MQTT monitor SSE — **cancelled as Wave L TODOs** (track separately) · sql-anomaly **PARKED** (optional; skipped this closeout)  
+**Plan TODOs:** L0–L8 + hygiene + UX/DM **completed**; Stage C / #782 **cancelled**; sql-anomaly **cancelled/PARKED** — Cursor SoT + repo mirror aligned  
 **K1:** MEGAs **#884 MERGED** (`5aed663c`). Docs K2/K3 → **#885**.  
 **K1b:** Plot-span **#886 MERGED** (`cee2f4ec`) — smoke on `sha-cee2f4e`.  
 **L1:** TenantContext **#891 MERGED** (`a11b6cb1`) — VERSION **3.5.0** · mode OFF  
@@ -34,6 +36,7 @@
 **L4:** Tenant UI/session **#901 MERGED** (`d67d27b9`) — VERSION **3.5.3** · mode OFF · gate 14  
 **L5:** Per-tenant budgets **#903 MERGED** (`581edf3e` / 3.5.4) + product UX **#904 MERGED** (`ecd97a47` / 3.5.5) + docs/harness **#905 MERGED** (`c5b3ccc9`) · mode OFF · gate 15  
 **L6+L7:** A/B isolation + tip digest + legacy migrate dry-run **#908 MERGED** (`1d15d423` / 3.5.6) + fieldbus env-lock flake **#909 MERGED** (`e80237c0` / **3.5.6 PINNED**) · gates 16–17  
+**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror overview **#911** · plan TODO/body sync (this PR) — ops tip remains **`sha-e80237c`**  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 
@@ -75,7 +78,7 @@
 | **wave-l-l5-tenant-budgets** | **CLOSED** (Wave L L5 / 3.5.5 / `sha-c5b3ccc`) | Per-tenant budgets OFF-safe (#903) + product UX Dump/Twin/OAT/zone comfort (#904) + docs/harness (#905); gate 15 | #903 · #904 · #905 · smoke `/tmp/wave_l_l5c_smoke_20260911T185328Z/` · gates 11–15 PASS · backup `20260911T185021Z` · gate15 jq `false//` harness fix | L6 qual hardening |
 | **wave-l-l6-ab-isolation** | **CLOSED** (Wave L L6 / 3.5.6 / `sha-e80237c`) | Tier-2 A/B path+MQTT harness + tip digest scan + ZAP AF mode-OFF; gate 16 | #908 · #909 · smoke `/tmp/wave_l_l8_smoke_20260912T033741Z/` · stress gate 16 PASS | L7 migrate |
 | **wave-l-l7-legacy-migrate** | **CLOSED** (Wave L L7 / 3.5.6 / `sha-e80237c`) | Legacy-tenant migrate dry-run + operator checklist; APPLY refused on HTTPS; gate 17 | #908 · checklist `WAVE_L_LEGACY_MIGRATE_CHECKLIST.md` · stress gate 17 PASS | L8 pin |
-| **wave-l-l8-pin** | **CLOSED** (Wave L L8 / **3.5.6 PINNED** / `sha-e80237c`) | Enhanced full stress gates 00–17; `fully_qualified=true`; mode OFF | stress `reports/nightly-ot-bench_20260912T033836Z/` · backup `20260912T031216Z` · no `SKIP_ZAP` | Stage C deferred |
+| **wave-l-l8-pin** | **CLOSED** (Wave L L8 / **3.5.6 PINNED** / `sha-e80237c`) | Enhanced full stress gates 00–17; `fully_qualified=true`; mode OFF; plan TODOs closed except SQL PARKED | stress `reports/nightly-ot-bench_20260912T033836Z/` · backup `20260912T031216Z` · no `SKIP_ZAP` · docs #910+#911 | — (outside Wave L) |
 | **lab-tuner-vibe19-parity** | **CLOSED** (3.3.37) | Vibe19 Lab tuners → production (~217→~444) | #864 · stress `reports/nightly-ot-bench_20260907T183808Z/` · `fully_qualified=true` | — |
 | **ghcr-publish-hub-blocked-by-fieldbus** | **CLOSED** (#865) | Serial Publish put mqtt after multi-arch fieldbus | Merged 2026-09-07; tip-completeness workflow live | — |
 | **mqtt-overview-spa-parity** | **CLOSED** (3.3.33) | Was: equipment=0 for MQTT `bldg2` → empty Overview | #856 · probe + stress | — |
@@ -150,8 +153,8 @@ Template + commands: [`PATCH_CYCLE.md`](PATCH_CYCLE.md). Check boxes as you go. 
 ### Upcoming trains (Cursor plans — optimized waves 2026-09-06)
 
 **Source of truth:** [`patch_trains/`](patch_trains/) · [`BENCH_RECOVERY.md`](BENCH_RECOVERY.md) · [`recovery/AI_CONTEXT_HANDOFF.md`](recovery/AI_CONTEXT_HANDOFF.md).  
-**Active:** none (Wave L **CLOSED / PINNED**). Next deferred: Stage C IdP/MFA/dedicated SKUs; optional #782 SSE; sql-anomaly PARKED.  
-**Last closed:** Wave L [`wave_l_shared_db_mega_master`](../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md) · tip `sha-e80237c` / **3.5.6** · stress `20260912T033836Z` **`fully_qualified=true`**. Prior Wave K tip `sha-9c3e8b1` / **3.4.0**.
+**Active:** none (Wave L **CLOSED / PINNED**). Wave L plan TODOs done except optional sql-anomaly **PARKED**. Stage C / #782 **out of Wave L** (cancelled TODOs).  
+**Last closed:** Wave L [`wave_l_shared_db_mega_master`](../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md) · ops tip `sha-e80237c` / **3.5.6** · stress `20260912T033836Z` **`fully_qualified=true`**. Prior Wave K tip `sha-9c3e8b1` / **3.4.0**.
 
 **This round stress rule:** Wave L L8 complete — cite `reports/nightly-ot-bench_20260912T033836Z/` only for 3.5.6 PINNED claims.
 

--- a/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
+++ b/docs/operations/patch_trains/openfdd_wave_l_shared_db_mega_program.plan.md
@@ -36,14 +36,14 @@ todos:
     content: "L8 DONE — sha-e80237c / 3.5.6 PINNED; stress 20260912T033836Z fully_qualified=true"
     status: completed
   - id: deferred-stage-c
-    content: IdP/MFA/dedicated SKUs — after shared-hosting baseline
-    status: pending
+    content: "OUT OF WAVE L — IdP/MFA/dedicated SKUs (Stage C); track separately after baseline"
+    status: cancelled
   - id: deferred-782-sse
-    content: Optional #782 MQTT monitor SSE — separate plan; never blocks Wave L
-    status: pending
+    content: "OUT OF WAVE L — #782 MQTT monitor SSE; separate plan only"
+    status: cancelled
   - id: deferred-sql-anomaly
-    content: sql-anomaly-screening PARKED — not Wave L shared-hosting
-    status: pending
+    content: "PARKED — sql-anomaly-screening (optional; not Wave L)"
+    status: cancelled
 isProject: false
 ---
 
@@ -51,20 +51,21 @@ isProject: false
 
 **Cursor SoT:** [`wave_l_shared_db_mega_master.plan.md`](../../../../.cursor/plans/wave_l_shared_db_mega_master.plan.md)
 
-## Where we are (2026-09-11) — **ACTIVE**
+## Where we are (2026-09-12) — **CLOSED / PINNED**
 
 | Item | State |
 |------|--------|
-| **Program** | **ACTIVE** — Wave L **3.5.x** |
+| **Program** | **CLOSED / PINNED** — Wave L **3.5.6** |
 | **Gate L0** | **DONE** — Wave K **3.4.0 PINNED** (`sha-9c3e8b1`) |
 | **Phase-0 ADR** | **DONE** (#885) — `docs/architecture/ADR_multi_client_shared_hosting.md` |
-| **L1** | **DONE** — #891 · tip **`sha-a11b6cb`** · health **`3.5.0+a11b6cb181fc`** · gate 11 PASS · `multi_tenant=false` |
-| **L2** | **DONE** — #894 product **`sha-2dea571`** · ops tip **`sha-af08ac7`** (#897 flake-fix) · health **`3.5.1+af08ac7b9889`** · gates **11+12 PASS** |
-| **L3** | **DONE** — #899 · tip **`sha-be65366`** · health **`3.5.2+be65366316bb`** · gates **11+12+13 PASS** · `multi_tenant=false` |
-| **L4** | **DONE** — #901 · tip **`sha-d67d27b`** · health **`3.5.3+d67d27b9e791`** · gates **11–14 PASS** · `multi_tenant=false` · `active_tenant_id=legacy` |
-| **L5** | **DONE / LIVE** — #903+#904+#905 · tip **`sha-c5b3ccc`** / **3.5.5** · health **`3.5.5+c5b3ccc947c8`** · gates **11–15 PASS** · `multi_tenant=false` · `tenant_budgets=false` |
-| **Ops pin** | **LIVE** **`sha-c5b3ccc`** / **3.5.5** · rollback Wave K **`sha-9c3e8b1`** / **3.4.0** |
-| **Step** | **Next: L6** — ZAP/AF + A↔B isolation harness + digest scans |
+| **L1–L5** | **DONE** — #891→#905 · prior ops tip **`sha-c5b3ccc`** / **3.5.5** · gates **11–15** |
+| **L6** | **DONE** — #908 A/B isolation + tip digest + ZAP AF OFF · gate **16** |
+| **L7** | **DONE** — #908 legacy migrate dry-run + checklist · gate **17** |
+| **L8** | **DONE** — #909+#910 · tip **`sha-e80237c`** / **3.5.6** · stress **`20260912T033836Z`** **`fully_qualified=true`** |
+| **Ops pin** | **LIVE** **`sha-e80237c`** / **3.5.6** · health **`3.5.6+e80237c0e758`** · rollback Wave K **`sha-9c3e8b1`** / **3.4.0** |
+| **Mode** | **`multi_tenant=false`** until operator checklist |
+| **Hygiene** | **0** open PRs · only `master` · tip Actions green (ops held at `sha-e80237c`; docs tip may advance) |
+| **Next** | Outside Wave L only (Stage C / #782 cancelled; sql-anomaly PARKED) |
 
 ### Progress board
 
@@ -75,10 +76,11 @@ isProject: false
 [x] L2  Tenant Parquet + DF + gate 12 (#894 / ops sha-af08ac7)
 [x] L3  MQTTS namespace + ACL (#899 / sha-be65366)
 [x] L4  Tenant UI/session (#901 / sha-d67d27b)
-[x] L5  Budgets + UX/DM + docs (#903+#904+#905 / sha-c5b3ccc) — LIVE
-[ ] L6  ZAP/AF + A↔B isolation harness + digest scans  ← YOU ARE HERE
-[ ] L7  Legacy migrate dry-run + operator checklist
-[ ] L8  ENHANCED full stress + BUG_REPORT 3.5.x PINNED
+[x] L5  Budgets + UX/DM + docs (#903+#904+#905 / sha-c5b3ccc)
+[x] L6  ZAP/AF + A↔B isolation harness + digest scans (#908)
+[x] L7  Legacy migrate dry-run + operator checklist (#908)
+[x] L8  ENHANCED full stress + BUG_REPORT 3.5.6 PINNED  ← DONE
+[-] Stage C / #782 / sql-anomaly — not Wave L (cancelled / PARKED)
 ```
 
 ---
@@ -158,8 +160,9 @@ control plane (tenants/users/memberships/buildings)
 | **3** | **3.5.2** | MQTTS ACL | **DONE** smoke + gates 11–13 |
 | **4** | **3.5.3** | UI membership | **DONE** smoke + gates 11–14 |
 | **5** | **3.5.4–3.5.5** | Budgets + UX/DM + docs (#903–#905) | **DONE** smoke + gates 11–15 (`sha-c5b3ccc`) |
-| **6** | **3.5.x** | ZAP/AF + isolation harness | Tier-2 (next) |
-| 7–8 | 3.5.x | Migrate dry-run + **L8 enhanced** | full 00–15+ |
+| **6** | **3.5.6** | ZAP/AF + A/B isolation harness (#908) | **DONE** gate 16 |
+| **7** | **3.5.6** | Legacy migrate dry-run + checklist (#908) | **DONE** gate 17 |
+| **8** | **3.5.6** | Enhanced L8 stress + BUG_REPORT PINNED (#909–#910) | **DONE** 00–17 `fully_qualified=true` (`sha-e80237c`) |
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- Sync `openfdd_wave_l_shared_db_mega_program.plan.md` body + deferred TODOs to Cursor SoT (**CLOSED / PINNED**): L0–L8 completed; Stage C / #782 cancelled; sql-anomaly PARKED.
- Update `BUG_REPORT_OT_MODBUS_HAYSTACK.md` with docs-tip hygiene (`sha-d01957d` lineage), plan TODO closeout, and L8 Next cleared — **ops pin remains `sha-e80237c` / 3.5.6**.

## Test plan
- [ ] Docs-only PR; no Railway re-pin
- [ ] Tip Actions green after merge
- [ ] Confirm 0 open PRs / only `master`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Wave L operational records with closeout details for version 3.5.6.
  * Marked Wave L as closed and pinned, with completed phases and refreshed progress tracking.
  * Clarified that Stage C, MQTT monitoring work, and SQL anomaly screening are cancelled for this wave and remain outside its scope.
  * Added guidance for documentation-only re-pinning and plan mirroring.
  * Recorded final gate and stress-validation milestones for the completed release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->