### PR TITLE
fix(central): share tenant OPENFDD_* test env lock

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -36,7 +36,7 @@
 **L4:** Tenant UI/session **#901 MERGED** (`d67d27b9`) — VERSION **3.5.3** · mode OFF · gate 14  
 **L5:** Per-tenant budgets **#903 MERGED** (`581edf3e` / 3.5.4) + product UX **#904 MERGED** (`ecd97a47` / 3.5.5) + docs/harness **#905 MERGED** (`c5b3ccc9`) · mode OFF · gate 15  
 **L6+L7:** A/B isolation + tip digest + legacy migrate dry-run **#908 MERGED** (`1d15d423` / 3.5.6) + fieldbus env-lock flake **#909 MERGED** (`e80237c0` / **3.5.6 PINNED**) · gates 16–17  
-**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror **#911+#912** · #912 cite **#913** — ops tip remains **`sha-e80237c`**  
+**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror **#911+#912** · docs tip **#913+#914** · tenant ENV_LOCK flake fix (this PR) — ops tip remains **`sha-e80237c`**  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 

--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -36,7 +36,7 @@
 **L4:** Tenant UI/session **#901 MERGED** (`d67d27b9`) — VERSION **3.5.3** · mode OFF · gate 14  
 **L5:** Per-tenant budgets **#903 MERGED** (`581edf3e` / 3.5.4) + product UX **#904 MERGED** (`ecd97a47` / 3.5.5) + docs/harness **#905 MERGED** (`c5b3ccc9`) · mode OFF · gate 15  
 **L6+L7:** A/B isolation + tip digest + legacy migrate dry-run **#908 MERGED** (`1d15d423` / 3.5.6) + fieldbus env-lock flake **#909 MERGED** (`e80237c0` / **3.5.6 PINNED**) · gates 16–17  
-**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror **#911+#912** · docs tip **#913+#914** · tenant ENV_LOCK flake fix (this PR) — ops tip remains **`sha-e80237c`**  
+**L8 docs:** BUG_REPORT PINNED **#910** · plan-mirror **#911+#912** · docs tip **#913+#914** · tenant ENV_LOCK flake fix **#915** — ops tip remains **`sha-e80237c`**  
 **Wait filler:** Vibe13 Part B (separate repo) during Open-FDD CI/Publish  
 **Pis freed (not in Open-FDD stress):** bosspi · BensFakeAhu · Zone1VAV.
 

--- a/services/central/src/main.rs
+++ b/services/central/src/main.rs
@@ -21,6 +21,8 @@ mod routes;
 mod state;
 mod tenant;
 mod tenant_budget;
+#[cfg(test)]
+mod test_env_lock;
 mod vibe21;
 mod wattlab_dump;
 

--- a/services/central/src/tenant.rs
+++ b/services/central/src/tenant.rs
@@ -193,14 +193,7 @@ pub struct TenantsListResponse {
 mod tests {
     use super::*;
     use crate::auth::{AuthUser, Role};
-    use std::sync::{Mutex, MutexGuard};
-
-    /// Serialize env mutations — `OPENFDD_MULTI_TENANT` is process-global.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn lock_env() -> MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    use crate::test_env_lock::lock_env;
 
     #[test]
     fn multi_tenant_flag_defaults_off() {

--- a/services/central/src/tenant_budget.rs
+++ b/services/central/src/tenant_budget.rs
@@ -149,12 +149,7 @@ pub struct TenantBudgetsResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard};
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-    fn lock_env() -> MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    use crate::test_env_lock::lock_env;
 
     #[test]
     fn budgets_disabled_when_multi_tenant_off() {

--- a/services/central/src/test_env_lock.rs
+++ b/services/central/src/test_env_lock.rs
@@ -1,7 +1,7 @@
 //! Process-wide lock for tests that mutate `OPENFDD_*` env vars.
 //!
-//! Multiple modules (`tenant`, `tenant_budget`, …) must share one lock — a
-//! per-module `ENV_LOCK` does not serialize across crates/modules and flakes
+//! Multiple modules (`tenant`, `tenant_budget`, ...) must share one lock - a
+//! per-module `ENV_LOCK` does not serialize across modules and flakes
 //! (e.g. `tenant::tests::resolve_on_scopes_buildings` vs budget flag tests).
 
 use std::sync::{Mutex, MutexGuard};

--- a/services/central/src/test_env_lock.rs
+++ b/services/central/src/test_env_lock.rs
@@ -1,0 +1,13 @@
+//! Process-wide lock for tests that mutate `OPENFDD_*` env vars.
+//!
+//! Multiple modules (`tenant`, `tenant_budget`, …) must share one lock — a
+//! per-module `ENV_LOCK` does not serialize across crates/modules and flakes
+//! (e.g. `tenant::tests::resolve_on_scopes_buildings` vs budget flag tests).
+
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+pub fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}


### PR DESCRIPTION
## Summary
- Tip Rust CI failed on `tenant::tests::resolve_on_scopes_buildings` (`assert!(ctx.multi_tenant)`) due to **cross-module env races**: `tenant` and `tenant_budget` each used a private `ENV_LOCK` while mutating `OPENFDD_MULTI_TENANT`.
- Add shared `test_env_lock` and wire both modules through it. Docs note in BUG_REPORT; **ops pin stays `sha-e80237c`**.

## Test plan
- [ ] Rust Stack CI green (tenant + tenant_budget tests)
- [ ] Tip Publish + tip completeness green after merge
- [ ] No Railway re-pin

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of environment-dependent test scenarios by coordinating access to shared test configuration.

* **Documentation**
  * Updated operational documentation references for the Wave L L8 release line, including the latest documentation and environment-lock fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->