### PR TITLE
docs(ops): cite #912 on Wave L L8 docs line

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -36,7 +36,7 @@
 **L4:** Tenant UI/session **#901 MERGED** (`d67d27b9`) — VERSION **3.5.3** · mode OFF · gate 14  
 **L5:** Per-tenant budgets **#903 MERGED** (`581edf3e` / 3.5.4) + product UX **#904 MERGED** (`ecd97a47` / 3.5.5) + docs/harness **#905 MERGED** (`c5b3ccc9`) · mode OFF · gate 15  
 **L6+L7:** A/B isolation + tip digest + legacy migrate dry-run **#908 MERGED** (`1d15d423` / 3.5.6) + fieldbus env-lock flake **#909 MERGED** (`e80237c0` / **3.5.6 PINNED**) · gates 16–17  
-**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror overview **#911** · plan TODO/body sync (this PR) — ops tip remains **`sha-e80237c`**  
+**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror overview **#911** · plan TODO/body sync **#912** — ops tip remains **`sha-e80237c`**  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 


### PR DESCRIPTION
## Summary
- One-line BUG_REPORT fix: replace leftover \"this PR\" with **#912** on the L8 docs line.

## Test plan
- [ ] Docs-only; no Railway re-pin

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Wave L L8 documentation to reference issue `#912` for the plan TODO/body synchronization issue.
  * Preserved the existing operations tip reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->