### PR TITLE
docs(ops): Wave L BUG_REPORT docs tip sha-6987ef9

### DIFF
--- a/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
+++ b/docs/operations/BUG_REPORT_OT_MODBUS_HAYSTACK.md
@@ -3,7 +3,7 @@
 **Date:** 2026-09-12 (Wave L **3.5.6 PINNED** · mode OFF · L8 closeout · plan TODOs closed except SQL PARKED)  
 **Platform:** Railway hub + bensbench **x86 fieldbus only** (no Raspberry Pi in Open-FDD stress)  
 **Tip / pin (ops):** `e80237c0` · VERSION **3.5.6** · health **`3.5.6+e80237c0e758`** · GHCR **central/web/mqtt/fieldbus `sha-e80237c`** · `multi_tenant=false` · `historian_prefix=""` · `active_tenant_id=legacy` · `tenant_budgets=false`  
-**Docs tip (post-pin; ops held):** `c1911149` · **`sha-c191114`** · TODOs sync **#912** · #912 cite fix **#913** (prior docs `sha-d01957d` / #910+#911) — **do not re-pin Railway** for docs-only tips  
+**Docs tip (post-pin; ops held):** `6987ef95` · **`sha-6987ef9`** · tenant ENV_LOCK **#915** (prior docs `sha-c191114` / #912–#914; `sha-d01957d` / #910+#911) — **do not re-pin Railway** for docs-only tips  
 **Rollback pin (Wave K):** `9c3e8b1c` · **`sha-9c3e8b1`** · **`3.4.0+9c3e8b1c30c1`** · MEGAs stress `20260910T021557Z` · docs **#890**  
 **Prior Wave L tip (L5 ops):** `c5b3ccc9` · **`sha-c5b3ccc`** · **`3.5.5+c5b3ccc947c8`** · docs **#906**  
 **Prior Wave L tip (L5 product):** `ecd97a47` · **`sha-ecd97a4`** · **`3.5.5+ecd97a473405`** · product **#904** · docs **#905**  


### PR DESCRIPTION
## Summary
- Advance BUG_REPORT docs tip to **`sha-6987ef9`** after #915; ops pin stays **`sha-e80237c` / 3.5.6**.
- Wave L plan TODOs already complete except SQL PARKED.

## Test plan
- [ ] Docs-only; no Railway re-pin
- [ ] Tip Actions green after merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the operations documentation tip to reference the latest tenant environment lock fix.
  - Preserved earlier documentation references for historical tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->