### PR TITLE
docs(ops): Wave L BUG_REPORT docs tip sha-c191114

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -3,7 +3,7 @@
 **Date:** 2026-09-12 (Wave L **3.5.6 PINNED** · mode OFF · L8 closeout · plan TODOs closed except SQL PARKED)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
 **Tip / pin (ops):** `e80237c0` · VERSION **3.5.6** · health **`3.5.6+e80237c0e758`** · GHCR **central/web/mqtt/fieldbus `sha-e80237c`** · `multi_tenant=false` · `historian_prefix=""` · `active_tenant_id=legacy` · `tenant_budgets=false`  
-**Docs tip (post-pin; ops held):** `d01957d9` · **`sha-d01957d`** · BUG_REPORT/#910 · plan-mirror/#911 · TODOs sync **#912** — **do not re-pin Railway** for docs-only tips  
+**Docs tip (post-pin; ops held):** `c1911149` · **`sha-c191114`** · TODOs sync **#912** · #912 cite fix **#913** (prior docs `sha-d01957d` / #910+#911) — **do not re-pin Railway** for docs-only tips  
 **Rollback pin (Wave K):** `9c3e8b1c` · **`sha-9c3e8b1`** · **`3.4.0+9c3e8b1c30c1`** · MEGAs stress `20260910T021557Z` · docs **#890**  
 **Prior Wave L tip (L5 ops):** `c5b3ccc9` · **`sha-c5b3ccc`** · **`3.5.5+c5b3ccc947c8`** · docs **#906**  
 **Prior Wave L tip (L5 product):** `ecd97a47` · **`sha-ecd97a4`** · **`3.5.5+ecd97a473405`** · product **#904** · docs **#905**  
@@ -36,7 +36,7 @@
 **L4:** Tenant UI/session **#901 MERGED** (`d67d27b9`) — VERSION **3.5.3** · mode OFF · gate 14  
 **L5:** Per-tenant budgets **#903 MERGED** (`581edf3e` / 3.5.4) + product UX **#904 MERGED** (`ecd97a47` / 3.5.5) + docs/harness **#905 MERGED** (`c5b3ccc9`) · mode OFF · gate 15  
 **L6+L7:** A/B isolation + tip digest + legacy migrate dry-run **#908 MERGED** (`1d15d423` / 3.5.6) + fieldbus env-lock flake **#909 MERGED** (`e80237c0` / **3.5.6 PINNED**) · gates 16–17  
-**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror overview **#911** · plan TODO/body sync **#912** — ops tip remains **`sha-e80237c`**  
+**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror **#911+#912** · #912 cite **#913** — ops tip remains **`sha-e80237c`**  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 


### PR DESCRIPTION
## Summary
- Advance BUG_REPORT docs tip to **`sha-c191114`** after #912/#913; ops pin stays **`sha-e80237c` / 3.5.6**.

## Test plan
- [ ] Docs-only; no Railway re-pin

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the bug report metadata to reference the latest documentation tip and related synchronization and citation fixes.
  - Revised the L8 documentation notes to reflect the current plan-mirror and citation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->